### PR TITLE
Fix: always generate a new id for notifications

### DIFF
--- a/hooks/useTxNotifications.ts
+++ b/hooks/useTxNotifications.ts
@@ -34,7 +34,6 @@ const useTxNotifications = (): void => {
 
         dispatch(
           showNotification({
-            id: '',
             message,
             groupKey: txId || '',
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,

--- a/store/notificationsSlice.ts
+++ b/store/notificationsSlice.ts
@@ -41,10 +41,9 @@ export const notificationsSlice = createSlice({
 export const { closeNotification, closeAllNotifications, deleteNotification, deleteAllNotifications } =
   notificationsSlice.actions
 
-// Custom thunk that returns the key in case it was auto-generated
-export const showNotification = (payload: Notification): AppThunk<string> => {
+export const showNotification = (payload: Omit<Notification, 'id'>): AppThunk<string> => {
   return (dispatch) => {
-    const id = payload.id || Math.random().toString(32).slice(2)
+    const id = Math.random().toString(32).slice(2)
 
     const notification: Notification = {
       ...payload,


### PR DESCRIPTION
Ids are always new and never the same, so I removed the ability to pass an id in `showNotification`.