### PR TITLE
Feat(Orgs): dashboard banner

### DIFF
--- a/apps/web/src/components/dashboard/index.tsx
+++ b/apps/web/src/components/dashboard/index.tsx
@@ -15,6 +15,7 @@ import { FEATURES } from '@/utils/chains'
 import css from './styles.module.css'
 import { InconsistentSignerSetupWarning } from '@/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning'
 import useIsStakingBannerEnabled from '@/features/stake/hooks/useIsStakingBannerEnabled'
+import OrgsDashboardWidget from '@/features/organisations/components/OrgsDashboardWidget'
 
 const RecoveryHeader = dynamic(() => import('@/features/recovery/components/RecoveryHeader'))
 
@@ -31,6 +32,10 @@ const Dashboard = (): ReactElement => {
 
         <Grid item xs={12}>
           <InconsistentSignerSetupWarning />
+        </Grid>
+
+        <Grid item xs={12}>
+          <OrgsDashboardWidget />
         </Grid>
 
         <Grid item xs={12}>

--- a/apps/web/src/features/organisations/components/OrgsDashboardWidget/index.tsx
+++ b/apps/web/src/features/organisations/components/OrgsDashboardWidget/index.tsx
@@ -1,0 +1,42 @@
+import { Box, Button, Stack, Typography } from '@mui/material'
+import Link from 'next/link'
+import Track from '@/components/common/Track'
+
+const gradientBg = {
+  background: 'linear-gradient(225deg, rgba(95, 221, 255, 0.15) 12.5%, rgba(18, 255, 128, 0.15) 88.07%)',
+}
+
+const OrgsDashboardWidget = () => {
+  return (
+    <Stack direction="row" flexWrap="wrap" gap={2} py={2} px={3} sx={gradientBg}>
+      <Box flex={1} minWidth="60%">
+        <Typography variant="h6" fontWeight="700" mb={2}>
+          Organizations are here!
+        </Typography>
+
+        <Typography variant="body2">
+          Organize your Safe Accounts, all in one place. Collaborate efficiently with your team members and simplify
+          treasury management.
+          <br />
+          Available now in beta.
+        </Typography>
+      </Box>
+
+      <Stack direction="row" gap={2} alignItems="center">
+        <Track action="" category="" label="dashboard">
+          <Link href="" passHref>
+            <Button variant="outlined">Learn more</Button>
+          </Link>
+        </Track>
+
+        <Track action="" category="" label="dashboard">
+          <Link href="" passHref>
+            <Button variant="contained">Try now</Button>
+          </Link>
+        </Track>
+      </Stack>
+    </Stack>
+  )
+}
+
+export default OrgsDashboardWidget


### PR DESCRIPTION
## What it solves

Resolves #4882

Caveats:
* I've left the links and tracking empty for now.
* I've added it to the dashboard unconditionally – a toggle tbd

## How this PR fixes it
Big screen:
<img width="1073" alt="Screenshot 2025-02-06 at 14 42 51" src="https://github.com/user-attachments/assets/992c0024-f655-4c20-9374-5f33e529afc1" />

Small screen:
<img width="584" alt="Screenshot 2025-02-06 at 14 42 58" src="https://github.com/user-attachments/assets/4a54f41d-cb46-4819-acb8-9909db69f73b" />
