### PR TITLE
fix(Nested signing): do not copy addresses in SignerForm

### DIFF
--- a/apps/web/src/components/tx/SignOrExecuteForm/SignerForm/index.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignerForm/index.tsx
@@ -100,7 +100,7 @@ export const SignerForm = ({ willExecute }: { willExecute?: boolean }) => {
           >
             {options?.map((owner) => (
               <MenuItem key={owner} value={owner} disabled={!isOptionEnabled(owner)}>
-                <EthHashInfo address={owner} avatarSize={32} onlyName />
+                <EthHashInfo address={owner} avatarSize={32} onlyName copyAddress={false} />
                 {!isOptionEnabled(owner) && (
                   <Typography variant="caption" component="span" className={css.disabledPill}>
                     Already signed


### PR DESCRIPTION
## What it solves
Clicking directly on the address in the `SignerForm` copied the address instead of chosing the signer.

## How this PR fixes it
Disables copying the address in the `SignerForm`

## How to test it
- Create a nested Safe tx
- Try to choose a signer which is not in the address book and click on the address

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
