### PR TITLE
feat(Orgs): empty members and accounts components for Orgs dashboard

### DIFF
--- a/apps/web/src/components/icons/OrganizationIcon.tsx
+++ b/apps/web/src/components/icons/OrganizationIcon.tsx
@@ -1,0 +1,12 @@
+import type { SvgIconProps } from '@mui/material'
+import { SvgIcon } from '@mui/material'
+
+const OrganizationIcon = (props: SvgIconProps) => {
+  return (
+    <SvgIcon {...props} viewBox="0 0 24 24">
+      <path d="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0-4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z" />
+    </SvgIcon>
+  )
+}
+
+export default OrganizationIcon

--- a/apps/web/src/features/myAccounts/components/AccountItems/styles.module.css
+++ b/apps/web/src/features/myAccounts/components/AccountItems/styles.module.css
@@ -28,6 +28,10 @@
   background-color: var(--color-background-paper);
 }
 
+.listItem {
+  background-color: var(--color-background-paper);
+}
+
 .listItem.subItem {
   margin-bottom: 8px;
 }

--- a/apps/web/src/features/organizations/components/AccountsList/index.tsx
+++ b/apps/web/src/features/organizations/components/AccountsList/index.tsx
@@ -1,4 +1,4 @@
-import { Typography, Button, Paper, Box, Grid } from '@mui/material'
+import { Typography, Paper, Box, Button } from '@mui/material'
 import type { AllSafeItems } from '@/features/myAccounts/hooks/useAllSafesGrouped'
 import { useAllSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGrouped'
 import SafesList from '@/features/myAccounts/components/SafesList'
@@ -17,17 +17,7 @@ const EmptyAccountsList = () => {
           connected wallet can be added to the organisation space.
         </Typography>
 
-        <Button
-          variant="contained"
-          onClick={() => {}}
-          sx={{
-            backgroundColor: 'black',
-            color: 'white',
-            '&:hover': {
-              backgroundColor: '#333',
-            },
-          }}
-        >
+        <Button variant="contained" onClick={() => {}}>
           Add existing account
         </Button>
       </Box>
@@ -39,7 +29,7 @@ const EmptyAccountsList = () => {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          borderRadius: '8px',
+          borderRadius: 1,
         }}
       >
         <Typography variant="body2" color="text.secondary">
@@ -50,31 +40,25 @@ const EmptyAccountsList = () => {
   )
 }
 
-const OrgAccountsList = () => {
+const OrgAccountsList = ({ hasAccounts }: { hasAccounts: boolean }) => {
   // TODO: replace with data from CGW
   const safes = useAllSafesGrouped()
   const allSafes = useMemo<AllSafeItems>(
     () => [...(safes.allMultiChainSafes ?? []), ...(safes.allSingleSafes ?? [])].slice(0, 5),
     [safes.allMultiChainSafes, safes.allSingleSafes],
   )
-  const hasAccounts = false
 
   if (!hasAccounts) {
     return <EmptyAccountsList />
   }
 
   return (
-    <Grid container spacing={3}>
-      <Grid item xs={12} md={8}>
-        <Typography variant="h5" fontWeight={700} mb={2}>
-          Safe Accounts ({allSafes.length})
-        </Typography>
-        <SafesList safes={allSafes} />
-      </Grid>
-      <Grid item xs={12} md={4}>
-        {/* Empty section for future content */}
-      </Grid>
-    </Grid>
+    <>
+      <Typography variant="h5" fontWeight={700} mb={2}>
+        Safe Accounts ({allSafes.length})
+      </Typography>
+      <SafesList safes={allSafes} />
+    </>
   )
 }
 

--- a/apps/web/src/features/organizations/components/AccountsList/index.tsx
+++ b/apps/web/src/features/organizations/components/AccountsList/index.tsx
@@ -1,0 +1,81 @@
+import { Typography, Button, Paper, Box, Grid } from '@mui/material'
+import type { AllSafeItems } from '@/features/myAccounts/hooks/useAllSafesGrouped'
+import { useAllSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGrouped'
+import SafesList from '@/features/myAccounts/components/SafesList'
+import { useMemo } from 'react'
+
+const EmptyAccountsList = () => {
+  return (
+    <Paper sx={{ p: 3, display: 'flex', gap: 3 }}>
+      <Box sx={{ flex: 2 }}>
+        <Typography variant="h4" fontWeight={700} mb={2}>
+          Link your Safe Accounts
+        </Typography>
+
+        <Typography variant="body1" color="text.secondary" mb={3} fontSize="small">
+          To set up your organisation you need to add existing Safe Accounts. Any accounts that are associated with your
+          connected wallet can be added to the organisation space.
+        </Typography>
+
+        <Button
+          variant="contained"
+          onClick={() => {}}
+          sx={{
+            backgroundColor: 'black',
+            color: 'white',
+            '&:hover': {
+              backgroundColor: '#333',
+            },
+          }}
+        >
+          Add existing account
+        </Button>
+      </Box>
+
+      <Box
+        sx={{
+          flex: 1,
+          backgroundColor: '#f5f5f5',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: '8px',
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          Image Placeholder
+        </Typography>
+      </Box>
+    </Paper>
+  )
+}
+
+const OrgAccountsList = () => {
+  // TODO: replace with data from CGW
+  const safes = useAllSafesGrouped()
+  const allSafes = useMemo<AllSafeItems>(
+    () => [...(safes.allMultiChainSafes ?? []), ...(safes.allSingleSafes ?? [])].slice(0, 5),
+    [safes.allMultiChainSafes, safes.allSingleSafes],
+  )
+  const hasAccounts = false
+
+  if (!hasAccounts) {
+    return <EmptyAccountsList />
+  }
+
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={12} md={8}>
+        <Typography variant="h5" fontWeight={700} mb={2}>
+          Safe Accounts ({allSafes.length})
+        </Typography>
+        <SafesList safes={allSafes} />
+      </Grid>
+      <Grid item xs={12} md={4}>
+        {/* Empty section for future content */}
+      </Grid>
+    </Grid>
+  )
+}
+
+export default OrgAccountsList

--- a/apps/web/src/features/organizations/components/Dashboard/index.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/index.tsx
@@ -1,7 +1,13 @@
 import { Box, Typography } from '@mui/material'
 import SignInButton from '@/features/organizations/components/SignInButton'
 import OrgAccountsList from '@/features/organizations/components/AccountsList'
+import MembersList from '../MembersList'
+import Grid from '@mui/material/Grid2'
 import css from './styles.module.css'
+
+const isSignedIn = true
+const hasAccounts = false
+const hasMembers = false
 
 const SignedOutState = () => {
   return (
@@ -24,16 +30,30 @@ const SignedOutState = () => {
 const OrganizationsDashboard = ({ organizationId }: { organizationId: string }) => {
   // TODO: use the organizationId to fetch the organization data
   console.log('organizationId', organizationId)
-  const isSignedIn = true
-  const hasSafes = false
+
+  if (!isSignedIn) {
+    return <SignedOutState />
+  }
 
   return (
     <>
       <Typography variant="h1" fontWeight={700} mb={4}>
-        {hasSafes ? 'Your Organization' : 'Getting started'}
+        Getting started
       </Typography>
 
-      <Box>{!isSignedIn ? <SignedOutState /> : <OrgAccountsList />}</Box>
+      <Grid container spacing={3}>
+        <Grid size={{ xs: 12, md: hasAccounts ? 8 : 12 }}>
+          <OrgAccountsList hasAccounts={hasAccounts} />
+        </Grid>
+        <Grid size={{ xs: 12, md: 4 }}>
+          {hasMembers && (
+            <Typography variant="h5" fontWeight={700} mb={2}>
+              Members
+            </Typography>
+          )}
+          <MembersList />
+        </Grid>
+      </Grid>
     </>
   )
 }

--- a/apps/web/src/features/organizations/components/Dashboard/index.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/index.tsx
@@ -1,31 +1,40 @@
 import { Box, Typography } from '@mui/material'
 import SignInButton from '@/features/organizations/components/SignInButton'
+import OrgAccountsList from '@/features/organizations/components/AccountsList'
 import css from './styles.module.css'
+
+const SignedOutState = () => {
+  return (
+    <Box className={css.content}>
+      <Box textAlign="center" p={3}>
+        <Typography variant="h2" fontWeight={700} mb={1}>
+          Sign in to see your organization
+        </Typography>
+
+        <Typography variant="body2" mb={2} color="primary.light">
+          Description
+        </Typography>
+
+        <SignInButton />
+      </Box>
+    </Box>
+  )
+}
 
 const OrganizationsDashboard = ({ organizationId }: { organizationId: string }) => {
   // TODO: use the organizationId to fetch the organization data
   console.log('organizationId', organizationId)
+  const isSignedIn = true
+  const hasSafes = false
 
   return (
-    <Box>
-      <Typography variant="h1" fontWeight={700} mb={2}>
-        Dashboard
+    <>
+      <Typography variant="h1" fontWeight={700} mb={4}>
+        {hasSafes ? 'Your Organization' : 'Getting started'}
       </Typography>
 
-      <Box className={css.content}>
-        <Box textAlign="center" p={3}>
-          <Typography variant="h2" fontWeight={700} mb={1}>
-            Sign in to see your organization
-          </Typography>
-
-          <Typography variant="body2" mb={2} color="primary.light">
-            Description
-          </Typography>
-
-          <SignInButton />
-        </Box>
-      </Box>
-    </Box>
+      <Box>{!isSignedIn ? <SignedOutState /> : <OrgAccountsList />}</Box>
+    </>
   )
 }
 

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -1,0 +1,48 @@
+import { Typography, Paper, Box, Button } from '@mui/material'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+
+const MembersList = () => {
+  const handleInviteClick = () => {
+    // TODO: Implement invite functionality
+    console.log('Invite clicked')
+  }
+
+  return (
+    <Paper sx={{ p: 3 }}>
+      {/* TODO: remove this circular image placeholder */}
+      <Box
+        sx={{
+          width: 40,
+          height: 40,
+          backgroundColor: 'grey.200',
+          borderRadius: '50%',
+          m: 1,
+        }}
+      />
+      <Button
+        onClick={handleInviteClick}
+        sx={{
+          width: '100%',
+          p: 1,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          textAlign: 'left',
+        }}
+        aria-label="Invite team members"
+      >
+        <Box>
+          <Typography variant="body1" color="text.primary" fontWeight={700}>
+            Invite team members
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Text description
+          </Typography>
+        </Box>
+        <ChevronRightIcon color="action" />
+      </Button>
+    </Paper>
+  )
+}
+
+export default MembersList


### PR DESCRIPTION
## What it solves

Resolves #4906

## How this PR fixes it
Adds empty states for Members and accounts widgets on the orgs dashboard
Also adds the orgs list with Orgs populated (using owned safes for now)

## How to test it

## Screenshots
![image](https://github.com/user-attachments/assets/6d519177-ddcd-46f5-8b2e-0f0feccc3b48)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
