### PR TITLE
ci(mobile): Make mobile dev releases on a new PR

### DIFF
--- a/.github/workflows/mobile-dev-release.yml
+++ b/.github/workflows/mobile-dev-release.yml
@@ -1,0 +1,46 @@
+name: EAS Dev Build
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - apps/mobile/**
+      - packages/**
+  pull_request:
+    paths:
+      - apps/mobile/**
+      - packages/**
+jobs:
+  build:
+    name: Install and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      # Set up Node.js
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.11.0' # jod
+          cache: 'yarn'
+
+      # Install dependencies
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build & deploy iOS on EAS
+        working-directory: apps/mobile
+        run: eas build --profile development --non-interactive --no-wait --platform ios --auto-submit-with-profile=development
+
+      - name: Build & deploy Android on EAS
+        working-directory: apps/mobile
+        run: eas build --profile development --non-interactive --no-wait --platform android --auto-submit-with-profile=development

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -32,7 +32,7 @@ export default {
       entitlements: {
         'aps-environment': 'production',
       },
-      googleServicesFile: process.env.GOOGLE_SERVICES_PLIST,
+      googleServicesFile: IS_DEV ? process.env.GOOGLE_SERVICES_PLIST_DEV : process.env.GOOGLE_SERVICES_PLIST,
     },
     android: {
       adaptiveIcon: {
@@ -42,6 +42,7 @@ export default {
       },
       package: IS_DEV ? 'global.safe.mobileapp.dev' : 'global.safe.mobileapp',
       googleServicesFile: process.env.GOOGLE_SERVICES_JSON,
+      permissions: ['android.permission.CAMERA'],
     },
     web: {
       bundler: 'metro',

--- a/apps/mobile/docs/release-procedure.md
+++ b/apps/mobile/docs/release-procedure.md
@@ -10,6 +10,11 @@ lanes in App Store and Google Play Store.
 
 The release has to be tested by QA and once approved can be promoted to the production lane.
 
+# Dev builds
+
+Devs builds are being automatically created on every PR that touches files inside `apps/mobile` or `packages/*` folders.
+Those builds are pushed to the internal distribution lanes in App Store and Google Play Store.
+
 ## Triggering Maestro E2E tests
 
 Any PR that touches files inside `apps/mobile` or `packages/*` folders will trigger an e2e iOS test.

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -16,12 +16,12 @@
     "development": {
       "extends": "base",
       "environment": "development",
-      "developmentClient": true,
+      "autoIncrement": true,
       "env": {
         "APP_VARIANT": "development"
       },
       "android": {
-        "image": "ubuntu-18.04-jdk-11-ndk-r19c"
+        "image": "sdk-52"
       }
     },
     "preview-ios-simulator": {
@@ -77,6 +77,15 @@
     }
   },
   "submit": {
+    "development": {
+      "ios": {
+        "ascAppId": "6741803832"
+      },
+      "android": {
+        "applicationId": "global.safe.mobileapp.dev",
+        "releaseStatus": "draft"
+      }
+    },
     "production": {
       "ios": {
         "ascAppId": "6738784305"


### PR DESCRIPTION
## What it solves
This PR makes it possible to release a dev version of the app on new PRs that touch the files inside `apps/mobile` or `packages`

Resolves #
Makes it easier for QA to test changes/bug fixes

Note:
One problem with android is that the dev mobile app is in a draft status. As such we can't automatically publish the releases on the internal lane. The releases are pushed to app store, but then need to be manually distributed. 

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
