### PR TITLE
Fix(CSS): fallback handler component styles

### DIFF
--- a/apps/web/src/components/settings/FallbackHandler/index.tsx
+++ b/apps/web/src/components/settings/FallbackHandler/index.tsx
@@ -1,10 +1,11 @@
 import { TWAP_FALLBACK_HANDLER, TWAP_FALLBACK_HANDLER_NETWORKS } from '@/features/swap/helpers/utils'
 import { getCompatibilityFallbackHandlerDeployments } from '@safe-global/safe-deployments'
 import NextLink from 'next/link'
-import { Typography, Box, Grid, Paper, Link, Alert } from '@mui/material'
+import { Typography, Box, Grid, Paper, Link } from '@mui/material'
 import semverSatisfies from 'semver/functions/satisfies'
 import { useMemo } from 'react'
 import type { ReactElement } from 'react'
+import classnames from 'classnames'
 
 import EthHashInfo from '@/components/common/EthHashInfo'
 import useSafeInfo from '@/hooks/useSafeInfo'
@@ -12,6 +13,7 @@ import { BRAND_NAME, HelpCenterArticle } from '@/config/constants'
 import ExternalLink from '@/components/common/ExternalLink'
 import { useTxBuilderApp } from '@/hooks/safe-apps/useTxBuilderApp'
 import { useCurrentChain } from '@/hooks/useChains'
+import css from '../TransactionGuards/styles.module.css'
 
 const FALLBACK_HANDLER_VERSION = '>=1.1.1'
 
@@ -102,18 +104,15 @@ export const FallbackHandler = (): ReactElement | null => {
               <ExternalLink href={HelpCenterArticle.FALLBACK_HANDLER}>here</ExternalLink>
             </Typography>
 
-            <Alert
-              severity={!hasFallbackHandler ? 'warning' : isOfficial || isTWAPFallbackHandler ? 'success' : 'info'}
-              icon={false}
-              sx={{ mt: 2 }}
+            <Box
+              className={classnames(css.guardDisplay, {
+                [css.warning]: !hasFallbackHandler,
+                [css.info]: hasFallbackHandler && !isOfficial,
+              })}
+              sx={{ display: 'block !important' }}
             >
               {warning && (
-                <Typography
-                  variant="body2"
-                  sx={{
-                    mb: hasFallbackHandler ? 1 : 0,
-                  }}
-                >
+                <Typography variant="body2" width="100%" mb={hasFallbackHandler ? 1 : 0}>
                   {warning}
                 </Typography>
               )}
@@ -128,7 +127,7 @@ export const FallbackHandler = (): ReactElement | null => {
                   hasExplorer
                 />
               )}
-            </Alert>
+            </Box>
           </Box>
         </Grid>
       </Grid>

--- a/apps/web/src/components/settings/TransactionGuards/styles.module.css
+++ b/apps/web/src/components/settings/TransactionGuards/styles.module.css
@@ -8,3 +8,13 @@
   align-items: center;
   justify-content: space-between;
 }
+
+.guardDisplay.warning {
+  background-color: var(--color-warning-background);
+  border-color: var(--color-warning-dark);
+}
+
+.guardDisplay.info {
+  background-color: var(--color-info-background);
+  border-color: var(--color-info-dark);
+}


### PR DESCRIPTION
## What it solves

A small CSS fix. Make the fallback handler display in the same way as modules and guards.

Before:
<img width="1324" alt="Screenshot 2025-02-06 at 11 36 27" src="https://github.com/user-attachments/assets/4f1cb4f7-a8e5-40e2-8d4a-38799aaf2cad" />

After:
<img width="1320" alt="Screenshot 2025-02-06 at 11 35 48" src="https://github.com/user-attachments/assets/4933d9a4-9af2-4804-8efc-bdc63af62a41" />