### PR TITLE
Refactor(Web): fix "button in button" warning

### DIFF
--- a/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
+++ b/apps/web/src/components/transactions/TxListItem/ExpandableTransactionItem.tsx
@@ -57,6 +57,7 @@ export const ExpandableTransactionItem = ({
             padding: '12px 0',
           },
         }}
+        component="div"
       >
         <TxSummary item={item} isConflictGroup={isConflictGroup} isBulkGroup={isBulkGroup} />
       </AccordionSummary>

--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -257,6 +257,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
             '& .MuiAccordionSummary-content': { m: '0 !important', alignItems: 'center' },
             '&.Mui-expanded': { backgroundColor: 'transparent !important' },
           }}
+          component="div"
         >
           <Box className={classnames(css.multiSafeLink, css.safeLink)} width="100%">
             <Box sx={{ pr: 2.5 }} data-testid="group-safe-icon">

--- a/apps/web/src/features/myAccounts/components/AllSafes/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AllSafes/index.tsx
@@ -34,6 +34,7 @@ const AllSafes = ({
           padding: 0,
           '& .MuiAccordionSummary-content': { margin: '0 !important', mb: 1, flexGrow: 0 },
         }}
+        component="div"
       >
         <div className={css.listHeader}>
           <Typography variant="h5" fontWeight={700}>

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -99,16 +99,16 @@ export const AppProviders = ({ children }: { children: ReactNode | ReactNode[] }
   )
 }
 
-interface WebCoreAppProps extends AppProps {
+interface SafeWalletAppProps extends AppProps {
   emotionCache?: EmotionCache
 }
 
-const WebCoreApp = ({
+const SafeWalletApp = ({
   Component,
   pageProps,
   router,
   emotionCache = clientSideEmotionCache,
-}: WebCoreAppProps): ReactElement => {
+}: SafeWalletAppProps): ReactElement => {
   const safeKey = useChangedValue(router.query.safe?.toString())
 
   return (
@@ -145,4 +145,4 @@ const WebCoreApp = ({
   )
 }
 
-export default WebCoreApp
+export default SafeWalletApp


### PR DESCRIPTION
Resolves the pesky "button cannot be inside a button" warning from React.
Plus, rename WebCoreApp to SafeWalletApp.