### PR TITLE
fix: Adjust tx flow elements height

### DIFF
--- a/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -8,6 +8,7 @@ import { isDeleteAllowance, isSetAllowance } from '@/utils/transaction-guards'
 import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import css from './styles.module.css'
+import accordionCss from '@/styles/accordion.module.css'
 import CodeIcon from '@mui/icons-material/Code'
 import { DelegateCallWarning } from '@/components/transactions/Warning'
 import { InfoDetails } from '@/components/transactions/InfoDetails'
@@ -55,7 +56,7 @@ export const SingleTxDecoded = ({
 
   return (
     <Accordion variant={variant} expanded={expanded} onChange={onChange}>
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} className={accordionCss.accordion}>
         <div className={css.summary}>
           <CodeIcon color="border" fontSize="small" />
           <Typography>{actionTitle}</Typography>

--- a/src/components/tx/DecodedTx/index.tsx
+++ b/src/components/tx/DecodedTx/index.tsx
@@ -32,6 +32,7 @@ import InfoIcon from '@/public/images/notifications/info.svg'
 import ExternalLink from '@/components/common/ExternalLink'
 import { HelpCenterArticle } from '@/config/constants'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import accordionCss from '@/styles/accordion.module.css'
 
 type DecodedTxProps = {
   tx?: SafeTransaction
@@ -94,7 +95,7 @@ const DecodedTx = ({ tx, txId }: DecodedTxProps): ReactElement | null => {
       )}
 
       <Accordion elevation={0} onChange={onChangeExpand} sx={!tx ? { pointerEvents: 'none' } : undefined}>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} className={accordionCss.accordion}>
           <span style={{ flex: 1 }}>Transaction details</span>
 
           {decodedData ? decodedData.method : tx?.data.operation === OperationType.DelegateCall ? 'Delegate call' : ''}

--- a/src/components/tx/ExecuteCheckbox/styles.module.css
+++ b/src/components/tx/ExecuteCheckbox/styles.module.css
@@ -8,7 +8,7 @@
   margin: 0;
   border: 1px solid var(--color-border-light);
   border-radius: 6px;
-  padding: 9px 3px;
+  padding: 6px 3px;
 }
 
 .select {

--- a/src/components/tx/GasParams/index.tsx
+++ b/src/components/tx/GasParams/index.tsx
@@ -7,6 +7,7 @@ import { type AdvancedParameters } from '../AdvancedParams/types'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
 import classnames from 'classnames'
 import css from './styles.module.css'
+import accordionCss from '@/styles/accordion.module.css'
 
 const GasDetail = ({ name, value, isLoading }: { name: string; value: string; isLoading: boolean }): ReactElement => {
   const valueSkeleton = <Skeleton variant="text" sx={{ minWidth: '5em' }} />
@@ -68,7 +69,7 @@ const GasParams = ({
       onChange={onChangeExpand}
       className={classnames({ [css.withExecutionMethod]: isExecution })}
     >
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} className={accordionCss.accordion}>
         {isExecution ? (
           <Typography display="flex" alignItems="center" justifyContent="space-between" width={1}>
             <span>Estimated fee </span>

--- a/src/components/tx/SponsoredBy/index.tsx
+++ b/src/components/tx/SponsoredBy/index.tsx
@@ -18,7 +18,7 @@ const SponsoredBy = ({ relays, tooltip }: { relays: RelayResponse; tooltip?: str
     <Box className={css.sponsoredBy}>
       <SvgIcon component={GasStationIcon} inheritViewBox className={css.icon} />
       <div>
-        <Stack direction="row" spacing={0.5} alignItems="center" mb={0.2}>
+        <Stack direction="row" spacing={0.5} alignItems="center">
           <Typography variant="body2" fontWeight={700} letterSpacing="0.1px">
             Sponsored by
           </Typography>

--- a/src/components/tx/security/redefine/styles.module.css
+++ b/src/components/tx/security/redefine/styles.module.css
@@ -20,6 +20,7 @@
   border: 1px solid var(--color-border-light);
   padding: 0;
   background-color: var(--color-background-main);
+  line-height: 1;
 }
 
 .loader {

--- a/src/components/tx/security/tenderly/index.tsx
+++ b/src/components/tx/security/tenderly/index.tsx
@@ -70,7 +70,7 @@ const TxSimulationBlock = ({ transactions, disabled, gasLimit }: TxSimulationPro
 
   return (
     <Paper variant="outlined" className={sharedCss.wrapper}>
-      <div>
+      <div className={css.wrapper}>
         <Typography variant="body2" fontWeight={700}>
           Run a simulation
           <Tooltip

--- a/src/components/tx/security/tenderly/styles.module.css
+++ b/src/components/tx/security/tenderly/styles.module.css
@@ -2,3 +2,7 @@
   margin: 0;
   padding: calc(var(--space-1) / 2) var(--space-2);
 }
+
+.wrapper {
+  line-height: 1;
+}

--- a/src/styles/accordion.module.css
+++ b/src/styles/accordion.module.css
@@ -1,0 +1,5 @@
+/* TODO: Apply this style in the MUI theme once its part of this repository */
+
+.accordion {
+  min-height: 56px !important;
+}


### PR DESCRIPTION
## What it solves

Part of #2067

## How this PR fixes it

- Changes the height of tx flow elements to be the same (56px)

## How to test it

1. Open a Safe
2. Create a transaction
3. Observe Transaction details, Tenderly, Redefine, Execute/Sign Checkbox are all the same height

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
