### PR TITLE
Fix: run LS migration only on prod

### DIFF
--- a/services/ls-migration/config.ts
+++ b/services/ls-migration/config.ts
@@ -1,7 +1,3 @@
-import { IS_PRODUCTION } from '@/config/constants'
-
-export const IFRAME_HOST = IS_PRODUCTION
-  ? 'https://gnosis-safe.io'
-  : 'https://pr4017--safereact.review-safe.gnosisdev.com' // 'https://safe-team.dev.gnosisdev.com'
+export const IFRAME_HOST = 'https://gnosis-safe.io'
 export const IFRAME_PATH = '/app/migrate.html'
 export const MIGRATION_KEY = 'migrationFinished'

--- a/services/ls-migration/index.ts
+++ b/services/ls-migration/index.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { IS_PRODUCTION } from '@/config/constants'
 import useLocalStorage from '@/services/localStorage/useLocalStorage'
 import { useAppDispatch } from '@/store'
 import { addressBookSlice } from '@/store/addressBookSlice'
@@ -35,4 +36,4 @@ const useStorageMigration = (): void => {
   }, [isMigrationFinished, setIsMigrationFinished, dispatch])
 }
 
-export default useStorageMigration
+export default IS_PRODUCTION ? useStorageMigration : () => void null


### PR DESCRIPTION
The safe-react PR is merged and will be eventually deployed.

Since it only accepts the "production" domains (web-core.pages.dev including), no point running it on localhost and preview branches.