### PR TITLE
added margin for continue button in ImportAccount and AddSigners fixes #5069

### DIFF
--- a/apps/mobile/src/features/ImportReadOnly/components/AddSignersFormView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/AddSignersFormView.tsx
@@ -27,7 +27,7 @@ export const AddSignersFormView = ({
       />
 
       <View paddingHorizontal={16}>
-        <SafeButton onPress={onPress} testID={'continue-button'}>
+        <SafeButton onPress={onPress} testID={'continue-button'} marginBottom={70}>
           Continue
         </SafeButton>
       </View>

--- a/apps/mobile/src/features/ImportReadOnly/components/ImportAccountFormView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/ImportAccountFormView.tsx
@@ -91,6 +91,7 @@ export const ImportAccountFormView: React.FC<ImportAccountFormViewProps> = ({
         onPress={onContinue}
         disabled={!isEnteredAddressValid || !safeExists}
         testID={'continue-button'}
+        marginBottom={70}
       >
         Continue
       </SafeButton>


### PR DESCRIPTION
## What it solves

Resolves #5069

## Environment

Iphone 16 (Xcode Simulator)

## How this PR fixes it

kept bottom margin to 70px in `<SafeButton />` component which adjusts to the keyboard properly in both
`apps/mobile/src/features/ImportReadOnly/components/ImportAccountFormView.tsx`
`apps/mobile/src/features/ImportReadOnly/components/AddSignersFormView.tsx`

## How to test it
Add an account in the ios app
## Screen Recordings


https://github.com/user-attachments/assets/1f23d274-af1a-456d-b4d4-37157cafdaa8



## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
