### PR TITLE
Feat(web): validate tx preview

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
@@ -55,17 +55,20 @@ export const ExecTransaction = ({
     [data?.hexData],
   )
 
-  const [txPreview, error] = useTxPreview(
-    childSafeTx
-      ? {
-          operation: Number(childSafeTx.data.operation),
-          data: childSafeTx.data.data,
-          to: childSafeTx.data.to,
-          value: childSafeTx.data.value.toString(),
-        }
-      : undefined,
-    data?.to.value,
+  const txData = useMemo(
+    () =>
+      childSafeTx
+        ? {
+            operation: Number(childSafeTx.data.operation),
+            data: childSafeTx.data.data,
+            to: childSafeTx.data.to,
+            value: childSafeTx.data.value.toString(),
+          }
+        : undefined,
+    [childSafeTx],
   )
+
+  const [txPreview, error] = useTxPreview(txData, data?.to.value)
 
   const decodedNestedTxDataBlock = txPreview ? (
     <DecodedTx {...txPreview} tx={childSafeTx} showMethodCall showAdvancedDetails={false} />

--- a/apps/web/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.test.tsx
@@ -3,7 +3,7 @@ import * as web3 from '@/hooks/wallets/web3'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import { render, screen } from '@/tests/test-utils'
 import * as execThroughRoleHooks from '@/components/tx/SignOrExecuteForm/ExecuteThroughRoleForm/hooks'
-import type { TransactionPreview } from '@safe-global/safe-gateway-typescript-sdk'
+import type { TransactionInfo, TransactionPreview } from '@safe-global/safe-gateway-typescript-sdk'
 import { SafeAppAccessPolicyTypes } from '@safe-global/safe-gateway-typescript-sdk'
 import ReviewSignMessageOnChain from '@/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain'
 import { JsonRpcProvider } from 'ethers'
@@ -18,10 +18,17 @@ import * as useTxPreviewHooks from '@/components/tx/confirmation-views/useTxPrev
 jest.spyOn(execThroughRoleHooks, 'useRoles').mockReturnValue([])
 describe('ReviewSignMessageOnChain', () => {
   test('can handle messages with EIP712Domain type in the JSON-RPC payload', async () => {
+    const safeTx = createSafeTx()
     jest.spyOn(useTxPreviewHooks, 'default').mockReturnValue([
       {
-        txInfo: {},
-        txData: {},
+        txInfo: {} as unknown as TransactionInfo,
+        txData: {
+          operation: safeTx.data.operation as number,
+          to: { value: safeTx.data.to },
+          hexData: safeTx.data.data,
+          value: safeTx.data.value,
+          trustedDelegateCallTarget: true,
+        },
       } as TransactionPreview,
       undefined,
       false,
@@ -42,7 +49,7 @@ describe('ReviewSignMessageOnChain', () => {
         <SafeTxContext.Provider
           value={
             {
-              safeTx: createSafeTx(),
+              safeTx,
             } as SafeTxContextParams
           }
         >

--- a/apps/web/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/ExecuteForm.tsx
@@ -31,6 +31,7 @@ import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
 import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 import { useValidateTxData } from '@/hooks/useValidateTxData'
+import { InvalidPreviewErrorName } from '../confirmation-views/useTxPreview'
 
 export const ExecuteForm = ({
   safeTx,
@@ -44,6 +45,7 @@ export const ExecuteForm = ({
   isExecutionLoop,
   txActions,
   txSecurity,
+  txPreviewError,
 }: SignOrExecuteProps & {
   isOwner: ReturnType<typeof useIsSafeOwner>
   isExecutionLoop: ReturnType<typeof useIsExecutionLoop>
@@ -51,6 +53,7 @@ export const ExecuteForm = ({
   txSecurity: ReturnType<typeof useTxSecurityContext>
   isCreation?: boolean
   safeTx?: SafeTransaction
+  txPreviewError?: Error
 }): ReactElement => {
   // Form state
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
@@ -62,6 +65,8 @@ export const ExecuteForm = ({
     () => (validationResult !== undefined ? new Error(validationResult) : undefined),
     [validationResult],
   )
+  const isInvalidPreview = txPreviewError?.name === InvalidPreviewErrorName
+
   // Hooks
   const currentChain = useCurrentChain()
   const { executeTx } = txActions
@@ -137,7 +142,8 @@ export const ExecuteForm = ({
     cannotPropose ||
     (needsRiskConfirmation && !isRiskConfirmed) ||
     validationError !== undefined ||
-    validationLoading
+    validationLoading ||
+    isInvalidPreview
 
   return (
     <>

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignForm.tsx
@@ -20,6 +20,7 @@ import { isWalletRejection } from '@/utils/wallets'
 import { useSigner } from '@/hooks/wallets/useWallet'
 import { NestedTxSuccessScreenFlow } from '@/components/tx-flow/flows'
 import { useValidateTxData } from '@/hooks/useValidateTxData'
+import { InvalidPreviewErrorName } from '../confirmation-views/useTxPreview'
 
 export const SignForm = ({
   safeTx,
@@ -33,12 +34,14 @@ export const SignForm = ({
   isOwner,
   txActions,
   txSecurity,
+  txPreviewError,
 }: SignOrExecuteProps & {
   isOwner: ReturnType<typeof useIsSafeOwner>
   txActions: ReturnType<typeof useTxActions>
   txSecurity: ReturnType<typeof useTxSecurityContext>
   isCreation?: boolean
   safeTx?: SafeTransaction
+  txPreviewError?: Error
 }): ReactElement => {
   // Form state
   const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
@@ -50,6 +53,8 @@ export const SignForm = ({
     () => (validationResult !== undefined ? new Error(validationResult) : undefined),
     [validationResult],
   )
+
+  const isInvalidPreview = txPreviewError?.name === InvalidPreviewErrorName
 
   // Hooks
   const { signTx, addToBatch } = txActions
@@ -112,7 +117,8 @@ export const SignForm = ({
     cannotPropose ||
     (needsRiskConfirmation && !isRiskConfirmed) ||
     validationError !== undefined ||
-    validationLoading
+    validationLoading ||
+    isInvalidPreview
 
   return (
     <form onSubmit={handleSubmit}>

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
@@ -65,6 +65,7 @@ export const SignOrExecuteForm = ({
   isCreation?: boolean
   txDetails?: TransactionDetails
   txPreview?: TransactionPreview
+  txPreviewError?: Error
 }): ReactElement => {
   const [customOrigin, setCustomOrigin] = useState<string | undefined>(props.origin)
   const { transactionExecution } = useAppSelector(selectSettings)
@@ -178,6 +179,9 @@ export const SignOrExecuteForm = ({
     <>
       <TxCard>
         {props.children}
+        {props.txPreviewError && (
+          <ErrorMessage error={props.txPreviewError}>Error decoding the transaction</ErrorMessage>
+        )}
 
         <ConfirmationView
           txId={props.txId}

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/SignOrExecute.test.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/SignOrExecute.test.tsx
@@ -1,6 +1,6 @@
 import SignOrExecute from '../index'
 import { render } from '@/tests/test-utils'
-import type { TransactionPreview } from '@safe-global/safe-gateway-typescript-sdk'
+import type { TransactionInfo, TransactionPreview } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { createSafeTx } from '@/tests/builders/safeTx'
@@ -37,10 +37,17 @@ describe('SignOrExecute', () => {
   })
 
   it('should display a confirmation screen', async () => {
+    const safeTx = createSafeTx()
     jest.spyOn(useTxPreviewHooks, 'default').mockReturnValue([
       {
-        txInfo: {},
-        txData: {},
+        txInfo: {} as unknown as TransactionInfo,
+        txData: {
+          operation: safeTx.data.operation as number,
+          to: { value: safeTx.data.to },
+          hexData: safeTx.data.data,
+          value: safeTx.data.value,
+          trustedDelegateCallTarget: true,
+        },
       } as TransactionPreview,
       undefined,
       false,
@@ -50,7 +57,7 @@ describe('SignOrExecute', () => {
       <SafeTxContext.Provider
         value={
           {
-            safeTx: createSafeTx(),
+            safeTx,
           } as SafeTxContextParams
         }
       >

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/SignOrExecute.test.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/SignOrExecute.test.tsx
@@ -67,7 +67,7 @@ describe('SignOrExecute', () => {
       .spyOn(useTxPreviewHooks, 'default')
       .mockReturnValue([undefined, new Error('This is a mock error message'), false])
 
-    const { container } = render(
+    const { container, getByTestId } = render(
       <SafeTxContext.Provider
         value={
           {
@@ -78,8 +78,7 @@ describe('SignOrExecute', () => {
         <SignOrExecute onSubmit={jest.fn()} isExecutable={true} />
       </SafeTxContext.Provider>,
     )
-
-    expect(container.querySelector('sign-btn')).not.toBeInTheDocument()
+    expect(getByTestId('sign-btn')).toBeInTheDocument()
     expect(container).toMatchSnapshot()
   })
 })

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
@@ -421,6 +421,32 @@ exports[`SignOrExecute should display an error screen 1`] = `
       data-testid="card-content"
     >
       <div
+        class="container error errorMessage"
+        data-testid="error-message"
+      >
+        <div
+          class="message"
+        >
+          <mock-icon
+            aria-hidden=""
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1vcpomi-MuiSvgIcon-root"
+            focusable="false"
+          />
+          <div>
+            <span
+              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+            >
+              Error decoding the transaction
+              <button
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiLink-button css-1oa03op-MuiTypography-root-MuiLink-root"
+              >
+                Details
+              </button>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
         class="MuiStack-root css-1sazv7p-MuiStack-root"
       >
         <div

--- a/apps/web/src/components/tx/SignOrExecuteForm/index.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/index.tsx
@@ -24,7 +24,7 @@ type SignOrExecuteExtendedProps = SignOrExecuteProps & {
 const SignOrExecute = (props: SignOrExecuteExtendedProps) => {
   const { safeTx, safeTxError } = useContext(SafeTxContext)
   const [txDetails, , txDetailsLoading] = useTxDetails(props.txId)
-  const [txPreview, , txPreviewLoading] = useTxPreview(safeTx?.data, undefined, props.txId)
+  const [txPreview, txPreviewError, txPreviewLoading] = useTxPreview(safeTx?.data, undefined, props.txId)
 
   if ((!safeTx && !safeTxError) || txDetailsLoading || txPreviewLoading) {
     return <SignOrExecuteSkeleton />
@@ -37,6 +37,7 @@ const SignOrExecute = (props: SignOrExecuteExtendedProps) => {
       txId={props.txId}
       txDetails={txDetails}
       txPreview={txPreview}
+      txPreviewError={txPreviewError}
     >
       {props.children}
     </SignOrExecuteForm>

--- a/apps/web/src/components/tx/confirmation-views/useTxPreview.ts
+++ b/apps/web/src/components/tx/confirmation-views/useTxPreview.ts
@@ -2,17 +2,6 @@ import { Operation, getTxPreview } from '@safe-global/safe-gateway-typescript-sd
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import useAsync from '@/hooks/useAsync'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { sameAddress } from '@/utils/addresses'
-import { Interface } from 'ethers'
-
-export const InvalidPreviewErrorName = 'InvalidPreviewError'
-class InvalidPreviewError extends Error {
-  constructor(message: string) {
-    super(message)
-
-    this.name = InvalidPreviewErrorName
-  }
-}
 
 const useTxPreview = (
   safeTxData?: {
@@ -34,38 +23,8 @@ const useTxPreview = (
 
   return useAsync(async () => {
     if (skip) return
-    const txPreview = await getTxPreview(chainId, address, operation, data, to, value)
-
-    // Validate that the tx preview matches the txData
-    // First of all the top level data needs to match:
-    const matchesSafeTxData =
-      sameAddress(txPreview.txData.to.value, safeTxData.to) &&
-      Number(txPreview.txData.operation) === Number(safeTxData.operation) &&
-      txPreview.txData.value === safeTxData.value &&
-      (txPreview.txData.hexData ?? '0x') === safeTxData.data
-
-    if (!matchesSafeTxData) {
-      throw new InvalidPreviewError("SafeTx data does not match the preview result's transaction data")
-    }
-
-    // validate the decodedData
-    const dataDecoded = txPreview.txData.dataDecoded
-
-    if (dataDecoded) {
-      const abiString = `function ${dataDecoded.method}(${dataDecoded.parameters?.map((param) => param.type).join(',')})`
-      const abiInterface = new Interface([abiString])
-      const rawDataFromDecodedData = abiInterface.encodeFunctionData(
-        dataDecoded.method,
-        dataDecoded.parameters?.map((param) => param.value),
-      )
-
-      if (rawDataFromDecodedData !== safeTxData.data) {
-        throw new InvalidPreviewError('Decoded data does not match raw data')
-      }
-    }
-
-    return txPreview
-  }, [skip, chainId, address, operation, data, to, value, safeTxData])
+    return getTxPreview(chainId, address, operation, data, to, value)
+  }, [skip, chainId, address, operation, data, to, value])
 }
 
 export default useTxPreview

--- a/apps/web/src/components/tx/confirmation-views/useTxPreview.ts
+++ b/apps/web/src/components/tx/confirmation-views/useTxPreview.ts
@@ -2,6 +2,17 @@ import { Operation, getTxPreview } from '@safe-global/safe-gateway-typescript-sd
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import useAsync from '@/hooks/useAsync'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { sameAddress } from '@/utils/addresses'
+import { Interface } from 'ethers'
+
+export const InvalidPreviewErrorName = 'InvalidPreviewError'
+class InvalidPreviewError extends Error {
+  constructor(message: string) {
+    super(message)
+
+    this.name = InvalidPreviewErrorName
+  }
+}
 
 const useTxPreview = (
   safeTxData?: {
@@ -21,10 +32,40 @@ const useTxPreview = (
   const address = customSafeAddress ?? safeAddress
   const { operation = Operation.CALL, data = '', to, value } = safeTxData ?? {}
 
-  return useAsync(() => {
+  return useAsync(async () => {
     if (skip) return
-    return getTxPreview(chainId, address, operation, data, to, value)
-  }, [skip, chainId, address, operation, data, to, value])
+    const txPreview = await getTxPreview(chainId, address, operation, data, to, value)
+
+    // Validate that the tx preview matches the txData
+    // First of all the top level data needs to match:
+    const matchesSafeTxData =
+      sameAddress(txPreview.txData.to.value, safeTxData.to) &&
+      Number(txPreview.txData.operation) === Number(safeTxData.operation) &&
+      txPreview.txData.value === safeTxData.value &&
+      (txPreview.txData.hexData ?? '0x') === safeTxData.data
+
+    if (!matchesSafeTxData) {
+      throw new InvalidPreviewError("SafeTx data does not match the preview result's transaction data")
+    }
+
+    // validate the decodedData
+    const dataDecoded = txPreview.txData.dataDecoded
+
+    if (dataDecoded) {
+      const abiString = `function ${dataDecoded.method}(${dataDecoded.parameters?.map((param) => param.type).join(',')})`
+      const abiInterface = new Interface([abiString])
+      const rawDataFromDecodedData = abiInterface.encodeFunctionData(
+        dataDecoded.method,
+        dataDecoded.parameters?.map((param) => param.value),
+      )
+
+      if (rawDataFromDecodedData !== safeTxData.data) {
+        throw new InvalidPreviewError('Decoded data does not match raw data')
+      }
+    }
+
+    return txPreview
+  }, [skip, chainId, address, operation, data, to, value, safeTxData])
 }
 
 export default useTxPreview

--- a/apps/web/src/hooks/__tests__/useValidateTxPreview.test.ts
+++ b/apps/web/src/hooks/__tests__/useValidateTxPreview.test.ts
@@ -56,6 +56,46 @@ describe('useValidateTxPreview', () => {
     expect(useValidateTxPreview(mockTxPreview, mockSafeTxData)).toBeUndefined()
   })
 
+  it('should validate fallback function calls successfully', () => {
+    const randomTxData = faker.string.hexadecimal({ length: 8 })
+    const mockFallbackTxPreview: TransactionPreview = {
+      txData: {
+        to: { value: toAddress },
+        operation: 0,
+        value: '420',
+        hexData: randomTxData,
+        dataDecoded: {
+          method: 'fallback',
+          parameters: [],
+        },
+        trustedDelegateCallTarget: true,
+      },
+      txInfo: {
+        type: TransactionInfoType.CUSTOM,
+        to: { value: toAddress },
+        dataSize: '68',
+        isCancellation: false,
+        value: '0',
+        actionCount: 0,
+      },
+    }
+
+    const mockFallbackSafeTxData: SafeTransaction['data'] = {
+      to: toAddress,
+      value: '420',
+      data: randomTxData,
+      operation: 0,
+      safeTxGas: '0',
+      baseGas: '0',
+      gasPrice: '0',
+      gasToken: ZeroAddress,
+      nonce: 0,
+      refundReceiver: ZeroAddress,
+    }
+
+    expect(useValidateTxPreview(mockFallbackTxPreview, mockFallbackSafeTxData)).toBeUndefined()
+  })
+
   it('should throw InvalidPreviewError if top level data does not match', () => {
     expect(
       useValidateTxPreview({ ...mockTxPreview, txData: { ...mockTxPreview.txData, operation: 1 } }, mockSafeTxData)

--- a/apps/web/src/hooks/__tests__/useValidateTxPreview.test.ts
+++ b/apps/web/src/hooks/__tests__/useValidateTxPreview.test.ts
@@ -1,0 +1,85 @@
+import { useValidateTxPreview } from '../useValidateTxPreview'
+import { ZeroAddress } from 'ethers'
+import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import { TransactionInfoType, type TransactionPreview } from '@safe-global/safe-gateway-typescript-sdk'
+import { faker } from '@faker-js/faker'
+import { ERC20__factory } from '@/types/contracts'
+
+const erc20Interface = ERC20__factory.createInterface()
+describe('useValidateTxPreview', () => {
+  const toAddress = faker.finance.ethereumAddress()
+
+  const transferTo = faker.finance.ethereumAddress()
+  const mockTxPreview: TransactionPreview = {
+    txData: {
+      to: { value: toAddress },
+      operation: 0,
+      value: '0',
+      hexData: erc20Interface.encodeFunctionData('transfer', [transferTo, '69']),
+      dataDecoded: {
+        method: 'transfer',
+        parameters: [
+          { type: 'address', value: transferTo, name: '_to' },
+          { type: 'uint256', value: '69', name: '_value' },
+        ],
+      },
+      trustedDelegateCallTarget: true,
+    },
+    txInfo: {
+      type: TransactionInfoType.CUSTOM,
+      to: { value: toAddress },
+      dataSize: '68',
+      isCancellation: false,
+      value: '0',
+      actionCount: 0,
+    },
+  }
+
+  const mockSafeTxData: SafeTransaction['data'] = {
+    to: toAddress,
+    value: '0',
+    data: erc20Interface.encodeFunctionData('transfer', [transferTo, '69']),
+    operation: 0,
+    safeTxGas: '0',
+    baseGas: '0',
+    gasPrice: '0',
+    gasToken: ZeroAddress,
+    nonce: 0,
+    refundReceiver: ZeroAddress,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should validate the transaction preview successfully', () => {
+    expect(useValidateTxPreview(mockTxPreview, mockSafeTxData)).toBeUndefined()
+  })
+
+  it('should throw InvalidPreviewError if top level data does not match', () => {
+    expect(
+      useValidateTxPreview({ ...mockTxPreview, txData: { ...mockTxPreview.txData, operation: 1 } }, mockSafeTxData)
+        ?.message,
+    ).toEqual("SafeTx data does not match the preview result's transaction data")
+  })
+
+  it('should throw InvalidPreviewError if decoded data does not match raw data', () => {
+    // Different receiver of erc20 transfer in raw data than in the decoded data
+    const newReceiver = faker.finance.ethereumAddress()
+    expect(
+      useValidateTxPreview(
+        {
+          ...mockTxPreview,
+          txData: {
+            ...mockTxPreview.txData,
+            hexData: erc20Interface.encodeFunctionData('transfer', [newReceiver, 69]),
+          },
+        },
+        {
+          ...mockSafeTxData,
+          data: erc20Interface.encodeFunctionData('transfer', [newReceiver, 69]),
+        },
+      )?.message,
+    ).toEqual('Decoded data does not match raw data')
+  })
+})

--- a/apps/web/src/hooks/useValidateTxPreview.ts
+++ b/apps/web/src/hooks/useValidateTxPreview.ts
@@ -1,3 +1,6 @@
+import { logError } from '@/services/exceptions'
+import ErrorCodes from '@/services/exceptions/ErrorCodes'
+import { asError } from '@/services/exceptions/utils'
 import { sameAddress } from '@/utils/addresses'
 import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { type TransactionPreview } from '@safe-global/safe-gateway-typescript-sdk'
@@ -15,39 +18,46 @@ class InvalidPreviewError extends Error {
 export const useValidateTxPreview = (
   txPreview: TransactionPreview | undefined,
   safeTxData: SafeTransaction['data'] | undefined,
-) => {
+): Error | undefined => {
   if (!txPreview || !safeTxData) {
     return
   }
-  // Validate that the tx preview matches the txData
-  // First of all the top level data needs to match:
-  const matchesSafeTxData =
-    sameAddress(txPreview.txData.to.value, safeTxData.to) &&
-    Number(txPreview.txData.operation) === Number(safeTxData.operation) &&
-    txPreview.txData.value === safeTxData.value &&
-    (txPreview.txData.hexData ?? '0x') === safeTxData.data
 
-  if (!matchesSafeTxData) {
-    return new InvalidPreviewError("SafeTx data does not match the preview result's transaction data")
-  }
+  try {
+    // Validate that the tx preview matches the txData
+    // First of all the top level data needs to match:
+    const matchesSafeTxData =
+      sameAddress(txPreview.txData.to.value, safeTxData.to) &&
+      Number(txPreview.txData.operation) === Number(safeTxData.operation) &&
+      txPreview.txData.value === safeTxData.value &&
+      (txPreview.txData.hexData ?? '0x') === safeTxData.data
 
-  // validate the decodedData
-  const dataDecoded = txPreview.txData.dataDecoded
-
-  if (dataDecoded) {
-    // Fallback functions are special as they are called for all data that does not match any other function
-    if (dataDecoded.method === 'fallback') {
-      return
+    if (!matchesSafeTxData) {
+      return new InvalidPreviewError("SafeTx data does not match the preview result's transaction data")
     }
-    const abiString = `function ${dataDecoded.method}(${dataDecoded.parameters?.map((param) => param.type).join(',')})`
-    const abiInterface = new Interface([abiString])
-    const rawDataFromDecodedData = abiInterface.encodeFunctionData(
-      dataDecoded.method,
-      dataDecoded.parameters?.map((param) => param.value),
-    )
 
-    if (rawDataFromDecodedData !== safeTxData.data) {
-      return new InvalidPreviewError('Decoded data does not match raw data')
+    // validate the decodedData
+    const dataDecoded = txPreview.txData.dataDecoded
+
+    if (dataDecoded) {
+      // Fallback functions are special as they are called for all data that does not match any other function
+      if (dataDecoded.method === 'fallback') {
+        return
+      }
+      const abiString = `function ${dataDecoded.method}(${dataDecoded.parameters?.map((param) => param.type).join(',')})`
+      const abiInterface = new Interface([abiString])
+      const rawDataFromDecodedData = abiInterface.encodeFunctionData(
+        dataDecoded.method,
+        dataDecoded.parameters?.map((param) => param.value),
+      )
+
+      if (rawDataFromDecodedData !== safeTxData.data) {
+        return new InvalidPreviewError('Decoded data does not match raw data')
+      }
     }
+  } catch (err) {
+    const error = asError(err)
+    logError(ErrorCodes._818, error)
+    return error
   }
 }

--- a/apps/web/src/hooks/useValidateTxPreview.ts
+++ b/apps/web/src/hooks/useValidateTxPreview.ts
@@ -35,6 +35,10 @@ export const useValidateTxPreview = (
   const dataDecoded = txPreview.txData.dataDecoded
 
   if (dataDecoded) {
+    // Fallback functions are special as they are called for all data that does not match any other function
+    if (dataDecoded.method === 'fallback') {
+      return
+    }
     const abiString = `function ${dataDecoded.method}(${dataDecoded.parameters?.map((param) => param.type).join(',')})`
     const abiInterface = new Interface([abiString])
     const rawDataFromDecodedData = abiInterface.encodeFunctionData(

--- a/apps/web/src/hooks/useValidateTxPreview.ts
+++ b/apps/web/src/hooks/useValidateTxPreview.ts
@@ -1,0 +1,49 @@
+import { sameAddress } from '@/utils/addresses'
+import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import { type TransactionPreview } from '@safe-global/safe-gateway-typescript-sdk'
+import { Interface } from 'ethers'
+
+export const InvalidPreviewErrorName = 'InvalidPreviewError'
+class InvalidPreviewError extends Error {
+  constructor(message: string) {
+    super(message)
+
+    this.name = InvalidPreviewErrorName
+  }
+}
+
+export const useValidateTxPreview = (
+  txPreview: TransactionPreview | undefined,
+  safeTxData: SafeTransaction['data'] | undefined,
+) => {
+  if (!txPreview || !safeTxData) {
+    return
+  }
+  // Validate that the tx preview matches the txData
+  // First of all the top level data needs to match:
+  const matchesSafeTxData =
+    sameAddress(txPreview.txData.to.value, safeTxData.to) &&
+    Number(txPreview.txData.operation) === Number(safeTxData.operation) &&
+    txPreview.txData.value === safeTxData.value &&
+    (txPreview.txData.hexData ?? '0x') === safeTxData.data
+
+  if (!matchesSafeTxData) {
+    return new InvalidPreviewError("SafeTx data does not match the preview result's transaction data")
+  }
+
+  // validate the decodedData
+  const dataDecoded = txPreview.txData.dataDecoded
+
+  if (dataDecoded) {
+    const abiString = `function ${dataDecoded.method}(${dataDecoded.parameters?.map((param) => param.type).join(',')})`
+    const abiInterface = new Interface([abiString])
+    const rawDataFromDecodedData = abiInterface.encodeFunctionData(
+      dataDecoded.method,
+      dataDecoded.parameters?.map((param) => param.value),
+    )
+
+    if (rawDataFromDecodedData !== safeTxData.data) {
+      return new InvalidPreviewError('Decoded data does not match raw data')
+    }
+  }
+}


### PR DESCRIPTION
## What this PR changes
- validates the decodedData of the transaction preview against the raw transaction data
- If it does not match it shows an error and disabled the sign and execute button

## How to test it
- Create different transactions
- No error should appear


## Screenshots
![Screenshot 2025-03-04 at 14 06 10](https://github.com/user-attachments/assets/82e0ba99-a95d-49b0-8024-fcc54ecac920)

## Checklist
- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
