### PR TITLE
Refactor(Tx decoding): use transaction preview endpoint

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,7 +55,7 @@
     "@safe-global/protocol-kit": "^4.1.3",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-client-gateway-sdk": "v1.60.1",
-    "@safe-global/safe-gateway-typescript-sdk": "3.22.6",
+    "@safe-global/safe-gateway-typescript-sdk": "3.22.7-beta.0",
     "@safe-global/safe-modules-deployments": "^2.2.1",
     "@sentry/react": "^7.91.0",
     "@spindl-xyz/attribution-lite": "^1.4.0",

--- a/apps/web/src/components/batch/BatchSidebar/BatchTxItem.tsx
+++ b/apps/web/src/components/batch/BatchSidebar/BatchTxItem.tsx
@@ -83,7 +83,13 @@ const BatchTxItem = ({ id, count, timestamp, txDetails, onDelete }: BatchTxItemP
 
         <AccordionDetails>
           <div className={css.details}>
-            <TxData txDetails={txDetails} trusted imitation={false} />
+            <TxData
+              txInfo={txDetails.txInfo}
+              txData={txDetails.txData}
+              txDetails={txDetails}
+              trusted
+              imitation={false}
+            />
 
             <TxDataRow title="Created:">{timestamp ? dateString(timestamp) : null}</TxDataRow>
 

--- a/apps/web/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
@@ -1,7 +1,6 @@
 import DecodedTx from '@/components/tx/DecodedTx'
 import useAsync from '@/hooks/useAsync'
 import { useCurrentChain } from '@/hooks/useChains'
-import useDecodeTx from '@/hooks/useDecodeTx'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { getMultiSendContractDeployment } from '@/services/contracts/deployments'
@@ -14,6 +13,7 @@ import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { MigrateToL2Information } from '@/components/tx/confirmation-views/MigrateToL2Information'
 import { Box } from '@mui/material'
 import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
+import useTxPreview from '@/components/tx/confirmation-views/useTxPreview'
 
 export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetails }) => {
   const readOnlyProvider = useWeb3ReadOnly()
@@ -66,9 +66,8 @@ export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetai
     }
   }, [txDetails.txHash, txDetails.detailedExecutionInfo, chain, sdk, readOnlyProvider, safe.version])
 
-  const [decodedRealTx, decodedRealTxError] = useDecodeTx(realSafeTx)
-
   const decodedDataUnavailable = !realSafeTx && !realSafeTxLoading
+  const [txPreview, txPreviewError] = useTxPreview(realSafeTx?.data)
 
   return (
     <Box>
@@ -76,12 +75,12 @@ export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetai
 
       {realSafeTxError ? (
         <ErrorMessage>{realSafeTxError.message}</ErrorMessage>
-      ) : decodedRealTxError ? (
-        <ErrorMessage>{decodedRealTxError.message}</ErrorMessage>
+      ) : txPreviewError ? (
+        <ErrorMessage>{txPreviewError.message}</ErrorMessage>
       ) : decodedDataUnavailable ? (
         <DecodedData txData={txDetails.txData} />
       ) : (
-        <DecodedTx decodedData={decodedRealTx} tx={realSafeTx} />
+        txPreview && <DecodedTx {...txPreview} tx={realSafeTx} />
       )}
     </Box>
   )

--- a/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
@@ -1,6 +1,6 @@
 import { Safe__factory } from '@/types/contracts'
 import { Skeleton } from '@mui/material'
-import { getConfirmationView, type TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
+import { type TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 
 import DecodedTx from '@/components/tx/DecodedTx'
@@ -9,9 +9,9 @@ import { useCurrentChain } from '@/hooks/useChains'
 import { AppRoutes } from '@/config/routes'
 import { useMemo } from 'react'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
-import useAsync from '@/hooks/useAsync'
 import ExternalLink from '@/components/common/ExternalLink'
 import { NestedTransaction } from '../NestedTransaction'
+import useTxPreview from '@/components/tx/confirmation-views/useTxPreview'
 
 const safeInterface = Safe__factory.createInterface()
 
@@ -55,20 +55,20 @@ export const ExecTransaction = ({
     [data?.hexData],
   )
 
-  const [decodedNestedTransaction, error] = useAsync(async () => {
-    if (chain?.chainId && data?.to.value && childSafeTx) {
-      return await getConfirmationView(
-        chain.chainId,
-        data.to.value,
-        childSafeTx.data.data,
-        childSafeTx.data.to,
-        childSafeTx.data.value.toString(),
-      )
-    }
-  }, [chain?.chainId, data?.to.value, childSafeTx])
+  const [txPreview, error] = useTxPreview(
+    childSafeTx
+      ? {
+          operation: childSafeTx.data.operation,
+          data: childSafeTx.data.data,
+          to: childSafeTx.data.to,
+          value: childSafeTx.data.value.toString(),
+        }
+      : undefined,
+    data?.to.value,
+  )
 
-  const decodedNestedTxDataBlock = decodedNestedTransaction ? (
-    <DecodedTx tx={childSafeTx} showMethodCall decodedData={decodedNestedTransaction} showAdvancedDetails={false} />
+  const decodedNestedTxDataBlock = txPreview ? (
+    <DecodedTx {...txPreview} tx={childSafeTx} showMethodCall showAdvancedDetails={false} />
   ) : null
 
   return (

--- a/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/OnChainConfirmation/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/OnChainConfirmation/index.tsx
@@ -52,7 +52,13 @@ export const OnChainConfirmation = ({
     <NestedTransaction txData={data} isConfirmationView={isConfirmationView}>
       {nestedTxDetails ? (
         <>
-          <TxData txDetails={nestedTxDetails} trusted imitation={false} />
+          <TxData
+            txData={nestedTxDetails.txData}
+            txInfo={nestedTxDetails.txInfo}
+            txDetails={nestedTxDetails}
+            trusted
+            imitation={false}
+          />
 
           {(isMultiSendTxInfo(nestedTxDetails.txInfo) || isOrderTxInfo(nestedTxDetails.txInfo)) && (
             <ErrorBoundary fallback={<div>Error parsing data</div>}>

--- a/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
@@ -20,7 +20,7 @@ import {
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
 import { SpendingLimits } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
-import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
+import { TransactionStatus, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import { type ReactElement } from 'react'
 import RejectionTxInfo from '@/components/transactions/TxDetails/TxData/Rejection'
 import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData'
@@ -36,68 +36,78 @@ import { ExecTransaction } from './NestedTransaction/ExecTransaction'
 import SafeUpdate from './SafeUpdate'
 
 const TxData = ({
+  txInfo,
+  txData,
   txDetails,
   trusted,
   imitation,
 }: {
-  txDetails: TransactionDetails
+  txInfo: TransactionDetails['txInfo']
+  txData: TransactionDetails['txData']
+  txDetails?: TransactionDetails
   trusted: boolean
   imitation: boolean
 }): ReactElement => {
   const chainId = useChainId()
-  const txInfo = txDetails.txInfo
-  const toInfo = isCustomTxInfo(txDetails.txInfo) ? txDetails.txInfo.to : undefined
+  const toInfo = isCustomTxInfo(txInfo) ? txInfo.to : undefined
 
-  if (isOrderTxInfo(txDetails.txInfo)) {
-    return <SwapOrder txData={txDetails.txData} txInfo={txDetails.txInfo} />
+  if (isOrderTxInfo(txInfo)) {
+    return <SwapOrder txData={txData} txInfo={txInfo} />
   }
 
-  if (isStakingTxDepositInfo(txDetails.txInfo)) {
-    return <StakingTxDepositDetails txData={txDetails.txData} info={txDetails.txInfo} />
+  if (isStakingTxDepositInfo(txInfo)) {
+    return <StakingTxDepositDetails txData={txData} info={txInfo} />
   }
 
-  if (isStakingTxExitInfo(txDetails.txInfo)) {
-    return <StakingTxExitDetails info={txDetails.txInfo} />
+  if (isStakingTxExitInfo(txInfo)) {
+    return <StakingTxExitDetails info={txInfo} />
   }
 
-  if (isStakingTxWithdrawInfo(txDetails.txInfo)) {
-    return <StakingTxWithdrawDetails info={txDetails.txInfo} />
+  if (isStakingTxWithdrawInfo(txInfo)) {
+    return <StakingTxWithdrawDetails info={txInfo} />
   }
 
   if (isTransferTxInfo(txInfo)) {
-    return <TransferTxInfo txInfo={txInfo} txStatus={txDetails.txStatus} trusted={trusted} imitation={imitation} />
+    return (
+      <TransferTxInfo
+        txInfo={txInfo}
+        txStatus={txDetails?.txStatus ?? TransactionStatus.AWAITING_CONFIRMATIONS}
+        trusted={trusted}
+        imitation={imitation}
+      />
+    )
   }
 
   if (isSettingsChangeTxInfo(txInfo)) {
     return <SettingsChangeTxInfo settingsInfo={txInfo.settingsInfo} />
   }
 
-  if (isCancellationTxInfo(txInfo) && isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)) {
+  if (txDetails && isCancellationTxInfo(txInfo) && isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)) {
     return <RejectionTxInfo nonce={txDetails.detailedExecutionInfo?.nonce} isTxExecuted={!!txDetails.executedAt} />
   }
 
-  const method = txDetails.txData?.dataDecoded?.method as SpendingLimitMethods
+  const method = txData?.dataDecoded?.method as SpendingLimitMethods
   if (isCustomTxInfo(txInfo) && isSupportedSpendingLimitAddress(txInfo, chainId) && isSpendingLimitMethod(method)) {
-    return <SpendingLimits txData={txDetails.txData} txInfo={txInfo} type={method} />
+    return <SpendingLimits txData={txData} txInfo={txInfo} type={method} />
   }
 
-  if (isMigrateToL2TxData(txDetails.txData, chainId)) {
+  if (txDetails && isMigrateToL2TxData(txData, chainId)) {
     return <MigrationToL2TxData txDetails={txDetails} />
   }
 
-  if (isOnChainConfirmationTxData(txDetails.txData)) {
-    return <OnChainConfirmation data={txDetails.txData} />
+  if (isOnChainConfirmationTxData(txData)) {
+    return <OnChainConfirmation data={txData} />
   }
 
-  if (isExecTxData(txDetails.txData)) {
-    return <ExecTransaction data={txDetails.txData} />
+  if (isExecTxData(txData)) {
+    return <ExecTransaction data={txData} />
   }
 
-  if (isSafeUpdateTxData(txDetails.txData)) {
-    return <SafeUpdate txData={txDetails.txData} />
+  if (isSafeUpdateTxData(txData)) {
+    return <SafeUpdate txData={txData} />
   }
 
-  return <DecodedData txData={txDetails.txData} toInfo={toInfo} />
+  return <DecodedData txData={txData} toInfo={toInfo} />
 }
 
 export default TxData

--- a/apps/web/src/components/transactions/TxDetails/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/index.tsx
@@ -93,7 +93,13 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
 
         <div className={css.txData}>
           <ErrorBoundary fallback={<div>Error parsing data</div>}>
-            <TxData txDetails={txDetails} trusted={isTrustedTransfer} imitation={isImitationTransaction} />
+            <TxData
+              txData={txDetails.txData}
+              txInfo={txDetails.txInfo}
+              txDetails={txDetails}
+              trusted={isTrustedTransfer}
+              imitation={isImitationTransaction}
+            />
           </ErrorBoundary>
         </div>
 

--- a/apps/web/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
+++ b/apps/web/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowReview.tsx
@@ -10,7 +10,6 @@ import DecodedTx from '@/components/tx/DecodedTx'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
 import TxChecks from '@/components/tx/SignOrExecuteForm/TxChecks'
-import useDecodeTx from '@/hooks/useDecodeTx'
 import TxCard from '../../common/TxCard'
 import { SafeTxContext } from '../../SafeTxProvider'
 import CheckWallet from '@/components/common/CheckWallet'
@@ -36,6 +35,7 @@ import { BlockaidBalanceChanges } from '@/components/tx/security/blockaid/Blocka
 import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 import { useGetTransactionDetailsQuery } from '@/store/api/gateway'
 import { skipToken } from '@reduxjs/toolkit/query'
+import useTxPreview from '@/components/tx/confirmation-views/useTxPreview'
 
 export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlowProps }): ReactElement | null {
   // Form state
@@ -46,7 +46,6 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
   // Hooks
   const { setTxFlow } = useContext(TxModalContext)
   const { safeTx, safeTxError, setSafeTx, setSafeTxError } = useContext(SafeTxContext)
-  const [decodedData] = useDecodeTx(safeTx)
   const { safe } = useSafeInfo()
   const wallet = useWallet()
   const onboard = useOnboard()
@@ -55,6 +54,7 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
   const [, executionValidationError] = useIsValidRecoveryExecTransactionFromModule(recovery?.address, safeTx)
 
   const { data: txDetails } = useGetTransactionDetailsQuery(skipToken)
+  const [txPreview] = useTxPreview(safeTx?.data, undefined, txDetails?.txId)
 
   // Proposal
   const newThreshold = Number(params[RecoverAccountFlowFields.threshold])
@@ -131,7 +131,7 @@ export function RecoverAccountFlowReview({ params }: { params: RecoverAccountFlo
 
         <Divider className={commonCss.nestedDivider} />
 
-        <DecodedTx txDetails={txDetails} tx={safeTx} decodedData={decodedData} />
+        <DecodedTx txDetails={txDetails} tx={safeTx} {...txPreview} />
 
         <BlockaidBalanceChanges />
       </TxCard>

--- a/apps/web/src/components/tx/DecodedTx/index.tsx
+++ b/apps/web/src/components/tx/DecodedTx/index.tsx
@@ -7,9 +7,8 @@ import {
   isTransferTxInfo,
 } from '@/utils/transaction-guards'
 import { Accordion, AccordionDetails, AccordionSummary, Box, Stack } from '@mui/material'
-import { OperationType, type SafeTransaction } from '@safe-global/safe-core-sdk-types'
-import type { DataDecoded, DecodedDataResponse, TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import { Operation } from '@safe-global/safe-gateway-typescript-sdk'
+import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import Summary, { PartialSummary } from '@/components/transactions/TxDetails/Summary'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
 import Multisend from '@/components/transactions/TxDetails/TxData/DecodedData/Multisend'
@@ -22,8 +21,9 @@ type DecodedTxProps = {
   tx?: SafeTransaction
   txId?: string
   txDetails?: TransactionDetails
+  txInfo?: TransactionDetails['txInfo']
+  txData?: TransactionDetails['txData']
   showMultisend?: boolean
-  decodedData?: DecodedDataResponse | DataDecoded
   showMethodCall?: boolean
   showAdvancedDetails?: boolean
 }
@@ -40,39 +40,29 @@ export const Divider = () => (
 const DecodedTx = ({
   tx,
   txDetails,
-  decodedData,
+  txInfo,
+  txData,
   showMultisend = true,
   showMethodCall = false,
   showAdvancedDetails = true,
 }: DecodedTxProps): ReactElement => {
+  const decodedData = txData?.dataDecoded
   const isMultisend = decodedData?.parameters && !!decodedData?.parameters[0]?.valueDecoded
   const isMethodCallInAdvanced = showAdvancedDetails && (!showMethodCall || (isMultisend && showMultisend))
 
   const onChangeExpand = (_: SyntheticEvent, expanded: boolean) => {
     trackEvent({ ...MODALS_EVENTS.TX_DETAILS, label: expanded ? 'Open' : 'Close' })
   }
-  const addressInfoIndex = txDetails?.txData?.addressInfoIndex
-
   const isCreation =
     txDetails &&
     isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo) &&
     txDetails.detailedExecutionInfo.confirmations.length === 0
 
-  const txData = {
-    dataDecoded: decodedData,
-    to: { value: tx?.data.to || '' },
-    value: tx?.data.value,
-    hexData: tx?.data.data,
-    operation: tx?.data.operation === OperationType.DelegateCall ? Operation.DELEGATE : Operation.CALL,
-    trustedDelegateCallTarget: txDetails?.txData?.trustedDelegateCallTarget ?? true,
-    addressInfoIndex,
-  }
-
   let toInfo = tx && {
     value: tx.data.to,
   }
-  if (txDetails && isCustomTxInfo(txDetails?.txInfo)) {
-    toInfo = txDetails?.txInfo.to
+  if (txInfo && isCustomTxInfo(txInfo)) {
+    toInfo = txInfo.to
   }
 
   const decodedDataBlock = <DecodedData txData={txData} toInfo={toInfo} />
@@ -91,7 +81,7 @@ const DecodedTx = ({
           {decodedDataBlock}
         </Box>
       )}
-      {isMultisend && showMultisend && <Multisend txData={txDetails?.txData || txData} compact />}
+      {isMultisend && showMultisend && <Multisend txData={txData} compact />}
 
       {showAdvancedDetails && (
         <Box>
@@ -109,10 +99,7 @@ const DecodedTx = ({
                 }}
               />
               {isMethodCallInAdvanced && decodedData?.method}
-              {txDetails &&
-                isTransferTxInfo(txDetails.txInfo) &&
-                isNativeTokenTransfer(txDetails.txInfo.transferInfo) &&
-                'native transfer'}
+              {txInfo && isTransferTxInfo(txInfo) && isNativeTokenTransfer(txInfo.transferInfo) && 'native transfer'}
             </AccordionSummary>
             <AccordionDetails data-testid="decoded-tx-details">
               {showDecodedData && (

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
@@ -179,6 +179,7 @@ export const SignOrExecuteForm = ({
         {props.children}
 
         <ConfirmationView
+          txId={props.txId}
           isCreation={isCreation}
           txDetails={props.txDetails}
           safeTx={safeTx}

--- a/apps/web/src/components/tx/SignOrExecuteForm/hooks.ts
+++ b/apps/web/src/components/tx/SignOrExecuteForm/hooks.ts
@@ -16,13 +16,10 @@ import {
 } from '@/services/tx/tx-sender'
 import { useHasPendingTxs } from '@/hooks/usePendingTxs'
 import { getSafeTxGas, getNonces } from '@/services/tx/tx-sender/recommendedNonce'
-import type { AsyncResult } from '@/hooks/useAsync'
 import useAsync from '@/hooks/useAsync'
 import { useUpdateBatch } from '@/hooks/useDraftBatch'
-import { getTransactionDetails, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
+import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import { useCurrentChain } from '@/hooks/useChains'
-import directProposeTx from '@/services/tx/proposeTransaction'
-import { getAndValidateSafeSDK } from '@/services/tx/tx-sender/sdk'
 
 type TxActions = {
   addToBatch: (safeTx?: SafeTransaction, origin?: string) => Promise<string>
@@ -36,26 +33,6 @@ type TxActions = {
   ) => Promise<string>
   signProposerTx: (safeTx?: SafeTransaction, origin?: string) => Promise<string>
   proposeTx: (safeTx: SafeTransaction, txId?: string, origin?: string) => Promise<TransactionDetails>
-}
-
-type txDetails = AsyncResult<TransactionDetails>
-
-export const useProposeTx = (safeTx?: SafeTransaction, txId?: string, origin?: string): txDetails => {
-  const { safe } = useSafeInfo()
-  const signer = useSigner()
-  const sender = signer?.address || safe.owners?.[0]?.value
-
-  return useAsync(
-    async () => {
-      if (txId) return getTransactionDetails(safe.chainId, txId)
-      if (!safeTx || !sender) return
-      const safeSDK = getAndValidateSafeSDK()
-      const safeTxHash = await safeSDK.getTransactionHash(safeTx)
-      return directProposeTx(safe.chainId, safe.address.value, sender, safeTx, safeTxHash, origin)
-    },
-    [safeTx, txId, origin, safe.chainId, safe.address.value, sender],
-    false,
-  )
 }
 
 export const useTxActions = (): TxActions => {

--- a/apps/web/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/index.tsx
@@ -1,10 +1,9 @@
+import { useContext } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import SignOrExecuteForm from './SignOrExecuteForm'
 import type { SignOrExecuteProps, SubmitCallback } from './SignOrExecuteForm'
 import SignOrExecuteSkeleton from './SignOrExecuteSkeleton'
-import { useProposeTx } from './hooks'
-import { useContext } from 'react'
-import useSafeInfo from '@/hooks/useSafeInfo'
+import useTxDetails from '@/hooks/useTxDetails'
 
 type SignOrExecuteExtendedProps = Omit<SignOrExecuteProps, 'txId'> & {
   onSubmit?: SubmitCallback
@@ -23,16 +22,15 @@ type SignOrExecuteExtendedProps = Omit<SignOrExecuteProps, 'txId'> & {
 
 const SignOrExecute = (props: SignOrExecuteExtendedProps) => {
   const { safeTx } = useContext(SafeTxContext)
-  const { safe } = useSafeInfo()
-  const [txDetails, error] = useProposeTx(safe.deployed ? safeTx : undefined, props.txId, props.origin)
+  const [txDetails, , error] = useTxDetails(props.txId)
 
   // Show the loader only the first time the tx is being loaded
-  if ((!txDetails && !error && safe.deployed) || !safeTx) {
+  if (!safeTx || (props.txId && !txDetails && !error)) {
     return <SignOrExecuteSkeleton />
   }
 
   return (
-    <SignOrExecuteForm {...props} isCreation={!props.txId} txId={props.txId || txDetails?.txId} txDetails={txDetails}>
+    <SignOrExecuteForm {...props} isCreation={!props.txId} txId={props.txId} txDetails={txDetails}>
       {props.children}
     </SignOrExecuteForm>
   )

--- a/apps/web/src/components/tx/confirmation-views/ChangeThreshold/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/ChangeThreshold/index.tsx
@@ -10,13 +10,13 @@ import { isChangeThresholdView } from '../utils'
 import { maybePlural } from '@/utils/formatters'
 
 interface ChangeThresholdProps {
-  txDetails?: TransactionDetails
+  txInfo?: TransactionDetails['txInfo']
 }
 
-function ChangeThreshold({ txDetails }: ChangeThresholdProps) {
+function ChangeThreshold({ txInfo }: ChangeThresholdProps) {
   const { safe } = useSafeInfo()
   const { newThreshold } = useContext(ChangeThresholdReviewContext)
-  const threshold = txDetails && isChangeThresholdView(txDetails.txInfo) && txDetails.txInfo.settingsInfo?.threshold
+  const threshold = txInfo && isChangeThresholdView(txInfo) && txInfo.settingsInfo?.threshold
 
   return (
     <>

--- a/apps/web/src/components/tx/confirmation-views/SwapOrder/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/SwapOrder/index.tsx
@@ -6,12 +6,12 @@ interface SwapOrderProps extends NarrowConfirmationViewProps {
   txInfo: Order
 }
 
-function SwapOrder({ txDetails, txInfo }: SwapOrderProps) {
+function SwapOrder({ txInfo, txData }: SwapOrderProps) {
   return (
     <SwapOrderConfirmation
       order={txInfo}
-      decodedData={txDetails?.txData?.dataDecoded}
-      settlementContract={txDetails?.txData?.to?.value ?? ''}
+      decodedData={txData?.dataDecoded}
+      settlementContract={txData?.to?.value ?? ''}
     />
   )
 }

--- a/apps/web/src/components/tx/confirmation-views/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/index.tsx
@@ -26,6 +26,7 @@ import SwapOrder from './SwapOrder'
 import StakingTx from './StakingTx'
 import UpdateSafe from './UpdateSafe'
 import { MigrateToL2Information } from './MigrateToL2Information'
+import useTxPreview from './useTxPreview'
 
 type ConfirmationViewProps = {
   txDetails?: TransactionDetails
@@ -38,51 +39,49 @@ type ConfirmationViewProps = {
   children?: ReactNode
 }
 
-// TODO: Maybe unify this with the if block in TxData
 const getConfirmationViewComponent = ({
-  txDetails,
   txInfo,
+  txData,
   txFlow,
 }: NarrowConfirmationViewProps & { txFlow?: ReactElement }) => {
-  if (isChangeThresholdView(txInfo)) return <ChangeThreshold txDetails={txDetails} />
+  if (isChangeThresholdView(txInfo)) return <ChangeThreshold txInfo={txInfo} />
 
   if (isConfirmBatchView(txFlow)) return <BatchTransactions />
 
-  if (isSettingsChangeView(txInfo)) return <SettingsChange txDetails={txDetails} txInfo={txInfo as SettingsChange} />
+  if (isSettingsChangeView(txInfo)) return <SettingsChange txInfo={txInfo as SettingsChange} />
 
-  if (isOnChainConfirmationTxData(txDetails.txData))
-    return <OnChainConfirmation data={txDetails.txData} isConfirmationView />
+  if (isOnChainConfirmationTxData(txData)) return <OnChainConfirmation data={txData} isConfirmationView />
 
-  if (isExecTxData(txDetails.txData)) return <ExecTransaction data={txDetails.txData} isConfirmationView />
+  if (isExecTxData(txData)) return <ExecTransaction data={txData} isConfirmationView />
 
-  if (isSwapOrderTxInfo(txInfo)) return <SwapOrder txDetails={txDetails} txInfo={txInfo} />
+  if (isSwapOrderTxInfo(txInfo)) return <SwapOrder txInfo={txInfo} txData={txData} />
 
-  if (isAnyStakingTxInfo(txInfo)) return <StakingTx txDetails={txDetails} txInfo={txInfo} />
+  if (isAnyStakingTxInfo(txInfo)) return <StakingTx txInfo={txInfo} />
 
-  if (isCustomTxInfo(txInfo) && isSafeUpdateTxData(txDetails.txData)) return <UpdateSafe />
+  if (isCustomTxInfo(txInfo) && isSafeUpdateTxData(txData)) return <UpdateSafe />
 
-  if (isCustomTxInfo(txInfo) && isSafeToL2MigrationTxData(txDetails.txData)) {
-    return <MigrateToL2Information variant="queue" txData={txDetails.txData} />
+  if (isCustomTxInfo(txInfo) && isSafeToL2MigrationTxData(txData)) {
+    return <MigrateToL2Information variant="queue" txData={txData} />
   }
 
   return null
 }
 
-const ConfirmationView = ({ txDetails, ...props }: ConfirmationViewProps) => {
-  const { txId } = txDetails || {}
+const ConfirmationView = ({ safeTx, txDetails, ...props }: ConfirmationViewProps) => {
+  const { txId } = props
   const { txFlow } = useContext(TxModalContext)
+  const [txPreview] = useTxPreview(safeTx?.data, undefined, txId)
+  const details = txDetails ?? txPreview
 
-  const ConfirmationViewComponent = useMemo(
-    () =>
-      txDetails
-        ? getConfirmationViewComponent({
-            txDetails,
-            txInfo: txDetails.txInfo,
-            txFlow,
-          })
-        : undefined,
-    [txDetails, txFlow],
-  )
+  const ConfirmationViewComponent = useMemo(() => {
+    return details
+      ? getConfirmationViewComponent({
+          txInfo: details.txInfo,
+          txData: details.txData,
+          txFlow,
+        })
+      : undefined
+  }, [details, txFlow])
 
   const showTxDetails =
     txId &&
@@ -95,14 +94,17 @@ const ConfirmationView = ({ txDetails, ...props }: ConfirmationViewProps) => {
   return (
     <>
       {ConfirmationViewComponent ||
-        (showTxDetails && txDetails && <TxData txDetails={txDetails} imitation={false} trusted />)}
+        (showTxDetails && details && (
+          <TxData txData={details?.txData} txInfo={details?.txInfo} txDetails={txDetails} imitation={false} trusted />
+        ))}
 
       {props.children}
 
       <DecodedTx
-        tx={props.safeTx}
+        tx={safeTx}
         txDetails={txDetails}
-        decodedData={txDetails?.txData?.dataDecoded}
+        txData={details?.txData}
+        txInfo={details?.txInfo}
         showMultisend={!props.isBatch}
         showMethodCall={props.showMethodCall && !ConfirmationViewComponent && !showTxDetails && !props.isApproval}
       />

--- a/apps/web/src/components/tx/confirmation-views/types.d.ts
+++ b/apps/web/src/components/tx/confirmation-views/types.d.ts
@@ -1,6 +1,6 @@
 import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 
 export type NarrowConfirmationViewProps = {
-  txDetails: TransactionDetails
   txInfo: TransactionDetails['txInfo']
+  txData?: TransactionDetails['txData']
 }

--- a/apps/web/src/components/tx/confirmation-views/useTxPreview.ts
+++ b/apps/web/src/components/tx/confirmation-views/useTxPreview.ts
@@ -1,0 +1,29 @@
+import { Operation, getTxPreview } from '@safe-global/safe-gateway-typescript-sdk'
+import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import useAsync from '@/hooks/useAsync'
+import useSafeInfo from '@/hooks/useSafeInfo'
+
+const useTxPreview = (
+  safeTxData?: {
+    operation: SafeTransaction['data']['operation']
+    data: SafeTransaction['data']['data']
+    value: SafeTransaction['data']['value']
+    to: SafeTransaction['data']['to']
+  },
+  customSafeAddress?: string,
+  txId?: string,
+) => {
+  const {
+    safe: { chainId },
+    safeAddress,
+  } = useSafeInfo()
+  const address = customSafeAddress ?? safeAddress
+
+  return useAsync(() => {
+    if (txId || !safeTxData?.data) return
+    const { operation = Operation.CALL, data = '', to, value } = safeTxData || {}
+    return getTxPreview(chainId, address, operation, data, to, value)
+  }, [txId, chainId, address, safeTxData?.data])
+}
+
+export default useTxPreview

--- a/apps/web/src/hooks/useDecodeTx.ts
+++ b/apps/web/src/hooks/useDecodeTx.ts
@@ -1,5 +1,5 @@
 import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
-import { getConfirmationView, type AnyConfirmationView } from '@safe-global/safe-gateway-typescript-sdk'
+import { getConfirmationView, type AnyConfirmationView, Operation } from '@safe-global/safe-gateway-typescript-sdk'
 import { getNativeTransferData } from '@/services/tx/tokenTransferParams'
 import { isEmptyHexData } from '@/utils/hex'
 import type { AsyncResult } from './useAsync'
@@ -10,7 +10,7 @@ import useSafeAddress from '@/hooks/useSafeAddress'
 const useDecodeTx = (tx?: SafeTransaction): AsyncResult<AnyConfirmationView> => {
   const chainId = useChainId()
   const safeAddress = useSafeAddress()
-  const { to, value, data } = tx?.data || {}
+  const { to, value, data, operation = Operation.CALL } = tx?.data || {}
 
   return useAsync<AnyConfirmationView | undefined>(
     () => {
@@ -23,7 +23,7 @@ const useDecodeTx = (tx?: SafeTransaction): AsyncResult<AnyConfirmationView> => 
         return Promise.resolve(nativeTransfer)
       }
 
-      return getConfirmationView(chainId, safeAddress, data, to, value)
+      return getConfirmationView(chainId, safeAddress, operation, data, to, value)
     },
     [chainId, safeAddress, to, value, data],
     false,


### PR DESCRIPTION
## What it solves

The old `confirmation-view` endpoint [was deprecated ](https://github.com/safe-global/safe-client-gateway/pull/1973) but there's a new, better, transaction `preview` endpoint.

This endpoint returns almost the same response as TransactionDetails and allows us to stop proposing new transactions just to decode them.

Todo: fix tests