### PR TITLE
fix: Adjust meta tag to fix PWA header position

### DIFF
--- a/apps/web/src/components/common/MetaTags/index.tsx
+++ b/apps/web/src/components/common/MetaTags/index.tsx
@@ -30,7 +30,7 @@ const MetaTags = ({ prefetchUrl }: { prefetchUrl: string }) => (
     <link rel="preconnect" href={prefetchUrl} crossOrigin="" />
 
     {/* Mobile tags */}
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
     {/* PWA primary color and manifest */}

--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -4,12 +4,14 @@
   top: 0;
   width: 100%;
   z-index: 1201;
+  background: var(--color-background-paper);
+  padding-top: env(safe-area-inset-top);
 }
 
 .main {
   background-color: var(--color-background-main);
   padding-left: 230px;
-  padding-top: var(--header-height);
+  padding-top: calc(var(--header-height) + env(safe-area-inset-top));
   min-height: 100vh;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What it solves

Resolves #4434 

## How this PR fixes it

- Adds the `viewport-fit=cover` directive to the meta tags -> This moves the whole app up into the "Dynamic island" on iOS
- Adds a padding (for PWA only) to the header and main element to move them down again and adds a background so the content is not visible when scrolling

## How to test it

1. Open the app on mobile (iOS and Android and iOS with a device without the notch), add it as a PWA to your Home Screen and open it again
2. Scroll up and down
3. Observe nothing is visible above the header
4. Open the app on web
5. Scroll up and down
6. Observe the header is at the very top
7. Make sure it works both in landscape and portrait mode on mobile

## Screenshots

![image](https://github.com/user-attachments/assets/2b61672a-2f23-4acb-be95-3dfdb17ebe59)

![image](https://github.com/user-attachments/assets/0fc450b9-7ba5-4aa7-9267-2271ac7ee96e)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
