### PR TITLE
Always pass safeTxGas

### DIFF
--- a/components/tx/ReviewTx/index.tsx
+++ b/components/tx/ReviewTx/index.tsx
@@ -52,8 +52,8 @@ const ReviewTx = ({ params }: { params: SendAssetsFormData }): ReactElement => {
     const editedTxParams = {
       ...txParams,
       nonce: data.nonce,
-      // @TODO: Safes <1.3.0 need safeTxGas
-      //safeTxGas: Number(safeGas?.safeTxGas || 0)
+      // Core SDK will ignore safeTxGas for 1.3.0+ Safes
+      safeTxGas: Number(safeGas?.safeTxGas || 0),
     }
 
     try {

--- a/services/safe-core/safeCoreSDK.ts
+++ b/services/safe-core/safeCoreSDK.ts
@@ -6,7 +6,10 @@ import Web3Adapter from '@gnosis.pm/safe-web3-lib'
 import semverSatisfies from 'semver/functions/satisfies'
 import chains from '@/config/chains'
 
-const LEGACY_VERSION = '<1.3.0'
+const isLegacyVersion = (safeVersion: string): boolean => {
+  const LEGACY_VERSION = '<1.3.0'
+  return semverSatisfies(safeVersion, LEGACY_VERSION)
+}
 
 // Safe Core SDK
 const initSafeSDK = async (
@@ -23,7 +26,7 @@ const initSafeSDK = async (
 
   let isL1SafeMasterCopy = walletChainId === chains.eth
   // Legacy Safe contracts
-  if (semverSatisfies(safeVersion, LEGACY_VERSION)) {
+  if (isLegacyVersion(safeVersion)) {
     isL1SafeMasterCopy = true
   }
 


### PR DESCRIPTION
In Safe Core SDK, there's already a piece of logic baked in for legacy Safes and safeTxGas:
https://github.com/safe-global/safe-core-sdk/blob/6bef2d6d3df4eb455e73392fa48a0d16bf36b0b2/packages/safe-core-sdk/src/utils/transactions/utils.ts#L43-L44

So we can just always pass safeTxGas.