### PR TITLE
fix(mobile): cannot select last networks in multichain safes

### DIFF
--- a/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
+++ b/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
@@ -1,7 +1,12 @@
 import { BackdropComponent, BackgroundComponent } from '@/src/components/Dropdown/sheetComponents'
-import { H5, ScrollView, View } from 'tamagui'
+import { getTokenValue, H5, View } from 'tamagui'
 import React, { useCallback } from 'react'
-import BottomSheet, { BottomSheetFooterProps, BottomSheetModalProps, BottomSheetView } from '@gorhom/bottom-sheet'
+import BottomSheet, {
+  BottomSheetFooterProps,
+  BottomSheetModalProps,
+  BottomSheetView,
+  BottomSheetScrollView,
+} from '@gorhom/bottom-sheet'
 import DraggableFlatList, { DragEndParams, RenderItemParams, ScaleDecorator } from 'react-native-draggable-flatlist'
 import { StyleSheet } from 'react-native'
 import { useRouter } from 'expo-router'
@@ -85,18 +90,18 @@ export function SafeBottomSheet<T>({
       footerComponent={footerComponent}
     >
       {!isSortable && !!title && <TitleHeader />}
-      <BottomSheetView style={[styles.contentContainer, !isSortable ? { flex: 1, paddingHorizontal: 20 } : undefined]}>
+      <BottomSheetView style={[styles.contentContainer, !isSortable ? { flex: 1 } : undefined]}>
         {isSortable ? (
           <DraggableFlatList<T>
             data={items}
-            containerStyle={{ height: '100%' }}
+            containerStyle={{ height: '90%' }}
             ListHeaderComponent={title ? <TitleHeader /> : undefined}
             onDragEnd={onDragEnd}
             keyExtractor={(item, index) => (keyExtractor ? keyExtractor({ item, index }) : index.toString())}
             renderItem={renderItem}
           />
         ) : (
-          <ScrollView>
+          <BottomSheetScrollView contentContainerStyle={styles.scrollInnerContainer}>
             <View minHeight={200} alignItems="center" paddingVertical="$3">
               <View alignItems="flex-start" paddingBottom="$4" width="100%">
                 {hasCustomItems
@@ -110,7 +115,7 @@ export function SafeBottomSheet<T>({
                   : children}
               </View>
             </View>
-          </ScrollView>
+          </BottomSheetScrollView>
         )}
       </BottomSheetView>
     </BottomSheet>
@@ -121,4 +126,5 @@ const styles = StyleSheet.create({
   contentContainer: {
     justifyContent: 'space-around',
   },
+  scrollInnerContainer: { paddingHorizontal: getTokenValue('$3'), paddingBottom: getTokenValue('$5') },
 })


### PR DESCRIPTION
## What it solves
The default ScrollView component is not accomodating for the fact that it is rendered inside of a scrollView. Because of this when one had a lot of networks they were hiden at the end of screen. Using the exported ScrollView from bottomSheetModal fixes this. 

Resolves #4931

## How this PR fixes it
Magic

## How to test it

1. Try to import eth:0x55d93DF21332615D48EA0c0144c7b1D176F3e7cb (the safe exist on 16 networks)
2. go to the home page
3. try to switch network and select Base sepolia ( end of the list)


## Screenshots
![2025-02-13 08 31 17](https://github.com/user-attachments/assets/0a0b0a92-24bf-4d98-8641-d5c9b9b1e295)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
