### PR TITLE
style: Limit width name in sidebars

### DIFF
--- a/components/common/EthHashInfo/index.tsx
+++ b/components/common/EthHashInfo/index.tsx
@@ -54,9 +54,9 @@ const EthHashInfo = ({
         </div>
       )}
 
-      <div>
+      <div className={css.nameRow}>
         {props.name && (
-          <Typography variant="body2" component="div">
+          <Typography variant="body2" component="div" textOverflow="ellipsis" overflow="hidden" title={props.name}>
             {props.name}
           </Typography>
         )}

--- a/components/common/EthHashInfo/styles.module.css
+++ b/components/common/EthHashInfo/styles.module.css
@@ -26,3 +26,7 @@
   gap: 0.25em;
   white-space: nowrap;
 }
+
+.nameRow {
+  overflow: hidden;
+}

--- a/components/sidebar/SafeListContextMenu/styles.module.css
+++ b/components/sidebar/SafeListContextMenu/styles.module.css
@@ -9,9 +9,6 @@
 .menu :global .MuiMenuItem-root {
   padding-left: 12px;
   min-height: 40px;
-}
-
-.menu :global .MuiMenuItem-root:hover {
   border-radius: 8px !important;
 }
 

--- a/components/sidebar/SafeListItem/index.tsx
+++ b/components/sidebar/SafeListItem/index.tsx
@@ -55,7 +55,7 @@ const SafeListItem = ({
       className={css.container}
       disablePadding
       secondaryAction={
-        <Box display="flex" alignItems="center">
+        <Box display="flex" alignItems="center" gap={1}>
           <SafeListItemSecondaryAction
             chainId={chainId}
             address={address}
@@ -78,7 +78,14 @@ const SafeListItem = ({
             <SafeIcon address={address} {...rest} />
           </ListItemIcon>
           <ListItemText
-            primaryTypographyProps={{ variant: 'body2', component: 'div' }}
+            sx={{ pr: 10 }}
+            primaryTypographyProps={{
+              variant: 'body2',
+              component: 'div',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+            }}
             secondaryTypographyProps={{ component: 'div' }}
             primary={name || ''}
             secondary={<EthHashInfo address={address} showAvatar={false} showName={false} />}

--- a/components/sidebar/SafeListItemSecondaryAction/index.tsx
+++ b/components/sidebar/SafeListItemSecondaryAction/index.tsx
@@ -10,6 +10,7 @@ import useChains from '@/hooks/useChains'
 import { isOwner } from '@/utils/transaction-guards'
 
 import css from './styles.module.css'
+import { formatAmount } from '@/utils/formatNumber'
 
 const SafeListItemSecondaryAction = ({
   chainId,
@@ -59,12 +60,14 @@ const SafeListItemSecondaryAction = ({
     )
   }
 
-  if (addedSafes?.[address]?.ethBalance) {
+  const balance = addedSafes?.[address]?.ethBalance
+
+  if (balance) {
     const { nativeCurrency } = configs.find((chain) => chain.chainId === chainId) || {}
 
     return (
       <Typography variant="body2" fontWeight={700}>
-        {addedSafes[address].ethBalance} {nativeCurrency?.symbol || 'ETH'}
+        {formatAmount(balance)} {nativeCurrency?.symbol || 'ETH'}
       </Typography>
     )
   }

--- a/components/sidebar/Sidebar/index.tsx
+++ b/components/sidebar/Sidebar/index.tsx
@@ -24,6 +24,16 @@ const Sidebar = (): ReactElement => {
     setIsDrawerOpen((prev) => !prev)
   }
 
+  if (!isSafeRoute) {
+    return (
+      <div className={css.noSafe}>
+        <div className={css.scroll}>
+          <OwnedSafes />
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className={css.container}>
       <div className={css.scroll}>
@@ -35,19 +45,9 @@ const Sidebar = (): ReactElement => {
           <ChevronRight />
         </IconButton>
 
-        {isSafeRoute ? (
-          <>
-            <SidebarHeader />
-
-            <Divider />
-
-            <SidebarNavigation />
-          </>
-        ) : (
-          <div className={css.noSafeHeader}>
-            <OwnedSafes />
-          </div>
-        )}
+        <SidebarHeader />
+        <Divider />
+        <SidebarNavigation />
 
         <div style={{ flexGrow: 1 }} />
 

--- a/components/sidebar/Sidebar/styles.module.css
+++ b/components/sidebar/Sidebar/styles.module.css
@@ -8,27 +8,25 @@
 }
 
 .container {
-  min-width: 220px;
+  width: 220px;
   border-right: 1px solid var(--color-border-light);
 }
 
 .scroll {
   position: relative;
-  width: inherit;
   overflow-y: auto;
   overflow-x: hidden;
   max-height: calc(100vh - var(--header-height)); /* needed for scroll */
 }
 
 .drawer,
-.noSafeHeader > * {
+.noSafe {
   width: 400px;
 }
 
 .drawer {
   text-align: center;
-  padding: 0;
-  padding-top: var(--header-height);
+  padding: var(--header-height) 0 0 0;
   border-right: 1px solid var(--color-border-light);
 }
 

--- a/components/sidebar/SidebarHeader/index.tsx
+++ b/components/sidebar/SidebarHeader/index.tsx
@@ -56,7 +56,7 @@ const SafeHeader = (): ReactElement => {
           )}
         </div>
 
-        <div>
+        <div className={css.address}>
           {safeLoading ? (
             <Typography variant="body2">
               <Skeleton variant="text" width={86} />

--- a/components/sidebar/SidebarHeader/styles.module.css
+++ b/components/sidebar/SidebarHeader/styles.module.css
@@ -1,5 +1,4 @@
 .container {
-  display: grid;
   padding: var(--space-2);
 }
 
@@ -27,4 +26,10 @@
 
 .iconButton:hover {
   background-color: var(--color-primary-background);
+}
+
+.address {
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
 }


### PR DESCRIPTION
## What it solves

- Adds text-overflow to safe name in sidebar
- Adds a native tooltip to the safe name element in the sidebar to display the full name
- Adds text-overflow to safe name in the safe list sidebar to not overlap with secondary actions
- Uses `formatAmount` for the safe balance to limit the number of fractions

## Screenshots
<img width="433" alt="Screenshot 2022-08-10 at 15 57 01" src="https://user-images.githubusercontent.com/5880855/183926899-e4b8414b-ec6a-4422-b9b4-34b65872dcd2.png">
<img width="255" alt="Screenshot 2022-08-10 at 15 57 04" src="https://user-images.githubusercontent.com/5880855/183926914-f4f6483b-94d3-485f-8122-e516264ee998.png">
<img width="413" alt="Screenshot 2022-08-10 at 16 27 19" src="https://user-images.githubusercontent.com/5880855/183926971-cfd996c2-7eed-432f-b959-6692c844aff7.png">

