### PR TITLE
Fix: a small optimization for useAddressResolver

### DIFF
--- a/hooks/useAddressResolver.ts
+++ b/hooks/useAddressResolver.ts
@@ -44,11 +44,13 @@ export const useAddressResolver = (address: string) => {
     return lookupOwnerAddress(debouncedValue)
   }, [lookupOwnerAddress, debouncedValue])
 
+  const resolving = isResolving && !!ethersProvider && !!debouncedValue
+
   return useMemo(
     () => ({
       name,
-      resolving: isResolving && !!ethersProvider && !!debouncedValue,
+      resolving,
     }),
-    [name, isResolving, ethersProvider, debouncedValue],
+    [name, resolving],
   )
 }


### PR DESCRIPTION
The point of this useMemo is to avoid returning a new object every time, so it's better to have less dependencies.