### PR TITLE
Fix(Swaps): TWAP order decoding

### DIFF
--- a/apps/web/src/components/tx/confirmation-views/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/index.tsx
@@ -11,6 +11,7 @@ import {
   isSafeToL2MigrationTxData,
   isSafeUpdateTxData,
   isSwapOrderTxInfo,
+  isTwapOrderTxInfo,
 } from '@/utils/transaction-guards'
 import { type ReactNode, useContext, useMemo } from 'react'
 import TxData from '@/components/transactions/TxDetails/TxData'
@@ -55,7 +56,7 @@ const getConfirmationViewComponent = ({
 
   if (isExecTxData(txData)) return <ExecTransaction data={txData} isConfirmationView />
 
-  if (isSwapOrderTxInfo(txInfo)) return <SwapOrder txInfo={txInfo} txData={txData} />
+  if (isSwapOrderTxInfo(txInfo) || isTwapOrderTxInfo(txInfo)) return <SwapOrder txInfo={txInfo} txData={txData} />
 
   if (isAnyStakingTxInfo(txInfo)) return <StakingTx txInfo={txInfo} />
 


### PR DESCRIPTION
## What it solves

Resolves #4802

## How this PR fixes it

TWAP confirmation view is the same as the Swap one so it just needed an extra mapping.