### PR TITLE
ci(mobile): restrict when we release and test

### DIFF
--- a/.github/workflows/mobile-dev-release.yml
+++ b/.github/workflows/mobile-dev-release.yml
@@ -1,4 +1,5 @@
 name: EAS Dev Build
+
 on:
   push:
     branches:
@@ -10,8 +11,13 @@ on:
     paths:
       - apps/mobile/**
       - packages/**
+
 jobs:
   build:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'mobile-dev-release'))
     name: Install and build
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +30,7 @@ jobs:
       # Set up Node.js
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.11.0' # jod
+          node-version: '22.11.0'
           cache: 'yarn'
 
       # Install dependencies

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -1,17 +1,17 @@
-name: EAS Build
+name: EAS Mobile E2E tests
+
 on:
-  push:
-    branches:
-      - dev
-    paths:
-      - apps/mobile/**
-      - packages/**
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
   pull_request:
     paths:
       - apps/mobile/**
       - packages/**
+
 jobs:
   build:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'mobile-e2e-test')
     name: Install and build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We were creating new releases on every PR - this was confusing as we were getting several builds served and it was not clear what features were available in the release. Now we only release when we merge into dev or if we set the “mobile-dev-release” label on a PR.

E2E tests are now going to run once daily or when we specify the mobile-e2e-label

## What it solves
Reduces the amount of builds and e2e tests we run on CI.

#4973

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
