### PR TITLE
fix: Resolve address when adding or replacing an owner

### DIFF
--- a/components/common/AddressInput/index.tsx
+++ b/components/common/AddressInput/index.tsx
@@ -44,6 +44,7 @@ const AddressInput = ({ name, validate, ...props }: AddressInputProps): ReactEle
         <TextField
           {...props}
           autoComplete="off"
+          // Need the fallback here otherwise the tests fail
           label={<>{error?.message || errors[name]?.message || props.label}</>}
           error={!!error || !!errors[name]}
           fullWidth


### PR DESCRIPTION
## What it solves

- Adds the `useAddressResolver` hook to the add owner modal
- Refactors Add Owner modal to reuse existing type `OwnerData`