### PR TITLE
feat(Orgs): Display orgs info and creation modals from the dashboard widget

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsCreationModal/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCreationModal/index.tsx
@@ -8,7 +8,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import NameInput from '@/components/common/NameInput'
 import { AppRoutes } from '@/config/routes'
 
-function OrgsCreationModal({ handleClose }: { handleClose: () => void }): ReactElement {
+function OrgsCreationModal({ onClose }: { onClose: () => void }): ReactElement {
   const methods = useForm<{ name: string }>({ mode: 'onChange' })
   const { handleSubmit, formState } = methods
 
@@ -17,14 +17,14 @@ function OrgsCreationModal({ handleClose }: { handleClose: () => void }): ReactE
     handleSubmit((data) => {
       console.log(data)
       // TODO: create the organization
-      handleClose()
+      onClose()
     })
   }
 
   return (
     <ModalDialog
       open
-      onClose={handleClose}
+      onClose={onClose}
       dialogTitle={
         <>
           <AccountBalanceIcon sx={{ mr: 1 }} />
@@ -48,7 +48,7 @@ function OrgsCreationModal({ handleClose }: { handleClose: () => void }): ReactE
           </DialogContent>
 
           <DialogActions>
-            <Button data-testid="cancel-btn" onClick={handleClose}>
+            <Button data-testid="cancel-btn" onClick={onClose}>
               Cancel
             </Button>
             <Button type="submit" variant="contained" disabled={!formState.isValid} disableElevation>

--- a/apps/web/src/features/organizations/components/OrgsDashboardWidget/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsDashboardWidget/index.tsx
@@ -1,41 +1,50 @@
 import { Box, Button, Stack, Typography } from '@mui/material'
-import Link from 'next/link'
 import Track from '@/components/common/Track'
+import OrgsCreationModal from '../OrgsCreationModal'
+import OrgsInfoModal from '../OrgsInfoModal'
+import { useState } from 'react'
 
 const gradientBg = {
   background: 'linear-gradient(225deg, rgba(95, 221, 255, 0.15) 12.5%, rgba(18, 255, 128, 0.15) 88.07%)',
 }
 
 const OrgsDashboardWidget = () => {
+  const [isInfoOpen, setIsInfoOpen] = useState<boolean>(false)
+  const [isCreationOpen, setIsCreationOpen] = useState<boolean>(false)
+
   return (
-    <Stack direction="row" flexWrap="wrap" gap={2} py={2} px={3} sx={gradientBg}>
-      <Box flex={1} minWidth="60%">
-        <Typography variant="h6" fontWeight="700" mb={2}>
-          Organizations are here!
-        </Typography>
+    <>
+      <Stack direction="row" flexWrap="wrap" gap={2} py={2} px={3} sx={gradientBg}>
+        <Box flex={1} minWidth="60%">
+          <Typography variant="h6" fontWeight="700" mb={2}>
+            Organizations are here!
+          </Typography>
 
-        <Typography variant="body2">
-          Organize your Safe Accounts, all in one place. Collaborate efficiently with your team members and simplify
-          treasury management.
-          <br />
-          Available now in beta.
-        </Typography>
-      </Box>
+          <Typography variant="body2">
+            Organize your Safe Accounts, all in one place. Collaborate efficiently with your team members and simplify
+            treasury management.
+            <br />
+            Available now in beta.
+          </Typography>
+        </Box>
 
-      <Stack direction="row" gap={2} alignItems="center">
-        <Track action="" category="" label="dashboard">
-          <Link href="" passHref>
-            <Button variant="outlined">Learn more</Button>
-          </Link>
-        </Track>
+        <Stack direction="row" gap={2} alignItems="center">
+          <Track action="" category="" label="dashboard">
+            <Button variant="outlined" onClick={() => setIsInfoOpen(true)}>
+              Learn more
+            </Button>
+          </Track>
 
-        <Track action="" category="" label="dashboard">
-          <Link href="" passHref>
-            <Button variant="contained">Try now</Button>
-          </Link>
-        </Track>
+          <Track action="" category="" label="dashboard">
+            <Button variant="contained" onClick={() => setIsCreationOpen(true)}>
+              Try now
+            </Button>
+          </Track>
+        </Stack>
       </Stack>
-    </Stack>
+      {isInfoOpen && <OrgsInfoModal onCreate={() => setIsCreationOpen(true)} onClose={() => setIsInfoOpen(false)} />}
+      {isCreationOpen && <OrgsCreationModal onClose={() => setIsCreationOpen(false)} />}
+    </>
   )
 }
 

--- a/apps/web/src/features/organizations/components/OrgsInfoModal/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsInfoModal/index.tsx
@@ -12,7 +12,6 @@ import {
 import CheckIcon from '@/public/images/common/circle-check.svg'
 import CloseIcon from '@mui/icons-material/Close'
 import NoEntriesIcon from '@/public/images/address-book/no-entries.svg'
-import Link from 'next/link'
 
 const ListIcon = () => (
   <ListItemIcon
@@ -28,7 +27,12 @@ const ListIcon = () => (
   </ListItemIcon>
 )
 
-const OrgsInfoModal = ({ onClose }: { onClose: () => void }) => {
+const OrgsInfoModal = ({ onClose, onCreate }: { onClose: () => void; onCreate: () => void }) => {
+  const handleCreate = () => {
+    onClose()
+    onCreate()
+  }
+
   return (
     <Dialog open PaperProps={{ style: { width: '800px', maxWidth: '98%' } }} onClose={onClose}>
       <DialogContent dividers sx={{ py: 3, px: 4 }}>
@@ -65,13 +69,11 @@ const OrgsInfoModal = ({ onClose }: { onClose: () => void }) => {
             </List>
 
             <Stack gap={2} mt={8}>
-              <Link href="" passHref>
-                <Button variant="contained" color="primary">
-                  Create an organization
-                </Button>
-              </Link>
+              <Button variant="contained" color="primary" onClick={handleCreate}>
+                Create an organization
+              </Button>
 
-              <Button variant="text" color="primary">
+              <Button variant="text" color="primary" onClick={onClose}>
                 Maybe later
               </Button>
             </Stack>


### PR DESCRIPTION
## What it solves

Resolves #4886

## How this PR fixes it
- displays the creation and info modals from the two buttons on the dashboard widget
- displays the creation modal from the CTA on the info modal
- handles closing of both modals

## How to test it
- Click Learn more on the dashboard widget. It should open the Learn more modal
- Click `Create Organization` either from the Dashboard widget or the Learn more Modal. It should open the create org modal

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
