### PR TITLE
Fix(mobile): show confirmation button if a tx has more signatures than threshold

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
+++ b/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
@@ -32,7 +32,7 @@ function ConfirmTxContainer() {
   const detailedExecutionInfo = data?.detailedExecutionInfo as MultisigExecutionDetails
   const { activeSigner, hasSigned } = useTxSigner(detailedExecutionInfo)
   const hasEnoughConfirmations =
-    detailedExecutionInfo?.confirmationsRequired === detailedExecutionInfo?.confirmations?.length
+    detailedExecutionInfo?.confirmationsRequired <= detailedExecutionInfo?.confirmations?.length
 
   if (isFetching || !data) {
     return <LoadingTx />


### PR DESCRIPTION
It changes the condition for showing the "sign" button in the mobile app. According to @katspaugh, a tx can have more signatures than the threshold, so we need to adjust the display condition.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
