### PR TITLE
fix: Show token symbol for spending limit tx data

### DIFF
--- a/components/balances/AssetsTable/index.tsx
+++ b/components/balances/AssetsTable/index.tsx
@@ -47,7 +47,7 @@ const AssetsTable = ({ items }: AssetsTableProps): ReactElement => {
         <div className={css.alignCenter}>
           <TokenIcon logoUri={item.tokenInfo.logoUri} tokenSymbol={item.tokenInfo.symbol} />
 
-          <Typography fontSize="medium">{item.tokenInfo.name}</Typography>
+          <Typography>{item.tokenInfo.name}</Typography>
 
           {item.tokenInfo.type !== TokenType.NATIVE_TOKEN && <TokenExplorerLink address={item.tokenInfo.address} />}
         </div>

--- a/components/common/TokenAmount/index.tsx
+++ b/components/common/TokenAmount/index.tsx
@@ -10,7 +10,7 @@ export const TokenIcon = (props: { logoUri?: string; tokenSymbol?: string; size?
   const { logoUri, tokenSymbol, size = DEFAULT_SIZE } = props
   const [src, setSrc] = useState<string>(logoUri || '')
 
-  useEffect(() => void setSrc(logoUri || ''), [logoUri])
+  useEffect(() => setSrc(logoUri || ''), [logoUri])
 
   return !src ? null : (
     <img src={src} alt={tokenSymbol} className={css.tokenIcon} onError={() => setSrc(FALLBACK_ICON)} height={size} />

--- a/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
+++ b/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
@@ -61,6 +61,8 @@ export const SpendingLimits = ({ txData, txInfo, type }: SpendingLimitsProps): R
           </Typography>
           <Box className={css.inline}>
             <TokenIcon logoUri={tokenInfo.logoUri} size={32} tokenSymbol={tokenInfo.symbol} />
+            <Typography>{tokenInfo.symbol}</Typography>
+
             {isSetAllowanceMethod ? (
               <Typography>
                 {formatDecimals(amount as string, tokenInfo.decimals)} {tokenInfo.symbol}


### PR DESCRIPTION
Before:
<img width="627" alt="Screenshot 2022-08-04 at 14 24 47" src="https://user-images.githubusercontent.com/5880855/182846311-6623ca61-6282-4e5d-8964-c7e617e98e2a.png">

After:
<img width="535" alt="Screenshot 2022-08-04 at 14 24 51" src="https://user-images.githubusercontent.com/5880855/182846325-878f92a1-e7de-418f-9dfd-958a9f088d95.png">

