### PR TITLE
Fix(Spending limits): check selected token

### DIFF
--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -91,9 +91,10 @@ export const CreateTokenTransfer = ({
   const selectedToken = balancesItems.find((item) => item.tokenInfo.address === tokenAddress)
   const { totalAmount, spendingLimitAmount } = useTokenAmount(selectedToken)
 
-  const canCreateSpendingLimitTxWithToken = useHasPermission(Permission.CreateSpendingLimitTransaction, {
-    token: selectedToken?.tokenInfo,
-  })
+  const canCreateSpendingLimitTxWithToken =
+    useHasPermission(Permission.CreateSpendingLimitTransaction, {
+      token: selectedToken?.tokenInfo,
+    }) && selectedToken
 
   const isSpendingLimitType = type === TokenTransferType.spendingLimit
 

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -91,10 +91,9 @@ export const CreateTokenTransfer = ({
   const selectedToken = balancesItems.find((item) => item.tokenInfo.address === tokenAddress)
   const { totalAmount, spendingLimitAmount } = useTokenAmount(selectedToken)
 
-  const canCreateSpendingLimitTxWithToken =
-    useHasPermission(Permission.CreateSpendingLimitTransaction, {
-      token: selectedToken?.tokenInfo,
-    }) && selectedToken
+  const canCreateSpendingLimitTxWithToken = useHasPermission(Permission.CreateSpendingLimitTransaction, {
+    token: selectedToken?.tokenInfo,
+  })
 
   const isSpendingLimitType = type === TokenTransferType.spendingLimit
 

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/__tests__/CreateTokenTransfer.test.tsx
@@ -5,6 +5,7 @@ import * as useHasPermission from '@/permissions/hooks/useHasPermission'
 import { Permission } from '@/permissions/types'
 import { render } from '@/tests/test-utils'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
+import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 
 describe('CreateTokenTransfer', () => {
   const mockParams = {
@@ -38,7 +39,33 @@ describe('CreateTokenTransfer', () => {
       .spyOn(tokenUtils, 'useTokenAmount')
       .mockReturnValue({ totalAmount: BigInt(1000), spendingLimitAmount: BigInt(500) })
 
-    const { getByText } = render(<CreateTokenTransfer params={mockParams} onSubmit={jest.fn()} />)
+    const tokenAddress = ZERO_ADDRESS
+
+    const { getByText } = render(<CreateTokenTransfer params={mockParams} onSubmit={jest.fn()} />, {
+      initialReduxState: {
+        balances: {
+          loading: false,
+          data: {
+            fiatTotal: '0',
+            items: [
+              {
+                balance: '10',
+                tokenInfo: {
+                  address: tokenAddress,
+                  decimals: 18,
+                  logoUri: 'someurl',
+                  name: 'Test token',
+                  symbol: 'TST',
+                  type: TokenType.ERC20,
+                },
+                fiatBalance: '10',
+                fiatConversion: '1',
+              },
+            ],
+          },
+        },
+      },
+    })
 
     expect(getByText('Send as')).toBeInTheDocument()
 

--- a/apps/web/src/permissions/config.ts
+++ b/apps/web/src/permissions/config.ts
@@ -35,9 +35,7 @@ export default <RolePermissionsConfig>{
     [ExecuteTransaction]: () => true,
     [EnablePushNotifications]: true,
     [CreateSpendingLimitTransaction]: ({ token } = {}) => {
-      if (!token) {
-        return true
-      }
+      if (!token) return false
 
       const spendingLimit = spendingLimits.find((sl) => sl.token.address === token.address)
 

--- a/apps/web/src/permissions/hooks/usePermission.ts
+++ b/apps/web/src/permissions/hooks/usePermission.ts
@@ -25,7 +25,7 @@ export const usePermission = <P extends Permission>(
     return Object.entries(userPermissions).reduce((acc, [role, permissions]) => {
       const permissionValue = permissions?.[permission]
 
-      if (!permissionValue) {
+      if (permissionValue === undefined) {
         // No permission defined for the role
         return acc
       }


### PR DESCRIPTION
## What it solves

Resolves this bug report by @liliya-soroka:

> 1. The bug with defining the spending limits amount -
Steps;
> 2. add spending limits in a new safe
> 3. start the send funds and select spending limits

https://github.com/user-attachments/assets/28c115b8-c79e-4229-a6d0-80de589e61ba


> Current result: The amount is 0 undefined 