### PR TITLE
Fix: hide SAP and Swaps if geoblocked

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -8,10 +8,9 @@ import classnames from 'classnames'
 import css from './styles.module.css'
 import ConnectWallet from '@/components/common/ConnectWallet'
 import NetworkSelector from '@/components/common/NetworkSelector'
-import SafeTokenWidget, { getSafeTokenAddress } from '@/components/common/SafeTokenWidget'
+import SafeTokenWidget from '@/components/common/SafeTokenWidget'
 import NotificationCenter from '@/components/notification-center/NotificationCenter'
 import { AppRoutes } from '@/config/routes'
-import useChainId from '@/hooks/useChainId'
 import SafeLogo from '@/public/images/logo.svg'
 import SafeLogoMobile from '@/public/images/logo-no-text.svg'
 import Link from 'next/link'
@@ -22,6 +21,7 @@ import { FEATURES } from '@/utils/chains'
 import { useHasFeature } from '@/hooks/useChains'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
+import { useSafeTokenEnabled } from '@/hooks/useSafeTokenEnabled'
 
 type HeaderProps = {
   onMenuToggle?: Dispatch<SetStateAction<boolean>>
@@ -37,9 +37,8 @@ function getLogoLink(router: ReturnType<typeof useRouter>): Url {
 }
 
 const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
-  const chainId = useChainId()
   const safeAddress = useSafeAddress()
-  const showSafeToken = safeAddress && !!getSafeTokenAddress(chainId)
+  const showSafeToken = useSafeTokenEnabled()
   const router = useRouter()
   const enableWc = useHasFeature(FEATURES.NATIVE_WALLETCONNECT)
 

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import FirstSteps from '@/components/dashboard/FirstSteps'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import type { ReactElement } from 'react'
+import { type ReactElement } from 'react'
 import dynamic from 'next/dynamic'
 import { Grid } from '@mui/material'
 import PendingTxsList from '@/components/dashboard/PendingTxs/PendingTxsList'
@@ -16,13 +16,17 @@ import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
 import css from './styles.module.css'
 import SwapWidget from '@/features/swap/components/SwapWidget'
+import useIsSwapFeatureEnabled from '@/features/swap/hooks/useIsSwapFeatureEnabled'
+import { useSafeTokenEnabled } from '@/hooks/useSafeTokenEnabled'
 
 const RecoveryHeader = dynamic(() => import('@/features/recovery/components/RecoveryHeader'))
 
 const Dashboard = (): ReactElement => {
   const { safe } = useSafeInfo()
   const showSafeApps = useHasFeature(FEATURES.SAFE_APPS)
-  const isSAPBannerEnabled = useHasFeature(FEATURES.SAP_BANNER)
+  const isSafeTokenEnabled = useSafeTokenEnabled()
+  const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
+  const isSAPBannerEnabled = useHasFeature(FEATURES.SAP_BANNER) && isSafeTokenEnabled
   const supportsRecovery = useIsRecoverySupported()
   const [recovery] = useRecovery()
   const showRecoveryWidget = supportsRecovery && !recovery
@@ -42,13 +46,17 @@ const Dashboard = (): ReactElement => {
 
         {safe.deployed && (
           <>
-            <Grid item xs={12} xl={isSAPBannerEnabled ? 6 : 12} className={css.hideIfEmpty}>
-              <SwapWidget />
-            </Grid>
+            {isSwapFeatureEnabled && (
+              <Grid item xs={12} xl={isSAPBannerEnabled ? 6 : 12} className={css.hideIfEmpty}>
+                <SwapWidget />
+              </Grid>
+            )}
 
-            <Grid item xs className={css.hideIfEmpty}>
-              <ActivityRewardsSection />
-            </Grid>
+            {isSAPBannerEnabled && (
+              <Grid item xs className={css.hideIfEmpty}>
+                <ActivityRewardsSection />
+              </Grid>
+            )}
 
             <Grid item xs={12} />
 

--- a/src/hooks/useSafeTokenEnabled.ts
+++ b/src/hooks/useSafeTokenEnabled.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { GeoblockingContext } from '@/components/common/GeoblockingProvider'
+import useSafeInfo from './useSafeInfo'
+import { getSafeTokenAddress } from '@/components/common/SafeTokenWidget'
+
+export function useSafeTokenEnabled(): boolean {
+  const isBlockedCountry = useContext(GeoblockingContext)
+  const { safe, safeLoaded } = useSafeInfo()
+  return !isBlockedCountry && safeLoaded && !!getSafeTokenAddress(safe.chainId)
+}


### PR DESCRIPTION
## What it solves

When Swaps and Safe Activity Program are unavailable in a sanctioned country, hide the corresponding widgets.

## How to test

Install Urban VPN for mac and simulate Russia.