### PR TITLE
Fix: always checksum addresses

### DIFF
--- a/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
+++ b/components/tx/modals/TokenTransferModal/ReviewTokenTx.tsx
@@ -74,7 +74,7 @@ const ReviewTokenTx = ({ params, onSubmit }: ReviewTokenTxProps): ReactElement =
         </Typography>
 
         <Box>
-          <EthHashInfo address={safeTx?.data.to || ''} shortAddress={false} hasExplorer showCopyButton />
+          <EthHashInfo address={params.recipient} shortAddress={false} hasExplorer showCopyButton />
         </Box>
       </Box>
     </SignOrExecuteForm>

--- a/utils/addresses.ts
+++ b/utils/addresses.ts
@@ -15,10 +15,15 @@ export type PrefixedAddress = {
 }
 
 export const parsePrefixedAddress = (value: string): PrefixedAddress => {
-  const [prefix, address] = value.split(':')
+  let [prefix, address] = value.split(':')
+
+  if (!address) {
+    address = value
+    prefix = ''
+  }
 
   return {
-    prefix: address ? prefix : undefined,
+    prefix: prefix || undefined,
     address: isAddress(address) ? getAddress(address) : value,
   }
 }


### PR DESCRIPTION
Bug: if an address was un-prefixed, it didn't checksum it.

Also, in the Review modal, it was displaying the wrong address in the Recipient field.