### PR TITLE
fix: Remove unsafe-inline and GA domains from CSP

### DIFF
--- a/apps/web/src/config/securityHeaders.ts
+++ b/apps/web/src/config/securityHeaders.ts
@@ -6,13 +6,12 @@ import { CYPRESS_MNEMONIC, IS_PRODUCTION } from '@/config/constants'
  * connect-src * because the RPCs are configurable (config service)
  * style-src unsafe-inline for our styled components
  * script-src unsafe-eval is needed by next.js in dev mode, otherwise only self
- *            unsafe-inline is needed for gtm https://developers.google.com/tag-platform/tag-manager/web/csp
  * frame-ancestors can not be set via meta tag
  */
 export const ContentSecurityPolicy = `
  default-src 'self';
  connect-src 'self' *;
- script-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com 'unsafe-inline' https://*.getbeamer.com https://www.googletagmanager.com https://*.ingest.sentry.io https://sentry.io ${
+ script-src 'self' https://*.getbeamer.com https://www.googletagmanager.com https://*.ingest.sentry.io https://sentry.io ${
    !IS_PRODUCTION || CYPRESS_MNEMONIC
      ? "'unsafe-eval'" // Dev server and cypress need unsafe-eval
      : "'wasm-unsafe-eval'"


### PR DESCRIPTION
## What it solves

Follow up #5159

## How this PR fixes it

- Removes `unsafe-inline` from script-src since the GTM script that was inlined before has been removed
- Removes `https://www.google-analytics.com` and `https://ssl.google-analytics.com` from script-src because nothing is loaded from those domains

## How to test it

1. Open the app
2. Observe no errors in the console regarding CSP
3. Observe that GA events are still tracked

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
