### PR TITLE
fix: initialize Firebase only if `projectId` is present in options

### DIFF
--- a/apps/web/src/services/push-notifications/firebase.ts
+++ b/apps/web/src/services/push-notifications/firebase.ts
@@ -9,7 +9,7 @@ const FIREBASE_VALID_KEY_PRODUCTION = process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY
 const FIREBASE_VALID_KEY_STAGING = process.env.NEXT_PUBLIC_FIREBASE_VAPID_KEY_STAGING
 export const FIREBASE_VAPID_KEY = FIREBASE_IS_PRODUCTION ? FIREBASE_VALID_KEY_PRODUCTION : FIREBASE_VALID_KEY_STAGING
 
-export const FIREBASE_OPTIONS: FirebaseOptions = (() => {
+export const FIREBASE_OPTIONS = (() => {
   const FIREBASE_OPTIONS_PRODUCTION = process.env.NEXT_PUBLIC_FIREBASE_OPTIONS_PRODUCTION || ''
   const FIREBASE_OPTIONS_STAGING = process.env.NEXT_PUBLIC_FIREBASE_OPTIONS_STAGING || ''
   try {
@@ -19,10 +19,13 @@ export const FIREBASE_OPTIONS: FirebaseOptions = (() => {
   }
 })()
 
-export const initializeFirebaseApp = () => {
-  const hasFirebaseOptions = Object.values(FIREBASE_OPTIONS).every(Boolean)
+const isFirebaseOptions = (options: object): options is FirebaseOptions => {
+  // At least projectId is required
+  return 'projectId' in options && Object.values(options).every(Boolean)
+}
 
-  if (!hasFirebaseOptions) {
+export const initializeFirebaseApp = () => {
+  if (!isFirebaseOptions(FIREBASE_OPTIONS)) {
     return
   }
 


### PR DESCRIPTION
## What it solves

Fixes error message when Firebase is initialized:
> FirebaseError: Installations: Missing App configuration value: "projectId" (installations/missing-app-config-values).

<img width="792" alt="Screenshot 2025-01-08 at 16 30 31" src="https://github.com/user-attachments/assets/8cc710cd-f242-4370-962b-59e3a7cbe657" />

## How this PR fixes it
[`apps/web/src/services/push-notifications/firebase.ts`](diffhunk://#diff-3be0086de4433400ec5c7c60f44c1230c7bc6da197c50edb0b8acbd480181378L22-R28): Added the `isFirebaseOptions` type guard function to ensure that the `FIREBASE_OPTIONS` object contains a `projectId`.

## How to test it (on localhost)
1. Clear `NEXT_PUBLIC_FIREBASE_OPTIONS_STAGING` in .env file
2. Load app while monitoring the dev console
3. Observe that the error message (see above) is not logged

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
