### PR TITLE
fix: upload build output to AWS using up to 20 parallel threads

### DIFF
--- a/apps/web/scripts/github/s3_upload.sh
+++ b/apps/web/scripts/github/s3_upload.sh
@@ -12,27 +12,10 @@ cd out
 aws s3 sync . $BUCKET --delete
 
 # Upload all HTML files again but w/o an extention so that URLs like /welcome open the right page
-# Max number of parallel processes
-MAX_PARALLEL=20
-
-# Counter to track the number of running processes
-counter=0
-
 for file in $(find . -name '*.html' | sed 's|^\./||'); do
-    # Launch the process
-    aws s3 cp "${file%}" "$BUCKET/${file%.*}" --content-type 'text/html' &
-
-    # Increment the counter
-    ((counter++))
-
-    # If the counter reaches the max limit, wait for all processes to complete
-    if ((counter >= MAX_PARALLEL)); then
-        wait
-        counter=0
-    fi
+    aws s3 cp ${file%} $BUCKET/${file%.*} --content-type 'text/html' &
 done
 
-# Wait for any remaining processes to complete
 wait
 
 cd -

--- a/apps/web/scripts/github/s3_upload.sh
+++ b/apps/web/scripts/github/s3_upload.sh
@@ -12,8 +12,27 @@ cd out
 aws s3 sync . $BUCKET --delete
 
 # Upload all HTML files again but w/o an extention so that URLs like /welcome open the right page
+# Max number of parallel processes
+MAX_PARALLEL=20
+
+# Counter to track the number of running processes
+counter=0
+
 for file in $(find . -name '*.html' | sed 's|^\./||'); do
-    aws s3 cp ${file%} $BUCKET/${file%.*} --content-type 'text/html'
+    # Launch the process
+    aws s3 cp "${file%}" "$BUCKET/${file%.*}" --content-type 'text/html' &
+
+    # Increment the counter
+    ((counter++))
+
+    # If the counter reaches the max limit, wait for all processes to complete
+    if ((counter >= MAX_PARALLEL)); then
+        wait
+        counter=0
+    fi
 done
+
+# Wait for any remaining processes to complete
+wait
 
 cd -


### PR DESCRIPTION
## What it solves

Identical to https://github.com/safe-global/safe-docs/pull/680 and https://github.com/safe-global/safe-homepage/pull/541, this fix aims to drastically reduce deployment times to AWS.

## How this PR fixes it

The issue is solved by uploading files in parallel using the `&` operator. A limit of 20 threads has been added for more safety.