### PR TITLE
chore: Add script to generate SRI hashes

### DIFF
--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -80,6 +80,10 @@ jobs:
         run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig' | sed 's/[A-Z]/\L&/g')" >> $GITHUB_OUTPUT
         id: extract_branch
 
+      - name: Add SRI to scripts
+        run: node ./scripts/integrity-hashes.cjs
+        working-directory: apps/web
+
       # Deploy to S3
       - name: Deploy PR branch
         if: github.event.number

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -48,6 +48,10 @@ jobs:
 
       #- uses: ./.github/workflows/build-storybook
 
+      - name: Add SRI to scripts
+        run: node ./scripts/integrity-hashes.cjs
+        working-directory: apps/web
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -79,10 +83,6 @@ jobs:
         ## e.g. "refs/heads/features/hello-1.2.0" -> "features_hello_1_2_0"
         run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig' | sed 's/[A-Z]/\L&/g')" >> $GITHUB_OUTPUT
         id: extract_branch
-
-      - name: Add SRI to scripts
-        run: node ./scripts/integrity-hashes.cjs
-        working-directory: apps/web
 
       # Deploy to S3
       - name: Deploy PR branch

--- a/.github/workflows/web-deploy-production.yml
+++ b/.github/workflows/web-deploy-production.yml
@@ -28,6 +28,10 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           prod: ${{ true }}
 
+      - name: Add SRI to scripts
+        run: node ./scripts/integrity-hashes.cjs
+        working-directory: apps/web
+
       - name: Create archive
         run: tar -czf "$ARCHIVE_NAME".tar.gz out
         working-directory: apps/web

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,8 @@
     "static-serve": "yarn build && yarn serve",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build --quiet"
+    "build-storybook": "storybook build --quiet",
+    "integrity": "node scripts/integrity-hashes.cjs"
   },
   "engines": {
     "node": ">=18"
@@ -130,6 +131,7 @@
     "@types/semver": "^7.3.10",
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^8.18.1",
+    "cheerio": "^1.0.0",
     "cross-env": "^7.0.3",
     "cypress": "^13.15.2",
     "cypress-file-upload": "^5.0.8",

--- a/apps/web/scripts/integrity-hashes.cjs
+++ b/apps/web/scripts/integrity-hashes.cjs
@@ -1,0 +1,65 @@
+const fs = require('fs')
+const path = require('path')
+const crypto = require('crypto')
+const cheerio = require('cheerio')
+
+const OUT_DIR = 'out'
+
+/**
+ * Given a local file path, compute the SHA-256 integrity hash.
+ */
+function generateIntegrityHash(filePath) {
+  const fileContents = fs.readFileSync(filePath)
+  const hash = crypto.createHash('sha256').update(fileContents).digest('base64')
+  return `sha256-${hash}`
+}
+
+/**
+ * Process a single .html file to add SRI attributes to local script tags.
+ */
+function processHtmlFile(htmlFilePath) {
+  const html = fs.readFileSync(htmlFilePath, 'utf8')
+  const $ = cheerio.load(html)
+
+  $('script[src]').each((_, scriptEl) => {
+    const scriptSrc = $(scriptEl).attr('src')
+    // Skip external or protocol-based (http/https) scripts:
+    if (!scriptSrc || scriptSrc.startsWith('http')) {
+      return
+    }
+
+    // Build an absolute path to the script
+    const scriptFilePath = path.join(path.dirname(htmlFilePath), scriptSrc)
+
+    // Ensure the file actually exists before hashing
+    if (fs.existsSync(scriptFilePath) && fs.lstatSync(scriptFilePath).isFile()) {
+      const integrityVal = generateIntegrityHash(scriptFilePath)
+      $(scriptEl).attr('integrity', integrityVal)
+      $(scriptEl).attr('crossorigin', 'anonymous')
+
+      console.log('Added integrity hash', integrityVal, scriptSrc)
+    }
+  })
+
+  // Write the updated HTML back to disk
+  fs.writeFileSync(htmlFilePath, $.html(), 'utf8')
+}
+
+/**
+ * Recursively traverse a directory, processing .html files.
+ */
+function addSRIToAllHtmlFiles(dirPath) {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true })
+
+  for (const entry of entries) {
+    const entryPath = path.join(dirPath, entry.name)
+
+    if (entry.isDirectory()) {
+      addSRIToAllHtmlFiles(entryPath)
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      processHtmlFile(entryPath)
+    }
+  }
+}
+
+addSRIToAllHtmlFiles(OUT_DIR)

--- a/apps/web/scripts/integrity-hashes.cjs
+++ b/apps/web/scripts/integrity-hashes.cjs
@@ -23,8 +23,12 @@ function processHtmlFile(htmlFilePath) {
 
   $('script[src]').each((_, scriptEl) => {
     const scriptSrc = $(scriptEl).attr('src')
-    // Skip external or protocol-based (http/https) scripts:
+    /**
+     * Skip external or protocol-based (http/https) scripts. Currently, no external scripts
+     * are loaded but if that is the case we should fetch those scripts here e.g. via curl
+     */
     if (!scriptSrc || scriptSrc.startsWith('http')) {
+      console.log('Skipping external script', scriptSrc)
       return
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8034,6 +8034,7 @@ __metadata:
     "@web3-onboard/injected-wallets": "npm:^2.11.2"
     "@web3-onboard/walletconnect": "npm:^2.6.1"
     blo: "npm:^1.1.1"
+    cheerio: "npm:^1.0.0"
     classnames: "npm:^2.5.1"
     cross-env: "npm:^7.0.3"
     cypress: "npm:^13.15.2"
@@ -14882,6 +14883,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cheerio-select@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "cheerio-select@npm:2.1.0"
+  dependencies:
+    boolbase: "npm:^1.0.0"
+    css-select: "npm:^5.1.0"
+    css-what: "npm:^6.1.0"
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.0.1"
+  checksum: 10/b5d89208c23468c3a32d1e04f88b9e8c6e332e3649650c5cd29255e2cebc215071ae18563f58c3dc3f6ef4c234488fc486035490fceb78755572288245e2931a
+  languageName: node
+  linkType: hard
+
+"cheerio@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "cheerio@npm:1.0.0"
+  dependencies:
+    cheerio-select: "npm:^2.1.0"
+    dom-serializer: "npm:^2.0.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.1.0"
+    encoding-sniffer: "npm:^0.2.0"
+    htmlparser2: "npm:^9.1.0"
+    parse5: "npm:^7.1.2"
+    parse5-htmlparser2-tree-adapter: "npm:^7.0.0"
+    parse5-parser-stream: "npm:^7.1.2"
+    undici: "npm:^6.19.5"
+    whatwg-mimetype: "npm:^4.0.0"
+  checksum: 10/b535070add0f86b0a1f234274ad3ffb2c1c375c05b322d8057e89c3c797b3b4d2f05826c34a04df218bec9abf21b9f0d0bd71974a8dfe28b943fb87ab0170c38
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:^3.5.1, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
@@ -16636,6 +16670,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"domutils@npm:^3.1.0":
+  version: 3.2.2
+  resolution: "domutils@npm:3.2.2"
+  dependencies:
+    dom-serializer: "npm:^2.0.0"
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+  checksum: 10/2e08842151aa406f50fe5e6d494f4ec73c2373199fa00d1f77b56ec604e566b7f226312ae35ab8160bb7f27a27c7285d574c8044779053e499282ca9198be210
+  languageName: node
+  linkType: hard
+
 "dot-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "dot-case@npm:3.0.4"
@@ -16831,6 +16876,16 @@ __metadata:
   version: 2.0.0
   resolution: "encodeurl@npm:2.0.0"
   checksum: 10/abf5cd51b78082cf8af7be6785813c33b6df2068ce5191a40ca8b1afe6a86f9230af9a9ce694a5ce4665955e5c1120871826df9c128a642e09c58d592e2807fe
+  languageName: node
+  linkType: hard
+
+"encoding-sniffer@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "encoding-sniffer@npm:0.2.0"
+  dependencies:
+    iconv-lite: "npm:^0.6.3"
+    whatwg-encoding: "npm:^3.1.1"
+  checksum: 10/fe61a759dbef4d94ddc6f4fa645459897f4275eba04f0135d0459099b5f62fbba8a7ae57d23c9ec9b118c4c39ce056b51f1b8e62ad73a8ab365699448d655f4c
   languageName: node
   linkType: hard
 
@@ -20204,6 +20259,18 @@ __metadata:
     domutils: "npm:^2.5.2"
     entities: "npm:^2.0.0"
   checksum: 10/c9c34b0b722f5923c4ae05e59268aeb768582152969e3338a1cd3342b87f8dd2c0420f4745e46d2fd87f1b677ea2f314c3a93436ed8831905997e6347e081a5d
+  languageName: node
+  linkType: hard
+
+"htmlparser2@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "htmlparser2@npm:9.1.0"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.1.0"
+    entities: "npm:^4.5.0"
+  checksum: 10/6352fa2a5495781fa9a02c9049908334cd068ff36d753870d30cd13b841e99c19646717567a2f9e9c44075bbe43d364e102f9d013a731ce962226d63746b794f
   languageName: node
   linkType: hard
 
@@ -25818,7 +25885,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^7.0.0, parse5@npm:^7.1.1":
+"parse5-htmlparser2-tree-adapter@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "parse5-htmlparser2-tree-adapter@npm:7.1.0"
+  dependencies:
+    domhandler: "npm:^5.0.3"
+    parse5: "npm:^7.0.0"
+  checksum: 10/75910af9137451e9c53e1e0d712f7393f484e89e592b1809ee62ad6cedd61b98daeaa5206ff5d9f06778002c91fac311afedde4880e1916fdb44fa71199dae73
+  languageName: node
+  linkType: hard
+
+"parse5-parser-stream@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "parse5-parser-stream@npm:7.1.2"
+  dependencies:
+    parse5: "npm:^7.0.0"
+  checksum: 10/75b232d460bce6bd0e35012750a78ef034f40ccf550b7c6cec3122395af6b4553202ad3663ad468cf537ead5a2e13b6727670395fd0ff548faccad1dc2dc93cf
+  languageName: node
+  linkType: hard
+
+"parse5@npm:^7.0.0, parse5@npm:^7.1.1, parse5@npm:^7.1.2":
   version: 7.2.1
   resolution: "parse5@npm:7.2.1"
   dependencies:
@@ -31359,7 +31445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.11.1, undici@npm:^6.18.2":
+"undici@npm:^6.11.1, undici@npm:^6.18.2, undici@npm:^6.19.5":
   version: 6.21.1
   resolution: "undici@npm:6.21.1"
   checksum: 10/eeccc07e9073ae8e755fdc0dc8cdfaa426c01ec6f815425c3ecedba2e5394cea4993962c040dd168951714a82f0d001a13018c3ae3ad4534f0fa97afe425c08d
@@ -32287,6 +32373,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-encoding@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "whatwg-encoding@npm:3.1.1"
+  dependencies:
+    iconv-lite: "npm:0.6.3"
+  checksum: 10/bbef815eb67f91487c7f2ef96329743f5fd8357d7d62b1119237d25d41c7e452dff8197235b2d3c031365a17f61d3bb73ca49d0ed1582475aa4a670815e79534
+  languageName: node
+  linkType: hard
+
 "whatwg-fetch@npm:^3.0.0":
   version: 3.6.20
   resolution: "whatwg-fetch@npm:3.6.20"
@@ -32298,6 +32393,13 @@ __metadata:
   version: 3.0.0
   resolution: "whatwg-mimetype@npm:3.0.0"
   checksum: 10/96f9f628c663c2ae05412c185ca81b3df54bcb921ab52fe9ebc0081c1720f25d770665401eb2338ab7f48c71568133845638e18a81ed52ab5d4dcef7d22b40ef
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "whatwg-mimetype@npm:4.0.0"
+  checksum: 10/894a618e2d90bf444b6f309f3ceb6e58cf21b2beaa00c8b333696958c4076f0c7b30b9d33413c9ffff7c5832a0a0c8569e5bb347ef44beded72aeefd0acd62e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

Resolves #5154

## How this PR fixes it

- Adds a new script called `integrity-hashes.cjs`
- Adds a dev dependency for `cheerio` in order to parse HTML
- When run it iterates over each file in the `out` directory, generates a sha-256 hash for each internal script and inserts the hash with the integrity attribute to the script element
- Runs this script for each PR deployment

## ToDo

- [x] Run the script for Dev, Staging and Prod deployments as well

## How to test it

1. Open the PR deployment
2. Inspect the DOM
3. Observe no errors in the console
4. Observe integrity hashes are added to the script elements

## Screenshots
<img width="611" alt="Screenshot 2025-03-04 at 11 41 51" src="https://github.com/user-attachments/assets/392217a3-4416-4a62-aa93-33719b07116e" />
<img width="1123" alt="Screenshot 2025-03-04 at 11 45 32" src="https://github.com/user-attachments/assets/d39d9112-e5b9-47f4-829b-a16adbcaaefe" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
