### PR TITLE
feat(web): remove l2 migration

### DIFF
--- a/apps/web/src/components/tx-flow/SafeTxProvider.tsx
+++ b/apps/web/src/components/tx-flow/SafeTxProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState, useEffect, useCallback } from 'react'
+import { createContext, useState, useEffect } from 'react'
 import type { Dispatch, ReactNode, SetStateAction, ReactElement } from 'react'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { createTx } from '@/services/tx/tx-sender'
@@ -6,8 +6,7 @@ import { useRecommendedNonce, useSafeTxGas } from '../tx/SignOrExecuteForm/hooks
 import { Errors, logError } from '@/services/exceptions'
 import type { EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { useCurrentChain } from '@/hooks/useChains'
-import { prependSafeToL2Migration } from '@/utils/safe-migrations'
+
 import { useSelectAvailableSigner } from '@/hooks/wallets/useSelectAvailableSigner'
 
 export type SafeTxContextParams = {
@@ -54,27 +53,7 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const [txOrigin, setTxOrigin] = useState<string>()
 
   const { safe } = useSafeInfo()
-  const chain = useCurrentChain()
   const selectAvailableSigner = useSelectAvailableSigner()
-
-  const setAndMigrateSafeTx: Dispatch<SetStateAction<SafeTransaction | undefined>> = useCallback(
-    (
-      value: SafeTransaction | undefined | ((prevState: SafeTransaction | undefined) => SafeTransaction | undefined),
-    ) => {
-      let safeTx: SafeTransaction | undefined
-      if (typeof value === 'function') {
-        safeTx = value(safeTx)
-      } else {
-        safeTx = value
-      }
-
-      prependSafeToL2Migration(safeTx, safe, chain).then(setSafeTx)
-
-      // Select a matching signer when we update the transaction
-      selectAvailableSigner(safeTx, safe)
-    },
-    [chain, safe, selectAvailableSigner],
-  )
 
   // Signed txs cannot be updated
   const isSigned = safeTx && safeTx.signatures.size > 0
@@ -88,6 +67,10 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const finalSafeTxGas = isSigned
     ? safeTx?.data.safeTxGas
     : (safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas)
+
+  useEffect(() => {
+    selectAvailableSigner(safeTx, safe)
+  }, [safeTx, safe, selectAvailableSigner])
 
   // Update the tx when the nonce or safeTxGas change
   useEffect(() => {
@@ -113,7 +96,7 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
       value={{
         safeTx,
         safeTxError,
-        setSafeTx: setAndMigrateSafeTx,
+        setSafeTx,
         setSafeTxError,
         safeMessage,
         setSafeMessage,

--- a/apps/web/src/hooks/__tests__/useSafeNotifications.test.ts
+++ b/apps/web/src/hooks/__tests__/useSafeNotifications.test.ts
@@ -155,33 +155,6 @@ describe('useSafeNotifications', () => {
         },
       })
     })
-    it('should show a notification when the mastercopy is invalid but can be migrated', () => {
-      ;(useSafeInfo as jest.Mock).mockReturnValue({
-        safe: {
-          implementation: { value: '0x123' },
-          implementationVersionState: 'UNKNOWN',
-          version: '1.3.0',
-          nonce: 0,
-          address: {
-            value: '0x1',
-          },
-          chainId: '10',
-        },
-      })
-
-      // render the hook
-      const { result } = renderHook(() => useSafeNotifications())
-
-      // check that the notification was shown
-      expect(result.current).toBeUndefined()
-      expect(showNotification).toHaveBeenCalledWith({
-        variant: 'info',
-        message: `This Safe Account was created with an unsupported base contract.
-           It is possible to migrate it to a compatible base contract. This migration will be automatically included with your first transaction.`,
-        groupKey: 'invalid-mastercopy',
-        link: undefined,
-      })
-    })
     it('should not show a notification when the mastercopy is valid', async () => {
       ;(useSafeInfo as jest.Mock).mockReturnValue({
         safe: {

--- a/apps/web/src/hooks/useSafeNotifications.ts
+++ b/apps/web/src/hooks/useSafeNotifications.ts
@@ -4,7 +4,7 @@ import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript
 import useSafeInfo from './useSafeInfo'
 import { useAppDispatch } from '@/store'
 import { AppRoutes } from '@/config/routes'
-import { isMigrationToL2Possible, isValidMasterCopy } from '@/services/contracts/safeContracts'
+import { isValidMasterCopy } from '@/services/contracts/safeContracts'
 import { useRouter } from 'next/router'
 import useIsSafeOwner from './useIsSafeOwner'
 import { isValidSafeVersion } from './coreSDK/safeCoreSDK'
@@ -134,21 +134,16 @@ const useSafeNotifications = (): void => {
   useEffect(() => {
     if (isValidMasterCopy(safe.implementationVersionState)) return
 
-    const isMigrationPossible = isMigrationToL2Possible(safe)
-
-    const message = isMigrationPossible
-      ? `This Safe Account was created with an unsupported base contract.
-           It is possible to migrate it to a compatible base contract. This migration will be automatically included with your first transaction.`
-      : `This Safe Account was created with an unsupported base contract.
+    const message = `This Safe Account was created with an unsupported base contract.
            The web interface might not work correctly.
            We recommend using the command line interface instead.`
 
     const id = dispatch(
       showNotification({
-        variant: isMigrationPossible ? 'info' : 'warning',
+        variant: 'warning',
         message,
         groupKey: 'invalid-mastercopy',
-        link: isMigrationPossible ? undefined : CLI_LINK,
+        link: CLI_LINK,
       }),
     )
 

--- a/apps/web/src/hooks/wallets/useSelectAvailableSigner.ts
+++ b/apps/web/src/hooks/wallets/useSelectAvailableSigner.ts
@@ -4,21 +4,24 @@ import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { useNestedSafeOwners } from '../useNestedSafeOwners'
 import { getAvailableSigners } from '@/utils/signers'
+import { sameAddress } from '@/utils/addresses'
 
 /**
  *
  * @returns a function that sets a signer that can sign the given transaction in the given Safe
  */
 export const useSelectAvailableSigner = () => {
-  const { connectedWallet: wallet, setSignerAddress } = useWalletContext() ?? {}
+  const { connectedWallet: wallet, setSignerAddress, signer } = useWalletContext() ?? {}
   const nestedSafeOwners = useNestedSafeOwners()
 
   return useCallback(
     (tx: SafeTransaction | undefined, safe: SafeInfo) => {
       const availableSigners = getAvailableSigners(wallet, nestedSafeOwners, safe, tx)
 
-      setSignerAddress?.(availableSigners[0])
+      if (!signer || !availableSigners.some((available) => sameAddress(available, signer.address))) {
+        setSignerAddress?.(availableSigners[0])
+      }
     },
-    [setSignerAddress, nestedSafeOwners, wallet],
+    [wallet, nestedSafeOwners, signer, setSignerAddress],
   )
 }

--- a/apps/web/src/services/contracts/__tests__/safeContracts.test.ts
+++ b/apps/web/src/services/contracts/__tests__/safeContracts.test.ts
@@ -1,11 +1,5 @@
 import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
-import {
-  _getValidatedGetContractProps,
-  isValidMasterCopy,
-  _getMinimumMultiSendCallOnlyVersion,
-  isMigrationToL2Possible,
-} from '../safeContracts'
-import { safeInfoBuilder } from '@/tests/builders/safe'
+import { _getValidatedGetContractProps, isValidMasterCopy, _getMinimumMultiSendCallOnlyVersion } from '../safeContracts'
 
 describe('safeContracts', () => {
   describe('isValidMasterCopy', () => {
@@ -67,20 +61,6 @@ describe('safeContracts', () => {
 
     it('should return the Safe version if the Safe version is higher than the initial version', () => {
       expect(_getMinimumMultiSendCallOnlyVersion('1.4.1')).toBe('1.4.1')
-    })
-  })
-
-  describe('isMigrationToL2Possible', () => {
-    it('should not be possible to migrate Safes on chains without migration lib', () => {
-      expect(isMigrationToL2Possible(safeInfoBuilder().with({ nonce: 0, chainId: '69420' }).build())).toBeFalsy()
-    })
-
-    it('should not be possible to migrate Safes with nonce > 0', () => {
-      expect(isMigrationToL2Possible(safeInfoBuilder().with({ nonce: 2, chainId: '10' }).build())).toBeFalsy()
-    })
-
-    it('should be possible to migrate Safes with nonce 0 on chains with migration lib', () => {
-      expect(isMigrationToL2Possible(safeInfoBuilder().with({ nonce: 0, chainId: '10' }).build())).toBeTruthy()
     })
   })
 })

--- a/apps/web/src/services/contracts/safeContracts.ts
+++ b/apps/web/src/services/contracts/safeContracts.ts
@@ -15,20 +15,12 @@ import type { SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { assertValidSafeVersion, getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import semver from 'semver'
 import { getLatestSafeVersion } from '@/utils/chains'
-import { getSafeToL2MigrationDeployment } from '@safe-global/safe-deployments'
 
 // `UNKNOWN` is returned if the mastercopy does not match supported ones
 // @see https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/handlers/safes.rs#L28-L31
 //      https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/safes/converters.rs#L77-L79
 export const isValidMasterCopy = (implementationVersionState: SafeInfo['implementationVersionState']): boolean => {
   return implementationVersionState !== ImplementationVersionState.UNKNOWN
-}
-
-export const isMigrationToL2Possible = (safe: SafeInfo): boolean => {
-  return (
-    safe.nonce === 0 &&
-    Boolean(getSafeToL2MigrationDeployment({ network: safe.chainId })?.networkAddresses[safe.chainId])
-  )
 }
 
 export const _getValidatedGetContractProps = (


### PR DESCRIPTION
## What this PR changes
Removes the l2 migration

## How to test it
- Add a network to a e.g. 1.3.0 L1 Safe
- Observe a warning about an unsupported masterCopy without any migration
- Create a Tx
- Observe no migration gets prepended

see #5156