### PR TITLE
fix: update `meta`

### DIFF
--- a/src/components/common/MetaTags/index.tsx
+++ b/src/components/common/MetaTags/index.tsx
@@ -5,7 +5,7 @@ import darkPalette from '@/styles/colors-dark'
 
 const descriptionText =
   'Safe (prev. Gnosis Safe) is the most trusted platform to manage digital assets on Ethereum and multiple EVMs. Over $40B secured. Unlock Ownership.'
-const titleText = 'Safe (prev. Gnosis Safe)'
+const titleText = 'Safe'
 
 const MetaTags = ({ prefetchUrl }: { prefetchUrl: string }) => (
   <>


### PR DESCRIPTION
## What it solves

Resolves inconsistent `meta`

## How this PR fixes it

In accordance with the [standardised `meta`](https://5afe.slack.com/archives/C03FNGQ1LTU/p1667910499284799?thread_ts=1667840653.495219&cid=C03FNGQ1LTU), it has been updated accordingly. 
Safe (prev. Gnosis Safe) is the most trusted platform to manage digital assets on Ethereum and multiple EVMs. Over $40B secured. Unlock Ownership.

## How to test it

Paste the PR link into a Tweet and observe the updated text.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/200577396-b5002b05-7a47-47a5-bba5-52f0fed6e7cd.png)