### PR TITLE
Feat(Orgs): Update members search to include invited members

### DIFF
--- a/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
@@ -1,9 +1,9 @@
-import { Paper, Stack, Typography, Button, Box } from '@mui/material'
+import { Paper, Button, Box } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
-import { InitialsAvatar } from '../OrgsCard'
 import PlusIcon from '@/public/images/common/plus.svg'
 import { useState } from 'react'
 import AddMembersModal from '../AddMembersModal'
+import MemberName from '../MembersList/MemberName'
 
 const DashboardMembersList = ({ members, displayLimit }: { members: UserOrganization[]; displayLimit: number }) => {
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
@@ -13,10 +13,9 @@ const DashboardMembersList = ({ members, displayLimit }: { members: UserOrganiza
     <>
       <Paper sx={{ p: 2, borderRadius: '8px' }}>
         {membersToDisplay.map((member) => (
-          <Stack direction="row" spacing={1} mb={2} alignItems="center" key={member.id}>
-            <InitialsAvatar size="medium" orgName={member.user.id.toString()} rounded />
-            <Typography fontSize="14px">User Id: {member.user.id}</Typography>
-          </Stack>
+          <Box mb={2} key={member.id}>
+            <MemberName key={member.id} member={member} />
+          </Box>
         ))}
         <Box display="flex" justifyContent="center">
           <Button size="small" variant="text" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>

--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -1,6 +1,5 @@
 import EnhancedTable from '@/components/common/EnhancedTable'
-import EthHashInfo from '@/components/common/EthHashInfo'
-import { Box, Button, Chip, IconButton, Stack, SvgIcon, Typography } from '@mui/material'
+import { Button, Chip, IconButton, Stack, SvgIcon } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useUserOrganizationsRemoveUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
@@ -8,6 +7,7 @@ import DeleteIcon from '@/public/images/common/delete.svg'
 import { MemberRole } from '../AddMembersModal'
 import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
 import { MemberStatus } from '@/features/organizations/hooks/useOrgMembers'
+import MemberName from '../MembersList/MemberName'
 
 const headCells = [
   {
@@ -48,9 +48,7 @@ const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] })
           rawValue: member.user.id,
           content: (
             <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
-              <Box>
-                <EthHashInfo address="0x0000000000000000000000000000000000000000" showCopyButton hasExplorer />
-              </Box>
+              <MemberName member={member} />
               {isDeclined && (
                 <Chip label="Declined" size="small" sx={{ backgroundColor: 'error.light', borderRadius: 0.5 }} />
               )}
@@ -89,9 +87,6 @@ const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] })
 
   return (
     <>
-      <Typography variant="h5" fontWeight={700} mb={2}>
-        Pending Invitations ({invitedMembers.length})
-      </Typography>
       <EnhancedTable rows={rows} headCells={headCells} />
     </>
   )

--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -6,7 +6,6 @@ import MembersList from '../MembersList'
 import InvitesList from './InvitesList'
 import SearchIcon from '@/public/images/common/search.svg'
 import { useMembersSearch } from '../../hooks/useMembersSearch'
-import { maybePlural } from '@/utils/formatters'
 import { useOrgMembers } from '../../hooks/useOrgMembers'
 
 const OrganizationMembers = () => {
@@ -15,6 +14,7 @@ const OrganizationMembers = () => {
   const { activeMembers, invitedMembers } = useOrgMembers()
 
   const filteredMembers = useMembersSearch(activeMembers, searchQuery)
+  const filteredInvites = useMembersSearch(invitedMembers, searchQuery)
 
   return (
     <>
@@ -44,18 +44,28 @@ const OrganizationMembers = () => {
           Add member
         </Button>
       </Stack>
-      {invitedMembers.length > 0 && !searchQuery && <InvitesList invitedMembers={invitedMembers} />}
       <>
-        {searchQuery ? (
+        {searchQuery && !filteredMembers.length && !filteredInvites.length && (
           <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">
-            Found {filteredMembers.length} result{maybePlural(filteredMembers)}
-          </Typography>
-        ) : (
-          <Typography variant="h5" fontWeight={700} mb={2} mt={1}>
-            All Members ({filteredMembers.length})
+            Found 0 results
           </Typography>
         )}
-        <MembersList members={filteredMembers} />
+        {filteredInvites.length > 0 && (
+          <>
+            <Typography variant="h5" fontWeight={700} mb={2}>
+              Pending Invitations ({filteredInvites.length})
+            </Typography>
+            <InvitesList invitedMembers={filteredInvites} />
+          </>
+        )}
+        {filteredMembers.length > 0 && (
+          <>
+            <Typography variant="h5" fontWeight={700} mb={2} mt={1}>
+              All Members ({filteredMembers.length})
+            </Typography>
+            <MembersList members={filteredMembers} />
+          </>
+        )}
       </>
 
       {openAddMembersModal && <AddMembersModal onClose={() => setOpenAddMembersModal(false)} />}

--- a/apps/web/src/features/organizations/components/MembersList/MemberName.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/MemberName.tsx
@@ -1,0 +1,14 @@
+import { InitialsAvatar } from '../OrgsCard'
+import { Stack, Typography } from '@mui/material'
+import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+
+const MemberName = ({ member }: { member: UserOrganization }) => {
+  return (
+    <Stack direction="row" spacing={1} alignItems="center" key={member.id}>
+      <InitialsAvatar size="medium" orgName={member.user.id.toString()} rounded />
+      <Typography fontSize="14px">User Id: {member.user.id}</Typography>
+    </Stack>
+  )
+}
+
+export default MemberName

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -1,10 +1,11 @@
-import { Chip, IconButton, Stack, SvgIcon, Tooltip } from '@mui/material'
+import { Chip, IconButton, SvgIcon, Tooltip } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import EditIcon from '@/public/images/common/edit.svg'
 import { MemberRole } from '../AddMembersModal'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import EnhancedTable from '@/components/common/EnhancedTable'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
+import MemberName from './MemberName'
 
 const headCells = [
   {
@@ -26,16 +27,16 @@ const headCells = [
 ]
 
 const MembersList = ({ members }: { members: UserOrganization[] }) => {
+  if (!members.length) {
+    return null
+  }
+
   const rows = members.map((member) => {
     return {
       cells: {
         name: {
           rawValue: member.user.id,
-          content: (
-            <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
-              User id: {member.user.id}
-            </Stack>
-          ),
+          content: <MemberName member={member} />,
         },
         role: {
           rawValue: member.role,

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -27,10 +27,6 @@ const headCells = [
 ]
 
 const MembersList = ({ members }: { members: UserOrganization[] }) => {
-  if (!members.length) {
-    return null
-  }
-
   const rows = members.map((member) => {
     return {
       cells: {

--- a/apps/web/src/features/organizations/hooks/useMembersSearch.ts
+++ b/apps/web/src/features/organizations/hooks/useMembersSearch.ts
@@ -6,7 +6,7 @@ const useMembersSearch = (members: UserOrganization[], query: string): UserOrgan
   const fuse = useMemo(
     () =>
       new Fuse(members, {
-        keys: [{ name: 'id' }],
+        keys: [{ name: 'user.id' }],
         threshold: 0.2,
         findAllMatches: true,
         ignoreLocation: true,


### PR DESCRIPTION
## What it solves

Partially Resolves https://github.com/safe-global/safe-wallet-monorepo/issues/4957#issue-2846012995

## How this PR fixes it
- Includes invited members in the search according to the [updated designs](https://www.figma.com/design/PeChIDi5UKPjf58IOChtET/Organizations?node-id=4229-25673&t=7u4n6iz9lfB4hBc1-1)
- Only display the name (for now the id) in the invites list.
- Extracts member name + icon into its own component

## How to test it
- On the members page, type in the search bar.
- If the text matches anything, the match will show.
- If it matches a member in both the invites and members table, both tables will be shown in the results.

## Screenshots
![image](https://github.com/user-attachments/assets/6dbdb96d-dbcd-4165-8b5f-4cbe9207504c)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
