### PR TITLE
fix: 404 on load safe page

### DIFF
--- a/components/sidebar/SafeListItem/index.tsx
+++ b/components/sidebar/SafeListItem/index.tsx
@@ -60,7 +60,7 @@ const SafeListItem = ({
             chainId={chainId}
             address={address}
             onClick={closeDrawer}
-            href={`${AppRoutes.load.safe}?safe=${chain?.shortName}:${address}`}
+            href={`${AppRoutes.load.safe}?address=${chain?.shortName}:${address}`}
           />
           <SafeListContextMenu address={address} chainId={chainId} />
         </Box>

--- a/pages/load/safe.tsx
+++ b/pages/load/safe.tsx
@@ -1,10 +1,12 @@
 import type { NextPage } from 'next'
 import LoadSafe from '@/components/load-safe'
 import { useEffect, useState } from 'react'
-import useSafeAddress from '@/hooks/useSafeAddress'
+import { useRouter } from 'next/router'
 
 const LoadSafeWithAddress: NextPage = () => {
-  const safeAddress = useSafeAddress()
+  const router = useRouter()
+  const { address = '' } = router.query
+  const safeAddress = Array.isArray(address) ? address[0] : address
   const [id, setId] = useState<string>(safeAddress)
 
   const initialData = {


### PR DESCRIPTION
## What it solves

We used the `safe` query param when loading a specific safe but our query rewrite hook would pick it up and replace it in the URL which caused a 404. Instead we now use a new query param `address`

## How to test

1. Click "Add Safe" in the Sidebar
2. Press F5
3. Observe no 404