### PR TITLE
fix(mobile): wrong text for on import screens

### DIFF
--- a/apps/mobile/src/app/import-signers/index.tsx
+++ b/apps/mobile/src/app/import-signers/index.tsx
@@ -15,7 +15,7 @@ const items = [
   {
     name: 'seed',
     title: 'Import private key',
-    description: 'Enter a private key or a 12-24 word seed phrase.',
+    description: 'Enter a private key.',
     icon: <SafeFontIcon name="wallet" size={16} />,
     Image: Seed,
     imageProps: { marginBottom: -31 },

--- a/apps/mobile/src/features/ImportPrivateKey/ImportPrivateKey.container.tsx
+++ b/apps/mobile/src/features/ImportPrivateKey/ImportPrivateKey.container.tsx
@@ -29,7 +29,7 @@ export function ImportPrivateKey() {
           <View marginTop="$2">
             <SectionTitle
               title="Import a private key"
-              description="Enter your seed phrase or a private key below. Make sure to do so in a safe and private place."
+              description="Enter your private key below. Make sure to do so in a safe and private place."
             />
           </View>
 

--- a/apps/mobile/src/features/ImportPrivateKey/ImportPrivateKey.test.tsx
+++ b/apps/mobile/src/features/ImportPrivateKey/ImportPrivateKey.test.tsx
@@ -9,9 +9,7 @@ describe('ImportPrivateKey', () => {
 
     expect(screen.getByText('Import a private key')).toBeTruthy()
     expect(
-      screen.getByText(
-        'Enter your seed phrase or a private key below. Make sure to do so in a safe and private place.',
-      ),
+      screen.getByText('Enter your private key below. Make sure to do so in a safe and private place.'),
     ).toBeTruthy()
   })
 

--- a/apps/mobile/src/features/ImportPrivateKey/components/ImportError/ImportError.tsx
+++ b/apps/mobile/src/features/ImportPrivateKey/components/ImportError/ImportError.tsx
@@ -46,7 +46,7 @@ export function ImportError() {
           <SafeFontIcon color="$backgroundPress" name="shield" />
 
           <Text color="$backgroundPress" fontSize="$4">
-            Safe doesn’t store your seed phrase.
+            Safe doesn’t store your private key.
           </Text>
         </View>
 


### PR DESCRIPTION
## What it solves
The MVP supports only private key import. Removed seedphrase from the text.


Resolves #4959 

## How this PR fixes it
Removes the text

## How to test it
Go to Import a signer- > no seedphrase should be mentioned
Go to the next screen- > no seed phrase should be mentioned
Import incorrect signer -> no seedphrase should be mentioned

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
