### PR TITLE
fix(web): re-verifying of address in new-safe/load when chain is switched fixes (#5067)

### DIFF
--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -64,6 +64,11 @@ const AddressInput = ({
   const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
   const { address, resolverError, resolving } = useNameResolver(isDomainLookupEnabled ? watchedValue : '')
 
+  // Re-validate when chainId changes
+  useEffect(() => {
+    trigger(address)
+  }, [currentChain?.chainId, trigger, address])
+
   // errors[name] doesn't work with nested field names like 'safe.address', need to use the lodash get
   const fieldError = resolverError || get(errors, name)
 

--- a/apps/web/src/components/common/NetworkSelector/index.tsx
+++ b/apps/web/src/components/common/NetworkSelector/index.tsx
@@ -81,6 +81,7 @@ export const getNetworkLink = (router: NextRouter, safeAddress: string, networkS
     safe?: string
     chain?: string
     safeViewRedirectURL?: string
+    appUrl?: string
   }
 
   const route = {
@@ -90,6 +91,10 @@ export const getNetworkLink = (router: NextRouter, safeAddress: string, networkS
 
   if (router.query?.safeViewRedirectURL) {
     route.query.safeViewRedirectURL = router.query?.safeViewRedirectURL.toString()
+  }
+
+  if (router.query?.appUrl) {
+    route.query.appUrl = router.query.appUrl.toString()
   }
 
   return route

--- a/apps/web/src/pages/apps/open.tsx
+++ b/apps/web/src/pages/apps/open.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useCallback } from 'react'
-import { Box, CircularProgress } from '@mui/material'
+import { Box, CircularProgress, Typography } from '@mui/material'
 
 import { useSafeAppUrl } from '@/hooks/safe-apps/useSafeAppUrl'
 import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
@@ -83,6 +83,32 @@ const SafeApps: NextPage = () => {
   if (isLoading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" height="100%">
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (!remoteSafeAppsLoading && !isLoading && safeApp.chainIds.length === 0) {
+    setTimeout(() => {
+      router.push({
+        pathname: AppRoutes.apps.index,
+        query: { safe: router.query.safe },
+      })
+    }, 3000)
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        height="100%"
+        textAlign="center"
+        p={2}
+      >
+        <Typography variant="body1" gutterBottom>
+          Chain {chainId} is not supported in this app. <br />
+          Redirecting to home page
+        </Typography>
         <CircularProgress />
       </Box>
     )


### PR DESCRIPTION
## What it solves
Resolves #5067 

## How this PR fixes it
**In `apps/web/src/components/common/AddressInput/index.tsx`**

The code change adds a dependency on `currentChain?.chainId` in the `useEffect` hook for the AddressInput component. This ensures that the input validation is re-triggered when the chain changes, preventing potential stale validation states across different blockchain networks.

```
  useEffect(() => {
    trigger(address)
  }, [currentChain?.chainId, trigger, address])
```

## How to test it
- Switch between different blockchain networks in the application
- Verify that address validation works correctly after network changes
## Screenshots


https://github.com/user-attachments/assets/9997eaa9-3aa5-46a5-8219-61d15a5cb3fb


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
