### PR TITLE
fix: `useWallet` state + execution button

### DIFF
--- a/components/transactions/ExecuteTxButton/index.tsx
+++ b/components/transactions/ExecuteTxButton/index.tsx
@@ -26,7 +26,7 @@ const ExecuteTxButton = ({ txSummary }: { txSummary: TransactionSummary }): Reac
     <div className={css.container}>
       <Tooltip title="Execute" arrow placement="top">
         <span>
-          <IconButton onClick={onClick} disabled={isDisabled}>
+          <IconButton onClick={onClick} disabled={isDisabled} color="primary">
             <RocketLaunchIcon />
           </IconButton>
         </span>

--- a/components/transactions/TxSummary/index.tsx
+++ b/components/transactions/TxSummary/index.tsx
@@ -12,6 +12,7 @@ import useWallet from '@/services/wallets/useWallet'
 import { isAwaitingExecution } from '@/components/transactions/utils'
 import RejectTxButton from '@/components/transactions/RejectTxButton'
 import Box from '@mui/material/Box'
+import { useRouter } from 'next/router'
 
 type TxSummaryProps = {
   item: Transaction
@@ -26,6 +27,8 @@ const TxSummary = ({ item }: TxSummaryProps): ReactElement => {
   const tx = item.transaction
   const type = useTransactionType(tx)
   const wallet = useWallet()
+  const router = useRouter()
+  const isQueue = router.pathname.includes('queue')
 
   const awaitingExecution = isAwaitingExecution(item.transaction.txStatus)
 
@@ -54,7 +57,7 @@ const TxSummary = ({ item }: TxSummaryProps): ReactElement => {
             {tx.txStatus !== TransactionStatus.SUCCESS && tx.txStatus}
           </Grid>
 
-          {wallet && (
+          {wallet && isQueue && (
             <Grid item md={1}>
               <Box display="flex" alignItems="center">
                 {awaitingExecution ? (

--- a/services/wallets/useWallet.ts
+++ b/services/wallets/useWallet.ts
@@ -3,7 +3,7 @@ import useOnboard, { ConnectedWallet, getConnectedWallet } from './useOnboard'
 
 const useWallet = (): ConnectedWallet | null => {
   const onboard = useOnboard()
-  const [wallet, setWallet] = useState<ConnectedWallet | null>(null)
+  const [wallet, setWallet] = useState<ConnectedWallet | null>(getConnectedWallet())
 
   useEffect(() => {
     if (!onboard) return


### PR DESCRIPTION
## Overview
The default state of `useWallet` was not updating as the state subscription only fires when the `wallets` change.

The execution buttons are now only shown on the queued route.