### PR TITLE
Feat(Safenet): Add new networks for Safenet-enabled accounts

### DIFF
--- a/apps/web/src/features/multichain/hooks/__tests__/useSafeCreationData.test.ts
+++ b/apps/web/src/features/multichain/hooks/__tests__/useSafeCreationData.test.ts
@@ -1,4 +1,5 @@
 import { PayMethod } from '@/features/counterfactual/PayNowPayLater'
+import { SafenetSetupAddress } from '@/features/safenet/config/constants'
 import * as web3 from '@/hooks/wallets/web3'
 import * as sdk from '@/services/tx/tx-sender/sdk'
 import { PendingSafeStatus, type UndeployedSafe } from '@/store/slices'
@@ -21,7 +22,6 @@ import { SAFE_CREATION_DATA_ERRORS, useSafeCreationData } from '../useSafeCreati
 
 const setupToL2Address = getSafeToL2SetupDeployment({ version: '1.4.1' })?.defaultAddress!
 const multiSendAddress = getMultiSendDeployment({ version: '1.4.1' })?.defaultAddress!
-const safeSetupAddress = '0x18261ff68cC8D05EE046EDF5F4049B2077624a1d' // TODO: getSafeSetupDeployment({ version: '1.4.1' })?.defaultAddress
 
 describe('useSafeCreationData', () => {
   beforeAll(() => {
@@ -824,7 +824,7 @@ describe('useSafeCreationData', () => {
       operation: 0,
     }
     const safeSetupTx = {
-      to: safeSetupAddress,
+      to: SafenetSetupAddress,
       value: '0',
       data: faker.string.hexadecimal({ length: 64 }),
       operation: 0,

--- a/apps/web/src/features/multichain/hooks/__tests__/useSafeCreationData.test.ts
+++ b/apps/web/src/features/multichain/hooks/__tests__/useSafeCreationData.test.ts
@@ -10,7 +10,11 @@ import { faker } from '@faker-js/faker'
 import { encodeMultiSendData, type SafeProvider } from '@safe-global/protocol-kit'
 import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import * as cgwSdk from '@safe-global/safe-client-gateway-sdk'
-import { getMultiSendDeployment, getSafeSingletonDeployment, getSafeToL2SetupDeployment } from '@safe-global/safe-deployments'
+import {
+  getMultiSendDeployment,
+  getSafeSingletonDeployment,
+  getSafeToL2SetupDeployment,
+} from '@safe-global/safe-deployments'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { type JsonRpcProvider } from 'ethers'
 import { SAFE_CREATION_DATA_ERRORS, useSafeCreationData } from '../useSafeCreationData'

--- a/apps/web/src/features/multichain/hooks/useSafeCreationData.ts
+++ b/apps/web/src/features/multichain/hooks/useSafeCreationData.ts
@@ -72,17 +72,19 @@ const validateAccountConfig = (safeAccountConfig: SafeAccountConfig) => {
 
   // setupModules used to opt in into Safenet
   if (safeAccountConfig.data) {
-    const safeSetupAddress = '0x18261ff68cC8D05EE046EDF5F4049B2077624a1d' // TODO: getSafeSetupDeployment({ version: '1.4.1' })?.defaultAddress
-    const multiSendAddress = getMultiSendDeployment({ version: '1.4.1' })?.defaultAddress
+    try {
+      const safeSetupAddress = '0x18261ff68cC8D05EE046EDF5F4049B2077624a1d' // TODO: getSafeSetupDeployment({ version: '1.4.1' })?.defaultAddress
+      const multiSendAddress = getMultiSendDeployment({ version: '1.4.1' })?.defaultAddress
 
-    const decodedData = decodeMultiSendData(safeAccountConfig.data)
+      const decodedData = decodeMultiSendData(safeAccountConfig.data)
 
-    const isSafenetSetup =
-      sameAddress(safeAccountConfig.to, multiSendAddress) &&
-      decodedData.length === 2 &&
-      sameAddress(decodedData[0].to, setupToL2Address) &&
-      sameAddress(decodedData[1].to, safeSetupAddress)
-    if (isSafenetSetup) return
+      const isSafenetSetup =
+        sameAddress(safeAccountConfig.to, multiSendAddress) &&
+        decodedData.length === 2 &&
+        sameAddress(decodedData[0].to, setupToL2Address) &&
+        sameAddress(decodedData[1].to, safeSetupAddress)
+      if (isSafenetSetup) return
+    } catch {}
   }
 
   if (safeAccountConfig.to !== ZERO_ADDRESS) {

--- a/apps/web/src/features/multichain/hooks/useSafeCreationData.ts
+++ b/apps/web/src/features/multichain/hooks/useSafeCreationData.ts
@@ -1,4 +1,5 @@
 import { determineMasterCopyVersion, isPredictedSafeProps } from '@/features/counterfactual/utils'
+import { SafenetSetupAddress } from '@/features/safenet/config/constants'
 import useAsync, { type AsyncResult } from '@/hooks/useAsync'
 import { createWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { logError } from '@/services/exceptions'
@@ -73,7 +74,6 @@ const validateAccountConfig = (safeAccountConfig: SafeAccountConfig) => {
   // setupModules used to opt in into Safenet
   if (safeAccountConfig.data) {
     try {
-      const safeSetupAddress = '0x18261ff68cC8D05EE046EDF5F4049B2077624a1d' // TODO: getSafeSetupDeployment({ version: '1.4.1' })?.defaultAddress
       const multiSendAddress = getMultiSendDeployment({ version: '1.4.1' })?.defaultAddress
 
       const decodedData = decodeMultiSendData(safeAccountConfig.data)
@@ -82,7 +82,7 @@ const validateAccountConfig = (safeAccountConfig: SafeAccountConfig) => {
         sameAddress(safeAccountConfig.to, multiSendAddress) &&
         decodedData.length === 2 &&
         sameAddress(decodedData[0].to, setupToL2Address) &&
-        sameAddress(decodedData[1].to, safeSetupAddress)
+        sameAddress(decodedData[1].to, SafenetSetupAddress)
       if (isSafenetSetup) return
     } catch {}
   }

--- a/apps/web/src/features/safenet/config/constants.ts
+++ b/apps/web/src/features/safenet/config/constants.ts
@@ -1,0 +1,1 @@
+export const SafenetSetupAddress = '0x18261ff68cC8D05EE046EDF5F4049B2077624a1d'


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safenet/issues/399

## How to test it

In the sidebar, adding a new network for an existing Safenet-enabled account is now possible.

## Screenshots

Adding a new chain for a Safenet-enabled accounts should now display the modal window with the networks dropdown instead of displaying an error.

<img width="1092" alt="Screenshot 2025-02-17 at 18 08 14" src="https://github.com/user-attachments/assets/a604735d-bf89-42b3-b4ad-269e7ac75a62" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
