### PR TITLE
fix(web): appUrl query was getting lost while switching network in safeApp 

### DIFF
--- a/apps/web/src/components/common/NetworkSelector/index.tsx
+++ b/apps/web/src/components/common/NetworkSelector/index.tsx
@@ -81,6 +81,7 @@ export const getNetworkLink = (router: NextRouter, safeAddress: string, networkS
     safe?: string
     chain?: string
     safeViewRedirectURL?: string
+    appUrl?: string
   }
 
   const route = {
@@ -90,6 +91,10 @@ export const getNetworkLink = (router: NextRouter, safeAddress: string, networkS
 
   if (router.query?.safeViewRedirectURL) {
     route.query.safeViewRedirectURL = router.query?.safeViewRedirectURL.toString()
+  }
+
+  if (router.query?.appUrl) {
+    route.query.appUrl = router.query.appUrl.toString()
   }
 
   return route

--- a/apps/web/src/pages/apps/open.tsx
+++ b/apps/web/src/pages/apps/open.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useCallback } from 'react'
-import { Box, CircularProgress } from '@mui/material'
+import { Box, CircularProgress, Typography } from '@mui/material'
 
 import { useSafeAppUrl } from '@/hooks/safe-apps/useSafeAppUrl'
 import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
@@ -83,6 +83,32 @@ const SafeApps: NextPage = () => {
   if (isLoading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" height="100%">
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (!remoteSafeAppsLoading && !isLoading && safeApp.chainIds.length === 0) {
+    setTimeout(() => {
+      router.push({
+        pathname: AppRoutes.apps.index,
+        query: { safe: router.query.safe },
+      })
+    }, 3000)
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        height="100%"
+        textAlign="center"
+        p={2}
+      >
+        <Typography variant="body1" gutterBottom>
+          Chain {chainId} is not supported in this app. <br />
+          Redirecting to home page
+        </Typography>
         <CircularProgress />
       </Box>
     )


### PR DESCRIPTION
## What it solves

Resolves #4980

## How this PR fixes it
In File _apps/web/src/components/common/NetworkSelector/index.tsx_
```
export const getNetworkLink = (router: NextRouter, safeAddress: string, networkShortName: string) => {
  const isSafeOpened = safeAddress !== ''

  const query = (
    isSafeOpened
      ? {
          safe: `${networkShortName}:${safeAddress}`,
        }
      : { chain: networkShortName }
  ) as {
    safe?: string
    chain?: string
    safeViewRedirectURL?: string
    appUrl?: string // Added this to the query
  }

  const route = {
    pathname: router.pathname,
    query,
  }

  if (router.query?.safeViewRedirectURL) {
    route.query.safeViewRedirectURL = router.query?.safeViewRedirectURL.toString()
  }

  if (router.query?.appUrl) {
    route.query.appUrl = router.query.appUrl.toString()
  } // if present then appUrl should be populated

  return route
}
```
## How to test it

yarn workspace @safe-global/web start

create a safe multi chain account
go inside a safeApp
switch network in there 

## Screenshots

https://github.com/user-attachments/assets/9ad91240-32f9-439e-b380-1770616202aa

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
