### PR TITLE
Chore: fix release jobs

### DIFF
--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -58,18 +58,16 @@ jobs:
         if: startsWith(github.ref, 'refs/heads/main')
         env:
           BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/current
-        run: |
-          cd ./apps/web
-          bash  ./scripts/github/s3_upload.sh
+        working-directory: apps/web
+        run: bash  ./scripts/github/s3_upload.sh
 
       # Dev
       - name: Deploy to the dev S3
         if: startsWith(github.ref, 'refs/heads/dev')
         env:
           BUCKET: s3://${{ secrets.AWS_DEVELOPMENT_BUCKET_NAME }}
-        run: |
-          cd ./apps/web
-          bash  ./scripts/github/s3_upload.sh
+        working-directory: apps/web
+        run: bash  ./scripts/github/s3_upload.sh
 
       ### PRs ###
 
@@ -86,9 +84,8 @@ jobs:
         if: github.event.number
         env:
           BUCKET: s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/walletweb/${{ steps.extract_branch.outputs.branch }}
-        run: |
-          cd ./apps/web
-          bash  ./scripts/github/s3_upload.sh
+        working-directory: apps/web
+        run: bash  ./scripts/github/s3_upload.sh
 
       # Comment
       - name: Post a deployment link in the PR

--- a/.github/workflows/web-deploy-production.yml
+++ b/.github/workflows/web-deploy-production.yml
@@ -28,9 +28,11 @@ jobs:
 
       - name: Create archive
         run: tar -czf "$ARCHIVE_NAME".tar.gz out
+        working-directory: apps/web
 
       - name: Create checksum
         run: sha256sum "$ARCHIVE_NAME".tar.gz > ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
+        working-directory: apps/web
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -44,10 +46,12 @@ jobs:
           BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }}
           CHECKSUM_FILE: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
         run: bash ./scripts/github/s3_upload.sh
+        working-directory: apps/web
 
       # Script to prepare production deployments
       - name: Prepare deployment
         run: bash ./scripts/github/prepare_production_deployment.sh
+        working-directory: apps/web
         env:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}

--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          NEW_VERSION=$(node -p 'require("./package.json").version')
+          NEW_VERSION=$(node -p 'require("./apps/web/package.json").version')
           echo "version=v$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Create a git tag


### PR DESCRIPTION
The tag-release and prod-deployment jobs were running in the wrong folder after the move to a monorepo.