### PR TITLE
Feat(Orgs): show list of pending invites on the orgs list screen 

### DIFF
--- a/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
@@ -1,16 +1,30 @@
 import { Card, Box, Stack, Button, Typography } from '@mui/material'
 import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { OrgLogo, OrgSummary } from '../OrgsCard'
+import {
+  useUserOrganizationsAcceptInviteV1Mutation,
+  useUserOrganizationsDeclineInviteV1Mutation,
+} from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 
 type OrgListInvite = {
   org: GetOrganizationResponse
 }
 
 const OrgListInvite = ({ org }: OrgListInvite) => {
+  const [acceptInvite] = useUserOrganizationsAcceptInviteV1Mutation()
+  const [declineInvite] = useUserOrganizationsDeclineInviteV1Mutation()
   const { name, userOrganizations: members } = org
   const safes = [] // TODO: Replace with actual safes data when available
   const numberOfAccounts = safes.length
   const numberOfMembers = members.length
+
+  const handleAcceptInvite = () => {
+    acceptInvite({ orgId: org.id })
+  }
+
+  const handleDeclineInvite = () => {
+    declineInvite({ orgId: org.id })
+  }
 
   return (
     <Card sx={{ p: 2, mb: 2 }}>
@@ -32,10 +46,10 @@ const OrgListInvite = ({ org }: OrgListInvite) => {
           </Box>
 
           <Stack direction="row" spacing={1}>
-            <Button variant="contained" onClick={() => {}} size="small">
+            <Button variant="contained" onClick={handleAcceptInvite} size="small">
               Accept
             </Button>
-            <Button variant="outlined" onClick={() => {}} size="small">
+            <Button variant="outlined" onClick={handleDeclineInvite} size="small">
               Decline
             </Button>
           </Stack>

--- a/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
@@ -46,10 +46,10 @@ const OrgListInvite = ({ org }: OrgListInvite) => {
           </Box>
 
           <Stack direction="row" spacing={1}>
-            <Button variant="contained" onClick={handleAcceptInvite} size="small">
+            <Button variant="contained" onClick={handleAcceptInvite} size="small" sx={{ px: 2, py: 0.5 }}>
               Accept
             </Button>
-            <Button variant="outlined" onClick={handleDeclineInvite} size="small">
+            <Button variant="outlined" onClick={handleDeclineInvite} size="small" sx={{ px: 2, py: 0.5 }}>
               Decline
             </Button>
           </Stack>

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -8,9 +8,12 @@ import { isAuthenticated } from '@/store/authSlice'
 import { Box, Button, Card, Grid2, Link, Typography } from '@mui/material'
 import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useOrganizationsGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import type { UserWithWallets } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import OrgListInvite from '../Dashboard/DashboardInvite'
+import { MemberStatus } from '../Members'
 import { useState } from 'react'
 import css from './styles.module.css'
-import OrgListInvite from '../Dashboard/DashboardInvite'
 
 const AddOrgButton = ({ disabled }: { disabled: boolean }) => {
   const [open, setOpen] = useState(false)
@@ -74,19 +77,25 @@ const NoOrgsState = () => {
   )
 }
 
-// todo: replace with real data
-const invites: GetOrganizationResponse[] = [
-  {
-    id: 123,
-    name: 'Bidget',
-    status: 'ACTIVE',
-    userOrganizations: [],
-  },
-]
+const filterOrgsByStatus = (
+  currentUser: UserWithWallets | undefined,
+  orgs: GetOrganizationResponse[],
+  status: MemberStatus,
+) => {
+  return orgs?.filter((org) => {
+    // @ts-ignore TODO: fix incorrect type from CGW
+    return org.userOrganizations.some((userOrg) => userOrg.user.id === currentUser?.id && userOrg.status === status)
+  })
+}
 
+// todo: replace with real data
 const OrgsList = () => {
   const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { data: currentUser } = useUsersGetWithWalletsV1Query()
   const { data: organizations } = useOrganizationsGetV1Query(undefined, { skip: !isUserSignedIn })
+
+  const pendingInvites = filterOrgsByStatus(currentUser, organizations || [], MemberStatus.INVITED)
+  const activeOrganizations = filterOrgsByStatus(currentUser, organizations || [], MemberStatus.ACTIVE)
 
   return (
     <Box className={css.container}>
@@ -97,15 +106,15 @@ const OrgsList = () => {
         </Box>
 
         {isUserSignedIn &&
-          invites.length > 0 &&
-          invites.map((invitingOrg: GetOrganizationResponse) => (
+          pendingInvites.length > 0 &&
+          pendingInvites.map((invitingOrg: GetOrganizationResponse) => (
             <OrgListInvite key={invitingOrg.id} org={invitingOrg} />
           ))}
 
         {isUserSignedIn && organizations ? (
           <Grid2 container spacing={2} flexWrap="wrap">
-            {organizations.length > 0 ? (
-              organizations.map((org) => (
+            {activeOrganizations.length > 0 ? (
+              activeOrganizations.map((org) => (
                 <Grid2 size={6} key={org.name}>
                   <OrgsCard org={org} />
                 </Grid2>


### PR DESCRIPTION
## What it solves

Resolves #5008

## How this PR fixes it
- Replaces the hardcoded invite list with data from the backend.
- Implements the `accept` and `reject` button functionality.
- Filters out invites from the list of orgs you are a member of.

## How to test it
- Invite a wallet to your org from the members page.
- switch to the invited wallet and sign in. (You may need to delete the previous auth cookie)
- go to `/welcome/organizations` and see that the invite is listed.
- Click `Accept`. The invite should be replaced by an entry in the list of organizations below.
- Clicking reject should remove the invite from the page

## Screenshots
![image](https://github.com/user-attachments/assets/39dbe6f9-8304-444e-b8c1-aab3a52b31fa)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
