### PR TITLE
fix: Add amount fallback for spending limit tx display

### DIFF
--- a/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
+++ b/components/transactions/TxDetails/TxData/SpendingLimits/index.tsx
@@ -56,7 +56,7 @@ export const SpendingLimits = ({ txData, txInfo, type }: SpendingLimitsProps): R
       </Box>
       <Box className={css.group}>
         <Typography sx={({ palette }) => ({ color: palette.secondary.light })}>
-          {isSetAllowanceMethod ? 'Amount' : 'Token'}
+          {isSetAllowanceMethod ? (tokenInfo ? 'Amount' : 'Raw Amount (in decimals)') : 'Token'}
         </Typography>
         <Box className={css.inline}>
           {tokenInfo && (


### PR DESCRIPTION
## What it solves

- In case we can't find the `tokenInfo` for a given spending limit tx i.e. if the token is no longer in the safe we display the raw amount

## Screenshot
<img width="1260" alt="Screenshot 2022-08-08 at 17 04 57" src="https://user-images.githubusercontent.com/5880855/183450657-b63e09b4-eca6-41fb-89ae-b818893a7d5b.png">

