### PR TITLE
Feat: add stubbed analytics

### DIFF
--- a/components/common/Track/index.tsx
+++ b/components/common/Track/index.tsx
@@ -1,0 +1,48 @@
+import { ReactElement, Fragment, useEffect, useRef } from 'react'
+
+import { EventLabel, GTM_EVENT, trackEvent } from '@/services/analytics'
+
+type Props = {
+  children: ReactElement
+  as?: 'span' | 'div'
+  category: string
+  action: string
+  label?: EventLabel
+}
+
+const Track = ({ children, as: Wrapper = 'div', ...trackData }: Props): typeof children => {
+  const el = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!el.current) {
+      return
+    }
+
+    const trackEl = el.current
+
+    const handleClick = () => {
+      trackEvent({
+        event: GTM_EVENT.CLICK,
+        ...trackData,
+      })
+    }
+
+    // We cannot use onClick as events in children do not always bubble up
+    trackEl.addEventListener('click', handleClick)
+    return () => {
+      trackEl.removeEventListener('click', handleClick)
+    }
+  }, [el, trackData])
+
+  if (children.type === Fragment) {
+    throw new Error('Fragments cannot be tracked.')
+  }
+
+  return (
+    <Wrapper data-track={`${trackData.category}: ${trackData.action}`} ref={el}>
+      {children}
+    </Wrapper>
+  )
+}
+
+export default Track

--- a/services/analytics.ts
+++ b/services/analytics.ts
@@ -1,0 +1,12 @@
+export enum GTM_EVENT {
+  PAGEVIEW = 'pageview',
+  CLICK = 'customClick',
+  META = 'metadata',
+  SAFE_APP = 'safeApp',
+}
+
+export type EventLabel = string | number | boolean | null
+
+export const trackEvent = (eventData: { event: GTM_EVENT; category: string; action: string; label?: EventLabel }) => {
+  console.log(eventData)
+}


### PR DESCRIPTION
Add `trackEvent` and the `Track` component so that we can instrument other components.