### PR TITLE
Fix: don't init onboard twice

### DIFF
--- a/hooks/wallets/useOnboard.ts
+++ b/hooks/wallets/useOnboard.ts
@@ -49,10 +49,10 @@ export const useInitOnboard = () => {
   const onboard = useStore()
 
   useEffect(() => {
-    if (configs.length > 0) {
+    if (configs.length > 0 && !onboard) {
       initOnboard(configs).then(setStore)
     }
-  }, [configs])
+  }, [configs, onboard])
 
   // Disable unsupported wallets on the current chain
   useEffect(() => {


### PR DESCRIPTION
Fixes onboard errors on hot reload.
It has caused so much teeth grinding yet the fix is super simple...