### PR TITLE
fix: decoding of migrateToL2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,8 @@
 # testing
 /coverage
 
-# types
-/src/types/contracts/
-
 # next.js
-/.next/
+**/.next/
 /out/
 
 # production

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,5 @@
+# Types
+src/types/contracts
+
+# Auto-generated service workers
+public/*.js

--- a/apps/web/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
@@ -8,7 +8,6 @@ import { getMultiSendContractDeployment } from '@/services/contracts/deployments
 import { createTx } from '@/services/tx/tx-sender/create'
 import { Safe__factory } from '@/types/contracts'
 import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import { zeroPadValue } from 'ethers'
 import DecodedData from '../DecodedData'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
@@ -38,7 +37,7 @@ export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetai
     if (!multiSendAddress) {
       return undefined
     }
-    const searchString = `${execTransactionSelector}${zeroPadValue(multiSendAddress, 32).slice(2)}`
+    const searchString = execTransactionSelector
     const indexOfTx = txData?.indexOf(searchString)
     if (indexOfTx && txData) {
       // Now we need to find the tx Data


### PR DESCRIPTION
## What it solves
Upgrading a Safe from 1.3.0 to 1.4.1 breaks the Migration decoding

## How this PR fixes it
Less strict by ignoring the to address when decoding `migrateToL2` transactions.

## How to test it
Open e.g. [this transaction](https://app.safe.global/transactions/tx?safe=aurora:0x72a4dCE2C0d068541A3890fC0B968D68A00F877e&id=multisig_0x72a4dCE2C0d068541A3890fC0B968D68A00F877e_0x6602b8ef9bc393b229bfd50033ce4f71581013979d37d56e0d707b8bd8df8a52)

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
