### PR TITLE
Refactor(Tx speed up): rm unused argument

### DIFF
--- a/apps/web/src/features/speedup/components/SpeedUpModal.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpModal.tsx
@@ -114,7 +114,6 @@ export const SpeedUpModal = ({
           pendingTx.data,
           wallet.provider,
           wallet.address,
-          safeAddress,
           pendingTx.nonce,
         )
         // Currently all custom txs are batch executes

--- a/apps/web/src/services/tx/tx-sender/dispatch.ts
+++ b/apps/web/src/services/tx/tx-sender/dispatch.ts
@@ -236,7 +236,6 @@ export const dispatchCustomTxSpeedUp = async (
   data: string,
   provider: Eip1193Provider,
   signerAddress: string,
-  safeAddress: string,
   nonce: number,
 ) => {
   const eventParams = { txId, nonce }


### PR DESCRIPTION
Just a tiny lint fix – the `safeAddress` param wasn't used in `dispatchCustomTxSpeedUp`.