### PR TITLE
feat(Safe Apps): Add option for Safe Apps to include Telegram ID as a social media link

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,7 +55,7 @@
     "@safe-global/protocol-kit": "^4.1.3",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-client-gateway-sdk": "v1.60.1",
-    "@safe-global/safe-gateway-typescript-sdk": "3.22.6-beta.0",
+    "@safe-global/safe-gateway-typescript-sdk": "3.22.6",
     "@safe-global/safe-modules-deployments": "^2.2.1",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",

--- a/apps/web/src/components/safe-apps/SafeAppSocialLinksCard/SafeAppSocialLinksCard.test.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppSocialLinksCard/SafeAppSocialLinksCard.test.tsx
@@ -40,7 +40,17 @@ const githubSocialProfileMock = {
   url: 'http://tx-builder-github',
 }
 
-const socialProfilesMock = [discordSocialProfileMock, twitterSocialProfileMock, githubSocialProfileMock]
+const telegramSocialProfileMock = {
+  platform: SafeAppSocialPlatforms.TELEGRAM,
+  url: 'http://tx-builder-telegram',
+}
+
+const socialProfilesMock = [
+  discordSocialProfileMock,
+  twitterSocialProfileMock,
+  githubSocialProfileMock,
+  telegramSocialProfileMock,
+]
 
 describe('SafeAppSocialLinksCard', () => {
   it('renders nothing if no social link is present in the safe app data', async () => {
@@ -76,6 +86,7 @@ describe('SafeAppSocialLinksCard', () => {
       expect(screen.getByLabelText('Discord link')).toBeInTheDocument()
       expect(screen.getByLabelText('Twitter link')).toBeInTheDocument()
       expect(screen.getByLabelText('Github link')).toBeInTheDocument()
+      expect(screen.getByLabelText('Telegram link')).toBeInTheDocument()
     })
   })
 
@@ -93,6 +104,7 @@ describe('SafeAppSocialLinksCard', () => {
       expect(screen.getByLabelText('Discord link')).toBeInTheDocument()
       expect(screen.getByLabelText('Twitter link')).toBeInTheDocument()
       expect(screen.getByLabelText('Github link')).toBeInTheDocument()
+      expect(screen.getByLabelText('Telegram link')).toBeInTheDocument()
     })
   })
 
@@ -109,6 +121,7 @@ describe('SafeAppSocialLinksCard', () => {
       expect(screen.queryByLabelText('Discord link')).toBeInTheDocument()
       expect(screen.queryByLabelText('Twitter link')).not.toBeInTheDocument()
       expect(screen.queryByLabelText('Github link')).not.toBeInTheDocument()
+      expect(screen.queryByLabelText('Telegram link')).not.toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/components/safe-apps/SafeAppSocialLinksCard/index.tsx
+++ b/apps/web/src/components/safe-apps/SafeAppSocialLinksCard/index.tsx
@@ -7,6 +7,7 @@ import Divider from '@mui/material/Divider'
 import { default as MuiLink } from '@mui/material/Link'
 import HelpOutlineRoundedIcon from '@mui/icons-material/HelpOutlineRounded'
 import GitHubIcon from '@mui/icons-material/GitHub'
+import TelegramIcon from '@mui/icons-material/Telegram'
 import TwitterIcon from '@mui/icons-material/Twitter'
 import { SafeAppSocialPlatforms } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeAppData, SafeAppSocialProfile } from '@safe-global/safe-gateway-typescript-sdk'
@@ -30,6 +31,7 @@ const SafeAppSocialLinksCard = ({ safeApp }: SafeAppSocialLinksCardProps) => {
   const discordSocialLink = getSocialProfile(socialProfiles, SafeAppSocialPlatforms.DISCORD)
   const twitterSocialLink = getSocialProfile(socialProfiles, SafeAppSocialPlatforms.TWITTER)
   const githubSocialLink = getSocialProfile(socialProfiles, SafeAppSocialPlatforms.GITHUB)
+  const telegramSocialLink = getSocialProfile(socialProfiles, SafeAppSocialPlatforms.TELEGRAM)
 
   return (
     <Card className={css.container}>
@@ -58,13 +60,25 @@ const SafeAppSocialLinksCard = ({ safeApp }: SafeAppSocialLinksCardProps) => {
 
             <Box display="flex" mt={0.2} minHeight="40px">
               {discordSocialLink && (
-                <IconButton aria-label="Discord link" component="a" target="_blank" href={discordSocialLink.url}>
+                <IconButton
+                  aria-label="Discord link"
+                  component="a"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={discordSocialLink.url}
+                >
                   <DiscordIcon />
                 </IconButton>
               )}
 
               {twitterSocialLink && (
-                <IconButton aria-label="Twitter link" component="a" target="_blank" href={twitterSocialLink.url}>
+                <IconButton
+                  aria-label="Twitter link"
+                  component="a"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={twitterSocialLink.url}
+                >
                   <TwitterIcon color="border" />
                 </IconButton>
               )}
@@ -75,9 +89,23 @@ const SafeAppSocialLinksCard = ({ safeApp }: SafeAppSocialLinksCardProps) => {
                   component="a"
                   href={githubSocialLink.url}
                   target="_blank"
+                  rel="noopener noreferrer"
                   style={{ height: '40px', width: '40px' }}
                 >
                   <GitHubIcon color="border" />
+                </IconButton>
+              )}
+
+              {telegramSocialLink && (
+                <IconButton
+                  aria-label="Telegram link"
+                  component="a"
+                  href={telegramSocialLink.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ height: '40px', width: '40px' }}
+                >
+                  <TelegramIcon color="border" />
                 </IconButton>
               )}
             </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7523,10 +7523,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-gateway-typescript-sdk@npm:3.22.6-beta.0":
-  version: 3.22.6-beta.0
-  resolution: "@safe-global/safe-gateway-typescript-sdk@npm:3.22.6-beta.0"
-  checksum: 10/9a4d0a1ac5d4e82a7e53904f7a8b7d955624e910f3eb041e1c99d09673c71dd9f8252bd33d1708470b1ecf1c80feeeb3d6f33e72e68ee2f4ba248e7ebbd4e80d
+"@safe-global/safe-gateway-typescript-sdk@npm:3.22.6":
+  version: 3.22.6
+  resolution: "@safe-global/safe-gateway-typescript-sdk@npm:3.22.6"
+  checksum: 10/021f605143d507b1fc9b9be34a1a0f96aecd268d5349428e92bf636b64c9123dd992e27ce95c6c47a092a80f95a3fb1756a651322eda497d1ef867a62a8710da
   languageName: node
   linkType: hard
 
@@ -7613,7 +7613,7 @@ __metadata:
     "@safe-global/safe-apps-sdk": "npm:^9.1.0"
     "@safe-global/safe-client-gateway-sdk": "npm:v1.60.1"
     "@safe-global/safe-core-sdk-types": "npm:^5.0.1"
-    "@safe-global/safe-gateway-typescript-sdk": "npm:3.22.6-beta.0"
+    "@safe-global/safe-gateway-typescript-sdk": "npm:3.22.6"
     "@safe-global/safe-modules-deployments": "npm:^2.2.1"
     "@sentry/react": "npm:^7.91.0"
     "@sentry/types": "npm:^7.74.0"


### PR DESCRIPTION
## What it solves
Resolves the lack of support for Telegram as a social media option for Safe Apps.

## How this PR fixes it
This PR adds an option for Safe Apps to include their Telegram ID in the social media section.

## How to test it
1. Navigate to the config service where social media options of Safe Apps are managed.
2. Check for the new option to add a Telegram ID.
3. Add a Telegram ID and verify that it is saved.
4. Navigate to the web app and check that the ID is displayed correctly.
5. Ensure there are no UI or functional issues with the existing social media options.

## Screenshot
<img width="399" alt="Screenshot 2025-01-13 at 12 03 47" src="https://github.com/user-attachments/assets/a52da2b9-d7b6-416f-9dde-440329e60c56" />

## Checklist

- [-] I've tested the branch on mobile 📱
- [-] I've documented how it affects the analytics (if at all) 📊
- [+] I've written a unit/e2e test for it (if applicable) 🧑‍💻
