### PR TITLE
typo fix useCompatibilityWarning.ts

### DIFF
--- a/apps/web/src/features/walletconnect/components/WcProposalForm/useCompatibilityWarning.ts
+++ b/apps/web/src/features/walletconnect/components/WcProposalForm/useCompatibilityWarning.ts
@@ -18,7 +18,7 @@ const Warnings: Record<string, { severity: AlertColor; message: string }> = {
   },
   WARNED_BRIDGE: {
     severity: 'warning',
-    message: `While bridging via ${NAME_PLACEHOLDER}, please make sure that the desination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.`,
+    message: `While bridging via ${NAME_PLACEHOLDER}, please make sure that the destination address you send funds to matches the Safe address you have on the respective chain. Otherwise, the funds will be lost.`,
   },
   UNSUPPORTED_CHAIN: {
     severity: 'error',


### PR DESCRIPTION
## Typo Fix in `useCompatibilityWarning.ts`

This pull request fixes a typographical error in the `useCompatibilityWarning.ts` file. The word "desination" was corrected to "destination" to ensure proper spelling in the warning message.

### Changes:
- Corrected the spelling of "desination" to "destination" in the warning message for bridging transactions.

### Checklist:
- [x] Fixed spelling error in the warning message.
- [x] Changes reviewed and tested.
