### PR TITLE
Fix typo

### DIFF
--- a/apps/web/src/markdown/terms/terms.md
+++ b/apps/web/src/markdown/terms/terms.md
@@ -18,7 +18,7 @@ Last updated: September, 2024
 
 [8\. Are we responsible for recovering your Safe Account?](#8.-are-we-responsible-for-recovering-your-safe-account?)
 
-[9\. Are we responsible for notifying you about events occuring in your Safe Account?](#9.-are-we-responsible-for-notifying-you-about-events-occuring-in-your-safe-account?)
+[9\. Are we responsible for notifying you about events occurring in your Safe Account?](#9.-are-we-responsible-for-notifying-you-about-events-occuring-in-your-safe-account?)
 
 [10\. Are we responsible for flagging malicious transactions?](#10.-are-we-responsible-for-flagging-malicious-transactions?)
 

--- a/apps/web/src/markdown/terms/terms.md
+++ b/apps/web/src/markdown/terms/terms.md
@@ -190,7 +190,7 @@ Our Services do not consist of:
 
 4. The recovery feature is provided free of charge and liability is limited pursuant to Section 18 below.
 
-# 9\. Are we responsible for notifying you about events occuring in your Safe Account? {#9.-are-we-responsible-for-notifying-you-about-events-occuring-in-your-safe-account?}
+# 9\. Are we responsible for notifying you about events occurring in your Safe Account? {#9.-are-we-responsible-for-notifying-you-about-events-occuring-in-your-safe-account?}
 
 1. We shall not be responsible for notifying you of any interactions or events occurring in your Safe Account, be it on the Blockchain, third-party interfaces, within any other infrastructure, or our Services.
 


### PR DESCRIPTION
I fixed a typo in the terms.md file by correcting the word "occuring" to "occurring" in multiple instances, ensuring consistent and proper spelling throughout the document.

Specific Changes:
Link Text:

Before:
[9\. Are we responsible for notifying you about events occuring in your Safe Account?]
After:
[9\. Are we responsible for notifying you about events occurring in your Safe Account?]
Section Header:

Before:
# 9\. Are we responsible for notifying you about events occuring in your Safe Account?
After:
# 9\. Are we responsible for notifying you about events occurring in your Safe Account?
These adjustments improve the professionalism and readability of the document by using the correct spelling of "occurring."