### PR TITLE
Upload build output using parallel threads

### DIFF
--- a/apps/web/scripts/github/s3_upload.sh
+++ b/apps/web/scripts/github/s3_upload.sh
@@ -13,7 +13,9 @@ aws s3 sync . $BUCKET --delete
 
 # Upload all HTML files again but w/o an extention so that URLs like /welcome open the right page
 for file in $(find . -name '*.html' | sed 's|^\./||'); do
-    aws s3 cp ${file%} $BUCKET/${file%.*} --content-type 'text/html'
+    aws s3 cp ${file%} $BUCKET/${file%.*} --content-type 'text/html' &
 done
+
+wait
 
 cd -


### PR DESCRIPTION
## What it solves

Identical to safe-global/safe-docs#680 and safe-global/safe-homepage#541, this fix aims to drastically reduce deployment times to AWS.

## How this PR fixes it

The issue is solved by uploading files in parallel using the `&` operator.