### PR TITLE
fix: Disable submit button if threshold hasn't changed

### DIFF
--- a/components/settings/owner/ChangeThresholdDialog/index.tsx
+++ b/components/settings/owner/ChangeThresholdDialog/index.tsx
@@ -46,26 +46,19 @@ export const ChangeThresholdDialog = () => {
 const ChangeThresholdStep = ({ data, onSubmit }: { data: ChangeThresholdData; onSubmit: (data: null) => void }) => {
   const { safe } = useSafeInfo()
   const [selectedThreshold, setSelectedThreshold] = useState<number>(data.threshold)
-  const [disableSubmit, setDisableSubmit] = useState<boolean>(true)
 
   const handleChange = (event: SelectChangeEvent<number>) => {
-    const newThreshold = parseInt(event.target.value.toString())
-    setSelectedThreshold(newThreshold)
-    setDisableSubmit(newThreshold === data.threshold)
+    setSelectedThreshold(parseInt(event.target.value.toString()))
   }
 
-  const [safeTx, safeTxError] = useAsync<SafeTransaction>(async () => {
+  const [safeTx, safeTxError] = useAsync<SafeTransaction | undefined>(async () => {
+    if (selectedThreshold === data.threshold) return
+
     return createUpdateThresholdTx(selectedThreshold)
   }, [selectedThreshold])
 
   return (
-    <SignOrExecuteForm
-      safeTx={safeTx}
-      isExecutable={safe.threshold === 1}
-      onSubmit={onSubmit}
-      error={safeTxError}
-      disableSubmit={disableSubmit}
-    >
+    <SignOrExecuteForm safeTx={safeTx} isExecutable={safe.threshold === 1} onSubmit={onSubmit} error={safeTxError}>
       <Typography mb={1}>Any transaction requires the confirmation of:</Typography>
 
       <Grid container direction="row" gap={1} alignItems="center" mb={2}>

--- a/components/tx/SignOrExecuteForm/index.tsx
+++ b/components/tx/SignOrExecuteForm/index.tsx
@@ -27,7 +27,6 @@ type SignOrExecuteProps = {
   isRejection?: boolean
   onlyExecute?: boolean
   onSubmit: (data: null) => void
-  disableSubmit?: boolean
   children?: ReactNode
   error?: Error
 }
@@ -39,7 +38,6 @@ const SignOrExecuteForm = ({
   isRejection,
   onlyExecute,
   onSubmit,
-  disableSubmit,
   children,
   error,
 }: SignOrExecuteProps): ReactElement => {
@@ -63,7 +61,7 @@ const SignOrExecuteForm = ({
   // If checkbox is checked and the transaction is executable, execute it, otherwise sign it
   const willExecute = shouldExecute && canExecute
 
-  // Syncronize the tx with the safeTx
+  // Synchronize the tx with the safeTx
   useEffect(() => setTx(safeTx), [safeTx])
 
   // Estimate gas limit
@@ -179,7 +177,7 @@ const SignOrExecuteForm = ({
     setManualParams(data)
   }
 
-  const submitDisabled = !isSubmittable || isEstimating || disableSubmit
+  const submitDisabled = !isSubmittable || isEstimating || !tx
 
   return isEditingGas ? (
     <AdvancedParamsForm


### PR DESCRIPTION
## What it solves

- Adds a new optional prop `disableSubmit` to `SignOrExecuteForm`
- Disables the Submit button in the Change Threshold modal until the threshold is changed