### PR TITLE
fix: Vertical stepper showing old step data when navigating

### DIFF
--- a/components/tx/TxStepper/vertical.tsx
+++ b/components/tx/TxStepper/vertical.tsx
@@ -22,7 +22,7 @@ const VerticalTxStepper = ({ steps, initialData, initialStep, onClose, onFinish 
           return (
             <Step key={label}>
               <StepLabel>{label}</StepLabel>
-              <StepContent>{render(stepData[Math.max(0, index)], onSubmit, onBack, setStep)}</StepContent>
+              <StepContent>{render(stepData[index], onSubmit, onBack, setStep)}</StepContent>
             </Step>
           )
         })}


### PR DESCRIPTION
## What it solves

We don't need to access the activeStep when already mapping over the steps.

## How to test

1. Open the safe creation stepper
2. Press Continue and Back
3. Observe the new step data not "flashing" in the previous step