### PR TITLE
Fix(Proposers): allow deleting tx proposals

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/index.tsx
@@ -68,10 +68,10 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
 
   let proposer, safeTxHash, proposedByDelegate
   if (isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)) {
-    proposer = txDetails.detailedExecutionInfo.proposer?.value
     safeTxHash = txDetails.detailedExecutionInfo.safeTxHash
     // @ts-expect-error TODO: Need to update the types from the new SDK
     proposedByDelegate = txDetails.detailedExecutionInfo.proposedByDelegate
+    proposer = proposedByDelegate?.value ?? txDetails.detailedExecutionInfo.proposer?.value
   }
 
   const expiredSwap = useIsExpiredSwap(txSummary.txInfo)


### PR DESCRIPTION
## What it solves

Transactions proposed by delegates were previously not deletable because the proposer value was wrong.

## How to test it

* Create a tx as a proposer
* Delete that tx as a proposer