### PR TITLE
[Draft] Refactor: use txHash for pending/tx events/notifications

### DIFF
--- a/components/transactions/TxSummary/index.tsx
+++ b/components/transactions/TxSummary/index.tsx
@@ -22,7 +22,10 @@ type TxSummaryProps = {
 const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
   const tx = item.transaction
   const wallet = useWallet()
-  const txStatusLabel = useTransactionStatus(tx)
+  const txStatusLabel = useTransactionStatus({
+    txStatus: tx.txStatus,
+    txHash: tx.id.split('_').pop() || '',
+  })
   const isQueue = tx.txStatus !== TransactionStatus.SUCCESS
   const awaitingExecution = isAwaitingExecution(item.transaction.txStatus)
   const nonce = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo.nonce : undefined

--- a/components/tx/SignOrExecuteForm/index.tsx
+++ b/components/tx/SignOrExecuteForm/index.tsx
@@ -103,21 +103,18 @@ const SignOrExecuteForm = ({
   const onExecute = async (): Promise<string> => {
     const [connectedWallet, createdTx] = assertSubmittable()
 
-    // If no txId was provided, it's an immediate execution of a new tx
-    let id = txId
-    if (!id) {
-      const proposedTx = await dispatchTxProposal(safe.chainId, safeAddress, connectedWallet.address, createdTx)
-      id = proposedTx.txId
-    }
-
     // @FIXME: pass maxFeePerGas and maxPriorityFeePerGas when Core SDK supports it
     const txOptions = {
       gasLimit: advancedParams.gasLimit?.toString(),
       gasPrice: advancedParams.maxFeePerGas?.toString(),
     }
-    await dispatchTxExecution(id, createdTx, txOptions)
+    await dispatchTxExecution(createdTx, txOptions)
 
-    return id
+    if (txId) return txId
+
+    // If no txId was provided, it's an immediate execution of a new tx
+    const proposedTx = await dispatchTxProposal(safe.chainId, safeAddress, connectedWallet.address, createdTx)
+    return proposedTx.txId
   }
 
   // On modal submit

--- a/hooks/loadables/useLoadTxQueue.ts
+++ b/hooks/loadables/useLoadTxQueue.ts
@@ -8,11 +8,11 @@ import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
 export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
   const { safe, safeAddress, safeLoaded } = useSafeInfo()
   const { chainId, txQueuedTag, txHistoryTag } = safe
-  const [proposedTxId, setProposedTxId] = useState<string>()
+  const [proposedHash, setProposedHash] = useState<string>()
 
   // Listen to newly proposed txns
   useEffect(() => {
-    return txSubscribe(TxEvent.PROPOSED, ({ txId }) => setProposedTxId(txId))
+    return txSubscribe(TxEvent.PROPOSED, ({ txHash }) => setProposedHash(txHash))
   }, [])
 
   // Re-fetch when chainId/address, or txQueueTag change
@@ -23,7 +23,7 @@ export const useLoadTxQueue = (): AsyncResult<TransactionListPage> => {
     },
     // N.B. we reload when either txQueuedTag or txHistoryTag changes
     // @TODO: evaluate if txHistoryTag should be included in the reload
-    [safeLoaded, chainId, safeAddress, txQueuedTag, txHistoryTag, proposedTxId],
+    [safeLoaded, chainId, safeAddress, txQueuedTag, txHistoryTag, proposedHash],
     false,
   )
 

--- a/hooks/useTransactionStatus.ts
+++ b/hooks/useTransactionStatus.ts
@@ -1,6 +1,6 @@
 import { useAppSelector } from '@/store'
-import { selectPendingTxById } from '@/store/pendingTxsSlice'
-import { TransactionSummary, TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk'
+import { selectPendingTxByHash } from '@/store/pendingTxsSlice'
+import { TransactionStatus } from '@gnosis.pm/safe-react-gateway-sdk'
 
 const BACKEND_STATUS_LABELS: { [key in TransactionStatus]: string } = {
   [TransactionStatus.AWAITING_CONFIRMATIONS]: 'Awaiting confirmations',
@@ -12,7 +12,7 @@ const BACKEND_STATUS_LABELS: { [key in TransactionStatus]: string } = {
   [TransactionStatus.PENDING]: '', // deprecated
 }
 
-export const useTransactionStatus = ({ txStatus, id }: TransactionSummary): TransactionStatus | string => {
-  const pendingTx = useAppSelector((state) => selectPendingTxById(state, id))
+export const useTransactionStatus = ({ txStatus, txHash }: { txStatus: TransactionStatus; txHash: string }): string => {
+  const pendingTx = useAppSelector((state) => selectPendingTxByHash(state, txHash))
   return pendingTx?.status || BACKEND_STATUS_LABELS[txStatus]
 }

--- a/hooks/useTxNotifications.ts
+++ b/hooks/useTxNotifications.ts
@@ -30,12 +30,11 @@ const useTxNotifications = (): void => {
         const isError = 'error' in detail
         const isSuccess = event === TxEvent.SUCCESS || event === TxEvent.PROPOSED
         const message = isError ? `${baseMessage} ${detail.error.message.slice(0, 300)}` : baseMessage
-        const txId = 'txId' in detail && detail.txId
 
         dispatch(
           showNotification({
             message,
-            groupKey: txId || '',
+            groupKey: detail.txHash,
             variant: isError ? Variant.ERROR : isSuccess ? Variant.SUCCESS : Variant.INFO,
           }),
         )

--- a/services/tx/__tests__/txEvents.test.ts
+++ b/services/tx/__tests__/txEvents.test.ts
@@ -10,9 +10,7 @@ describe('txEvents', () => {
     const event = TxEvent.MINING
 
     const detail = {
-      txId: '123',
       txHash: '0x123',
-      tx,
     }
 
     const callback = jest.fn()
@@ -24,9 +22,7 @@ describe('txEvents', () => {
     expect(callback).toHaveBeenCalledWith(detail)
 
     const detail2 = {
-      txId: '123',
       txHash: '0x456',
-      tx,
     }
 
     txDispatch(event, detail2)
@@ -44,8 +40,7 @@ describe('txEvents', () => {
     const event = TxEvent.FAILED
 
     const detail = {
-      txId: '0x123',
-      tx,
+      txHash: '0x123',
       error: new Error('Tx failed'),
     }
 

--- a/services/tx/__tests__/txMonitor.test.ts
+++ b/services/tx/__tests__/txMonitor.test.ts
@@ -29,7 +29,7 @@ describe('txMonitor', () => {
 
       waitForTxSpy.mockImplementationOnce(() => Promise.resolve(receipt))
 
-      await waitForTx(provider, '0x0', '0x0')
+      await waitForTx(provider, '0x0')
 
       expect(txDispatchSpy).not.toHaveBeenCalled()
     })
@@ -42,7 +42,7 @@ describe('txMonitor', () => {
 
       waitForTxSpy.mockImplementationOnce(() => Promise.resolve(receipt))
 
-      await waitForTx(provider, '0x0', '0x0')
+      await waitForTx(provider, '0x0')
 
       expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', { txId: '0x0', error: expect.any(Error) })
     })
@@ -52,7 +52,7 @@ describe('txMonitor', () => {
         () => Promise.resolve(null) as unknown as ReturnType<typeof provider.waitForTransaction>,
       )
 
-      await waitForTx(provider, '0x0', '0x0')
+      await waitForTx(provider, '0x0')
 
       expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', {
         txId: '0x0',
@@ -67,7 +67,7 @@ describe('txMonitor', () => {
 
       waitForTxSpy.mockImplementationOnce(() => Promise.resolve(receipt))
 
-      await waitForTx(provider, '0x0', '0x0')
+      await waitForTx(provider, '0x0')
 
       expect(txDispatchSpy).toHaveBeenCalledWith('REVERTED', {
         txId: '0x0',
@@ -79,7 +79,7 @@ describe('txMonitor', () => {
     it('emits a FAILED event if waitForTransaction times out', async () => {
       waitForTxSpy.mockImplementationOnce(() => Promise.reject(new Error('Test error.')))
 
-      await waitForTx(provider, '0x0', '0x0')
+      await waitForTx(provider, '0x0')
 
       // 6.5 minutes (timeout of txMonitor) + 1ms
       jest.advanceTimersByTime(6.5 * 60_000 + 1)
@@ -90,7 +90,7 @@ describe('txMonitor', () => {
     it('emits a FAILED event if waitForTransaction throws', async () => {
       waitForTxSpy.mockImplementationOnce(() => Promise.reject(new Error('Test error.')))
 
-      await waitForTx(provider, '0x0', '0x0')
+      await waitForTx(provider, '0x0')
 
       expect(txDispatchSpy).toHaveBeenCalledWith('FAILED', { txId: '0x0', error: new Error('Test error.') })
     })

--- a/services/tx/proposeTransaction.ts
+++ b/services/tx/proposeTransaction.ts
@@ -1,19 +1,17 @@
 import { proposeTransaction, Operation, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
 import type { SafeTransaction } from '@gnosis.pm/safe-core-sdk-types'
-import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 
 // It's important to cache proposals to avoid re-proposing the same transaction
 // Backend returns an error if you try to propose the same transaction twice
 const cache: Record<string, TransactionDetails> = {}
 
-const proposeTx = async (chainId: string, safeAddress: string, sender: string, tx: SafeTransaction) => {
-  const safeSDK = getSafeSDK()
-
-  if (!safeSDK) {
-    throw new Error('Safe SDK not initialized')
-  }
-
-  const safeTxHash = await safeSDK.getTransactionHash(tx)
+const proposeTx = async (
+  chainId: string,
+  safeAddress: string,
+  sender: string,
+  safeTxHash: string,
+  tx: SafeTransaction,
+): Promise<TransactionDetails> => {
   const signatures = tx.signatures.size ? tx.encodedSignatures() : undefined
   const cacheKey = `${safeTxHash}_${signatures || ''}`
 

--- a/services/tx/txEvents.ts
+++ b/services/tx/txEvents.ts
@@ -1,4 +1,3 @@
-import type { SafeTransaction } from '@gnosis.pm/safe-core-sdk-types'
 import type { ContractReceipt } from 'ethers/lib/ethers'
 import EventBus from '@/services/EventBus'
 
@@ -17,17 +16,17 @@ export enum TxEvent {
 }
 
 interface TxEvents {
-  [TxEvent.CREATED]: { tx: SafeTransaction }
-  [TxEvent.SIGNED]: { txId?: string; tx: SafeTransaction }
-  [TxEvent.SIGN_FAILED]: { txId?: string; tx: SafeTransaction; error: Error }
-  [TxEvent.PROPOSE_FAILED]: { tx: SafeTransaction; error: Error }
-  [TxEvent.PROPOSED]: { txId: string; tx: SafeTransaction }
-  [TxEvent.EXECUTING]: { txId: string; tx: SafeTransaction }
-  [TxEvent.MINING]: { txId: string; txHash: string; tx: SafeTransaction }
-  [TxEvent.MINED]: { txId: string; receipt: ContractReceipt; tx: SafeTransaction }
-  [TxEvent.REVERTED]: { txId: string; error: Error; receipt: ContractReceipt; tx?: SafeTransaction }
-  [TxEvent.FAILED]: { txId: string; error: Error; tx?: SafeTransaction }
-  [TxEvent.SUCCESS]: { txId: string }
+  [TxEvent.CREATED]: { txHash: string }
+  [TxEvent.SIGNED]: { txHash: string }
+  [TxEvent.SIGN_FAILED]: { txHash: string; error: Error }
+  [TxEvent.PROPOSE_FAILED]: { txHash: string; error: Error }
+  [TxEvent.PROPOSED]: { txHash: string }
+  [TxEvent.EXECUTING]: { txHash: string }
+  [TxEvent.MINING]: { txHash: string }
+  [TxEvent.MINED]: { txHash: string; receipt: ContractReceipt }
+  [TxEvent.REVERTED]: { txHash: string; error: Error; receipt: ContractReceipt }
+  [TxEvent.FAILED]: { txHash: string; error: Error }
+  [TxEvent.SUCCESS]: { txHash: string }
 }
 
 const txEventBus = new EventBus<TxEvents>()

--- a/services/tx/txMonitor.ts
+++ b/services/tx/txMonitor.ts
@@ -4,7 +4,7 @@ import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import type { JsonRpcProvider } from '@ethersproject/providers'
 
 // Provider must be passed as an argument as it is undefined until initialised by `useInitWeb3`
-export const waitForTx = async (provider: JsonRpcProvider, txId: string, txHash: string) => {
+export const waitForTx = async (provider: JsonRpcProvider, txHash: string) => {
   const TIMEOUT_MINUTES = 6.5
 
   try {
@@ -18,7 +18,7 @@ export const waitForTx = async (provider: JsonRpcProvider, txId: string, txHash:
 
     if (didRevert(receipt)) {
       txDispatch(TxEvent.REVERTED, {
-        txId,
+        txHash,
         error: new Error(`Transaction reverted by EVM.`),
         receipt,
       })
@@ -27,7 +27,7 @@ export const waitForTx = async (provider: JsonRpcProvider, txId: string, txHash:
     // Tx successfully mined but we don't dispatch SUCCESS as this may be faster than our indexer
   } catch (error) {
     txDispatch(TxEvent.FAILED, {
-      txId,
+      txHash,
       error: error as Error,
     })
   }

--- a/store/pendingTxsSlice.ts
+++ b/store/pendingTxsSlice.ts
@@ -2,15 +2,13 @@ import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolki
 
 import type { RootState } from '@/store'
 
-type PendingTxsState =
-  | {
-      [txId: string]: {
-        chainId: string
-        status: string
-        txHash?: string
-      }
-    }
-  | Record<string, never>
+type PendingTx = {
+  txHash: string
+  chainId: string
+  status: string
+}
+
+type PendingTxsState = Record<PendingTx['txHash'], PendingTx>
 
 const initialState: PendingTxsState = {}
 
@@ -18,15 +16,12 @@ export const pendingTxsSlice = createSlice({
   name: 'pendingTxs',
   initialState,
   reducers: {
-    setPendingTx: (
-      state,
-      action: PayloadAction<{ chainId: string; txId: string; txHash?: string; status: string }>,
-    ) => {
-      const { txId, ...pendingTx } = action.payload
-      state[txId] = pendingTx
+    setPendingTx: (state, action: PayloadAction<PendingTx>) => {
+      const { txHash } = action.payload
+      state[txHash] = action.payload
     },
-    clearPendingTx: (state, action: PayloadAction<{ txId: string }>) => {
-      delete state[action.payload.txId]
+    clearPendingTx: (state, action: PayloadAction<{ txHash: string }>) => {
+      delete state[action.payload.txHash]
     },
   },
 })
@@ -37,7 +32,7 @@ export const selectPendingTxs = (state: RootState): PendingTxsState => {
   return state[pendingTxsSlice.name]
 }
 
-export const selectPendingTxById = createSelector(
-  [selectPendingTxs, (_: RootState, txId: string) => txId],
-  (pendingTxs, txId) => pendingTxs[txId],
+export const selectPendingTxByHash = createSelector(
+  [selectPendingTxs, (_: RootState, txHash: string) => txHash],
+  (pendingTxs, txHash) => pendingTxs[txHash],
 )

--- a/store/txHistorySlice.ts
+++ b/store/txHistorySlice.ts
@@ -33,10 +33,11 @@ export const txHistoryMiddleware: Middleware<{}, RootState> = (store) => (next) 
         if (!isTransactionListItem(result)) {
           continue
         }
+        // @TODO: have CGW add txHash to the TransactionSummary
+        const txHash = result.transaction.id.split('_').pop() || ''
 
-        const { id } = result.transaction
-        if (pendingTxs[id]) {
-          txDispatch(TxEvent.SUCCESS, { txId: id })
+        if (pendingTxs[txHash]) {
+          txDispatch(TxEvent.SUCCESS, { txHash })
         }
       }
     }


### PR DESCRIPTION
So I refactored this, and realized that txHash isn't available in TransactionSummary, whereas id is, and we rely quite a lot on that.

There's a hack to extract the hash from an id, but it's a hack. Ideally CGW should add a hash field to txSummary.