### PR TITLE
Refa: Loadable slices

### DIFF
--- a/components/common/SafeHeader/index.tsx
+++ b/components/common/SafeHeader/index.tsx
@@ -15,7 +15,7 @@ interface SafeHeaderProps {
 
 const SafeHeader = (): ReactElement => {
   const { safe } = useSafeInfo()
-  const { fiatTotal } = useBalances()
+  const { balances } = useBalances()
 
   const address = safe?.address.value || ''
   const { threshold, owners } = safe || {}
@@ -34,7 +34,7 @@ const SafeHeader = (): ReactElement => {
 
       <div className={css.totalValue}>
         <span>Total value</span>
-        <FiatValue value={fiatTotal} />
+        <FiatValue value={balances.fiatTotal} />
       </div>
     </div>
   )

--- a/components/tx/ReviewTx/index.tsx
+++ b/components/tx/ReviewTx/index.tsx
@@ -36,7 +36,7 @@ const ReviewTx = ({
   params: SendAssetsFormData
   onSubmit: (tx: SafeTransaction) => void
 }): ReactElement => {
-  const balances = useBalances()
+  const { balances } = useBalances()
   const token = balances.items.find((item) => item.tokenInfo.address === params.tokenAddress)
   const tokenInfo = token?.tokenInfo
   const txParams = tokenInfo

--- a/components/tx/SendAssetsForm/index.tsx
+++ b/components/tx/SendAssetsForm/index.tsx
@@ -35,7 +35,7 @@ const abFilterOptions = createFilterOptions({
 })
 
 const SendAssetsForm = ({ onSubmit, formData }: SendAssetsFormProps): ReactElement => {
-  const balances = useBalances()
+  const { balances } = useBalances()
   const addressBook = useAddressBook()
 
   const addressBookEntries = Object.entries(addressBook).map(([address, name]) => ({

--- a/pages/safe/balances/index.tsx
+++ b/pages/safe/balances/index.tsx
@@ -5,7 +5,7 @@ import CurrencySelect from '@/components/balances/CurrencySelect'
 import useBalances from '@/services/useBalances'
 
 const Balances: NextPage = () => {
-  const balances = useBalances()
+  const { balances } = useBalances()
 
   return (
     <main>

--- a/pages/safe/balances/nfts.tsx
+++ b/pages/safe/balances/nfts.tsx
@@ -4,7 +4,7 @@ import useCollectibles from '@/services/useCollectibles'
 import { NftGrid } from '@/components/nfts'
 
 const NFTs: NextPage = () => {
-  const collectibles = useCollectibles()
+  const { collectibles } = useCollectibles()
 
   return (
     <main>

--- a/services/useChains.ts
+++ b/services/useChains.ts
@@ -11,6 +11,7 @@ export const useInitChains = (): void => {
 
   const [data, error, loading] = useAsync<ChainListResponse>(getChainsConfig, [])
 
+  // Update data
   useEffect(() => {
     dispatch(
       setChains({
@@ -19,8 +20,9 @@ export const useInitChains = (): void => {
         loading,
       }),
     )
-  }, [data, error, loading, dispatch])
+  }, [dispatch, data, error, loading])
 
+  // Log errors
   useEffect(() => {
     if (error) {
       logError(Errors._904, error.message)

--- a/services/useCollectibles.ts
+++ b/services/useCollectibles.ts
@@ -13,26 +13,21 @@ export const useInitCollectibles = (): void => {
   const dispatch = useAppDispatch()
 
   // Re-fetch assets when the Safe address or the collectibes tag updates
-  const [data, error] = useAsync<SafeCollectibleResponse[] | undefined>(async () => {
+  const [data, error, loading] = useAsync<SafeCollectibleResponse[] | undefined>(async () => {
     if (!address || !chainId) return
-
     return getCollectibles(chainId, address)
   }, [address, chainId, collectiblesTag])
 
-  // Clear the old Collectibles when Safe address is changed
-  useEffect(() => {
-    dispatch(setCollectibles(undefined))
-  }, [address, chainId, dispatch])
-
   // Save the Collectibles in the store
   useEffect(() => {
-    if (data) dispatch(setCollectibles(data))
-  }, [data, dispatch])
+    dispatch(setCollectibles({ collectibles: data || [], error, loading }))
+  }, [dispatch, data, error, loading])
 
   // Log errors
   useEffect(() => {
-    if (!error) return
-    logError(Errors._604, error.message)
+    if (error) {
+      logError(Errors._604, error.message)
+    }
   }, [error])
 }
 

--- a/store/balancesSlice.ts
+++ b/store/balancesSlice.ts
@@ -1,20 +1,27 @@
 import { type SafeBalanceResponse } from '@gnosis.pm/safe-react-gateway-sdk'
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { RootState } from '@/store'
+import { Loadable } from './common'
 
-type BalancesState = SafeBalanceResponse
+interface BalancesState extends Loadable {
+  balances: SafeBalanceResponse
+}
 
-const initialState: BalancesState = {
-  fiatTotal: '0',
-  items: [],
+export const initialState: BalancesState = {
+  loading: true,
+  error: undefined,
+  balances: {
+    fiatTotal: '0',
+    items: [],
+  },
 }
 
 export const balancesSlice = createSlice({
   name: 'balances',
   initialState,
   reducers: {
-    setBalances: (_, action: PayloadAction<SafeBalanceResponse | undefined>): BalancesState => {
-      return action.payload || initialState
+    setBalances: (_, action: PayloadAction<BalancesState>): BalancesState => {
+      return action.payload
     },
   },
 })

--- a/store/chainsSlice.ts
+++ b/store/chainsSlice.ts
@@ -1,11 +1,10 @@
 import { type ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { RootState } from '.'
+import { Loadable } from './common'
 
-type ChainsState = {
+interface ChainsState extends Loadable {
   configs: ChainInfo[]
-  error?: Error
-  loading: boolean
 }
 
 const initialState: ChainsState = {
@@ -27,7 +26,7 @@ export const chainsSlice = createSlice({
 export const { setChains } = chainsSlice.actions
 
 export const selectChains = (state: RootState): ChainsState => {
-  return state.chains
+  return state[chainsSlice.name]
 }
 
 export const selectChainById = createSelector(

--- a/store/collectiblesSlice.ts
+++ b/store/collectiblesSlice.ts
@@ -1,17 +1,24 @@
 import { type SafeCollectibleResponse } from '@gnosis.pm/safe-react-gateway-sdk'
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { RootState } from '@/store'
+import { Loadable } from './common'
 
-type CollectiblesState = SafeCollectibleResponse[]
+interface CollectiblesState extends Loadable {
+  collectibles: SafeCollectibleResponse[]
+}
 
-const initialState: CollectiblesState = []
+const initialState: CollectiblesState = {
+  loading: true,
+  error: undefined,
+  collectibles: [],
+}
 
 export const collectiblesSlice = createSlice({
   name: 'collectibles',
   initialState,
   reducers: {
-    setCollectibles: (_, action: PayloadAction<CollectiblesState | undefined>): CollectiblesState => {
-      return action.payload || initialState
+    setCollectibles: (_, action: PayloadAction<CollectiblesState>): CollectiblesState => {
+      return action.payload
     },
   },
 })

--- a/store/common.d.ts
+++ b/store/common.d.ts
@@ -1,0 +1,4 @@
+export type Loadable = {
+  loading: boolean
+  error?: Error
+}

--- a/store/safeInfoSlice.ts
+++ b/store/safeInfoSlice.ts
@@ -1,42 +1,29 @@
 import { AddressEx, SafeInfo } from '@gnosis.pm/safe-react-gateway-sdk'
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { RootState } from '.'
+import { Loadable } from './common'
 
-const emptyAddressEx: AddressEx = {
-  value: '',
-  name: null,
-  logoUri: null,
-}
-
-type SafeInfoState = {
+interface SafeInfoState extends Loadable {
   safe?: SafeInfo
-  loading: boolean
-  error?: Error
 }
 
 const initialState: SafeInfoState = {
-  safe: undefined,
   loading: true,
   error: undefined,
+  safe: undefined,
 }
 
 export const safeInfoSlice = createSlice({
   name: 'safeInfo',
   initialState,
   reducers: {
-    setSafeInfo: (state, action: PayloadAction<SafeInfo | undefined>) => {
-      return { ...state, safe: action.payload }
-    },
-    setSafeError: (state, action: PayloadAction<Error>) => {
-      return { ...state, error: action.payload }
-    },
-    setSafeLoading: (state, action: PayloadAction<boolean>) => {
-      return { ...state, loading: action.payload }
+    setSafeInfo: (state, action: PayloadAction<SafeInfoState>) => {
+      return action.payload
     },
   },
 })
 
-export const { setSafeInfo, setSafeError, setSafeLoading } = safeInfoSlice.actions
+export const { setSafeInfo } = safeInfoSlice.actions
 
 export const selectSafeInfo = (state: RootState): SafeInfoState => {
   return state[safeInfoSlice.name]

--- a/store/txHistorySlice.ts
+++ b/store/txHistorySlice.ts
@@ -1,18 +1,22 @@
 import { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { RootState } from '@/store'
+import { Loadable } from './common'
 
-type TxHistoryState = {
+interface TxHistoryState extends Loadable {
   page: TransactionListPage
   pageUrl?: string
 }
 
 const initialState: TxHistoryState = {
+  error: undefined,
+  loading: true,
   page: {
     results: [],
     next: '',
     previous: '',
   },
+  pageUrl: '',
 }
 
 export const txHistorySlice = createSlice({

--- a/store/txQueueSlice.ts
+++ b/store/txQueueSlice.ts
@@ -1,18 +1,22 @@
 import { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
 import type { RootState } from '@/store'
+import { Loadable } from './common'
 
-type TxQueueState = {
+interface TxQueueState extends Loadable {
   page: TransactionListPage
   pageUrl?: string
 }
 
 const initialState: TxQueueState = {
+  error: undefined,
+  loading: true,
   page: {
     results: [],
     next: '',
     previous: '',
   },
+  pageUrl: '',
 }
 
 export const txQueueSlice = createSlice({
@@ -20,6 +24,7 @@ export const txQueueSlice = createSlice({
   initialState,
   reducers: {
     setQueuePage: (state, action: PayloadAction<TransactionListPage | undefined>) => {
+      // @ts-ignore: Type instantiation is excessively deep and possibly infinite.
       state.page = action.payload || initialState.page
     },
 


### PR DESCRIPTION
Inspired by #26, this PR unifies all store slices that are fetched from the CGW.

They now all have an `error` and a `loading` field. They inherit from the `Loadable` type.
This also simplifies the reducers – basically there's just one reducer that sets the entire slice.