### PR TITLE
Feat(Orgs): Add empty members view

### DIFF
--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -1,0 +1,12 @@
+import EmptyMembers from '@/features/organizations/components/MembersList/EmptyMembers'
+
+const OrganizationMembers = () => {
+  const members = [] // TODO: Fetch from backend
+
+  if (members.length === 0) return <EmptyMembers />
+
+  // TODO: Render members list
+  return <></>
+}
+
+export default OrganizationMembers

--- a/apps/web/src/features/organizations/components/MembersList/EmptyMembers.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/EmptyMembers.tsx
@@ -1,0 +1,30 @@
+import OrgsIcon from '@/public/images/orgs/orgs.svg'
+import { Card, Link, Typography } from '@mui/material'
+
+const InfoModal = () => {
+  const openInfoModal = () => {
+    // TODO: implement
+  }
+
+  return (
+    <Link onClick={openInfoModal} href="#">
+      What are team members?
+    </Link>
+  )
+}
+
+const EmptyMembers = () => {
+  return (
+    <Card sx={{ p: 5, textAlign: 'center' }}>
+      <OrgsIcon />
+
+      <Typography color="text.secondary" mb={2}>
+        Your organisation has no team members yet.
+        <br />
+        <InfoModal />
+      </Typography>
+    </Card>
+  )
+}
+
+export default EmptyMembers

--- a/apps/web/src/pages/organizations/[orgId]/members.tsx
+++ b/apps/web/src/pages/organizations/[orgId]/members.tsx
@@ -1,3 +1,4 @@
+import OrganizationMembers from '@/features/organizations/components/Members'
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { BRAND_NAME } from '@/config/constants'
@@ -9,7 +10,9 @@ const OrganizationDashboard: NextPage = () => {
         <title>{`${BRAND_NAME} – Organization members`}</title>
       </Head>
 
-      <main>Members</main>
+      <main>
+        <OrganizationMembers />
+      </main>
     </>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves #4956 

## How this PR fixes it

- Adds a new component `EmptyMembers` and `OrganizationMembers` and displays them on the member page

## How to test it

1. Open an organization and navigate to the members page
2. Observe the empty members view

## Screenshots

<img width="1512" alt="Screenshot 2025-02-14 at 11 01 58" src="https://github.com/user-attachments/assets/ee159db4-72ea-474d-9abc-3e54f9eca24c" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
