### PR TITLE
Fix(Tx notes): hide for 1/X safes

### DIFF
--- a/apps/web/src/features/tx-notes/TxNoteForm.tsx
+++ b/apps/web/src/features/tx-notes/TxNoteForm.tsx
@@ -2,6 +2,7 @@ import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sd
 import TxCard from '@/components/tx-flow/common/TxCard'
 import { TxNote } from './TxNote'
 import { TxNoteInput } from './TxNoteInput'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 export function TxNoteForm({
   isCreation,
@@ -12,6 +13,9 @@ export function TxNoteForm({
   txDetails?: TransactionDetails
   onChange: (note: string) => void
 }) {
+  const { safe } = useSafeInfo()
+  if (safe.threshold === 1) return null // Notes don't work yet for 1/X Safes
+
   // @FIXME: update CGW types to include note
   const note = (txDetails as TransactionDetails & { note: string | null })?.note
 


### PR DESCRIPTION
## What it solves

Resolves #4779.

* Disable tx notes for 1/X Safes

## Why?
Notes cannot be added when doing an immediate execution in 1/X Safes because we propose the tx before a note is added and then it's impossible to overwrite it unless the tx is signed.

So for now, we're disabling notes for all 1/X Safes. A better solution will be done later in #4783.