### PR TITLE
chore(web): force higher elliptic version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@safe-global/protocol-kit/ethers": "6.13.4",
     "@safe-global/api-kit/ethers": "6.13.4",
     "@gnosis.pm/zodiac/ethers": "6.13.4",
-    "@cowprotocol/events": "1.3.0"
+    "@cowprotocol/events": "1.3.0",
+    "@ethersproject/signing-key/elliptic": "^6.6.1"
   },
   "devDependencies": {
     "husky": "^9.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16210,22 +16210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.5.4":
-  version: 6.5.4
-  resolution: "elliptic@npm:6.5.4"
-  dependencies:
-    bn.js: "npm:^4.11.9"
-    brorand: "npm:^1.1.0"
-    hash.js: "npm:^1.0.0"
-    hmac-drbg: "npm:^1.0.1"
-    inherits: "npm:^2.0.4"
-    minimalistic-assert: "npm:^1.0.1"
-    minimalistic-crypto-utils: "npm:^1.0.1"
-  checksum: 10/2cd7ff4b69720dbb2ca1ca650b2cf889d1df60c96d4a99d331931e4fe21e45a7f3b8074e86618ca7e56366c4b6258007f234f9d61d9b0c87bbbc8ea990b99e94
-  languageName: node
-  linkType: hard
-
-"elliptic@npm:6.6.1, elliptic@npm:^6.5.3, elliptic@npm:^6.5.5, elliptic@npm:^6.5.7":
+"elliptic@npm:6.6.1, elliptic@npm:^6.5.3, elliptic@npm:^6.5.5, elliptic@npm:^6.5.7, elliptic@npm:^6.6.1":
   version: 6.6.1
   resolution: "elliptic@npm:6.6.1"
   dependencies:


### PR DESCRIPTION
## What it solves
Pin a higher elliptic curve version of the package

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
