### PR TITLE
fix: Redirect to home if safe address is part of the URL path

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -10,7 +10,7 @@ export const _getRedirectUrl = (location: Location): string | undefined => {
   const [, pathSafe] = pathname.match(re) || []
 
   if (pathSafe) {
-    let newPath = pathname.replace(re, '') || '/'
+    let newPath = pathname.replace(re, '') || AppRoutes.home
     let newSearch = search ? '&' + search.slice(1) : ''
 
     // TxId used to be in the path, rewrite it to the query

--- a/src/tests/pages/404.test.tsx
+++ b/src/tests/pages/404.test.tsx
@@ -9,6 +9,14 @@ describe('_getRedirectUrl', () => {
     expect(url).toBe('/balances?safe=eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6')
   })
 
+  it('adds home to the path in case there is no path defined', () => {
+    const url = _getRedirectUrl({
+      pathname: '/eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+      search: '',
+    } as Location)
+    expect(url).toBe('/home?safe=eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6')
+  })
+
   it('returns undefined if the path is not a safe address', () => {
     const url = _getRedirectUrl({
       pathname: '/welcome',


### PR DESCRIPTION
## What it solves

Follow up on #3356 

## How this PR fixes it

#3356 removed the redirect to last used safe but also the redirect in case there is a safe address in the URL. This adds it back as part of the 404 page so instead of redirecting to `/` there we redirect the user to their `/home` to bypass the new redirection logic of the index page.

## How to test it

1. Open `/sep:<safe address>`
2. You should be redirected to `/home?safe=sep:<safe address>`

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
