### PR TITLE
Tests: Fix regression tests

### DIFF
--- a/apps/web/cypress/e2e/pages/batches.pages.js
+++ b/apps/web/cypress/e2e/pages/batches.pages.js
@@ -27,6 +27,8 @@ const listBox = 'ul[role="listbox"]'
 const amountInput = '[name="amount"]'
 const nonceInput = 'input[name="nonce"]'
 const executeOptionsContainer = 'div[role="radiogroup"]'
+const expandedItem = 'div[class*="MuiCollapse-entered"]'
+const collapsedItem = 'div[class*="MuiCollapse-hidden"]'
 
 export function addToBatch(EOA, currentNonce, amount, verify = false) {
   fillTransactionData(EOA, amount)
@@ -114,9 +116,10 @@ export function verifyNewTxButtonStatus(param) {
 }
 
 export function isTxExpanded(index, option) {
+  let item = option ? expandedItem : collapsedItem
   cy.contains(batchedTxs)
     .parent()
     .within(() => {
-      cy.get('li').eq(index).find(`div[aria-expanded="${option}"]`)
+      cy.get('li').eq(index).find(item)
     })
 }

--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -49,6 +49,7 @@ const deleteTxModalBtn = '[data-testid="delete-tx-btn"]'
 const toggleUntrustedBtn = '[data-testid="toggle-untrusted"]'
 const simulateTxBtn = '[data-testid="simulate-btn"]'
 const simulateSuccess = '[data-testid="simulation-success-msg"]'
+const signBtn = '[data-testid="sign-btn"]'
 
 const viewTransactionBtn = 'View transaction'
 const transactionDetailsTitle = 'Transaction details'
@@ -65,7 +66,6 @@ export const executeStr = 'Execute'
 const editBtnStr = 'Edit'
 const executionParamsStr = 'Execution parameters'
 const noLaterStr = 'No, later'
-const signBtnStr = 'Sign'
 const confirmBtnStr = 'Confirm'
 const expandAllBtnStr = 'Expand all'
 const collapseAllBtnStr = 'Collapse all'
@@ -545,7 +545,7 @@ export function clickOnNoLaterOption() {
 }
 
 export function clickOnSignTransactionBtn() {
-  cy.get('button').contains(signBtnStr).click()
+  cy.get(signBtn).click()
 }
 
 export function clickOnConfirmTransactionBtn() {

--- a/apps/web/cypress/e2e/pages/sidebar.pages.js
+++ b/apps/web/cypress/e2e/pages/sidebar.pages.js
@@ -167,6 +167,7 @@ export function clickOnSidebarImportBtn() {
 }
 
 export function showAllSafes() {
+  cy.wait(500)
   cy.get('body').then(($body) => {
     if ($body.find(expandSafesList).length > 0) {
       cy.get(expandSafesList).click()

--- a/apps/web/cypress/e2e/prodhealthcheck/swaps_history_2.cy.js
+++ b/apps/web/cypress/e2e/prodhealthcheck/swaps_history_2.cy.js
@@ -59,7 +59,7 @@ describe('[PROD] Swaps history tests 2', () => {
         swapsHistory.forAtMost,
       ])
       main.verifyValuesDoNotExist(create_tx.transactionItem, [swapsHistory.title, swapsHistory.cow, swapsHistory.dai])
-      main.verifyValuesExist(create_tx.transactionItem, [swapsHistory.actionPreSignatureG, swapsHistory.gGpV2])
+      main.verifyValuesExist(create_tx.transactionItem, [swapsHistory.actionPreSignatureG])
     },
   )
 })

--- a/apps/web/cypress/e2e/regression/sidebar_5.cy.js
+++ b/apps/web/cypress/e2e/regression/sidebar_5.cy.js
@@ -87,6 +87,7 @@ describe('Sidebar search tests', () => {
     sideBar.searchSafe('0xC')
     sideBar.checkSearchResults(1)
     sideBar.clearSearchInput()
+    sideBar.showAllSafes()
     sideBar.verifyAccountListSafeCount(6)
   })
 })

--- a/apps/web/cypress/e2e/regression/swaps_history_2.cy.js
+++ b/apps/web/cypress/e2e/regression/swaps_history_2.cy.js
@@ -120,7 +120,7 @@ describe('Swaps history tests 2', () => {
         swapsHistory.forAtMost,
       ])
       main.verifyValuesDoNotExist(create_tx.transactionItem, [swapsHistory.title, swapsHistory.cow, swapsHistory.dai])
-      main.verifyValuesExist(create_tx.transactionItem, [swapsHistory.actionPreSignatureG, swapsHistory.gGpV2])
+      main.verifyValuesExist(create_tx.transactionItem, [swapsHistory.actionPreSignatureG])
     },
   )
 

--- a/apps/web/cypress/fixtures/txhistory_data_data.json
+++ b/apps/web/cypress/fixtures/txhistory_data_data.json
@@ -58,9 +58,9 @@
       "txHashDAI": "0x7156...3e47",
       "nftHash": "0x3873...6d0b",
       "txHashEth": "0xdc6b...f250",
-      "executionDateDAI": "30/10/2023, 02:37:11",
-      "executionDateNFT": "28/09/2023, 02:48:11",
-      "executionDateEth": "19/08/2020, 08:51:31"
+      "executionDateDAI": "10/30/2023, 2:37:11 AM",
+      "executionDateNFT": "9/28/2023, 2:48:11 AM",
+      "executionDateEth": "8/19/2020, 8:51:31 AM"
     },
     "send": {
       "title": "Sent",

--- a/apps/web/cypress/support/e2e.js
+++ b/apps/web/cypress/support/e2e.js
@@ -35,6 +35,15 @@ addCompareSnapshotCommand()
 const beamer = JSON.parse(Cypress.env('BEAMER_DATA_E2E') || '{}')
 const productID = beamer.PRODUCT_ID
 
+Cypress.on('test:before:run', () => {
+  Cypress.automation('remote:debugger:protocol', {
+    command: 'Emulation.setLocaleOverride',
+    params: {
+      locale: 'en-US',
+    },
+  })
+})
+
 before(() => {
   Cypress.on('uncaught:exception', (err, runnable) => {
     return false


### PR DESCRIPTION
## What it solves

## How this PR fixes it
Fix failing regression tests:

- Set en-US locale globally to keep consistency with CI/CD when running tests locally
- Update date formats in tx history tests
- Update expanded/collapsed element class and its relative method logic
- Update sign button element with data-testid
- Update tests steps

## How to test it

- Run Cypress tests and observe outcome
