### PR TITLE
Feat(Orgs): Add members list to the dashboard

### DIFF
--- a/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
@@ -1,6 +1,6 @@
 import { Card, Box, Stack, Button, Typography } from '@mui/material'
 import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
-import { OrgLogo, OrgSummary } from '../OrgsCard'
+import { InitialsAvatar, OrgSummary } from '../OrgsCard'
 import {
   useUserOrganizationsAcceptInviteV1Mutation,
   useUserOrganizationsDeclineInviteV1Mutation,
@@ -38,7 +38,7 @@ const OrgListInvite = ({ org }: OrgListInvite) => {
       <Card sx={{ p: 2, backgroundColor: 'background.main' }}>
         <Stack direction="row" spacing={2} alignItems="center">
           <Box>
-            <OrgLogo orgName={name} size="large" />
+            <InitialsAvatar orgName={name} size="large" />
           </Box>
 
           <Box flexGrow={1}>

--- a/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
@@ -15,9 +15,7 @@ const DashboardMembersList = ({ members, displayLimit }: { members: UserOrganiza
         {membersToDisplay.map((member) => (
           <Stack direction="row" spacing={1} mb={2} alignItems="center" key={member.id}>
             <InitialsAvatar size="medium" orgName={member.user.id.toString()} rounded />
-            <Typography fontSize="14px" key={member.id}>
-              User Id: {member.user.id}
-            </Typography>
+            <Typography fontSize="14px">User Id: {member.user.id}</Typography>
           </Stack>
         ))}
         <Box display="flex" justifyContent="center">

--- a/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
@@ -1,6 +1,6 @@
 import { Paper, Stack, Typography, Button, Box } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
-import { OrgLogo } from '../OrgsCard'
+import { InitialsAvatar } from '../OrgsCard'
 import PlusIcon from '@/public/images/common/plus.svg'
 import { useState } from 'react'
 import AddMembersModal from '../AddMembersModal'
@@ -14,7 +14,7 @@ const DashboardMembersList = ({ members, displayLimit }: { members: UserOrganiza
       <Paper sx={{ p: 2, borderRadius: '8px' }}>
         {membersToDisplay.map((member) => (
           <Stack direction="row" spacing={1} mb={2} alignItems="center" key={member.id}>
-            <OrgLogo size="medium" orgName={member.user.id.toString()} rounded />
+            <InitialsAvatar size="medium" orgName={member.user.id.toString()} rounded />
             <Typography fontSize="14px" key={member.id}>
               User Id: {member.user.id}
             </Typography>

--- a/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
@@ -1,0 +1,34 @@
+import { Paper, Stack, Typography, Button, Box } from '@mui/material'
+import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { OrgLogo } from '../OrgsCard'
+import PlusIcon from '@/public/images/common/plus.svg'
+import { useState } from 'react'
+import AddMembersModal from '../AddMembersModal'
+
+const DashboardMembersList = ({ members, displayLimit }: { members: UserOrganization[]; displayLimit: number }) => {
+  const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
+  const membersToDisplay = members.slice(0, displayLimit)
+
+  return (
+    <>
+      <Paper sx={{ p: 2, borderRadius: '8px' }}>
+        {membersToDisplay.map((member) => (
+          <Stack direction="row" spacing={1} mb={2} alignItems="center" key={member.id}>
+            <OrgLogo size="medium" orgName={member.user.id.toString()} rounded />
+            <Typography fontSize="14px" key={member.id}>
+              User Id: {member.user.id}
+            </Typography>
+          </Stack>
+        ))}
+        <Box display="flex" justifyContent="center">
+          <Button size="small" variant="text" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>
+            Add member
+          </Button>
+        </Box>
+      </Paper>
+      {openAddMembersModal && <AddMembersModal onClose={() => setOpenAddMembersModal(false)} />}
+    </>
+  )
+}
+
+export default DashboardMembersList

--- a/apps/web/src/features/organizations/components/Dashboard/index.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/index.tsx
@@ -4,17 +4,19 @@ import OrgsCTACard from '@/features/organizations/components/Dashboard/OrgsCTACa
 import { Box, Grid2, Stack, Typography } from '@mui/material'
 import SignInButton from '@/features/organizations/components/SignInButton'
 import Grid from '@mui/material/Grid2'
-import css from './styles.module.css'
 import { useOrgSafes } from '@/features/organizations/hooks/useOrgSafes'
 import SafesList from '@/features/myAccounts/components/SafesList'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import AddAccountsCard from './AddAccountsCard'
 import { AppRoutes } from '@/config/routes'
-import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
+import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
 import NextLink from 'next/link'
 import { Link } from '@mui/material'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import DashboardMembersList from '@/features/organizations/components/Dashboard/DashboardMembersList'
+import { useOrgMembers } from '@/features/organizations/hooks/useOrgMembers'
+import css from './styles.module.css'
 
 const SignedOutState = () => {
   return (
@@ -57,6 +59,7 @@ const OrganizationsDashboard = () => {
   const safes = useOrgSafes()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const orgId = useCurrentOrgId()
+  const { activeMembers } = useOrgMembers()
 
   if (!isUserSignedIn) {
     return <SignedOutState />
@@ -72,7 +75,7 @@ const OrganizationsDashboard = () => {
 
           <Grid container spacing={3}>
             <Grid size={{ xs: 12, md: 8 }}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center" mb={3}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
                 <Typography variant="h5">Safe Accounts ({safes.length})</Typography>
                 {orgId && <ViewAllLink url={AppRoutes.organizations.safeAccounts(orgId)} />}
               </Stack>
@@ -80,10 +83,11 @@ const OrganizationsDashboard = () => {
               <SafesList safes={safes} isOrgSafe />
             </Grid>
             <Grid size={{ xs: 12, md: 4 }}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center" mb={3}>
-                <Typography variant="h5">Members</Typography>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+                <Typography variant="h5">Members ({activeMembers.length})</Typography>
                 {orgId && <ViewAllLink url={AppRoutes.organizations.members(orgId)} />}
               </Stack>
+              <DashboardMembersList members={activeMembers} displayLimit={5} />
             </Grid>
           </Grid>
         </>

--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -6,8 +6,8 @@ import { useUserOrganizationsRemoveUserV1Mutation } from '@safe-global/store/gat
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import { MemberRole } from '../AddMembersModal'
-import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
-import { MemberStatus } from '../../hooks/useOrgMembers'
+import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
+import { MemberStatus } from '@/features/organizations/hooks/useOrgMembers'
 
 const headCells = [
   {

--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -5,9 +5,9 @@ import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED
 import { useUserOrganizationsRemoveUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import DeleteIcon from '@/public/images/common/delete.svg'
-import { MemberStatus } from '.'
 import { MemberRole } from '../AddMembersModal'
 import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
+import { MemberStatus } from '../../hooks/useOrgMembers'
 
 const headCells = [
   {

--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -4,29 +4,15 @@ import AddMembersModal from '@/features/organizations/components/AddMembersModal
 import { useState } from 'react'
 import MembersList from '../MembersList'
 import InvitesList from './InvitesList'
-import { useUserOrganizationsGetUsersV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
-import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 import SearchIcon from '@/public/images/common/search.svg'
 import { useMembersSearch } from '../../hooks/useMembersSearch'
 import { maybePlural } from '@/utils/formatters'
-
-export enum MemberStatus {
-  INVITED = 'INVITED',
-  ACTIVE = 'ACTIVE',
-  DECLINED = 'DECLINED',
-}
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 
 const OrganizationMembers = () => {
-  const orgId = useCurrentOrgId()
-  const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
-
-  const invited =
-    data?.members.filter(
-      (member) => member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED,
-    ) || []
-  const activeMembers = data?.members.filter((member) => member.status === MemberStatus.ACTIVE) || []
+  const { activeMembers, invitedMembers } = useOrgMembers()
 
   const filteredMembers = useMembersSearch(activeMembers, searchQuery)
 
@@ -58,7 +44,7 @@ const OrganizationMembers = () => {
           Add member
         </Button>
       </Stack>
-      {invited.length > 0 && !searchQuery && <InvitesList invitedMembers={invited} />}
+      {invitedMembers.length > 0 && !searchQuery && <InvitesList invitedMembers={invitedMembers} />}
       <>
         {searchQuery ? (
           <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -33,7 +33,7 @@ const MembersList = ({ members }: { members: UserOrganization[] }) => {
           rawValue: member.id,
           content: (
             <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
-              User id: {member.id}
+              User id: {member.user.id}
             </Stack>
           ),
         },

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -30,7 +30,7 @@ const MembersList = ({ members }: { members: UserOrganization[] }) => {
     return {
       cells: {
         name: {
-          rawValue: member.id,
+          rawValue: member.user.id,
           content: (
             <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
               User id: {member.user.id}

--- a/apps/web/src/features/organizations/components/OrgsCard/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCard/index.tsx
@@ -22,10 +22,17 @@ export function getDeterministicColor(str: string): string {
   return hslToRgb(`hsl(${hue}, ${saturation}, ${lightness})`)
 }
 
-export const OrgLogo = ({ orgName, size = 'large' }: { orgName: string; size?: 'small' | 'medium' | 'large' }) => {
+export const OrgLogo = ({
+  orgName,
+  size = 'large',
+  rounded = false,
+}: {
+  orgName: string
+  size?: 'small' | 'medium' | 'large'
+  rounded?: boolean
+}) => {
   const logoLetters = orgName.slice(0, 2)
   const logoColor = getDeterministicColor(orgName)
-
   const dimensions = {
     small: { width: 24, height: 24, fontSize: '12px !important' },
     medium: { width: 32, height: 32, fontSize: '16px !important' },
@@ -35,7 +42,14 @@ export const OrgLogo = ({ orgName, size = 'large' }: { orgName: string; size?: '
   const { width, height, fontSize } = dimensions[size]
 
   return (
-    <Box className={css.orgLogo} bgcolor={logoColor} width={width} height={height} fontSize={fontSize}>
+    <Box
+      className={css.orgLogo}
+      bgcolor={logoColor}
+      width={width}
+      height={height}
+      fontSize={fontSize}
+      borderRadius={rounded ? '50%' : '6px'}
+    >
       {logoLetters}
     </Box>
   )

--- a/apps/web/src/features/organizations/components/OrgsCard/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCard/index.tsx
@@ -22,7 +22,7 @@ export function getDeterministicColor(str: string): string {
   return hslToRgb(`hsl(${hue}, ${saturation}, ${lightness})`)
 }
 
-export const OrgLogo = ({
+export const InitialsAvatar = ({
   orgName,
   size = 'large',
   rounded = false,
@@ -43,7 +43,7 @@ export const OrgLogo = ({
 
   return (
     <Box
-      className={css.orgLogo}
+      className={css.initialsAvatar}
       bgcolor={logoColor}
       width={width}
       height={height}
@@ -105,9 +105,7 @@ const OrgsCard = ({
     <Card className={classNames(css.card, { [css.compact]: isCompact })}>
       {isLink && <Link className={css.cardLink} href={AppRoutes.organizations.index(id.toString())} />}
 
-      <Box className={css.orgLogo}>
-        <OrgLogo orgName={name} size={isCompact ? 'medium' : 'large'} />
-      </Box>
+      <InitialsAvatar orgName={name} size={isCompact ? 'medium' : 'large'} />
 
       <OrgSummary
         name={name}

--- a/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
+++ b/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
@@ -20,7 +20,7 @@
   border: 0;
 }
 
-.orgLogo {
+.initialsAvatar {
   grid-area: logo;
   text-transform: uppercase;
   font-weight: bold;

--- a/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
+++ b/apps/web/src/features/organizations/components/OrgsCard/styles.module.css
@@ -22,7 +22,6 @@
 
 .orgLogo {
   grid-area: logo;
-  border-radius: 6px;
   text-transform: uppercase;
   font-weight: bold;
   display: flex;

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -13,7 +13,7 @@ import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_G
 import OrgListInvite from '../Dashboard/DashboardInvite'
 import { useState } from 'react'
 import css from './styles.module.css'
-import { MemberStatus } from '../../hooks/useOrgMembers'
+import { MemberStatus } from '@/features/organizations/hooks/useOrgMembers'
 
 const AddOrgButton = ({ disabled }: { disabled: boolean }) => {
   const [open, setOpen] = useState(false)

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -11,9 +11,9 @@ import { useOrganizationsGetV1Query } from '@safe-global/store/gateway/AUTO_GENE
 import type { UserWithWallets } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 import OrgListInvite from '../Dashboard/DashboardInvite'
-import { MemberStatus } from '../Members'
 import { useState } from 'react'
 import css from './styles.module.css'
+import { MemberStatus } from '../../hooks/useOrgMembers'
 
 const AddOrgButton = ({ disabled }: { disabled: boolean }) => {
   const [open, setOpen] = useState(false)

--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
@@ -6,7 +6,7 @@ import {
 import { useState } from 'react'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import CheckIcon from '@mui/icons-material/Check'
-import OrgsCard, { OrgLogo } from '../OrgsCard'
+import OrgsCard, { InitialsAvatar } from '../OrgsCard'
 import css from './styles.module.css'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
@@ -61,7 +61,7 @@ const OrgsSidebarSelector = () => {
           className={css.orgSelectorButton}
         >
           <Box display="flex" alignItems="center" gap={1}>
-            <OrgLogo orgName={selectedOrg.name} size="small" />
+            <InitialsAvatar orgName={selectedOrg.name} size="small" />
             <Typography
               variant="body2"
               fontWeight="bold"
@@ -96,7 +96,7 @@ const OrgsSidebarSelector = () => {
               }}
             >
               <Box display="flex" alignItems="center" gap={1}>
-                <OrgLogo orgName={org.name} size="small" />
+                <InitialsAvatar orgName={org.name} size="small" />
                 <Typography variant="body2">{org.name}</Typography>
               </Box>
               {org.id === selectedOrg.id && <CheckIcon fontSize="small" color="primary" />}

--- a/apps/web/src/features/organizations/hooks/useOrgMembers.tsx
+++ b/apps/web/src/features/organizations/hooks/useOrgMembers.tsx
@@ -1,0 +1,21 @@
+import { useUserOrganizationsGetUsersV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useCurrentOrgId } from './useCurrentOrgId'
+
+export enum MemberStatus {
+  INVITED = 'INVITED',
+  ACTIVE = 'ACTIVE',
+  DECLINED = 'DECLINED',
+}
+
+export const useOrgMembers = () => {
+  const orgId = useCurrentOrgId()
+  const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
+
+  const invitedMembers =
+    data?.members.filter(
+      (member) => member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED,
+    ) || []
+  const activeMembers = data?.members.filter((member) => member.status === MemberStatus.ACTIVE) || []
+
+  return { activeMembers, invitedMembers }
+}


### PR DESCRIPTION
## What it solves

Resolves #5111

## How this PR fixes it
- Extracts members fetch and filtering into a hook.
- Displays limited list of members on the dashboard (5 max)
- Allows adding members from the dashboard.

## How to test
- Go to the Dashboard page.
- Ensure the org is not in the initial state (have some safes added)
- Check that the members list on the dashboard matches the designs.
- Check that you can add an org from the dashboard using the button at the bottom of the members list.

## Screenshots
![image](https://github.com/user-attachments/assets/d51eb753-21a6-45ac-a7a0-788866336709)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
