### PR TITLE
fix: TxStepper data persistence

### DIFF
--- a/components/tx/TxStepper/index.tsx
+++ b/components/tx/TxStepper/index.tsx
@@ -17,7 +17,7 @@ const TxStepper = ({ steps, initialData, onClose }: TxStepperProps): ReactElemen
           </Typography>
         </Box>
 
-        {steps[activeStep].render(stepData[Math.max(0, activeStep - 1)], onSubmit, onBack)}
+        {steps[activeStep].render(stepData[Math.max(0, activeStep)], onSubmit, onBack)}
       </Box>
 
       <DialogActions sx={{ m: -3, mt: 3 }}>

--- a/components/tx/TxStepper/useTxStepper.ts
+++ b/components/tx/TxStepper/useTxStepper.ts
@@ -34,16 +34,18 @@ export const useTxStepper = ({ steps, initialData, onClose }: TxStepperProps) =>
   }
 
   const firstStep = activeStep === 0
+  const lastStep = activeStep === steps.length - 1
 
   const onBack = firstStep ? onClose : handleBack
 
   const onSubmit = (data: unknown) => {
-    if (activeStep === steps.length - 1) {
+    if (lastStep) {
       onClose()
       return
     }
     const allData = [...stepData]
     allData[activeStep] = data
+    allData[activeStep + 1] = data
     setStepData(allData)
     handleNext()
   }

--- a/components/tx/TxStepper/vertical.tsx
+++ b/components/tx/TxStepper/vertical.tsx
@@ -18,9 +18,7 @@ const VerticalTxStepper = ({ steps, initialData, onClose }: TxStepperProps): Rea
           return (
             <Step key={label} {...stepProps}>
               <StepLabel>{label}</StepLabel>
-              <StepContent>
-                {steps[activeStep].render(stepData[Math.max(0, activeStep - 1)], onSubmit, onBack)}
-              </StepContent>
+              <StepContent>{steps[activeStep].render(stepData[Math.max(0, activeStep)], onSubmit, onBack)}</StepContent>
             </Step>
           )
         })}


### PR DESCRIPTION
A small fix for the `TxStepper` that copies over the previous step data to the current step and accesses that instead of the previous cell. This solves a problem with persisting the data when going to a previous step, which currently only works if its the first step because of the `Math.max` expression. For safe creation we need to access previously selected options in step 2 and 3.

Might be worth considering to move away from an array based structure and just have an object if the data is cumulative