### PR TITLE
Fix notifications: redux cannot store JSX

### DIFF
--- a/services/tx/txEvents.ts
+++ b/services/tx/txEvents.ts
@@ -51,6 +51,6 @@ export const txSubscribe = <T extends TxEvent>(eventType: T, callback: (detail: 
 // Log all events
 Object.values(TxEvent).forEach((event: TxEvent) => {
   txSubscribe<TxEvent>(event, (detail) => {
-    console.info(`${event} event received: ${detail}`)
+    console.info(`${event} event received`, detail)
   })
 })

--- a/services/useNotifier.tsx
+++ b/services/useNotifier.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react'
 import { useSnackbar, type SnackbarKey } from 'notistack'
+import { IconButton } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
 
 import { useAppDispatch, useAppSelector } from '@/store'
 import { closeNotification, selectNotifications } from '@/store/notificationsSlice'
@@ -13,17 +15,24 @@ const useNotifier = () => {
 
   useEffect(() => {
     for (const notification of notifications) {
+      const key = notification.options?.key ?? ''
+
       if (notification.dismissed) {
-        closeSnackbar(notification.options?.key)
+        closeSnackbar(key)
         continue
       }
 
-      if (notification.options?.key && onScreenKeys.includes(notification.options.key)) {
+      if (key && onScreenKeys.includes(key)) {
         continue
       }
 
-      const key = enqueueSnackbar(notification.message, {
-        key: notification.options?.key,
+      enqueueSnackbar(notification.message, {
+        key,
+        action: (
+          <IconButton onClick={() => dispatch(closeNotification({ key }))}>
+            <CloseIcon />
+          </IconButton>
+        ),
         ...notification.options,
         // Run callback when notification is closing
         onClose: (event, reason, key) => {
@@ -34,7 +43,7 @@ const useNotifier = () => {
         onExited: (_, key) => {
           // Cleanup store/cache when notification has unmounted
           dispatch(closeNotification({ key }))
-          onScreenKeys = onScreenKeys.filter((onScreenKey) => onScreenKey !== notification.options?.key)
+          onScreenKeys = onScreenKeys.filter((onScreenKey) => onScreenKey !== key)
         },
       })
 

--- a/store/notificationsSlice.ts
+++ b/store/notificationsSlice.ts
@@ -1,6 +1,4 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
-import { IconButton } from '@mui/material'
-import CloseIcon from '@mui/icons-material/Close'
 import type { OptionsObject, SnackbarKey, SnackbarMessage } from 'notistack'
 
 import type { AppThunk, RootState } from '@/store'
@@ -45,16 +43,11 @@ export const { closeNotification, closeAllNotifications, deleteNotification, del
 // Custom thunk that returns the key in case it was auto-generated
 export const showNotification = (payload: Pick<Notification, 'message' | 'options'>): AppThunk<SnackbarKey> => {
   return (dispatch) => {
-    const key = payload.options?.key || new Date().getTime() + Math.random()
+    const key = payload.options?.key || Math.random().toString(32).slice(2)
 
     const notification: Notification = {
       ...payload,
       options: {
-        action: (
-          <IconButton onClick={() => dispatch(closeNotification({ key }))}>
-            <CloseIcon />
-          </IconButton>
-        ),
         ...payload.options,
         key,
       },


### PR DESCRIPTION
There were errors in the console that Redux cannot store `options.action`. State needs to be serializable.