### PR TITLE
feat(Assets): mask fiat balance when missing conversion

### DIFF
--- a/apps/web/src/components/balances/AssetsTable/FiatBalance.tsx
+++ b/apps/web/src/components/balances/AssetsTable/FiatBalance.tsx
@@ -1,0 +1,24 @@
+import FiatValue from '@/components/common/FiatValue'
+import { Stack, SvgIcon, Tooltip } from '@mui/material'
+import InfoIcon from '@/public/images/notifications/info.svg'
+import type { Balance } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
+
+export const FiatBalance = ({ balanceItem }: { balanceItem: Balance }) => {
+  const isMissingFiatConversion = balanceItem.fiatConversion === '0' && balanceItem.fiatBalance === '0'
+
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="flex-end">
+      <FiatValue value={isMissingFiatConversion ? null : balanceItem.fiatBalance} />
+
+      {isMissingFiatConversion && (
+        <Tooltip
+          title="Provided values are indicative and we are unable to accommodate pricing requests for individual assets"
+          placement="top"
+          arrow
+        >
+          <SvgIcon component={InfoIcon} inheritViewBox color="error" fontSize="small" />
+        </Tooltip>
+      )}
+    </Stack>
+  )
+}

--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -1,17 +1,15 @@
 import CheckBalance from '@/features/counterfactual/CheckBalance'
 import { type ReactElement } from 'react'
-import { Box, IconButton, Checkbox, Skeleton, SvgIcon, Tooltip, Typography } from '@mui/material'
+import { Box, IconButton, Checkbox, Skeleton, Tooltip, Typography } from '@mui/material'
 import type { TokenInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 import css from './styles.module.css'
-import FiatValue from '@/components/common/FiatValue'
 import TokenAmount from '@/components/common/TokenAmount'
 import TokenIcon from '@/components/common/TokenIcon'
 import EnhancedTable, { type EnhancedTableProps } from '@/components/common/EnhancedTable'
 import TokenExplorerLink from '@/components/common/TokenExplorerLink'
 import Track from '@/components/common/Track'
 import { ASSETS_EVENTS } from '@/services/analytics/events/assets'
-import InfoIcon from '@/public/images/notifications/info.svg'
 import { VisibilityOutlined } from '@mui/icons-material'
 import TokenMenu from '../TokenMenu'
 import useBalances from '@/hooks/useBalances'
@@ -24,6 +22,7 @@ import useIsSwapFeatureEnabled from '@/features/swap/hooks/useIsSwapFeatureEnabl
 import useIsStakingFeatureEnabled from '@/features/stake/hooks/useIsStakingFeatureEnabled'
 import { STAKE_LABELS } from '@/services/analytics/events/stake'
 import StakeButton from '@/features/stake/components/StakeButton'
+import { FiatBalance } from './FiatBalance'
 
 const skeletonCells: EnhancedTableProps['rows'][0]['cells'] = {
   asset: {
@@ -116,7 +115,6 @@ const AssetsTable = ({
   const rows = loading
     ? skeletonRows
     : (visibleAssets || []).map((item) => {
-        const isMissingFiatConversion = item.fiatConversion === '0' && item.fiatBalance === '0'
         const rawFiatValue = parseFloat(item.fiatBalance)
         const isNative = isNativeToken(item.tokenInfo)
         const isSelected = isAssetSelected(item.tokenInfo.address)
@@ -157,29 +155,7 @@ const AssetsTable = ({
             value: {
               rawValue: rawFiatValue,
               collapsed: item.tokenInfo.address === hidingAsset,
-              content: (
-                <Typography textAlign="right">
-                  <FiatValue value={isMissingFiatConversion ? null : item.fiatBalance} />
-
-                  {isMissingFiatConversion && (
-                    <Tooltip
-                      title="Provided values are indicative and we are unable to accommodate pricing requests for individual assets"
-                      placement="top"
-                      arrow
-                    >
-                      <span>
-                        <SvgIcon
-                          component={InfoIcon}
-                          inheritViewBox
-                          color="error"
-                          fontSize="small"
-                          sx={{ verticalAlign: 'middle', ml: 0.5, mr: [0, '-20px'], mt: '-2px' }}
-                        />
-                      </span>
-                    </Tooltip>
-                  )}
-                </Typography>
-              ),
+              content: <FiatBalance balanceItem={item} />,
             },
             actions: {
               rawValue: '',

--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -116,6 +116,7 @@ const AssetsTable = ({
   const rows = loading
     ? skeletonRows
     : (visibleAssets || []).map((item) => {
+        const isMissingFiatConversion = item.fiatConversion === '0' && item.fiatBalance === '0'
         const rawFiatValue = parseFloat(item.fiatBalance)
         const isNative = isNativeToken(item.tokenInfo)
         const isSelected = isAssetSelected(item.tokenInfo.address)
@@ -158,9 +159,9 @@ const AssetsTable = ({
               collapsed: item.tokenInfo.address === hidingAsset,
               content: (
                 <Typography textAlign="right">
-                  <FiatValue value={item.fiatBalance} />
+                  <FiatValue value={isMissingFiatConversion ? null : item.fiatBalance} />
 
-                  {rawFiatValue === 0 && (
+                  {isMissingFiatConversion && (
                     <Tooltip
                       title="Provided values are indicative and we are unable to accommodate pricing requests for individual assets"
                       placement="top"

--- a/apps/web/src/components/common/FiatValue/FiatValue.test.tsx
+++ b/apps/web/src/components/common/FiatValue/FiatValue.test.tsx
@@ -34,4 +34,22 @@ describe('FiatValue', () => {
     expect(getByText((content) => normalizer(content) === '$ 100', { normalizer })).toBeInTheDocument()
     expect(getByText('.35')).toBeInTheDocument()
   })
+
+  it('should render fiat value with maxLength=3', () => {
+    const FiatValue = require('.').default
+    const { getByText } = render(<FiatValue value={100.35} maxLength={3} />)
+    expect(getByText((content) => normalizer(content) === '$ 100', { normalizer })).toBeInTheDocument()
+  })
+
+  it('should render fiat value with maxLength=3 and precise=true', () => {
+    const FiatValue = require('.').default
+    const { getByText } = render(<FiatValue value={100.35} maxLength={3} precise />)
+    expect(getByText((content) => normalizer(content) === '$ 100', { normalizer })).toBeInTheDocument()
+  })
+
+  it('should render `--` if passed value is null', () => {
+    const FiatValue = require('.').default
+    const { getByText } = render(<FiatValue value={null} />)
+    expect(getByText('--')).toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/common/FiatValue/index.tsx
+++ b/apps/web/src/components/common/FiatValue/index.tsx
@@ -12,24 +12,32 @@ const FiatValue = ({
   maxLength,
   precise,
 }: {
-  value: string | number
+  value: string | number | null
   maxLength?: number
   precise?: boolean
 }): ReactElement => {
   const currency = useAppSelector(selectCurrency)
 
   const fiat = useMemo(() => {
-    return formatCurrency(value, currency, maxLength)
+    return value != null ? formatCurrency(value, currency, maxLength) : null
   }, [value, currency, maxLength])
 
   const preciseFiat = useMemo(() => {
-    return formatCurrencyPrecise(value, currency)
+    return value != null ? formatCurrencyPrecise(value, currency) : null
   }, [value, currency])
 
   const [whole, decimals, endCurrency] = useMemo(() => {
-    const match = preciseFiat.match(/(.+)(\D\d+)(\D+)?$/)
+    const match = (preciseFiat ?? '').match(/(.+)(\D\d+)(\D+)?$/)
     return match ? match.slice(1) : ['', preciseFiat, '', '']
   }, [preciseFiat])
+
+  if (fiat == null) {
+    return (
+      <Typography component="span" color="text.secondary">
+        --
+      </Typography>
+    )
+  }
 
   return (
     <Tooltip title={precise ? undefined : preciseFiat}>

--- a/apps/web/src/components/dashboard/Assets/index.tsx
+++ b/apps/web/src/components/dashboard/Assets/index.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { Box, Skeleton, Typography, Paper } from '@mui/material'
 import type { SafeBalanceResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import useBalances from '@/hooks/useBalances'
-import FiatValue from '@/components/common/FiatValue'
 import TokenAmount from '@/components/common/TokenAmount'
 import SwapButton from '@/features/swap/components/SwapButton'
 import { AppRoutes } from '@/config/routes'
@@ -14,6 +13,7 @@ import { useVisibleAssets } from '@/components/balances/AssetsTable/useHideAsset
 import BuyCryptoButton from '@/components/common/BuyCryptoButton'
 import SendButton from '@/components/balances/AssetsTable/SendButton'
 import useIsSwapFeatureEnabled from '@/features/swap/hooks/useIsSwapFeatureEnabled'
+import { FiatBalance } from '@/components/balances/AssetsTable/FiatBalance'
 
 const MAX_ASSETS = 5
 
@@ -43,34 +43,30 @@ const NoAssets = () => (
   </Paper>
 )
 
-const AssetRow = ({ item, showSwap }: { item: SafeBalanceResponse['items'][number]; showSwap?: boolean }) => {
-  const isMissingFiatConversion = item.fiatConversion === '0' && item.fiatBalance === '0'
-
-  return (
-    <Box className={css.container} key={item.tokenInfo.address}>
-      <Box flex={1}>
-        <TokenAmount
-          value={item.balance}
-          decimals={item.tokenInfo.decimals}
-          tokenSymbol={item.tokenInfo.symbol}
-          logoUri={item.tokenInfo.logoUri}
-        />
-      </Box>
-
-      <Box flex={1} display={['none', 'block']} textAlign="right" pr={4}>
-        <FiatValue value={isMissingFiatConversion ? null : item.fiatBalance} />
-      </Box>
-
-      <Box my={-0.7}>
-        {showSwap ? (
-          <SwapButton tokenInfo={item.tokenInfo} amount="0" trackingLabel={SWAP_LABELS.dashboard_assets} />
-        ) : (
-          <SendButton tokenInfo={item.tokenInfo} isOutlined />
-        )}
-      </Box>
+const AssetRow = ({ item, showSwap }: { item: SafeBalanceResponse['items'][number]; showSwap?: boolean }) => (
+  <Box className={css.container} key={item.tokenInfo.address}>
+    <Box flex={1}>
+      <TokenAmount
+        value={item.balance}
+        decimals={item.tokenInfo.decimals}
+        tokenSymbol={item.tokenInfo.symbol}
+        logoUri={item.tokenInfo.logoUri}
+      />
     </Box>
-  )
-}
+
+    <Box display={['none', 'block']} pr={4}>
+      <FiatBalance balanceItem={item} />
+    </Box>
+
+    <Box my={-0.7}>
+      {showSwap ? (
+        <SwapButton tokenInfo={item.tokenInfo} amount="0" trackingLabel={SWAP_LABELS.dashboard_assets} />
+      ) : (
+        <SendButton tokenInfo={item.tokenInfo} isOutlined />
+      )}
+    </Box>
+  </Box>
+)
 
 const AssetList = ({ items }: { items: SafeBalanceResponse['items'] }) => {
   const isSwapFeatureEnabled = useIsSwapFeatureEnabled()

--- a/apps/web/src/components/dashboard/Assets/index.tsx
+++ b/apps/web/src/components/dashboard/Assets/index.tsx
@@ -43,30 +43,34 @@ const NoAssets = () => (
   </Paper>
 )
 
-const AssetRow = ({ item, showSwap }: { item: SafeBalanceResponse['items'][number]; showSwap?: boolean }) => (
-  <Box className={css.container} key={item.tokenInfo.address}>
-    <Box flex={1}>
-      <TokenAmount
-        value={item.balance}
-        decimals={item.tokenInfo.decimals}
-        tokenSymbol={item.tokenInfo.symbol}
-        logoUri={item.tokenInfo.logoUri}
-      />
-    </Box>
+const AssetRow = ({ item, showSwap }: { item: SafeBalanceResponse['items'][number]; showSwap?: boolean }) => {
+  const isMissingFiatConversion = item.fiatConversion === '0' && item.fiatBalance === '0'
 
-    <Box flex={1} display={['none', 'block']} textAlign="right" pr={4}>
-      <FiatValue value={item.fiatBalance} />
-    </Box>
+  return (
+    <Box className={css.container} key={item.tokenInfo.address}>
+      <Box flex={1}>
+        <TokenAmount
+          value={item.balance}
+          decimals={item.tokenInfo.decimals}
+          tokenSymbol={item.tokenInfo.symbol}
+          logoUri={item.tokenInfo.logoUri}
+        />
+      </Box>
 
-    <Box my={-0.7}>
-      {showSwap ? (
-        <SwapButton tokenInfo={item.tokenInfo} amount="0" trackingLabel={SWAP_LABELS.dashboard_assets} />
-      ) : (
-        <SendButton tokenInfo={item.tokenInfo} isOutlined />
-      )}
+      <Box flex={1} display={['none', 'block']} textAlign="right" pr={4}>
+        <FiatValue value={isMissingFiatConversion ? null : item.fiatBalance} />
+      </Box>
+
+      <Box my={-0.7}>
+        {showSwap ? (
+          <SwapButton tokenInfo={item.tokenInfo} amount="0" trackingLabel={SWAP_LABELS.dashboard_assets} />
+        ) : (
+          <SendButton tokenInfo={item.tokenInfo} isOutlined />
+        )}
+      </Box>
     </Box>
-  </Box>
-)
+  )
+}
 
 const AssetList = ({ items }: { items: SafeBalanceResponse['items'] }) => {
   const isSwapFeatureEnabled = useIsSwapFeatureEnabled()


### PR DESCRIPTION
## What it solves

Resolves #5126 

Ensures that when a fiat conversion rate is missing, the UI displays `--` instead of `0`, preventing confusion about the balance. 

## How this PR fixes it

This PR updates key components responsible for displaying fiat values and introduces proper handling of missing conversion rates. It also adds new test cases to validate the changes.  

**Key updates**  
- **Handled missing fiat conversion rate** in a new component `FiatBalance` and use it in:
  -  `AssetsTable` (Assets view)
  -  `AssetRow` (Dashboard)
- **Updated `FiatValue` component** to support `null` values and display `--`.  
- **Added test cases** to ensure correct behavior for missing fiat conversion rates.  


## How to test it

1. Open a Safe that holds a token **without a fiat conversion rate**.  
2. The fiat value should display `--` instead of `0` in:  
   - **Home view:** “Top assets” list.  
   - **Assets view:** Full token balance list.  

## Screenshots

<img width="772" alt="Screenshot 2025-02-27 at 09 25 09" src="https://github.com/user-attachments/assets/e00d8635-b242-4229-b615-af66343666e5" />
<img width="776" alt="Screenshot 2025-02-27 at 09 25 41" src="https://github.com/user-attachments/assets/c40d7cd5-e50a-4123-85bf-1d29a4f008d5" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
