### PR TITLE
Fix(Orgs): use correct format for add accounts request

### DIFF
--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -72,7 +72,8 @@ const AddAccounts = () => {
       })
 
     try {
-      const result = await addSafesToOrg({ organizationId: Number(orgId), body: safesToAdd })
+      // @ts-ignore TODO: Fix type issue
+      const result = await addSafesToOrg({ organizationId: Number(orgId), body: { safes: safesToAdd } })
 
       if (result.error) {
         // TODO: Handle error message

--- a/apps/web/src/features/organizations/components/SafeAccountList/index.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccountList/index.tsx
@@ -7,6 +7,7 @@ import { useAppSelector } from '@/store'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import { useOrganizationSafesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useMemo } from 'react'
+import EmptySafeAccounts from './EmptySafeAccounts'
 
 function _buildSafeItems(safes: Record<string, string[]>): SafeItem[] {
   const result: SafeItem[] = []
@@ -44,7 +45,7 @@ const SafeAccountList = () => {
     [safes.allMultiChainSafes, safes.allSingleSafes, sortComparator],
   )
 
-  return <SafesList safes={allSafes} isOrgSafe />
+  return allSafes.length === 0 ? <EmptySafeAccounts /> : <SafesList safes={allSafes} isOrgSafe />
 }
 
 export default SafeAccountList


### PR DESCRIPTION
## What it solves
The payload type for the add accounts request from the CGW is wrong.

## How this PR fixes it
- Use the correct type and add a todo to update the type from the CGW when it is fixed.
- also adds back in the empty state for the accounts page when the org has no accounts.

## How to test it
- Go to the accounts page of an org. 
- If there are no accounts added yet you should see the empty accounts component.
- Click the add accounts button, select a safe, and submit. See that the form submits succesfully, and the safe now appears in the accounts page.


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
