### PR TITLE
fix: Safe list spacing, pointer, names + removal

### DIFF
--- a/components/sidebar/SafeList/index.tsx
+++ b/components/sidebar/SafeList/index.tsx
@@ -129,7 +129,7 @@ const SafeList = ({ closeDrawer }: { closeDrawer: () => void }): ReactElement =>
                 {chain.chainName}
               </Typography>
               {!addedSafeEntriesOnChain.length && !ownedSafesOnChain.length && (
-                <Typography variant="body2" sx={({ palette }) => ({ color: palette.secondary.light })}>
+                <Typography variant="body2" sx={({ palette }) => ({ color: palette.secondary.light, my: '8px' })}>
                   <Link href={{ href: AppRoutes.welcome, query: router.query }} passHref>
                     Create or add
                   </Link>{' '}
@@ -154,8 +154,8 @@ const SafeList = ({ closeDrawer }: { closeDrawer: () => void }): ReactElement =>
                   variant="body2"
                   sx={({ palette }) => ({
                     color: palette.secondary.light,
-                    mt: '8px',
-                    mb: '8px',
+                    my: '8px',
+                    cursor: 'pointer',
                   })}
                   display="inline"
                 >

--- a/components/sidebar/SafeListContextMenu/index.tsx
+++ b/components/sidebar/SafeListContextMenu/index.tsx
@@ -9,6 +9,8 @@ import ListItemText from '@mui/material/ListItemText'
 import useAddressBook from '@/hooks/useAddressBook'
 import EntryDialog from '@/components/address-book/EntryDialog'
 import SafeListRemoveDialog from '@/components/sidebar/SafeListRemoveDialog'
+import { useAppSelector } from '@/store'
+import { selectAddedSafes } from '@/store/addedSafesSlice'
 
 enum ModalType {
   RENAME = 'rename',
@@ -17,7 +19,10 @@ enum ModalType {
 
 const defaultOpen = { [ModalType.RENAME]: false, [ModalType.REMOVE]: false }
 
-const SafeListContextMenu = ({ address }: { address: string }): ReactElement => {
+const SafeListContextMenu = ({ address, chainId }: { address: string; chainId: string }): ReactElement => {
+  const addedSafes = useAppSelector((state) => selectAddedSafes(state, chainId))
+  const isAdded = !!addedSafes?.[address]
+
   const addressBook = useAddressBook()
   const name = addressBook?.[address]
 
@@ -70,19 +75,23 @@ const SafeListContextMenu = ({ address }: { address: string }): ReactElement => 
           <ListItemText>Rename</ListItemText>
         </MenuItem>
 
-        <MenuItem onClick={handleOpenModal(ModalType.REMOVE)}>
-          <ListItemIcon>
-            <img src="/images/sidebar/safe-list/trash.svg" alt="Remove" height="16px" width="16px" />
-          </ListItemIcon>
-          <ListItemText>Remove</ListItemText>
-        </MenuItem>
+        {isAdded && (
+          <MenuItem onClick={handleOpenModal(ModalType.REMOVE)}>
+            <ListItemIcon>
+              <img src="/images/sidebar/safe-list/trash.svg" alt="Remove" height="16px" width="16px" />
+            </ListItemIcon>
+            <ListItemText>Remove</ListItemText>
+          </MenuItem>
+        )}
       </Menu>
 
       {open[ModalType.RENAME] && (
         <EntryDialog handleClose={handleCloseModal} defaultValues={{ name, address }} disableAddressInput />
       )}
 
-      {open[ModalType.REMOVE] && <SafeListRemoveDialog handleClose={handleCloseModal} address={address} />}
+      {open[ModalType.REMOVE] && (
+        <SafeListRemoveDialog handleClose={handleCloseModal} address={address} chainId={chainId} />
+      )}
     </>
   )
 }

--- a/components/sidebar/SafeListItem/index.tsx
+++ b/components/sidebar/SafeListItem/index.tsx
@@ -9,13 +9,13 @@ import SafeIcon from '@/components/common/SafeIcon'
 import { shortenAddress } from '@/utils/formatters'
 import { useAppSelector } from '@/store'
 import useSafeAddress from '@/hooks/useSafeAddress'
-import useAddressBook from '@/hooks/useAddressBook'
 import { selectChainById } from '@/store/chainsSlice'
 import SafeListItemSecondaryAction from '@/components/sidebar/SafeListItemSecondaryAction'
 import useChainId from '@/hooks/useChainId'
 import { AppRoutes } from '@/config/routes'
 import SafeListContextMenu from '@/components/sidebar/SafeListContextMenu'
 import Box from '@mui/material/Box'
+import { selectAllAddressBooks } from '@/store/addressBookSlice'
 
 const SafeListItem = ({
   address,
@@ -34,6 +34,7 @@ const SafeListItem = ({
   const safeRef = useRef<HTMLDivElement>(null)
   const safeAddress = useSafeAddress()
   const chain = useAppSelector((state) => selectChainById(state, chainId))
+  const allAddressBooks = useAppSelector(selectAllAddressBooks)
 
   const currChainId = useChainId()
   const isCurrentSafe = currChainId === currChainId && safeAddress.toLowerCase() === address.toLowerCase()
@@ -44,8 +45,7 @@ const SafeListItem = ({
     }
   }, [isCurrentSafe, shouldScrollToSafe])
 
-  const addressBook = useAddressBook()
-  const name = addressBook?.[address]
+  const name = allAddressBooks[chainId]?.[address]
 
   const isOpen = address.toLowerCase() === safeAddress.toLowerCase()
 
@@ -66,7 +66,7 @@ const SafeListItem = ({
             onClick={closeDrawer}
             href={`${AppRoutes.welcome}?chain=${chain?.shortName}`}
           />
-          <SafeListContextMenu address={address} />
+          <SafeListContextMenu address={address} chainId={chainId} />
         </Box>
       }
       sx={{ my: '8px', px: '8px' }}

--- a/components/sidebar/SafeListRemoveDialog/index.tsx
+++ b/components/sidebar/SafeListRemoveDialog/index.tsx
@@ -6,13 +6,19 @@ import type { ReactElement } from 'react'
 
 import ModalDialog from '@/components/common/ModalDialog'
 import { useAppDispatch } from '@/store'
-import useChainId from '@/hooks/useChainId'
 import useAddressBook from '@/hooks/useAddressBook'
 import { removeSafe } from '@/store/addedSafesSlice'
 
-const SafeListRemoveDialog = ({ handleClose, address }: { handleClose: () => void; address: string }): ReactElement => {
+const SafeListRemoveDialog = ({
+  handleClose,
+  address,
+  chainId,
+}: {
+  handleClose: () => void
+  address: string
+  chainId: string
+}): ReactElement => {
   const dispatch = useAppDispatch()
-  const chainId = useChainId()
   const addressBook = useAddressBook()
 
   const safe = addressBook?.[address] || address


### PR DESCRIPTION
## Overview

This adjusts: the margin and cursor of the "Safes owned on {{chain}}" label, persisting names of Safes when switching chains and only allowing removal of Safes when they are added.

Further points to discuss with design:
- Why has spacing changed from multiples of 8?
- Should we reduce Safe list width?
- How can we implement hover or something similar to the aforementioned labels?