### PR TITLE
Restore: update queue when proposing a tx

### DIFF
--- a/hooks/loadables/useLoadTxQueue.ts
+++ b/hooks/loadables/useLoadTxQueue.ts
@@ -1,13 +1,20 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { getTransactionQueue, type TransactionListPage } from '@gnosis.pm/safe-react-gateway-sdk'
 import useAsync, { type AsyncResult } from '../useAsync'
 import useSafeInfo from '../useSafeInfo'
 import { Errors, logError } from '@/services/exceptions'
+import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
 
 export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
   const { safe } = useSafeInfo()
   const { chainId, txQueuedTag } = safe || {}
   const address = safe?.address.value
+  const [proposedTxId, setProposedTxId] = useState<string>()
+
+  // Listen to newly proposed txns
+  useEffect(() => {
+    return txSubscribe(TxEvent.PROPOSED, ({ txId }) => setProposedTxId(txId))
+  }, [])
 
   // Re-fetch when chainId/address, or txQueueTag change
   const [data, error, loading] = useAsync<TransactionListPage | undefined>(
@@ -16,7 +23,7 @@ export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
         return getTransactionQueue(chainId, address)
       }
     },
-    [chainId, address, txQueuedTag],
+    [chainId, address, txQueuedTag, proposedTxId],
     false,
   )
 


### PR DESCRIPTION
This was removed for simplicity in #140, but it's actually needed for good UX when creating/signing a tx.