### PR TITLE
fix(web): Updated re-verifying of address in new-safe/load when chain is switched fixes (#5067)

### DIFF
--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -64,6 +64,11 @@ const AddressInput = ({
   const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
   const { address, resolverError, resolving } = useNameResolver(isDomainLookupEnabled ? watchedValue : '')
 
+  // Re-validate when chainId changes
+  useEffect(() => {
+    trigger(address)
+  }, [currentChain?.chainId, trigger, address])
+
   // errors[name] doesn't work with nested field names like 'safe.address', need to use the lodash get
   const fieldError = resolverError || get(errors, name)
 


### PR DESCRIPTION
## What it solves
Resolves #5067

## How this PR fixes it
`In apps/web/src/components/common/AddressInput/index.tsx
`

The code change adds a dependency on currentChain?.chainId in the useEffect hook for the AddressInput component. This ensures that the input validation is re-triggered when the chain changes, preventing potential stale validation states across different blockchain networks.

```
  useEffect(() => {
    trigger(address)
  }, [currentChain?.chainId, trigger, address])
```

## How to test it
- Switch between different blockchain networks in the application
- Verify that address validation works correctly after network changes

## Screen Recordings

https://github.com/user-attachments/assets/3543c8c9-533f-493b-9e5d-13675f482373



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻