### PR TITLE
fix: Add tx action buttons to details screen

### DIFF
--- a/components/transactions/ExecuteTxButton/index.tsx
+++ b/components/transactions/ExecuteTxButton/index.tsx
@@ -1,18 +1,20 @@
 import { useState, type ReactElement, SyntheticEvent } from 'react'
 import { type TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
-import { Tooltip } from '@mui/material'
+import { Button, Tooltip } from '@mui/material'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import ExecuteTxModal from '@/components/tx/modals/ExecuteTxModal'
 import useIsPending from '@/hooks/useIsPending'
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch'
+import IconButton from '@mui/material/IconButton'
 
 const ExecuteTxButton = ({
   txSummary,
-  children,
+  compact = false,
 }: {
   txSummary: TransactionSummary
-  children: (onClick: (e: SyntheticEvent) => void, isDisabled: boolean) => ReactElement
+  compact?: boolean
 }): ReactElement => {
   const [open, setOpen] = useState<boolean>(false)
   const { safe } = useSafeInfo()
@@ -29,9 +31,17 @@ const ExecuteTxButton = ({
 
   return (
     <>
-      <Tooltip title="Execute" arrow placement="top">
-        {children(onClick, isDisabled)}
-      </Tooltip>
+      {compact ? (
+        <Tooltip title="Execute" arrow placement="top">
+          <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
+            <RocketLaunchIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Button onClick={onClick} variant="contained" disabled={isDisabled}>
+          Execute
+        </Button>
+      )}
 
       {open && <ExecuteTxModal onClose={() => setOpen(false)} initialData={[txSummary]} />}
     </>

--- a/components/transactions/RejectTxButton/index.tsx
+++ b/components/transactions/RejectTxButton/index.tsx
@@ -1,20 +1,24 @@
 import { TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
-import { Tooltip } from '@mui/material'
+import { Button, Tooltip } from '@mui/material'
 
 import { useState, type ReactElement, SyntheticEvent } from 'react'
 import { useQueuedTxByNonce } from '@/hooks/useTxQueue'
 import { isCustomTxInfo, isMultisigExecutionInfo } from '@/utils/transaction-guards'
 import RejectTxModal from '@/components/tx/modals/RejectTxModal'
 import useIsPending from '@/hooks/useIsPending'
+import IconButton from '@mui/material/IconButton'
+import HighlightOffIcon from '@mui/icons-material/HighlightOff'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 
 const RejectTxButton = ({
   txSummary,
-  children,
+  compact = false,
 }: {
   txSummary: TransactionSummary
-  children: (onClick: (e: SyntheticEvent) => void, isDisabled: boolean) => ReactElement
+  compact?: boolean
 }): ReactElement | null => {
   const [open, setOpen] = useState<boolean>(false)
+  const isSafeOwner = useIsSafeOwner()
   const txNonce = isMultisigExecutionInfo(txSummary.executionInfo) ? txSummary.executionInfo.nonce : undefined
   const queuedTxsByNonce = useQueuedTxByNonce(txNonce)
   const canCancel = !queuedTxsByNonce?.some(
@@ -22,7 +26,7 @@ const RejectTxButton = ({
   )
   const isPending = useIsPending({ txId: txSummary.id })
 
-  const isDisabled = isPending
+  const isDisabled = isPending || !isSafeOwner
 
   const onClick = (e: SyntheticEvent) => {
     e.stopPropagation()
@@ -33,9 +37,17 @@ const RejectTxButton = ({
 
   return (
     <>
-      <Tooltip title="Reject" arrow placement="top">
-        {children(onClick, isDisabled)}
-      </Tooltip>
+      {compact ? (
+        <Tooltip title="Reject" arrow placement="top">
+          <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>
+            <HighlightOffIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Button onClick={onClick} color="error" variant="contained" disabled={isDisabled}>
+          Reject
+        </Button>
+      )}
 
       {open && <RejectTxModal onClose={() => setOpen(false)} initialData={[txSummary]} />}
     </>

--- a/components/transactions/SignTxButton/index.tsx
+++ b/components/transactions/SignTxButton/index.tsx
@@ -1,19 +1,21 @@
 import { useState, type ReactElement, SyntheticEvent } from 'react'
 import { type TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
-import { Tooltip } from '@mui/material'
+import { Button, Tooltip } from '@mui/material'
 
 import { isSignableBy } from '@/utils/transaction-guards'
 import useWallet from '@/hooks/wallets/useWallet'
 import ConfirmTxModal from '@/components/tx/modals/ConfirmTxModal'
 import useIsPending from '@/hooks/useIsPending'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import IconButton from '@mui/material/IconButton'
+import CheckIcon from '@mui/icons-material/Check'
 
 const SignTxButton = ({
   txSummary,
-  children,
+  compact = false,
 }: {
   txSummary: TransactionSummary
-  children: (onClick: (e: SyntheticEvent) => void, isDisabled: boolean) => ReactElement
+  compact?: boolean
 }): ReactElement => {
   const [open, setOpen] = useState<boolean>(false)
   const wallet = useWallet()
@@ -30,9 +32,17 @@ const SignTxButton = ({
 
   return (
     <>
-      <Tooltip title="Sign" arrow placement="top">
-        {children(onClick, isDisabled)}
-      </Tooltip>
+      {compact ? (
+        <Tooltip title="Sign" arrow placement="top">
+          <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
+            <CheckIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Button onClick={onClick} variant="contained" disabled={isDisabled}>
+          Sign
+        </Button>
+      )}
 
       {open && <ConfirmTxModal onClose={() => setOpen(false)} initialData={[txSummary]} />}
     </>

--- a/components/transactions/TxDetails/index.tsx
+++ b/components/transactions/TxDetails/index.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement } from 'react'
 import { getTransactionDetails, TransactionDetails, TransactionSummary } from '@gnosis.pm/safe-react-gateway-sdk'
-import { Box, Button, CircularProgress } from '@mui/material'
+import { Box, CircularProgress } from '@mui/material'
 
 import TxSigners from '@/components/transactions/TxSigners'
 import Summary from '@/components/transactions/TxDetails/Summary'
@@ -25,6 +25,7 @@ import ExecuteTxButton from '@/components/transactions/ExecuteTxButton'
 import SignTxButton from '@/components/transactions/SignTxButton'
 import RejectTxButton from '@/components/transactions/RejectTxButton'
 import useWallet from '@/hooks/wallets/useWallet'
+import useIsWrongChain from '@/hooks/useIsWrongChain'
 
 export const NOT_AVAILABLE = 'n/a'
 
@@ -35,6 +36,7 @@ type TxDetailsProps = {
 
 const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement => {
   const wallet = useWallet()
+  const isWrongChain = useIsWrongChain()
   const isQueue = isTxQueued(txSummary.txStatus)
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
   // confirmations are in detailedExecutionInfo
@@ -83,32 +85,10 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
       {hasSigners && (
         <div className={css.txSigners}>
           <TxSigners txDetails={txDetails} txSummary={txSummary} />
-          {wallet && isQueue && (
+          {wallet && !isWrongChain && isQueue && (
             <Box display="flex" alignItems="center" justifyContent="center" gap={1} mt={2}>
-              {awaitingExecution ? (
-                <ExecuteTxButton txSummary={txSummary}>
-                  {(onClick, isDisabled) => (
-                    <Button onClick={onClick} variant="contained" disabled={isDisabled}>
-                      Execute
-                    </Button>
-                  )}
-                </ExecuteTxButton>
-              ) : (
-                <SignTxButton txSummary={txSummary}>
-                  {(onClick, isDisabled) => (
-                    <Button onClick={onClick} variant="contained" disabled={isDisabled}>
-                      Sign
-                    </Button>
-                  )}
-                </SignTxButton>
-              )}
-              <RejectTxButton txSummary={txSummary}>
-                {(onClick, isDisabled) => (
-                  <Button onClick={onClick} color="error" variant="contained" disabled={isDisabled}>
-                    Reject
-                  </Button>
-                )}
-              </RejectTxButton>
+              {awaitingExecution ? <ExecuteTxButton txSummary={txSummary} /> : <SignTxButton txSummary={txSummary} />}
+              <RejectTxButton txSummary={txSummary} />
             </Box>
           )}
         </div>

--- a/components/transactions/TxSummary/index.tsx
+++ b/components/transactions/TxSummary/index.tsx
@@ -13,10 +13,7 @@ import RejectTxButton from '@/components/transactions/RejectTxButton'
 import { useTransactionStatus } from '@/hooks/useTransactionStatus'
 import TxType from '@/components/transactions/TxType'
 import GroupIcon from '@mui/icons-material/Group'
-import IconButton from '@mui/material/IconButton'
-import RocketLaunchIcon from '@mui/icons-material/RocketLaunch'
-import CheckIcon from '@mui/icons-material/Check'
-import HighlightOffIcon from '@mui/icons-material/HighlightOff'
+import useIsWrongChain from '@/hooks/useIsWrongChain'
 
 const getStatusColor = (value: TransactionStatus, palette: Palette) => {
   switch (value) {
@@ -41,6 +38,7 @@ type TxSummaryProps = {
 const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
   const tx = item.transaction
   const wallet = useWallet()
+  const isWrongChain = useIsWrongChain()
   const txStatusLabel = useTransactionStatus(tx)
   const isQueue = isTxQueued(tx.txStatus)
   const awaitingExecution = isAwaitingExecution(tx.txStatus)
@@ -86,32 +84,14 @@ const TxSummary = ({ item, isGrouped }: TxSummaryProps): ReactElement => {
         </Box>
       )}
 
-      {wallet && isQueue && (
+      {wallet && !isWrongChain && isQueue && (
         <Box gridArea="actions">
           {awaitingExecution ? (
-            <ExecuteTxButton txSummary={item.transaction}>
-              {(onClick, isDisabled) => (
-                <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
-                  <RocketLaunchIcon fontSize="small" />
-                </IconButton>
-              )}
-            </ExecuteTxButton>
+            <ExecuteTxButton txSummary={item.transaction} compact />
           ) : (
-            <SignTxButton txSummary={item.transaction}>
-              {(onClick, isDisabled) => (
-                <IconButton onClick={onClick} color="primary" disabled={isDisabled} size="small">
-                  <CheckIcon fontSize="small" />
-                </IconButton>
-              )}
-            </SignTxButton>
+            <SignTxButton txSummary={item.transaction} compact />
           )}
-          <RejectTxButton txSummary={item.transaction}>
-            {(onClick, isDisabled) => (
-              <IconButton onClick={onClick} color="error" size="small" disabled={isDisabled}>
-                <HighlightOffIcon fontSize="small" />
-              </IconButton>
-            )}
-          </RejectTxButton>
+          <RejectTxButton txSummary={item.transaction} compact />
         </Box>
       )}
 


### PR DESCRIPTION
## What it solves

- Displays Execute, Sign, Reject Buttons under TxSigners
- Converts Button components into HoC to support both IconButtons for the summary and normal Buttons for the details

## Screenshot
<img width="1273" alt="Screenshot 2022-08-03 at 11 04 13" src="https://user-images.githubusercontent.com/5880855/182569802-66a63c5d-3499-4c42-a262-1889f6336126.png">

