### PR TITLE
Feat(Orgs): Create orgs safe accounts list view

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -344,7 +344,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isOrgSafe = false
               />
             ))}
           </Box>
-          {!isReadOnly && hasReplayableSafe && (
+          {!isReadOnly && hasReplayableSafe && !isOrgSafe && (
             <>
               <Divider sx={{ ml: '-12px', mr: '-12px' }} />
               <Box

--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -1,5 +1,7 @@
 import { selectUndeployedSafes } from '@/features/counterfactual/store/undeployedSafesSlice'
 import NetworkLogosList from '@/features/multichain/components/NetworkLogosList'
+import type { SafeListProps } from '@/features/myAccounts/components/SafesList'
+import OrgSafeContextMenu from '@/features/organizations/components/SafeAccounts/OrgSafeContextMenu'
 import { showNotification } from '@/store/notificationsSlice'
 import SingleAccountItem from '@/features/myAccounts/components/AccountItems/SingleAccountItem'
 import type { SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
@@ -45,12 +47,6 @@ import { addOrUpdateSafe, pinSafe, selectAllAddedSafes, unpinSafe } from '@/stor
 import { defaultSafeInfo } from '@/store/safeInfoSlice'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import { getComparator } from '@/features/myAccounts/utils/utils'
-
-type MultiAccountItemProps = {
-  multiSafeAccountItem: MultiChainSafeItem
-  safeOverviews?: SafeOverview[]
-  onLinkClick?: () => void
-}
 
 export const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
   return (
@@ -213,7 +209,14 @@ function usePinActions(
   return { addToPinnedList, removeFromPinnedList }
 }
 
-const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountItemProps) => {
+type MultiAccountItemProps = {
+  multiSafeAccountItem: MultiChainSafeItem
+  safeOverviews?: SafeOverview[]
+  onLinkClick?: SafeListProps['onLinkClick']
+  isOrgSafe?: boolean
+}
+
+const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isOrgSafe = false }: MultiAccountItemProps) => {
   const {
     address,
     name,
@@ -297,29 +300,37 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
               )}
             </Typography>
           </Box>
-          <IconButton
-            data-testid="bookmark-icon"
-            edge="end"
-            size="medium"
-            sx={{ mx: 1 }}
-            onClick={(event) => {
-              event.stopPropagation()
-              isPinned ? removeFromPinnedList() : addToPinnedList()
-            }}
-          >
-            <SvgIcon
-              component={isPinned ? BookmarkedIcon : BookmarkIcon}
-              inheritViewBox
-              color={isPinned ? 'primary' : undefined}
-              fontSize="small"
+
+          {!isOrgSafe && (
+            <IconButton
+              data-testid="bookmark-icon"
+              edge="end"
+              size="medium"
+              sx={{ mx: 1 }}
+              onClick={(event) => {
+                event.stopPropagation()
+                isPinned ? removeFromPinnedList() : addToPinnedList()
+              }}
+            >
+              <SvgIcon
+                component={isPinned ? BookmarkedIcon : BookmarkIcon}
+                inheritViewBox
+                color={isPinned ? 'primary' : undefined}
+                fontSize="small"
+              />
+            </IconButton>
+          )}
+
+          {isOrgSafe ? (
+            <OrgSafeContextMenu />
+          ) : (
+            <MultiAccountContextMenu
+              name={multiSafeAccountItem.name ?? ''}
+              address={address}
+              chainIds={deployedChainIds}
+              addNetwork={hasReplayableSafe}
             />
-          </IconButton>
-          <MultiAccountContextMenu
-            name={multiSafeAccountItem.name ?? ''}
-            address={address}
-            chainIds={deployedChainIds}
-            addNetwork={hasReplayableSafe}
-          />
+          )}
         </AccordionSummary>
         <AccordionDetails sx={{ padding: '0px 12px' }}>
           <Box data-testid="subacounts-container">
@@ -329,6 +340,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem }: MultiAccountIte
                 safeItem={safeItem}
                 key={`${safeItem.chainId}:${safeItem.address}`}
                 isMultiChainItem
+                isOrgSafe={isOrgSafe}
               />
             ))}
           </Box>

--- a/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
@@ -3,7 +3,17 @@ import type { SafeListProps } from '@/features/myAccounts/components/SafesList'
 import OrgSafeContextMenu from '@/features/organizations/components/SafeAccounts/OrgSafeContextMenu'
 import { type SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
 import { useMemo, useRef } from 'react'
-import { ListItemButton, Box, Typography, IconButton, SvgIcon, Skeleton, useTheme, useMediaQuery } from '@mui/material'
+import {
+  ListItemButton,
+  Box,
+  Typography,
+  IconButton,
+  SvgIcon,
+  Skeleton,
+  useTheme,
+  useMediaQuery,
+  ListItem,
+} from '@mui/material'
 import Link from 'next/link'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS, PIN_SAFE_LABELS, trackEvent } from '@/services/analytics'
@@ -272,16 +282,10 @@ const SingleAccountItem = ({
   )
 
   return isOrgSafe ? (
-    <ListItemButton
-      ref={elementRef}
-      data-testid="safe-list-item"
-      selected={isCurrentSafe}
-      className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe })}
-      disableRipple
-    >
+    <ListItem className={css.listItem}>
       <Box className={css.safeLink}>{content}</Box>
       {actions}
-    </ListItemButton>
+    </ListItem>
   ) : (
     <ListItemButton
       ref={elementRef}

--- a/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
@@ -1,4 +1,6 @@
 import { selectUndeployedSafe } from '@/features/counterfactual/store/undeployedSafesSlice'
+import type { SafeListProps } from '@/features/myAccounts/components/SafesList'
+import OrgSafeContextMenu from '@/features/organizations/components/SafeAccounts/OrgSafeContextMenu'
 import { type SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
 import { useMemo, useRef } from 'react'
 import { ListItemButton, Box, Typography, IconButton, SvgIcon, Skeleton, useTheme, useMediaQuery } from '@mui/material'
@@ -36,11 +38,17 @@ import { AccountInfoChips } from '../AccountInfoChips'
 type AccountItemProps = {
   safeItem: SafeItem
   safeOverview?: SafeOverview
-  onLinkClick?: () => void
+  onLinkClick?: SafeListProps['onLinkClick']
   isMultiChainItem?: boolean
+  isOrgSafe?: boolean
 }
 
-const SingleAccountItem = ({ onLinkClick, safeItem, isMultiChainItem = false }: AccountItemProps) => {
+const SingleAccountItem = ({
+  onLinkClick,
+  safeItem,
+  isMultiChainItem = false,
+  isOrgSafe = false,
+}: AccountItemProps) => {
   const { chainId, address, isReadOnly, isPinned } = safeItem
   const chain = useAppSelector((state) => selectChainById(state, chainId))
   const undeployedSafe = useAppSelector((state) => selectUndeployedSafe(state, chainId, address))
@@ -131,117 +139,119 @@ const SingleAccountItem = ({ onLinkClick, safeItem, isMultiChainItem = false }: 
     trackEvent({ ...OVERVIEW_EVENTS.PIN_SAFE, label: PIN_SAFE_LABELS.unpin })
   }
 
-  return (
-    <ListItemButton
-      ref={elementRef}
-      data-testid="safe-list-item"
-      selected={isCurrentSafe}
-      className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe })}
-    >
-      <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
-        <Link onClick={onLinkClick} href={href} className={css.safeLink}>
-          <Box
+  const content = (
+    <>
+      <Box
+        sx={{
+          pr: 2.5,
+        }}
+      >
+        <SafeIcon
+          address={address}
+          owners={safeOwners.length > 0 ? safeOwners.length : undefined}
+          threshold={safeThreshold > 0 ? safeThreshold : undefined}
+          isMultiChainItem={isMultiChainItem}
+          chainId={chainId}
+        />
+      </Box>
+
+      <Typography variant="body2" component="div" className={css.safeAddress}>
+        {name && (
+          <Typography
+            variant="subtitle2"
+            component="p"
+            className={css.safeName}
             sx={{
-              pr: 2.5,
+              fontWeight: 'bold',
             }}
           >
-            <SafeIcon
-              address={address}
-              owners={safeOwners.length > 0 ? safeOwners.length : undefined}
-              threshold={safeThreshold > 0 ? safeThreshold : undefined}
-              isMultiChainItem={isMultiChainItem}
-              chainId={chainId}
-            />
-          </Box>
-
-          <Typography variant="body2" component="div" className={css.safeAddress}>
-            {name && (
-              <Typography
-                variant="subtitle2"
-                component="p"
-                className={css.safeName}
-                sx={{
-                  fontWeight: 'bold',
-                }}
-              >
-                {name}
-              </Typography>
-            )}
-            {isMultiChainItem ? (
-              <Typography
-                component="span"
-                sx={{
-                  color: 'var(--color-primary-light)',
-                  fontSize: 'inherit',
-                }}
-              >
-                {chain?.chainName}
-              </Typography>
-            ) : (
-              <>
-                {chain?.shortName}:
-                <Typography
-                  component="span"
-                  sx={{
-                    color: 'var(--color-primary-light)',
-                    fontSize: 'inherit',
-                  }}
-                >
-                  {shortenAddress(address)}
-                </Typography>
-              </>
-            )}
-            {!isMobile && (
-              <AccountInfoChips
-                isActivating={isActivating}
-                isReadOnly={isReadOnly}
-                undeployedSafe={!!undeployedSafe}
-                isVisible={isVisible}
-                safeOverview={safeOverview ?? null}
-                chain={chain}
-                href={href}
-                onLinkClick={onLinkClick}
-                trackingLabel={trackingLabel}
-              />
-            )}
+            {name}
           </Typography>
-
-          {!isMultiChainItem && <ChainIndicator chainId={chainId} responsive onlyLogo className={css.chainIndicator} />}
-
-          <Typography variant="body2" sx={{ fontWeight: 'bold', textAlign: 'right', pl: 2 }}>
-            {undeployedSafe ? null : safeOverview ? (
-              <FiatValue value={safeOverview.fiatTotal} />
-            ) : (
-              <Skeleton variant="text" sx={{ ml: 'auto' }} />
-            )}
+        )}
+        {isMultiChainItem ? (
+          <Typography
+            component="span"
+            sx={{
+              color: 'var(--color-primary-light)',
+              fontSize: 'inherit',
+            }}
+          >
+            {chain?.chainName}
           </Typography>
-        </Link>
-      </Track>
+        ) : (
+          <>
+            {chain?.shortName}:
+            <Typography
+              component="span"
+              sx={{
+                color: 'var(--color-primary-light)',
+                fontSize: 'inherit',
+              }}
+            >
+              {shortenAddress(address)}
+            </Typography>
+          </>
+        )}
+        {!isMobile && (
+          <AccountInfoChips
+            isActivating={isActivating}
+            isReadOnly={isReadOnly}
+            undeployedSafe={!!undeployedSafe}
+            isVisible={isVisible}
+            safeOverview={safeOverview ?? null}
+            chain={chain}
+            href={href}
+            onLinkClick={onLinkClick}
+            trackingLabel={trackingLabel}
+          />
+        )}
+      </Typography>
+
+      {!isMultiChainItem && <ChainIndicator chainId={chainId} responsive onlyLogo className={css.chainIndicator} />}
+
+      <Typography variant="body2" sx={{ fontWeight: 'bold', textAlign: 'right', pl: 2 }}>
+        {undeployedSafe ? null : safeOverview ? (
+          <FiatValue value={safeOverview.fiatTotal} />
+        ) : (
+          <Skeleton variant="text" sx={{ ml: 'auto' }} />
+        )}
+      </Typography>
+    </>
+  )
+
+  const actions = (
+    <>
       {!isMultiChainItem && (
         <>
-          <IconButton
-            data-testid="bookmark-icon"
-            edge="end"
-            size="medium"
-            sx={{ mx: 1 }}
-            onClick={isPinned ? removeFromPinnedList : addToPinnedList}
-          >
-            <SvgIcon
-              component={isPinned ? BookmarkedIcon : BookmarkIcon}
-              inheritViewBox
-              color={isPinned ? 'primary' : undefined}
-              fontSize="small"
-            />
-          </IconButton>
+          {!isOrgSafe && (
+            <IconButton
+              data-testid="bookmark-icon"
+              edge="end"
+              size="medium"
+              sx={{ mx: 1 }}
+              onClick={isPinned ? removeFromPinnedList : addToPinnedList}
+            >
+              <SvgIcon
+                component={isPinned ? BookmarkedIcon : BookmarkIcon}
+                inheritViewBox
+                color={isPinned ? 'primary' : undefined}
+                fontSize="small"
+              />
+            </IconButton>
+          )}
 
-          <SafeListContextMenu
-            name={name}
-            address={address}
-            chainId={chainId}
-            addNetwork={isReplayable}
-            rename
-            undeployedSafe={!!undeployedSafe}
-          />
+          {isOrgSafe ? (
+            <OrgSafeContextMenu />
+          ) : (
+            <SafeListContextMenu
+              name={name}
+              address={address}
+              chainId={chainId}
+              addNetwork={isReplayable}
+              rename
+              undeployedSafe={!!undeployedSafe}
+            />
+          )}
         </>
       )}
 
@@ -258,6 +268,34 @@ const SingleAccountItem = ({ onLinkClick, safeItem, isMultiChainItem = false }: 
           trackingLabel={trackingLabel}
         />
       )}
+    </>
+  )
+
+  return isOrgSafe ? (
+    <ListItemButton
+      ref={elementRef}
+      data-testid="safe-list-item"
+      selected={isCurrentSafe}
+      className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe })}
+      disableRipple
+    >
+      <Box className={css.safeLink}>{content}</Box>
+      {actions}
+    </ListItemButton>
+  ) : (
+    <ListItemButton
+      ref={elementRef}
+      data-testid="safe-list-item"
+      selected={isCurrentSafe}
+      className={classnames(css.listItem, { [css.currentListItem]: isCurrentSafe })}
+    >
+      <Track {...OVERVIEW_EVENTS.OPEN_SAFE} label={trackingLabel}>
+        <Link onClick={onLinkClick} href={href} className={css.safeLink}>
+          {content}
+        </Link>
+      </Track>
+
+      {actions}
     </ListItemButton>
   )
 }

--- a/apps/web/src/features/myAccounts/components/SafesList/index.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesList/index.tsx
@@ -6,21 +6,26 @@ import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
 import { TransitionGroup } from 'react-transition-group'
 import { Collapse } from '@mui/material'
 
-type SafeListProps = {
+export type SafeListProps = {
   safes?: (SafeItem | MultiChainSafeItem)[]
   onLinkClick?: () => void
   useTransitions?: boolean
+  isOrgSafe?: boolean
 }
 
-const renderSafeItem = (item: SafeItem | MultiChainSafeItem, onLinkClick?: () => void) => {
+const renderSafeItem = (
+  item: SafeItem | MultiChainSafeItem,
+  onLinkClick?: SafeListProps['onLinkClick'],
+  isOrgSafe = false,
+) => {
   return isMultiChainSafeItem(item) ? (
-    <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} />
+    <MultiAccountItem onLinkClick={onLinkClick} multiSafeAccountItem={item} isOrgSafe={isOrgSafe} />
   ) : (
-    <SingleAccountItem onLinkClick={onLinkClick} safeItem={item} />
+    <SingleAccountItem onLinkClick={onLinkClick} safeItem={item} isOrgSafe={isOrgSafe} />
   )
 }
 
-const SafesList = ({ safes, onLinkClick, useTransitions = true }: SafeListProps) => {
+const SafesList = ({ safes, onLinkClick, useTransitions = true, isOrgSafe = false }: SafeListProps) => {
   if (!safes || safes.length === 0) {
     return null
   }
@@ -29,14 +34,14 @@ const SafesList = ({ safes, onLinkClick, useTransitions = true }: SafeListProps)
     <TransitionGroup>
       {safes.map((item) => (
         <Collapse key={item.address} timeout="auto">
-          {renderSafeItem(item, onLinkClick)}
+          {renderSafeItem(item, onLinkClick, isOrgSafe)}
         </Collapse>
       ))}
     </TransitionGroup>
   ) : (
     <>
       {safes.map((item) => (
-        <div key={item.address}>{renderSafeItem(item, onLinkClick)}</div>
+        <div key={item.address}>{renderSafeItem(item, onLinkClick, isOrgSafe)}</div>
       ))}
     </>
   )

--- a/apps/web/src/features/myAccounts/hooks/useAllSafesGrouped.ts
+++ b/apps/web/src/features/myAccounts/hooks/useAllSafesGrouped.ts
@@ -42,8 +42,9 @@ export const _getSingleChainAccounts = (safes: SafeItems, allMultiChainSafes: Mu
   return safes.filter((safe) => !allMultiChainSafes.some((multiSafe) => sameAddress(multiSafe.address, safe.address)))
 }
 
-export const useAllSafesGrouped = () => {
-  const allSafes = useAllSafes()
+export const useAllSafesGrouped = (customSafes?: SafeItems) => {
+  const safes = useAllSafes()
+  const allSafes = customSafes ?? safes
 
   return useMemo<AllSafeItemsGrouped>(() => {
     if (!allSafes) {

--- a/apps/web/src/features/organizations/components/SafeAccountList/EmptySafeAccounts.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccountList/EmptySafeAccounts.tsx
@@ -1,37 +1,9 @@
-import AddAccounts from '@/features/organizations/components/AddAccounts'
-import { useState } from 'react'
-import { Card, Stack, SvgIcon, TextField, Typography } from '@mui/material'
-import InputAdornment from '@mui/material/InputAdornment'
-import SearchIcon from '@/public/images/common/search.svg'
+import { Card, Typography } from '@mui/material'
 import SafeAccountsIcon from '@/public/images/orgs/safe-accounts.svg'
 
 const EmptySafeAccounts = () => {
-  const [searchQuery, setSearchQuery] = useState('')
-
   return (
     <>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2} mb={3}>
-        <TextField
-          placeholder="Search"
-          variant="filled"
-          hiddenLabel
-          value={searchQuery}
-          onChange={(e) => {
-            setSearchQuery(e.target.value)
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" />
-              </InputAdornment>
-            ),
-            disableUnderline: true,
-          }}
-          size="small"
-        />
-
-        <AddAccounts />
-      </Stack>
       <Card sx={{ p: 5, textAlign: 'center' }}>
         <SafeAccountsIcon />
 

--- a/apps/web/src/features/organizations/components/SafeAccountList/index.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccountList/index.tsx
@@ -1,12 +1,41 @@
 import SafesList from '@/features/myAccounts/components/SafesList'
+import type { SafeItem } from '@/features/myAccounts/hooks/useAllSafes'
 import { type AllSafeItems, useAllSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGrouped'
 import { getComparator } from '@/features/myAccounts/utils/utils'
+import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
 import { useAppSelector } from '@/store'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
+import { useOrganizationSafesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useMemo } from 'react'
 
+function _buildSafeItems(safes: Record<string, string[]>): SafeItem[] {
+  const result: SafeItem[] = []
+
+  for (const chainId in safes) {
+    const addresses = safes[chainId]
+    console.log(addresses)
+
+    addresses.forEach((address) => {
+      result.push({
+        chainId,
+        address,
+        isReadOnly: false,
+        isPinned: false,
+        lastVisited: 0,
+        name: undefined,
+      })
+    })
+  }
+
+  return result
+}
+
 const SafeAccountList = () => {
-  const safes = useAllSafesGrouped()
+  const orgId = useCurrentOrgId()
+  const { data } = useOrganizationSafesGetV1Query({ organizationId: Number(orgId) })
+  // @ts-ignore TODO: Fix type issue
+  const safeItems = data ? _buildSafeItems(data.safes) : undefined
+  const safes = useAllSafesGrouped(safeItems)
   const { orderBy } = useAppSelector(selectOrderByPreference)
   const sortComparator = getComparator(orderBy)
 

--- a/apps/web/src/features/organizations/components/SafeAccountList/index.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccountList/index.tsx
@@ -1,0 +1,21 @@
+import SafesList from '@/features/myAccounts/components/SafesList'
+import { type AllSafeItems, useAllSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGrouped'
+import { getComparator } from '@/features/myAccounts/utils/utils'
+import { useAppSelector } from '@/store'
+import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
+import { useMemo } from 'react'
+
+const SafeAccountList = () => {
+  const safes = useAllSafesGrouped()
+  const { orderBy } = useAppSelector(selectOrderByPreference)
+  const sortComparator = getComparator(orderBy)
+
+  const allSafes = useMemo<AllSafeItems>(
+    () => [...(safes.allMultiChainSafes ?? []), ...(safes.allSingleSafes ?? [])].sort(sortComparator),
+    [safes.allMultiChainSafes, safes.allSingleSafes, sortComparator],
+  )
+
+  return <SafesList safes={allSafes} isOrgSafe />
+}
+
+export default SafeAccountList

--- a/apps/web/src/features/organizations/components/SafeAccounts/OrgSafeContextMenu.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccounts/OrgSafeContextMenu.tsx
@@ -1,0 +1,74 @@
+import { type MouseEvent, useState } from 'react'
+import MoreVertIcon from '@mui/icons-material/MoreVert'
+import { SvgIcon } from '@mui/material'
+import IconButton from '@mui/material/IconButton'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import MenuItem from '@mui/material/MenuItem'
+import ContextMenu from '@/components/common/ContextMenu'
+import DeleteIcon from '@/public/images/common/delete.svg'
+import EditIcon from '@/public/images/common/edit.svg'
+
+enum ModalType {
+  RENAME = 'rename',
+  REMOVE = 'remove',
+}
+
+const defaultOpen = { [ModalType.RENAME]: false, [ModalType.REMOVE]: false }
+
+const OrgSafeContextMenu = () => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>()
+  const [open, setOpen] = useState<typeof defaultOpen>(defaultOpen)
+
+  const handleOpenContextMenu = (e: MouseEvent<HTMLButtonElement, globalThis.MouseEvent>) => {
+    e.stopPropagation()
+    setAnchorEl(e.currentTarget)
+  }
+
+  const handleCloseContextMenu = (e: Event) => {
+    e.stopPropagation()
+    setAnchorEl(undefined)
+  }
+
+  const handleOpenModal = (type: keyof typeof open) => () => {
+    setAnchorEl(undefined)
+    setOpen((prev) => ({ ...prev, [type]: true }))
+  }
+
+  /*
+  const handleCloseModal = () => {
+    setOpen(defaultOpen)
+  }
+  */
+
+  const hasName = false
+
+  return (
+    <>
+      <IconButton data-testid="safe-options-btn" edge="end" size="small" onClick={handleOpenContextMenu}>
+        <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />
+      </IconButton>
+      <ContextMenu anchorEl={anchorEl} open={!!anchorEl} onClose={handleCloseContextMenu}>
+        <MenuItem onClick={handleOpenModal(ModalType.RENAME)}>
+          <ListItemIcon>
+            <SvgIcon component={EditIcon} inheritViewBox fontSize="small" color="success" />
+          </ListItemIcon>
+          <ListItemText data-testid="rename-btn">{hasName ? 'Rename' : 'Give name'}</ListItemText>
+        </MenuItem>
+
+        <MenuItem onClick={handleOpenModal(ModalType.REMOVE)}>
+          <ListItemIcon>
+            <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" color="error" />
+          </ListItemIcon>
+          <ListItemText data-testid="remove-btn">Remove</ListItemText>
+        </MenuItem>
+      </ContextMenu>
+
+      {open[ModalType.RENAME] && <>{/* TODO: Render rename safe account modal */}</>}
+
+      {open[ModalType.REMOVE] && <>{/* TODO: Render Remove safe account modal */}</>}
+    </>
+  )
+}
+
+export default OrgSafeContextMenu

--- a/apps/web/src/features/organizations/components/SafeAccounts/OrgSafeContextMenu.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccounts/OrgSafeContextMenu.tsx
@@ -35,12 +35,6 @@ const OrgSafeContextMenu = () => {
     setOpen((prev) => ({ ...prev, [type]: true }))
   }
 
-  /*
-  const handleCloseModal = () => {
-    setOpen(defaultOpen)
-  }
-  */
-
   const hasName = false
 
   return (

--- a/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
@@ -1,12 +1,48 @@
+import AddAccounts from '@/features/organizations/components/AddAccounts'
+import SafeAccountList from '@/features/organizations/components/SafeAccountList'
 import EmptySafeAccounts from '@/features/organizations/components/SafeAccountList/EmptySafeAccounts'
+import SearchIcon from '@/public/images/common/search.svg'
+import { Stack, SvgIcon, TextField, Typography } from '@mui/material'
+import InputAdornment from '@mui/material/InputAdornment'
+import { useState } from 'react'
 
 const OrganizationSafeAccounts = () => {
+  const [searchQuery, setSearchQuery] = useState('')
+
   const safeAccounts = [] // TODO: Fetch from backend
 
-  if (safeAccounts.length === 0) return <EmptySafeAccounts />
+  return (
+    <>
+      <Typography variant="h1" mb={3}>
+        Safe Accounts
+      </Typography>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2} mb={3}>
+        <TextField
+          placeholder="Search"
+          variant="filled"
+          hiddenLabel
+          value={searchQuery}
+          onChange={(e) => {
+            setSearchQuery(e.target.value)
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" />
+              </InputAdornment>
+            ),
+            disableUnderline: true,
+          }}
+          size="small"
+        />
 
-  // TODO: Render safe acounts list
-  return <></>
+        <AddAccounts />
+      </Stack>
+
+      {/* TODO: Fix the condition once data is ready */}
+      {safeAccounts.length !== 0 ? <EmptySafeAccounts /> : <SafeAccountList />}
+    </>
+  )
 }
 
 export default OrganizationSafeAccounts


### PR DESCRIPTION
## What it solves

Resolves #5065

## How this PR fixes it

- Creates a new component called `SafeAccountList`
- Adjusts `SafesList`, `SingleAccountItem` and `MultiAccountItem` to take a new prop called `isOrgSafe`
- Adjusts render logic depending on `isOrgSafe`

## How to test it

1. Open an org
2. Go to the safe accounts view
3. Observe a list of owned safes rendering
4. Compare with the Design

## Screenshots

<img width="1508" alt="Screenshot 2025-02-21 at 13 16 47" src="https://github.com/user-attachments/assets/59c29939-e2d6-474c-855a-90b6d0c3afc7" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
