### PR TITLE
fix: Display exact date of tx after a certain threshold

### DIFF
--- a/components/common/DateTime/index.tsx
+++ b/components/common/DateTime/index.tsx
@@ -2,12 +2,14 @@ import { ReactElement } from 'react'
 import { Tooltip } from '@mui/material'
 import { formatDateTime, formatTimeInWords } from '@/utils/date'
 
+const DAYS_THRESHOLD = 60
+
 const DateTime = ({ value }: { value: number }): ReactElement => {
-  const olderThan60Days = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > 60
+  const displayExactDate = Math.floor((Date.now() - value) / 1000 / 60 / 60 / 24) > DAYS_THRESHOLD
 
   return (
-    <Tooltip title={olderThan60Days ? '' : formatDateTime(value)} placement="top">
-      <span>{olderThan60Days ? formatDateTime(value) : formatTimeInWords(value)}</span>
+    <Tooltip title={displayExactDate ? '' : formatDateTime(value)} placement="top">
+      <span>{displayExactDate ? formatDateTime(value) : formatTimeInWords(value)}</span>
     </Tooltip>
   )
 }


### PR DESCRIPTION
## What it solves

- Displays the exact Datetime for transactions that are older than 60 days

## Screenshot
<img width="1273" alt="Screenshot 2022-08-08 at 16 02 27" src="https://user-images.githubusercontent.com/5880855/183436452-afbf3fb6-ad48-4239-9bf9-ab6f1da49269.png">

