### PR TITLE
[Orgs] Create Org toggle

### DIFF
--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -30,6 +30,12 @@ export const AppRoutes = {
     create: '/new-safe/create',
     advancedCreate: '/new-safe/advanced-create',
   },
+  organizations: {
+    members: '/organizations/members',
+    '[orgId]': {
+      index: '/organizations/[orgId]',
+    },
+  },
   settings: {
     setup: '/settings/setup',
     security: '/settings/security',
@@ -56,10 +62,8 @@ export const AppRoutes = {
     history: '/transactions/history',
   },
   welcome: {
+    organizations: '/welcome/organizations',
     index: '/welcome',
     accounts: '/welcome/accounts',
-  },
-  organizations: {
-    index: '/organizations',
   },
 }

--- a/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
@@ -1,6 +1,7 @@
 import ConnectWalletButton from '@/components/common/ConnectWallet/ConnectWalletButton'
 import Track from '@/components/common/Track'
 import { AppRoutes } from '@/config/routes'
+import AccountsNavigation from '@/features/myAccounts/components/AccountsNavigation'
 import CreateButton from '@/features/myAccounts/components/CreateButton'
 import css from '@/features/myAccounts/styles.module.css'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -37,9 +38,13 @@ const AccountsHeader = ({ isSidebar, onLinkClick }: { isSidebar: boolean; onLink
 
   return (
     <Box className={classNames(css.header, { [css.sidebarHeader]: isSidebar })}>
-      <Typography variant="h1" fontWeight={700} className={css.title}>
-        My accounts
-      </Typography>
+      {isSidebar ? (
+        <Typography variant="h1" fontWeight={700} className={css.title}>
+          Accounts
+        </Typography>
+      ) : (
+        <AccountsNavigation />
+      )}
 
       <Box className={css.headerButtons}>
         <AddSafeButton trackingLabel={trackingLabel} onLinkClick={onLinkClick} />

--- a/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
@@ -1,0 +1,38 @@
+import { AppRoutes } from '@/config/routes'
+import css from '@/features/myAccounts/styles.module.css'
+import { Chip, Link, Stack, Typography } from '@mui/material'
+import classNames from 'classnames'
+import { useRouter } from 'next/router'
+
+const AccountsNavigation = () => {
+  const router = useRouter()
+
+  const isActiveNavigation = (pathname: string) => {
+    return router.pathname === pathname
+  }
+
+  return (
+    <Stack direction="row" spacing={2}>
+      <Typography variant="h1" fontWeight={700} className={css.title}>
+        <Link
+          href={AppRoutes.welcome.accounts}
+          className={classNames(css.link, { [css.active]: isActiveNavigation(AppRoutes.welcome.accounts) })}
+        >
+          Accounts
+        </Link>
+      </Typography>
+
+      <Typography variant="h1" fontWeight={700} className={css.title}>
+        <Link
+          href={AppRoutes.welcome.organizations}
+          className={classNames(css.link, { [css.active]: isActiveNavigation(AppRoutes.welcome.organizations) })}
+        >
+          Organizations
+          <Chip label="Beta" size="small" sx={{ ml: 1, fontWeight: 'normal', borderRadius: '4px' }} />
+        </Link>
+      </Typography>
+    </Stack>
+  )
+}
+
+export default AccountsNavigation

--- a/apps/web/src/features/myAccounts/styles.module.css
+++ b/apps/web/src/features/myAccounts/styles.module.css
@@ -59,6 +59,16 @@
   stroke: var(--color-text-primary);
 }
 
+.link {
+  text-decoration: none;
+  color: var(--color-text-secondary);
+}
+
+.active {
+  pointer-events: none;
+  color: var(--color-text-primary);
+}
+
 @media (max-width: 899.95px) {
   .container {
     width: auto;

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -1,0 +1,26 @@
+import AccountsNavigation from '@/features/myAccounts/components/AccountsNavigation'
+import { Box, Button } from '@mui/material'
+import css from './styles.module.css'
+
+const AddOrgButton = ({ onClick }: { onClick?: () => void }) => {
+  return (
+    <Button disableElevation variant="contained" size="small" onClick={onClick} sx={{ height: '36px', px: 2 }}>
+      <Box mt="1px">Create organization</Box>
+    </Button>
+  )
+}
+
+const OrgsList = () => {
+  return (
+    <Box className={css.container}>
+      <Box className={css.myOrgs}>
+        <Box className={css.orgsHeader}>
+          <AccountsNavigation />
+          <AddOrgButton />
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export default OrgsList

--- a/apps/web/src/features/organizations/components/OrgsList/styles.module.css
+++ b/apps/web/src/features/organizations/components/OrgsList/styles.module.css
@@ -1,0 +1,19 @@
+.container {
+  container-type: inline-size;
+  container-name: my-orgs-container;
+  display: flex;
+  justify-content: center;
+}
+
+.myOrgs {
+  width: 100vw;
+  max-width: 750px;
+  margin: var(--space-2);
+}
+
+.orgsHeader {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--space-3) 0;
+  gap: var(--space-2);
+}

--- a/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
@@ -8,11 +8,11 @@ export const navItems: NavItem[] = [
   {
     label: 'All organizations',
     icon: <SvgIcon component={HomeIcon} inheritViewBox />,
-    href: AppRoutes.organizations.index,
+    href: AppRoutes.organizations.members, // Placeholder
   },
   {
     label: 'Members',
     icon: <SvgIcon component={HomeIcon} inheritViewBox />,
-    href: AppRoutes.organizations.index,
+    href: AppRoutes.organizations.members,
   },
 ]

--- a/apps/web/src/hooks/useIsOrganizationRoute.ts
+++ b/apps/web/src/hooks/useIsOrganizationRoute.ts
@@ -5,5 +5,5 @@ export const useIsOrganizationRoute = (pathname: string): boolean => {
   const clientPathname = usePathname()
   const route = pathname || clientPathname || ''
 
-  return route.startsWith(AppRoutes.organizations.index)
+  return route.startsWith(AppRoutes.organizations['[orgId]'].index)
 }

--- a/apps/web/src/hooks/useIsSidebarRoute.ts
+++ b/apps/web/src/hooks/useIsSidebarRoute.ts
@@ -9,6 +9,7 @@ const NO_SIDEBAR_ROUTES = [
   AppRoutes.index,
   AppRoutes.welcome.index,
   AppRoutes.welcome.accounts,
+  AppRoutes.welcome.organizations,
   AppRoutes.imprint,
   AppRoutes.privacy,
   AppRoutes.cookie,

--- a/apps/web/src/pages/welcome/organizations.tsx
+++ b/apps/web/src/pages/welcome/organizations.tsx
@@ -1,0 +1,18 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import OrgsList from '@/features/organizations/components/OrgsList'
+import { BRAND_NAME } from '@/config/constants'
+
+const Organizations: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>{`${BRAND_NAME} – Organizations`}</title>
+      </Head>
+
+      <OrgsList />
+    </>
+  )
+}
+
+export default Organizations


### PR DESCRIPTION
## What it solves

Resolves #4937 

## How this PR fixes it

- Adds a navigation on the accounts page to switch between accounts and orgs
- Creates a new page `/welcome/organizations` with the same navigation
- Adds an empty `Create organization` button

## How to test it

Compare with the designs

## Screenshots
<img width="826" alt="Screenshot 2025-02-11 at 11 44 43" src="https://github.com/user-attachments/assets/ad4e2318-2283-40af-9119-741cb547ac10" />

<img width="898" alt="Screenshot 2025-02-11 at 11 44 54" src="https://github.com/user-attachments/assets/78c00177-eafe-481a-ab29-680d80ca91b2" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
