### PR TITLE
Fix(Simulation): change the error styling

### DIFF
--- a/apps/web/src/components/tx/security/tenderly/index.tsx
+++ b/apps/web/src/components/tx/security/tenderly/index.tsx
@@ -173,15 +173,15 @@ export const TxSimulationMessage = () => {
   if (!isSuccess || isError || isCallTraceError) {
     return (
       <Alert severity="error" sx={{ border: 'unset' }}>
-        <Typography variant="body2" fontWeight={700}>
+        <Typography variant="body1" fontWeight={700}>
           Simulation failed
         </Typography>
         {requestError ? (
-          <Typography color="error">
+          <Typography color="error" variant='body2'>
             An unexpected error occurred during simulation: <b>{requestError}</b>.
           </Typography>
         ) : (
-          <Typography>
+          <Typography variant='body2'>
             {isCallTraceError ? (
               <>The transaction failed during the simulation.</>
             ) : (

--- a/apps/web/src/components/tx/security/tenderly/index.tsx
+++ b/apps/web/src/components/tx/security/tenderly/index.tsx
@@ -177,7 +177,7 @@ export const TxSimulationMessage = () => {
           Simulation failed
         </Typography>
         {requestError ? (
-          <Typography color="error" variant='body2'>
+          <Typography color="error" variant="body2">
             An unexpected error occurred during simulation: <b>{requestError}</b>.
           </Typography>
         ) : (

--- a/apps/web/src/components/tx/security/tenderly/index.tsx
+++ b/apps/web/src/components/tx/security/tenderly/index.tsx
@@ -181,7 +181,7 @@ export const TxSimulationMessage = () => {
             An unexpected error occurred during simulation: <b>{requestError}</b>.
           </Typography>
         ) : (
-          <Typography variant='body2'>
+          <Typography variant="body2">
             {isCallTraceError ? (
               <>The transaction failed during the simulation.</>
             ) : (


### PR DESCRIPTION
## What it solves

Resolves the issue: #4042. The title appeared smaller than the subtitle.

## How this PR fixes it
I have added the variants body1 to title and body2 subtitle. 

## How to test it
1) Go to a pending transaction
2) Click 'Confirm'
3) Click 'Simulate' in transaction checks block
4) See the alert on the right side

## Screenshots
![Screenshot 2025-02-16 at 10 15 18 PM](https://github.com/user-attachments/assets/dd74b609-55c8-4b2a-98e2-7484003e82fe)

PS: The bold text in the subtitle was just for testing as i could not get to see the error message in the local host.
## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
