### PR TITLE
chore(yarn): prevent postinstall by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,24 +4,26 @@ enableGlobalCache: true
 
 nodeLinker: node-modules
 
+enableScripts: false
+
 packageExtensions:
   # fixing https://github.com/vercel/next.js/issues/38939
   eslint-config-next@*:
     dependencies:
-      next: "*"
+      next: '*'
   # the following changes are necessary because tsc was loading
   # the wrong version of @types/react (it was taking 18 from main
   # instead of 19 from the web package) & linting was failing
   # START FIX FOR TSC
-  "@cowprotocol/widget-react@*":
+  '@cowprotocol/widget-react@*':
     peerDependencies:
-      react: "^19.0.0"
-      "@types/react": "^19.0.0"
+      react: '^19.0.0'
+      '@types/react': '^19.0.0'
   react-papaparse@*:
     peerDependencies:
-      react: "^19.0.0"
-  "@storybook/core@*":
+      react: '^19.0.0'
+  '@storybook/core@*':
     dependencies:
-      react: "^19.0.0"
-      "@types/react": "^19.0.0"
+      react: '^19.0.0'
+      '@types/react': '^19.0.0'
   # END FIX FOR TSC

--- a/package.json
+++ b/package.json
@@ -28,5 +28,5 @@
     "msw": "^2.7.0",
     "prettier": "^3.4.2"
   },
-  "packageManager": "yarn@4.5.3"
+  "packageManager": "yarn@4.6.0"
 }


### PR DESCRIPTION
Initially, I was thinking of using lavamoat for this, but then discovered that lavamoat by default actually sets enableScripts to false, so it seemed like kind of unnecessary to drag lavamoat into this. Having this option set to false means that postinstall scripts from 3rd party packages won't automatically run. Yarn is warning us about this:

![grafik](https://github.com/user-attachments/assets/3d89a6d8-3f78-41c0-bacf-158d10c1ec76)

I'm not sure what the scripts are doing and initially thought that nothing is going to work without them, but it turns out that at least on my machine everything I testesd seems to work:
- starting the app in dev mode
- building the web app
- building the mobile app
- running tests on both web and mobile
- linting

