### PR TITLE
fix: Don't use faker for extendedSafeInfoBuilder

### DIFF
--- a/src/tests/builders/safe.ts
+++ b/src/tests/builders/safe.ts
@@ -42,6 +42,6 @@ export function safeInfoBuilder(): IBuilder<SafeInfo> {
 export function extendedSafeInfoBuilder(): IBuilder<ExtendedSafeInfo> {
   return Builder.new<ExtendedSafeInfo>().with({
     ...safeInfoBuilder().build(),
-    deployed: faker.datatype.boolean(),
+    deployed: true,
   })
 }


### PR DESCRIPTION
## What it solves

Resolves #

## How this PR fixes it

- Removes faker for `extendedSafeInfoBuilder` and sets `deployed: true` instead since thats the default state we should expect

## How to test it

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
