### PR TITLE
Fix: larger coingecko icons

### DIFF
--- a/apps/web/src/components/common/TokenIcon/index.tsx
+++ b/apps/web/src/components/common/TokenIcon/index.tsx
@@ -1,9 +1,8 @@
-import { memo, type ReactElement } from 'react'
+import { useMemo, type ReactElement } from 'react'
 import ImageFallback from '../ImageFallback'
 import css from './styles.module.css'
 
 const FALLBACK_ICON = '/images/common/token-placeholder.svg'
-const COINGECKO_URL = 'https://assets.coingecko.com/'
 const COINGECKO_THUMB = '/thumb/'
 const COINGECKO_SMALL = '/small/'
 
@@ -18,13 +17,9 @@ const TokenIcon = ({
   size?: number
   fallbackSrc?: string
 }): ReactElement => {
-  let crossOrigin = false
-  let src = logoUri
-
-  if (logoUri?.startsWith(COINGECKO_URL)) {
-    src = logoUri?.replace(COINGECKO_THUMB, COINGECKO_SMALL)
-    crossOrigin = true
-  }
+  const src = useMemo(() => {
+    return logoUri?.replace(COINGECKO_THUMB, COINGECKO_SMALL)
+  }, [])
 
   return (
     <ImageFallback
@@ -33,11 +28,10 @@ const TokenIcon = ({
       fallbackSrc={fallbackSrc || FALLBACK_ICON}
       height={size}
       className={css.image}
+      referrerPolicy="no-referrer"
       loading="lazy"
-      referrerPolicy={crossOrigin ? 'no-referrer' : undefined}
-      crossOrigin={crossOrigin ? 'anonymous' : undefined}
     />
   )
 }
 
-export default memo(TokenIcon)
+export default TokenIcon

--- a/apps/web/src/components/common/TokenIcon/index.tsx
+++ b/apps/web/src/components/common/TokenIcon/index.tsx
@@ -1,8 +1,11 @@
-import { type ReactElement } from 'react'
+import { memo, type ReactElement } from 'react'
 import ImageFallback from '../ImageFallback'
 import css from './styles.module.css'
 
 const FALLBACK_ICON = '/images/common/token-placeholder.svg'
+const COINGECKO_URL = 'https://assets.coingecko.com/'
+const COINGECKO_THUMB = '/thumb/'
+const COINGECKO_SMALL = '/small/'
 
 const TokenIcon = ({
   logoUri,
@@ -15,15 +18,26 @@ const TokenIcon = ({
   size?: number
   fallbackSrc?: string
 }): ReactElement => {
+  let crossOrigin = false
+  let src = logoUri
+
+  if (logoUri?.startsWith(COINGECKO_URL)) {
+    src = logoUri?.replace(COINGECKO_THUMB, COINGECKO_SMALL)
+    crossOrigin = true
+  }
+
   return (
     <ImageFallback
-      src={logoUri}
+      src={src}
       alt={tokenSymbol}
       fallbackSrc={fallbackSrc || FALLBACK_ICON}
       height={size}
       className={css.image}
+      loading="lazy"
+      referrerPolicy={crossOrigin ? 'no-referrer' : undefined}
+      crossOrigin={crossOrigin ? 'anonymous' : undefined}
     />
   )
 }
 
-export default TokenIcon
+export default memo(TokenIcon)

--- a/apps/web/src/components/tx/confirmation-views/__snapshots__/ConfirmationView.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/__snapshots__/ConfirmationView.test.tsx.snap
@@ -288,6 +288,8 @@ exports[`ConfirmationView should display a confirmation screen for a SETTINGS_CH
                             alt="ETH"
                             class="image"
                             height="26"
+                            loading="lazy"
+                            referrerpolicy="no-referrer"
                             src="/images/common/token-placeholder.svg"
                           />
                           <p
@@ -793,6 +795,8 @@ exports[`ConfirmationView should display a confirmation with method call when th
                             alt="ETH"
                             class="image"
                             height="26"
+                            loading="lazy"
+                            referrerpolicy="no-referrer"
                             src="/images/common/token-placeholder.svg"
                           />
                           <p


### PR DESCRIPTION
## What it solves

* Token icons from Coingecko are now `referrerPolicy="no-referrer"`
* I also made them larger (50x50) because they were too low-res (25x25)
