### PR TITLE
chore(e2e): Select events from new dataLayer structure

### DIFF
--- a/apps/web/cypress/support/utils/gtag.js
+++ b/apps/web/cypress/support/utils/gtag.js
@@ -14,7 +14,7 @@ export const checkDataLayerEvents = (expectedEvents) => {
     expectedEvents.forEach((expectedEvent) => {
       const eventExists = dataLayer.some((event) => {
         return Object.keys(expectedEvent).every((key) => {
-          return event[key] === expectedEvent[key]
+          return event[2]?.[key] === expectedEvent[key]
         })
       })
       expect(eventExists, `Expected event matching fields: ${JSON.stringify(expectedEvent)} not found`).to.be.true


### PR DESCRIPTION
## What it solves

Follow up on #5164 

## How this PR fixes it

Since #5164 events are pushed directly to GA. We still push them into the dataLayer but with a slightly different structure. This PR adjusts the util function to select the event payload correctly.