### PR TITLE
PoC: Add search field in header

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -15,6 +15,7 @@ import SafeLogo from '@/public/images/logo.svg'
 import Link from 'next/link'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import BatchIndicator from '@/components/batch/BatchIndicator'
+import SearchSafeWidget from '@/components/common/SearchSafeWidget'
 
 type HeaderProps = {
   onMenuToggle?: Dispatch<SetStateAction<boolean>>
@@ -56,6 +57,10 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
         <Link href={logoHref} passHref>
           <SafeLogo alt="Safe logo" />
         </Link>
+      </div>
+
+      <div className={classnames(css.element, css.hideMobile)}>
+        <SearchSafeWidget />
       </div>
 
       {showSafeToken && (

--- a/src/components/common/SearchSafeWidget/index.tsx
+++ b/src/components/common/SearchSafeWidget/index.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Autocomplete, CircularProgress, InputAdornment, TextField, Typography } from '@mui/material'
+import Link from 'next/link'
+import css from './styles.module.css'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import { getSafeInfo, type SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import useChainId from '@/hooks/useChainId'
+import { validateAddress } from '@/utils/validation'
+import Button from '@mui/material/Button'
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
+import { parsePrefixedAddress } from '@/utils/addresses'
+import { useCurrentChain } from '@/hooks/useChains'
+import { getExplorerLink } from '@/utils/gateway'
+import SearchIcon from '@mui/icons-material/Search'
+import LibraryAddIcon from '@mui/icons-material/LibraryAdd'
+import { FEATURES, hasFeature } from '@/utils/chains'
+import useNameResolver from '@/components/common/AddressInput/useNameResolver'
+import { addOrUpdateSafe } from '@/store/addedSafesSlice'
+import { defaultSafeInfo } from '@/store/safeInfoSlice'
+import { useAppDispatch } from '@/store'
+import { AppRoutes } from '@/config/routes'
+import { useRouter } from 'next/router'
+
+const validateSafeAddress = async (address: string, chainId: string) => {
+  try {
+    const safeInfo = await getSafeInfo(chainId, address)
+    return safeInfo
+  } catch (error) {
+    return
+  }
+}
+
+enum AddressType {
+  SafeAccount = 'SafeAccount',
+  EOA = 'EOA',
+}
+
+const SearchSafeWidget = () => {
+  const chainId = useChainId()
+  const currentChain = useCurrentChain()
+  const [value, setValue] = useState<string>('')
+  const [result, setResult] = useState<string>('')
+  const [type, setType] = useState<AddressType>()
+  const [safe, setSafe] = useState<SafeInfo>()
+  const [open, setOpen] = useState<boolean>(false)
+  const dispatch = useAppDispatch()
+  const router = useRouter()
+
+  const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
+  const { address, resolving } = useNameResolver(isDomainLookupEnabled ? value : '')
+
+  const handleChange = useCallback(
+    async (value: string) => {
+      setValue(value)
+      setOpen(!!value)
+
+      const { address } = parsePrefixedAddress(value)
+      const invalidAddress = validateAddress(address)
+
+      if (invalidAddress) return
+
+      const safe = await validateSafeAddress(address, chainId)
+
+      setType(safe ? AddressType.SafeAccount : AddressType.EOA)
+
+      if (safe) {
+        setResult(safe.address.name || safe.address.value)
+        setSafe(safe)
+      } else {
+        setResult(address)
+      }
+    },
+    [chainId],
+  )
+
+  const handleAddSafe = () => {
+    if (!safe) return
+
+    setValue('')
+    setResult('')
+
+    dispatch(
+      addOrUpdateSafe({
+        safe: {
+          ...defaultSafeInfo,
+          address: { value: result },
+          threshold: safe.threshold,
+          owners: safe.owners.map((owner) => ({
+            value: owner.value,
+            name: owner.name,
+          })),
+          chainId,
+        },
+      }),
+    )
+
+    // TODO: Show notification and track?
+
+    router.push({
+      pathname: AppRoutes.home,
+      query: { safe: `${currentChain?.shortName}:${result}` },
+    })
+  }
+
+  const handleOpenSafe = () => {
+    if (type === AddressType.SafeAccount) {
+      setValue('')
+      setResult('')
+    }
+  }
+
+  useEffect(() => {
+    if (!address) return
+
+    void handleChange(address)
+  }, [address, handleChange])
+
+  return (
+    <Autocomplete
+      className={css.autocomplete}
+      value={value}
+      open={open}
+      freeSolo
+      onInputChange={(_, value) => handleChange(value)}
+      componentsProps={{
+        paper: {
+          elevation: 2,
+        },
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          className={css.input}
+          placeholder="Safe Account, Address, ENS"
+          size="small"
+          InputProps={{
+            ...params.InputProps,
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon sx={{ fontSize: '1.25em' }} />
+              </InputAdornment>
+            ),
+            endAdornment: resolving ? (
+              <InputAdornment position="end">
+                <CircularProgress size={16} />
+              </InputAdornment>
+            ) : (
+              params.InputProps.endAdornment
+            ),
+          }}
+        />
+      )}
+      renderOption={(props, option) =>
+        option ? (
+          <Link
+            target={type === AddressType.EOA ? '_blank' : '_self'}
+            onClick={handleOpenSafe}
+            // TODO: clean this up
+            href={
+              type === AddressType.EOA && currentChain
+                ? getExplorerLink(option, currentChain?.blockExplorerUriTemplate).href
+                : type === AddressType.SafeAccount
+                ? {
+                    pathname: AppRoutes.home,
+                    query: { safe: `${currentChain?.shortName}:${result}` },
+                  }
+                : ''
+            }
+          >
+            <Typography variant="body2" {...props} className={css.option}>
+              <EthHashInfo address={option || ''} shortAddress={true} avatarSize={24} />
+              {type === AddressType.SafeAccount ? (
+                <Button
+                  className={css.tinyButton}
+                  variant="contained"
+                  size="small"
+                  onClick={handleAddSafe}
+                  startIcon={<LibraryAddIcon fontSize="small" />}
+                >
+                  Add Safe Account
+                </Button>
+              ) : (
+                <Button
+                  className={css.tinyButton}
+                  variant="contained"
+                  size="small"
+                  startIcon={<ArrowOutwardIcon fontSize="small" />}
+                  target="_blank"
+                  href={currentChain ? getExplorerLink(option, currentChain?.blockExplorerUriTemplate).href : ''}
+                >
+                  View in Explorer
+                </Button>
+              )}
+            </Typography>
+          </Link>
+        ) : null
+      }
+      options={[result]}
+    />
+  )
+}
+
+export default SearchSafeWidget

--- a/src/components/common/SearchSafeWidget/styles.module.css
+++ b/src/components/common/SearchSafeWidget/styles.module.css
@@ -1,0 +1,45 @@
+.autocomplete {
+  min-width: 400px;
+  font-size: 14px;
+}
+
+.option {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px var(--space-1);
+  cursor: pointer;
+}
+
+.option:hover {
+  background: var(--color-background-main);
+}
+
+.tinyButton {
+  font-size: 12px;
+  font-weight: normal;
+  padding: 4px 8px;
+}
+
+.input {
+  background: var(--color-background-main);
+  border-radius: 8px;
+}
+
+.input > div {
+  padding: 4px 12px 4px 6px !important;
+}
+
+.input :global .MuiInputAdornment-root {
+  margin-right: 0;
+}
+
+.input fieldset {
+  border: 0;
+}
+
+.input input {
+  padding-right: 24px !important;
+  font-size: 14px !important;
+}


### PR DESCRIPTION
## What it solves

Adds a search field to the header section.

- Search for Safe Accounts and one-click add them to the safe list
- Search for any other addresses and open them on the block explorer

## ToDos

- Display added safes/loaded safes in the dropdown
- Extract enum logic
- Add error handling
- Add keyboard shortcut support
- Add token lookup / cross-chain lookup

## Screenshots
<img width="1491" alt="Screenshot 2023-09-15 at 16 21 15" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/7e6e541c-b8ef-4f3a-af50-904c22549baf">
<img width="423" alt="Screenshot 2023-09-15 at 16 14 36" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/11b6154f-a13f-41c3-8e7b-b838d8377a31">
<img width="460" alt="Screenshot 2023-09-15 at 16 14 46" src="https://github.com/safe-global/safe-wallet-web/assets/5880855/c2b98fef-e17a-44fb-b958-2365b29dc6c1">

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
