### PR TITLE
fix: Don't trim trailing slashes from safe apps

### DIFF
--- a/src/components/safe-apps/AddCustomAppModal/index.tsx
+++ b/src/components/safe-apps/AddCustomAppModal/index.tsx
@@ -22,7 +22,7 @@ import useAsync from '@/hooks/useAsync'
 import useDebounce from '@/hooks/useDebounce'
 import { fetchSafeAppFromManifest } from '@/services/safe-apps/manifest'
 import { SAFE_APPS_EVENTS, trackSafeAppEvent } from '@/services/analytics'
-import { isSameUrl, trimTrailingSlash } from '@/utils/url'
+import { isSameUrl } from '@/utils/url'
 import CustomAppPlaceholder from './CustomAppPlaceholder'
 import CustomApp from './CustomApp'
 import { useShareSafeAppUrl } from '@/components/safe-apps/hooks/useShareSafeAppUrl'
@@ -70,7 +70,7 @@ export const AddCustomAppModal = ({ open, onClose, onSave, safeAppsList }: Props
   }
 
   const appUrl = watch('appUrl')
-  const debouncedUrl = useDebounce(trimTrailingSlash(appUrl || ''), 300)
+  const debouncedUrl = useDebounce(appUrl || '', 300)
 
   const [safeApp, manifestError] = useAsync<SafeAppData | undefined>(() => {
     if (!isValidURL(debouncedUrl)) return

--- a/src/services/safe-apps/manifest.ts
+++ b/src/services/safe-apps/manifest.ts
@@ -89,19 +89,18 @@ const fetchSafeAppFromManifest = async (
   appUrl: string,
   currentChainId: string,
 ): Promise<SafeAppDataWithPermissions> => {
-  const normalizedAppUrl = trimTrailingSlash(appUrl)
   const appManifest = await fetchAppManifest(appUrl)
 
   if (!isAppManifestValid(appManifest)) {
     throw new Error('Invalid Safe App manifest')
   }
 
-  const iconUrl = getAppLogoUrl(normalizedAppUrl, appManifest)
+  const iconUrl = getAppLogoUrl(appUrl, appManifest)
 
   return {
     // Must satisfy https://docs.djangoproject.com/en/5.0/ref/models/fields/#positiveintegerfield
     id: Math.round(Math.random() * 1e9 + 1e6),
-    url: normalizedAppUrl,
+    url: appUrl,
     name: appManifest.name,
     description: appManifest.description,
     accessControl: { type: SafeAppAccessPolicyTypes.NoRestrictions },


### PR DESCRIPTION
## What it solves

Resolves #4347 

## How this PR fixes it

- Doesn't remove the trailing slash anymore when fetching manifest.json and when adding custom safe apps

## How to test it

1. Open safe apps from the list
2. Observe that they should still open
3. Add a custom safe app with a trailing slash
4. Observe that it should still open

## Screenshots

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
