### PR TITLE
chore: rename API generation command

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest",
-    "api-generate": " npx @rtk-query/codegen-openapi scripts/openapi-config.ts"
+    "generate-api": " npx @rtk-query/codegen-openapi scripts/openapi-config.ts"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
## What it solves

Inconsistency with README

## How this PR fixes it

The `@safe-global/store` package's README states that the generation command is `generate-api`. This changes the command to match instead of `api-generate`.

## How to test it

Run `generate-api` command in `@safe-global/store` package and observe no error.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
