### PR TITLE
fix(mobile): blokie was not rendered correctly on iOS

### DIFF
--- a/apps/mobile/src/components/Identicon/Identicon.test.tsx
+++ b/apps/mobile/src/components/Identicon/Identicon.test.tsx
@@ -11,21 +11,22 @@ describe('Identicon', () => {
 
   it('applies rounded style when rounded prop is true', () => {
     const { getByTestId } = render(<Identicon address="0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6" rounded />)
-    const image = getByTestId('identicon-image')
+    const image = getByTestId('identicon-image-container')
     expect(image.props.style.borderRadius).toBe('50%')
   })
 
   it('applies default size when size prop is not provided', () => {
     const { getByTestId } = render(<Identicon address="0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6" />)
     const image = getByTestId('identicon-image')
-    expect(image.props.style.width).toBe(56)
-    expect(image.props.style.height).toBe(56)
+    expect(image.props.width).toBe(56)
+    expect(image.props.height).toBe(56)
   })
 
   it('applies custom size when size prop is provided', () => {
     const { getByTestId } = render(<Identicon address="0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6" size={100} />)
     const image = getByTestId('identicon-image')
-    expect(image.props.style.width).toBe(100)
-    expect(image.props.style.height).toBe(100)
+
+    expect(image.props.width).toBe(100)
+    expect(image.props.height).toBe(100)
   })
 })

--- a/apps/mobile/src/components/Identicon/Identicon.tsx
+++ b/apps/mobile/src/components/Identicon/Identicon.tsx
@@ -16,7 +16,7 @@ export const Identicon = ({ address, rounded, size }: Props) => {
   const blockieSvg = bloSvg(address)
 
   return (
-    <View style={{ borderRadius: rounded ? '50%' : 0, overflow: 'hidden' }}>
+    <View style={{ borderRadius: rounded ? '50%' : 0, overflow: 'hidden' }} testID={'identicon-image-container'}>
       <SvgXml testID={'identicon-image'} xml={blockieSvg} width={size} height={size} />
     </View>
   )

--- a/apps/mobile/src/components/Identicon/Identicon.tsx
+++ b/apps/mobile/src/components/Identicon/Identicon.tsx
@@ -1,7 +1,7 @@
-import { blo } from 'blo'
-import { Image } from 'expo-image'
+import { bloSvg } from 'blo'
 import { type Address } from '@/src/types/address'
 import { View } from 'tamagui'
+import { SvgXml } from 'react-native-svg'
 
 type Props = {
   address: Address
@@ -11,17 +11,13 @@ type Props = {
 
 const DEFAULT_SIZE = 56
 export const Identicon = ({ address, rounded, size }: Props) => {
-  const style = {
-    borderRadius: rounded ? '50%' : 0,
-    width: size ? size : DEFAULT_SIZE,
-    height: size ? size : DEFAULT_SIZE,
-  }
+  size = size ? size : DEFAULT_SIZE
 
-  const blockie = blo(address)
+  const blockieSvg = bloSvg(address)
 
   return (
-    <View style={{ borderRadius: '50%', overflow: 'hidden' }}>
-      <Image testID={'identicon-image'} source={{ uri: blockie }} style={style} />
+    <View style={{ borderRadius: rounded ? '50%' : 0, overflow: 'hidden' }}>
+      <SvgXml testID={'identicon-image'} xml={blockieSvg} width={size} height={size} />
     </View>
   )
 }


### PR DESCRIPTION
## What it solves
Without this fix the identicons generated in iOS were different than the ones on web:
![grafik](https://github.com/user-attachments/assets/7a5be5fe-30d5-4add-bd96-d2ebfc9d63f7)

with this fix they are identical:
![grafik](https://github.com/user-attachments/assets/212a3db4-cb43-412f-aba8-ee7f5f78f11d)

I’ve compared the generated data-uri on web and ios and they are 100% identical. So the problem can't be in the userd library: blockie. It must be something in expo-image that uses different kind of rendering for the data-uri. As a workaround I now generate the svg with bloSvg and use react-native-svg to render it directly. Seems to work fine.


## How to test it
The problem doesn't occur with every address. This one was different, but now should be the same:
eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6

Open that safe both on mobile and in web and the blockies should match.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
