### PR TITLE
Feat(Orgs): add members list to members page

### DIFF
--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -19,11 +19,13 @@ const OrganizationMembers = () => {
   const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
 
-  const members = []
   const invited =
     data?.members.filter(
       (member) => member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED,
     ) || []
+  const activeMembers =
+    data?.members.filter((member) => member.status === MemberStatus.INVITED || member.status === MemberStatus.ACTIVE) ||
+    []
 
   // TODO: Render members list
   return (
@@ -37,12 +39,13 @@ const OrganizationMembers = () => {
         </Button>
       </Stack>
       {/* Show the empty state placeholder if if the org creator is the only member */}
-      {members.length === 1 && invited.length === 0 ? (
+      {activeMembers.length === 0 && invited.length === 0 ? (
+        // {members.length === 0 && invited.length === 0 ? (
         <EmptyMembers />
       ) : (
         <>
           {invited.length > 0 && <InvitesList invitedMembers={invited} />}
-          {members.length === 0 ? <EmptyMembers /> : <MembersList />}
+          {activeMembers.length === 0 ? <EmptyMembers /> : <MembersList members={activeMembers} />}
         </>
       )}
       {openAddMembersModal && <AddMembersModal onClose={() => setOpenAddMembersModal(false)} />}

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -1,5 +1,6 @@
-import { Chip, IconButton, Stack, SvgIcon, Typography } from '@mui/material'
+import { Chip, IconButton, Stack, SvgIcon, Tooltip, Typography } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import EditIcon from '@/public/images/common/edit.svg'
 import { MemberRole } from '../AddMembersModal'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import EnhancedTable from '@/components/common/EnhancedTable'
@@ -51,6 +52,11 @@ const MembersList = ({ members }: { members: UserOrganization[] }) => {
           sticky: true,
           content: (
             <div className={tableCss.actions}>
+              <Tooltip title="Edit entry" placement="top">
+                <IconButton onClick={() => {}} size="small">
+                  <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
+                </IconButton>
+              </Tooltip>
               <IconButton onClick={() => {}} size="small">
                 <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
               </IconButton>

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -1,6 +1,74 @@
-const MembersList = () => {
-  // TODO: Implement this for the dashboard and members view
-  return <></>
+import { Chip, IconButton, Stack, SvgIcon, Typography } from '@mui/material'
+import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { MemberRole } from '../AddMembersModal'
+import DeleteIcon from '@/public/images/common/delete.svg'
+import EnhancedTable from '@/components/common/EnhancedTable'
+import tableCss from '@/components/common/EnhancedTable/styles.module.css'
+
+const headCells = [
+  {
+    id: 'name',
+    label: 'Name',
+    width: '70%',
+  },
+  {
+    id: 'role',
+    label: 'Role',
+    width: '15%',
+  },
+  {
+    id: 'actions',
+    label: '',
+    width: '15%',
+    sticky: true,
+  },
+]
+
+const MembersList = ({ members }: { members: UserOrganization[] }) => {
+  const rows = members.map((member) => {
+    return {
+      cells: {
+        name: {
+          rawValue: member.id,
+          content: (
+            <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
+              User id: {member.id}
+            </Stack>
+          ),
+        },
+        role: {
+          rawValue: member.role,
+          content: (
+            <Chip
+              size="small"
+              label={member.role === MemberRole.ADMIN ? 'Admin' : 'Member'}
+              sx={{ backgroundColor: 'background.lightgrey', borderRadius: 0.5 }}
+            />
+          ),
+        },
+        actions: {
+          rawValue: '',
+          sticky: true,
+          content: (
+            <div className={tableCss.actions}>
+              <IconButton onClick={() => {}} size="small">
+                <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
+              </IconButton>
+            </div>
+          ),
+        },
+      },
+    }
+  })
+
+  return (
+    <>
+      <Typography variant="h5" fontWeight={700} mb={2} mt={1}>
+        All Members ({members.length})
+      </Typography>
+      <EnhancedTable rows={rows} headCells={headCells} />
+    </>
+  )
 }
 
 export default MembersList


### PR DESCRIPTION
## What it solves

Partially Resolves #4957

## How this PR fixes it
- adds the list of members for the current org to the members page.
Note: only displays the user id for now since we have not handled setting names yet.

## How to test it
- go to the members page.
- see that the members list contains the list of all current members in the org.

## Screenshots
![image](https://github.com/user-attachments/assets/fe6f327f-1b8f-4549-a986-dd10c76cb856)

Only one member:
![image](https://github.com/user-attachments/assets/fb19b95b-77ab-4f56-853f-cc677572bb09)



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
