### PR TITLE
fix: Edit address name from sidebar on correct chain

### DIFF
--- a/src/components/address-book/EntryDialog/index.tsx
+++ b/src/components/address-book/EntryDialog/index.tsx
@@ -25,13 +25,15 @@ const EntryDialog = ({
     address: '',
   },
   disableAddressInput = false,
+  chainId,
 }: {
   handleClose: () => void
   defaultValues?: AddressEntry
   disableAddressInput?: boolean
+  chainId?: string
 }): ReactElement => {
   const dispatch = useAppDispatch()
-  const chainId = useChainId()
+  const currentChainId = useChainId()
 
   const methods = useForm<AddressEntry>({
     defaultValues,
@@ -42,7 +44,7 @@ const EntryDialog = ({
   const onSubmit = (data: AddressEntry) => {
     const { address } = parsePrefixedAddress(data.address)
 
-    dispatch(upsertAddressBookEntry({ chainId, name: data.name, address }))
+    dispatch(upsertAddressBookEntry({ chainId: chainId || currentChainId, name: data.name, address }))
 
     handleClose()
   }

--- a/src/components/sidebar/SafeListContextMenu/index.tsx
+++ b/src/components/sidebar/SafeListContextMenu/index.tsx
@@ -6,7 +6,6 @@ import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import ListItemText from '@mui/material/ListItemText'
 
-import useAddressBook from '@/hooks/useAddressBook'
 import EntryDialog from '@/components/address-book/EntryDialog'
 import SafeListRemoveDialog from '@/components/sidebar/SafeListRemoveDialog'
 import { useAppSelector } from '@/store'
@@ -21,12 +20,17 @@ enum ModalType {
 
 const defaultOpen = { [ModalType.RENAME]: false, [ModalType.REMOVE]: false }
 
-const SafeListContextMenu = ({ address, chainId }: { address: string; chainId: string }): ReactElement => {
+const SafeListContextMenu = ({
+  name,
+  address,
+  chainId,
+}: {
+  name: string
+  address: string
+  chainId: string
+}): ReactElement => {
   const addedSafes = useAppSelector((state) => selectAddedSafes(state, chainId))
   const isAdded = !!addedSafes?.[address]
-
-  const addressBook = useAddressBook()
-  const name = addressBook?.[address]
 
   const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>()
   const [open, setOpen] = useState<typeof defaultOpen>(defaultOpen)
@@ -82,7 +86,12 @@ const SafeListContextMenu = ({ address, chainId }: { address: string; chainId: s
       </Menu>
 
       {open[ModalType.RENAME] && (
-        <EntryDialog handleClose={handleCloseModal} defaultValues={{ name, address }} disableAddressInput />
+        <EntryDialog
+          handleClose={handleCloseModal}
+          defaultValues={{ name, address }}
+          chainId={chainId}
+          disableAddressInput
+        />
       )}
 
       {open[ModalType.REMOVE] && (

--- a/src/components/sidebar/SafeListItem/index.tsx
+++ b/src/components/sidebar/SafeListItem/index.tsx
@@ -63,7 +63,7 @@ const SafeListItem = ({
             onClick={closeDrawer}
             href={`${AppRoutes.load.safe}?chain=${shortName}&address=${shortName}:${address}`}
           />
-          <SafeListContextMenu address={address} chainId={chainId} />
+          <SafeListContextMenu name={name} address={address} chainId={chainId} />
         </Box>
       }
     >


### PR DESCRIPTION
## What it solves

Editing an address book entry always used the current chain id. This didn't work when trying to edit an added safe in the sidebar

## How to test

1. Open the safe
2. Add a safe on rinkeby
3. Switch to a different chain
4. Try to rename the safe on rinkeby from the sidebar
5. Observe the previous name being displayed
6. Observe that there is no new entry for that safe on the current chain
7. Observe the new name being persisted on the rinkeby addressbook