### PR TITLE
fix: Push tx dialog further down on the screen

### DIFF
--- a/apps/web/src/components/common/TxModalDialog/styles.module.css
+++ b/apps/web/src/components/common/TxModalDialog/styles.module.css
@@ -3,6 +3,7 @@
   left: 230px;
   z-index: 3;
   transition: left 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+  padding-top: 60px; /* Remove once temporary banner is removed */
 }
 
 .dialog.fullWidth {


### PR DESCRIPTION
## What it solves

Pushes the tx dialog further down to make room for the temporary banner

## How to test

1. Create a transaction
2. Observe the close button is visible

## Screenshots
<img width="1512" alt="Screenshot 2025-02-26 at 18 06 01" src="https://github.com/user-attachments/assets/05207dc2-b32a-4ae2-b523-35074d0ab237" />


- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
