### PR TITLE
Feat(Orgs): sign out on disconnect wallet

### DIFF
--- a/apps/web/src/components/common/WalletInfo/index.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.tsx
@@ -6,11 +6,13 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import ChainSwitcher from '@/components/common/ChainSwitcher'
 import useOnboard, { type ConnectedWallet, switchWallet } from '@/hooks/wallets/useOnboard'
 import useAddressBook from '@/hooks/useAddressBook'
-import { useAppSelector } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
 import { selectChainById } from '@/store/chainsSlice'
 import madProps from '@/utils/mad-props'
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 import useChainId from '@/hooks/useChainId'
+import { useAuthLogoutV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
+import { setUnauthenticated } from '@/store/authSlice'
 
 type WalletInfoProps = {
   wallet: ConnectedWallet
@@ -22,6 +24,8 @@ type WalletInfoProps = {
 }
 
 export const WalletInfo = ({ wallet, balance, currentChainId, onboard, addressBook, handleClose }: WalletInfoProps) => {
+  const [authLogout] = useAuthLogoutV1Mutation()
+  const dispatch = useAppDispatch()
   const chainInfo = useAppSelector((state) => selectChainById(state, wallet.chainId))
   const prefix = chainInfo?.shortName
 
@@ -36,6 +40,8 @@ export const WalletInfo = ({ wallet, balance, currentChainId, onboard, addressBo
     onboard?.disconnectWallet({
       label: wallet.label,
     })
+    authLogout()
+    dispatch(setUnauthenticated())
 
     handleClose()
   }

--- a/apps/web/src/components/common/WalletInfo/index.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.tsx
@@ -36,12 +36,16 @@ export const WalletInfo = ({ wallet, balance, currentChainId, onboard, addressBo
     }
   }
 
-  const handleDisconnect = () => {
+  const handleDisconnect = async () => {
     onboard?.disconnectWallet({
       label: wallet.label,
     })
-    authLogout()
-    dispatch(setUnauthenticated())
+    try {
+      await authLogout()
+      dispatch(setUnauthenticated())
+    } catch (error) {
+      // TODO: handle error
+    }
 
     handleClose()
   }


### PR DESCRIPTION
## What it solves
Currently there is no way to go from the signed in state to the signed out state. We should allow the user to be able to sign out.

## How this PR fixes it
- Call the sign out endpoint when disconnecting the connected wallet.
- Set the redux state to logged out.

## How to test it
- go to the orgs list page in the signed in state. you should see the list of orgs.
- Disconnect your wallet.
- You should see the signed out state of the orgs list

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
