### PR TITLE
Fix(Analytics): Console log GA events

### DIFF
--- a/apps/web/src/services/analytics/gtm.ts
+++ b/apps/web/src/services/analytics/gtm.ts
@@ -132,7 +132,7 @@ export const gtmTrack = (eventData: AnalyticsEvent): void => {
     gtmEvent.abTest = abTest
   }
 
-  sendGAEvent('event', gtmEvent.event, gtmEvent)
+  sendEvent(gtmEvent.event, gtmEvent)
 }
 
 export const gtmTrackPageview = (pagePath: string, pathWithQuery: string): void => {
@@ -144,7 +144,7 @@ export const gtmTrackPageview = (pagePath: string, pathWithQuery: string): void 
     send_to: GA_TRACKING_ID,
   }
 
-  sendGAEvent('event', 'page_view', gtmEvent)
+  sendEvent('page_view', gtmEvent)
 }
 
 export const normalizeAppName = (appName?: string): string => {
@@ -183,5 +183,13 @@ export const gtmTrackSafeApp = (eventData: AnalyticsEvent, appName?: string, sdk
     safeAppGtmEvent.eventLabel = eventData.label
   }
 
-  sendGAEvent('event', 'safeAppEvent', safeAppGtmEvent)
+  sendEvent('safeAppEvent', safeAppGtmEvent)
+}
+
+const sendEvent = (eventName: string, data: object) => {
+  sendGAEvent('event', eventName, data)
+
+  if (!IS_PRODUCTION) {
+    console.info('[GA] -', data)
+  }
 }


### PR DESCRIPTION
## What it solves

Part of #5159

## How this PR fixes it

Adds back the console log on non-prod environments whenever an analytics event is sent

## How to test it

1. Open the app
2. Open the console
3. Navigate around
4. Observe console logs for GA events

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
