### PR TITLE
docs(mobile): update getting started steps

### DIFF
--- a/apps/mobile/.env.development
+++ b/apps/mobile/.env.development
@@ -1,0 +1,6 @@
+# Environment: development
+
+APP_VARIANT=production
+GOOGLE_SERVICES_PLIST_DEV=./GoogleService-Info.plist
+GOOGLE_SERVICES_JSON=./google-services.json
+GOOGLE_SERVICES_PLIST=./GoogleService-Info.plist

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,6 +1,7 @@
 # Safe{Wallet} mobile app 📱
 
-This project is now part of the **@safe-global/safe-wallet** monorepo! The monorepo setup allows centralized management of multiple
+This project is now part of the **@safe-global/safe-wallet** monorepo! The monorepo setup allows centralized management
+of multiple
 applications and shared libraries. This workspace (`apps/mobile`) contains the Safe Mobile App.
 
 You can run commands for this workspace in two ways:
@@ -16,7 +17,8 @@ In the addition to the monorepo prerequisites, the mobile app requires the follo
 - iOS/Android Development Tools
 - [Maestro](https://maestro.mobile.dev/) if you want to run E2E tests
 
-You can follow the [expo documentation](https://docs.expo.dev/get-started/set-up-your-environment/) to install the CLI and set up your development environment.
+You can follow the [expo documentation](https://docs.expo.dev/get-started/set-up-your-environment/) to install the CLI
+and set up your development environment.
 
 Follow the [Maestro](https://maestro.mobile.dev/) documentation to install the tool for E2E testing.
 
@@ -29,6 +31,21 @@ yarn install
 ```
 
 ## Running the app
+
+There is a .env.development file in the root of the mobile app that contains the following environment variables:
+
+```bash
+APP_VARIANT=production
+GOOGLE_SERVICES_PLIST_DEV=./GoogleService-Info.plist
+GOOGLE_SERVICES_JSON=./google-services.json
+GOOGLE_SERVICES_PLIST=./GoogleService-Info.plist
+```
+
+When any expo command runs it will automatically load the `.env.development` file. If you want to make modifications
+to the environment variables, you can create a `.env.local` file in the root of the mobile app.
+
+For local development you need to place the `google-services.json` and `GoogleService-Info.plist` files in the root of
+the mobile app.
 
 ### Running on iOS
 
@@ -46,7 +63,8 @@ yarn start:ios
 
 > [!NOTE]
 >
-> From now on for brevity we will only show the command to run from the root of the monorepo. You can always run the command from the `apps/mobile` directory you just need to omit the `workspace @safe-global/mobile`.
+> From now on for brevity we will only show the command to run from the root of the monorepo. You can always run the
+> command from the `apps/mobile` directory you just need to omit the `workspace @safe-global/mobile`.
 
 ### Running on Android
 


### PR DESCRIPTION
## What it solves
The PR to run the e2e tests on expo changed the way we deal with the firebase service file and this had to be reflected in the README

Resolves #
Makes it easier to run the app for the first time.

## How this PR fixes it
Explains better what is needed

## How to test it
- follow the guide on a clean repo clone

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
