### PR TITLE
fix: cookie banner hydration

### DIFF
--- a/components/common/CookieBanner/index.tsx
+++ b/components/common/CookieBanner/index.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useState, ChangeEvent, ReactElement } from 'react'
+import { useState, ChangeEvent, ReactElement } from 'react'
 import { Box, Button, Checkbox, FormControlLabel, Link, Typography } from '@mui/material'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
 
@@ -22,7 +22,7 @@ const COOKIE_WARNING: Record<keyof CookieConsent, string> = {
   [ANALYTICS_COOKIE]: '',
 }
 
-const CookieBanner = (): ReactElement | null => {
+const CookieBanner = (): ReactElement => {
   const dispatch = useAppDispatch()
   const cookies = useAppSelector(selectCookies)
   const [consent, setConsent] = useState(cookies.consent)
@@ -32,8 +32,7 @@ const CookieBanner = (): ReactElement | null => {
     setConsent((prev) => ({ ...prev, [name]: checked }))
   }
 
-  const handleSubmit = (e?: FormEvent<HTMLFormElement>) => {
-    e?.preventDefault()
+  const handleAccept = () => {
     dispatch(saveCookieConsent({ consent }))
     dispatch(closeCookieBanner())
   }
@@ -44,11 +43,7 @@ const CookieBanner = (): ReactElement | null => {
       [SUPPORT_COOKIE]: true,
       [ANALYTICS_COOKIE]: true,
     })
-    handleSubmit()
-  }
-
-  if (!cookies.open) {
-    return null
+    handleAccept()
   }
 
   return (
@@ -56,6 +51,8 @@ const CookieBanner = (): ReactElement | null => {
       sx={({ palette }) => ({
         backgroundColor: 'background.paper',
         borderTop: `1px solid ${palette.gray[500]}`,
+        // Rendering `null` causes hydration error
+        display: !cookies.open ? 'none' : undefined,
       })}
       className={css.container}
     >
@@ -76,7 +73,7 @@ const CookieBanner = (): ReactElement | null => {
         enhance site navigation, analyze site usage and provide customer support.
       </Typography>
 
-      <form onSubmit={handleSubmit} className={css.form}>
+      <form className={css.form}>
         <FormControlLabel control={<Checkbox defaultChecked name={NECESSARY_COOKIE} disabled />} label="Necessary" />
         <FormControlLabel
           control={<Checkbox checked={consent[SUPPORT_COOKIE]} name={SUPPORT_COOKIE} onChange={handleChange} />}
@@ -87,7 +84,7 @@ const CookieBanner = (): ReactElement | null => {
           label="Analytics"
         />
 
-        <Button type="submit" variant="outlined" disableElevation>
+        <Button onClick={handleAccept} variant="outlined" disableElevation>
           Accept selection
         </Button>
         <Button onClick={handleAcceptAll} variant="contained" disableElevation>

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -9,5 +9,5 @@ export const FORTMATIC_KEY = process.env.NEXT_PUBLIC_FORTMATIC_KEY || 'pk_test_C
 export const PORTIS_KEY = process.env.NEXT_PUBLIC_PORTIS_KEY || '852b763d-f28b-4463-80cb-846d7ec5806b'
 export const TREZOR_APP_URL = 'gnosis-safe.io'
 export const TREZOR_EMAIL = 'safe@gnosis.io'
-export const LATEST_SAFE_VERSION = process.env.REACT_APP_LATEST_SAFE_VERSION || '1.3.0'
-export const BEAMER_ID = process.env.REACT_APP_BEAMER_ID
+export const LATEST_SAFE_VERSION = process.env.NEXT_PUBLIC_SAFE_VERSION || '1.3.0'
+export const BEAMER_ID = IS_PRODUCTION ? process.env.NEXT_PUBLIC_BEAMER_ID : 'ehlRMhQi41258'


### PR DESCRIPTION
## Overview

As we persist the cookie banner `open` state alongisde the consent, it was causing hydration errors when getting the preloaded state. As such, we no longer 'render' `null` when the banner should be closed, instead displaying it as `"none"`.