### PR TITLE
fix(mobile): android not able to open screen

### DIFF
--- a/apps/mobile/src/components/Dropdown/sheetComponents.tsx
+++ b/apps/mobile/src/components/Dropdown/sheetComponents.tsx
@@ -31,7 +31,7 @@ const BackdropComponent = React.memo(() => {
       width="100%"
       height="100%"
     >
-      <BlurView style={styles.absolute} intensity={100} experimentalBlurMethod={'dimezisBlurView'} tint={'dark'} />
+      <BlurView style={styles.absolute} intensity={100} tint={'dark'} />
     </View>
   )
 })


### PR DESCRIPTION
Enabling the BlurView on android with the experimentalBlurMethod={'dimezisBlurView'} params causes issues on android. I’ve reported the bug here. Until it is resolved or we find a workaround we can’t use BlurView on android: https://github.com/expo/expo/issues/34367
If we have any blurred view on android modal screens no longer work as expected. 

## What it solves
Android builds are now again usable

Resolves #

## How this PR fixes it

## How to test it
Play around with the android build

## Screenshots
![2025-02-18 13 23 18](https://github.com/user-attachments/assets/619a9742-e6d4-40bc-9cba-b1aee9058b6f)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
