### PR TITLE
feat(Orgs): Add org selector dropdown to orgs sidebar

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsCard/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCard/index.tsx
@@ -46,14 +46,22 @@ export type Organization = {
   safes: Array<object>
 }
 
-const OrgsCard = ({ org, isCompact = false }: { org: Organization; isCompact?: boolean }) => {
+const OrgsCard = ({
+  org,
+  isCompact = false,
+  isLink = true,
+}: {
+  org: Organization
+  isCompact?: boolean
+  isLink?: boolean
+}) => {
   const { id, safes, name, members } = org
   const numberOfAccounts = safes.length
   const numberOfMembers = members.length
 
   return (
     <Card className={css.card} sx={{ px: 2, py: isCompact ? 1 : 2 }}>
-      <Link className={css.cardLink} href={AppRoutes.organizations.index(id.toString())} />
+      {isLink && <Link className={css.cardLink} href={AppRoutes.organizations.index(id.toString())} />}
 
       <Stack
         alignItems={isCompact ? 'center' : 'left'}

--- a/apps/web/src/features/organizations/components/OrgsCard/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCard/index.tsx
@@ -20,52 +20,71 @@ export function getDeterministicColor(str: string): string {
   return hslToRgb(`hsl(${hue}, ${saturation}, ${lightness})`)
 }
 
-const OrgLogo = ({ orgName }: { orgName: string }) => {
+export const OrgLogo = ({ orgName, size = 'large' }: { orgName: string; size?: 'small' | 'medium' | 'large' }) => {
   const logoLetters = orgName.slice(0, 2)
   const logoColor = getDeterministicColor(orgName)
 
+  const dimensions = {
+    small: { width: 24, height: 24, fontSize: '12px !important' },
+    medium: { width: 32, height: 32, fontSize: '16px !important' },
+    large: { width: 48, height: 48, fontSize: '20px !important' },
+  }
+
+  const { width, height, fontSize } = dimensions[size]
+
   return (
-    <Box className={css.orgLogo} bgcolor={logoColor}>
+    <Box className={css.orgLogo} bgcolor={logoColor} width={width} height={height} fontSize={fontSize}>
       {logoLetters}
     </Box>
   )
 }
 
-type Organization = {
+export type Organization = {
   id: number
   name: string
   members: Array<object>
   safes: Array<object>
 }
 
-const OrgsCard = ({ org }: { org: Organization }) => {
+const OrgsCard = ({ org, isCompact = false }: { org: Organization; isCompact?: boolean }) => {
   const { id, safes, name, members } = org
   const numberOfAccounts = safes.length
   const numberOfMembers = members.length
 
   return (
-    <Card className={css.card}>
+    <Card className={css.card} sx={{ px: 2, py: isCompact ? 1 : 2 }}>
       <Link className={css.cardLink} href={AppRoutes.organizations.index(id.toString())} />
 
-      <OrgLogo orgName={name} />
+      <Stack
+        alignItems={isCompact ? 'center' : 'left'}
+        direction={isCompact ? 'row' : 'column'}
+        spacing={isCompact ? 1 : 0}
+      >
+        <OrgLogo orgName={name} size={isCompact ? 'medium' : 'large'} />
 
-      <Typography mt={2} variant="body2" fontWeight="bold">
-        {name}
-      </Typography>
+        <Box>
+          <Typography mt={isCompact ? 0 : 2} variant="body2" fontWeight="bold">
+            {name}
+          </Typography>
 
-      <Stack direction="row" spacing={1} alignItems="center" mt={0.5}>
-        <Typography variant="caption" color="text.secondary">
-          {numberOfAccounts} Accounts
-        </Typography>
+          <Stack direction="row" spacing={1} alignItems="center" mt={isCompact ? 0 : 0.5}>
+            <Typography variant="caption" color="text.secondary">
+              {numberOfAccounts} Accounts
+            </Typography>
 
-        <div className={css.dot} />
+            <div className={css.dot} />
 
-        <Typography variant="caption" color="text.secondary">
-          {numberOfMembers} Members
-        </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {numberOfMembers} Members
+            </Typography>
+          </Stack>
+        </Box>
       </Stack>
-
-      <IconButton className={css.orgActions} size="small" onClick={() => {}}>
+      <IconButton
+        sx={{ position: 'absolute', top: isCompact ? 8 : 16, right: isCompact ? 8 : 16 }}
+        size="small"
+        onClick={() => {}}
+      >
         <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />
       </IconButton>
     </Card>

--- a/apps/web/src/features/organizations/components/OrgsCard/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCard/index.tsx
@@ -3,6 +3,7 @@ import { Box, Card, hslToRgb, Stack, Typography } from '@mui/material'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import IconButton from '@mui/material/IconButton'
 import Link from 'next/link'
+import classNames from 'classnames'
 
 import css from './styles.module.css'
 
@@ -60,39 +61,32 @@ const OrgsCard = ({
   const numberOfMembers = members.length
 
   return (
-    <Card className={css.card} sx={{ px: 2, py: isCompact ? 1 : 2 }}>
+    <Card className={classNames(css.card, { [css.compact]: isCompact })}>
       {isLink && <Link className={css.cardLink} href={AppRoutes.organizations.index(id.toString())} />}
 
-      <Stack
-        alignItems={isCompact ? 'center' : 'left'}
-        direction={isCompact ? 'row' : 'column'}
-        spacing={isCompact ? 1 : 0}
-      >
+      <Box className={css.orgLogo}>
         <OrgLogo orgName={name} size={isCompact ? 'medium' : 'large'} />
+      </Box>
 
-        <Box>
-          <Typography mt={isCompact ? 0 : 2} variant="body2" fontWeight="bold">
-            {name}
+      <Box className={css.orgInfo}>
+        <Typography variant="body2" fontWeight="bold">
+          {name}
+        </Typography>
+
+        <Stack direction="row" spacing={1} alignItems="center" mt={isCompact ? 0 : 0.5}>
+          <Typography variant="caption" color="text.secondary">
+            {numberOfAccounts} Accounts
           </Typography>
 
-          <Stack direction="row" spacing={1} alignItems="center" mt={isCompact ? 0 : 0.5}>
-            <Typography variant="caption" color="text.secondary">
-              {numberOfAccounts} Accounts
-            </Typography>
+          <div className={css.dot} />
 
-            <div className={css.dot} />
+          <Typography variant="caption" color="text.secondary">
+            {numberOfMembers} Members
+          </Typography>
+        </Stack>
+      </Box>
 
-            <Typography variant="caption" color="text.secondary">
-              {numberOfMembers} Members
-            </Typography>
-          </Stack>
-        </Box>
-      </Stack>
-      <IconButton
-        sx={{ position: 'absolute', top: isCompact ? 8 : 16, right: isCompact ? 8 : 16 }}
-        size="small"
-        onClick={() => {}}
-      >
+      <IconButton className={css.orgActions} size="small" onClick={() => {}}>
         <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />
       </IconButton>
     </Card>

--- a/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
+++ b/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
@@ -1,12 +1,9 @@
 .card {
-  padding: var(--space-2);
   position: relative;
   flex-basis: 50%;
 }
 
 .orgLogo {
-  width: 48px;
-  height: 48px;
   border-radius: 6px;
   text-transform: uppercase;
   font-weight: bold;
@@ -14,7 +11,6 @@
   align-items: center;
   justify-content: center;
   color: white;
-  font-size: 20px;
 }
 
 .dot {

--- a/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
+++ b/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
@@ -1,9 +1,27 @@
 .card {
   position: relative;
   flex-basis: 50%;
+  display: grid;
+  grid-template-areas:
+    'logo logo actions'
+    'info info actions';
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  padding: var(--space-2);
+}
+
+.card.compact {
+  grid-template-areas:
+    'logo info actions'
+    'logo info actions';
+  grid-template-columns: auto 1fr auto;
+  padding: var(--space-1);
+  padding-left: 12px;
+  border: 0;
 }
 
 .orgLogo {
+  grid-area: logo;
   border-radius: 6px;
   text-transform: uppercase;
   font-weight: bold;
@@ -11,6 +29,11 @@
   align-items: center;
   justify-content: center;
   color: white;
+  justify-self: start;
+}
+
+.orgInfo {
+  grid-area: info;
 }
 
 .dot {
@@ -21,9 +44,8 @@
 }
 
 .orgActions {
-  position: absolute;
-  top: var(--space-2);
-  right: var(--space-2);
+  grid-area: actions;
+  align-self: start;
 }
 
 .cardLink {

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -1,4 +1,5 @@
 import AccountsNavigation from '@/features/myAccounts/components/AccountsNavigation'
+import type { Organization } from '@/features/organizations/components/OrgsCard'
 import OrgsCard from '@/features/organizations/components/OrgsCard'
 import OrgsCreationModal from '@/features/organizations/components/OrgsCreationModal'
 import SignInButton from '@/features/organizations/components/SignInButton'
@@ -69,7 +70,7 @@ const NoOrgsState = () => {
   )
 }
 
-const ORGS = [
+export const ORGS: Organization[] = [
   {
     name: 'Safe DAO',
     id: 1,
@@ -77,7 +78,7 @@ const ORGS = [
     safes: [{ id: 1 }, { id: 4 }, { id: 2 }],
   },
   {
-    name: 'Optimism Foundation',
+    name: 'Optimism Foundation Organization',
     id: 2,
     members: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }],
     safes: [{ id: 1 }, { id: 4 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }],

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -78,7 +78,7 @@ export const ORGS: Organization[] = [
     safes: [{ id: 1 }, { id: 4 }, { id: 2 }],
   },
   {
-    name: 'Optimism Foundation Organization',
+    name: 'Optimism Foundation',
     id: 2,
     members: [{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }],
     safes: [{ id: 1 }, { id: 4 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }],

--- a/apps/web/src/features/organizations/components/OrgsSidebar/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebar/index.tsx
@@ -3,11 +3,13 @@ import { type ReactElement } from 'react'
 import css from './styles.module.css'
 import { Drawer } from '@mui/material'
 import OrgsSidebarNavigation from '@/features/organizations/components/OrgsSidebarNavigation'
+import OrgsSidebarSelector from '../OrgsSidebarSelector'
 
 const OrgsSidebar = (): ReactElement => {
   return (
     <Drawer variant="permanent" anchor="left">
       <div className={css.container}>
+        <OrgsSidebarSelector />
         <OrgsSidebarNavigation />
       </div>
     </Drawer>

--- a/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
@@ -25,7 +25,7 @@ export const navItems: DynamicNavItem[] = [
   {
     label: 'Members',
     icon: <SvgIcon component={HomeIcon} inheritViewBox />,
-    href: AppRoutes.organizations.members,
+    href: AppRoutes.organizations.index,
   },
   {
     label: 'Settings',

--- a/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
@@ -25,7 +25,7 @@ export const navItems: DynamicNavItem[] = [
   {
     label: 'Members',
     icon: <SvgIcon component={HomeIcon} inheritViewBox />,
-    href: AppRoutes.organizations.index,
+    href: AppRoutes.organizations.members,
   },
   {
     label: 'Settings',

--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
@@ -73,7 +73,7 @@ const OrgsSidebarSelector = () => {
           onClose={handleClose}
           sx={{ '& .MuiPaper-root': { minWidth: '260px !important' } }}
         >
-          <OrgsCard org={selectedOrg} isCompact />
+          <OrgsCard org={selectedOrg} isCompact isLink={false} />
           <Divider sx={{ mb: 1 }} />
           {ORGS.map((org) => (
             <MenuItem

--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
@@ -1,0 +1,122 @@
+import { Box, Button, Divider, Menu, MenuItem, Typography } from '@mui/material'
+import { useState } from 'react'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import CheckIcon from '@mui/icons-material/Check'
+import type { Organization } from '../OrgsCard'
+import OrgsCard, { OrgLogo } from '../OrgsCard'
+import css from './styles.module.css'
+import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
+import OrgsCreationModal from '../OrgsCreationModal'
+import { ORGS } from '../OrgsList'
+
+const OrgsSidebarSelector = () => {
+  const [selectedOrg, setSelectedOrg] = useState(ORGS[0])
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+  const router = useRouter()
+  const [isCreationModalOpen, setIsCreationModalOpen] = useState(false)
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  const handleSelectOrg = (org: Organization) => {
+    const currentPath = router.asPath
+    const newPath = currentPath.replace(/\/organizations\/\d+/, `/organizations/${org.id}`)
+    if (newPath !== currentPath) {
+      router.push(newPath)
+    }
+
+    setSelectedOrg(org)
+    handleClose()
+  }
+
+  return (
+    <>
+      <Box display="flex" width="100%">
+        <Button
+          id="org-selector-button"
+          onClick={handleClick}
+          endIcon={
+            <ExpandMoreIcon
+              className={css.expandIcon}
+              sx={{
+                transform: open ? 'rotate(180deg)' : undefined,
+                color: 'border.main',
+              }}
+            />
+          }
+          fullWidth
+          className={css.orgSelectorButton}
+        >
+          <Box display="flex" alignItems="center" gap={1}>
+            <OrgLogo orgName={selectedOrg.name} size="small" />
+            <Typography
+              variant="body2"
+              fontWeight="bold"
+              noWrap
+              sx={{ maxWidth: '140px', textOverflow: 'ellipsis', overflow: 'hidden' }}
+            >
+              {selectedOrg.name}
+            </Typography>
+          </Box>
+        </Button>
+        <Menu
+          id="org-selector-menu"
+          anchorEl={anchorEl}
+          open={open}
+          onClose={handleClose}
+          sx={{ '& .MuiPaper-root': { minWidth: '260px !important' } }}
+        >
+          <OrgsCard org={selectedOrg} isCompact />
+          <Divider sx={{ mb: 1 }} />
+          {ORGS.map((org) => (
+            <MenuItem
+              key={org.id}
+              onClick={() => handleSelectOrg(org)}
+              selected={org.id === selectedOrg.id}
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                gap: 1,
+              }}
+            >
+              <Box display="flex" alignItems="center" gap={1}>
+                <OrgLogo orgName={org.name} size="small" />
+                {org.name}
+              </Box>
+              {org.id === selectedOrg.id && <CheckIcon fontSize="small" color="primary" />}
+            </MenuItem>
+          ))}
+          <Divider />
+          <MenuItem
+            onClick={() => {
+              handleClose()
+              setIsCreationModalOpen(true)
+            }}
+            sx={{ fontWeight: 700 }}
+          >
+            Create organization
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              handleClose()
+              router.push(AppRoutes.welcome.organizations)
+            }}
+            sx={{ fontWeight: 700 }}
+          >
+            View organizations
+          </MenuItem>
+        </Menu>
+      </Box>
+      {isCreationModalOpen && <OrgsCreationModal onClose={() => setIsCreationModalOpen(false)} />}
+    </>
+  )
+}
+
+export default OrgsSidebarSelector

--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
@@ -88,7 +88,7 @@ const OrgsSidebarSelector = () => {
             >
               <Box display="flex" alignItems="center" gap={1}>
                 <OrgLogo orgName={org.name} size="small" />
-                {org.name}
+                <Typography variant="body2">{org.name}</Typography>
               </Box>
               {org.id === selectedOrg.id && <CheckIcon fontSize="small" color="primary" />}
             </MenuItem>

--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/styles.module.css
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/styles.module.css
@@ -1,0 +1,12 @@
+.orgSelectorButton {
+  justify-content: space-between;
+  text-align: 'left';
+  padding: var(--space-1);
+  margin: var(--space-1);
+  border: 1px solid var(--color-border-light);
+  font-size: 14px;
+}
+
+.orgSelectorButton:hover {
+  border: 1px solid var(--color-border-light);
+}

--- a/apps/web/src/pages/organizations/[orgId]/members.tsx
+++ b/apps/web/src/pages/organizations/[orgId]/members.tsx
@@ -1,8 +1,13 @@
-import type { NextPage } from 'next'
+import { useRouter } from 'next/router'
 import Head from 'next/head'
 import { BRAND_NAME } from '@/config/constants'
 
-const OrganizationDashboard: NextPage = () => {
+export default function OrganizationPage() {
+  const router = useRouter()
+  const { orgId } = router.query
+
+  if (!router.isReady || !orgId || typeof orgId !== 'string') return null
+
   return (
     <>
       <Head>
@@ -13,5 +18,3 @@ const OrganizationDashboard: NextPage = () => {
     </>
   )
 }
-
-export default OrganizationDashboard

--- a/apps/web/src/pages/organizations/[orgId]/members.tsx
+++ b/apps/web/src/pages/organizations/[orgId]/members.tsx
@@ -1,13 +1,8 @@
-import { useRouter } from 'next/router'
 import Head from 'next/head'
 import { BRAND_NAME } from '@/config/constants'
+import type { NextPage } from 'next'
 
-export default function OrganizationPage() {
-  const router = useRouter()
-  const { orgId } = router.query
-
-  if (!router.isReady || !orgId || typeof orgId !== 'string') return null
-
+const OrganizationDashboard: NextPage = () => {
   return (
     <>
       <Head>
@@ -18,3 +13,5 @@ export default function OrganizationPage() {
     </>
   )
 }
+
+export default OrganizationDashboard


### PR DESCRIPTION
## What it solves

Resolves #4976

## How this PR fixes it
- adds the org selector to the orgs sidebar
- allows switching between orgs in the list.
- shows an overview of the currently selected org
- the dropdown contains buttons to create a new org and go to the orgs list.


## Screenshots
![image](https://github.com/user-attachments/assets/14ba9836-5dff-49ef-90f6-2ca0d1d918ff)
![image](https://github.com/user-attachments/assets/9378c02a-b67c-498d-b781-b309881c566c)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
