### PR TITLE
Fix: shrink AddressInput if value not empty

### DIFF
--- a/components/common/AddressInput/index.tsx
+++ b/components/common/AddressInput/index.tsx
@@ -16,10 +16,10 @@ const AddressInput = ({ name, validate, ...props }: AddressInputProps): ReactEle
     formState: { errors },
   } = useFormContext()
   const currentChain = useCurrentChain()
-  const currentValue = watch(name)?.trim()
+  const currentValue = watch(name)
 
   // Fetch an ENS resolution for the current address
-  const { address, resolving } = useNameResolver(currentValue)
+  const { address, resolving } = useNameResolver(currentValue?.trim())
 
   const setAddressValue = useCallback(
     (value: string) => {
@@ -49,6 +49,10 @@ const AddressInput = ({ name, validate, ...props }: AddressInputProps): ReactEle
                 <CircularProgress size={20} />
               </InputAdornment>
             ),
+          }}
+          InputLabelProps={{
+            ...(props.InputLabelProps || {}),
+            shrink: !!currentValue,
           }}
           {...register(name, {
             required: true,


### PR DESCRIPTION
Fixes the AddressInput having an overlapping placeholder when inserting the address from a QR code.