### PR TITLE
feat: add copy address + open block explorer

### DIFF
--- a/components/sidebar/SidebarHeader/index.tsx
+++ b/components/sidebar/SidebarHeader/index.tsx
@@ -13,8 +13,11 @@ import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/sessionSlice'
 
 import css from './styles.module.css'
+import { selectSettings } from '@/store/settingsSlice'
+import { useCurrentChain } from '@/hooks/useChains'
+import { getExplorerLink } from '@/utils/gateway'
 
-const HeaderIconButton = ({ children }: Omit<IconButtonProps, 'className' | 'disableRipple' | 'sx'>) => (
+const HeaderIconButton = ({ children, ...props }: Omit<IconButtonProps, 'className' | 'disableRipple' | 'sx'>) => (
   <IconButton
     className={css.iconButton}
     sx={({ palette }) => ({
@@ -23,6 +26,7 @@ const HeaderIconButton = ({ children }: Omit<IconButtonProps, 'className' | 'dis
         backgroundColor: palette.primaryGreen[200],
       },
     })}
+    {...props}
   >
     {children}
   </IconButton>
@@ -32,6 +36,8 @@ const SafeHeader = (): ReactElement => {
   const currency = useAppSelector(selectCurrency)
   const { balances } = useBalances()
   const { safe, loading } = useSafeInfo()
+  const chain = useCurrentChain()
+  const settings = useAppSelector(selectSettings)
 
   const address = safe?.address.value || ''
 
@@ -41,6 +47,11 @@ const SafeHeader = (): ReactElement => {
   const fiat = useMemo(() => {
     return formatCurrency(balances.fiatTotal, currency)
   }, [currency, balances.fiatTotal])
+
+  const handleCopy = () => {
+    const text = settings.shortName.copy && chain ? `${chain.shortName}:${address}` : address
+    navigator.clipboard.writeText(text)
+  }
 
   return (
     <div className={css.container}>
@@ -60,15 +71,19 @@ const SafeHeader = (): ReactElement => {
         </div>
       </div>
       <div className={css.iconButtons}>
-        <HeaderIconButton>
+        {/* 
+        TODO: Add QR functionality */}
+        <HeaderIconButton disabled>
           <img src="/images/sidebar/qr.svg" alt="Address QR Code" height="16px" width="16px" />
         </HeaderIconButton>
-        <HeaderIconButton>
+        <HeaderIconButton onClick={handleCopy}>
           <img src="/images/sidebar/copy.svg" alt="Copy Address" height="16px" width="16px" />
         </HeaderIconButton>
-        <HeaderIconButton>
-          <img src="/images/sidebar/block-explorer.svg" alt="Open Block Explorer" height="16px" width="16px" />
-        </HeaderIconButton>
+        <a target="_blank" rel="noreferrer" {...(chain && getExplorerLink(address, chain.blockExplorerUriTemplate))}>
+          <HeaderIconButton>
+            <img src="/images/sidebar/block-explorer.svg" alt="Open Block Explorer" height="16px" width="16px" />
+          </HeaderIconButton>
+        </a>
       </div>
       <NewTxButton />
     </div>

--- a/utils/__tests__/gateway.test.ts
+++ b/utils/__tests__/gateway.test.ts
@@ -1,0 +1,62 @@
+import { getExplorerLink, getHashedExplorerUrl, _replaceTemplate } from '../gateway'
+
+describe('gateway', () => {
+  describe('replaceTemplate', () => {
+    it('should replace template syntax with data', () => {
+      const uri = 'Hello {{this}}'
+      const data = { this: 'world' }
+
+      const result = _replaceTemplate(uri, data)
+      expect(result).toEqual('Hello world')
+    })
+    it("shouldn't replace non-template text", () => {
+      const uri = 'Hello this'
+      const data = { this: 'world' }
+
+      const result = _replaceTemplate(uri, data)
+      expect(result).toEqual('Hello this')
+    })
+  })
+
+  describe('getHashedExplorerUrl', () => {
+    it('should return a url with a transaction hash', () => {
+      const txHash = '0x4d32cc132307cde65b44162156f961ed421a84f83bb8cf3730c91f53374cc5de'
+
+      const result = getHashedExplorerUrl(txHash, {
+        address: 'https://etherscan.io/address/{{address}}',
+        txHash: 'https://etherscan.io/tx/{{txHash}}',
+        api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+      })
+
+      expect(result).toEqual(
+        'https://etherscan.io/tx/0x4d32cc132307cde65b44162156f961ed421a84f83bb8cf3730c91f53374cc5de',
+      )
+    })
+    it('should return a url with an address', () => {
+      const address = '0xabcdbc2ecb47642ee8cf52fd7b88fa42fbb69f98'
+
+      const result = getHashedExplorerUrl(address, {
+        address: 'https://etherscan.io/address/{{address}}',
+        txHash: 'https://etherscan.io/tx/{{txHash}}',
+        api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+      })
+
+      expect(result).toEqual('https://etherscan.io/address/0xabcdbc2ecb47642ee8cf52fd7b88fa42fbb69f98')
+    })
+  })
+
+  describe('getExplorerLink', () => {
+    it('should return an object with a href and title', () => {
+      const address = '0xabcdbc2ecb47642ee8cf52fd7b88fa42fbb69f98'
+
+      const { href, title } = getExplorerLink(address, {
+        address: 'https://etherscan.io/address/{{address}}',
+        txHash: 'https://etherscan.io/tx/{{txHash}}',
+        api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+      })
+
+      expect(href).toEqual('https://etherscan.io/address/0xabcdbc2ecb47642ee8cf52fd7b88fa42fbb69f98')
+      expect(title).toEqual('View on etherscan.io')
+    })
+  })
+})

--- a/utils/gateway.ts
+++ b/utils/gateway.ts
@@ -1,0 +1,28 @@
+import { ChainInfo } from '@gnosis.pm/safe-react-gateway-sdk'
+
+export const _replaceTemplate = (uri: string, data: Record<string, string>): string => {
+  // Template syntax returned from gateway is {{this}}
+  const TEMPLATE_REGEX = /\{\{([^}]+)\}\}/g
+
+  return uri.replace(TEMPLATE_REGEX, (_, key: string) => data[key])
+}
+
+export const getHashedExplorerUrl = (
+  hash: string,
+  blockExplorerUriTemplate: ChainInfo['blockExplorerUriTemplate'],
+): string => {
+  const isTx = hash.length > 42
+  const param = isTx ? 'txHash' : 'address'
+
+  return _replaceTemplate(blockExplorerUriTemplate[param], { [param]: hash })
+}
+
+export const getExplorerLink = (
+  hash: string,
+  blockExplorerUriTemplate: ChainInfo['blockExplorerUriTemplate'],
+): { href: string; title: string } => {
+  const href = getHashedExplorerUrl(hash, blockExplorerUriTemplate)
+  const title = `View on ${new URL(href).hostname}`
+
+  return { href, title }
+}


### PR DESCRIPTION
## Overview

This adds functionality to the buttons in the sidebar: copy address and open block explorer. The QR button has been disabled for the time being.