### PR TITLE
Style: a small fix for the placeholder

### DIFF
--- a/components/common/PagePlaceholder/styles.module.css
+++ b/components/common/PagePlaceholder/styles.module.css
@@ -4,4 +4,6 @@
   align-items: center;
   justify-content: center;
   height: 100%;
+  padding-top: 5vh;
+  text-align: center;
 }


### PR DESCRIPTION
A small fix for the page placeholder. Otherwise it sticks to the top of the container.

<img width="788" alt="Screenshot 2022-08-11 at 12 28 32" src="https://user-images.githubusercontent.com/381895/184114614-8654b5a9-89c8-4532-b792-3426aa4b084c.png">
