### PR TITLE
refactor: simplify `isValidMasterCopy`

### DIFF
--- a/src/hooks/__tests__/useSafeNotifications.test.ts
+++ b/src/hooks/__tests__/useSafeNotifications.test.ts
@@ -1,9 +1,7 @@
-import { act } from '@testing-library/react'
 import { renderHook } from '@/tests//test-utils'
 import useSafeNotifications from '../../hooks/useSafeNotifications'
 import useSafeInfo from '../../hooks/useSafeInfo'
 import { showNotification } from '@/store/notificationsSlice'
-import * as contracts from '@/services/contracts/safeContracts'
 
 // mock showNotification
 jest.mock('@/store/notificationsSlice', () => {
@@ -36,7 +34,7 @@ describe('useSafeNotifications', () => {
   })
 
   describe('Safe upgrade', () => {
-    it('should show a notification when the Safe version is out of date', async () => {
+    it('should show a notification when the Safe version is out of date', () => {
       // mock useSafeInfo to return a SafeInfo with an outdated version
       ;(useSafeInfo as jest.Mock).mockReturnValue({
         safe: {
@@ -49,9 +47,6 @@ describe('useSafeNotifications', () => {
 
       // render the hook
       const { result } = renderHook(() => useSafeNotifications())
-
-      // await
-      await act(async () => Promise.resolve())
 
       // check that the notification was shown
       expect(result.current).toBeUndefined()
@@ -69,7 +64,7 @@ describe('useSafeNotifications', () => {
       })
     })
 
-    it('should show a notification for legacy Safes', async () => {
+    it('should show a notification for legacy Safes', () => {
       // mock useSafeInfo to return a SafeInfo with an outdated version
       ;(useSafeInfo as jest.Mock).mockReturnValue({
         safe: {
@@ -82,9 +77,6 @@ describe('useSafeNotifications', () => {
 
       // render the hook
       const { result } = renderHook(() => useSafeNotifications())
-
-      // await
-      await act(async () => Promise.resolve())
 
       // check that the notification was shown
       expect(result.current).toBeUndefined()
@@ -99,7 +91,7 @@ describe('useSafeNotifications', () => {
       })
     })
 
-    it('should not show a notification when the Safe version is up to date', async () => {
+    it('should not show a notification when the Safe version is up to date', () => {
       ;(useSafeInfo as jest.Mock).mockReturnValue({
         safe: {
           implementation: { value: '0x123' },
@@ -110,9 +102,6 @@ describe('useSafeNotifications', () => {
 
       // render the hook
       const { result } = renderHook(() => useSafeNotifications())
-
-      // await
-      await act(async () => Promise.resolve())
 
       // check that the notification was shown
       expect(result.current).toBeUndefined()
@@ -121,21 +110,17 @@ describe('useSafeNotifications', () => {
   })
 
   describe('Invalid mastercopy', () => {
-    it('should show a notification when the mastercopy is invalid', async () => {
+    it('should show a notification when the mastercopy is invalid', () => {
       ;(useSafeInfo as jest.Mock).mockReturnValue({
         safe: {
           implementation: { value: '0x123' },
-          implementationVersionState: 'UP_TO_DATE',
+          implementationVersionState: 'UNKNOWN',
           version: '1.3.0',
         },
       })
-      jest.spyOn(contracts, 'isValidMasterCopy').mockImplementation((...args: any[]) => Promise.resolve(false))
 
       // render the hook
       const { result } = renderHook(() => useSafeNotifications())
-
-      // await
-      await act(async () => Promise.resolve())
 
       // check that the notification was shown
       expect(result.current).toBeUndefined()
@@ -159,13 +144,9 @@ describe('useSafeNotifications', () => {
           version: '1.3.0',
         },
       })
-      jest.spyOn(contracts, 'isValidMasterCopy').mockImplementation((...args: any[]) => Promise.resolve(true))
 
       // render the hook
       const { result } = renderHook(() => useSafeNotifications())
-
-      // await
-      await act(async () => Promise.resolve())
 
       // check that the notification was shown
       expect(result.current).toBeUndefined()

--- a/src/hooks/useSafeNotifications.ts
+++ b/src/hooks/useSafeNotifications.ts
@@ -4,7 +4,6 @@ import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript
 import useSafeInfo from './useSafeInfo'
 import { useAppDispatch } from '@/store'
 import { AppRoutes } from '@/config/routes'
-import useAsync from './useAsync'
 import { isValidMasterCopy } from '@/services/contracts/safeContracts'
 import { useRouter } from 'next/router'
 import useIsSafeOwner from './useIsSafeOwner'
@@ -68,15 +67,8 @@ const useSafeNotifications = (): void => {
    * Show a notification when the Safe master copy is not supported
    */
 
-  const masterCopy = safe.implementation.value
-
-  const [validMasterCopy] = useAsync(() => {
-    if (!masterCopy) return
-    return isValidMasterCopy(chainId, masterCopy)
-  }, [chainId, masterCopy])
-
   useEffect(() => {
-    if (validMasterCopy === undefined || validMasterCopy) return
+    if (isValidMasterCopy(safe)) return
 
     const id = dispatch(
       showNotification({
@@ -92,7 +84,7 @@ const useSafeNotifications = (): void => {
     return () => {
       dispatch(closeNotification({ id }))
     }
-  }, [dispatch, validMasterCopy])
+  }, [dispatch, safe])
 }
 
 export default useSafeNotifications

--- a/src/services/__tests__/safeContracts.test.ts
+++ b/src/services/__tests__/safeContracts.test.ts
@@ -1,49 +1,29 @@
-import { getMasterCopies } from '@safe-global/safe-gateway-typescript-sdk'
+import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { _getValidatedGetContractProps, isValidMasterCopy } from '../contracts/safeContracts'
-
-jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
-  getMasterCopies: jest.fn(),
-}))
 
 describe('safeContracts', () => {
   describe('isValidMasterCopy', () => {
-    it('returns false if address is not contained in result', async () => {
-      ;(getMasterCopies as jest.Mock).mockResolvedValue([
-        {
-          address: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
-          version: '1.3.0',
-          deployer: 'Gnosis',
-          deployedBlockNumber: 12504268,
-          lastIndexedBlockNumber: 14927028,
-          l2: false,
-        },
-      ])
+    it('returns false if the implementation is unknown', async () => {
+      const isValid = isValidMasterCopy({
+        implementationVersionState: 'UNKNOWN',
+      } as SafeInfo)
 
-      const isValid = await isValidMasterCopy('1', '0x0000000000000000000000000000000000000005')
       expect(isValid).toBe(false)
     })
 
-    it('returns true if address is contained in list', async () => {
-      ;(getMasterCopies as jest.Mock).mockResolvedValue([
-        {
-          address: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552',
-          version: '1.3.0',
-          deployer: 'Gnosis',
-          deployedBlockNumber: 12504268,
-          lastIndexedBlockNumber: 14927028,
-          l2: false,
-        },
-        {
-          address: '0x3E5c63644E683549055b9Be8653de26E0B4CD36E',
-          version: '1.3.0+L2',
-          deployer: 'Gnosis',
-          deployedBlockNumber: 12504423,
-          lastIndexedBlockNumber: 14927028,
-          l2: true,
-        },
-      ])
+    it('returns true if the implementation is up-to-date', async () => {
+      const isValid = isValidMasterCopy({
+        implementationVersionState: 'UP_TO_DATE',
+      } as SafeInfo)
 
-      const isValid = await isValidMasterCopy('1', '0x3E5c63644E683549055b9Be8653de26E0B4CD36E')
+      expect(isValid).toBe(true)
+    })
+
+    it('returns true if the implementation is outdated', async () => {
+      const isValid = isValidMasterCopy({
+        implementationVersionState: 'OUTDATED',
+      } as SafeInfo)
+
       expect(isValid).toBe(true)
     })
   })

--- a/src/services/contracts/safeContracts.ts
+++ b/src/services/contracts/safeContracts.ts
@@ -10,17 +10,18 @@ import {
 } from '@safe-global/safe-deployments'
 import { LATEST_SAFE_VERSION } from '@/config/constants'
 import semverSatisfies from 'semver/functions/satisfies'
-import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import { getMasterCopies, type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
+import type { ChainInfo, SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { GetContractProps, SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { assertValidSafeVersion, createEthersAdapter } from '@/hooks/coreSDK/safeCoreSDK'
-import { sameAddress } from '@/utils/addresses'
 import type SignMessageLibEthersContract from '@safe-global/safe-ethers-lib/dist/src/contracts/SignMessageLib/SignMessageLibEthersContract'
 import type CompatibilityFallbackHandlerEthersContract from '@safe-global/safe-ethers-lib/dist/src/contracts/CompatibilityFallbackHandler/CompatibilityFallbackHandlerEthersContract'
 
-export const isValidMasterCopy = async (chainId: string, address: string): Promise<boolean> => {
-  const masterCopies = await getMasterCopies(chainId)
-  return masterCopies.some((masterCopy) => sameAddress(masterCopy.address, address))
+// `UNKNOWN` is returned if the mastercopy does not match supported ones
+// @see https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/handlers/safes.rs#L28-L31
+//      https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/converters.rs#L77-L79
+export const isValidMasterCopy = (safe: SafeInfo): boolean => {
+  return safe.implementationVersionState !== ImplementationVersionState.UNKNOWN
 }
 
 export const _getValidatedGetContractProps = (


### PR DESCRIPTION
## What it solves

Simplifes `isValidMasterCopy`

## How this PR fixes it

We now check the `implementationVersionState` for the validity of a Safe's master copy. The gateway [internally checks whether the implementation address is that of a "supported" master copy](https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/converters.rs#L77-L79) and [returns `UNKNOWN` as the `implementationVersionState` if it is not](https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/handlers/safes.rs#L28-L31).

## How to test it

Open a Safe with an unsupported base contract (e.g. `matic:0x2B7a8C8afaEc010140970488190275A26b1436DD`) and observe that a notification is still shown.

## Screenshots

![image](https://user-images.githubusercontent.com/20442784/224996145-d9616753-b2ea-4349-824b-15142d4eadf8.png)

## Checklist
* [x] I've tested the branch on mobile 📱
* [x] I've documented how it affects the analytics (if at all) 📊
* [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
