### PR TITLE
fix: truncate breadcrumb addresses on mobile

### DIFF
--- a/apps/web/src/components/common/NestedSafeBreadcrumbs/index.tsx
+++ b/apps/web/src/components/common/NestedSafeBreadcrumbs/index.tsx
@@ -1,12 +1,13 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
-import { Tooltip, Typography } from '@mui/material'
+import { Tooltip, Typography, useMediaQuery, useTheme } from '@mui/material'
 import type { ReactElement } from 'react'
 import type { UrlObject } from 'url'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useAddressBook from '@/hooks/useAddressBook'
 import Identicon from '../Identicon'
+import { shortenAddress } from '@/utils/formatters'
 
 import css from './styles.module.css'
 import { useParentSafe } from '@/hooks/useParentSafe'
@@ -34,8 +35,10 @@ export function NestedSafeBreadcrumbs(): ReactElement | null {
 }
 
 const BreadcrumbItem = ({ title, address, href }: { title: string; address: string; href?: UrlObject }) => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
   const addressBook = useAddressBook()
-  const name = addressBook[address] ?? address
+  const name = addressBook[address] ?? (isMobile ? shortenAddress(address) : address)
 
   return (
     <Tooltip title={title}>


### PR DESCRIPTION
## What it solves

Resolves #5038

## How this PR fixes it

Should the resolution be that of mobile, addresses present in the Nested Safe breadcrumbs are now truncated.

## How to test it

Open a Nested Safe on mobile and observe the addresses truncated. (The name from the address book takes precendence.)

## Screenshots

![image](https://github.com/user-attachments/assets/b44279aa-5037-423e-9c34-f8c4f0689345)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
