### PR TITLE
Fix(Tx history filter): incoming amount with decimals

### DIFF
--- a/apps/web/src/components/transactions/TxFilterForm/index.tsx
+++ b/apps/web/src/components/transactions/TxFilterForm/index.tsx
@@ -22,6 +22,7 @@ import NumberField from '@/components/common/NumberField'
 
 import css from './styles.module.css'
 import inputCss from '@/styles/inputs.module.css'
+import AddressInput from '@/components/common/AddressInput'
 
 enum TxFilterFormFieldNames {
   FILTER_TYPE = 'type',
@@ -172,13 +173,14 @@ const TxFilterForm = ({ toggleFilter }: { toggleFilter: () => void }): ReactElem
                           }}
                         />
                       </Grid>
+
                       <Grid item xs={12} md={6}>
                         <Controller
                           name={TxFilterFormFieldNames.AMOUNT}
                           control={control}
                           rules={{
                             validate: (val: TxFilterFormState[TxFilterFormFieldNames.AMOUNT]) => {
-                              if (val.length > 0) {
+                              if (val?.length > 0) {
                                 return validateAmount(val)
                               }
                             },
@@ -189,7 +191,9 @@ const TxFilterForm = ({ toggleFilter }: { toggleFilter: () => void }): ReactElem
                               className={inputCss.input}
                               label={
                                 fieldState.error?.message ||
-                                `Amount${isMultisigFilter && chain ? ` (only ${chain.nativeCurrency.symbol})` : ''}`
+                                (isIncomingFilter
+                                  ? 'Amount (with decimals)'
+                                  : `Amount (only ${chain?.nativeCurrency.symbol || 'ETH'})`)
                               }
                               error={!!fieldState.error}
                               {...field}
@@ -203,9 +207,9 @@ const TxFilterForm = ({ toggleFilter }: { toggleFilter: () => void }): ReactElem
 
                   {isIncomingFilter && (
                     <Grid item xs={12} md={6}>
-                      <AddressBookInput
+                      <AddressInput
                         data-testid="token-input"
-                        label="Token"
+                        label="Token address"
                         name={TxFilterFormFieldNames.TOKEN_ADDRESS}
                         required={false}
                         fullWidth
@@ -229,7 +233,7 @@ const TxFilterForm = ({ toggleFilter }: { toggleFilter: () => void }): ReactElem
                           control={control}
                           rules={{
                             validate: (val: TxFilterFormState[TxFilterFormFieldNames.NONCE]) => {
-                              if (val.length > 0) {
+                              if (val?.length > 0) {
                                 return validateAmount(val)
                               }
                             },

--- a/apps/web/src/utils/__tests__/tx-history-filter.test.ts
+++ b/apps/web/src/utils/__tests__/tx-history-filter.test.ts
@@ -214,7 +214,7 @@ describe('tx-history-filter', () => {
       it('should return incoming filters', () => {
         const result = txFilter.parseFormData({
           execution_date__gte: new Date('1970-01-01'),
-          value: '123',
+          value: '123000000000000000000',
           type: 'Incoming' as TxFilterType,
         } as TxFilterFormState)
 


### PR DESCRIPTION
## What it solves

Resolves #4942

## How this PR fixes it

For the incoming filter, the amount now must be specified in a decimal format (with zeroes) and not assume the default 18 decimals. This allows filtering by amounts for various tokens w/o specifying a token address.

<img width="1214" alt="Screenshot 2025-02-11 at 12 20 08" src="https://github.com/user-attachments/assets/69ef4ad2-8b13-4bff-a830-fdfd80e4ae53" />

## How to test it

* Open a Safe with incoming USDC transfers
* Filter by incoming with an amount with 6 trailing zeroes
* Filter for incoming ETH transfers with 18 zeroes