### PR TITLE
Issue3876

### DIFF
--- a/apps/web/src/components/common/ProgressBar/styles.module.css
+++ b/apps/web/src/components/common/ProgressBar/styles.module.css
@@ -9,6 +9,10 @@
   border-radius: 6px;
 }
 
+[data-theme="light"] .progressBar :global .MuiLinearProgress-bar {
+  background: var(--color-secondary-main);
+}
+
 @media (max-width: 599.95px) {
   .progressBar {
     border-radius: 0;

--- a/apps/web/src/components/tx-flow/common/TxStatusWidget/styles.module.css
+++ b/apps/web/src/components/tx-flow/common/TxStatusWidget/styles.module.css
@@ -39,6 +39,10 @@
   background-color: var(--color-background-paper);
 }
 
+[data-theme='light'] .status :global .MuiListItemIcon-root {
+  color: var(--color-secondary-dark);
+}
+
 .incomplete > * {
   color: var(--color-text-secondary) !important;
 }

--- a/apps/web/src/components/tx/security/tenderly/index.tsx
+++ b/apps/web/src/components/tx/security/tenderly/index.tsx
@@ -173,15 +173,15 @@ export const TxSimulationMessage = () => {
   if (!isSuccess || isError || isCallTraceError) {
     return (
       <Alert severity="error" sx={{ border: 'unset' }}>
-        <Typography variant="body2" fontWeight={700}>
+        <Typography variant="body1" fontWeight={700}>
           Simulation failed
         </Typography>
         {requestError ? (
-          <Typography color="error">
+          <Typography color="error" variant='body2'>
             An unexpected error occurred during simulation: <b>{requestError}</b>.
           </Typography>
         ) : (
-          <Typography>
+          <Typography variant='body2'>
             {isCallTraceError ? (
               <>The transaction failed during the simulation.</>
             ) : (


### PR DESCRIPTION
## What it solves

Resolves the issue: 3876. The progress bar and the checklist icons color in the light mode are fixed.

## How this PR fixes it

I have added the conditional rendering of the variable color as per the theme. Earlier in both the themes the color name was but , the color values defined in the var.css were different. I added conditions in css so that the required color is used.
## How to test it

## Screenshots
<img width="1164" alt="Screenshot 2025-02-17 at 12 14 12 AM" src="https://github.com/user-attachments/assets/1c3cc2d8-3fab-44ad-99f8-7a4ead1ad1e0" />

now both the things are renders with the required color.
## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
