### PR TITLE
fix: adjust padding

### DIFF
--- a/components/create-safe/status/styles.module.css
+++ b/components/create-safe/status/styles.module.css
@@ -1,7 +1,7 @@
 .loading {
-  width: 134px;
-  height: 92px;
-  padding: 0px 10px;
+  width: 138px;
+  height: 94px;
+  padding: 1px 12px;
   border-radius: 4px;
   background-color: #fff;
 }


### PR DESCRIPTION
## What this solves

As a follow-up to https://github.com/safe-global/web-core/pull/305, on higher resolution screens, the loading indicator borders were not crisp on the top and bottom in dark mode.

![image](https://user-images.githubusercontent.com/20442784/183652145-b8314e33-6883-41db-907a-e3589fdb6125.png)