### PR TITLE
Feat(Orgs): add org invite component to orgs list

### DIFF
--- a/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
@@ -1,0 +1,48 @@
+import { Card, Box, Stack, Button, Typography } from '@mui/material'
+import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { OrgLogo, OrgSummary } from '../OrgsCard'
+
+type OrgListInvite = {
+  org: GetOrganizationResponse
+}
+
+const OrgListInvite = ({ org }: OrgListInvite) => {
+  const { name, userOrganizations: members } = org
+  const safes = [] // TODO: Replace with actual safes data when available
+  const numberOfAccounts = safes.length
+  const numberOfMembers = members.length
+
+  return (
+    <Card sx={{ p: 2, mb: 2 }}>
+      <Typography variant="h4" fontWeight={700} mb={2} color="primary.light">
+        You were invited to join{' '}
+        <Typography component="span" variant="h4" fontWeight={700} color="primary.main">
+          {name}
+        </Typography>
+      </Typography>
+
+      <Card sx={{ p: 2, backgroundColor: 'background.main' }}>
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Box>
+            <OrgLogo orgName={name} size="large" />
+          </Box>
+
+          <Box flexGrow={1}>
+            <OrgSummary name={name} numberOfAccounts={numberOfAccounts} numberOfMembers={numberOfMembers} />
+          </Box>
+
+          <Stack direction="row" spacing={1}>
+            <Button variant="contained" onClick={() => {}} size="small">
+              Accept
+            </Button>
+            <Button variant="outlined" onClick={() => {}} size="small">
+              Decline
+            </Button>
+          </Stack>
+        </Stack>
+      </Card>
+    </Card>
+  )
+}
+
+export default OrgListInvite

--- a/apps/web/src/features/organizations/components/OrgsCard/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCard/index.tsx
@@ -2,11 +2,11 @@ import { AppRoutes } from '@/config/routes'
 import { Box, Card, hslToRgb, Stack, Typography } from '@mui/material'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import IconButton from '@mui/material/IconButton'
-import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import Link from 'next/link'
-import classNames from 'classnames'
 
 import css from './styles.module.css'
+import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import classNames from 'classnames'
 
 /**
  * Returns a deterministic "random" color (in Hex format) based on a string.
@@ -41,6 +41,38 @@ export const OrgLogo = ({ orgName, size = 'large' }: { orgName: string; size?: '
   )
 }
 
+export const OrgSummary = ({
+  name,
+  numberOfAccounts,
+  numberOfMembers,
+  isCompact = false,
+}: {
+  name: string
+  numberOfAccounts: number
+  numberOfMembers: number
+  isCompact?: boolean
+}) => {
+  return (
+    <Box className={css.orgInfo}>
+      <Typography variant="body2" fontWeight="bold">
+        {name}
+      </Typography>
+
+      <Stack direction="row" spacing={1} alignItems="center" mt={isCompact ? 0 : 0.5}>
+        <Typography variant="caption" color="text.secondary">
+          {numberOfAccounts} Accounts
+        </Typography>
+
+        <div className={css.dot} />
+
+        <Typography variant="caption" color="text.secondary">
+          {numberOfMembers} Members
+        </Typography>
+      </Stack>
+    </Box>
+  )
+}
+
 const OrgsCard = ({
   org,
   isCompact = false,
@@ -63,23 +95,12 @@ const OrgsCard = ({
         <OrgLogo orgName={name} size={isCompact ? 'medium' : 'large'} />
       </Box>
 
-      <Box className={css.orgInfo}>
-        <Typography variant="body2" fontWeight="bold">
-          {name}
-        </Typography>
-
-        <Stack direction="row" spacing={1} alignItems="center" mt={isCompact ? 0 : 0.5}>
-          <Typography variant="caption" color="text.secondary">
-            {numberOfAccounts} Accounts
-          </Typography>
-
-          <div className={css.dot} />
-
-          <Typography variant="caption" color="text.secondary">
-            {numberOfMembers} Members
-          </Typography>
-        </Stack>
-      </Box>
+      <OrgSummary
+        name={name}
+        numberOfAccounts={numberOfAccounts}
+        numberOfMembers={numberOfMembers}
+        isCompact={isCompact}
+      />
 
       <IconButton className={css.orgActions} size="small" onClick={() => {}}>
         <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -6,9 +6,11 @@ import OrgsIcon from '@/public/images/orgs/orgs.svg'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import { Box, Button, Card, Grid2, Link, Typography } from '@mui/material'
+import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useOrganizationsGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useState } from 'react'
 import css from './styles.module.css'
+import OrgListInvite from '../Dashboard/DashboardInvite'
 
 const AddOrgButton = ({ disabled }: { disabled: boolean }) => {
   const [open, setOpen] = useState(false)
@@ -72,6 +74,16 @@ const NoOrgsState = () => {
   )
 }
 
+// todo: replace with real data
+const invites: GetOrganizationResponse[] = [
+  {
+    id: 123,
+    name: 'Bidget',
+    status: 1,
+    userOrganizations: [],
+  },
+]
+
 const OrgsList = () => {
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { data: organizations } = useOrganizationsGetV1Query(undefined, { skip: !isUserSignedIn })
@@ -83,6 +95,12 @@ const OrgsList = () => {
           <AccountsNavigation />
           <AddOrgButton disabled={!isUserSignedIn} />
         </Box>
+
+        {isUserSignedIn &&
+          invites.length > 0 &&
+          invites.map((invitingOrg: GetOrganizationResponse) => (
+            <OrgListInvite key={invitingOrg.id} org={invitingOrg} />
+          ))}
 
         {isUserSignedIn && organizations ? (
           <Grid2 container spacing={2} flexWrap="wrap">


### PR DESCRIPTION
## What it solves

Resolves #5008

## How this PR fixes it
- adds the non functional component.
- accepting, declining, and linking to the detailed invite will come in a separate PR

## How to test it
- go to the orgs list.
- see that the org invite matches the designs

## Screenshots
![image](https://github.com/user-attachments/assets/48cb6b96-a120-44e6-9165-ee9ec3b00037)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
