### PR TITLE
Fix: footer padding

### DIFF
--- a/components/common/Footer/styles.module.css
+++ b/components/common/Footer/styles.module.css
@@ -1,5 +1,5 @@
 .container {
-  margin-top: var(--space-2);
+  padding: var(--space-2);
   font-size: 13px;
 }
 

--- a/components/common/PaginatedTxns/index.tsx
+++ b/components/common/PaginatedTxns/index.tsx
@@ -19,7 +19,7 @@ const PaginatedTxns = ({ useTxns }: { useTxns: typeof useTxHistory | typeof useT
     ) : null
 
   return (
-    <>
+    <Box mb={3}>
       {loading ? (
         <CircularProgress size={20} sx={{ marginTop: 2 }} />
       ) : error ? (
@@ -35,7 +35,7 @@ const PaginatedTxns = ({ useTxns }: { useTxns: typeof useTxHistory | typeof useT
           <Pagination page={pageUrl} nextPage={page?.next} prevPage={page?.previous} onPageChange={setPageUrl} />
         </Box>
       )}
-    </>
+    </Box>
   )
 }
 


### PR DESCRIPTION
A fix for #283. Because footer was in `.main`, it lost the padding, so it needs its own padding.