### PR TITLE
feat: Create SafeInput component

### DIFF
--- a/apps/mobile/src/components/SafeInput/SafeInput.stories.tsx
+++ b/apps/mobile/src/components/SafeInput/SafeInput.stories.tsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import { SafeInput, SafeInputProps } from './SafeInput'
+import type { Meta, StoryObj } from '@storybook/react'
+import { View } from 'tamagui'
+
+const SafeInputMeta: Meta = {
+  title: 'Components/SafeInput',
+  component: SafeInput,
+  decorators: [
+    (Story) => (
+      <View padding={16}>
+        <Story />
+      </View>
+    ),
+  ],
+  args: {
+    height: 52,
+  },
+  argTypes: {
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text',
+    },
+    value: {
+      control: 'text',
+      description: 'Input value',
+    },
+    error: {
+      control: 'text',
+      description: 'Error message',
+    },
+    multiline: {
+      control: 'boolean',
+      description: 'Enable multiline input',
+    },
+    textAlign: {
+      control: {
+        type: 'select',
+        options: ['left', 'center', 'right'],
+      },
+      description: 'Text alignment',
+    },
+  },
+}
+
+export default SafeInputMeta
+
+type SafeInputStory = StoryObj<typeof SafeInput>
+
+export const Default: SafeInputStory = (args: SafeInputProps) => <SafeInput {...args} />
+Default.args = {
+  placeholder: 'Enter text...',
+  value: '',
+}
+
+export const WithError: SafeInputStory = (args: SafeInputProps) => <SafeInput {...args} />
+WithError.args = {
+  placeholder: 'Enter text...',
+  value: 'Invalid input',
+  error: 'This is an error message',
+}
+
+export const Multiline: SafeInputStory = (args: SafeInputProps) => <SafeInput {...args} />
+Multiline.args = {
+  placeholder: 'Enter multiple lines...',
+  value: '',
+  multiline: true,
+  height: 100,
+}
+
+export const CenteredText: SafeInputStory = (args: SafeInputProps) => <SafeInput {...args} />
+CenteredText.args = {
+  placeholder: 'Centered text...',
+  value: 'This text is centered',
+  textAlign: 'center',
+}
+
+export const WithLongText: SafeInputStory = (args: SafeInputProps) => <SafeInput {...args} />
+WithLongText.args = {
+  placeholder: 'Enter text...',
+  value: 'This is a very long text that should wrap to multiple lines when it exceeds the width of the input component',
+  multiline: true,
+  height: 100,
+}

--- a/apps/mobile/src/components/SafeInput/SafeInput.test.tsx
+++ b/apps/mobile/src/components/SafeInput/SafeInput.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@/src/tests/test-utils'
+import { SafeInput } from './SafeInput'
+import { Text } from 'tamagui'
+
+describe('SafeInput', () => {
+  it('should render the default component', () => {
+    const { getByTestId } = render(<SafeInput placeholder="Please enter something..." />)
+    const input = getByTestId('safe-input')
+
+    expect(input).toBeDefined()
+    expect(input.attributes.placeholder).toBe('Please enter something...')
+    expect(input.style.borderColor).toBe('gray')
+  })
+
+  it('should render an error message when an error message is provided', () => {
+    const { getByTestId, getByText } = render(<SafeInput error="This field is required" />)
+    const input = getByTestId('safe-input')
+
+    expect(input.style.borderColor).toBe('red')
+    expect(input.style.borderWidth).toBe(2)
+    expect(getByText('This field is required')).toBeDefined()
+  })
+
+  it('should accept a custom error message component', () => {
+    const { getByTestId, getByText } = render(<SafeInput error={<Text>This field is required</Text>} />)
+    const input = getByTestId('safe-input')
+
+    expect(input.style.borderColor).toBe('red')
+    expect(input.style.borderWidth).toBe(2)
+    expect(getByText('This field is required')).toBeDefined()
+  })
+})

--- a/apps/mobile/src/components/SafeInput/SafeInput.test.tsx
+++ b/apps/mobile/src/components/SafeInput/SafeInput.test.tsx
@@ -8,16 +8,22 @@ describe('SafeInput', () => {
     const input = getByTestId('safe-input')
 
     expect(input).toBeDefined()
-    expect(input.attributes.placeholder).toBe('Please enter something...')
-    expect(input.style.borderColor).toBe('gray')
+
+    expect(input.children[0].props.placeholder).toBe('Please enter something...')
+    expect(input.props.style.borderTopColor).toBe('#DCDEE0')
+    expect(input.props.style.borderBottomColor).toBe('#DCDEE0')
+    expect(input.props.style.borderLeftColor).toBe('#DCDEE0')
+    expect(input.props.style.borderRightColor).toBe('#DCDEE0')
   })
 
   it('should render an error message when an error message is provided', () => {
     const { getByTestId, getByText } = render(<SafeInput error="This field is required" />)
     const input = getByTestId('safe-input')
 
-    expect(input.style.borderColor).toBe('red')
-    expect(input.style.borderWidth).toBe(2)
+    expect(input.props.style.borderTopColor).toBe('#FF5F72')
+    expect(input.props.style.borderBottomColor).toBe('#FF5F72')
+    expect(input.props.style.borderLeftColor).toBe('#FF5F72')
+    expect(input.props.style.borderRightColor).toBe('#FF5F72')
     expect(getByText('This field is required')).toBeDefined()
   })
 
@@ -25,8 +31,20 @@ describe('SafeInput', () => {
     const { getByTestId, getByText } = render(<SafeInput error={<Text>This field is required</Text>} />)
     const input = getByTestId('safe-input')
 
-    expect(input.style.borderColor).toBe('red')
-    expect(input.style.borderWidth).toBe(2)
+    expect(input.props.style.borderTopColor).toBe('#FF5F72')
+    expect(input.props.style.borderBottomColor).toBe('#FF5F72')
+    expect(input.props.style.borderLeftColor).toBe('#FF5F72')
+    expect(input.props.style.borderRightColor).toBe('#FF5F72')
     expect(getByText('This field is required')).toBeDefined()
+  })
+
+  it('should change the color when a success prop is provided', () => {
+    const { getByTestId } = render(<SafeInput success />)
+    const input = getByTestId('safe-input')
+
+    expect(input.props.style.borderTopColor).toBe('#12FF80')
+    expect(input.props.style.borderBottomColor).toBe('#12FF80')
+    expect(input.props.style.borderLeftColor).toBe('#12FF80')
+    expect(input.props.style.borderRightColor).toBe('#12FF80')
   })
 })

--- a/apps/mobile/src/components/SafeInput/SafeInput.tsx
+++ b/apps/mobile/src/components/SafeInput/SafeInput.tsx
@@ -4,7 +4,7 @@ import { StyledInput, StyledInputContainer } from './styled'
 import { getInputThemeName } from './utils'
 import { SafeFontIcon } from '../SafeFontIcon'
 
-interface SafeInputProps {
+export interface SafeInputProps {
   error?: React.ReactNode | string
   placeholder?: string
   height?: number
@@ -31,7 +31,7 @@ export function SafeInput({
   error,
   success,
   placeholder,
-  height,
+  height = 52,
   left,
   right,
   ...props

--- a/apps/mobile/src/components/SafeInput/SafeInput.tsx
+++ b/apps/mobile/src/components/SafeInput/SafeInput.tsx
@@ -40,7 +40,7 @@ export function SafeInput({
 
   return (
     <Theme name={`input_${getInputThemeName(hasError, success)}`}>
-      <StyledInputContainer minHeight={height}>
+      <StyledInputContainer minHeight={height} testID="safe-input">
         {left}
 
         <StyledInput

--- a/apps/mobile/src/components/SafeInput/SafeInput.tsx
+++ b/apps/mobile/src/components/SafeInput/SafeInput.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { InputProps, Text, Theme, View } from 'tamagui'
+import { StyledInput, StyledInputContainer } from './styled'
+import { getInputThemeName } from './utils'
+import { SafeFontIcon } from '../SafeFontIcon'
+
+interface SafeInputProps {
+  error?: React.ReactNode | string
+  placeholder?: string
+  height?: number
+  success?: boolean
+  left?: React.ReactNode
+  right?: React.ReactNode
+}
+
+const ErrorDisplay = ({ error }: { error: React.ReactNode | string }) => {
+  if (typeof error === 'string') {
+    return (
+      <View flexDirection="row" alignItems="center" gap="$1">
+        <SafeFontIcon color="$textColor" size={16} name="info" />
+        <Text color="$textColor" fontWeight="600">
+          {error}
+        </Text>
+      </View>
+    )
+  }
+  return error
+}
+
+export function SafeInput({
+  error,
+  success,
+  placeholder,
+  height,
+  left,
+  right,
+  ...props
+}: SafeInputProps & Omit<InputProps, 'left' | 'right'>) {
+  const hasError = !!error
+
+  return (
+    <Theme name={`input_${getInputThemeName(hasError, success)}`}>
+      <StyledInputContainer minHeight={height}>
+        {left}
+
+        <StyledInput
+          {...props}
+          size="$5"
+          flex={1}
+          maxHeight={height}
+          autoCapitalize="none"
+          autoCorrect={false}
+          placeholder={placeholder}
+        />
+        {right}
+      </StyledInputContainer>
+      {hasError && <ErrorDisplay error={error} />}
+    </Theme>
+  )
+}

--- a/apps/mobile/src/components/SafeInput/styled.ts
+++ b/apps/mobile/src/components/SafeInput/styled.ts
@@ -1,0 +1,27 @@
+import { Input, styled, View } from 'tamagui'
+
+export const StyledInputContainer = styled(View, {
+  borderWidth: 2,
+  borderRadius: '$4',
+  borderColor: '$borderColor',
+  flex: 1,
+  flexDirection: 'row',
+  paddingHorizontal: '$3',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginBottom: '$3',
+
+  variants: {
+    error: {
+      true: {
+        borderWidth: 2,
+      },
+    },
+  },
+})
+
+export const StyledInput = styled(Input, {
+  color: '$inputTextColor',
+  placeholderTextColor: '$placeholderColor',
+  borderWidth: 0,
+})

--- a/apps/mobile/src/components/SafeInput/theme.ts
+++ b/apps/mobile/src/components/SafeInput/theme.ts
@@ -1,0 +1,40 @@
+import { tokens } from '@/src/theme/tokens'
+
+export const inputTheme = {
+  light_input_default: {
+    borderColor: tokens.color.borderLightLight,
+    textColor: tokens.color.textPrimaryLight,
+    placeholderColor: tokens.color.textSecondaryLight,
+    inputTextColor: tokens.color.textPrimaryLight,
+  },
+  dark_input_default: {
+    borderColor: tokens.color.borderLightDark,
+    textColor: tokens.color.textPrimaryDark,
+    placeholderColor: tokens.color.textSecondaryDark,
+    inputTextColor: tokens.color.textPrimaryDark,
+  },
+  light_input_success: {
+    borderColor: tokens.color.primaryMainDark,
+    textColor: tokens.color.textPrimaryLight,
+    placeholderColor: tokens.color.textSecondaryLight,
+    inputTextColor: tokens.color.textPrimaryLight,
+  },
+  dark_input_success: {
+    borderColor: tokens.color.primaryMainDark,
+    textColor: tokens.color.textPrimaryDark,
+    placeholderColor: tokens.color.textSecondaryDark,
+    inputTextColor: tokens.color.textPrimaryDark,
+  },
+  light_input_error: {
+    borderColor: tokens.color.errorMainLight,
+    textColor: tokens.color.errorMainLight,
+    placeholderColor: tokens.color.errorMainLight,
+    inputTextColor: tokens.color.textPrimaryLight,
+  },
+  dark_input_error: {
+    borderColor: tokens.color.errorMainDark,
+    textColor: tokens.color.errorMainDark,
+    placeholderColor: tokens.color.errorMainDark,
+    inputTextColor: tokens.color.textPrimaryDark,
+  },
+}

--- a/apps/mobile/src/components/SafeInput/utils.ts
+++ b/apps/mobile/src/components/SafeInput/utils.ts
@@ -1,0 +1,11 @@
+export const getInputThemeName = (hasError?: boolean, hasSuccess?: boolean) => {
+  if (hasError) {
+    return 'error'
+  }
+
+  if (hasSuccess) {
+    return 'success'
+  }
+
+  return 'default'
+}

--- a/apps/mobile/src/theme/tamagui.config.ts
+++ b/apps/mobile/src/theme/tamagui.config.ts
@@ -3,6 +3,7 @@ import { createDmSansFont } from '@tamagui/font-dm-sans'
 import { badgeTheme } from '@/src/components/Badge/theme'
 import { tokens } from '@/src/theme/tokens'
 import { createAnimations } from '@tamagui/animations-moti'
+import { inputTheme } from '../components/SafeInput/theme'
 
 const DmSansFont = createDmSansFont({
   face: {
@@ -49,6 +50,7 @@ export const config = createTamagui({
       color: tokens.color.infoMainDark,
     },
     ...badgeTheme,
+    ...inputTheme,
     light_success: {
       background: tokens.color.successBackgroundLight,
       color: tokens.color.successMainLight,


### PR DESCRIPTION
## What it solves
It creates reusable SafeInput component.

## Screenshots
<img width="381" alt="Screenshot 2025-01-30 at 15 36 15" src="https://github.com/user-attachments/assets/5f1c6f05-7138-4531-bcd2-91b46ed56374" />
<img width="425" alt="Screenshot 2025-01-30 at 15 37 13" src="https://github.com/user-attachments/assets/e1233f29-c62a-4b95-9ba8-e7bdacf601c1" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
