### PR TITLE
Fix(Orgs): Fetch orgs and display them in the selector

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -6,10 +6,7 @@ import OrgsIcon from '@/public/images/orgs/orgs.svg'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import { Box, Button, Card, Grid2, Link, Typography } from '@mui/material'
-import {
-  type GetOrganizationResponse,
-  useOrganizationsGetV1Query,
-} from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useOrganizationsGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useState } from 'react'
 import css from './styles.module.css'
 
@@ -74,21 +71,6 @@ const NoOrgsState = () => {
     </Card>
   )
 }
-
-export const ORGS: GetOrganizationResponse[] = [
-  {
-    name: 'Safe DAO',
-    status: 1,
-    id: 1,
-    userOrganizations: ['1', '2', '3'],
-  },
-  {
-    name: 'Optimism Foundation',
-    status: 1,
-    id: 2,
-    userOrganizations: ['1', '2', '3', '4', '5', '6'],
-  },
-]
 
 const OrgsList = () => {
   const isUserSignedIn = useAppSelector(isAuthenticated)

--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
@@ -1,5 +1,8 @@
 import { Box, Button, Divider, Menu, MenuItem, Typography } from '@mui/material'
-import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import {
+  type GetOrganizationResponse,
+  useOrganizationsGetV1Query,
+} from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useState } from 'react'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import CheckIcon from '@mui/icons-material/Check'
@@ -8,14 +11,15 @@ import css from './styles.module.css'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
 import OrgsCreationModal from '../OrgsCreationModal'
-import { ORGS } from '../OrgsList'
 
 const OrgsSidebarSelector = () => {
-  const [selectedOrg, setSelectedOrg] = useState(ORGS[0])
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
-  const router = useRouter()
   const [isCreationModalOpen, setIsCreationModalOpen] = useState(false)
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const router = useRouter()
+  const open = Boolean(anchorEl)
+  const orgId = Array.isArray(router.query.orgId) ? router.query.orgId[0] : router.query.orgId
+  const { data: orgs } = useOrganizationsGetV1Query()
+  const selectedOrg = orgs?.find((org) => org.id === Number(orgId))
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)
@@ -32,9 +36,10 @@ const OrgsSidebarSelector = () => {
       router.push(newPath)
     }
 
-    setSelectedOrg(org)
     handleClose()
   }
+
+  if (!selectedOrg) return null
 
   return (
     <>
@@ -66,6 +71,7 @@ const OrgsSidebarSelector = () => {
             </Typography>
           </Box>
         </Button>
+
         <Menu
           id="org-selector-menu"
           anchorEl={anchorEl}
@@ -74,8 +80,10 @@ const OrgsSidebarSelector = () => {
           sx={{ '& .MuiPaper-root': { minWidth: '260px !important' } }}
         >
           <OrgsCard org={selectedOrg} isCompact isLink={false} />
+
           <Divider sx={{ mb: 1 }} />
-          {ORGS.map((org) => (
+
+          {orgs?.map((org) => (
             <MenuItem
               key={org.id}
               onClick={() => handleSelectOrg(org)}
@@ -93,7 +101,9 @@ const OrgsSidebarSelector = () => {
               {org.id === selectedOrg.id && <CheckIcon fontSize="small" color="primary" />}
             </MenuItem>
           ))}
+
           <Divider />
+
           <MenuItem
             onClick={() => {
               handleClose()
@@ -103,6 +113,7 @@ const OrgsSidebarSelector = () => {
           >
             Create organization
           </MenuItem>
+
           <MenuItem
             onClick={() => {
               handleClose()
@@ -114,6 +125,7 @@ const OrgsSidebarSelector = () => {
           </MenuItem>
         </Menu>
       </Box>
+
       {isCreationModalOpen && <OrgsCreationModal onClose={() => setIsCreationModalOpen(false)} />}
     </>
   )


### PR DESCRIPTION
## What it solves

Resolves #5022

## How this PR fixes it

- Fetches all orgs for the orgs selector and displays them

## How to test it

1. Open an org
2. Observe the correct name showing in the selector
3. Click on the selector
4. Observe the rest of your orgs

## Screenshots

<img width="479" alt="Screenshot 2025-02-18 at 10 07 50" src="https://github.com/user-attachments/assets/20b6bc9a-8d5d-49a1-824b-1a451281da87" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
