### PR TITLE
fix: hide Nested Safes behind targeted feature flag

### DIFF
--- a/apps/web/src/components/settings/NestedSafesList/index.tsx
+++ b/apps/web/src/components/settings/NestedSafesList/index.tsx
@@ -16,16 +16,19 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import { useGetOwnedSafesQuery } from '@/store/slices'
 import { NESTED_SAFE_EVENTS } from '@/services/analytics/events/nested-safes'
 import Track from '@/components/common/Track'
+import { useIsTargetedFeature } from '@/features/targetedFeatures/hooks/useIsTargetedFeature'
+import { FEATURES } from '@/utils/chains'
 
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 
 export function NestedSafesList(): ReactElement | null {
+  const isEnabled = useIsTargetedFeature(FEATURES.TARGETED_NESTED_SAFES)
   const { setTxFlow } = useContext(TxModalContext)
   const [addressToRename, setAddressToRename] = useState<string | null>(null)
 
   const { safe, safeLoaded, safeAddress } = useSafeInfo()
   const { data: nestedSafes } = useGetOwnedSafesQuery(
-    safeLoaded ? { chainId: safe.chainId, ownerAddress: safeAddress } : skipToken,
+    isEnabled && safeLoaded ? { chainId: safe.chainId, ownerAddress: safeAddress } : skipToken,
   )
 
   const rows = useMemo(() => {
@@ -63,6 +66,10 @@ export function NestedSafesList(): ReactElement | null {
       }
     })
   }, [nestedSafes?.safes])
+
+  if (!isEnabled) {
+    return null
+  }
 
   return (
     <>

--- a/apps/web/src/components/sidebar/NestedSafesButton/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesButton/index.tsx
@@ -6,14 +6,27 @@ import type { ReactElement } from 'react'
 import NestedSafesIcon from '@/public/images/sidebar/nested-safes-icon.svg'
 import { NestedSafesPopover } from '@/components/sidebar/NestedSafesPopover'
 import { useGetOwnedSafesQuery } from '@/store/slices'
+import { useIsTargetedFeature } from '@/features/targetedFeatures/hooks/useIsTargetedFeature'
+import { FEATURES } from '@/utils/chains'
 
 import headerCss from '@/components/sidebar/SidebarHeader/styles.module.css'
 import css from './styles.module.css'
 
-export function NestedSafesButton({ chainId, safeAddress }: { chainId: string; safeAddress: string }): ReactElement {
+export function NestedSafesButton({
+  chainId,
+  safeAddress,
+}: {
+  chainId: string
+  safeAddress: string
+}): ReactElement | null {
+  const isEnabled = useIsTargetedFeature(FEATURES.TARGETED_NESTED_SAFES)
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
-  const { data } = useGetOwnedSafesQuery(safeAddress ? { chainId, ownerAddress: safeAddress } : skipToken)
+  const { data } = useGetOwnedSafesQuery(isEnabled && safeAddress ? { chainId, ownerAddress: safeAddress } : skipToken)
   const nestedSafes = data?.safes ?? []
+
+  if (!isEnabled) {
+    return null
+  }
 
   const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)

--- a/apps/web/src/components/sidebar/SafeListContextMenu/index.tsx
+++ b/apps/web/src/components/sidebar/SafeListContextMenu/index.tsx
@@ -23,6 +23,8 @@ import { CreateSafeOnNewChain } from '@/features/multichain/components/CreateSaf
 import { useGetOwnedSafesQuery } from '@/store/slices'
 import { NestedSafesPopover } from '../NestedSafesPopover'
 import { NESTED_SAFE_EVENTS, NESTED_SAFE_LABELS } from '@/services/analytics/events/nested-safes'
+import { useIsTargetedFeature } from '@/features/targetedFeatures/hooks/useIsTargetedFeature'
+import { FEATURES } from '@/utils/chains'
 
 enum ModalType {
   NESTED_SAFES = 'nested_safes',
@@ -53,7 +55,10 @@ const SafeListContextMenu = ({
   rename: boolean
   undeployedSafe: boolean
 }): ReactElement => {
-  const { data: nestedSafes } = useGetOwnedSafesQuery(address ? { chainId, ownerAddress: address } : skipToken)
+  const isNestedSafesEnabled = useIsTargetedFeature(FEATURES.TARGETED_NESTED_SAFES)
+  const { data: nestedSafes } = useGetOwnedSafesQuery(
+    isNestedSafesEnabled && address ? { chainId, ownerAddress: address } : skipToken,
+  )
   const addressBook = useAddressBook()
   const hasName = address in addressBook
 
@@ -90,7 +95,7 @@ const SafeListContextMenu = ({
         <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />
       </IconButton>
       <ContextMenu anchorEl={anchorEl} open={!!anchorEl} onClose={handleCloseContextMenu}>
-        {!undeployedSafe && nestedSafes?.safes && nestedSafes.safes.length > 0 && (
+        {isNestedSafesEnabled && !undeployedSafe && nestedSafes?.safes && nestedSafes.safes.length > 0 && (
           <MenuItem
             onClick={handleOpenModal(ModalType.NESTED_SAFES, {
               ...NESTED_SAFE_EVENTS.OPEN_LIST,

--- a/apps/web/src/hooks/useParentSafe.ts
+++ b/apps/web/src/hooks/useParentSafe.ts
@@ -2,15 +2,18 @@ import { useGetSafeQuery } from '@/store/slices'
 import { skipToken } from '@reduxjs/toolkit/query'
 import useSafeInfo from './useSafeInfo'
 import type { getSafe } from '@safe-global/safe-client-gateway-sdk'
+import { useIsTargetedFeature } from '@/features/targetedFeatures/hooks/useIsTargetedFeature'
+import { FEATURES } from '@/utils/chains'
 
 export function useParentSafe(): getSafe | undefined {
+  const isEnabled = useIsTargetedFeature(FEATURES.TARGETED_NESTED_SAFES)
   const { safe } = useSafeInfo()
 
   // Nested Safes are deployed by a single owner
   const maybeParent = safe.owners.length === 1 ? safe.owners[0].value : undefined
 
   const { data: parentSafe } = useGetSafeQuery(
-    maybeParent
+    isEnabled && maybeParent
       ? {
           chainId: safe.chainId,
           safeAddress: maybeParent,


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-client-gateway/issues/2323

## How this PR fixes it

This hides Nested Safes behind a targeted feature (`TARGETED_NESTED_SAFES`) but coniditonally rendering specific elements:

- `NestedSafesList` in setup settings
- `NestedSafesButton` in sidebar header
- `MenuItem` in `SafeListContextMenu` of drawer

Note: in all three of the above, the relevant Nested Safe data fetching has also been disabled to prevent the unnecessary request. `useParentSafe` has also been disabled in accordance with the flag in a similar fashion.

## How to test it

Open a targeted Safe and observe the feature present in the sidebar, drawer and settings. It should be possible to view, create and open Nested Safes with a breadcrumb visible in children. The feature should also be "unlocked" across non-targeted Safes. (Disabling the feature on the Config Service should mean it is no longer present in the UI.)

Open a non-targeted Safe and observe the feature is not enabled, providing the feature was not previously "unlocked".

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
