### PR TITLE
chore(ci): generate artifact attestation

### DIFF
--- a/.github/workflows/web-deploy-production.yml
+++ b/.github/workflows/web-deploy-production.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   release:
     permissions:
+      attestations: write
       contents: write
       id-token: write
 
@@ -30,6 +31,11 @@ jobs:
       - name: Create archive
         run: tar -czf "$ARCHIVE_NAME".tar.gz out
         working-directory: apps/web
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ env.ARCHIVE_NAME }}.tar.gz
 
       - name: Create checksum
         run: sha256sum "$ARCHIVE_NAME".tar.gz > ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt


### PR DESCRIPTION
## What it solves
This will generate an attestation over the archive file. One can then verify that this archive was generated on github by using the `gh attestation verify PATH/TO/YOUR/BUILD/ARTIFACT-BINARY -R ORGANIZATION_NAME/REPOSITORY_NAME` command. 

More info on attestation here:

https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds
