### PR TITLE
Fix: nested tx preview

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
@@ -58,7 +58,7 @@ export const ExecTransaction = ({
   const [txPreview, error] = useTxPreview(
     childSafeTx
       ? {
-          operation: childSafeTx.data.operation,
+          operation: Number(childSafeTx.data.operation),
           data: childSafeTx.data.data,
           to: childSafeTx.data.to,
           value: childSafeTx.data.value.toString(),

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
   >
     <div
       class="MuiCardContent-root cardContent css-1lt5qva-MuiCardContent-root"
+      data-testid="card-content"
     >
       <div
         class="MuiStack-root css-1sazv7p-MuiStack-root"
@@ -172,6 +173,7 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
   >
     <div
       class="MuiCardContent-root cardContent css-1lt5qva-MuiCardContent-root"
+      data-testid="card-content"
     >
       <div
         class="wrapper"
@@ -279,6 +281,7 @@ exports[`SignOrExecute should display a loading component 1`] = `
   >
     <div
       class="MuiCardContent-root cardContent css-1lt5qva-MuiCardContent-root"
+      data-testid="card-content"
     >
       <div
         class="MuiBox-root css-17luq05"
@@ -343,6 +346,7 @@ exports[`SignOrExecute should display an error screen 1`] = `
   >
     <div
       class="MuiCardContent-root cardContent css-1lt5qva-MuiCardContent-root"
+      data-testid="card-content"
     >
       <div
         class="MuiStack-root css-1sazv7p-MuiStack-root"
@@ -507,6 +511,7 @@ exports[`SignOrExecute should display an error screen 1`] = `
   >
     <div
       class="MuiCardContent-root cardContent css-1lt5qva-MuiCardContent-root"
+      data-testid="card-content"
     >
       <div
         class="wrapper"

--- a/apps/web/src/components/tx/confirmation-views/useTxPreview.ts
+++ b/apps/web/src/components/tx/confirmation-views/useTxPreview.ts
@@ -13,17 +13,18 @@ const useTxPreview = (
   customSafeAddress?: string,
   txId?: string,
 ) => {
+  const skip = !!txId || !safeTxData
   const {
     safe: { chainId },
     safeAddress,
   } = useSafeInfo()
   const address = customSafeAddress ?? safeAddress
+  const { operation = Operation.CALL, data = '', to, value } = safeTxData ?? {}
 
   return useAsync(() => {
-    if (txId || !safeTxData?.data) return
-    const { operation = Operation.CALL, data = '', to, value } = safeTxData || {}
+    if (skip) return
     return getTxPreview(chainId, address, operation, data, to, value)
-  }, [txId, chainId, address, safeTxData])
+  }, [skip, chainId, address, operation, data, to, value])
 }
 
 export default useTxPreview


### PR DESCRIPTION
## What it solves

Resolves #4840

It was a regression after #4783 (not live yet).

## How this PR fixes it

The `operation` field in a nested tx was BigInt and it wasn't working well with the tx preview endpoint. So I converted it to a number.

Also optimized the dependencies of useAsync in useTxPreview to avoid an infinite loop if a passed tx object is re-created.