### PR TITLE
Fix(Web): use only validated safe address

### DIFF
--- a/apps/web/src/hooks/__tests__/useSafeAddressFromUrl.test.ts
+++ b/apps/web/src/hooks/__tests__/useSafeAddressFromUrl.test.ts
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import { renderHook } from '@/tests/test-utils'
-import useSafeAddress from '@/hooks/useSafeAddress'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 
 // Mock useRouter
 jest.mock('next/router', () => ({
@@ -15,7 +15,7 @@ jest.mock('next/router', () => ({
 // Tests for the useSafeAddress hook
 describe('useSafeAddress hook', () => {
   it('should return the safe address', () => {
-    const { result } = renderHook(() => useSafeAddress())
+    const { result } = renderHook(() => useSafeAddressFromUrl())
     expect(result.current).toBe('0x0000000000000000000000000000000000000001')
   })
 
@@ -27,7 +27,7 @@ describe('useSafeAddress hook', () => {
       },
     }))
 
-    const { result } = renderHook(() => useSafeAddress())
+    const { result } = renderHook(() => useSafeAddressFromUrl())
     expect(result.current).toBe('')
   })
 
@@ -39,7 +39,7 @@ describe('useSafeAddress hook', () => {
       },
     }))
 
-    const { result } = renderHook(() => useSafeAddress())
+    const { result } = renderHook(() => useSafeAddressFromUrl())
     expect(result.current).toBe('0x220866B1A2219f40e72f5c628B65D54268cA3A9D')
   })
 
@@ -49,7 +49,7 @@ describe('useSafeAddress hook', () => {
       query: {},
     }))
 
-    const { result } = renderHook(() => useSafeAddress())
+    const { result } = renderHook(() => useSafeAddressFromUrl())
     expect(result.current).toBe('')
   })
 })

--- a/apps/web/src/hooks/loadables/useLoadSafeInfo.ts
+++ b/apps/web/src/hooks/loadables/useLoadSafeInfo.ts
@@ -4,16 +4,16 @@ import { useAppSelector } from '@/store'
 import { useEffect } from 'react'
 import { getSafeInfo, type SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import useAsync, { type AsyncResult } from '../useAsync'
-import useSafeAddress from '../useSafeAddress'
 import { useChainId } from '../useChainId'
 import useIntervalCounter from '../useIntervalCounter'
 import useSafeInfo from '../useSafeInfo'
 import { Errors, logError } from '@/services/exceptions'
 import { POLLING_INTERVAL } from '@/config/constants'
 import { useCurrentChain } from '../useChains'
+import { useSafeAddressFromUrl } from '../useSafeAddressFromUrl'
 
 export const useLoadSafeInfo = (): AsyncResult<SafeInfo> => {
-  const address = useSafeAddress()
+  const address = useSafeAddressFromUrl()
   const chainId = useChainId()
   const chain = useCurrentChain()
   const [pollCount, resetPolling] = useIntervalCounter(POLLING_INTERVAL)

--- a/apps/web/src/hooks/useSafeAddress.ts
+++ b/apps/web/src/hooks/useSafeAddress.ts
@@ -1,19 +1,8 @@
-import { useMemo } from 'react'
-import { useRouter } from 'next/router'
-import { parsePrefixedAddress } from '@/utils/addresses'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 const useSafeAddress = (): string => {
-  const router = useRouter()
-  const { safe = '' } = router.query
-  const fullAddress = Array.isArray(safe) ? safe[0] : safe
-
-  const checksummedAddress = useMemo(() => {
-    if (!fullAddress) return ''
-    const { address } = parsePrefixedAddress(fullAddress)
-    return address
-  }, [fullAddress])
-
-  return checksummedAddress
+  const { safeAddress } = useSafeInfo()
+  return safeAddress
 }
 
 export default useSafeAddress

--- a/apps/web/src/hooks/useSafeAddressFromUrl.ts
+++ b/apps/web/src/hooks/useSafeAddressFromUrl.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import { useRouter } from 'next/router'
+import { parsePrefixedAddress } from '@/utils/addresses'
+
+export const useSafeAddressFromUrl = (): string => {
+  const router = useRouter()
+  const { safe = '' } = router.query
+  const fullAddress = Array.isArray(safe) ? safe[0] : safe
+
+  const checksummedAddress = useMemo(() => {
+    if (!fullAddress) return ''
+    const { address } = parsePrefixedAddress(fullAddress)
+    return address
+  }, [fullAddress])
+
+  return checksummedAddress
+}


### PR DESCRIPTION
## What it solves

`useSafeAddress` was used throughout the app to get the current Safe address. Some places use `safeAddress` from Safe Info instead.

This hook reads directly from the URL params which violates the single source of truth principle and also it doesn't validate that the Safe actually exists.