### PR TITLE
style: Adjust noSafe sidebar style

### DIFF
--- a/components/sidebar/Sidebar/index.tsx
+++ b/components/sidebar/Sidebar/index.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactElement } from 'react'
 import { Divider, Drawer, IconButton } from '@mui/material'
 import { ChevronRight } from '@mui/icons-material'
 import { useRouter } from 'next/router'
+import classnames from 'classnames'
 
 import ChainIndicator from '@/components/common/ChainIndicator'
 import SidebarHeader from '@/components/sidebar/SidebarHeader'
@@ -24,18 +25,8 @@ const Sidebar = (): ReactElement => {
     setIsDrawerOpen((prev) => !prev)
   }
 
-  if (!isSafeRoute) {
-    return (
-      <div className={css.noSafe}>
-        <div className={css.scroll}>
-          <OwnedSafes />
-        </div>
-      </div>
-    )
-  }
-
   return (
-    <div className={css.container}>
+    <div className={classnames(css.container, { [css.noSafe]: !isSafeRoute })}>
       <div className={css.scroll}>
         <div className={css.chain}>
           <ChainIndicator />
@@ -45,9 +36,17 @@ const Sidebar = (): ReactElement => {
           <ChevronRight />
         </IconButton>
 
-        <SidebarHeader />
-        <Divider />
-        <SidebarNavigation />
+        {isSafeRoute ? (
+          <>
+            <SidebarHeader />
+            <Divider />
+            <SidebarNavigation />
+          </>
+        ) : (
+          <div className={css.noSafeHeader}>
+            <OwnedSafes />
+          </div>
+        )}
 
         <div style={{ flexGrow: 1 }} />
 


### PR DESCRIPTION
## What it solves

I've reverted some of the changes done in #325 so the no-safe sidebar is displayed correctly.

## Screenshots
<img width="671" alt="Screenshot 2022-08-11 at 11 19 05" src="https://user-images.githubusercontent.com/5880855/184102757-979cf71f-cf10-4cac-a3ff-b4e4ba648dea.png">
<img width="1444" alt="Screenshot 2022-08-11 at 11 21 15" src="https://user-images.githubusercontent.com/5880855/184102789-cff9c82e-a88d-4d29-adef-5efd76788731.png">

