### PR TITLE
Feat(Orgs): Implement sign in button

### DIFF
--- a/apps/web/src/components/welcome/WelcomeLogin/WalletLogin.tsx
+++ b/apps/web/src/components/welcome/WelcomeLogin/WalletLogin.tsx
@@ -4,7 +4,15 @@ import { Box, Button, Typography } from '@mui/material'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import WalletIcon from '@/components/common/WalletIcon'
 
-const WalletLogin = ({ onLogin, onContinue }: { onLogin: () => void; onContinue: () => void }) => {
+const WalletLogin = ({
+  onLogin,
+  onContinue,
+  buttonText,
+}: {
+  onLogin: () => void
+  onContinue: () => void
+  buttonText?: string
+}) => {
   const wallet = useWallet()
   const connectWallet = useConnectWallet()
 
@@ -15,46 +23,24 @@ const WalletLogin = ({ onLogin, onContinue }: { onLogin: () => void; onContinue:
 
   if (wallet !== null) {
     return (
-      <Box sx={{ width: '100%' }}>
-        <Button variant="contained" sx={{ padding: '8px 16px' }} fullWidth onClick={onContinue}>
-          <Box
-            width="100%"
-            justifyContent="space-between"
-            display="flex"
-            flexDirection="row"
-            alignItems="center"
-            gap={1}
-          >
-            <Box display="flex" flexDirection="column" alignItems="flex-start">
-              <Typography variant="subtitle2" fontWeight={700}>
-                Continue with {wallet.label}
-              </Typography>
-              {wallet.address && (
-                <EthHashInfo
-                  address={wallet.address}
-                  shortAddress
-                  avatarSize={16}
-                  showName={false}
-                  copyAddress={false}
-                />
-              )}
-            </Box>
-            {wallet.icon && <WalletIcon icon={wallet.icon} provider={wallet.label} width={24} height={24} />}
+      <Button variant="contained" sx={{ padding: '8px 16px' }} onClick={onContinue}>
+        <Box justifyContent="space-between" display="flex" flexDirection="row" alignItems="center" gap={1}>
+          <Box display="flex" flexDirection="column" alignItems="flex-start">
+            <Typography variant="subtitle2" fontWeight={700}>
+              {buttonText || 'Continue with'} {wallet.label}
+            </Typography>
+            {wallet.address && (
+              <EthHashInfo address={wallet.address} shortAddress avatarSize={16} showName={false} copyAddress={false} />
+            )}
           </Box>
-        </Button>
-      </Box>
+          {wallet.icon && <WalletIcon icon={wallet.icon} provider={wallet.label} width={24} height={24} />}
+        </Box>
+      </Button>
     )
   }
 
   return (
-    <Button
-      onClick={onConnectWallet}
-      sx={{ minHeight: '42px' }}
-      variant="contained"
-      size="small"
-      disableElevation
-      fullWidth
-    >
+    <Button onClick={onConnectWallet} sx={{ minHeight: '42px' }} variant="contained" size="small" disableElevation>
       Connect wallet
     </Button>
   )

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -14,6 +14,7 @@ import OrgListInvite from '../Dashboard/DashboardInvite'
 import { useState } from 'react'
 import css from './styles.module.css'
 import { MemberStatus } from '@/features/organizations/hooks/useOrgMembers'
+import useWallet from '@/hooks/wallets/useWallet'
 
 const AddOrgButton = ({ disabled }: { disabled: boolean }) => {
   const [open, setOpen] = useState(false)
@@ -48,12 +49,15 @@ const InfoModal = () => {
 }
 
 const EmptyState = () => {
+  const wallet = useWallet()
+
   return (
     <Card sx={{ p: 5, textAlign: 'center' }}>
       <OrgsIcon />
 
       <Typography color="text.secondary" mb={2}>
-        To view your organization or create one, sign in with your connected wallet.
+        To view your organization or create one,{' '}
+        {!!wallet ? 'sign in with your connected wallet.' : 'connect your wallet.'}
         <br />
         <InfoModal />
       </Typography>

--- a/apps/web/src/features/organizations/components/SignInButton/index.tsx
+++ b/apps/web/src/features/organizations/components/SignInButton/index.tsx
@@ -1,13 +1,21 @@
+import WalletLogin from '@/components/welcome/WelcomeLogin/WalletLogin'
+import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
+import { ORG_EVENTS, SIGN_IN_BUTTON_LABELS } from '@/services/analytics/events/organizations'
 import { useSiwe } from '@/services/siwe/useSiwe'
 import { useAppDispatch } from '@/store'
 import { setAuthenticated } from '@/store/authSlice'
-import { Button } from '@mui/material'
 
 const SignInButton = () => {
   const dispatch = useAppDispatch()
   const { signIn } = useSiwe()
 
+  const handleLogin = () => {
+    trackEvent({ ...OVERVIEW_EVENTS.OPEN_ONBOARD, label: OVERVIEW_LABELS.orgs_list_page })
+  }
+
   const handleSignIn = async () => {
+    trackEvent({ ...ORG_EVENTS.SIGN_IN_BUTTON, label: SIGN_IN_BUTTON_LABELS.orgs_list_page })
+
     try {
       const result = await signIn()
 
@@ -22,11 +30,7 @@ const SignInButton = () => {
     }
   }
 
-  return (
-    <Button onClick={handleSignIn} variant="contained">
-      Sign in
-    </Button>
-  )
+  return <WalletLogin onLogin={handleLogin} onContinue={handleSignIn} />
 }
 
 export default SignInButton

--- a/apps/web/src/features/organizations/components/SignInButton/index.tsx
+++ b/apps/web/src/features/organizations/components/SignInButton/index.tsx
@@ -30,7 +30,7 @@ const SignInButton = () => {
     }
   }
 
-  return <WalletLogin onLogin={handleLogin} onContinue={handleSignIn} />
+  return <WalletLogin onLogin={handleLogin} onContinue={handleSignIn} buttonText="Sign in with" />
 }
 
 export default SignInButton

--- a/apps/web/src/services/analytics/events/organizations.ts
+++ b/apps/web/src/services/analytics/events/organizations.ts
@@ -1,0 +1,12 @@
+const ORG_CATEGORY = 'organizations'
+
+export const ORG_EVENTS = {
+  SIGN_IN_BUTTON: {
+    action: 'Open sign in message',
+    category: ORG_CATEGORY,
+  },
+}
+
+export enum SIGN_IN_BUTTON_LABELS {
+  orgs_list_page = 'orgs_list_page',
+}

--- a/apps/web/src/services/analytics/events/overview.ts
+++ b/apps/web/src/services/analytics/events/overview.ts
@@ -208,4 +208,5 @@ export enum OVERVIEW_LABELS {
   welcome_page = 'welcome_page',
   login_page = 'login_page',
   settings = 'settings',
+  orgs_list_page = 'orgs_list_page',
 }


### PR DESCRIPTION
## What it solves

Resolves #[4965](https://github.com/safe-global/safe-wallet-monorepo/issues/4965)

## How this PR fixes it
- Re-uses the connect/continue button from the welcome page.
- Removes some unused styles from that component
- Prompts user to sign in once wallet is connected.
- Adds tracking for the button.
- Changes the text on the orgs list page for when there is a no connected wallet vs connected wallet but not signed in.

## How to test it
- Open the orgs list page with no wallet connected
- A connect wallet button should be shown.
- Connected a wallet.
- A sign in button should be shown with the icon and name of the connected wallet, and the connected address, similar to the welcome page.

## Screenshots
No connected wallet:
![image](https://github.com/user-attachments/assets/d808ae3b-ef8e-4615-b9e0-dc01b5981c46)
With connected wallet:
![image](https://github.com/user-attachments/assets/2b1e6d11-e47b-4c4a-9ec4-33f4a26cb3af)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
