### PR TITLE
fix(mobile): navbar, tabs had transparent backgrounds

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -93,7 +93,7 @@
     "react-native-gesture-handler": "~2.20.2",
     "react-native-keychain": "^9.2.2",
     "react-native-mmkv": "^3.1.0",
-    "react-native-pager-view": "^6.5.1",
+    "react-native-pager-view": "^6.7.0",
     "react-native-progress": "^5.0.1",
     "react-native-quick-crypto": "^0.7.11",
     "react-native-reanimated": "~3.16.7",

--- a/apps/mobile/src/components/SafeTab/SafeTab.tsx
+++ b/apps/mobile/src/components/SafeTab/SafeTab.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useState } from 'react'
 import { TabBarProps, Tabs } from 'react-native-collapsible-tab-view'
 import { safeTabItem } from './types'
 import { SafeTabBar } from './SafeTabBar'
+import { Theme } from 'tamagui'
 
 interface SafeTabProps {
   renderHeader?: (props: TabBarProps<string>) => ReactElement
@@ -13,24 +14,26 @@ export function SafeTab({ renderHeader, headerHeight, items }: SafeTabProps) {
   const [activeTab, setActiveTab] = useState(items[0].label)
 
   return (
-    <Tabs.Container
-      renderHeader={renderHeader}
-      headerContainerStyle={headerContainerStyle}
-      headerHeight={headerHeight}
-      renderTabBar={(props) => <SafeTabBar activeTab={activeTab} setActiveTab={setActiveTab} {...props} />}
-      onTabChange={(event) => setActiveTab(event.tabName)}
-      initialTabName={items[0].label}
-    >
-      {items.map(({ label, Component }, index) => (
-        <Tabs.Tab name={label} key={`${label}-${index}`}>
-          <Component />
-        </Tabs.Tab>
-      ))}
-    </Tabs.Container>
+    <Theme name={'tab'}>
+      <Tabs.Container
+        renderHeader={renderHeader}
+        headerContainerStyle={headerContainerStyle}
+        headerHeight={headerHeight}
+        renderTabBar={(props) => <SafeTabBar activeTab={activeTab} setActiveTab={setActiveTab} {...props} />}
+        onTabChange={(event) => setActiveTab(event.tabName)}
+        initialTabName={items[0].label}
+      >
+        {items.map(({ label, Component }, index) => (
+          <Tabs.Tab name={label} key={`${label}-${index}`}>
+            <Component />
+          </Tabs.Tab>
+        ))}
+      </Tabs.Container>
+    </Theme>
   )
 }
 
-const headerContainerStyle = { backgroundColor: '$background' }
+const headerContainerStyle = { backgroundColor: '$background', shadowColor: 'transparent' }
 
 SafeTab.FlashList = Tabs.FlashList
 SafeTab.FlatList = Tabs.FlatList

--- a/apps/mobile/src/components/SafeTab/SafeTabBar.tsx
+++ b/apps/mobile/src/components/SafeTab/SafeTabBar.tsx
@@ -20,7 +20,7 @@ export const SafeTabBar = ({
   const activeButtonStyle = {
     paddingBottom: 8,
     borderBottomColor: theme.color?.get(),
-    borderBottomWidth: 1,
+    borderBottomWidth: 2,
   }
 
   const handleTabPressed = (name: string) => () => {
@@ -34,8 +34,7 @@ export const SafeTabBar = ({
 
   return (
     <View
-      backgroundColor="transparent"
-      marginBottom="$4"
+      backgroundColor="$background"
       gap="$6"
       paddingHorizontal="$4"
       flexDirection="row"

--- a/apps/mobile/src/components/SafeTab/theme.ts
+++ b/apps/mobile/src/components/SafeTab/theme.ts
@@ -1,0 +1,10 @@
+import { tokens } from '@/src/theme/tokens'
+
+export const safeTabTheme = {
+  light_tab: {
+    background: tokens.color.backgroundMainLight,
+  },
+  dark_tab: {
+    background: tokens.color.backgroundDefaultDark,
+  },
+}

--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
@@ -15,10 +15,10 @@ const MyAccountsFooterContainer = styled(View, {
 })
 
 const MyAccountsButton = styled(View, {
-  columnGap: '$3',
+  columnGap: '$2',
   alignItems: 'center',
   flexDirection: 'row',
-  marginBottom: '$7',
+  marginBottom: '$4',
 })
 
 interface CustomFooterProps extends BottomSheetFooterProps {}

--- a/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
+++ b/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
@@ -14,7 +14,7 @@ interface AssetsHeaderProps {
 export function AssetsHeader({ amount, isLoading, onPendingTransactionsPress, hasMore }: AssetsHeaderProps) {
   return (
     <StyledAssetsHeader>
-      <View marginBottom="$10" marginTop="0">
+      <View marginBottom="$8" marginTop="$4">
         {amount > 0 && (
           <PendingTransactions
             isLoading={isLoading}

--- a/apps/mobile/src/features/Assets/components/AssetsHeader/styles.ts
+++ b/apps/mobile/src/features/Assets/components/AssetsHeader/styles.ts
@@ -2,4 +2,5 @@ import { styled, View } from 'tamagui'
 
 export const StyledAssetsHeader = styled(View, {
   paddingHorizontal: '$4',
+  backgroundColor: '$background',
 })

--- a/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
@@ -22,15 +22,17 @@ export function Balance({ activeChainId, chains, isLoading, balanceAmount, chain
 
   return (
     <View>
-      <View marginBottom="$8">
+      <View marginBottom="$4">
         {activeChainId && (
-          <DropdownLabel
-            label={chainName}
-            leftNode={<ChainsDisplay activeChainId={activeChainId} chains={chains} max={1} />}
-            onPress={() => {
-              router.push('/networks-sheet')
-            }}
-          />
+          <View paddingBottom={'$4'}>
+            <DropdownLabel
+              label={chainName}
+              leftNode={<ChainsDisplay activeChainId={activeChainId} chains={chains} max={1} />}
+              onPress={() => {
+                router.push('/networks-sheet')
+              }}
+            />
+          </View>
         )}
 
         {isLoading ? (

--- a/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
+++ b/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import { XStack } from 'tamagui'
+import { Theme, XStack, getTokenValue } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Identicon } from '@/src/components/Identicon'
 import { shortenAddress } from '@/src/utils/formatters'
@@ -29,29 +29,32 @@ export const Navbar = () => {
   }
 
   return (
-    <XStack
-      paddingTop={insets.top}
-      justifyContent={'space-between'}
-      paddingHorizontal={16}
-      alignItems={'center'}
-      paddingBottom={'$2'}
-    >
-      <DropdownLabel
-        label={shortenAddress(activeSafe.address)}
-        labelProps={dropdownLabelProps}
-        leftNode={<Identicon address={activeSafe.address} rounded={true} size={30} />}
-        onPress={() => {
-          router.push('/accounts-sheet')
-        }}
-      />
-      <XStack alignItems={'center'} justifyContent={'center'} gap={12}>
-        <TouchableOpacity onPress={handleNotificationAccess}>
-          <SafeFontIcon name="lightbulb" />
-        </TouchableOpacity>
-        <TouchableOpacity>
-          <SafeFontIcon name="apps" />
-        </TouchableOpacity>
+    <Theme name="navbar">
+      <XStack
+        paddingTop={getTokenValue('$2') + insets.top}
+        justifyContent={'space-between'}
+        paddingHorizontal={16}
+        alignItems={'center'}
+        paddingBottom={'$2'}
+        backgroundColor={'$background'}
+      >
+        <DropdownLabel
+          label={shortenAddress(activeSafe.address)}
+          labelProps={dropdownLabelProps}
+          leftNode={<Identicon address={activeSafe.address} rounded={true} size={30} />}
+          onPress={() => {
+            router.push('/accounts-sheet')
+          }}
+        />
+        <XStack alignItems={'center'} justifyContent={'center'} gap={12}>
+          <TouchableOpacity onPress={handleNotificationAccess}>
+            <SafeFontIcon name="lightbulb" />
+          </TouchableOpacity>
+          <TouchableOpacity>
+            <SafeFontIcon name="apps" />
+          </TouchableOpacity>
+        </XStack>
       </XStack>
-    </XStack>
+    </Theme>
   )
 }

--- a/apps/mobile/src/features/Assets/components/Navbar/theme.ts
+++ b/apps/mobile/src/features/Assets/components/Navbar/theme.ts
@@ -1,0 +1,10 @@
+import { tokens } from '@/src/theme/tokens'
+
+export const navbarTheme = {
+  light_navbar: {
+    background: tokens.color.backgroundPaperLight,
+  },
+  dark_navbar: {
+    background: tokens.color.backgroundDefaultDark,
+  },
+}

--- a/apps/mobile/src/theme/tamagui.config.ts
+++ b/apps/mobile/src/theme/tamagui.config.ts
@@ -2,9 +2,11 @@ import { createTamagui } from 'tamagui'
 import { createDmSansFont } from '@tamagui/font-dm-sans'
 import { badgeTheme } from '@/src/components/Badge/theme'
 import { badgeTheme as NetworkBadgeTheme } from '@/src/components/NetworkBadge/theme'
+import { navbarTheme } from '@/src/features/Assets/components/Navbar/theme'
 import { tokens } from '@/src/theme/tokens'
 import { createAnimations } from '@tamagui/animations-moti'
 import { inputTheme } from '../components/SafeInput/theme'
+import { safeTabTheme } from '@/src/components/SafeTab/theme'
 
 const DmSansFont = createDmSansFont({
   face: {
@@ -59,6 +61,8 @@ export const config = createTamagui({
     ...badgeTheme,
     ...inputTheme,
     ...NetworkBadgeTheme,
+    ...navbarTheme,
+    ...safeTabTheme,
     light_success: {
       background: tokens.color.successBackgroundLight,
       color: tokens.color.successMainLight,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8273,7 +8273,7 @@ __metadata:
     react-native-gesture-handler: "npm:~2.20.2"
     react-native-keychain: "npm:^9.2.2"
     react-native-mmkv: "npm:^3.1.0"
-    react-native-pager-view: "npm:^6.5.1"
+    react-native-pager-view: "npm:^6.7.0"
     react-native-progress: "npm:^5.0.1"
     react-native-quick-crypto: "npm:^0.7.11"
     react-native-reanimated: "npm:~3.16.7"
@@ -28990,13 +28990,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-pager-view@npm:^6.5.1":
-  version: 6.6.1
-  resolution: "react-native-pager-view@npm:6.6.1"
+"react-native-pager-view@npm:^6.7.0":
+  version: 6.7.0
+  resolution: "react-native-pager-view@npm:6.7.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/f56c3598a0e88fc66bdea806abacb0dd366bbd16a0c371a9a0c4dc21b2e53b020321bb896e1ae0f07c75caea16aaed292ae66c1a7546ade9c6d2a14aee8b9d63
+  checksum: 10/01257ced1f51e798423c9af6c891dfa0ab3bac22c4e67fa5995dc0f25f36013beed92e1e8b509d57af85f934f316dad017dc05db7142cd063849c1acbff3f7ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves
Without this:
![grafik](https://github.com/user-attachments/assets/1cf61024-89d5-4fbe-923e-caee7120a0ed)

with this:
![grafik](https://github.com/user-attachments/assets/25321534-ece2-48ca-aa73-687e3c845de5)

## How this PR fixes it
We had some transparent backgrouds. Now we apply a theme around those elements. 


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
