### PR TITLE
Tests: Update polygon tests

### DIFF
--- a/.github/workflows/web-e2e-full-ondemand.yml
+++ b/.github/workflows/web-e2e-full-ondemand.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-20.04
-    timeout-minutes: 90
+    timeout-minutes: 40
     name: Cypress Full Regression on demand tests
     strategy:
       fail-fast: false

--- a/.github/workflows/web-e2e-full-ondemand.yml
+++ b/.github/workflows/web-e2e-full-ondemand.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4, 5]
+        containers: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/web/cypress/e2e/pages/create_wallet.pages.js
+++ b/apps/web/cypress/e2e/pages/create_wallet.pages.js
@@ -5,6 +5,7 @@ import * as constants from '../../support/constants'
 
 const welcomeLoginScreen = '[data-testid="welcome-login"]'
 const expandMoreIcon = 'svg[data-testid="ExpandMoreIcon"]'
+const newtworkSelectorDiv = 'div[class*="networkSelector"]'
 const nameInput = 'input[name="name"]'
 const ownerInput = 'input[name^="owners"][name$="name"]'
 const ownerAddress = 'input[name^="owners"][name$="address"]'
@@ -209,7 +210,7 @@ export function clearWalletName() {
 }
 
 export function openNetworkSelector() {
-  cy.get('header').find(expandMoreIcon).parent().click()
+  cy.get(newtworkSelectorDiv).find(expandMoreIcon).parent().click()
 }
 export function selectNetwork(network) {
   cy.wait(1000)

--- a/apps/web/cypress/e2e/pages/sidebar.pages.js
+++ b/apps/web/cypress/e2e/pages/sidebar.pages.js
@@ -398,7 +398,7 @@ export function checkAddNetworkBtnPosition(index) {
     })
 }
 export function clickOnAddNetworkBtn() {
-  cy.get(addNetworkBtn).click()
+  cy.get(addNetworkBtn).eq(0).click()
   cy.get(addChainDialog).should('be.visible')
 }
 

--- a/apps/web/cypress/e2e/regression/multichain_network.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_network.cy.js
@@ -10,8 +10,7 @@ let staticSafes = []
 const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
 const signer = walletCredentials.OWNER_4_PRIVATE_KEY
 
-// Skip due to issues with Polygon
-describe.skip('Multichain add network tests', () => {
+describe('Multichain add network tests', { defaultCommandTimeout: 60000 }, () => {
   before(async () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })

--- a/apps/web/cypress/e2e/regression/multichain_networkswitch.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_networkswitch.cy.js
@@ -14,8 +14,7 @@ const signer = walletCredentials.OWNER_4_PRIVATE_KEY
 // DO NOT use OWNER_2_PRIVATE_KEY for safe creation. Used for CF safes.
 const signer2 = walletCredentials.OWNER_2_PRIVATE_KEY
 
-// Skip due to issues with Polygon
-describe.skip('Multichain header network switch tests', { defaultCommandTimeout: 30000 }, () => {
+describe('Multichain header network switch tests', { defaultCommandTimeout: 60000 }, () => {
   before(async () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
@@ -60,7 +59,7 @@ describe.skip('Multichain header network switch tests', { defaultCommandTimeout:
     create_wallet.openNetworkSelector()
     sideBar.clickOnShowAllNetworksBtn()
     sideBar.checkNetworkPresence([constants.networks.gnosis, constants.networks.ethereum], sideBar.addNetworkOption)
-    main.verifyElementsCount(sideBar.addNetworkOption, 2)
+    main.verifyElementsCount(sideBar.addNetworkOption, 4)
   })
 
   it('Verify that test networks and main networks are splitted', () => {

--- a/apps/web/cypress/e2e/regression/multichain_setup.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_setup.cy.js
@@ -8,6 +8,8 @@ import * as navigation from '../pages/navigation.page.js'
 import * as create_wallet from '../pages/create_wallet.pages.js'
 import * as owner from '../pages/owners.pages.js'
 
+import { suspendOutreachModal } from '../pages/modals.page.js'
+
 let staticSafes = []
 
 const walletCredentials = JSON.parse(Cypress.env('CYPRESS_WALLET_CREDENTIALS'))
@@ -71,6 +73,8 @@ describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
     cy.visit(constants.setupUrl + safe)
 
     owner.waitForConnectionStatus()
+    navigation.verifyTxBtnStatus(constants.enabledStates.enabled)
+    suspendOutreachModal()
     owner.openRemoveOwnerWindow(1)
     cy.wait(1000)
     create_wallet.clickOnNextBtn()
@@ -81,6 +85,8 @@ describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
     let safe = main.changeSafeChainName(staticSafes.MATIC_STATIC_SAFE_28, 'sep')
     cy.visit(constants.setupUrl + safe)
     owner.waitForConnectionStatus()
+    navigation.verifyTxBtnStatus(constants.enabledStates.enabled)
+    suspendOutreachModal()
     owner.clickOnChangeThresholdBtn()
     create_wallet.updateThreshold(2)
     owner.clickOnThresholdNextBtn()
@@ -91,6 +97,8 @@ describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
     let safe = main.changeSafeChainName(staticSafes.MATIC_STATIC_SAFE_28, 'sep')
     cy.visit(constants.setupUrl + safe)
     owner.waitForConnectionStatus()
+    navigation.verifyTxBtnStatus(constants.enabledStates.enabled)
+    suspendOutreachModal()
     owner.openReplaceOwnerWindow(1)
     owner.typeOwnerAddress(constants.SEPOLIA_OWNER_2)
     cy.wait(2000)

--- a/apps/web/cypress/e2e/regression/multichain_setup.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_setup.cy.js
@@ -15,8 +15,7 @@ const signer = walletCredentials.OWNER_4_PRIVATE_KEY
 // DO NOT use OWNER_2_PRIVATE_KEY for safe creation. Used for CF safes.
 const signer2 = walletCredentials.OWNER_2_PRIVATE_KEY
 
-// Skip due to issues with Polygon
-describe.skip('Multichain setup tests', { defaultCommandTimeout: 30000 }, () => {
+describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
   before(async () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })


### PR DESCRIPTION
## What it solves

Resolves #4850 

## How this PR fixes it

- Updated and enabled Polygon tests
- Increased timeouts where necessary
- Increased containers from 5 to 8 in speedup tests 
- Decreased full regression workflow timeout to 40 minutes

## How to test it

- Run Cypress tests and observe outcome