### PR TITLE
fix: improve truncation + add NFT fallbacks

### DIFF
--- a/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
+++ b/src/components/tx/modals/NftTransferModal/SendNftForm.tsx
@@ -40,7 +40,7 @@ export type SendNftFormProps = {
 }
 
 const NftMenuItem = ({ image, name, description }: { image: string; name: string; description?: string }) => (
-  <Grid container spacing={1} alignItems="center" wrap="nowrap" overflow="hidden">
+  <Grid container spacing={1} alignItems="center" wrap="nowrap">
     <Grid item>
       <Box width={20} height={20}>
         <ImageFallback src={image} fallbackSrc="/images/nft-placeholder.png" alt={name} height={20} />
@@ -136,6 +136,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
                       </InputAdornment>
                     )
                   }
+                  sx={{ '&.MuiMenu-paper': { overflow: 'hidden' } }}
                 >
                   {collections.map((item) => {
                     const count = allNfts.filter((nft) => nft.address === item.address).length
@@ -165,6 +166,7 @@ const SendNftForm = ({ params, onSubmit }: SendNftFormProps) => {
                   labelId="asset-label"
                   label={errors.tokenId?.message || 'Select an NFT'}
                   error={!!errors.tokenId}
+                  sx={{ '&.MuiMenu-paper': { overflow: 'hidden' } }}
                 >
                   {selectedTokens.map((item) => (
                     <MenuItem key={item.address + item.id} value={item.id}>


### PR DESCRIPTION
## What it solves

Resolves #639 & #640

## How this PR fixes it

1. `MenuItem` truncation has been improved: truncation only occurs when the menu is not expanded.
2. Defaults have been added to "unknown" items: "Unknown collection" and "Unknown NFT"

Note: @francovenica, I do not have a Safe where the horizontal scrollbar appeared but I have added an `overflow` which should prevent this.

## How to test it

1. Open `rin:0x1230B3d59858296A31053C1b8562Ecf89A2f888b` and attempt to send an NFT (using impersonator.xyz if necessary). Observe the truncation only occuring on the closed menu.
2. Open `rin:0x9913B9180C20C6b0F21B6480c84422F6ebc4B808` and attempt to send an NFT (using impersonator.xyz if necessary). Observe the fallback values.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/192463190-74db47ee-e494-4759-a537-11cd5d485df6.png)
![image](https://user-images.githubusercontent.com/20442784/192462969-c25c47d1-6a22-4819-b416-60a66e611077.png)

---

![image](https://user-images.githubusercontent.com/20442784/192462731-f30047fa-0d63-44be-9747-f634a87a0a70.png)
![image](https://user-images.githubusercontent.com/20442784/192462762-763ef973-61c6-41f3-b36e-343ba5566ee0.png)