### PR TITLE
ci(web): upload release assets to github release

### DIFF
--- a/.github/workflows/web-deploy-production.yml
+++ b/.github/workflows/web-deploy-production.yml
@@ -56,3 +56,23 @@ jobs:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
           VERSION_TAG: ${{ github.event.release.tag_name }}
+
+      - name: Upload archive as release asset
+        run: |
+          echo "Uploading asset to release..."
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @"./${{ env.ARCHIVE_NAME }}.tar.gz" \
+            "${{ github.event.release.upload_url }}?name=${{ env.ARCHIVE_NAME }}.tar.gz"
+        working-directory: apps/web
+
+      - name: Upload checksum as release asset (checksum)
+        run: |
+          echo "Uploading asset to release..."
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @"./${{ env.ARCHIVE_NAME }}-sha256-checksum.txt" \
+            "${{ github.event.release.upload_url }}?name=${{ env.ARCHIVE_NAME }}-sha256-checksum.txt"
+        working-directory: apps/web


### PR DESCRIPTION
## What it solves
Uploads the arhive tar and checkum to github release for easier reference.
