### PR TITLE
Fix(TWAP): executedFee can be undefined

### DIFF
--- a/apps/web/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
+++ b/apps/web/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
@@ -12,7 +12,7 @@ export const SurplusFee = ({
   const bps = getOrderFeeBps(order)
   const { executedFee, executedFeeToken } = order
 
-  if (executedFee === null || executedFee === '0') {
+  if (!executedFee || executedFee === '0') {
     return null
   }
 


### PR DESCRIPTION
## What it solves

`executedFee` can be undefined and it was crashing the entire TWAP preview component.
