### PR TITLE
fix: env-relative relay URL

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -62,4 +62,10 @@ export enum SafeAppsTag {
 }
 
 // Safe Gelato relay service
-export const SAFE_GELATO_RELAY_SERVICE_URL = process.env.NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL || ''
+const SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION =
+  process.env.NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION || 'https://safe-client-nest.safe.global/v1/relay'
+const SAFE_GELATO_RELAY_SERVICE_URL_STAGING =
+  process.env.NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL_STAGING || 'https://safe-client-nest.staging.5afe.dev/v1/relay'
+export const SAFE_GELATO_RELAY_SERVICE_URL = IS_PRODUCTION
+  ? SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION
+  : SAFE_GELATO_RELAY_SERVICE_URL_STAGING


### PR DESCRIPTION
## What it solves

Resolves env-relative relaying endpoints

## How this PR fixes it

<s>Switching between the prod. and staging gateway also switches the relaying endpoint.</s> Relaying service URL is set based on the `IS_PRODUCTION` flag.

## How to test it

1. Ensure `NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION` and `NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL_STAGING` are set in the env. vars.
2. Switch to prod. and observe that relays are working on Gnosis Chain with the prod. relay endpoint.
3. Switch to staging and observe that relays are working on Goerli with the staging relay endpoint.

## Checklist
* [x] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
