### PR TITLE
Feat(sidebar): change safe search placeholder text

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
@@ -23,7 +23,7 @@ const AccountListFilters = ({ setSearchQuery }: { setSearchQuery: Dispatch<SetSt
       <Box display="flex" justifyContent="space-between" width="100%" gap={1}>
         <TextField
           id="search-by-name"
-          placeholder="Search"
+          placeholder="Search Safes by name, address, or chain"
           aria-label="Search Safe list by name"
           variant="filled"
           hiddenLabel

--- a/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
@@ -23,7 +23,7 @@ const AccountListFilters = ({ setSearchQuery }: { setSearchQuery: Dispatch<SetSt
       <Box display="flex" justifyContent="space-between" width="100%" gap={1}>
         <TextField
           id="search-by-name"
-          placeholder="Search Safes by name, address, or chain"
+          placeholder="Search by name, ENS, address, or chain"
           aria-label="Search Safe list by name"
           variant="filled"
           hiddenLabel


### PR DESCRIPTION
## What it solves
It is not clear that the search bar can be used for filtering safe names, addresses, and chains all using the same input

## How this PR fixes it
Changes the placeholder text to explain what the search can be used for. 

## Screenshots
![image](https://github.com/user-attachments/assets/6e5bf1b4-27f8-4e22-a37a-0a183070889e)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
