### PR TITLE
feat: Add empty org pages, adjust route generation

### DIFF
--- a/apps/web/scripts/generate-routes.js
+++ b/apps/web/scripts/generate-routes.js
@@ -1,6 +1,16 @@
 import * as fs from 'fs'
+import path from 'path'
 
 const isFile = (item) => item.endsWith`.tsx`
+
+function makeKeyFromName(name) {
+  const dynamicMatch = name.match(/^\[(.+)\]$/)
+  if (dynamicMatch) {
+    name = dynamicMatch[1]
+  }
+
+  return name.replace(/[-_]\w/g, (m) => m[1].toUpperCase())
+}
 
 const iterate = (folderName, parentRoute, root) => {
   const items = fs.readdirSync(folderName)
@@ -11,26 +21,98 @@ const iterate = (folderName, parentRoute, root) => {
       // Skip service files
       if (/_app|_document/.test(item)) return
 
+      const fullPath = path.join(folderName, item)
+
       // A folder, continue iterating
       if (!isFile(item)) {
-        const key = item.replace(/-\w/g, (match) => match.replace(/-/g, '').toUpperCase()) // spending-limit -> spendingLimit
-        root[key] = {}
-        iterate(`${folderName}/${item}`, `${parentRoute}/${item}`, root[key])
+        const isDynamic = /^\[.+\]$/.test(item)
+
+        if (isDynamic) {
+          const dynamicSegment = item.slice(1, -1)
+          const nextRoute = `${parentRoute}/[${dynamicSegment}]`
+          // Recurse without creating a new sub-object
+          iterate(fullPath, nextRoute, root)
+        } else {
+          const key = makeKeyFromName(item)
+
+          if (!root[key]) {
+            root[key] = {}
+          }
+
+          const nextRoute = `${parentRoute}/${item}`
+          iterate(fullPath, nextRoute, root[key])
+        }
+
         return
       }
 
       // A file
       const name = item.split('.')[0]
-      const path = name === 'index' ? parentRoute : `${parentRoute}/${name}`
-      const key = name
-        .replace(/-\w/g, (match) => match.replace(/-/g, '').toUpperCase()) // spending-limit -> spendingLimit
-        .replace(/\W/g, '') // [txId] -> txId
-      root[key] = path || '/'
+      const routePath = name === 'index' ? parentRoute : `${parentRoute}/${name}`
+      const key = makeKeyFromName(name)
+
+      const dynamicMatches = [...routePath.matchAll(/\[(.+?)\]/g)]
+      if (dynamicMatches.length === 0) {
+        root[key] = routePath || '/'
+      } else {
+        const paramNames = dynamicMatches.map((m) => m[1])
+
+        root[key] = {
+          __dynamicFn: {
+            paramNames,
+            routeTemplate: routePath,
+          },
+        }
+      }
     })
 
   return root
 }
 
-const routes = iterate('src/pages', '', {})
+/**
+ * Convert the "route tree object" into a string of valid
+ * JavaScript/TypeScript code, embedding arrow functions for dynamic routes.
+ */
+function generateRoutesCode(obj, indent = 2) {
+  if (obj && typeof obj === 'object' && '__dynamicFn' in obj) {
+    const { paramNames, routeTemplate } = obj.__dynamicFn
 
-console.log(`export const AppRoutes = ${JSON.stringify(routes, null, 2)}`)
+    let fnBody = routeTemplate.replace(/\[(.+?)\]/g, (_, p1) => `\${${p1}}`)
+
+    const signature = paramNames.map((p) => `${p}: string`).join(', ')
+    return `(${signature}) => \`${fnBody}\``
+  }
+
+  if (Array.isArray(obj)) {
+    const items = obj.map((item) => generateRoutesCode(item, indent + 2))
+    return `[${items.join(', ')}]`
+  }
+
+  if (obj && typeof obj === 'object') {
+    // It's a nested object of routes
+    const entries = Object.entries(obj)
+    const spacing = ' '.repeat(indent)
+    const innerSpacing = ' '.repeat(indent + 2)
+
+    const props = entries.map(([key, value]) => {
+      // If the key is not a valid identifier, quote it
+      const safeKey = /^[a-zA-Z_]\w*$/.test(key) ? key : JSON.stringify(key)
+
+      return `${innerSpacing}${safeKey}: ${generateRoutesCode(value, indent + 2)}`
+    })
+
+    return `{\n${props.join(',\n')}\n${spacing}}`
+  }
+
+  // Otherwise, it's presumably a string route => quote it
+  return JSON.stringify(obj)
+}
+
+function main() {
+  const routes = iterate('src/pages', '', {})
+  const code = `export const AppRoutes = ${generateRoutesCode(routes, 2)}\n`
+
+  console.log(code)
+}
+
+main()

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -14,7 +14,7 @@ export const AppRoutes = {
   bridge: '/bridge',
   addressBook: '/address-book',
   addOwner: '/addOwner',
-  _offline: '/_offline',
+  Offline: '/_offline',
   apps: {
     open: '/apps/open',
     index: '/apps',
@@ -31,10 +31,10 @@ export const AppRoutes = {
     advancedCreate: '/new-safe/advanced-create',
   },
   organizations: {
-    members: '/organizations/members',
-    '[orgId]': {
-      index: '/organizations/[orgId]',
-    },
+    settings: (orgId: string) => `/organizations/${orgId}/settings`,
+    safeAccounts: (orgId: string) => `/organizations/${orgId}/safeAccounts`,
+    members: (orgId: string) => `/organizations/${orgId}/members`,
+    index: (orgId: string) => `/organizations/${orgId}`,
   },
   settings: {
     setup: '/settings/setup',

--- a/apps/web/src/features/organizations/components/OrgsCard/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCard/index.tsx
@@ -1,6 +1,8 @@
+import { AppRoutes } from '@/config/routes'
 import { Box, Card, hslToRgb, Stack, Typography } from '@mui/material'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import IconButton from '@mui/material/IconButton'
+import Link from 'next/link'
 
 import css from './styles.module.css'
 
@@ -30,22 +32,25 @@ const OrgLogo = ({ orgName }: { orgName: string }) => {
 }
 
 type Organization = {
+  id: number
   name: string
   members: Array<object>
   safes: Array<object>
 }
 
 const OrgsCard = ({ org }: { org: Organization }) => {
-  const orgName = org.name
-  const numberOfAccounts = org.safes.length
-  const numberOfMembers = org.members.length
+  const { id, safes, name, members } = org
+  const numberOfAccounts = safes.length
+  const numberOfMembers = members.length
 
   return (
     <Card className={css.card}>
-      <OrgLogo orgName={orgName} />
+      <Link className={css.cardLink} href={AppRoutes.organizations.index(id.toString())} />
+
+      <OrgLogo orgName={name} />
 
       <Typography mt={2} variant="body2" fontWeight="bold">
-        {orgName}
+        {name}
       </Typography>
 
       <Stack direction="row" spacing={1} alignItems="center" mt={0.5}>

--- a/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
+++ b/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
@@ -29,3 +29,11 @@
   top: var(--space-2);
   right: var(--space-2);
 }
+
+.cardLink {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -65,11 +65,13 @@ const NoOrgsState = () => {
 const ORGS = [
   {
     name: 'Safe DAO',
+    id: 1,
     members: [{ id: 1 }, { id: 2 }, { id: 3 }],
     safes: [{ id: 1 }, { id: 4 }, { id: 2 }],
   },
   {
     name: 'Optimism Foundation',
+    id: 2,
     members: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }],
     safes: [{ id: 1 }, { id: 4 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }],
   },

--- a/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
@@ -1,18 +1,35 @@
-import React from 'react'
+import React, { type ReactElement } from 'react'
 import { AppRoutes } from '@/config/routes'
 import HomeIcon from '@/public/images/sidebar/home.svg'
 import { SvgIcon } from '@mui/material'
-import type { NavItem } from '@/components/sidebar/SidebarNavigation/config'
 
-export const navItems: NavItem[] = [
+export type DynamicNavItem = {
+  label: string
+  icon?: ReactElement
+  href: (pathParam: string) => string
+  tag?: ReactElement
+  disabled?: boolean
+}
+
+export const navItems: DynamicNavItem[] = [
   {
-    label: 'All organizations',
+    label: 'Home',
     icon: <SvgIcon component={HomeIcon} inheritViewBox />,
-    href: AppRoutes.organizations.members, // Placeholder
+    href: AppRoutes.organizations.index,
+  },
+  {
+    label: 'Safe Accounts',
+    icon: <SvgIcon component={HomeIcon} inheritViewBox />,
+    href: AppRoutes.organizations.safeAccounts,
   },
   {
     label: 'Members',
     icon: <SvgIcon component={HomeIcon} inheritViewBox />,
     href: AppRoutes.organizations.members,
+  },
+  {
+    label: 'Settings',
+    icon: <SvgIcon component={HomeIcon} inheritViewBox />,
+    href: AppRoutes.organizations.settings,
   },
 ]

--- a/apps/web/src/features/organizations/components/OrgsSidebarNavigation/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarNavigation/index.tsx
@@ -12,16 +12,18 @@ import { navItems } from './config'
 
 const Navigation = (): ReactElement => {
   const router = useRouter()
+  const orgId = Array.isArray(router.query.orgId) ? router.query.orgId[0] : router.query.orgId || ''
 
   return (
     <SidebarList>
       {navItems.map((item) => {
-        const isSelected = router.pathname === item.href
+        const itemPath = item.href(orgId)
+        const isSelected = router.pathname === itemPath
 
         return (
-          <div key={item.href}>
-            <ListItemButton sx={{ padding: 0 }} selected={isSelected} key={item.href}>
-              <SidebarListItemButton selected={isSelected} href={item.href}>
+          <div key={itemPath}>
+            <ListItemButton sx={{ padding: 0 }} selected={isSelected} key={itemPath}>
+              <SidebarListItemButton selected={isSelected} href={itemPath}>
                 {item.icon && <SidebarListItemIcon>{item.icon}</SidebarListItemIcon>}
 
                 <SidebarListItemText data-testid="sidebar-list-item" bold>

--- a/apps/web/src/hooks/useIsOrganizationRoute.ts
+++ b/apps/web/src/hooks/useIsOrganizationRoute.ts
@@ -5,5 +5,5 @@ export const useIsOrganizationRoute = (pathname: string): boolean => {
   const clientPathname = usePathname()
   const route = pathname || clientPathname || ''
 
-  return route.startsWith(AppRoutes.organizations['[orgId]'].index)
+  return route.startsWith(AppRoutes.organizations.index('')) // This will check against /organizations/
 }

--- a/apps/web/src/pages/organizations/[orgId]/members.tsx
+++ b/apps/web/src/pages/organizations/[orgId]/members.tsx
@@ -9,7 +9,7 @@ const OrganizationDashboard: NextPage = () => {
         <title>{`${BRAND_NAME} – Organization members`}</title>
       </Head>
 
-      <main></main>
+      <main>Members</main>
     </>
   )
 }

--- a/apps/web/src/pages/organizations/[orgId]/safeAccounts.tsx
+++ b/apps/web/src/pages/organizations/[orgId]/safeAccounts.tsx
@@ -1,0 +1,17 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import { BRAND_NAME } from '@/config/constants'
+
+const SafeAccounts: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>{`${BRAND_NAME} – Organization safe accounts`}</title>
+      </Head>
+
+      <main>Safe accounts</main>
+    </>
+  )
+}
+
+export default SafeAccounts

--- a/apps/web/src/pages/organizations/[orgId]/safeAccounts.tsx
+++ b/apps/web/src/pages/organizations/[orgId]/safeAccounts.tsx
@@ -6,7 +6,7 @@ const SafeAccounts: NextPage = () => {
   return (
     <>
       <Head>
-        <title>{`${BRAND_NAME} – Organization safe accounts`}</title>
+        <title>{`${BRAND_NAME} – Organization Safe Accounts`}</title>
       </Head>
 
       <main>Safe accounts</main>

--- a/apps/web/src/pages/organizations/[orgId]/safeAccounts.tsx
+++ b/apps/web/src/pages/organizations/[orgId]/safeAccounts.tsx
@@ -9,7 +9,7 @@ const SafeAccounts: NextPage = () => {
         <title>{`${BRAND_NAME} – Organization Safe Accounts`}</title>
       </Head>
 
-      <main>Safe accounts</main>
+      <main>Safe Accounts</main>
     </>
   )
 }

--- a/apps/web/src/pages/organizations/[orgId]/settings.tsx
+++ b/apps/web/src/pages/organizations/[orgId]/settings.tsx
@@ -1,0 +1,17 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import { BRAND_NAME } from '@/config/constants'
+
+const OrgSettings: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>{`${BRAND_NAME} – Organization settings`}</title>
+      </Head>
+
+      <main>Org settings</main>
+    </>
+  )
+}
+
+export default OrgSettings


### PR DESCRIPTION
## What it solves

Resolves #4955

## How this PR fixes it

- Creates pages for org members, org settings and org safe accounts
- Adjusts `generate-routes.js` to handle dynamic routes
- Adds links to the org cards to go to the org dashboard

## How to test it

1. Open the app
2. Go to the welcome org page
3. Click on a card
4. Observe seeing the org dashboard
5. Navigate around through the sidebar
6. Observe seeing pages for each route

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
