### PR TITLE
fix: Only show single txs for current safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@gnosis.pm/safe-ethers-lib": "^1.4.0",
     "@gnosis.pm/safe-modules-deployments": "^1.0.0",
     "@gnosis.pm/safe-react-components": "git+https://github.com/safe-global/safe-react-components#revamp-safe-react-components",
-    "@gnosis.pm/safe-react-gateway-sdk": "^3.3.4",
+    "@gnosis.pm/safe-react-gateway-sdk": "^3.3.5",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.3",
     "@reduxjs/toolkit": "^1.8.2",

--- a/pages/safe/transactions/tx.tsx
+++ b/pages/safe/transactions/tx.tsx
@@ -48,7 +48,6 @@ const SingleTransaction: NextPage = () => {
     false,
   )
 
-  // @ts-ignore TODO: Update TransactionDetails type in gateway-sdk
   const isCurrentSafeTx = sameAddress(txDetails?.safeAddress, safeAddress)
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,10 +2770,10 @@
     react-media "^1.10.0"
     web3-utils "^1.6.0"
 
-"@gnosis.pm/safe-react-gateway-sdk@^3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-3.3.4.tgz#fea5e427e5e5a4bdbcdd865fd8da4e0c4b89e354"
-  integrity sha512-WGg9xoraotuKe99Xw/75HggoQCojzCMR5TN1AHy39oerVX7thsNBs0WU7NiJ/X/rvmWXfZ/DOqeOijswZDgrJw==
+"@gnosis.pm/safe-react-gateway-sdk@^3.3.5":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-3.3.5.tgz#b18f85f67487ce198efc9b480c84ed38680127fa"
+  integrity sha512-EXrVrAsIsO1+OB3Hk1VG8Bv1p4gIFDBu3k++7GT7tAE4B/m4cj3B2FhQx8oX4PK8SGExM/BJZtFHVrScMC+lhg==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
## What it solves

- Displays a not found error if the `tx` is not a `tx` of the current safe

## ToDos

- [x] Update gateway-sdk version to reflect type

## Screenshot
<img width="1400" alt="Screenshot 2022-08-08 at 15 16 34" src="https://user-images.githubusercontent.com/5880855/183426871-1abc3948-0bce-4c06-976b-abcff095a4a4.png">

