### PR TITLE
fix: move pending success event to middleware

### DIFF
--- a/services/useNotifier.tsx
+++ b/services/useNotifier.tsx
@@ -15,32 +15,26 @@ const useNotifier = () => {
 
   useEffect(() => {
     for (const notification of notifications) {
-      const key = notification.options?.key ?? ''
+      // Unspecified keys are automatically generated in `showNotification`
+      const key = notification.options!.key!
 
       if (notification.dismissed) {
         closeSnackbar(key)
         continue
       }
 
-      if (key && onScreenKeys.includes(key)) {
+      if (onScreenKeys.includes(key)) {
         continue
       }
 
       enqueueSnackbar(notification.message, {
-        key,
+        ...notification.options,
         action: (
           <IconButton onClick={() => dispatch(closeNotification({ key }))}>
             <CloseIcon />
           </IconButton>
         ),
-        ...notification.options,
-        // Run callback when notification is closing
-        onClose: (event, reason, key) => {
-          if (notification.options?.onClose) {
-            notification.options.onClose(event, reason, key)
-          }
-        },
-        onExited: (_, key) => {
+        onExited: () => {
           // Cleanup store/cache when notification has unmounted
           dispatch(closeNotification({ key }))
           onScreenKeys = onScreenKeys.filter((onScreenKey) => onScreenKey !== key)

--- a/services/useTxQueue.ts
+++ b/services/useTxQueue.ts
@@ -44,15 +44,9 @@ export const useInitTxQueue = (): void => {
     // Don't reload the queue if we're not on the first page
     if (pageUrl) return
 
-    const reloadQueue = () => setReloadCount((prev) => prev + 1)
-
-    const unsubscribePropose = txSubscribe(TxEvent.PROPOSED, reloadQueue)
-    const unsubscribeSuccess = txSubscribe(TxEvent.SUCCESS, reloadQueue)
-
-    return () => {
-      unsubscribePropose()
-      unsubscribeSuccess()
-    }
+    return txSubscribe(TxEvent.PROPOSED, () => {
+      setReloadCount((prev) => prev + 1)
+    })
   }, [pageUrl])
 }
 

--- a/store/index.ts
+++ b/store/index.ts
@@ -11,7 +11,7 @@ import { safeInfoSlice } from './safeInfoSlice'
 import { balancesSlice } from './balancesSlice'
 import { collectiblesSlice } from './collectiblesSlice'
 import { currencySlice } from './currencySlice'
-import { txHistorySlice } from './txHistorySlice'
+import { txHistorySlice, txHistoryMiddleware } from './txHistorySlice'
 import { txQueueSlice } from './txQueueSlice'
 import { addressBookSlice } from './addressBookSlice'
 import { notificationsSlice } from './notificationsSlice'
@@ -40,7 +40,7 @@ const persistedSlices: (keyof PreloadedState<RootState>)[] = [
   addedSafesSlice.name,
 ]
 
-const middleware = [persistState(persistedSlices)]
+const middleware = [persistState(persistedSlices), txHistoryMiddleware]
 
 export const store = configureStore({
   reducer: rootReducer,

--- a/store/pendingTxsSlice.ts
+++ b/store/pendingTxsSlice.ts
@@ -1,9 +1,6 @@
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
 
 import type { RootState } from '@/store'
-import { SetHistoryPageAction, txHistorySlice } from './txHistorySlice'
-import { isTransaction } from '@/components/transactions/utils'
-import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 
 interface PendingTxsState {
   [txId: string]: {
@@ -29,32 +26,6 @@ export const pendingTxsSlice = createSlice({
     clearPendingTx: (state, action: PayloadAction<{ txId: string }>) => {
       delete state[action.payload.txId]
     },
-  },
-
-  extraReducers: (builder) => {
-    builder.addMatcher(
-      // Remove pending transaction when it is loaded in the history list
-      (action) => action.type === txHistorySlice.actions.setHistoryPage.type,
-      (state, action: SetHistoryPageAction) => {
-        if (!action.payload) {
-          return
-        }
-
-        for (const result of action.payload.results) {
-          if (!isTransaction(result)) {
-            continue
-          }
-          const { id } = result.transaction
-          const pendingTx = state[id]
-          if (pendingTx) {
-            // A small timeout to avoid triggering triggering another reducer immediately
-            setTimeout(() => {
-              txDispatch(TxEvent.SUCCESS, { txId: id })
-            }, 100)
-          }
-        }
-      },
-    )
   },
 })
 

--- a/store/txHistorySlice.ts
+++ b/store/txHistorySlice.ts
@@ -1,7 +1,10 @@
 import { TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
-import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import { createSlice, type Middleware, type PayloadAction } from '@reduxjs/toolkit'
 import type { RootState } from '@/store'
 import { Loadable } from './common'
+import { isTransaction } from '@/components/transactions/utils'
+import { txDispatch, TxEvent } from '@/services/tx/txEvents'
+import { selectPendingTxs } from './pendingTxsSlice'
 
 interface TxHistoryState extends Loadable {
   page: TransactionListPage
@@ -19,13 +22,11 @@ const initialState: TxHistoryState = {
   pageUrl: '',
 }
 
-export type SetHistoryPageAction = PayloadAction<TransactionListPage | undefined>
-
 export const txHistorySlice = createSlice({
   name: 'txHistory',
   initialState,
   reducers: {
-    setHistoryPage: (state, action: SetHistoryPageAction) => {
+    setHistoryPage: (state, action: PayloadAction<TransactionListPage | undefined>) => {
       // @ts-ignore: Type instantiation is excessively deep and possibly infinite.
       state.page = action.payload || initialState.page
     },
@@ -40,4 +41,33 @@ export const { setHistoryPage, setPageUrl } = txHistorySlice.actions
 
 export const selectTxHistory = (state: RootState): TxHistoryState => {
   return state[txHistorySlice.name]
+}
+
+export const txHistoryMiddleware: Middleware<{}, RootState> = (store) => (next) => (action) => {
+  const result = next(action)
+
+  switch (action.type) {
+    // Dispatch SUCCESS event when pending transaction is in history payload
+    case setHistoryPage.type: {
+      if (!action.payload) {
+        break
+      }
+
+      const state = store.getState()
+      const pendingTxs = selectPendingTxs(state)
+
+      for (const result of action.payload.results) {
+        if (!isTransaction(result)) {
+          continue
+        }
+
+        const { id } = result.transaction
+        if (pendingTxs[id]) {
+          txDispatch(TxEvent.SUCCESS, { txId: id })
+        }
+      }
+    }
+  }
+
+  return result
 }


### PR DESCRIPTION
## Overview
The side effect logic for removing pending status existent in history pages has been moved from the reducer to middleware. Some duplicate queue fetching logic was also removed and `useNotifier` code cleaned up.