### PR TITLE
fix: Enable Add proposer button for owners only

### DIFF
--- a/apps/web/src/components/common/OnlyOwner/index.tsx
+++ b/apps/web/src/components/common/OnlyOwner/index.tsx
@@ -9,6 +9,7 @@ type CheckWalletProps = {
 }
 
 enum Message {
+  WalletNotConnected = 'Please connect your wallet',
   NotSafeOwner = 'Your connected wallet is not a signer of this Safe Account',
 }
 
@@ -17,7 +18,15 @@ const OnlyOwner = ({ children }: CheckWalletProps): ReactElement => {
   const isSafeOwner = useIsSafeOwner()
   const connectWallet = useConnectWallet()
 
-  const message = useMemo(() => (!isSafeOwner ? Message.NotSafeOwner : undefined), [isSafeOwner])
+  const message = useMemo(() => {
+    if (!wallet) {
+      return Message.WalletNotConnected
+    }
+
+    if (!isSafeOwner) {
+      return Message.NotSafeOwner
+    }
+  }, [isSafeOwner, wallet])
 
   if (!message) return children(true)
 

--- a/apps/web/src/components/common/OnlyOwner/index.tsx
+++ b/apps/web/src/components/common/OnlyOwner/index.tsx
@@ -1,0 +1,31 @@
+import { useMemo, type ReactElement } from 'react'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import useWallet from '@/hooks/wallets/useWallet'
+import useConnectWallet from '../ConnectWallet/useConnectWallet'
+import { Tooltip } from '@mui/material'
+
+type CheckWalletProps = {
+  children: (ok: boolean) => ReactElement
+}
+
+enum Message {
+  NotSafeOwner = 'Your connected wallet is not a signer of this Safe Account',
+}
+
+const OnlyOwner = ({ children }: CheckWalletProps): ReactElement => {
+  const wallet = useWallet()
+  const isSafeOwner = useIsSafeOwner()
+  const connectWallet = useConnectWallet()
+
+  const message = useMemo(() => (!isSafeOwner ? Message.NotSafeOwner : undefined), [isSafeOwner])
+
+  if (!message) return children(true)
+
+  return (
+    <Tooltip title={message}>
+      <span onClick={wallet ? undefined : connectWallet}>{children(false)}</span>
+    </Tooltip>
+  )
+}
+
+export default OnlyOwner

--- a/apps/web/src/components/settings/ProposersList/index.tsx
+++ b/apps/web/src/components/settings/ProposersList/index.tsx
@@ -1,7 +1,7 @@
-import CheckWallet from '@/components/common/CheckWallet'
 import { Chip } from '@/components/common/Chip'
 import EnhancedTable from '@/components/common/EnhancedTable'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
+import OnlyOwner from '@/components/common/OnlyOwner'
 import Track from '@/components/common/Track'
 import UpsertProposer from '@/features/proposers/components/UpsertProposer'
 import DeleteProposerDialog from '@/features/proposers/components/DeleteProposerDialog'
@@ -100,7 +100,7 @@ const ProposersList = () => {
 
             {isEnabled && (
               <Box mb={2}>
-                <CheckWallet allowProposer={false}>
+                <OnlyOwner>
                   {(isOk) => (
                     <Track {...SETTINGS_EVENTS.PROPOSERS.ADD_PROPOSER}>
                       <Button
@@ -115,7 +115,7 @@ const ProposersList = () => {
                       </Button>
                     </Track>
                   )}
-                </CheckWallet>
+                </OnlyOwner>
               </Box>
             )}
 


### PR DESCRIPTION
## What it solves

Resolves #4743 

## How this PR fixes it

- Adds a new HoC called `OnlyOwner` and uses it for the Add proposer button instead of the `CheckWallet` component

## How to test it

1. Open a Safe
2. Go to the Settings page
3. Connect with an owner
4. The Add proposer button is enabled
5. Connect with a different wallet e.g. spending limit beneficiary, proposer, nested safe owner, recoverer
6. Observe that the add proposer button is disabled

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
