### PR TITLE
Rm thunk, use hooks

### DIFF
--- a/services/useBalances.ts
+++ b/services/useBalances.ts
@@ -1,20 +1,41 @@
+import { getBalances, SafeBalanceResponse } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useEffect } from 'react'
 import { useAppDispatch, useAppSelector } from 'store'
 import { selectSafeInfo } from 'store/safeInfoSlice'
-import { fetchBalances } from 'store/balancesSlice'
+import { GATEWAY_URL } from 'config/constants'
+import useAsync from './useAsync'
+import { Errors, logError } from './exceptions/CodedException'
+import { setBalances } from 'store/balancesSlice'
+
+const loadBalances = (chainId: string, address: string) => {
+  return getBalances(GATEWAY_URL, chainId, address)
+}
 
 const useBalances = (): void => {
   const { safe } = useAppSelector(selectSafeInfo)
   const dispatch = useAppDispatch()
 
-  useEffect(() => {
-    const { chainId } = safe
-    const address = safe.address.value
+  // Re-fetch assets when the entire SafeInfo updates
+  const [data, error] = useAsync<SafeBalanceResponse | undefined>(async () => {
+    if (!safe.address.value) return
+    return loadBalances(safe.chainId, safe.address.value)
+  }, [safe])
 
-    if (chainId && address) {
-      dispatch(fetchBalances({ chainId, address }))
-    }
-  }, [dispatch, safe])
+  // Clear the old Balances when Safe address is changed
+  useEffect(() => {
+    dispatch(setBalances(undefined))
+  }, [safe.address.value, safe.chainId])
+
+  // Save the Balances in the store
+  useEffect(() => {
+    if (data) dispatch(setBalances(data))
+  }, [data, dispatch])
+
+  // Log errors
+  useEffect(() => {
+    if (!error) return
+    logError(Errors._601, error.message)
+  }, [error])
 }
 
 export default useBalances

--- a/services/useChains.ts
+++ b/services/useChains.ts
@@ -1,13 +1,33 @@
+import { getChainsConfig, type ChainListResponse } from '@gnosis.pm/safe-react-gateway-sdk'
+import { GATEWAY_URL } from 'config/constants'
 import { useEffect } from 'react'
 import { useAppDispatch } from 'store'
-import { fetchChains } from 'store/chainsSlice'
+import { setChains } from 'store/chainsSlice'
+import { Errors, logError } from './exceptions/CodedException'
+import useAsync from './useAsync'
 
-const useChains = (): void => {
+const getChains = (): Promise<ChainListResponse> => {
+  return getChainsConfig(GATEWAY_URL)
+}
+
+const useChains = (): { error?: Error; loading: boolean } => {
   const dispatch = useAppDispatch()
 
+  const [data, error, loading] = useAsync<ChainListResponse>(getChains, [])
+
   useEffect(() => {
-    dispatch(fetchChains())
-  }, [])
+    if (data) {
+      dispatch(setChains(data.results))
+    }
+  }, [data, dispatch])
+
+  useEffect(() => {
+    if (error) {
+      logError(Errors._904, error.message)
+    }
+  }, [error])
+
+  return { error, loading }
 }
 
 export default useChains

--- a/services/useSafeInfo.ts
+++ b/services/useSafeInfo.ts
@@ -1,39 +1,83 @@
-import { useEffect } from 'react'
-
+import { useCallback, useEffect } from 'react'
+import { getSafeInfo, SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { useAppDispatch } from 'store'
-import { fetchSafeInfo } from 'store/safeInfoSlice'
-import useSafeAddress from 'services/useSafeAddress'
-import { POLLING_INTERVAL } from 'config/constants'
+import { setSafeError, setSafeInfo, setSafeLoading } from 'store/safeInfoSlice'
+import useSafeAddress from './useSafeAddress'
+import { GATEWAY_URL, POLLING_INTERVAL } from 'config/constants'
+import { Errors, logError } from './exceptions/CodedException'
+
+const fetchSafeInfo = (chainId: string, address: string): Promise<SafeInfo> => {
+  return getSafeInfo(GATEWAY_URL, chainId, address)
+}
 
 // Poll & dispatch the Safe Info into the store
 const useSafeInfo = (): void => {
-  const { chainId, address } = useSafeAddress()
+  const { address, chainId } = useSafeAddress()
   const dispatch = useAppDispatch()
 
+  const onError = useCallback(
+    (error: Error, isFirst: boolean) => {
+      logError(Errors._605, error.message)
+
+      // Pass the error to the store only on first request
+      if (isFirst) {
+        dispatch(setSafeError(error))
+      }
+    },
+    [dispatch],
+  )
+
+  const onLoading = useCallback(
+    (loading: boolean, isFirst: boolean) => {
+      if (isFirst) {
+        dispatch(setSafeLoading(loading))
+      }
+    },
+    [dispatch],
+  )
+
+  const onData = useCallback(
+    (data: SafeInfo | undefined, isFirst: boolean) => {
+      if (data || isFirst) {
+        dispatch(setSafeInfo(data))
+      }
+    },
+    [dispatch],
+  )
+
   useEffect(() => {
-    if (!chainId || !address) {
-      return
-    }
+    if (!chainId || !address) return
 
     let isCurrent = true
     let timer: NodeJS.Timeout | null = null
 
-    let promise = dispatch(fetchSafeInfo({ chainId, address }))
+    const loadSafe = async (isFirst = false) => {
+      if (!isCurrent) return
 
-    promise.finally(() => {
-      if (isCurrent) {
-        timer = setTimeout(() => {
-          promise = dispatch(fetchSafeInfo({ chainId, address }))
-        }, POLLING_INTERVAL)
+      onData(undefined, isFirst)
+      onLoading(true, isFirst)
+
+      try {
+        const data = await fetchSafeInfo(chainId, address)
+        isCurrent && onData(data, isFirst)
+      } catch (err) {
+        isCurrent && onError(err as Error, isFirst)
+      } finally {
+        isCurrent && onLoading(false, isFirst)
       }
-    })
+
+      // Set a timer to fetch Safe Info again
+      if (isCurrent) {
+        timer = setTimeout(() => loadSafe(), POLLING_INTERVAL)
+      }
+    }
+
+    // First load
+    loadSafe(true)
 
     return () => {
       isCurrent = false
-      promise.abort()
-      if (timer) {
-        clearTimeout(timer)
-      }
+      timer && clearTimeout(timer)
     }
   }, [chainId, address])
 }

--- a/services/useTxHistory.ts
+++ b/services/useTxHistory.ts
@@ -1,7 +1,15 @@
-import { useEffect, useState } from 'react'
+import { getTransactionHistory, TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
+import { useEffect } from 'react'
 import { useAppDispatch, useAppSelector } from 'store'
 import { selectSafeInfo } from 'store/safeInfoSlice'
-import { fetchTxHistory, selectTxHistory, setPageUrl } from 'store/txHistorySlice'
+import { GATEWAY_URL } from 'config/constants'
+import useAsync from './useAsync'
+import { Errors, logError } from './exceptions/CodedException'
+import { selectTxHistory, setHistoryPage, setPageUrl } from 'store/txHistorySlice'
+
+const loadTxHistory = (chainId: string, address: string, pageUrl?: string) => {
+  return getTransactionHistory(GATEWAY_URL, chainId, address, pageUrl)
+}
 
 const useTxHistory = (): void => {
   const { safe } = useAppSelector(selectSafeInfo)
@@ -9,27 +17,30 @@ const useTxHistory = (): void => {
   const dispatch = useAppDispatch()
   const { chainId, txHistoryTag } = safe
   const address = safe.address.value
-  const [, setPrevAddress] = useState<[string, string]>([chainId, address])
 
-  // Fetch TxHistory when the Safe address, txHistoryTag, or pageUrl is updated
+  // Re-fetch assets when pageUrl, chainId/address, or txHistoryTag change
+  const [data, error] = useAsync<TransactionListPage | undefined>(async () => {
+    if (chainId && address) {
+      return loadTxHistory(chainId, address, pageUrl)
+    }
+  }, [txHistoryTag, chainId, address, pageUrl])
+
+  // Clear the old TxHistory when Safe address is changed
   useEffect(() => {
-    setPrevAddress((prev) => {
-      // If Safe chainId/address has changed, reset the pageUrl
-      const [prevChainId, prevAddress] = prev
-      if (prevChainId !== chainId || prevAddress !== address) {
-        dispatch(setPageUrl(undefined))
-        return [chainId, address]
-      }
+    dispatch(setHistoryPage(undefined))
+    dispatch(setPageUrl(undefined))
+  }, [address, chainId])
 
-      // Otherwise, if pageUrl or txHistoryTag have changed, fetch new history
-      if (chainId && address) {
-        dispatch(fetchTxHistory({ chainId, address, pageUrl }))
-      }
+  // Save the TxHistory in the store
+  useEffect(() => {
+    if (data) dispatch(setHistoryPage(data))
+  }, [data, dispatch])
 
-      // And keep the previous chainId/address unchanged
-      return prev
-    })
-  }, [dispatch, chainId, address, txHistoryTag, pageUrl, setPrevAddress])
+  // Log errors
+  useEffect(() => {
+    if (!error) return
+    logError(Errors._602, error.message)
+  }, [error])
 }
 
 export default useTxHistory

--- a/store/balancesSlice.ts
+++ b/store/balancesSlice.ts
@@ -1,54 +1,26 @@
-import { getBalances, type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import { createAsyncThunk, createSlice, SerializedError } from '@reduxjs/toolkit'
+import { type SafeBalanceResponse } from '@gnosis.pm/safe-react-gateway-sdk'
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from 'store'
 
-import { GATEWAY_URL } from 'config/constants'
-import { LOADING_STATUS } from 'store/commonTypes'
-import { Errors, logError } from 'services/exceptions/CodedException'
-import { RootState } from 'store'
-
-type BalancesState = {
-  balances: ChainInfo[]
-  status: LOADING_STATUS
-  error?: SerializedError
-}
+type BalancesState = SafeBalanceResponse
 
 const initialState: BalancesState = {
-  balances: [],
-  status: LOADING_STATUS.IDLE,
-  error: undefined,
+  fiatTotal: '0',
+  items: [],
 }
 
 export const balancesSlice = createSlice({
   name: 'balances',
   initialState,
-  reducers: {},
-  extraReducers: (builder) => {
-    builder.addCase(fetchBalances.pending, (state) => {
-      state.status = LOADING_STATUS.PENDING
-      state.error = undefined
-    })
-
-    builder.addCase(fetchBalances.fulfilled, (state, { payload }) => {
-      state.status = LOADING_STATUS.SUCCEEDED
-      state.balances = payload
-    })
-
-    builder.addCase(fetchBalances.rejected, (state, { error }) => {
-      state.status = LOADING_STATUS.FAILED
-      state.error = error
-
-      logError(Errors._904, error.message)
-    })
+  reducers: {
+    setBalances: (_, action: PayloadAction<SafeBalanceResponse | undefined>): BalancesState => {
+      return action.payload || initialState
+    },
   },
 })
 
-export const fetchBalances = createAsyncThunk(
-  `${balancesSlice.name}/fetchBalances`,
-  ({ chainId, address }: { chainId: string; address: string }) => {
-    return getBalances(GATEWAY_URL, chainId, address)
-  },
-)
+export const { setBalances } = balancesSlice.actions
 
-export const selectBalances = (state: RootState): BalancesState['balances'] => {
-  return state[balancesSlice.name].balances
+export const selectBalances = (state: RootState): BalancesState => {
+  return state[balancesSlice.name]
 }

--- a/store/chainsSlice.ts
+++ b/store/chainsSlice.ts
@@ -1,53 +1,25 @@
-import { getChainsConfig, type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
-import { createAsyncThunk, createSelector, createSlice, SerializedError } from '@reduxjs/toolkit'
+import { type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from '.'
 
-import { GATEWAY_URL } from 'config/constants'
-import { LOADING_STATUS } from 'store/commonTypes'
-import { Errors, logError } from 'services/exceptions/CodedException'
-import { RootState } from 'store'
+type ChainsState = ChainInfo[]
 
-type ChainsState = {
-  chains: ChainInfo[]
-  status: LOADING_STATUS
-  error?: SerializedError
-}
-
-const initialState: ChainsState = {
-  chains: [],
-  status: LOADING_STATUS.IDLE,
-  error: undefined,
-}
+const initialState: ChainsState = []
 
 export const chainsSlice = createSlice({
   name: 'chains',
   initialState,
-  reducers: {},
-  extraReducers: (builder) => {
-    builder.addCase(fetchChains.pending, (state) => {
-      state.status = LOADING_STATUS.PENDING
-      state.error = undefined
-    })
-
-    builder.addCase(fetchChains.fulfilled, (state, { payload }) => {
-      state.status = LOADING_STATUS.SUCCEEDED
-      state.chains = payload
-    })
-
-    builder.addCase(fetchChains.rejected, (state, { error }) => {
-      state.status = LOADING_STATUS.FAILED
-      state.error = error
-
-      logError(Errors._904, error.message)
-    })
+  reducers: {
+    setChains: (_, action: PayloadAction<ChainsState>): ChainsState => {
+      return action.payload
+    },
   },
 })
 
-export const fetchChains = createAsyncThunk(`${chainsSlice.name}/fetchSafeInfo`, async () => {
-  return (await getChainsConfig(GATEWAY_URL)).results
-})
+export const { setChains } = chainsSlice.actions
 
-export const selectChains = (state: RootState): ChainsState['chains'] => {
-  return state[chainsSlice.name].chains
+export const selectChains = (state: RootState): ChainsState => {
+  return state.chains
 }
 
 export const selectChainById = createSelector(

--- a/store/commonTypes.ts
+++ b/store/commonTypes.ts
@@ -1,6 +1,0 @@
-export const enum LOADING_STATUS {
-  IDLE = 'IDLE',
-  PENDING = 'PENDING',
-  SUCCEEDED = 'SUCCEEDED',
-  FAILED = 'FAILED',
-}

--- a/store/txHistorySlice.ts
+++ b/store/txHistorySlice.ts
@@ -1,16 +1,10 @@
-import { getTransactionHistory, type TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
-import { createAsyncThunk, createSlice, PayloadAction, SerializedError } from '@reduxjs/toolkit'
-
-import { GATEWAY_URL } from 'config/constants'
-import { LOADING_STATUS } from 'store/commonTypes'
+import { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { RootState } from 'store'
-import { Errors, logError } from 'services/exceptions/CodedException'
 
 type TxHistoryState = {
   page: TransactionListPage
   pageUrl?: string
-  status: LOADING_STATUS
-  error?: SerializedError
 }
 
 const initialState: TxHistoryState = {
@@ -19,47 +13,23 @@ const initialState: TxHistoryState = {
     next: '',
     previous: '',
   },
-  pageUrl: '',
-  status: LOADING_STATUS.IDLE,
-  error: undefined,
 }
 
 export const txHistorySlice = createSlice({
   name: 'txHistory',
   initialState,
   reducers: {
-    setPageUrl: (state, action: PayloadAction<TxHistoryState['pageUrl']>) => {
+    setHistoryPage: (state, action: PayloadAction<TransactionListPage | undefined>) => {
+      state.page = action.payload || initialState.page
+    },
+
+    setPageUrl: (state, action: PayloadAction<string | undefined>) => {
       state.pageUrl = action.payload
     },
   },
-  extraReducers: (builder) => {
-    builder.addCase(fetchTxHistory.pending, (state) => {
-      state.status = LOADING_STATUS.PENDING
-      state.error = undefined
-    })
-
-    builder.addCase(fetchTxHistory.fulfilled, (state, { payload }) => {
-      state.status = LOADING_STATUS.SUCCEEDED
-      state.page = payload
-    })
-
-    builder.addCase(fetchTxHistory.rejected, (state, { error }) => {
-      state.status = LOADING_STATUS.FAILED
-      state.error = error
-
-      logError(Errors._602, error.message)
-    })
-  },
 })
 
-export const { setPageUrl } = txHistorySlice.actions
-
-export const fetchTxHistory = createAsyncThunk(
-  `${txHistorySlice.name}/fetchTxHistory`,
-  ({ chainId, address, pageUrl }: { chainId: string; address: string; pageUrl?: string }) => {
-    return getTransactionHistory(GATEWAY_URL, chainId, address, pageUrl)
-  },
-)
+export const { setHistoryPage, setPageUrl } = txHistorySlice.actions
 
 export const selectTxHistory = (state: RootState): TxHistoryState => {
   return state[txHistorySlice.name]


### PR DESCRIPTION
After having refactored all the store hooks to Thunk as per your example, @iamacook, I've realized we lost a couple features.

1) `isCurrent`-protection in Balances and History. SafeInfo happens to return a safe address so you can easily compare it with the requested one, so it was easy to have this race condition protection there. But Balances and History don't return the address, so it's not as easy.

2) We don't want to show errors or loading state when we poll SafeInfo. Only when Safe address is changed.

In general, I find fetching data from hooks simpler to write and understand. I also like the separation of fetching and storing, where hooks provide a way to glue them together flexibly.

Where Thunk definitely wins, though, is the error/loading state handling. I suggest we continue exploring in this direction.