### PR TITLE
Feat(Orgs): add search to members list

### DIFF
--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -90,7 +90,7 @@ const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] })
   return (
     <>
       <Typography variant="h5" fontWeight={700} mb={2}>
-        Pending Invitations
+        Pending Invitations ({invitedMembers.length})
       </Typography>
       <EnhancedTable rows={rows} headCells={headCells} />
     </>

--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -1,12 +1,14 @@
-import EmptyMembers from '@/features/organizations/components/MembersList/EmptyMembers'
 import PlusIcon from '@/public/images/common/plus.svg'
-import { Button, Stack, Typography } from '@mui/material'
+import { Button, InputAdornment, Stack, SvgIcon, TextField, Typography } from '@mui/material'
 import AddMembersModal from '@/features/organizations/components/AddMembersModal'
 import { useState } from 'react'
 import MembersList from '../MembersList'
 import InvitesList from './InvitesList'
 import { useUserOrganizationsGetUsersV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
+import SearchIcon from '@/public/images/common/search.svg'
+import { useMembersSearch } from '../../hooks/useMembersSearch'
+import { maybePlural } from '@/utils/formatters'
 
 export enum MemberStatus {
   INVITED = 'INVITED',
@@ -18,6 +20,7 @@ const OrganizationMembers = () => {
   const orgId = useCurrentOrgId()
   const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
 
   const invited =
     data?.members.filter(
@@ -25,20 +28,50 @@ const OrganizationMembers = () => {
     ) || []
   const activeMembers = data?.members.filter((member) => member.status === MemberStatus.ACTIVE) || []
 
+  const filteredMembers = useMembersSearch(activeMembers, searchQuery)
+
   // TODO: Render members list
   return (
     <>
+      <Typography variant="h1" mb={3}>
+        Members
+      </Typography>
       <Stack direction="row" justifyContent="space-between" alignItems="center" mb={3}>
-        <Typography variant="h1" fontWeight={700}>
-          Members
-        </Typography>
-        <Button size="small" variant="contained" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>
+        <TextField
+          placeholder="Search"
+          variant="filled"
+          hiddenLabel
+          value={searchQuery}
+          onChange={(e) => {
+            setSearchQuery(e.target.value)
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" />
+              </InputAdornment>
+            ),
+            disableUnderline: true,
+          }}
+          size="small"
+        />
+        <Button variant="contained" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>
           Add member
         </Button>
       </Stack>
-      {invited.length > 0 && <InvitesList invitedMembers={invited} />}
-      <MembersList members={activeMembers} />
-      {invited.length === 0 && activeMembers.length === 1 && <EmptyMembers />}
+      {invited.length > 0 && !searchQuery && <InvitesList invitedMembers={invited} />}
+      <>
+        {searchQuery ? (
+          <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">
+            Found {filteredMembers.length} result{maybePlural(filteredMembers)}
+          </Typography>
+        ) : (
+          <Typography variant="h5" fontWeight={700} mb={2} mt={1}>
+            All Members ({filteredMembers.length})
+          </Typography>
+        )}
+        <MembersList members={filteredMembers} />
+      </>
 
       {openAddMembersModal && <AddMembersModal onClose={() => setOpenAddMembersModal(false)} />}
     </>

--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -30,7 +30,6 @@ const OrganizationMembers = () => {
 
   const filteredMembers = useMembersSearch(activeMembers, searchQuery)
 
-  // TODO: Render members list
   return (
     <>
       <Typography variant="h1" mb={3}>

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -1,4 +1,4 @@
-import { Chip, IconButton, Stack, SvgIcon, Tooltip, Typography } from '@mui/material'
+import { Chip, IconButton, Stack, SvgIcon, Tooltip } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import EditIcon from '@/public/images/common/edit.svg'
 import { MemberRole } from '../AddMembersModal'
@@ -66,15 +66,11 @@ const MembersList = ({ members }: { members: UserOrganization[] }) => {
       },
     }
   })
+  if (!rows.length) {
+    return null
+  }
 
-  return (
-    <>
-      <Typography variant="h5" fontWeight={700} mb={2} mt={1}>
-        All Members ({members.length})
-      </Typography>
-      <EnhancedTable rows={rows} headCells={headCells} />
-    </>
-  )
+  return <EnhancedTable rows={rows} headCells={headCells} />
 }
 
 export default MembersList

--- a/apps/web/src/features/organizations/hooks/useMembersSearch.ts
+++ b/apps/web/src/features/organizations/hooks/useMembersSearch.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react'
+import Fuse from 'fuse.js'
+import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+
+const useMembersSearch = (members: UserOrganization[], query: string): UserOrganization[] => {
+  const fuse = useMemo(
+    () =>
+      new Fuse(members, {
+        keys: [{ name: 'id' }],
+        threshold: 0.2,
+        findAllMatches: true,
+        ignoreLocation: true,
+      }),
+    [members],
+  )
+
+  return useMemo(() => (query ? fuse.search(query).map((result) => result.item) : members), [fuse, query, members])
+}
+
+export { useMembersSearch }


### PR DESCRIPTION
## What it solves

Resolves #5100

## How this PR fixes it
- implements search on the members list.

NOTE: since names are not implemented yet on the backend, it searches with the member ID for now.
exact implementation is tbd so for no it only searches added members and not pending.

## How to test it
- Open an org and go to the members page.
- type in the search bar. 
- The members list should be updated
- Type the id of one of the members in the list.
- That member should be shown, and all other members should be filtered out.

## Screenshots
![image](https://github.com/user-attachments/assets/48d5efae-5d51-42e6-90ca-422caf92a133)
![image](https://github.com/user-attachments/assets/6cc311b8-34d3-4f26-b2d3-c10f0e4f51de)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
