### PR TITLE
fix(mobile): network badge was not following design

### DIFF
--- a/apps/mobile/src/components/NetworkBadge/NetworkBadge.tsx
+++ b/apps/mobile/src/components/NetworkBadge/NetworkBadge.tsx
@@ -13,14 +13,14 @@ export const NetworkBadge = ({ network }: Props) => {
         flexDirection="row"
         alignItems="center"
         justifyContent="center"
-        backgroundColor="$backgroundPaper"
+        backgroundColor="$background"
         borderRadius="$10"
         paddingLeft="$1"
         paddingRight="$3"
         paddingVertical="$1"
       >
         <Logo size={'$6'} logoUri={network.chainLogoUri} />
-        <Text marginLeft={'$1'}>{network.chainName}</Text>
+        <Text marginLeft={'$2'}>{network.chainName}</Text>
       </View>
     </Theme>
   )

--- a/apps/mobile/src/components/NetworkBadge/theme.ts
+++ b/apps/mobile/src/components/NetworkBadge/theme.ts
@@ -2,11 +2,11 @@ import { tokens } from '@/src/theme/tokens'
 
 export const badgeTheme = {
   light_network_badge: {
-    background: tokens.color.successLightDark,
+    background: tokens.color.backgroundSecondaryLight,
     color: tokens.color.backgroundMainDark,
   },
-  dark_network_badge_dark: {
-    color: tokens.color.backgroundMainDark,
-    background: tokens.color.primaryMainDark,
+  dark_network_badge: {
+    color: tokens.color.textPrimaryDark,
+    background: tokens.color.backgroundSecondaryDark,
   },
 }

--- a/apps/mobile/src/features/ImportReadOnly/components/AvailableNetworks.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/AvailableNetworks.tsx
@@ -7,7 +7,7 @@ export const AvailableNetworks = ({ networks }: { networks: SafeOverview[] }) =>
   return (
     <YStack marginTop={'$5'} gap={'$1'}>
       <Text fontWeight={'600'}>Available on networks:</Text>
-      <XStack gap={'$1'} marginTop={'$3'}>
+      <XStack marginTop={'$3'} flexWrap={'wrap'} columnGap={'$1'} rowGap={'$2'}>
         {networks?.map((safe) => <NetworkBadgeContainer key={safe.chainId} chainId={safe.chainId} />)}
       </XStack>
     </YStack>


### PR DESCRIPTION
## What it solves
https://www.figma.com/design/sRo9PST52xElbawgukeagI/New-Mobile-App?node-id=4453-19762&m=dev

Network display was cut off and in addition to this didn't follow the latest design changes:
![grafik](https://github.com/user-attachments/assets/469fa462-260e-488c-ab87-ce9ca87f9d78)

Now it looks like this:
<img width="415" alt="grafik" src="https://github.com/user-attachments/assets/20d531d1-d4c6-4acf-9874-667db5cc1f94" />

<img width="457" alt="grafik" src="https://github.com/user-attachments/assets/344e9676-d252-46bb-857e-99ed33280b0c" />

Resolves #
fixes #4929

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
