### PR TITLE
Feat(Orgs): send invites and show invited members

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
+++ b/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
@@ -26,14 +26,14 @@ import css from './styles.module.css'
 import { useUserOrganizationsInviteUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 
-enum Role {
+export enum MemberRole {
   ADMIN = 'ADMIN',
   MEMBER = 'MEMBER',
 }
 
 type MemberField = {
   address: string
-  role: Role
+  role: MemberRole
 }
 
 const RoleMenuItem = ({
@@ -41,11 +41,11 @@ const RoleMenuItem = ({
   hasDescription = false,
   selected = false,
 }: {
-  role: Role
+  role: MemberRole
   hasDescription?: boolean
   selected?: boolean
 }): ReactElement => {
-  const isAdmin = role === Role.ADMIN
+  const isAdmin = role === MemberRole.ADMIN
 
   return (
     <Box width="100%" alignItems="center" className={css.roleMenuItem}>
@@ -104,7 +104,7 @@ const MemberRow = ({
       <Controller
         control={control}
         name={`members.${index}.role`}
-        defaultValue={Role.MEMBER}
+        defaultValue={MemberRole.MEMBER}
         render={({ field: { value, onChange, ...field } }) => (
           <Select
             {...field}
@@ -112,13 +112,13 @@ const MemberRow = ({
             onChange={onChange}
             required
             sx={{ minWidth: '150px', py: 0.5 }}
-            renderValue={(val) => <RoleMenuItem role={val as Role} />}
+            renderValue={(val) => <RoleMenuItem role={val as MemberRole} />}
           >
-            <MenuItem value={Role.ADMIN}>
-              <RoleMenuItem role={Role.ADMIN} hasDescription selected={value === Role.ADMIN} />
+            <MenuItem value={MemberRole.ADMIN}>
+              <RoleMenuItem role={MemberRole.ADMIN} hasDescription selected={value === MemberRole.ADMIN} />
             </MenuItem>
-            <MenuItem value={Role.MEMBER}>
-              <RoleMenuItem role={Role.MEMBER} hasDescription selected={value === Role.MEMBER} />
+            <MenuItem value={MemberRole.MEMBER}>
+              <RoleMenuItem role={MemberRole.MEMBER} hasDescription selected={value === MemberRole.MEMBER} />
             </MenuItem>
           </Select>
         )}
@@ -140,7 +140,7 @@ const AddMembersModal = ({ onClose }: { onClose: () => void }): ReactElement => 
   const methods = useForm<AddMembersFormFields>({
     mode: 'onChange',
     defaultValues: {
-      members: [{ address: '', role: Role.MEMBER }],
+      members: [{ address: '', role: MemberRole.MEMBER }],
     },
   })
   const { handleSubmit, formState, control } = methods
@@ -151,7 +151,7 @@ const AddMembersModal = ({ onClose }: { onClose: () => void }): ReactElement => 
   })
 
   const handleAddMember = () => {
-    append({ address: '', role: Role.MEMBER })
+    append({ address: '', role: MemberRole.MEMBER })
   }
 
   const onSubmit = handleSubmit(async (data) => {

--- a/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
+++ b/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
@@ -166,7 +166,8 @@ const AddMembersModal = ({ onClose }: { onClose: () => void }): ReactElement => 
 
       const response = await inviteMembers({
         orgId: Number(orgId),
-        body: data.members.map((member) => ({ address: member.address, role: member.role })),
+        // TODO: update type from CGW
+        body: { users: data.members.map((member) => ({ address: member.address, role: member.role })) },
       })
       if (response.data) {
         onClose()

--- a/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
+++ b/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
@@ -167,6 +167,7 @@ const AddMembersModal = ({ onClose }: { onClose: () => void }): ReactElement => 
       const response = await inviteMembers({
         orgId: Number(orgId),
         // TODO: update type from CGW
+        // @ts-ignore
         body: { users: data.members.map((member) => ({ address: member.address, role: member.role })) },
       })
       if (response.data) {

--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -5,6 +5,7 @@ import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import { MemberStatus } from '.'
+import { MemberRole } from '../AddMembersModal'
 
 const headCells = [
   {
@@ -48,7 +49,7 @@ const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] })
           content: (
             <Chip
               size="small"
-              label={member.role}
+              label={member.role === MemberRole.ADMIN ? 'Admin' : 'Member'}
               sx={{ backgroundColor: 'background.lightgrey', borderRadius: 0.5 }}
             />
           ),

--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -1,0 +1,64 @@
+import EnhancedTable from '@/components/common/EnhancedTable'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import { Chip, IconButton, SvgIcon, Typography } from '@mui/material'
+import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import tableCss from '@/components/common/EnhancedTable/styles.module.css'
+import DeleteIcon from '@/public/images/common/delete.svg'
+
+const headCells = [
+  {
+    id: 'name',
+    label: 'Name',
+    width: '70%',
+  },
+  {
+    id: 'role',
+    label: 'Role',
+    width: '15%',
+  },
+  {
+    id: 'actions',
+    label: '',
+    width: '15%',
+    sticky: true,
+  },
+]
+
+const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] }) => {
+  const rows = invitedMembers.map((member) => {
+    return {
+      cells: {
+        name: {
+          rawValue: member.user.id,
+          content: <EthHashInfo address="0x0000000000000000000000000000000000000000" showCopyButton hasExplorer />,
+        },
+        role: {
+          rawValue: member.role,
+          content: <Chip label={member.role} />,
+        },
+        actions: {
+          rawValue: '',
+          sticky: true,
+          content: (
+            <div className={tableCss.actions}>
+              <IconButton onClick={() => {}} size="small">
+                <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
+              </IconButton>
+            </div>
+          ),
+        },
+      },
+    }
+  })
+
+  return (
+    <>
+      <Typography variant="h5" fontWeight={700} mb={2}>
+        Pending Invitations
+      </Typography>
+      <EnhancedTable rows={rows} headCells={headCells} />
+    </>
+  )
+}
+
+export default InvitesList

--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -1,9 +1,10 @@
 import EnhancedTable from '@/components/common/EnhancedTable'
 import EthHashInfo from '@/components/common/EthHashInfo'
-import { Chip, IconButton, SvgIcon, Typography } from '@mui/material'
+import { Box, Button, Chip, IconButton, Stack, SvgIcon, Typography } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import DeleteIcon from '@/public/images/common/delete.svg'
+import { MemberStatus } from '.'
 
 const headCells = [
   {
@@ -26,21 +27,42 @@ const headCells = [
 
 const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] }) => {
   const rows = invitedMembers.map((member) => {
+    const isDeclined = member.status === MemberStatus.DECLINED
     return {
       cells: {
         name: {
           rawValue: member.user.id,
-          content: <EthHashInfo address="0x0000000000000000000000000000000000000000" showCopyButton hasExplorer />,
+          content: (
+            <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
+              <Box>
+                <EthHashInfo address="0x0000000000000000000000000000000000000000" showCopyButton hasExplorer />
+              </Box>
+              {isDeclined && (
+                <Chip label="Declined" size="small" sx={{ backgroundColor: 'error.light', borderRadius: 0.5 }} />
+              )}
+            </Stack>
+          ),
         },
         role: {
           rawValue: member.role,
-          content: <Chip label={member.role} />,
+          content: (
+            <Chip
+              size="small"
+              label={member.role}
+              sx={{ backgroundColor: 'background.lightgrey', borderRadius: 0.5 }}
+            />
+          ),
         },
         actions: {
           rawValue: '',
           sticky: true,
           content: (
             <div className={tableCss.actions}>
+              {isDeclined && (
+                <Button variant="outlined" size="small" sx={{ px: 2, py: 0.5, mr: 1 }} onClick={() => {}}>
+                  Resend
+                </Button>
+              )}
               <IconButton onClick={() => {}} size="small">
                 <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
               </IconButton>

--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -36,8 +36,15 @@ const OrganizationMembers = () => {
           Add member
         </Button>
       </Stack>
-      {invited.length > 0 && <InvitesList invitedMembers={invited} />}
-      {members.length === 0 ? <EmptyMembers /> : <MembersList />}
+      {/* Show the empty state placeholder if if the org creator is the only member */}
+      {members.length === 1 && invited.length === 0 ? (
+        <EmptyMembers />
+      ) : (
+        <>
+          {invited.length > 0 && <InvitesList invitedMembers={invited} />}
+          {members.length === 0 ? <EmptyMembers /> : <MembersList />}
+        </>
+      )}
       {openAddMembersModal && <AddMembersModal onClose={() => setOpenAddMembersModal(false)} />}
     </>
   )

--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -3,10 +3,19 @@ import PlusIcon from '@/public/images/common/plus.svg'
 import { Button, Stack, Typography } from '@mui/material'
 import AddMembersModal from '@/features/organizations/components/AddMembersModal'
 import { useState } from 'react'
+import MembersList from '../MembersList'
+import InvitesList from './InvitesList'
+import { useUserOrganizationsGetUsersV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 
 const OrganizationMembers = () => {
-  const members = [] // TODO: Fetch from backend
+  const orgId = useCurrentOrgId()
+  const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
+
+  const members = []
+  const invited = data?.members.filter((member) => member.status === 'INVITED') || []
+
   // TODO: Render members list
   return (
     <>
@@ -18,7 +27,8 @@ const OrganizationMembers = () => {
           Add member
         </Button>
       </Stack>
-      {members.length === 0 ? <EmptyMembers /> : <></>}
+      {invited.length > 0 && <InvitesList invitedMembers={invited} />}
+      {members.length === 0 ? <EmptyMembers /> : <MembersList />}
       {openAddMembersModal && <AddMembersModal onClose={() => setOpenAddMembersModal(false)} />}
     </>
   )

--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -8,13 +8,22 @@ import InvitesList from './InvitesList'
 import { useUserOrganizationsGetUsersV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 
+export enum MemberStatus {
+  INVITED = 'INVITED',
+  ACTIVE = 'ACTIVE',
+  DECLINED = 'DECLINED',
+}
+
 const OrganizationMembers = () => {
   const orgId = useCurrentOrgId()
   const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
 
   const members = []
-  const invited = data?.members.filter((member) => member.status === 'INVITED') || []
+  const invited =
+    data?.members.filter(
+      (member) => member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED,
+    ) || []
 
   // TODO: Render members list
   return (

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -79,7 +79,7 @@ const invites: GetOrganizationResponse[] = [
   {
     id: 123,
     name: 'Bidget',
-    status: 1,
+    status: 'ACTIVE',
     userOrganizations: [],
   },
 ]

--- a/apps/web/src/features/organizations/components/OrgsSettings/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSettings/index.tsx
@@ -26,6 +26,7 @@ import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import css from './styles.module.css'
+import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 
 const ListIcon = ({ variant }: { variant: 'success' | 'danger' }) => {
   const Icon = variant === 'success' ? CheckIcon : CloseIcon
@@ -45,7 +46,7 @@ const OrgsSettings = () => {
   const [deleteOrgOpen, setDeleteOrgOpen] = useState(false)
   const router = useRouter()
   const dispatch = useAppDispatch()
-  const orgId = Array.isArray(router.query.orgId) ? router.query.orgId[0] : router.query.orgId
+  const orgId = useCurrentOrgId()
   const { data: org } = useOrganizationsGetOneV1Query({ id: Number(orgId) })
   const [updateOrg] = useOrganizationsUpdateV1Mutation()
   const [deleteOrg] = useOrganizationsDeleteV1Mutation()

--- a/apps/web/src/features/organizations/components/OrgsSidebarNavigation/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarNavigation/index.tsx
@@ -9,15 +9,16 @@ import {
   SidebarListItemText,
 } from '@/components/sidebar/SidebarList'
 import { navItems } from './config'
+import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 
 const Navigation = (): ReactElement => {
   const router = useRouter()
-  const orgId = Array.isArray(router.query.orgId) ? router.query.orgId[0] : router.query.orgId || ''
+  const orgId = useCurrentOrgId()
 
   return (
     <SidebarList>
       {navItems.map((item) => {
-        const itemPath = item.href(orgId)
+        const itemPath = item.href(orgId || '')
         const isSelected = router.asPath === itemPath
 
         return (

--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
@@ -11,13 +11,14 @@ import css from './styles.module.css'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
 import OrgsCreationModal from '../OrgsCreationModal'
+import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 
 const OrgsSidebarSelector = () => {
   const [isCreationModalOpen, setIsCreationModalOpen] = useState(false)
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const router = useRouter()
   const open = Boolean(anchorEl)
-  const orgId = Array.isArray(router.query.orgId) ? router.query.orgId[0] : router.query.orgId
+  const orgId = useCurrentOrgId()
   const { data: orgs } = useOrganizationsGetV1Query()
   const selectedOrg = orgs?.find((org) => org.id === Number(orgId))
 

--- a/apps/web/src/features/organizations/hooks/useCurrentOrgId.ts
+++ b/apps/web/src/features/organizations/hooks/useCurrentOrgId.ts
@@ -1,0 +1,7 @@
+import { useRouter } from 'next/router'
+
+export const useCurrentOrgId = () => {
+  const router = useRouter()
+  const orgId = Array.isArray(router.query.orgId) ? router.query.orgId[0] : router.query.orgId
+  return orgId
+}

--- a/packages/store/scripts/api-schema/schema.json
+++ b/packages/store/scripts/api-schema/schema.json
@@ -2354,10 +2354,129 @@
         "tags": ["organizations"]
       }
     },
+    "/v1/organizations/{organizationId}/safes": {
+      "post": {
+        "operationId": "organizationSafesCreateV1",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CreateOrganizationSafeDto"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Safes created successfully"
+          },
+          "401": {
+            "description": "User unauthorize OR signer address not provided"
+          },
+          "404": {
+            "description": "User not found."
+          }
+        },
+        "tags": ["organizations-safe"]
+      },
+      "get": {
+        "operationId": "organizationSafesGetV1",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Safes fetched successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetOrganizationSafeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User unauthorized OR signer address not provided"
+          },
+          "404": {
+            "description": "User not found."
+          }
+        },
+        "tags": ["organizations-safe"]
+      },
+      "delete": {
+        "operationId": "organizationSafesDeleteV1",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Safes deleted successfully"
+          },
+          "401": {
+            "description": "User unauthorized OR signer address not provided"
+          },
+          "404": {
+            "description": "Organization has no Safes OR user not found."
+          }
+        },
+        "tags": ["organizations-safe"]
+      }
+    },
     "/v1/organizations/{orgId}/members/invite": {
       "post": {
         "operationId": "userOrganizationsInviteUserV1",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -2401,7 +2520,16 @@
     "/v1/organizations/{orgId}/members/accept": {
       "post": {
         "operationId": "userOrganizationsAcceptInviteV1",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Invite accepted"
@@ -2422,7 +2550,16 @@
     "/v1/organizations/{orgId}/members/decline": {
       "post": {
         "operationId": "userOrganizationsDeclineInviteV1",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Invite declined"
@@ -2443,7 +2580,16 @@
     "/v1/organizations/{orgId}/members": {
       "get": {
         "operationId": "userOrganizationsGetUsersV1",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Organization and members list",
@@ -2468,7 +2614,24 @@
     "/v1/organizations/{orgId}/members/{userId}/role": {
       "patch": {
         "operationId": "userOrganizationsUpdateRoleV1",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Role updated"
@@ -2492,7 +2655,24 @@
     "/v1/organizations/{orgId}/members/{userId}": {
       "delete": {
         "operationId": "userOrganizationsRemoveUserV1",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "orgId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Membership deleted"
@@ -5373,6 +5553,31 @@
         },
         "required": ["name", "id"]
       },
+      "UserDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["PENDING", "ACTIVE"]
+          }
+        },
+        "required": ["id", "status"]
+      },
+      "UserOrganizationsDto": {
+        "type": "object",
+        "properties": {
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserOrganization"
+            }
+          }
+        },
+        "required": ["members"]
+      },
       "GetOrganizationResponse": {
         "type": "object",
         "properties": {
@@ -5383,13 +5588,13 @@
             "type": "string"
           },
           "status": {
-            "type": "number",
-            "enum": [1]
+            "type": "string",
+            "enum": ["ACTIVE"]
           },
           "userOrganizations": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/UserOrganizationsDto"
             }
           }
         },
@@ -5402,8 +5607,8 @@
             "type": "string"
           },
           "status": {
-            "type": "number",
-            "enum": [1]
+            "type": "string",
+            "enum": ["ACTIVE"]
           }
         }
       },
@@ -5416,6 +5621,34 @@
         },
         "required": ["id"]
       },
+      "CreateOrganizationSafeDto": {
+        "type": "object",
+        "properties": {
+          "chainId": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          }
+        },
+        "required": ["chainId", "address"]
+      },
+      "GetOrganizationSafes": {
+        "type": "object",
+        "properties": {}
+      },
+      "GetOrganizationSafeResponse": {
+        "type": "object",
+        "properties": {
+          "safes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GetOrganizationSafes"
+            }
+          }
+        },
+        "required": ["safes"]
+      },
       "Invitation": {
         "type": "object",
         "properties": {
@@ -5427,11 +5660,11 @@
           },
           "role": {
             "type": "string",
-            "enum": ["1", "2", "ADMIN", "MEMBER"]
+            "enum": ["ADMIN", "MEMBER"]
           },
           "status": {
             "type": "string",
-            "enum": ["0", "1", "2", "INVITED", "ACTIVE", "DECLINED"]
+            "enum": ["INVITED", "ACTIVE", "DECLINED"]
           }
         },
         "required": ["userId", "orgId", "role", "status"]
@@ -5444,7 +5677,7 @@
           },
           "status": {
             "type": "string",
-            "enum": ["0", "1", "PENDING", "ACTIVE"]
+            "enum": ["PENDING", "ACTIVE"]
           }
         },
         "required": ["id", "status"]
@@ -5457,11 +5690,11 @@
           },
           "role": {
             "type": "string",
-            "enum": ["1", "2", "ADMIN", "MEMBER"]
+            "enum": ["ADMIN", "MEMBER"]
           },
           "status": {
             "type": "string",
-            "enum": ["0", "1", "2", "INVITED", "ACTIVE", "DECLINED"]
+            "enum": ["INVITED", "ACTIVE", "DECLINED"]
           },
           "createdAt": {
             "format": "date-time",
@@ -5476,18 +5709,6 @@
           }
         },
         "required": ["id", "role", "status", "createdAt", "updatedAt", "user"]
-      },
-      "UserOrganizationsDto": {
-        "type": "object",
-        "properties": {
-          "members": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/UserOrganization"
-            }
-          }
-        },
-        "required": ["members"]
       },
       "SafeList": {
         "type": "object",
@@ -6705,6 +6926,22 @@
         },
         "required": ["to", "operation"]
       },
+      "MultisigConfirmationDetails": {
+        "type": "object",
+        "properties": {
+          "signer": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "signature": {
+            "type": "string",
+            "nullable": true
+          },
+          "submittedAt": {
+            "type": "number"
+          }
+        },
+        "required": ["signer", "submittedAt"]
+      },
       "MultisigExecutionDetails": {
         "type": "object",
         "properties": {
@@ -6747,7 +6984,7 @@
           "signers": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/AddressInfo"
             }
           },
           "confirmationsRequired": {
@@ -6756,7 +6993,7 @@
           "confirmations": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/MultisigConfirmationDetails"
             }
           },
           "rejectors": {

--- a/packages/store/scripts/openapi-config.ts
+++ b/packages/store/scripts/openapi-config.ts
@@ -1,12 +1,5 @@
 import type { ConfigFile } from '@rtk-query/codegen-openapi'
 
-const pathMatcher = (pattern: RegExp) => {
-  return (_, operationDefinition) => {
-    console.log(operationDefinition.path, operationName, pattern.test(operationDefinition.path))
-    return pattern.test(operationDefinition.path)
-  }
-}
-
 const config: ConfigFile = {
   schemaFile: './api-schema/schema.json',
   prettierConfigFile: '../../../.prettierrc',

--- a/packages/store/scripts/openapi-config.ts
+++ b/packages/store/scripts/openapi-config.ts
@@ -1,5 +1,12 @@
 import type { ConfigFile } from '@rtk-query/codegen-openapi'
 
+const pathMatcher = (pattern: RegExp) => {
+  return (_, operationDefinition) => {
+    console.log(operationDefinition.path, operationName, pattern.test(operationDefinition.path))
+    return pattern.test(operationDefinition.path)
+  }
+}
+
 const config: ConfigFile = {
   schemaFile: './api-schema/schema.json',
   prettierConfigFile: '../../../.prettierrc',
@@ -71,7 +78,7 @@ const config: ConfigFile = {
       filterEndpoints: [/^users/],
     },
     '../src/gateway/AUTO_GENERATED/organizations.ts': {
-      filterEndpoints: [/^organizations/],
+      filterEndpoints: [/^(organizations|userOrganizations)/],
     },
   },
 }

--- a/packages/store/src/gateway/AUTO_GENERATED/organizations.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/organizations.ts
@@ -41,6 +41,58 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/v1/organizations/${queryArg.id}`, method: 'DELETE' }),
         invalidatesTags: ['organizations'],
       }),
+      userOrganizationsInviteUserV1: build.mutation<
+        UserOrganizationsInviteUserV1ApiResponse,
+        UserOrganizationsInviteUserV1ApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/v1/organizations/${queryArg.orgId}/members/invite`,
+          method: 'POST',
+          body: queryArg.body,
+        }),
+        invalidatesTags: ['organizations'],
+      }),
+      userOrganizationsAcceptInviteV1: build.mutation<
+        UserOrganizationsAcceptInviteV1ApiResponse,
+        UserOrganizationsAcceptInviteV1ApiArg
+      >({
+        query: (queryArg) => ({ url: `/v1/organizations/${queryArg.orgId}/members/accept`, method: 'POST' }),
+        invalidatesTags: ['organizations'],
+      }),
+      userOrganizationsDeclineInviteV1: build.mutation<
+        UserOrganizationsDeclineInviteV1ApiResponse,
+        UserOrganizationsDeclineInviteV1ApiArg
+      >({
+        query: (queryArg) => ({ url: `/v1/organizations/${queryArg.orgId}/members/decline`, method: 'POST' }),
+        invalidatesTags: ['organizations'],
+      }),
+      userOrganizationsGetUsersV1: build.query<
+        UserOrganizationsGetUsersV1ApiResponse,
+        UserOrganizationsGetUsersV1ApiArg
+      >({
+        query: (queryArg) => ({ url: `/v1/organizations/${queryArg.orgId}/members` }),
+        providesTags: ['organizations'],
+      }),
+      userOrganizationsUpdateRoleV1: build.mutation<
+        UserOrganizationsUpdateRoleV1ApiResponse,
+        UserOrganizationsUpdateRoleV1ApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/v1/organizations/${queryArg.orgId}/members/${queryArg.userId}/role`,
+          method: 'PATCH',
+        }),
+        invalidatesTags: ['organizations'],
+      }),
+      userOrganizationsRemoveUserV1: build.mutation<
+        UserOrganizationsRemoveUserV1ApiResponse,
+        UserOrganizationsRemoveUserV1ApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/v1/organizations/${queryArg.orgId}/members/${queryArg.userId}`,
+          method: 'DELETE',
+        }),
+        invalidatesTags: ['organizations'],
+      }),
     }),
     overrideExisting: false,
   })
@@ -69,6 +121,34 @@ export type OrganizationsDeleteV1ApiResponse = unknown
 export type OrganizationsDeleteV1ApiArg = {
   id: number
 }
+export type UserOrganizationsInviteUserV1ApiResponse = /** status 200 Users invited */ Invitation[]
+export type UserOrganizationsInviteUserV1ApiArg = {
+  orgId: number
+  body: string[]
+}
+export type UserOrganizationsAcceptInviteV1ApiResponse = unknown
+export type UserOrganizationsAcceptInviteV1ApiArg = {
+  orgId: number
+}
+export type UserOrganizationsDeclineInviteV1ApiResponse = unknown
+export type UserOrganizationsDeclineInviteV1ApiArg = {
+  orgId: number
+}
+export type UserOrganizationsGetUsersV1ApiResponse =
+  /** status 200 Organization and members list */ UserOrganizationsDto
+export type UserOrganizationsGetUsersV1ApiArg = {
+  orgId: number
+}
+export type UserOrganizationsUpdateRoleV1ApiResponse = unknown
+export type UserOrganizationsUpdateRoleV1ApiArg = {
+  orgId: number
+  userId: number
+}
+export type UserOrganizationsRemoveUserV1ApiResponse = unknown
+export type UserOrganizationsRemoveUserV1ApiArg = {
+  orgId: number
+  userId: number
+}
 export type CreateOrganizationResponse = {
   name: string
   id: number
@@ -76,18 +156,39 @@ export type CreateOrganizationResponse = {
 export type CreateOrganizationDto = {
   name: string
 }
+export type UserOrganizationUser = {
+  id: number
+  status: 'PENDING' | 'ACTIVE'
+}
+export type UserOrganization = {
+  id: number
+  role: 'ADMIN' | 'MEMBER'
+  status: 'INVITED' | 'ACTIVE' | 'DECLINED'
+  createdAt: string
+  updatedAt: string
+  user: UserOrganizationUser
+}
+export type UserOrganizationsDto = {
+  members: UserOrganization[]
+}
 export type GetOrganizationResponse = {
   id: number
   name: string
-  status: 1
-  userOrganizations: string[]
+  status: 'ACTIVE'
+  userOrganizations: UserOrganizationsDto[]
 }
 export type UpdateOrganizationResponse = {
   id: number
 }
 export type UpdateOrganizationDto = {
   name?: string
-  status?: 1
+  status?: 'ACTIVE'
+}
+export type Invitation = {
+  userId: number
+  orgId: number
+  role: 'ADMIN' | 'MEMBER'
+  status: 'INVITED' | 'ACTIVE' | 'DECLINED'
 }
 export const {
   useOrganizationsCreateV1Mutation,
@@ -98,4 +199,11 @@ export const {
   useLazyOrganizationsGetOneV1Query,
   useOrganizationsUpdateV1Mutation,
   useOrganizationsDeleteV1Mutation,
+  useUserOrganizationsInviteUserV1Mutation,
+  useUserOrganizationsAcceptInviteV1Mutation,
+  useUserOrganizationsDeclineInviteV1Mutation,
+  useUserOrganizationsGetUsersV1Query,
+  useLazyUserOrganizationsGetUsersV1Query,
+  useUserOrganizationsUpdateRoleV1Mutation,
+  useUserOrganizationsRemoveUserV1Mutation,
 } = injectedRtkApi

--- a/packages/store/src/gateway/AUTO_GENERATED/transactions.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/transactions.ts
@@ -513,6 +513,11 @@ export type TransactionData = {
   trustedDelegateCallTarget?: boolean | null
   addressInfoIndex?: object | null
 }
+export type MultisigConfirmationDetails = {
+  signer: AddressInfo
+  signature?: string | null
+  submittedAt: number
+}
 export type Token = {
   address: string
   decimals?: number | null
@@ -532,9 +537,9 @@ export type MultisigExecutionDetails = {
   refundReceiver: AddressInfo
   safeTxHash: string
   executor?: AddressInfo | null
-  signers: string[]
+  signers: AddressInfo[]
   confirmationsRequired: number
-  confirmations: string[]
+  confirmations: MultisigConfirmationDetails[]
   rejectors: AddressInfo[]
   gasTokenInfo?: Token | null
   trusted: boolean


### PR DESCRIPTION
## What it solves

Partially Resolves #4957

## How this PR fixes it
- Creates an invite for a user after submitting the invite users modal.
- Displays an orgs invited members on the members page.
- Shows a resend button and status chip for members who declined an invite.

## How to test it
- On the members page click the invite members button.
- Add an address in the form, choose a role, and submit the form.
- On the members page, see that there is a new row in the invited members list for each invited address
Note: We currently do not have access to the invited members address so a placeholder address is shown instead. The design for this section will likely need to be changed to show all connected addresses for the user.

## Screenshots
![image](https://github.com/user-attachments/assets/aa271330-3306-4f57-adb7-599d63d551ca)
![image](https://github.com/user-attachments/assets/5145fc03-593a-4f05-9c30-cb0c87640282)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
