### PR TITLE
Fix(Blockaid): pass dapp origin

### DIFF
--- a/apps/web/src/components/tx-flow/SafeTxProvider.tsx
+++ b/apps/web/src/components/tx-flow/SafeTxProvider.tsx
@@ -29,6 +29,9 @@ export type SafeTxContextParams = {
   setSafeTxGas: Dispatch<SetStateAction<string | undefined>>
 
   recommendedNonce?: number
+
+  txOrigin?: string
+  setTxOrigin: Dispatch<SetStateAction<string | undefined>>
 }
 
 export const SafeTxContext = createContext<SafeTxContextParams>({
@@ -38,6 +41,7 @@ export const SafeTxContext = createContext<SafeTxContextParams>({
   setNonce: () => {},
   setNonceNeeded: () => {},
   setSafeTxGas: () => {},
+  setTxOrigin: () => {},
 })
 
 const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => {
@@ -47,6 +51,7 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const [nonce, setNonce] = useState<number>()
   const [nonceNeeded, setNonceNeeded] = useState<boolean>(true)
   const [safeTxGas, setSafeTxGas] = useState<string>()
+  const [txOrigin, setTxOrigin] = useState<string>()
 
   const { safe } = useSafeInfo()
   const chain = useCurrentChain()
@@ -119,6 +124,8 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
         safeTxGas: finalSafeTxGas,
         setSafeTxGas,
         recommendedNonce,
+        txOrigin,
+        setTxOrigin,
       }}
     >
       {children}

--- a/apps/web/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
+++ b/apps/web/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
@@ -25,9 +25,14 @@ const ReviewSafeAppsTx = ({
 }: ReviewSafeAppsTxProps): ReactElement => {
   const onboard = useOnboard()
   const wallet = useWallet()
-  const { safeTx, setSafeTx, safeTxError, setSafeTxError } = useContext(SafeTxContext)
+  const { safeTx, setSafeTx, safeTxError, setSafeTxError, setTxOrigin } = useContext(SafeTxContext)
 
   useHighlightHiddenTab()
+
+  useEffect(() => {
+    setTxOrigin(app?.url)
+    return () => setTxOrigin(undefined)
+  }, [setTxOrigin, app?.url])
 
   useEffect(() => {
     const createSafeTx = async (): Promise<SafeTransaction> => {

--- a/apps/web/src/components/tx/security/blockaid/useBlockaid.ts
+++ b/apps/web/src/components/tx/security/blockaid/useBlockaid.ts
@@ -17,6 +17,7 @@ const DEFAULT_ERROR_MESSAGE = 'Unavailable'
 
 export const useBlockaid = (
   data: SafeTransaction | EIP712TypedData | undefined,
+  origin?: string,
 ): AsyncResult<SecurityResponse<BlockaidModuleResponse>> => {
   const { safe, safeAddress } = useSafeInfo()
   const signer = useSigner()
@@ -34,9 +35,10 @@ export const useBlockaid = (
         safeAddress,
         walletAddress: signer.address,
         threshold: safe.threshold,
+        origin,
       })
     },
-    [safe.chainId, safe.threshold, safeAddress, data, signer?.address, isFeatureEnabled],
+    [safe.chainId, safe.threshold, safeAddress, data, signer?.address, isFeatureEnabled, origin],
     false,
   )
 

--- a/apps/web/src/components/tx/security/shared/TxSecurityContext.tsx
+++ b/apps/web/src/components/tx/security/shared/TxSecurityContext.tsx
@@ -53,8 +53,8 @@ export type TxSecurityContextProps = {
 export const TxSecurityContext = createContext<TxSecurityContextProps>(defaultSecurityContextValues)
 
 export const TxSecurityProvider = ({ children }: { children: ReactElement }) => {
-  const { safeTx, safeMessage } = useContext(SafeTxContext)
-  const [blockaidResponse, blockaidError, blockaidLoading] = useBlockaid(safeTx ?? safeMessage)
+  const { safeTx, safeMessage, txOrigin } = useContext(SafeTxContext)
+  const [blockaidResponse, blockaidError, blockaidLoading] = useBlockaid(safeTx ?? safeMessage, txOrigin)
 
   const [isRiskConfirmed, setIsRiskConfirmed] = useState(false)
   const [isRiskIgnored, setIsRiskIgnored] = useState(false)

--- a/apps/web/src/services/security/modules/BlockaidModule/index.ts
+++ b/apps/web/src/services/security/modules/BlockaidModule/index.ts
@@ -23,6 +23,7 @@ export type BlockaidModuleRequest = {
   walletAddress: string
   data: SafeTransaction | EIP712TypedData
   threshold: number
+  origin?: string
 }
 
 export type BlockaidModuleResponse = {
@@ -89,8 +90,7 @@ export class BlockaidModule implements SecurityModule<BlockaidModuleRequest, Blo
       },
       options: ['simulation', 'validation'],
       metadata: {
-        // TODO: Pass domain from safe app or wallet connect connection if the tx originates from there
-        domain: window.location.host,
+        domain: request.origin ?? 'non_dapp',
       },
     }
     const res = await fetch(`${BLOCKAID_API}/v0/evm/json-rpc/scan`, {


### PR DESCRIPTION
## What it solves

We were passing the wrong `metadata.domain` to Blockaid API:
* For txs made via Safe Wallet itself, it should be `non_dapp`
* For Safe Apps and apps connected via WalletConnect – their URL