### PR TITLE
fix(mobile): couldn’t properly scroll in sheet

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -113,7 +113,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.26.3",
     "@eslint/js": "^9.18.0",
-    "@gorhom/bottom-sheet": "^5.0.6",
+    "@gorhom/bottom-sheet": "^5.1.1",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/datetimepicker": "8.2.0",
     "@react-native-community/slider": "4.5.5",

--- a/apps/mobile/src/features/AccountsSheet/AccountsSheet.container.tsx
+++ b/apps/mobile/src/features/AccountsSheet/AccountsSheet.container.tsx
@@ -21,7 +21,7 @@ export const AccountsSheetContainer = () => {
       title="My accounts"
       items={safes}
       keyExtractor={({ item }) => item.SafeInfo.address.value}
-      footerComponent={MyAccountsFooter}
+      FooterComponent={MyAccountsFooter}
       renderItem={MyAccountsContainer}
       sortable={isEdit}
       onDragEnd={onDragEnd}

--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.test.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.test.tsx
@@ -1,10 +1,9 @@
 import { render } from '@/src/tests/test-utils'
 import { MyAccountsFooter } from './MyAccountsFooter'
-import { SharedValue } from 'react-native-reanimated'
 
 describe('MyAccountsFooter', () => {
   it('should render the defualt template', () => {
-    const container = render(<MyAccountsFooter animatedFooterPosition={2 as unknown as SharedValue<number>} />)
+    const container = render(<MyAccountsFooter />)
 
     expect(container.getByText('Add Existing Account')).toBeDefined()
     expect(container.getByText('Join New Account')).toBeDefined()

--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
@@ -1,6 +1,5 @@
 import { Badge } from '@/src/components/Badge'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
-import { BottomSheetFooter, BottomSheetFooterProps } from '@gorhom/bottom-sheet'
 import React from 'react'
 import { TouchableOpacity } from 'react-native'
 import { styled, Text, View } from 'tamagui'
@@ -9,8 +8,8 @@ import { Link } from 'expo-router'
 const MyAccountsFooterContainer = styled(View, {
   borderTopWidth: 1,
   borderTopColor: '$colorSecondary',
-  paddingVertical: '$7',
-  paddingHorizontal: '$5',
+  paddingVertical: '$4',
+  paddingHorizontal: '$4',
   backgroundColor: '$backgroundPaper',
 })
 
@@ -18,44 +17,40 @@ const MyAccountsButton = styled(View, {
   columnGap: '$2',
   alignItems: 'center',
   flexDirection: 'row',
-  marginBottom: '$4',
+  padding: '$2',
 })
 
-interface CustomFooterProps extends BottomSheetFooterProps {}
-
-export function MyAccountsFooter({ animatedFooterPosition }: CustomFooterProps) {
-  const onAddAccountClick = () => null
+export function MyAccountsFooter() {
   const onJoinAccountClick = () => null
-
   return (
-    <BottomSheetFooter animatedFooterPosition={animatedFooterPosition}>
-      <MyAccountsFooterContainer>
-        <TouchableOpacity onPress={onAddAccountClick}>
-          <Link href={'/(import-accounts)'} asChild>
-            <MyAccountsButton testID="add-existing-account">
-              <Badge
-                themeName="badge_background"
-                circleSize="$10"
-                content={<SafeFontIcon size={20} name="plus-filled" />}
-              />
+    <MyAccountsFooterContainer paddingBottom={'$7'}>
+      <Link href={'/(import-accounts)'} asChild>
+        <MyAccountsButton testID="add-existing-account">
+          <View paddingLeft="$2">
+            <Badge
+              themeName="badge_background"
+              circleSize="$10"
+              content={<SafeFontIcon size={20} name="plus-filled" />}
+            />
+          </View>
 
-              <Text fontSize="$4" fontWeight={600}>
-                Add Existing Account
-              </Text>
-            </MyAccountsButton>
-          </Link>
-        </TouchableOpacity>
+          <Text fontSize="$4" fontWeight={600}>
+            Add Existing Account
+          </Text>
+        </MyAccountsButton>
+      </Link>
 
-        <TouchableOpacity onPress={onJoinAccountClick}>
-          <MyAccountsButton testID="join-new-account">
+      <TouchableOpacity onPress={onJoinAccountClick}>
+        <MyAccountsButton testID="join-new-account">
+          <View paddingLeft="$2">
             <Badge themeName="badge_background" circleSize="$10" content={<SafeFontIcon size={20} name="owners" />} />
+          </View>
 
-            <Text fontSize="$4" fontWeight={600}>
-              Join New Account
-            </Text>
-          </MyAccountsButton>
-        </TouchableOpacity>
-      </MyAccountsFooterContainer>
-    </BottomSheetFooter>
+          <Text fontSize="$4" fontWeight={600}>
+            Join New Account
+          </Text>
+        </MyAccountsButton>
+      </TouchableOpacity>
+    </MyAccountsFooterContainer>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5345,9 +5345,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gorhom/bottom-sheet@npm:^5.0.6":
-  version: 5.0.6
-  resolution: "@gorhom/bottom-sheet@npm:5.0.6"
+"@gorhom/bottom-sheet@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@gorhom/bottom-sheet@npm:5.1.1"
   dependencies:
     "@gorhom/portal": "npm:1.0.14"
     invariant: "npm:^2.2.4"
@@ -5363,7 +5363,7 @@ __metadata:
       optional: true
     "@types/react-native":
       optional: true
-  checksum: 10/b8beb6bb4d80828deed5c74c8b19926cbb4887d530d07c19eaaa1d8faae6c79f942f83baad076c84d065f357f6666cbc257799fe8fc58cb375e6cbebf52b6227
+  checksum: 10/6da29c3927f6a0b6d2a459e2a1cae48ce7c0fce41663b46b0aba98490af15199e31248f83ca18753eeb439faf2c1dd957f26e4eacc9796b4962df44170b1a2d3
   languageName: node
   linkType: hard
 
@@ -8190,7 +8190,7 @@ __metadata:
     "@ethersproject/shims": "npm:^5.7.0"
     "@expo/config-plugins": "npm:^9.0.10"
     "@expo/vector-icons": "npm:^14.0.2"
-    "@gorhom/bottom-sheet": "npm:^5.0.6"
+    "@gorhom/bottom-sheet": "npm:^5.1.1"
     "@notifee/react-native": "npm:^9.1.8"
     "@react-native-async-storage/async-storage": "npm:1.23.1"
     "@react-native-clipboard/clipboard": "npm:^1.15.0"


### PR DESCRIPTION
## What it solves
When the list of safes was big one was not able to scroll inside of it.

Resolves #
fixes #4972

## How this PR fixes it
🪄 
There were a couple of gotchas. The Sheet doesn't automatically account for safe areas. So we had to apply an inset on the top, because previously we were behind the notch. We tried to go around this by using the snap point and setting the laste one at 90%, but this doesn't work with dynamic resizing. There is a bug in bottom-sheet in combination with react-native-animated. Bottom sheet is ignoring the max snap point. So, by setting the correct inset we can expand the sheet to 100% and the content will still be visible. Then we had to take the inset bottom in account. By relying on some random padding we were making the layout unpredictable. According to the docs of bottom shett it should auto account for the height of the footer, but it didn't seem to be the case. I had to calculate the height of the footer content and apply a marginbottom on the scrollview inside of it. This way the safes were visible. 

## How to test it
Add a lot of safes and try to scroll in the list and select the ones that were previously behind the bottom footer.

## Screenshots
![2025-02-18 11 55 41](https://github.com/user-attachments/assets/cb33374e-b829-4909-93e2-1ef64369042e)

![2025-02-18 12 04 12](https://github.com/user-attachments/assets/22493998-3aaa-4b1c-bb21-1053daf6ea9c)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
