### PR TITLE
fix: add `ThemeProvider` to test renderer

### DIFF
--- a/components/safe-apps/AppCard.tsx
+++ b/components/safe-apps/AppCard.tsx
@@ -17,16 +17,16 @@ const AppCard = ({ safeApp }: Props) => {
 
   return (
     <Card
-      sx={{
+      sx={({ palette }) => ({
         maxWidth: 345,
         height: 190,
         transition: 'all 0.3s ease-in-out',
         '&:hover': {
-          backgroundColor: theme.palette.primaryGreen[200],
+          backgroundColor: palette.primaryGreen[200],
           // @ts-expect-error type '300' can't be used to index type 'PaletteColor'
-          border: `2px solid ${theme.palette.primary[300]}`,
+          border: `2px solid ${palette.primary[300]}`,
         },
-      }}
+      })}
     >
       <CardHeader
         avatar={

--- a/tests/test-utils.tsx
+++ b/tests/test-utils.tsx
@@ -2,6 +2,8 @@ import { render, renderHook, RenderHookOptions } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { NextRouter } from 'next/router'
 import { RouterContext } from 'next/dist/shared/lib/router-context'
+import { ThemeProvider } from '@mui/material'
+import theme from '@/styles/theme'
 
 const mockRouter = (props: Partial<NextRouter> = {}): NextRouter => ({
   asPath: '/',
@@ -35,7 +37,9 @@ const getProviders: (routerProps: Partial<NextRouter>) => React.FC<{ children: R
 
     return (
       <RouterContext.Provider value={mockRouter(routerProps)}>
-        <Provider store={store}>{children}</Provider>
+        <ThemeProvider theme={theme}>
+          <Provider store={store}>{children}</Provider>
+        </ThemeProvider>
       </RouterContext.Provider>
     )
   }


### PR DESCRIPTION
## Overview

Custom colours would fail tests. As such, our `theme` is now provided in the test `render` function.