### PR TITLE
Feat(Orgs): Add safes manually for orgs

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -1,5 +1,6 @@
 import AddressInputReadOnly from '@/components/common/AddressInputReadOnly'
 import useAddressBook from '@/hooks/useAddressBook'
+import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { ReactElement } from 'react'
 import { useEffect, useCallback, useRef, useMemo } from 'react'
 import {
@@ -33,6 +34,7 @@ export type AddressInputProps = TextFieldProps & {
   validate?: Validate<string>
   deps?: string | string[]
   onAddressBookClick?: () => void
+  chain?: ChainInfo
 }
 
 const AddressInput = ({
@@ -43,6 +45,7 @@ const AddressInput = ({
   isAutocompleteOpen,
   onAddressBookClick,
   deps,
+  chain,
   ...props
 }: AddressInputProps): ReactElement => {
   const {
@@ -56,7 +59,7 @@ const AddressInput = ({
   const currentChain = useCurrentChain()
   const rawValueRef = useRef<string>('')
   const watchedValue = useWatch({ name, control })
-  const currentShortName = currentChain?.shortName || ''
+  const currentShortName = chain?.shortName || currentChain?.shortName || ''
 
   const addressBook = useAddressBook()
 

--- a/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
@@ -2,6 +2,7 @@ import AddressInput from '@/components/common/AddressInput'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import ModalDialog from '@/components/common/ModalDialog'
 import networkSelectorCss from '@/components/common/NetworkSelector/styles.module.css'
+import chains from '@/config/chains'
 import css from './styles.module.css'
 import useChains from '@/hooks/useChains'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -23,7 +24,7 @@ const AddManually = ({ handleAddSafe }: { handleAddSafe: (data: AddManuallyFormV
     mode: 'onChange',
     defaultValues: {
       address: '',
-      chainId: '1',
+      chainId: chains.eth,
     },
   })
 
@@ -76,7 +77,7 @@ const AddManually = ({ handleAddSafe }: { handleAddSafe: (data: AddManuallyFormV
       <Button size="compact" onClick={() => setAddManuallyOpen(true)}>
         + Add manually
       </Button>
-      <ModalDialog open={addManuallyOpen} dialogTitle="Add safe account" hideChainIndicator>
+      <ModalDialog open={addManuallyOpen} dialogTitle="Add safe account" onClose={onCancel} hideChainIndicator>
         <FormProvider {...formMethods}>
           <form onSubmit={onSubmit}>
             <DialogContent>

--- a/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
@@ -1,0 +1,122 @@
+import AddressInput from '@/components/common/AddressInput'
+import ChainIndicator from '@/components/common/ChainIndicator'
+import ModalDialog from '@/components/common/ModalDialog'
+import networkSelectorCss from '@/components/common/NetworkSelector/styles.module.css'
+import css from './styles.module.css'
+import useChains from '@/hooks/useChains'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { Button, DialogActions, DialogContent, MenuItem, Select, Stack, Box } from '@mui/material'
+import { getSafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import React, { useCallback, useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+
+export type AddManuallyFormValues = {
+  address: string
+  chainId: string
+}
+
+const AddManually = ({ handleAddSafe }: { handleAddSafe: (data: AddManuallyFormValues) => void }) => {
+  const [addManuallyOpen, setAddManuallyOpen] = useState(false)
+  const { configs } = useChains()
+
+  const formMethods = useForm<AddManuallyFormValues>({
+    mode: 'onChange',
+    defaultValues: {
+      address: '',
+      chainId: '1',
+    },
+  })
+
+  const { handleSubmit, watch, register, reset, formState } = formMethods
+
+  const chainId = watch('chainId')
+  const selectedChain = configs.find((chain) => chain.chainId === chainId)
+
+  const onSubmit = handleSubmit((data) => {
+    handleAddSafe(data)
+    setAddManuallyOpen(false)
+  })
+
+  const onCancel = () => {
+    reset()
+    setAddManuallyOpen(false)
+  }
+
+  const validateSafeAddress = async (address: string) => {
+    try {
+      await getSafeInfo(chainId, address)
+    } catch (error) {
+      return 'Address given is not a valid Safe Account address'
+    }
+  }
+
+  const renderMenuItem = useCallback(
+    (chainId: string, isSelected: boolean) => {
+      const chain = configs.find((chain) => chain.chainId === chainId)
+      if (!chain) return null
+
+      return (
+        <MenuItem
+          key={chainId}
+          value={chainId}
+          sx={{ '&:hover': { backgroundColor: isSelected ? 'transparent' : 'inherit' } }}
+          disableRipple={isSelected}
+        >
+          <ChainIndicator chainId={chainId} />
+        </MenuItem>
+      )
+    },
+    [configs],
+  )
+
+  const chainIdField = register('chainId')
+
+  return (
+    <>
+      <Button size="compact" onClick={() => setAddManuallyOpen(true)}>
+        + Add manually
+      </Button>
+      <ModalDialog open={addManuallyOpen} dialogTitle="Add safe account" hideChainIndicator>
+        <FormProvider {...formMethods}>
+          <form onSubmit={onSubmit}>
+            <DialogContent>
+              <Stack direction="row" spacing={2}>
+                <AddressInput
+                  label="Safe Account"
+                  chain={selectedChain}
+                  validate={validateSafeAddress}
+                  name="address"
+                  deps={chainId}
+                />
+                <Box className={css.selectWrapper}>
+                  <Select
+                    {...chainIdField}
+                    value={chainId}
+                    size="small"
+                    className={networkSelectorCss.select}
+                    variant="standard"
+                    IconComponent={ExpandMoreIcon}
+                    renderValue={(value) => renderMenuItem(value, true)}
+                    MenuProps={{
+                      transitionDuration: 0,
+                    }}
+                  >
+                    {configs.map((chain) => renderMenuItem(chain.chainId, false))}
+                  </Select>
+                </Box>
+              </Stack>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={onCancel}>Cancel</Button>
+              <Button variant="contained" disabled={!formState.isValid} type="submit">
+                Add
+              </Button>
+            </DialogActions>
+          </form>
+        </FormProvider>
+      </ModalDialog>
+    </>
+  )
+}
+
+export default AddManually

--- a/apps/web/src/features/organizations/components/AddAccounts/FilteredSafesList.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/FilteredSafesList.tsx
@@ -1,7 +1,0 @@
-import SafesList from '@/features/organizations/components/AddAccounts/SafesList'
-
-const FilteredSafesList = ({ filteredSafes }: { filteredSafes: any }) => {
-  return <SafesList safes={filteredSafes} />
-}
-
-export default FilteredSafesList

--- a/apps/web/src/features/organizations/components/AddAccounts/SafesList.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/SafesList.tsx
@@ -46,7 +46,7 @@ const ChainItem = ({ chainId }: { chainId: string }) => {
   )
 }
 
-const getSafeId = (safeItem: SafeItem) => {
+export const getSafeId = (safeItem: SafeItem) => {
   return `${safeItem.chainId}:${safeItem.address}`
 }
 

--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -2,7 +2,6 @@ import ModalDialog from '@/components/common/ModalDialog'
 import type { SafeItem, SafeItems } from '@/features/myAccounts/hooks/useAllSafes'
 import { useSafesSearch } from '@/features/myAccounts/hooks/useSafesSearch'
 import AddManually, { type AddManuallyFormValues } from '@/features/organizations/components/AddAccounts/AddManually'
-import FilteredSafesList from '@/features/organizations/components/AddAccounts/FilteredSafesList'
 import SafesList, { getSafeId } from '@/features/organizations/components/AddAccounts/SafesList'
 import SearchIcon from '@/public/images/common/search.svg'
 import debounce from 'lodash/debounce'
@@ -132,7 +131,7 @@ const AddAccounts = () => {
                     />
                   </Box>
 
-                  {searchQuery ? <FilteredSafesList filteredSafes={filteredSafes} /> : <SafesList safes={allSafes} />}
+                  {searchQuery ? <SafesList safes={filteredSafes} /> : <SafesList safes={allSafes} />}
 
                   <Box p={2}>
                     <AddManually handleAddSafe={handleAddSafe} />

--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -140,7 +140,9 @@ const AddAccounts = () => {
               </FormProvider>
               <DialogActions>
                 <Button onClick={() => setOpen(false)}>Cancel</Button>
-                <Button variant="contained">Add Accounts ({selectedSafesLength})</Button>
+                <Button variant="contained" disabled={selectedSafesLength === 0}>
+                  Add Accounts ({selectedSafesLength})
+                </Button>
               </DialogActions>
             </Card>
           </Container>

--- a/apps/web/src/features/organizations/components/AddAccounts/styles.module.css
+++ b/apps/web/src/features/organizations/components/AddAccounts/styles.module.css
@@ -13,3 +13,11 @@
 .search :global .MuiInputBase-root {
   border: 1px solid transparent !important;
 }
+
+.selectWrapper {
+  display: flex;
+  align-items: center;
+  border-radius: 8px;
+  border: 1px solid var(--color-border-light);
+  height: 66px;
+}

--- a/apps/web/src/features/recovery/components/RecoverySettings/ChooseRecoveryMethodModal.tsx
+++ b/apps/web/src/features/recovery/components/RecoverySettings/ChooseRecoveryMethodModal.tsx
@@ -53,7 +53,7 @@ type Fields = {
 export function ChooseRecoveryMethodModal({ open, onClose }: { open: boolean; onClose: () => void }): ReactElement {
   const { setTxFlow } = useContext(TxModalContext)
   const [openZkEmailModal, setOpenZkEmailModal] = useState(false)
-  const querySafe = useSearchParams().get('safe')
+  const querySafe = useSearchParams()?.get('safe')
   const [matchingApps] = useRemoteSafeApps(SafeAppsTag.RECOVERY_SYGNUM)
   const hasSygnumApp = Boolean(matchingApps?.length)
 


### PR DESCRIPTION
## What it solves

Resolves #5048

## How this PR fixes it

- Adds a form to manually add a safe account in orgs

## How to test it

1. Open an org
2. Add safe accounts
3. Press Add manually
4. Type in a safe address and chain id
5. Submit the form
6. Observe the safe appears in the list of safes and is checked
7. Observe the number in the Submit button updating

## Screenshots
<img width="659" alt="Screenshot 2025-02-20 at 18 31 11" src="https://github.com/user-attachments/assets/9c860a7f-f33a-40d1-bb31-509701c0216d" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
