### PR TITLE
fix: show explorer link in decoded data

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/MethodDetails/index.tsx
@@ -27,7 +27,7 @@ export const MethodDetails = ({ data }: MethodDetailsProps): ReactElement => {
             {isArrayValueParam ? (
               <Value method={methodName} type={param.type} value={param.value as string} />
             ) : (
-              generateDataRowValue(param.value as string, inlineType)
+              generateDataRowValue(param.value as string, inlineType, true)
             )}
           </TxDataRow>
         )


### PR DESCRIPTION
## What it solves

Missing explorer link

## How this PR fixes it

The explorer link is now shown for addresses/hashes in decoded data.

## How to test it

Open a transaction with decoded data and observe the explorer link next to addresses/hashes.

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/20442784/200592116-527f61cf-5200-4f72-b58e-517f55dd3749.png)

After:

![image](https://user-images.githubusercontent.com/20442784/200592253-720bf1e8-38c8-43ed-b41e-6eeac388e930.png)