### PR TITLE
fix: Open history when clicking on Transactions in sidebar

### DIFF
--- a/components/sidebar/SidebarNavigation/index.tsx
+++ b/components/sidebar/SidebarNavigation/index.tsx
@@ -48,7 +48,7 @@ const navItems: NavItem[] = [
   {
     label: 'Transactions',
     icon: '/images/sidebar/transactions.svg',
-    href: AppRoutes.safe.transactions.index,
+    href: AppRoutes.safe.transactions.history,
     items: [
       {
         label: 'Queue',


### PR DESCRIPTION
## What it solves

The History link in the sidebar wasn't highlighted when the user clicked on Transactions.