### PR TITLE
fix: Hide approval editor for non-approval transactions

### DIFF
--- a/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
+++ b/src/components/tx/ApprovalEditor/ApprovalEditor.test.tsx
@@ -24,7 +24,7 @@ describe('ApprovalEditor', () => {
     expect(result.container).toBeEmptyDOMElement()
   })
 
-  it.skip('renders an error', async () => {
+  it('renders an error', async () => {
     jest
       .spyOn(approvalInfos, 'useApprovalInfos')
       .mockReturnValue([undefined, new Error('Error parsing approvals'), false])
@@ -35,7 +35,7 @@ describe('ApprovalEditor', () => {
     expect(await result.queryByText('Error while decoding approval transactions.')).toBeInTheDocument()
   })
 
-  it.skip('renders a loading skeleton', async () => {
+  it('renders a loading skeleton', async () => {
     jest.spyOn(approvalInfos, 'useApprovalInfos').mockReturnValue([undefined, undefined, true])
     const mockSafeTx = createMockSafeTransaction({ to: '0x1', data: '0x', operation: OperationType.DelegateCall })
 

--- a/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.test.ts
+++ b/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.test.ts
@@ -22,13 +22,13 @@ describe('useApprovalInfos', () => {
     jest.restoreAllMocks()
   })
 
-  it('returns undefined if no Safe Transaction exists', async () => {
+  it('returns an empty array if no Safe Transaction exists', async () => {
     const { result } = renderHook(() => useApprovalInfos(undefined))
 
-    expect(result.current).toStrictEqual([undefined, undefined, true])
+    expect(result.current).toStrictEqual([[], undefined, true])
 
     await waitFor(() => {
-      expect(result.current).toStrictEqual([undefined, undefined, false])
+      expect(result.current).toStrictEqual([[], undefined, false])
     })
   })
 

--- a/src/components/tx/ApprovalEditor/index.tsx
+++ b/src/components/tx/ApprovalEditor/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, SvgIcon, Typography } from '@mui/material'
+import { Alert, Box, Divider, Skeleton, SvgIcon, Typography } from '@mui/material'
 import { type MetaTransactionData, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import css from './styles.module.css'
 import { ApprovalEditorForm } from './ApprovalEditorForm'
@@ -32,9 +32,9 @@ export const ApprovalEditor = ({
   safeTransaction: SafeTransaction | undefined
   updateTransaction?: (txs: MetaTransactionData[]) => void
 }) => {
-  const [readableApprovals] = useApprovalInfos(safeTransaction)
+  const [readableApprovals, error, loading] = useApprovalInfos(safeTransaction)
 
-  if (!readableApprovals || readableApprovals?.length === 0 || !safeTransaction) {
+  if (readableApprovals?.length === 0 || !safeTransaction) {
     return null
   }
 
@@ -52,7 +52,11 @@ export const ApprovalEditor = ({
   return (
     <Box display="flex" flexDirection="column" gap={2} mb={3}>
       <Title />
-      {isReadOnly ? (
+      {error ? (
+        <Alert severity="error">Error while decoding approval transactions.</Alert>
+      ) : loading || !readableApprovals ? (
+        <Skeleton variant="rounded" height={100} data-testid="approval-editor-loading" />
+      ) : isReadOnly ? (
         <Approvals approvalInfos={readableApprovals} />
       ) : (
         <ApprovalEditorForm approvalInfos={readableApprovals} updateApprovals={updateApprovals} />

--- a/src/services/security/modules/ApprovalModule/index.ts
+++ b/src/services/security/modules/ApprovalModule/index.ts
@@ -35,7 +35,7 @@ export class ApprovalModule implements SecurityModule<ApprovalModuleRequest, App
     return []
   }
 
-  async scanTransaction(request: ApprovalModuleRequest): Promise<SecurityResponse<ApprovalModuleResponse>> {
+  scanTransaction(request: ApprovalModuleRequest): SecurityResponse<ApprovalModuleResponse> {
     const { safeTransaction } = request
     const safeTxData = safeTransaction.data.data
     const approvalInfos: Approval[] = []

--- a/src/services/security/modules/types.ts
+++ b/src/services/security/modules/types.ts
@@ -17,5 +17,5 @@ export type SecurityResponse<Res> =
     }
 
 export interface SecurityModule<Req, Res> {
-  scanTransaction(request: Req): Promise<SecurityResponse<Res>>
+  scanTransaction(request: Req): Promise<SecurityResponse<Res>> | SecurityResponse<Res>
 }


### PR DESCRIPTION
## What it solves

Part of #2067 

## How this PR fixes it

- Hides the approval editor when a tx doesn't have any approvals

## How to test it

1. Open a Safe with a non-approval transaction in the queue
2. Execute/Sign the transaction
3. Observe the ApprovalEditor is not flashing

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
