### PR TITLE
Fix(Orgs): duplicate nav items in orgs sidebar 

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsSidebarNavigation/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarNavigation/index.tsx
@@ -22,8 +22,8 @@ const Navigation = (): ReactElement => {
         const isSelected = router.asPath === itemPath
 
         return (
-          <div key={itemPath}>
-            <ListItemButton disabled={item.disabled} sx={{ padding: 0 }} selected={isSelected} key={itemPath}>
+          <div key={item.label}>
+            <ListItemButton disabled={item.disabled} sx={{ padding: 0 }} selected={isSelected}>
               <SidebarListItemButton selected={isSelected} href={itemPath}>
                 {item.icon && <SidebarListItemIcon>{item.icon}</SidebarListItemIcon>}
 


### PR DESCRIPTION
## What it solves
Duplicate nav items in the orgs sidebar

## How this PR fixes it
Uses the nav label as the list key.

## How to test it
- Load a route with the orgs sidebar.
- observe no console errors.
- when running locally, hot reloads will not cause duplicate items to appear in the sidebar list.


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
