### PR TITLE
Fix(Tx notes): fire analytics on tx submit + adjust design

### DIFF
--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
@@ -33,7 +33,7 @@ import ConfirmationView from '../confirmation-views'
 import { SignerForm } from './SignerForm'
 import { useSigner } from '@/hooks/wallets/useWallet'
 import { trackTxEvents } from './tracking'
-import { TxNoteForm, encodeTxNote } from '@/features/tx-notes'
+import { TxNoteForm, encodeTxNote, trackAddNote } from '@/features/tx-notes'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -112,8 +112,12 @@ export const SignOrExecuteForm = ({
         !!signer?.isSafe,
         customOrigin,
       )
+
+      if (customOrigin !== props.origin) {
+        trackAddNote()
+      }
     },
-    [chainId, isCreation, onSubmit, trigger, signer?.isSafe, customOrigin],
+    [chainId, isCreation, onSubmit, trigger, signer?.isSafe, customOrigin, props.origin],
   )
 
   const onRoleExecutionSubmit = useCallback<typeof onFormSubmit>(
@@ -126,7 +130,7 @@ export const SignOrExecuteForm = ({
     [onFormSubmit],
   )
 
-  const onNoteSubmit = useCallback(
+  const onNoteChange = useCallback(
     (note: string) => {
       setCustomOrigin(encodeTxNote(note, props.origin))
     },
@@ -194,7 +198,7 @@ export const SignOrExecuteForm = ({
 
       {!isCounterfactualSafe && !props.isRejection && <TxChecks />}
 
-      <TxNoteForm isCreation={isCreation ?? false} onSubmit={onNoteSubmit} txDetails={props.txDetails} />
+      <TxNoteForm isCreation={isCreation ?? false} onChange={onNoteChange} txDetails={props.txDetails} />
 
       <SignerForm willExecute={willExecute} />
 

--- a/apps/web/src/features/tx-notes/TxNoteForm.tsx
+++ b/apps/web/src/features/tx-notes/TxNoteForm.tsx
@@ -6,11 +6,11 @@ import { TxNoteInput } from './TxNoteInput'
 export function TxNoteForm({
   isCreation,
   txDetails,
-  onSubmit,
+  onChange,
 }: {
   isCreation: boolean
   txDetails?: TransactionDetails
-  onSubmit: (note: string) => void
+  onChange: (note: string) => void
 }) {
-  return <TxCard>{isCreation ? <TxNoteInput onSubmit={onSubmit} /> : <TxNote txDetails={txDetails} />}</TxCard>
+  return <TxCard>{isCreation ? <TxNoteInput onChange={onChange} /> : <TxNote txDetails={txDetails} />}</TxCard>
 }

--- a/apps/web/src/features/tx-notes/TxNoteForm.tsx
+++ b/apps/web/src/features/tx-notes/TxNoteForm.tsx
@@ -12,5 +12,10 @@ export function TxNoteForm({
   txDetails?: TransactionDetails
   onChange: (note: string) => void
 }) {
+  // @FIXME: update CGW types to include note
+  const note = (txDetails as TransactionDetails & { note: string | null })?.note
+
+  if (!isCreation && !note) return null
+
   return <TxCard>{isCreation ? <TxNoteInput onChange={onChange} /> : <TxNote txDetails={txDetails} />}</TxCard>
 }

--- a/apps/web/src/features/tx-notes/TxNoteInput.tsx
+++ b/apps/web/src/features/tx-notes/TxNoteInput.tsx
@@ -1,23 +1,21 @@
 import { useCallback, useState } from 'react'
 import { InputAdornment, Stack, TextField, Typography } from '@mui/material'
 import InfoIcon from '@/public/images/notifications/info.svg'
-import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 
 const MAX_NOTE_LENGTH = 120
 
-export const TxNoteInput = ({ onSubmit }: { onSubmit: (note: string) => void }) => {
+export const TxNoteInput = ({ onChange }: { onChange: (note: string) => void }) => {
   const [note, setNote] = useState('')
 
   const onInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setNote(e.target.value)
   }, [])
 
-  const onChange = useCallback(
+  const onInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      onSubmit(e.target.value.slice(0, MAX_NOTE_LENGTH))
-      trackEvent(MODALS_EVENTS.ADD_TX_NOTE)
+      onChange(e.target.value.slice(0, MAX_NOTE_LENGTH))
     },
-    [onSubmit],
+    [onChange],
   )
 
   return (
@@ -46,7 +44,7 @@ export const TxNoteInput = ({ onSubmit }: { onSubmit: (note: string) => void }) 
           },
         }}
         onInput={onInput}
-        onChange={onChange}
+        onChange={onInputChange}
       />
 
       <Typography variant="caption" color="text.secondary" display="flex" alignItems="center">

--- a/apps/web/src/features/tx-notes/TxNoteInput.tsx
+++ b/apps/web/src/features/tx-notes/TxNoteInput.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useState } from 'react'
-import { InputAdornment, Stack, TextField, Typography } from '@mui/material'
-import InfoIcon from '@/public/images/notifications/info.svg'
+import { InputAdornment, Stack, TextField, Typography, Alert } from '@mui/material'
 
-const MAX_NOTE_LENGTH = 120
+const MAX_NOTE_LENGTH = 60
 
 export const TxNoteInput = ({ onChange }: { onChange: (note: string) => void }) => {
   const [note, setNote] = useState('')
@@ -21,15 +20,19 @@ export const TxNoteInput = ({ onChange }: { onChange: (note: string) => void }) 
   return (
     <>
       <Stack direction="row" alignItems="flex-end" gap={1}>
-        <Typography variant="h5">What does this transaction do?</Typography>
+        <Typography variant="h5">Optional note</Typography>
         <Typography variant="body2" color="text.secondary">
-          Optional
+          Experimental
         </Typography>
       </Stack>
 
+      <Alert severity="info">
+        The notes are <b>publicly visible</b>, do not share any private or sensitive details.
+      </Alert>
+
       <TextField
         name="note"
-        label="Add note"
+        label="Note"
         fullWidth
         slotProps={{
           htmlInput: { maxLength: MAX_NOTE_LENGTH },
@@ -46,11 +49,6 @@ export const TxNoteInput = ({ onChange }: { onChange: (note: string) => void }) 
         onInput={onInput}
         onChange={onInputChange}
       />
-
-      <Typography variant="caption" color="text.secondary" display="flex" alignItems="center">
-        <InfoIcon height="1.2em" />
-        This note will be publicly visible and accessible to anyone.
-      </Typography>
     </>
   )
 }

--- a/apps/web/src/features/tx-notes/encodeTxNote.ts
+++ b/apps/web/src/features/tx-notes/encodeTxNote.ts
@@ -1,7 +1,5 @@
 const MAX_ORIGIN_LENGTH = 200
 
-const stringifyOrigin = (origin: Record<string, string>): string => JSON.stringify(origin, null, 0)
-
 export function encodeTxNote(note: string, origin = ''): string {
   let originalOrigin = {}
 
@@ -13,13 +11,13 @@ export function encodeTxNote(note: string, origin = ''): string {
     }
   }
 
-  let result = stringifyOrigin({
+  let result = JSON.stringify({
     ...originalOrigin,
     note,
   })
 
   if (result.length > MAX_ORIGIN_LENGTH) {
-    result = stringifyOrigin({
+    result = JSON.stringify({
       ...originalOrigin,
       note: note.slice(0, MAX_ORIGIN_LENGTH - origin.length),
     })

--- a/apps/web/src/features/tx-notes/index.tsx
+++ b/apps/web/src/features/tx-notes/index.tsx
@@ -8,5 +8,5 @@ export const TxNoteForm = featureToggled(TxNoteFormComponent, FEATURES.TX_NOTES)
 export * from './encodeTxNote'
 
 export function trackAddNote() {
-  trackEvent(MODALS_EVENTS.ADD_TX_NOTE)
+  trackEvent(MODALS_EVENTS.SUBMIT_TX_NOTE)
 }

--- a/apps/web/src/features/tx-notes/index.tsx
+++ b/apps/web/src/features/tx-notes/index.tsx
@@ -1,7 +1,12 @@
 import { featureToggled, FEATURES } from '@/utils/featureToggled'
 import { TxNote as TxNoteComponent } from './TxNote'
 import { TxNoteForm as TxNoteFormComponent } from './TxNoteForm'
+import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 
 export const TxNote = featureToggled(TxNoteComponent, FEATURES.TX_NOTES)
 export const TxNoteForm = featureToggled(TxNoteFormComponent, FEATURES.TX_NOTES)
 export * from './encodeTxNote'
+
+export function trackAddNote() {
+  trackEvent(MODALS_EVENTS.ADD_TX_NOTE)
+}

--- a/apps/web/src/services/analytics/events/modals.ts
+++ b/apps/web/src/services/analytics/events/modals.ts
@@ -87,8 +87,8 @@ export const MODALS_EVENTS = {
     category: MODALS_CATEGORY,
     event: EventType.CLICK,
   },
-  ADD_TX_NOTE: {
-    action: 'Add tx note',
+  SUBMIT_TX_NOTE: {
+    action: 'Submit tx note',
     category: MODALS_CATEGORY,
     event: EventType.CLICK,
   },


### PR DESCRIPTION
## What it solves

A follow-up on #4693.

Triggering the `Add tx note` on input change is firing too many times, so I'm changing it to fire only when you submit a tx with a note.

Also, we've adjusted the design as per internal feedback:

<img width="677" alt="Screenshot 2025-01-14 at 16 42 31" src="https://github.com/user-attachments/assets/b6247bce-f860-4594-81d0-844d47ee6128" />

## How this PR fixes it

* GA event is moved to tx modal submit callback
* GA event is renamed to `Submit tx note` to differentiate it from the previous, incorrectly tracked, event
* I also renamed the `onSubmit` prop name to `onChange` for clarity
* Slight adjustments to the design
* Character limit is reduced to 60 to fit in the `origin` limit better + align with the size of the input.