### PR TITLE
Fix: show spending limit only if enabled

### DIFF
--- a/components/common/EthHashInfo/index.tsx
+++ b/components/common/EthHashInfo/index.tsx
@@ -25,7 +25,7 @@ type EthHashInfoProps = {
   avatarSize?: number
 }
 
-const SRCEthHashInfo = ({
+const EthHashInfo = ({
   address,
   customAvatar,
   prefix = '',
@@ -55,7 +55,11 @@ const SRCEthHashInfo = ({
       )}
 
       <div>
-        {props.name && <Typography variant="body2">{props.name}</Typography>}
+        {props.name && (
+          <Typography variant="body2" component="div">
+            {props.name}
+          </Typography>
+        )}
 
         <Box className={css.addressRow}>
           <Typography variant="body2" fontWeight="inherit" component="div" className={css.address}>
@@ -72,7 +76,10 @@ const SRCEthHashInfo = ({
   )
 }
 
-const EthHashInfo = ({ showName = true, ...props }: EthHashInfoProps & { showName?: boolean }): ReactElement => {
+const PrefixedEthHashInfo = ({
+  showName = true,
+  ...props
+}: EthHashInfoProps & { showName?: boolean }): ReactElement => {
   const settings = useAppSelector(selectSettings)
   const chain = useCurrentChain()
   const addressBook = useAddressBook()
@@ -80,7 +87,7 @@ const EthHashInfo = ({ showName = true, ...props }: EthHashInfoProps & { showNam
   const name = showName ? addressBook[props.address] || props.name : undefined
   const prefix = settings.shortName.show ? chain?.shortName : undefined
 
-  return <SRCEthHashInfo prefix={prefix} {...props} name={name} />
+  return <EthHashInfo prefix={prefix} {...props} name={name} />
 }
 
-export default EthHashInfo
+export default PrefixedEthHashInfo

--- a/components/settings/SpendingLimits/index.tsx
+++ b/components/settings/SpendingLimits/index.tsx
@@ -6,12 +6,17 @@ import { selectSpendingLimits } from '@/store/spendingLimitsSlice'
 import { NewSpendingLimit } from '@/components/settings/SpendingLimits/NewSpendingLimit'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import useIsWrongChain from '@/hooks/useIsWrongChain'
+import { useCurrentChain } from '@/hooks/useChains'
+import { hasFeature } from '@/utils/chains'
+import { FEATURES } from '@gnosis.pm/safe-react-gateway-sdk'
 
 const SpendingLimits = () => {
   const isSafeOwner = useIsSafeOwner()
   const isWrongChain = useIsWrongChain()
   const spendingLimits = useSelector(selectSpendingLimits)
+  const currentChain = useCurrentChain()
 
+  const isEnabled = currentChain && hasFeature(currentChain, FEATURES.SPENDING_LIMIT)
   const isGranted = isSafeOwner && !isWrongChain
 
   return (
@@ -22,18 +27,30 @@ const SpendingLimits = () => {
             Spending limit
           </Typography>
         </Grid>
+
         <Grid item sm={12} md={8}>
-          <Box>
-            <Typography>
-              You can set rules for specific beneficiaries to access funds from this Safe without having to collect all
-              signatures.
-            </Typography>
-            {isGranted && <NewSpendingLimit />}
-          </Box>
+          {isEnabled ? (
+            <Box>
+              <Typography>
+                You can set rules for specific beneficiaries to access funds from this Safe without having to collect
+                all signatures.
+              </Typography>
+
+              {isGranted && <NewSpendingLimit />}
+            </Box>
+          ) : (
+            <Typography>The spending limit module is not yet available on this chain.</Typography>
+          )}
         </Grid>
       </Grid>
 
-      {spendingLimits.length > 0 ? <SpendingLimitsTable spendingLimits={spendingLimits} /> : <NoSpendingLimits />}
+      {isEnabled ? (
+        spendingLimits.length > 0 ? (
+          <SpendingLimitsTable spendingLimits={spendingLimits} />
+        ) : (
+          <NoSpendingLimits />
+        )
+      ) : null}
     </Paper>
   )
 }

--- a/components/sidebar/SafeListItem/index.tsx
+++ b/components/sidebar/SafeListItem/index.tsx
@@ -78,7 +78,8 @@ const SafeListItem = ({
             <SafeIcon address={address} {...rest} />
           </ListItemIcon>
           <ListItemText
-            primaryTypographyProps={{ variant: 'body2' }}
+            primaryTypographyProps={{ variant: 'body2', component: 'div' }}
+            secondaryTypographyProps={{ component: 'div' }}
             primary={name || ''}
             secondary={<EthHashInfo address={address} showAvatar={false} showName={false} />}
           />

--- a/config/chains.ts
+++ b/config/chains.ts
@@ -239,7 +239,7 @@ const chains: Record<string, string> = {
   oasis: '42262',
   avaeth: '43110',
   fuji: '43113',
-  avalanche: '43114',
+  avax: '43114',
   alfa: '44787',
   rei: '47805',
   tnrg: '49797',


### PR DESCRIPTION
<img width="1459" alt="Screenshot 2022-08-08 at 12 04 41" src="https://user-images.githubusercontent.com/381895/183393547-61992acd-70f3-492e-ae6f-dfc726e316ae.png">

Also fixed the Avalanche short name and the warning about a div in p.
