### PR TITLE
fix: Include bn.js and mainnet.json only once in the bundle

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ const nextConfig = {
     config.resolve.alias = {
       ...config.resolve.alias,
       'bn.js': path.join(__dirname, 'node_modules/bn.js/lib/bn.js'),
+      'mainnet.json': path.join(__dirname, 'node_modules/@ethereumjs/common/dist.browser/genesisStates/mainnet.json'),
     }
     return config
   },


### PR DESCRIPTION
## What it solves

`bn.js` and `mainnet.json` are included only once in the bundle.

References:
- https://github.com/vercel/next.js/tree/canary/packages/next-bundle-analyzer
- https://stackoverflow.com/questions/65118808/the-same-dependency-is-included-many-times-in-my-bundle
- https://nextjs.org/docs/messages/invalid-resolve-alias

## Screenshots

Before:
<img width="1184" alt="c" src="https://user-images.githubusercontent.com/5880855/167307187-3e8ba67f-499c-4ad1-8b7c-7eb102be4b7c.png">

After:
<img width="503" alt="Screenshot 2022-05-08 at 19 13 34" src="https://user-images.githubusercontent.com/5880855/167307618-dac2cab3-f0c0-4c2a-b086-6b1a0b34b4f1.png">

