### PR TITLE
Fix PagePlaceholder: move padding to container

### DIFF
--- a/components/common/PagePlaceholder/styles.module.css
+++ b/components/common/PagePlaceholder/styles.module.css
@@ -4,6 +4,5 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  padding-top: 5vh;
   text-align: center;
 }

--- a/components/common/PaginatedTxns/index.tsx
+++ b/components/common/PaginatedTxns/index.tsx
@@ -15,7 +15,9 @@ const PaginatedTxns = ({ useTxns }: { useTxns: typeof useTxHistory | typeof useT
 
   const placeholder =
     noTransactions && useTxns === useTxQueue ? (
-      <PagePlaceholder imageUrl="/images/no-transactions.svg" text="Queued transactions will appear here" />
+      <Box mt="5vh">
+        <PagePlaceholder imageUrl="/images/no-transactions.svg" text="Queued transactions will appear here" />
+      </Box>
     ) : null
 
   return (


### PR DESCRIPTION
Oops, I forgot that the same component is used on the Dashboard.

Case in point reg. paddings in components.

<img width="547" alt="Screenshot 2022-08-11 at 12 39 55" src="https://user-images.githubusercontent.com/381895/184116299-d0bb180f-460b-459e-a910-6e4b286ab79b.png">

