### PR TITLE
Add tests for txEvents and txSender

### DIFF
--- a/services/safe-core/safeCoreSDK.ts
+++ b/services/safe-core/safeCoreSDK.ts
@@ -11,7 +11,7 @@ const isLegacyVersion = (safeVersion: string): boolean => {
 }
 
 // Safe Core SDK
-const initSafeSDK = async (
+export const initSafeSDK = async (
   provider: EIP1193Provider,
   walletChainId: string,
   safeAddress: string,
@@ -39,4 +39,6 @@ const initSafeSDK = async (
 
 let safeSDK: Safe
 export const getSafeSDK = (): Safe => safeSDK
-export const setSafeSDK: typeof initSafeSDK = (...args) => initSafeSDK(...args).then((safe) => (safeSDK = safe))
+export const setSafeSDK = (sdkInstance: Safe) => {
+  safeSDK = sdkInstance
+}

--- a/services/safe-core/useInitSafeCoreSDK.ts
+++ b/services/safe-core/useInitSafeCoreSDK.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useCurrentChain } from '@/services/useChains'
 import useWallet from '../wallets/useWallet'
 import useSafeInfo from '../useSafeInfo'
-import { setSafeSDK } from './safeCoreSDK'
+import { initSafeSDK, setSafeSDK } from './safeCoreSDK'
 
 export const useInitSafeCoreSDK = (): Error | null => {
   const chain = useCurrentChain()
@@ -15,7 +15,9 @@ export const useInitSafeCoreSDK = (): Error | null => {
       return
     }
 
-    setSafeSDK(wallet.provider, wallet.chainId, safe.address.value, safe.version).catch(setError)
+    const safeSdk = initSafeSDK(wallet.provider, wallet.chainId, safe.address.value, safe.version)
+      .then(setSafeSDK)
+      .catch(setError)
   }, [chain, wallet, safe])
 
   return error

--- a/services/tx/__tests__/extractTxInfo.test.ts
+++ b/services/tx/__tests__/extractTxInfo.test.ts
@@ -1,5 +1,5 @@
 import type { TransactionDetails, TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
-import extractTxInfo from '../tx/extractTxInfo'
+import extractTxInfo from '../extractTxInfo'
 
 describe('extractTxInfo', () => {
   it('should extract tx info for an ETH transfer', () => {

--- a/services/tx/__tests__/tokenTransferParams.test.ts
+++ b/services/tx/__tests__/tokenTransferParams.test.ts
@@ -1,4 +1,4 @@
-import { createTokenTransferParams } from '../tx/tokenTransferParams'
+import { createTokenTransferParams } from '../tokenTransferParams'
 
 // Test createTokenTransferParams
 describe('createTokenTransferParams', () => {

--- a/services/tx/__tests__/txEvents.test.ts
+++ b/services/tx/__tests__/txEvents.test.ts
@@ -1,0 +1,64 @@
+import { SafeTransaction } from '@gnosis.pm/safe-core-sdk-types'
+import { txDispatch, txSubscribe, TxEvent } from '../txEvents'
+
+const tx = {
+  safeTxHash: '0x123',
+} as unknown as SafeTransaction
+
+describe('txEvents', () => {
+  it('should dispatch and subscribe to the MINING event', () => {
+    const event = TxEvent.MINING
+
+    const detail = {
+      txHash: '0x123',
+      tx,
+    }
+
+    const callback = jest.fn()
+
+    const unsubscribe = txSubscribe(event, callback)
+
+    txDispatch(event, detail)
+
+    expect(callback).toHaveBeenCalledWith(detail)
+
+    const detail2 = {
+      txHash: '0x456',
+      tx,
+    }
+
+    txDispatch(event, detail2)
+
+    expect(callback).toHaveBeenCalledWith(detail2)
+
+    unsubscribe()
+
+    txDispatch(event, detail)
+
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  it('should dispatch and subscribe to the FAILED event', () => {
+    const event = TxEvent.FAILED
+
+    const detail = {
+      txId: '0x123',
+      tx,
+      error: new Error('Tx failed'),
+    }
+
+    const callback = jest.fn()
+
+    const unsubscribe = txSubscribe(event, callback)
+
+    txDispatch(event, detail)
+
+    expect(callback).toHaveBeenCalledWith(detail)
+
+    unsubscribe()
+
+    txDispatch(event, detail)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/services/tx/__tests__/txSender.test.ts
+++ b/services/tx/__tests__/txSender.test.ts
@@ -1,0 +1,138 @@
+import { setSafeSDK } from '@/services/safe-core/safeCoreSDK'
+import Safe from '@gnosis.pm/safe-core-sdk'
+import { getTransactionDetails, TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
+import extractTxInfo from '../extractTxInfo'
+import proposeTx from '../proposeTransaction'
+import {
+  createExistingTx,
+  createRejectTx,
+  createTx,
+  dispatchTxExecution,
+  dispatchTxProposal,
+  dispatchTxSigning,
+} from '../txSender'
+
+// Mock getTransactionDetails
+jest.mock('@gnosis.pm/safe-react-gateway-sdk', () => ({
+  getTransactionDetails: jest.fn(),
+}))
+
+// Mock extractTxInfo
+jest.mock('../extractTxInfo', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    txParams: {},
+    signatures: [],
+  })),
+}))
+
+// Mock proposeTx
+jest.mock('../proposeTransaction', () => ({
+  __esModule: true,
+  default: jest.fn(() => Promise.resolve({ txId: '123' })),
+}))
+
+// Mock Safe SDK
+const mockSafeSDK = {
+  createTransaction: jest.fn(() => ({
+    addSignature: jest.fn(),
+  })),
+  createRejectionTransaction: jest.fn(() => ({
+    addSignature: jest.fn(),
+  })),
+  signTransaction: jest.fn(),
+  executeTransaction: jest.fn(),
+} as unknown as Safe
+
+describe('txSender', () => {
+  beforeAll(() => {
+    setSafeSDK(mockSafeSDK)
+  })
+
+  describe('createTx', () => {
+    it('should create a tx', async () => {
+      const txParams = {
+        to: '0x123',
+        value: '1',
+        data: '0x0',
+      }
+      const tx = await createTx(txParams)
+
+      expect(mockSafeSDK.createTransaction).toHaveBeenCalledWith(txParams)
+    })
+  })
+
+  describe('createExistingTx', () => {
+    it('should create a tx from an existing proposal', async () => {
+      const tx = await createExistingTx('4', '0x123', {
+        id: '0x345',
+      } as unknown as TransactionSummary)
+
+      expect(getTransactionDetails).toHaveBeenCalledWith('4', '0x345')
+      expect(extractTxInfo).toHaveBeenCalled()
+      expect(mockSafeSDK.createTransaction).toHaveBeenCalled()
+
+      expect(tx).toBeDefined()
+      expect(tx.addSignature).toBeDefined()
+    })
+  })
+
+  describe('createRejectTx', () => {
+    it('should create a tx to reject a proposal', async () => {
+      const tx = await createRejectTx(1)
+
+      expect(mockSafeSDK.createRejectionTransaction).toHaveBeenCalledWith(1)
+      expect(tx).toBeDefined()
+      expect(tx.addSignature).toBeDefined()
+    })
+  })
+
+  describe('dispatchTxProposal', () => {
+    it('should dispatch a tx proposal', async () => {
+      const tx = await createTx({
+        to: '0x123',
+        value: '1',
+        data: '0x0',
+      })
+
+      const proposedTx = await dispatchTxProposal('4', '0x123', '0x456', tx)
+
+      expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx)
+      expect(proposedTx).toEqual({ txId: '123' })
+    })
+  })
+
+  describe('dispatchTxSigning', () => {
+    it('should sign a tx', async () => {
+      const tx = await createTx({
+        to: '0x123',
+        value: '1',
+        data: '0x0',
+      })
+
+      const signedTx = await dispatchTxSigning(tx, '0x345')
+
+      expect(mockSafeSDK.createTransaction).toHaveBeenCalled()
+      expect(signedTx).toBe(tx)
+    })
+  })
+
+  describe('dispatchTxExecution', () => {
+    it('should execute a tx', async () => {
+      const tx = await createTx({
+        to: '0x123',
+        value: '1',
+        data: '0x0',
+      })
+
+      expect(dispatchTxExecution).toBeDefined()
+
+      // TODO: after PromiEvent is replaced
+
+      // const hash = await dispatchTxExecution(tx)
+
+      // expect(mockSafeSDK.executeTransaction).toHaveBeenCalledWith(tx)
+      // expect(hash).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
A couple tests for `txEvents` and `txSender`.

`dispatchTxExecution` will be finished after we get rid of the PromiEvent (cc @iamacook)