### PR TITLE
Rename optimisim network to OP Mainnet

### DIFF
--- a/apps/web/cypress/support/constants.js
+++ b/apps/web/cypress/support/constants.js
@@ -143,7 +143,7 @@ export const networks = {
   berachain: 'Berachain',
   zkSync: 'zkSync Era',
   base: 'Base',
-  optimism: 'Optimism',
+  optimism: 'OP Mainnet',
   gnosisChiado: 'Gnosis Chiado',
 }
 


### PR DESCRIPTION
## What it solves

Resolves #

This PR just changes the name for the optimism network. We detected that when working in safe utils https://github.com/OpenZeppelin/safe-utils/pull/15

https://optimistic.etherscan.io/

## Screenshots

![image](https://github.com/user-attachments/assets/7171faed-e326-412c-b19e-1e4b0fa4e9fa)
![image](https://github.com/user-attachments/assets/b5e3f47c-1169-44cb-88a4-c4c1a198c221)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
