### PR TITLE
Refactor: call propose only after execution is confirmed

### DIFF
--- a/services/tx/__tests__/txSender.test.ts
+++ b/services/tx/__tests__/txSender.test.ts
@@ -49,6 +49,7 @@ const mockSafeSDK = {
   executeTransaction: jest.fn(),
   getChainId: jest.fn(() => Promise.resolve(4)),
   getAddress: jest.fn(() => '0x0000000000000000000000000000000000000123'),
+  getTransactionHash: jest.fn(() => Promise.resolve('0x1234567890')),
 } as unknown as Safe
 
 describe('txSender', () => {
@@ -127,7 +128,7 @@ describe('txSender', () => {
 
       const proposedTx = await dispatchTxProposal('4', '0x123', '0x456', tx)
 
-      expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx)
+      expect(proposeTx).toHaveBeenCalledWith('4', '0x123', '0x456', tx, '0x1234567890')
       expect(proposedTx).toEqual({ txId: '123' })
     })
   })

--- a/services/tx/proposeTransaction.ts
+++ b/services/tx/proposeTransaction.ts
@@ -1,19 +1,17 @@
 import { proposeTransaction, Operation, TransactionDetails } from '@gnosis.pm/safe-react-gateway-sdk'
 import type { SafeTransaction } from '@gnosis.pm/safe-core-sdk-types'
-import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 
 // It's important to cache proposals to avoid re-proposing the same transaction
 // Backend returns an error if you try to propose the same transaction twice
 const cache: Record<string, TransactionDetails> = {}
 
-const proposeTx = async (chainId: string, safeAddress: string, sender: string, tx: SafeTransaction) => {
-  const safeSDK = getSafeSDK()
-
-  if (!safeSDK) {
-    throw new Error('Safe SDK not initialized')
-  }
-
-  const safeTxHash = await safeSDK.getTransactionHash(tx)
+const proposeTx = async (
+  chainId: string,
+  safeAddress: string,
+  sender: string,
+  tx: SafeTransaction,
+  safeTxHash: string,
+) => {
   const signatures = tx.signatures.size ? tx.encodedSignatures() : undefined
   const cacheKey = `${safeTxHash}_${signatures || ''}`
 

--- a/services/tx/txEvents.ts
+++ b/services/tx/txEvents.ts
@@ -22,11 +22,11 @@ interface TxEvents {
   [TxEvent.SIGN_FAILED]: { txId?: string; tx: SafeTransaction; error: Error }
   [TxEvent.PROPOSE_FAILED]: { tx: SafeTransaction; error: Error }
   [TxEvent.PROPOSED]: { txId: string; tx: SafeTransaction }
-  [TxEvent.EXECUTING]: { txId: string; tx: SafeTransaction }
+  [TxEvent.EXECUTING]: { txId?: string; tx: SafeTransaction }
   [TxEvent.MINING]: { txId: string; txHash: string; tx: SafeTransaction }
   [TxEvent.MINED]: { txId: string; receipt: ContractReceipt; tx: SafeTransaction }
   [TxEvent.REVERTED]: { txId: string; error: Error; receipt: ContractReceipt; tx?: SafeTransaction }
-  [TxEvent.FAILED]: { txId: string; error: Error; tx?: SafeTransaction }
+  [TxEvent.FAILED]: { txId?: string; error: Error; tx?: SafeTransaction }
   [TxEvent.SUCCESS]: { txId: string }
 }
 


### PR DESCRIPTION
Propose is now called after execution is submitted in the wallet.