### PR TITLE
Feat(Orgs): allow deletion of invited users

### DIFF
--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -2,10 +2,12 @@ import EnhancedTable from '@/components/common/EnhancedTable'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { Box, Button, Chip, IconButton, Stack, SvgIcon, Typography } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useUserOrganizationsRemoveUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import { MemberStatus } from '.'
 import { MemberRole } from '../AddMembersModal'
+import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 
 const headCells = [
   {
@@ -27,6 +29,13 @@ const headCells = [
 ]
 
 const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] }) => {
+  const [deleteInvite] = useUserOrganizationsRemoveUserV1Mutation()
+  const currentOrgId = useCurrentOrgId()
+
+  const handleDeleteInvite = (invitedId: number) => {
+    deleteInvite({ orgId: Number(currentOrgId), userId: invitedId })
+  }
+
   const rows = invitedMembers.map((member) => {
     const isDeclined = member.status === MemberStatus.DECLINED
     return {
@@ -64,7 +73,7 @@ const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] })
                   Resend
                 </Button>
               )}
-              <IconButton onClick={() => {}} size="small">
+              <IconButton onClick={() => handleDeleteInvite(member.user.id)} size="small">
                 <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
               </IconButton>
             </div>

--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -32,8 +32,12 @@ const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] })
   const [deleteInvite] = useUserOrganizationsRemoveUserV1Mutation()
   const currentOrgId = useCurrentOrgId()
 
-  const handleDeleteInvite = (invitedId: number) => {
-    deleteInvite({ orgId: Number(currentOrgId), userId: invitedId })
+  const handleDeleteInvite = async (invitedId: number) => {
+    try {
+      await deleteInvite({ orgId: Number(currentOrgId), userId: invitedId })
+    } catch (error) {
+      // TODO: handle error
+    }
   }
 
   const rows = invitedMembers.map((member) => {


### PR DESCRIPTION
## What it solves

Partially Resolves #4957

## How this PR fixes it
- allows user to remove invited accounts from the pending invites list.

## How to test it
- go to the members page.
- Invite an address to join the org.
- when the invited user appears in the list, click the delete icon on the right.
- the invited user should be removed from the list.
- The invited user should no longer see the invite in their orgs list.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
