### PR TITLE
Feat: show blockaid simulation results on tx confirmation screen

### DIFF
--- a/apps/web/src/components/settings/FallbackHandler/index.tsx
+++ b/apps/web/src/components/settings/FallbackHandler/index.tsx
@@ -107,7 +107,7 @@ export const FallbackHandler = (): ReactElement | null => {
               })}
               sx={{ display: 'block !important' }}
             >
-              {true && (
+              {warning && (
                 <Typography variant="body2" width="100%" mb={hasFallbackHandler ? 1 : 0}>
                   {warning}
                 </Typography>

--- a/apps/web/src/components/settings/FallbackHandler/index.tsx
+++ b/apps/web/src/components/settings/FallbackHandler/index.tsx
@@ -107,7 +107,7 @@ export const FallbackHandler = (): ReactElement | null => {
               })}
               sx={{ display: 'block !important' }}
             >
-              {warning && (
+              {true && (
                 <Typography variant="body2" width="100%" mb={hasFallbackHandler ? 1 : 0}>
                   {warning}
                 </Typography>

--- a/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
+++ b/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
@@ -1,0 +1,49 @@
+import { Box, Stack, Typography } from '@mui/material'
+import type { ContractManagementChange } from '@/services/security/modules/BlockaidModule/types'
+import { SecuritySeverity } from '@/services/security/modules/types'
+import { mapSecuritySeverity } from '../utils'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import { Warning } from '.'
+
+export const CONTRACT_CHANGE_TITLES_MAPPING: Record<ContractManagementChange['type'], string> = {
+  PROXY_UPGRADE: 'This transaction will change the mastercopy of the Safe',
+  OWNERSHIP_CHANGE: 'This transaction will change the ownership of the Safe',
+  MODULE_CHANGE: 'This transaction contains a Safe module change',
+}
+
+export const ProxyUpgradeSummary = ({
+  beforeAddress,
+  afterAddress,
+}: {
+  beforeAddress: string
+  afterAddress: string
+}) => {
+  return (
+    <Stack direction="column" spacing={0.5}>
+      <Typography variant="body2">Current mastercopy:</Typography>
+      <Box sx={{ padding: '6px 12px', borderRadius: '6px', backgroundColor: 'background.paper' }}>
+        <EthHashInfo address={beforeAddress} showCopyButton hasExplorer shortAddress={false} showAvatar={false} />
+      </Box>
+
+      <Typography variant="body2">New mastercopy:</Typography>
+      <Box sx={{ padding: '6px 12px', borderRadius: '6px', backgroundColor: 'background.paper' }}>
+        <EthHashInfo address={afterAddress} showCopyButton hasExplorer shortAddress={false} showAvatar={false} />
+      </Box>
+    </Stack>
+  )
+}
+
+export const ContractChangeWarning = ({ contractChange }: { contractChange: ContractManagementChange }) => {
+  const title = CONTRACT_CHANGE_TITLES_MAPPING[contractChange.type]
+  const severityProps = mapSecuritySeverity[SecuritySeverity.MEDIUM]
+  const { before, after, type } = contractChange
+
+  const warningContent =
+    type === 'PROXY_UPGRADE' ? (
+      <ProxyUpgradeSummary beforeAddress={before.address} afterAddress={after.address} />
+    ) : (
+      <Typography variant="body2">Please verify that these changes are correct before proceeding.</Typography>
+    )
+
+  return <Warning title={title} severityProps={severityProps} content={warningContent} isTransaction={true} />
+}

--- a/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
+++ b/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
@@ -9,7 +9,7 @@ import { mapSecuritySeverity } from '../utils'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { Warning } from '.'
 
-export const CONTRACT_CHANGE_TITLES_MAPPING: Record<
+const CONTRACT_CHANGE_TITLES_MAPPING: Record<
   ProxyUpgradeManagement['type'] | OwnershipChangeManagement['type'] | ModulesChangeManagement['type'],
   string
 > = {
@@ -18,21 +18,17 @@ export const CONTRACT_CHANGE_TITLES_MAPPING: Record<
   MODULE_CHANGE: 'This transaction contains a Safe module change',
 }
 
-export const ProxyUpgradeSummary = ({
-  beforeAddress,
-  afterAddress,
-}: {
-  beforeAddress: string
-  afterAddress: string
-}) => {
+const ProxyUpgradeSummary = ({ beforeAddress, afterAddress }: { beforeAddress: string; afterAddress: string }) => {
   return (
     <Stack direction="column" spacing={0.5}>
-      <Typography variant="body2">Current mastercopy:</Typography>
+      <Typography variant="overline" mt={1}>
+        Current mastercopy:
+      </Typography>
       <Box sx={{ padding: '6px 12px', borderRadius: '6px', backgroundColor: 'background.paper' }}>
         <EthHashInfo address={beforeAddress} showCopyButton hasExplorer shortAddress={false} showAvatar={false} />
       </Box>
 
-      <Typography variant="body2">New mastercopy:</Typography>
+      <Typography variant="overline">New mastercopy:</Typography>
       <Box sx={{ padding: '6px 12px', borderRadius: '6px', backgroundColor: 'background.paper' }}>
         <EthHashInfo address={afterAddress} showCopyButton hasExplorer shortAddress={false} showAvatar={false} />
       </Box>
@@ -48,13 +44,17 @@ export const ContractChangeWarning = ({
   const title = CONTRACT_CHANGE_TITLES_MAPPING[contractChange.type]
   const severityProps = mapSecuritySeverity[SecuritySeverity.MEDIUM]
   const { before, after, type } = contractChange
+  const isProxyUpgrade = type === 'PROXY_UPGRADE'
 
-  const warningContent =
-    type === 'PROXY_UPGRADE' ? (
-      <ProxyUpgradeSummary beforeAddress={before.address} afterAddress={after.address} />
-    ) : (
-      <Typography variant="body2">Please verify that these changes are correct before proceeding.</Typography>
-    )
+  const warningContent = (
+    <>
+      <Typography variant="body2" mb={2}>
+        {isProxyUpgrade && 'This could allow someone else to take ownership of your account. '}Please verify that this
+        change is correct before proceeding.
+      </Typography>
+      {isProxyUpgrade && <ProxyUpgradeSummary beforeAddress={before.address} afterAddress={after.address} />}
+    </>
+  )
 
   return <Warning title={title} severityProps={severityProps} content={warningContent} isTransaction={true} />
 }

--- a/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
+++ b/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
@@ -1,11 +1,18 @@
 import { Box, Stack, Typography } from '@mui/material'
-import type { ContractManagementChange } from '@/services/security/modules/BlockaidModule/types'
+import type {
+  ModulesChangeManagement,
+  OwnershipChangeManagement,
+  ProxyUpgradeManagement,
+} from '@/services/security/modules/BlockaidModule/types'
 import { SecuritySeverity } from '@/services/security/modules/types'
 import { mapSecuritySeverity } from '../utils'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { Warning } from '.'
 
-export const CONTRACT_CHANGE_TITLES_MAPPING: Record<ContractManagementChange['type'], string> = {
+export const CONTRACT_CHANGE_TITLES_MAPPING: Record<
+  ProxyUpgradeManagement['type'] | OwnershipChangeManagement['type'] | ModulesChangeManagement['type'],
+  string
+> = {
   PROXY_UPGRADE: 'This transaction will change the mastercopy of the Safe',
   OWNERSHIP_CHANGE: 'This transaction will change the ownership of the Safe',
   MODULE_CHANGE: 'This transaction contains a Safe module change',
@@ -33,7 +40,11 @@ export const ProxyUpgradeSummary = ({
   )
 }
 
-export const ContractChangeWarning = ({ contractChange }: { contractChange: ContractManagementChange }) => {
+export const ContractChangeWarning = ({
+  contractChange,
+}: {
+  contractChange: ProxyUpgradeManagement | OwnershipChangeManagement | ModulesChangeManagement
+}) => {
   const title = CONTRACT_CHANGE_TITLES_MAPPING[contractChange.type]
   const severityProps = mapSecuritySeverity[SecuritySeverity.MEDIUM]
   const { before, after, type } = contractChange

--- a/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
+++ b/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
@@ -21,9 +21,10 @@ const CONTRACT_CHANGE_TITLES_MAPPING: Record<
 const ProxyUpgradeSummary = ({ beforeAddress, afterAddress }: { beforeAddress: string; afterAddress: string }) => {
   return (
     <Stack direction="column" spacing={0.5}>
-      <Typography variant="overline" mt={1}>
-        Current mastercopy:
+      <Typography variant="body2" sx={{ marginBottom: 'var(--space-2) !important' }}>
+        Please verify that this change is intended and correct as it may overwrite the ownership of your account
       </Typography>
+      <Typography variant="overline">Current mastercopy:</Typography>
       <Box sx={{ padding: '6px 12px', borderRadius: '6px', backgroundColor: 'background.paper' }}>
         <EthHashInfo address={beforeAddress} showCopyButton hasExplorer shortAddress={false} showAvatar={false} />
       </Box>
@@ -48,11 +49,11 @@ export const ContractChangeWarning = ({
 
   const warningContent = (
     <>
-      <Typography variant="body2" mb={2}>
-        {isProxyUpgrade && 'This could allow someone else to take ownership of your account. '}Please verify that this
-        change is correct before proceeding.
-      </Typography>
-      {isProxyUpgrade && <ProxyUpgradeSummary beforeAddress={before.address} afterAddress={after.address} />}
+      {isProxyUpgrade ? (
+        <ProxyUpgradeSummary beforeAddress={before.address} afterAddress={after.address} />
+      ) : (
+        <Typography variant="body2">Please verify that this change is intended and correct.</Typography>
+      )}
     </>
   )
 

--- a/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
+++ b/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
@@ -15,7 +15,7 @@ const CONTRACT_CHANGE_TITLES_MAPPING: Record<
 > = {
   PROXY_UPGRADE: 'This transaction will change the mastercopy of the Safe',
   OWNERSHIP_CHANGE: 'This transaction will change the ownership of the Safe',
-  MODULE_CHANGE: 'This transaction contains a Safe module change',
+  MODULES_CHANGE: 'This transaction contains a Safe modules change',
 }
 
 const ProxyUpgradeSummary = ({ beforeAddress, afterAddress }: { beforeAddress: string; afterAddress: string }) => {

--- a/apps/web/src/components/tx/security/blockaid/index.tsx
+++ b/apps/web/src/components/tx/security/blockaid/index.tsx
@@ -50,15 +50,15 @@ export const Warning = ({
   severityProps,
   needsRiskConfirmation = false,
   isRiskConfirmed = true,
-  isTransaction,
+  isTransaction = true,
   toggleConfirmation,
 }: {
   title: ReactNode
-  content?: ReactNode
-  severityProps?: SecurityWarningProps
+  content: ReactNode
+  severityProps: SecurityWarningProps
   needsRiskConfirmation?: boolean
   isRiskConfirmed?: boolean
-  isTransaction: boolean
+  isTransaction?: boolean
   toggleConfirmation?: () => void
 }) => {
   return (
@@ -179,9 +179,9 @@ const BlockaidWarning = () => {
   }
 
   return (
-    <Box>
-      {!!blockaidResponse.severity ? (
-        <>
+    <>
+      {!!severityProps ? (
+        <Box>
           <Warning
             isRiskConfirmed={isRiskConfirmed}
             isTransaction={isTransaction}
@@ -198,18 +198,18 @@ const BlockaidWarning = () => {
             severityProps={severityProps}
           />
           <PoweredByBlockaid />
-        </>
+        </Box>
       ) : blockaidResponse?.contractManagement && blockaidResponse.contractManagement.length > 0 ? (
-        <>
+        <Box>
           <Stack direction="column" spacing={1}>
             {blockaidResponse?.contractManagement.map((contractChange) => (
               <ContractChangeWarning key={contractChange.type} contractChange={contractChange} />
             ))}
           </Stack>
           <PoweredByBlockaid />
-        </>
+        </Box>
       ) : null}
-    </Box>
+    </>
   )
 }
 

--- a/apps/web/src/components/tx/security/blockaid/index.tsx
+++ b/apps/web/src/components/tx/security/blockaid/index.tsx
@@ -1,5 +1,6 @@
+import type { ReactNode } from 'react'
 import { useContext } from 'react'
-import { TxSecurityContext, type TxSecurityContextProps } from '@/components/tx/security/shared/TxSecurityContext'
+import { TxSecurityContext } from '@/components/tx/security/shared/TxSecurityContext'
 import groupBy from 'lodash/groupBy'
 import { Alert, AlertTitle, Box, Checkbox, FormControlLabel, Stack, Typography } from '@mui/material'
 import { FEATURES } from '@/utils/chains'
@@ -14,7 +15,7 @@ import BlockaidIcon from '@/public/images/transactions/blockaid-icon.svg'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { type SecurityWarningProps, mapSecuritySeverity } from '../utils'
 import { BlockaidHint } from './BlockaidHint'
-import { SecuritySeverity } from '@/services/security/modules/types'
+import { ContractChangeWarning } from './ContractChangeWarning'
 
 export const REASON_MAPPING: Record<string, string> = {
   raw_ether_transfer: 'transfers native currency',
@@ -43,84 +44,48 @@ export const CLASSIFICATION_MAPPING: Record<string, string> = {
   other: 'resulting in a malicious outcome',
 }
 
-const BlockaidResultWarning = ({
-  blockaidResponse,
+export const Warning = ({
+  title,
+  content,
   severityProps,
-  needsRiskConfirmation,
-  isRiskConfirmed,
+  needsRiskConfirmation = false,
+  isRiskConfirmed = true,
   isTransaction,
   toggleConfirmation,
 }: {
-  blockaidResponse?: TxSecurityContextProps['blockaidResponse']
+  title: ReactNode
+  content?: ReactNode
   severityProps?: SecurityWarningProps
-  needsRiskConfirmation: boolean
-  isRiskConfirmed: boolean
+  needsRiskConfirmation?: boolean
+  isRiskConfirmed?: boolean
   isTransaction: boolean
-  toggleConfirmation: () => void
+  toggleConfirmation?: () => void
 }) => {
   return (
     <Box>
-      {blockaidResponse && blockaidResponse.severity !== SecuritySeverity.NONE && (
-        <>
-          <Alert
-            severity={severityProps?.color}
-            className={css.customAlert}
-            sx={
-              needsRiskConfirmation
-                ? {
-                    borderBottomLeftRadius: '0px',
-                    borderBottomRightRadius: '0px',
-                  }
-                : undefined
-            }
-          >
-            <AlertTitle fontWeight="700 !important" mb={1}>
-              <ResultDescription
-                classification={blockaidResponse.classification}
-                reason={blockaidResponse.reason}
-                description={blockaidResponse.description}
-              />
-            </AlertTitle>
-            <BlockaidMessage />
-          </Alert>
-          {needsRiskConfirmation && (
-            <Box
-              className={css.riskConfirmationBlock}
-              sx={{
-                pl: 2,
-              }}
-            >
-              <Track {...MODALS_EVENTS.ACCEPT_RISK}>
-                <FormControlLabel
-                  label={
-                    <Typography variant="body2" color="static.main">
-                      I understand the risks and would like to sign this {isTransaction ? 'transaction' : 'message'}
-                    </Typography>
-                  }
-                  control={<Checkbox checked={isRiskConfirmed} onChange={toggleConfirmation} color="primary" />}
-                />
-              </Track>
-            </Box>
-          )}
-          <Stack
-            direction="row"
-            spacing={0.5}
-            sx={{
-              alignItems: 'center',
-              mt: 1,
-            }}
-          >
-            <Typography
-              variant="caption"
-              sx={{
-                color: 'text.secondary',
-              }}
-            >
-              Powered by
-            </Typography>
-            <BlockaidIcon />
-          </Stack>
-        </>
+      <Alert
+        severity={severityProps?.color}
+        className={css.customAlert}
+        sx={needsRiskConfirmation ? { borderBottomLeftRadius: '0px', borderBottomRightRadius: '0px' } : undefined}
+      >
+        <AlertTitle fontWeight="700 !important" mb={1}>
+          {title}
+        </AlertTitle>
+        {content}
+      </Alert>
+      {needsRiskConfirmation && (
+        <Box className={css.riskConfirmationBlock} sx={{ pl: 2 }}>
+          <Track {...MODALS_EVENTS.ACCEPT_RISK}>
+            <FormControlLabel
+              label={
+                <Typography variant="body2" color="static.main">
+                  I understand the risks and would like to sign this {isTransaction ? 'transaction' : 'message'}
+                </Typography>
+              }
+              control={<Checkbox checked={isRiskConfirmed} onChange={toggleConfirmation} color="primary" />}
+            />
+          </Track>
+        </Box>
       )}
     </Box>
   )
@@ -209,21 +174,56 @@ const BlockaidWarning = () => {
     return <BlockaidError />
   }
 
-  if (isLoading || !blockaidResponse || !blockaidResponse.severity) {
+  if (isLoading || !blockaidResponse) {
     return null
   }
 
   return (
-    <BlockaidResultWarning
-      isRiskConfirmed={isRiskConfirmed}
-      isTransaction={isTransaction}
-      needsRiskConfirmation={needsRiskConfirmation}
-      toggleConfirmation={toggleConfirmation}
-      blockaidResponse={blockaidResponse}
-      severityProps={severityProps}
-    />
+    <Box>
+      {!!blockaidResponse.severity ? (
+        <>
+          <Warning
+            isRiskConfirmed={isRiskConfirmed}
+            isTransaction={isTransaction}
+            needsRiskConfirmation={needsRiskConfirmation}
+            toggleConfirmation={toggleConfirmation}
+            title={
+              <ResultDescription
+                classification={blockaidResponse.classification}
+                reason={blockaidResponse.reason}
+                description={blockaidResponse.description}
+              />
+            }
+            content={<BlockaidMessage />}
+            severityProps={severityProps}
+          />
+          <PoweredByBlockaid />
+        </>
+      ) : blockaidResponse?.contractManagement && blockaidResponse.contractManagement.length > 0 ? (
+        <>
+          <Stack direction="column" spacing={1}>
+            {blockaidResponse?.contractManagement.map((contractChange) => (
+              <ContractChangeWarning key={contractChange.type} contractChange={contractChange} />
+            ))}
+            {blockaidResponse?.contractManagement.map((contractChange) => (
+              <ContractChangeWarning key={contractChange.type} contractChange={contractChange} />
+            ))}
+          </Stack>
+          <PoweredByBlockaid />
+        </>
+      ) : null}
+    </Box>
   )
 }
+
+const PoweredByBlockaid = () => (
+  <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', mt: 1 }}>
+    <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+      Powered by
+    </Typography>
+    <BlockaidIcon />
+  </Stack>
+)
 
 export const BlockaidMessage = () => {
   const { blockaidResponse } = useContext(TxSecurityContext)

--- a/apps/web/src/components/tx/security/blockaid/index.tsx
+++ b/apps/web/src/components/tx/security/blockaid/index.tsx
@@ -55,7 +55,7 @@ export const Warning = ({
 }: {
   title: ReactNode
   content: ReactNode
-  severityProps: SecurityWarningProps
+  severityProps?: SecurityWarningProps
   needsRiskConfirmation?: boolean
   isRiskConfirmed?: boolean
   isTransaction?: boolean
@@ -180,7 +180,7 @@ const BlockaidWarning = () => {
 
   return (
     <>
-      {!!severityProps ? (
+      {!!blockaidResponse.severity ? (
         <Box>
           <Warning
             isRiskConfirmed={isRiskConfirmed}

--- a/apps/web/src/components/tx/security/blockaid/index.tsx
+++ b/apps/web/src/components/tx/security/blockaid/index.tsx
@@ -205,9 +205,6 @@ const BlockaidWarning = () => {
             {blockaidResponse?.contractManagement.map((contractChange) => (
               <ContractChangeWarning key={contractChange.type} contractChange={contractChange} />
             ))}
-            {blockaidResponse?.contractManagement.map((contractChange) => (
-              <ContractChangeWarning key={contractChange.type} contractChange={contractChange} />
-            ))}
           </Stack>
           <PoweredByBlockaid />
         </>

--- a/apps/web/src/components/tx/security/shared/TxSecurityContext.tsx
+++ b/apps/web/src/components/tx/security/shared/TxSecurityContext.tsx
@@ -20,6 +20,7 @@ export const defaultSecurityContextValues = {
     reason: undefined,
     balanceChange: undefined,
     severity: SecuritySeverity.NONE,
+    contractManagement: undefined,
     isLoading: false,
     error: undefined,
   },
@@ -39,6 +40,7 @@ export type TxSecurityContextProps = {
         warnings: NonNullable<BlockaidModuleResponse['issues']>
         balanceChange: BlockaidModuleResponse['balanceChange'] | undefined
         severity: SecuritySeverity | undefined
+        contractManagement: BlockaidModuleResponse['contractManagement'] | undefined
         isLoading: boolean
         error: Error | undefined
       }
@@ -68,6 +70,7 @@ export const TxSecurityProvider = ({ children }: { children: ReactElement }) => 
         severity: blockaidResponse?.severity,
         warnings: blockaidResponse?.payload?.issues || [],
         balanceChange: blockaidResponse?.payload?.balanceChange,
+        contractManagement: blockaidResponse?.payload?.contractManagement,
         error: blockaidError,
         isLoading: blockaidLoading,
       },

--- a/apps/web/src/services/security/modules/BlockaidModule/index.ts
+++ b/apps/web/src/services/security/modules/BlockaidModule/index.ts
@@ -133,7 +133,7 @@ export class BlockaidModule implements SecurityModule<BlockaidModuleRequest, Blo
 
     const simulation = result.simulation
     let balanceChange: AssetDiff[] = []
-    let contractManagement: any[] = []
+    let contractManagement: Array<ProxyUpgradeManagement | OwnershipChangeManagement | ModulesChangeManagement> = []
     let error: Error | undefined = undefined
     if (simulation?.status === 'Success') {
       balanceChange = simulation.assets_diffs[safeAddress]

--- a/apps/web/src/services/security/modules/BlockaidModule/index.ts
+++ b/apps/web/src/services/security/modules/BlockaidModule/index.ts
@@ -4,7 +4,13 @@ import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { generateTypedData } from '@safe-global/protocol-kit/dist/src/utils/eip-712'
 import type { EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
 import { type SecurityResponse, type SecurityModule, SecuritySeverity } from '../types'
-import type { AssetDiff, ContractManagementChange, TransactionScanResponse } from './types'
+import type {
+  AssetDiff,
+  ModulesChangeManagement,
+  OwnershipChangeManagement,
+  ProxyUpgradeManagement,
+  TransactionScanResponse,
+} from './types'
 import { BLOCKAID_API, BLOCKAID_CLIENT_ID } from '@/config/constants'
 import { numberToHex } from '@/utils/hex'
 
@@ -35,7 +41,7 @@ export type BlockaidModuleResponse = {
     description: string
   }[]
   balanceChange: AssetDiff[]
-  contractManagement: ContractManagementChange[]
+  contractManagement: Array<ProxyUpgradeManagement | OwnershipChangeManagement | ModulesChangeManagement>
   error: Error | undefined
 }
 
@@ -82,8 +88,6 @@ export class BlockaidModule implements SecurityModule<BlockaidModuleRequest, Blo
     if (!BLOCKAID_CLIENT_ID) {
       throw new Error('Security check CLIENT_ID not configured')
     }
-
-    // return BENIGN_PAYLOAD
 
     const { chainId, safeAddress } = request
     const message = BlockaidModule.prepareMessage(request)

--- a/apps/web/src/services/security/modules/BlockaidModule/index.ts
+++ b/apps/web/src/services/security/modules/BlockaidModule/index.ts
@@ -89,12 +89,12 @@ export class BlockaidModule implements SecurityModule<BlockaidModuleRequest, Blo
       throw new Error('Security check CLIENT_ID not configured')
     }
 
-    const { chainId, safeAddress } = request
+    const { chainId, safeAddress, walletAddress } = request
     const message = BlockaidModule.prepareMessage(request)
 
     const payload: BlockaidPayload = {
       chain: numberToHex(chainId),
-      account_address: safeAddress,
+      account_address: walletAddress,
       data: {
         method: 'eth_signTypedData_v4',
         params: [safeAddress, message],

--- a/apps/web/src/services/security/modules/BlockaidModule/index.ts
+++ b/apps/web/src/services/security/modules/BlockaidModule/index.ts
@@ -4,7 +4,7 @@ import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { generateTypedData } from '@safe-global/protocol-kit/dist/src/utils/eip-712'
 import type { EIP712TypedData } from '@safe-global/safe-gateway-typescript-sdk'
 import { type SecurityResponse, type SecurityModule, SecuritySeverity } from '../types'
-import type { AssetDiff, TransactionScanResponse } from './types'
+import type { AssetDiff, ContractManagementChange, TransactionScanResponse } from './types'
 import { BLOCKAID_API, BLOCKAID_CLIENT_ID } from '@/config/constants'
 import { numberToHex } from '@/utils/hex'
 
@@ -35,6 +35,7 @@ export type BlockaidModuleResponse = {
     description: string
   }[]
   balanceChange: AssetDiff[]
+  contractManagement: ContractManagementChange[]
   error: Error | undefined
 }
 
@@ -82,6 +83,8 @@ export class BlockaidModule implements SecurityModule<BlockaidModuleRequest, Blo
       throw new Error('Security check CLIENT_ID not configured')
     }
 
+    // return BENIGN_PAYLOAD
+
     const { chainId, safeAddress } = request
     const message = BlockaidModule.prepareMessage(request)
 
@@ -126,9 +129,11 @@ export class BlockaidModule implements SecurityModule<BlockaidModuleRequest, Blo
 
     const simulation = result.simulation
     let balanceChange: AssetDiff[] = []
+    let contractManagement: any[] = []
     let error: Error | undefined = undefined
     if (simulation?.status === 'Success') {
       balanceChange = simulation.assets_diffs[safeAddress]
+      contractManagement = simulation.contract_management?.[safeAddress] || []
     } else if (simulation?.status === 'Error') {
       error = new Error('Simulation failed')
     }
@@ -148,6 +153,7 @@ export class BlockaidModule implements SecurityModule<BlockaidModuleRequest, Blo
         reason: result.validation?.reason,
         issues,
         balanceChange,
+        contractManagement,
         error,
       },
     }

--- a/apps/web/src/services/security/modules/BlockaidModule/types.ts
+++ b/apps/web/src/services/security/modules/BlockaidModule/types.ts
@@ -480,7 +480,32 @@ export interface TransactionSimulation {
    * spenders
    */
   total_usd_exposure: Record<string, Record<string, string>>
+
+  /**
+   * dictionary describes contract management changes as a result of this transaction
+   * for every involved address
+   */
+  contract_management?: Record<string, Array<ContractManagementChange>>
 }
+interface ProxyUpgrade {
+  type: 'PROXY_UPGRADE'
+  before: { address: string }
+  after: { address: string }
+}
+
+interface OwnershipChange {
+  type: 'OWNERSHIP_CHANGE'
+  before: { owners: string[] }
+  after: { owners: string[] }
+}
+
+interface ModulesChange {
+  type: 'MODULE_CHANGE'
+  before: { modules: string[] }
+  after: { modules: string[] }
+}
+
+export type ContractManagementChange = ProxyUpgrade | OwnershipChange | ModulesChange
 
 export namespace TransactionSimulation {
   /**

--- a/apps/web/src/services/security/modules/BlockaidModule/types.ts
+++ b/apps/web/src/services/security/modules/BlockaidModule/types.ts
@@ -572,7 +572,7 @@ export interface ModulesChangeManagement {
   /**
    * The type of the state change
    */
-  type: 'MODULE_CHANGE'
+  type: 'MODULES_CHANGE'
 }
 
 export namespace ModulesChangeManagement {

--- a/apps/web/src/services/security/modules/BlockaidModule/types.ts
+++ b/apps/web/src/services/security/modules/BlockaidModule/types.ts
@@ -485,27 +485,111 @@ export interface TransactionSimulation {
    * dictionary describes contract management changes as a result of this transaction
    * for every involved address
    */
-  contract_management?: Record<string, Array<ContractManagementChange>>
+  // contract_management?: Record<string, Array<ContractManagementChange>>
+  contract_management?: Record<
+    string,
+    Array<ProxyUpgradeManagement | OwnershipChangeManagement | ModulesChangeManagement>
+  >
 }
-interface ProxyUpgrade {
+
+export interface ProxyUpgradeManagement {
+  /**
+   * The state after the transaction
+   */
+  after: ProxyUpgradeManagement.After
+
+  /**
+   * The state before the transaction
+   */
+  before: ProxyUpgradeManagement.Before
+
+  /**
+   * The type of the state change
+   */
   type: 'PROXY_UPGRADE'
-  before: { address: string }
-  after: { address: string }
 }
 
-interface OwnershipChange {
+export namespace ProxyUpgradeManagement {
+  /**
+   * The state after the transaction
+   */
+  export interface After {
+    address: string
+  }
+
+  /**
+   * The state before the transaction
+   */
+  export interface Before {
+    address: string
+  }
+}
+
+export interface OwnershipChangeManagement {
+  /**
+   * The state after the transaction
+   */
+  after: OwnershipChangeManagement.After
+
+  /**
+   * The state before the transaction
+   */
+  before: OwnershipChangeManagement.Before
+
+  /**
+   * The type of the state change
+   */
   type: 'OWNERSHIP_CHANGE'
-  before: { owners: string[] }
-  after: { owners: string[] }
 }
 
-interface ModulesChange {
+export namespace OwnershipChangeManagement {
+  /**
+   * The state after the transaction
+   */
+  export interface After {
+    owners: Array<string>
+  }
+
+  /**
+   * The state before the transaction
+   */
+  export interface Before {
+    owners: Array<string>
+  }
+}
+
+export interface ModulesChangeManagement {
+  /**
+   * The state after the transaction
+   */
+  after: ModulesChangeManagement.After
+
+  /**
+   * The state before the transaction
+   */
+  before: ModulesChangeManagement.Before
+
+  /**
+   * The type of the state change
+   */
   type: 'MODULE_CHANGE'
-  before: { modules: string[] }
-  after: { modules: string[] }
 }
 
-export type ContractManagementChange = ProxyUpgrade | OwnershipChange | ModulesChange
+export namespace ModulesChangeManagement {
+  /**
+   * The state after the transaction
+   */
+  export interface After {
+    modules: Array<string>
+  }
+
+  /**
+   * The state before the transaction
+   */
+  export interface Before {
+    modules: Array<string>
+  }
+}
 
 export namespace TransactionSimulation {
   /**


### PR DESCRIPTION
## What it solves
Blockaid returns a simulation which we don’t use for anything other than balance changes.

## How this PR fixes it
Show the simulation results for transactions that make contract changes:
- Delegate call to update the mastercopy
- Changing signers or threshold.
- Changing Safe modules

Note: if the blockaid scan already shows that the tx may be malicious then don't show these additional warnings (there are already warnings in place). Only show the simulation results as a fallback if the transactions is otherwise marked as benign.

## How to test it
- Create a tx which updates the mastercopy of a safe. See that a warning is shown near the sign button
- Create a tx that changes the signer setup or threshold of a safe. See that the warning is shown.

## Screenshots

![image](https://github.com/user-attachments/assets/aeb9f9de-cf2a-4560-b898-2553d7dd5998)
![image](https://github.com/user-attachments/assets/5d5a6c6c-cc64-453f-aa9c-d346d15a469b)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
