### PR TITLE
fix(permissions): check spending limits for connected wallet

### DIFF
--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -92,7 +92,7 @@ export const CreateTokenTransfer = ({
   const { totalAmount, spendingLimitAmount } = useTokenAmount(selectedToken)
 
   const canCreateSpendingLimitTxWithToken = useHasPermission(Permission.CreateSpendingLimitTransaction, {
-    token: selectedToken?.tokenInfo,
+    tokenAddress,
   })
 
   const isSpendingLimitType = type === TokenTransferType.spendingLimit

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/SpendingLimitRow/index.tsx
@@ -24,7 +24,9 @@ const SpendingLimitRow = ({
 }) => {
   const { control, trigger, resetField } = useFormContext()
   const canCreateStandardTx = useHasPermission(Permission.CreateTransaction)
-  const canCreateSpendingLimitTx = useHasPermission(Permission.CreateSpendingLimitTransaction, { token: selectedToken })
+  const canCreateSpendingLimitTx = useHasPermission(Permission.CreateSpendingLimitTransaction, {
+    tokenAddress: selectedToken?.address,
+  })
   const { setNonceNeeded } = useContext(SafeTxContext)
 
   const formattedAmount = safeFormatUnits(availableAmount, selectedToken?.decimals)

--- a/apps/web/src/permissions/config.test.ts
+++ b/apps/web/src/permissions/config.test.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker'
 import rolePermissionsConfig, { Permission, Role } from './config'
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
-import useWallet from '@/hooks/wallets/useWallet'
-import { SafeTransaction } from '@safe-global/safe-core-sdk-types'
-import { SpendingLimitState } from '@/store/spendingLimitsSlice'
+import type useWallet from '@/hooks/wallets/useWallet'
+import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
 
 describe('RolePermissionsConfig', () => {
   const safeAddress = faker.finance.ethereumAddress()

--- a/apps/web/src/permissions/config.test.ts
+++ b/apps/web/src/permissions/config.test.ts
@@ -1,0 +1,156 @@
+import { faker } from '@faker-js/faker'
+import rolePermissionsConfig, { Permission, Role } from './config'
+import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
+import useWallet from '@/hooks/wallets/useWallet'
+import { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import { SpendingLimitState } from '@/store/spendingLimitsSlice'
+
+describe('RolePermissionsConfig', () => {
+  const safeAddress = faker.finance.ethereumAddress()
+  const walletAddress = faker.finance.ethereumAddress()
+
+  const mockSafeTx = { data: { nonce: 1 } } as SafeTransaction
+
+  const mockSafe = extendedSafeInfoBuilder()
+    .with({ address: { value: safeAddress } })
+    .with({ deployed: true })
+    .build()
+
+  const mockWallet = {
+    address: walletAddress,
+  } as ReturnType<typeof useWallet>
+
+  const mockCommonProps = {
+    safe: mockSafe,
+    wallet: mockWallet,
+  }
+
+  describe('Owner', () => {
+    it('should return correct permissions', () => {
+      const permissions = rolePermissionsConfig[Role.Owner]!(mockCommonProps)
+      expect(permissions).toEqual({
+        [Permission.CreateTransaction]: true,
+        [Permission.ProposeTransaction]: true,
+        [Permission.SignTransaction]: true,
+        [Permission.ExecuteTransaction]: expect.any(Function),
+        [Permission.EnablePushNotifications]: true,
+      })
+      expect(permissions[Permission.ExecuteTransaction]!({ safeTx: mockSafeTx })).toBe(true)
+    })
+  })
+
+  describe('Proposer', () => {
+    it('should return correct permissions', () => {
+      const permissions = rolePermissionsConfig[Role.Proposer]!(mockCommonProps)
+      expect(permissions).toEqual({
+        [Permission.CreateTransaction]: true,
+        [Permission.ProposeTransaction]: true,
+        [Permission.ExecuteTransaction]: expect.any(Function),
+        [Permission.EnablePushNotifications]: true,
+      })
+      expect(permissions[Permission.ExecuteTransaction]!({ safeTx: mockSafeTx })).toBe(true)
+    })
+  })
+
+  describe('Executioner', () => {
+    it('should return correct permissions', () => {
+      const permissions = rolePermissionsConfig[Role.Executioner]!(mockCommonProps)
+      expect(permissions).toEqual({
+        [Permission.ExecuteTransaction]: expect.any(Function),
+        [Permission.EnablePushNotifications]: true,
+      })
+      expect(permissions[Permission.ExecuteTransaction]!({ safeTx: mockSafeTx })).toBe(true)
+    })
+  })
+
+  describe('SpendingLimitBeneficiary', () => {
+    const mockSpendingLimits = [
+      { token: { address: '0xToken1' }, beneficiary: faker.finance.ethereumAddress(), amount: '1000', spent: '0' },
+      { token: { address: '0xToken2' }, beneficiary: faker.finance.ethereumAddress(), amount: '2000', spent: '0' },
+    ] as SpendingLimitState[]
+
+    it('should return correct permissions', () => {
+      const permissions = rolePermissionsConfig[Role.SpendingLimitBeneficiary]!(mockCommonProps, {
+        spendingLimits: mockSpendingLimits,
+      })
+
+      expect(permissions).toEqual({
+        [Permission.ExecuteTransaction]: expect.any(Function),
+        [Permission.EnablePushNotifications]: true,
+        [Permission.CreateSpendingLimitTransaction]: expect.any(Function),
+      })
+
+      expect(permissions[Permission.ExecuteTransaction]!({ safeTx: mockSafeTx })).toBe(true)
+    })
+
+    describe('CreateSpendingLimitTransaction', () => {
+      const mockTokenAddress = '0xToken1'
+
+      it('should return `false` if no wallet connected', () => {
+        const permissions = rolePermissionsConfig[Role.SpendingLimitBeneficiary]!(
+          { safe: mockSafe, wallet: null },
+          { spendingLimits: mockSpendingLimits },
+        )
+
+        expect(permissions[Permission.CreateSpendingLimitTransaction]!({ tokenAddress: mockTokenAddress })).toBe(false)
+      })
+
+      describe('without tokenAddress', () => {
+        it('should return `true` if any spending limit defined for connected wallet address', () => {
+          const permissions = rolePermissionsConfig[Role.SpendingLimitBeneficiary]!(mockCommonProps, {
+            spendingLimits: [
+              ...mockSpendingLimits,
+              { token: { address: '0xToken3' }, beneficiary: walletAddress, amount: '3000', spent: '0' },
+            ] as SpendingLimitState[],
+          })
+
+          expect(permissions[Permission.CreateSpendingLimitTransaction]!({})).toBe(true)
+        })
+
+        it('should return `false` if no spending limit defined for connected wallet address', () => {
+          const permissions = rolePermissionsConfig[Role.SpendingLimitBeneficiary]!(mockCommonProps, {
+            spendingLimits: mockSpendingLimits,
+          })
+
+          expect(permissions[Permission.CreateSpendingLimitTransaction]!({})).toBe(false)
+        })
+      })
+
+      describe('with tokenAddress', () => {
+        it('should return `true` if a spending limit defined for token and connected wallet address', () => {
+          const permissions = rolePermissionsConfig[Role.SpendingLimitBeneficiary]!(mockCommonProps, {
+            spendingLimits: [
+              ...mockSpendingLimits,
+              { token: { address: mockTokenAddress }, beneficiary: walletAddress, amount: '3000', spent: '0' },
+            ] as SpendingLimitState[],
+          })
+
+          expect(permissions[Permission.CreateSpendingLimitTransaction]!({ tokenAddress: mockTokenAddress })).toBe(true)
+        })
+
+        it('should return `false` if no spending limit defined for token and connected wallet address', () => {
+          const permissions = rolePermissionsConfig[Role.SpendingLimitBeneficiary]!(mockCommonProps, {
+            spendingLimits: mockSpendingLimits,
+          })
+
+          expect(permissions[Permission.CreateSpendingLimitTransaction]!({ tokenAddress: mockTokenAddress })).toBe(
+            false,
+          )
+        })
+
+        it('should return `false` if the spending limit defined is reached', () => {
+          const permissions = rolePermissionsConfig[Role.SpendingLimitBeneficiary]!(mockCommonProps, {
+            spendingLimits: [
+              ...mockSpendingLimits,
+              { token: { address: mockTokenAddress }, beneficiary: walletAddress, amount: '3000', spent: '3000' },
+            ] as SpendingLimitState[],
+          })
+
+          expect(permissions[Permission.CreateSpendingLimitTransaction]!({ tokenAddress: mockTokenAddress })).toBe(
+            false,
+          )
+        })
+      })
+    })
+  })
+})

--- a/apps/web/src/permissions/config.test.ts
+++ b/apps/web/src/permissions/config.test.ts
@@ -12,7 +12,7 @@ describe('RolePermissionsConfig', () => {
   const mockSafeTx = { data: { nonce: 1 } } as SafeTransaction
 
   const mockSafe = extendedSafeInfoBuilder()
-    .with({ address: { value: safeAddress } })
+    .with({ address: { value: safeAddress }, owners: [{ value: walletAddress }] })
     .with({ deployed: true })
     .build()
 

--- a/apps/web/src/permissions/config.ts
+++ b/apps/web/src/permissions/config.ts
@@ -1,6 +1,7 @@
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import type { ExtendedSafeInfo } from '@/store/safeInfoSlice'
 import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
+import { sameAddress } from '@/utils/addresses'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 
 export enum Role {
@@ -102,12 +103,12 @@ export default <RolePermissionsConfig>{
 
       if (!tokenAddress) {
         // Check if the connected wallet has a spending limit for any token
-        return spendingLimits.some((sl) => sl.beneficiary === wallet.address)
+        return spendingLimits.some((sl) => sameAddress(sl.beneficiary, wallet.address))
       }
 
       // Check if the connected wallet has a spending limit for the given token
       const spendingLimit = spendingLimits.find(
-        (sl) => sl.token.address === tokenAddress && sl.beneficiary === wallet.address,
+        (sl) => sameAddress(sl.token.address, tokenAddress) && sameAddress(sl.beneficiary, wallet.address),
       )
 
       if (spendingLimit) {

--- a/apps/web/src/permissions/config.ts
+++ b/apps/web/src/permissions/config.ts
@@ -1,3 +1,5 @@
+import { ConnectedWallet } from '@/hooks/wallets/useOnboard'
+import { ExtendedSafeInfo } from '@/store/safeInfoSlice'
 import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import type { TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
@@ -58,8 +60,15 @@ export type PermissionSet = {
   [P in Permission]?: PermissionFn<P> extends undefined ? boolean : PermissionFn<P>
 }
 
+export type CommonProps = {
+  safe: ExtendedSafeInfo
+  wallet: ConnectedWallet | null
+}
+
 export type RolePermissionsFn<R extends Role> =
-  RoleProps<R> extends undefined ? () => PermissionSet : (props: RoleProps<R>) => PermissionSet
+  RoleProps<R> extends undefined
+    ? (props: CommonProps) => PermissionSet
+    : (props: CommonProps, roleProps: RoleProps<R>) => PermissionSet
 
 type RolePermissionsConfig = {
   [R in Role]?: RolePermissionsFn<R>
@@ -86,7 +95,7 @@ export default <RolePermissionsConfig>{
     [Permission.ExecuteTransaction]: () => true,
     [Permission.EnablePushNotifications]: true,
   }),
-  [Role.SpendingLimitBeneficiary]: ({ spendingLimits }) => ({
+  [Role.SpendingLimitBeneficiary]: ({ wallet }, { spendingLimits }) => ({
     [Permission.ExecuteTransaction]: () => true,
     [Permission.EnablePushNotifications]: true,
     [Permission.CreateSpendingLimitTransaction]: ({ token } = {}) => {

--- a/apps/web/src/permissions/getRolePermissions.test.ts
+++ b/apps/web/src/permissions/getRolePermissions.test.ts
@@ -1,6 +1,12 @@
 import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import { getRolePermissions } from './getRolePermissions'
 import { Role } from './config'
+import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
+import { connectedWalletBuilder } from '@/tests/builders/wallet'
+import { faker } from '@faker-js/faker'
+
+const safeAddress = faker.finance.ethereumAddress()
+const walletAddress = faker.finance.ethereumAddress()
 
 jest.mock('./config', () => ({
   ...jest.requireActual('./config'),
@@ -17,8 +23,11 @@ jest.mock('./config', () => ({
       ProposeTransaction: true,
       ExecuteTransaction: () => true,
     }),
-    SpendingLimitBeneficiary: ({ spendingLimits }: { spendingLimits: number[] }) => ({
-      CreateTransaction: spendingLimits.includes(1),
+    SpendingLimitBeneficiary: (
+      { wallet }: { wallet: { address: string } },
+      { spendingLimits }: { spendingLimits: number[] },
+    ) => ({
+      CreateTransaction: spendingLimits.includes(1) && wallet.address === walletAddress,
       ProposeTransaction: spendingLimits.includes(5),
     }),
   },
@@ -26,7 +35,17 @@ jest.mock('./config', () => ({
 
 describe('getRolePermissions', () => {
   it('should return the permissions for the given roles', () => {
-    const rolePermissions = getRolePermissions([Role.Owner, Role.Proposer], {})
+    const rolePermissions = getRolePermissions(
+      [Role.Owner, Role.Proposer],
+      {
+        wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
+        safe: extendedSafeInfoBuilder()
+          .with({ address: { value: safeAddress } })
+          .with({ deployed: false })
+          .build(),
+      },
+      {},
+    )
 
     expect(rolePermissions).toEqual({
       Owner: {
@@ -44,7 +63,17 @@ describe('getRolePermissions', () => {
   })
 
   it('should ignore roles that do not have permissions defined', () => {
-    const rolePermissions = getRolePermissions([Role.Owner, Role.NestedOwner], {})
+    const rolePermissions = getRolePermissions(
+      [Role.Owner, Role.NestedOwner],
+      {
+        wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
+        safe: extendedSafeInfoBuilder()
+          .with({ address: { value: safeAddress } })
+          .with({ deployed: false })
+          .build(),
+      },
+      {},
+    )
 
     expect(rolePermissions).toEqual({
       Owner: {
@@ -57,9 +86,19 @@ describe('getRolePermissions', () => {
   })
 
   it('should return the permissions for the given roles with the specific props', () => {
-    const rolePermissions = getRolePermissions([Role.SpendingLimitBeneficiary], {
-      SpendingLimitBeneficiary: { spendingLimits: [1, 2, 3] as unknown as SpendingLimitState[] },
-    })
+    const rolePermissions = getRolePermissions(
+      [Role.SpendingLimitBeneficiary],
+      {
+        wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
+        safe: extendedSafeInfoBuilder()
+          .with({ address: { value: safeAddress } })
+          .with({ deployed: false })
+          .build(),
+      },
+      {
+        SpendingLimitBeneficiary: { spendingLimits: [1, 2, 3] as unknown as SpendingLimitState[] },
+      },
+    )
 
     expect(rolePermissions).toEqual({
       SpendingLimitBeneficiary: {
@@ -70,12 +109,32 @@ describe('getRolePermissions', () => {
   })
 
   it('should return an empty object if no permissions are defined for the roles', () => {
-    const rolePermissions = getRolePermissions([Role.NestedOwner, Role.Recoverer], {})
+    const rolePermissions = getRolePermissions(
+      [Role.NestedOwner, Role.Recoverer],
+      {
+        wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
+        safe: extendedSafeInfoBuilder()
+          .with({ address: { value: safeAddress } })
+          .with({ deployed: false })
+          .build(),
+      },
+      {},
+    )
     expect(rolePermissions).toEqual({})
   })
 
   it('should return an empty object if being called with an empty roles array', () => {
-    const rolePermissions = getRolePermissions([], {})
+    const rolePermissions = getRolePermissions(
+      [],
+      {
+        wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
+        safe: extendedSafeInfoBuilder()
+          .with({ address: { value: safeAddress } })
+          .with({ deployed: false })
+          .build(),
+      },
+      {},
+    )
     expect(rolePermissions).toEqual({})
   })
 })

--- a/apps/web/src/permissions/getRolePermissions.test.ts
+++ b/apps/web/src/permissions/getRolePermissions.test.ts
@@ -40,7 +40,7 @@ describe('getRolePermissions', () => {
       {
         wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
         safe: extendedSafeInfoBuilder()
-          .with({ address: { value: safeAddress } })
+          .with({ address: { value: safeAddress }, owners: [{ value: walletAddress }] })
           .with({ deployed: false })
           .build(),
       },
@@ -68,7 +68,7 @@ describe('getRolePermissions', () => {
       {
         wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
         safe: extendedSafeInfoBuilder()
-          .with({ address: { value: safeAddress } })
+          .with({ address: { value: safeAddress }, owners: [{ value: walletAddress }] })
           .with({ deployed: false })
           .build(),
       },
@@ -91,7 +91,7 @@ describe('getRolePermissions', () => {
       {
         wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
         safe: extendedSafeInfoBuilder()
-          .with({ address: { value: safeAddress } })
+          .with({ address: { value: safeAddress }, owners: [{ value: walletAddress }] })
           .with({ deployed: false })
           .build(),
       },
@@ -114,7 +114,7 @@ describe('getRolePermissions', () => {
       {
         wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
         safe: extendedSafeInfoBuilder()
-          .with({ address: { value: safeAddress } })
+          .with({ address: { value: safeAddress }, owners: [{ value: walletAddress }] })
           .with({ deployed: false })
           .build(),
       },
@@ -129,7 +129,7 @@ describe('getRolePermissions', () => {
       {
         wallet: connectedWalletBuilder().with({ address: walletAddress }).build(),
         safe: extendedSafeInfoBuilder()
-          .with({ address: { value: safeAddress } })
+          .with({ address: { value: safeAddress }, owners: [{ value: walletAddress }] })
           .with({ deployed: false })
           .build(),
       },

--- a/apps/web/src/permissions/getRolePermissions.ts
+++ b/apps/web/src/permissions/getRolePermissions.ts
@@ -1,13 +1,18 @@
 import rolePermissionConfig from './config'
-import type { PermissionSet, Role, RoleProps } from './config'
+import type { CommonProps, PermissionSet, Role, RoleProps } from './config'
 
 /**
  * Get the PermissionSet for multiple roles with the given role props object.
  * @param roles Roles to get permissions for
- * @param props Object with specific parameters for the roles
+ * @param props Common props used to evaluate the permissions
+ * @param roleProps Object with specific parameters for the roles
  * @returns Object with PermissionSet for each of the give roles that has permissions defined
  */
-export const getRolePermissions = <R extends Role>(roles: R[], props: { [K in R]?: RoleProps<K> }) =>
+export const getRolePermissions = <R extends Role>(
+  roles: R[],
+  props: CommonProps,
+  roleProps: { [K in R]?: RoleProps<K> },
+) =>
   roles.reduce<{ [_K in R]?: PermissionSet }>((acc, role) => {
     const rolePermissionsFn = rolePermissionConfig[role]
 
@@ -15,5 +20,5 @@ export const getRolePermissions = <R extends Role>(roles: R[], props: { [K in R]
       return acc
     }
 
-    return { ...acc, [role]: rolePermissionsFn(props[role] as RoleProps<R>) }
+    return { ...acc, [role]: rolePermissionsFn(props, roleProps[role] as RoleProps<R>) }
   }, {})

--- a/apps/web/src/permissions/hooks/usePermission.ts
+++ b/apps/web/src/permissions/hooks/usePermission.ts
@@ -3,6 +3,8 @@ import { useRoles } from './useRoles'
 import { useRoleProps } from './useRoleProps'
 import { getRolePermissions } from '../getRolePermissions'
 import type { Permission, Role, PermissionProps } from '../config'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import useWallet from '@/hooks/wallets/useWallet'
 
 /**
  * Hook to get the result of a permission check for the current user based on the Safe and the connected wallet.
@@ -16,9 +18,11 @@ export const usePermission = <P extends Permission>(
 ): { [_R in Role]?: boolean } => {
   const userRoles = useRoles()
   const roleProps = useRoleProps()
+  const { safe } = useSafeInfo()
+  const wallet = useWallet()
 
   const userPermissions = useMemo(() => {
-    return getRolePermissions(userRoles, roleProps)
+    return getRolePermissions(userRoles, { safe, wallet }, roleProps)
   }, [userRoles, roleProps])
 
   const permissionPerRole = useMemo(() => {

--- a/apps/web/src/permissions/hooks/usePermission.ts
+++ b/apps/web/src/permissions/hooks/usePermission.ts
@@ -23,7 +23,7 @@ export const usePermission = <P extends Permission>(
 
   const userPermissions = useMemo(() => {
     return getRolePermissions(userRoles, { safe, wallet }, roleProps)
-  }, [userRoles, roleProps])
+  }, [userRoles, roleProps, safe, wallet])
 
   const permissionPerRole = useMemo(() => {
     return Object.entries(userPermissions).reduce((acc, [role, permissions]) => {


### PR DESCRIPTION
## What it solves

Fixes a **permission check bug** when creating a **spending limit transaction**.  

### Problem

The current permission function **does not verify whether the connected wallet matches the spending limit beneficiary address**. As a result, the permission check incorrectly returns `true` if a spending limit exists for the selected token—regardless of the beneficiary.  

#### Steps to reproduce

1. Open a Safe that has **spending limits** for multiple signers for tokens **A** and **B**.  
2. Connect a signer with a spending limit for token **B** and without a spending limit for token **A**.  
3. Go to the **"Send token"** form and select token **A**.  
4. The **spending limit option is incorrectly available** (showing a limit of 0).  

![Screenshot 2025-02-18 at 15 43 36](https://github.com/user-attachments/assets/3a7f39d7-6c01-4c92-a763-a1063037b5be)  

## How this PR fixes it

To address this issue:  

* **Introduced `CommonProps`** – a shared structure that contains Safe and connected wallet information.  
* **Refactored permission checks** to ensure they correctly evaluate whether the **connected wallet is the intended beneficiary** of the spending limit.  

### Changes in code

#### Permission checks

- **Updated `useHasPermission`** to use `tokenAddress` instead of `tokenInfo`.  
  - _Files modified_:  
    - [`CreateTokenTransfer.tsx`](diffhunk://#diff-fdc7a442bd1d1f3b1de0dbd89c339cf973f17059e99923cfa92e296d815b0d4dL95-R95)  
    - [`SpendingLimitRow/index.tsx`](diffhunk://#diff-ff17ef377872d4a072ee794877e4d152c93e309bf9a57320204a954a6ae37117L27-R29)  

#### Refactoring role permissions

- **Updated `RolePermissionsConfig`** to leverage `CommonProps`.  
  - _Files modified_:  
    - [`config.ts`](diffhunk://#diff-f2bea05f47a984e5505d85cefc1561cc2fb64b79688bacf5cd585812d5e3c998R1-L3)  

- **Refactored `getRolePermissions`** to accept `CommonProps`.  
  - _Files modified_:  
    - [`getRolePermissions.ts`](diffhunk://#diff-f29e0dd53a20f870019917cd1c87bcc1a6e311152dfc657ca9feb5b5d211d63bL2-R23)  

#### Testing improvements

- **Added comprehensive unit tests** for various roles (`Owner`, `Proposer`, `Executioner`, `SpendingLimitBeneficiary`).  
  - _Files modified_:  
    - [`config.test.ts`](diffhunk://#diff-1d74b119001ec59170fbfc5b3036314ffc37a41b5f60e3ea541a70777a07e4faR1-R156)  
    - [`getRolePermissions.test.ts`](diffhunk://#diff-7425431734d34b3415a415f90c89fda551eadb8334f318218909a8f08e9be8d6R4-R9)  
    - [`usePermission.test.ts`](diffhunk://#diff-eaa3abe1ee94e2362371c93e75440f430270bdc0fe26a38287a01ec32ba1515dR7-R18)  

## How to test it

1. Follow the **Steps to reproduce** above.  
2. Verify that the bug **no longer occurs** (i.e., the spending limit option does not appear unless the connected wallet is the correct beneficiary).  

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻