### PR TITLE
Fix: a small CSS fix for the page layout

### DIFF
--- a/components/common/PageLayout/styles.module.css
+++ b/components/common/PageLayout/styles.module.css
@@ -19,7 +19,7 @@
   grid-area: main;
   padding: 25px;
   overflow: auto;
-  height: 100vh;
+  height: calc(100vh - 52px);
 }
 
 .sidebar {
@@ -27,17 +27,12 @@
   height: 100vh;
 }
 
-.toolbar {
-  max-height: 52px;
-  min-height: 52px;
-}
-
 @media (max-width: 768px) {
   .container {
     grid-template-columns: 1fr;
     grid-template-areas: 'header' 'main';
   }
-    
+
   .sidebar {
     display: none;
   }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "start": "next dev",
     "build": "next build",
-    "start": "next start",
     "lint": "next lint",
     "prettier": "prettier -w './**/*.{ts,tsx}'",
     "test": "jest",


### PR DESCRIPTION
The height of the main container was too big.
Not sure if there's a better way instead of using `calc()`.