### PR TITLE
Fix: lowercase chain name in the mnenonic fallback

### DIFF
--- a/hooks/useMnemonicName/index.ts
+++ b/hooks/useMnemonicName/index.ts
@@ -19,6 +19,6 @@ export const useMnemonicName = (noun?: string): string => {
 }
 
 export const useMnemonicSafeName = (): string => {
-  const networkName = useCurrentChain()?.chainName
+  const networkName = useCurrentChain()?.chainName.toLowerCase()
   return useMnemonicName(`${networkName}-safe`)
 }

--- a/hooks/useMnemonicName/useMnemonicName.test.ts
+++ b/hooks/useMnemonicName/useMnemonicName.test.ts
@@ -1,10 +1,10 @@
-import { getRandomName, useMnemonicName, useMnemonicSafeName } from '../useMnemonicName'
+import { getRandomName, useMnemonicName, useMnemonicSafeName } from '.'
 import { renderHook } from '@/tests/test-utils'
 
 // Mock useCurrentChain hook
 jest.mock('@/hooks/useChains', () => ({
   useCurrentChain: () => ({
-    chainName: 'rinkeby',
+    chainName: 'Rinkeby',
   }),
 }))
 


### PR DESCRIPTION
Fixes generated Safe names: from `brilliant-Rinkeby-safe` to `brilliant-rinkeby-safe`.