### PR TITLE
Fix(Orgs): do not set gridArea directly on a DOM element

### DIFF
--- a/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
+++ b/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
@@ -47,7 +47,9 @@ const RoleMenuItem = ({
 
   return (
     <Box width="100%" alignItems="center" className={css.roleMenuItem}>
-      <SvgIcon mr={1} gridArea="icon" component={isAdmin ? adminIcon : memberIcon} inheritViewBox fontSize="small" />
+      <Box sx={{ gridArea: 'icon', display: 'flex', alignItems: 'center' }}>
+        <SvgIcon mr={1} component={isAdmin ? adminIcon : memberIcon} inheritViewBox fontSize="small" />
+      </Box>
       <Typography gridArea="title" fontWeight={hasDescription ? 'bold' : undefined}>
         {isAdmin ? 'Admin' : 'Member'}
       </Typography>


### PR DESCRIPTION
## What it solves
There is a console error when opening the add members modal:
`React does not recognize the `gridArea` prop on a DOM element. `

## How this PR fixes it
- Wraps the svg in a box and sets gridArea on that instead.

## How to test it
- Open the add members modal
- Observe no console error.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
