### PR TITLE
Chore(Web): make dev workflows depend on linter

### DIFF
--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -1,15 +1,10 @@
 name: Web Deploy to dev/staging
 
 on:
-  pull_request:
-
-  push:
-    branches:
-      - dev
-      - main
-    paths:
-      - apps/web/**
-      - packages/**
+  workflow_run:
+    workflows: ['Web Lint']
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/web-e2e-smoke.yml
+++ b/.github/workflows/web-e2e-smoke.yml
@@ -1,10 +1,11 @@
 name: Web Smoke tests
 
 on:
-  pull_request:
-    paths:
-      - apps/web/**
-      - packages/**
+  workflow_run:
+    workflows: ['Web Lint']
+    types:
+      - completed
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -1,9 +1,11 @@
 name: Web Lint
+
 on:
   pull_request:
     paths:
       - apps/web/**
       - packages/**
+      - .github/workflows/web-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/web-nextjs-bundle-analysis.yml
+++ b/.github/workflows/web-nextjs-bundle-analysis.yml
@@ -4,15 +4,11 @@
 name: 'Web Next.js Bundle Analysis'
 
 on:
-  pull_request:
-    paths:
-      - apps/web/**
-  push:
-    branches:
-      - dev
-    paths:
-      - apps/web/**
-      - packages/**
+  workflow_run:
+    workflows: ['Web Lint']
+    types:
+      - completed
+
 permissions:
   contents: read # for checkout repository
   actions: read # for fetching base branch bundle stats

--- a/.github/workflows/web-unit-tests.yml
+++ b/.github/workflows/web-unit-tests.yml
@@ -1,15 +1,11 @@
 name: Web Unit tests
-on:
-  pull_request:
-    paths:
-      - apps/web/**
 
-  push:
-    branches:
-      - main
-    paths:
-      - apps/web/**
-      - packages/**
+on:
+  workflow_run:
+    workflows: ['Web Lint']
+    types:
+      - completed
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## What it solves

In the linter fails, everything else should not run. Otherwise it's hard to see what exactly failed.