### PR TITLE
Feat(mobile): create transaction parameters page

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -45,7 +45,6 @@ function RootLayout() {
                           ...getDefaultScreenOptions(navigation.goBack),
                         })}
                       >
-                        {/*<Stack.Screen name="index" />*/}
                         <Stack.Screen
                           name="onboarding"
                           options={{
@@ -68,6 +67,8 @@ function RootLayout() {
                         <Stack.Screen name="sign-transaction" options={{ headerShown: false }} />
                         <Stack.Screen name="pending-transactions" options={{ headerShown: true, title: '' }} />
                         <Stack.Screen name="notifications" options={{ headerShown: true, title: '' }} />
+
+                        <Stack.Screen name="transaction-parameters" options={{ headerShown: true, title: '' }} />
 
                         <Stack.Screen name="signers" options={{ headerShown: false }} />
                         <Stack.Screen name="import-signers" options={{ headerShown: false }} />

--- a/apps/mobile/src/app/transaction-parameters.tsx
+++ b/apps/mobile/src/app/transaction-parameters.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+import { TransactionParametersContainer } from '@/src/features/TransactionParameters'
+
+function TransactionParameters() {
+  return (
+    <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
+      <TransactionParametersContainer />
+    </SafeAreaView>
+  )
+}
+
+export default TransactionParameters

--- a/apps/mobile/src/components/CopyButton/CopyButton.tsx
+++ b/apps/mobile/src/components/CopyButton/CopyButton.tsx
@@ -6,10 +6,11 @@ interface CopyButtonProps {
   value: string
   color: TextProps['color']
   size?: number
+  text?: string
 }
 
-export const CopyButton = ({ value, color, size = 13 }: CopyButtonProps) => {
-  const copyAndDispatchToast = useCopyAndDispatchToast()
+export const CopyButton = ({ value, color, size = 13, text }: CopyButtonProps) => {
+  const copyAndDispatchToast = useCopyAndDispatchToast(text)
   return (
     <Button
       onPress={() => {

--- a/apps/mobile/src/config/constants.ts
+++ b/apps/mobile/src/config/constants.ts
@@ -3,7 +3,7 @@ import { Platform } from 'react-native'
 
 // export const isProduction = process.env.NODE_ENV === 'production'
 // TODO: put it to get from process.env.NODE_ENV once we remove the mocks for the user account.
-export const isProduction = false
+export const isProduction = true
 export const isAndroid = Platform.OS === 'android'
 export const isTestingEnv = process.env.NODE_ENV === 'test'
 export const isStorybookEnv = Constants?.expoConfig?.extra?.storybookEnabled === 'true'

--- a/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
+++ b/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
@@ -32,7 +32,7 @@ function ConfirmTxContainer() {
   const detailedExecutionInfo = data?.detailedExecutionInfo as MultisigExecutionDetails
   const { activeSigner, hasSigned } = useTxSigner(detailedExecutionInfo)
   const hasEnoughConfirmations =
-    detailedExecutionInfo?.confirmationsRequired === detailedExecutionInfo?.confirmations?.length
+    detailedExecutionInfo?.confirmationsRequired <= detailedExecutionInfo?.confirmations?.length
 
   if (isFetching || !data) {
     return <LoadingTx />

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
@@ -44,6 +44,7 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
     case ETxType.ADD_SIGNER:
       return (
         <AddSigner
+          txId={txDetails.txId}
           executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
           txInfo={txDetails.txInfo as NormalizedSettingsChangeTransaction}
         />
@@ -51,6 +52,7 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
     case ETxType.REMOVE_SIGNER:
       return (
         <RemoveSigner
+          txId={txDetails.txId}
           executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
           txInfo={txDetails.txInfo as NormalizedSettingsChangeTransaction}
         />
@@ -65,6 +67,7 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
     case ETxType.CONTRACT_INTERACTION:
       return (
         <Contract
+          txId={txDetails.txId}
           executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
           txInfo={txDetails.txInfo as CustomTransactionInfo}
         />
@@ -73,6 +76,7 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
       return (
         <GenericView
           executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
+          txId={txDetails.txId}
           txInfo={txDetails.txInfo as SettingsChangeTransaction}
           txData={txDetails.txData as TransactionData}
         />

--- a/apps/mobile/src/features/ConfirmTx/components/ListTable/ListTable.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ListTable/ListTable.tsx
@@ -2,15 +2,17 @@ import { Container } from '@/src/components/Container'
 import React from 'react'
 import { Text, View } from 'tamagui'
 
+export type ListTableItem = {
+  label: string
+  value?: string
+  render?: () => React.ReactNode
+}
 interface ListTableProps {
-  items: {
-    label: string
-    value?: string
-    render?: () => React.ReactNode
-  }[]
+  items: ListTableItem[]
+  children?: React.ReactNode
 }
 
-export function ListTable({ items }: ListTableProps) {
+export function ListTable({ items, children }: ListTableProps) {
   return (
     <Container padding="$4" gap="$5" borderRadius="$3">
       {items.map((item, index) => (
@@ -22,6 +24,8 @@ export function ListTable({ items }: ListTableProps) {
           {item.render ? item.render() : <Text fontSize="$4">{item.value}</Text>}
         </View>
       ))}
+
+      {children}
     </Container>
   )
 }

--- a/apps/mobile/src/features/ConfirmTx/components/ListTable/ListTable.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ListTable/ListTable.tsx
@@ -6,6 +6,8 @@ export type ListTableItem = {
   label: string
   value?: string
   render?: () => React.ReactNode
+  direction?: 'row' | 'column'
+  alignItems?: 'center' | 'flex-start'
 }
 interface ListTableProps {
   items: ListTableItem[]
@@ -16,7 +18,12 @@ export function ListTable({ items, children }: ListTableProps) {
   return (
     <Container padding="$4" gap="$5" borderRadius="$3">
       {items.map((item, index) => (
-        <View key={index} alignItems="center" flexDirection="row" justifyContent="space-between">
+        <View
+          key={index}
+          alignItems={item.alignItems || 'center'}
+          flexDirection={item.direction || 'row'}
+          justifyContent="space-between"
+        >
           <Text color="$textSecondaryLight" fontSize="$4">
             {item.label}
           </Text>

--- a/apps/mobile/src/features/ConfirmTx/components/ListTable/index.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/ListTable/index.ts
@@ -1,1 +1,1 @@
-export { ListTable } from './ListTable'
+export { ListTable, type ListTableItem } from './ListTable'

--- a/apps/mobile/src/features/ConfirmTx/components/ParametersButton/ParametersButton.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ParametersButton/ParametersButton.tsx
@@ -1,0 +1,33 @@
+import { router } from 'expo-router'
+import React from 'react'
+import { Button, View } from 'tamagui'
+
+interface ParametersButtonProps {
+  txId: string
+}
+
+export function ParametersButton({ txId }: ParametersButtonProps) {
+  const handleViewParameters = () => {
+    router.push({
+      pathname: '/transaction-parameters',
+      params: { txId },
+    })
+  }
+
+  return (
+    <View height="$10" alignItems="center">
+      <Button
+        paddingHorizontal="$2"
+        height="$10"
+        borderRadius="$3"
+        backgroundColor="$borderLight"
+        fontWeight="500"
+        size="$5"
+        fullscreen
+        onPress={handleViewParameters}
+      >
+        View Parameters
+      </Button>
+    </View>
+  )
+}

--- a/apps/mobile/src/features/ConfirmTx/components/ParametersButton/index.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/ParametersButton/index.ts
@@ -1,0 +1,1 @@
+export { ParametersButton } from './ParametersButton'

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/AddSigner.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/AddSigner.tsx
@@ -1,20 +1,24 @@
 import React, { useMemo } from 'react'
 import { YStack } from 'tamagui'
-import { TransactionHeader } from '../../TransactionHeader'
-import { ListTable } from '../../ListTable'
 import { formatAddSignerItems, getSignerName } from './utils'
 import { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useAppSelector } from '@/src/store/hooks'
 import { RootState } from '@/src/store'
 import { selectChainById } from '@/src/store/chains'
+
+import { ListTable } from '../../ListTable'
+import { TransactionHeader } from '../../TransactionHeader'
+import { ParametersButton } from '../../ParametersButton'
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
+
 interface AddSignerProps {
   txInfo: NormalizedSettingsChangeTransaction
   executionInfo: MultisigExecutionDetails
+  txId: string
 }
 
-export function AddSigner({ txInfo, executionInfo }: AddSignerProps) {
+export function AddSigner({ txInfo, executionInfo, txId }: AddSignerProps) {
   const activeSafe = useDefinedActiveSafe()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const items = useMemo(
@@ -34,7 +38,9 @@ export function AddSigner({ txInfo, executionInfo }: AddSignerProps) {
         title={newSignerAddress}
       />
 
-      <ListTable items={items} />
+      <ListTable items={items}>
+        <ParametersButton txId={txId} />
+      </ListTable>
     </YStack>
   )
 }

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/utils.tsx
@@ -8,6 +8,7 @@ import { shortenAddress } from '@safe-global/utils/formatters'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { Identicon } from '@/src/components/Identicon'
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
+import { CopyButton } from '@/src/components/CopyButton'
 
 export const getSignerName = (txInfo: NormalizedSettingsChangeTransaction) => {
   if (!txInfo.settingsInfo) {
@@ -37,7 +38,8 @@ export const formatAddSignerItems = (
         <View flexDirection="row" alignItems="center" gap="$2">
           <Identicon address={txInfo.settingsInfo?.owner?.value} size={24} />
           <Text fontSize="$4">{newSignerAddress}</Text>
-          <SafeFontIcon name="copy" size={14} color="textSecondaryLight" />
+          <CopyButton value={txInfo.settingsInfo?.owner?.value} color={'$textSecondaryLight'} />
+
           <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
         </View>
       ),

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
@@ -11,13 +11,15 @@ import { useAppSelector } from '@/src/store/hooks'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Badge } from '@/src/components/Badge'
+import { ParametersButton } from '../../ParametersButton'
 
 interface ContractProps {
   txInfo: CustomTransactionInfo
   executionInfo: MultisigExecutionDetails
+  txId: string
 }
 
-export function Contract({ txInfo, executionInfo }: ContractProps) {
+export function Contract({ txInfo, executionInfo, txId }: ContractProps) {
   const activeSafe = useDefinedActiveSafe()
   const chain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const items = useMemo(() => formatContractItems(txInfo, chain), [txInfo, chain])
@@ -33,7 +35,9 @@ export function Contract({ txInfo, executionInfo }: ContractProps) {
         submittedAt={executionInfo.submittedAt}
       />
 
-      <ListTable items={items} />
+      <ListTable items={items}>
+        <ParametersButton txId={txId} />
+      </ListTable>
 
       {txInfo.actionCount && (
         <SafeListItem

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
@@ -7,6 +7,7 @@ import { CircleProps, Text, View } from 'tamagui'
 import { CustomTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { shortenAddress } from '@safe-global/utils/formatters'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { CopyButton } from '@/src/components/CopyButton'
 
 const mintBadgeProps: CircleProps = { borderRadius: '$2', paddingHorizontal: '$2', paddingVertical: '$1' }
 
@@ -32,7 +33,7 @@ export const formatContractItems = (txInfo: CustomTransactionInfo, chain: Chain)
         <View flexDirection="row" alignItems="center" gap="$2">
           <Logo logoUri={txInfo.to.logoUri} size="$6" />
           <Text fontSize="$4">{contractName}</Text>
-          <SafeFontIcon name="copy" size={14} color="textSecondaryLight" />
+          <CopyButton value={txInfo.to.value} color={'$textSecondaryLight'} />
           <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
         </View>
       ),

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/GenericView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/GenericView.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo } from 'react'
 import { View, YStack } from 'tamagui'
-import { TransactionHeader } from '../../TransactionHeader'
-import { ListTable } from '../../ListTable'
 import { formatGenericViewItems } from './utils'
 import {
   SettingsChangeTransaction,
@@ -16,13 +14,18 @@ import { SafeListItem } from '@/src/components/SafeListItem'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Badge } from '@/src/components/Badge'
 
+import { ListTable } from '../../ListTable'
+import { TransactionHeader } from '../../TransactionHeader'
+import { ParametersButton } from '../../ParametersButton'
+
 interface GenericViewProps {
   txInfo: SettingsChangeTransaction
   executionInfo: MultisigExecutionDetails
   txData: TransactionData
+  txId: string
 }
 
-export function GenericView({ txInfo, txData, executionInfo }: GenericViewProps) {
+export function GenericView({ txInfo, txData, executionInfo, txId }: GenericViewProps) {
   const activeSafe = useDefinedActiveSafe()
   const chain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const items = useMemo(
@@ -41,7 +44,9 @@ export function GenericView({ txInfo, txData, executionInfo }: GenericViewProps)
         submittedAt={executionInfo.submittedAt}
       />
 
-      <ListTable items={items} />
+      <ListTable items={items}>
+        <ParametersButton txId={txId} />
+      </ListTable>
 
       {'actionCount' in txInfo && (
         <SafeListItem

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/utils.tsx
@@ -13,6 +13,7 @@ import {
 } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { Identicon } from '@/src/components/Identicon'
 import { Address } from '@/src/types/address'
+import { CopyButton } from '@/src/components/CopyButton'
 
 const mintBadgeProps: CircleProps = { borderRadius: '$2', paddingHorizontal: '$2', paddingVertical: '$1' }
 
@@ -52,7 +53,7 @@ export const formatGenericViewItems = ({
             <Identicon address={txData.to.value as Address} size={24} />
           )}
           <Text fontSize="$4">{genericViewName}</Text>
-          <SafeFontIcon name="copy" size={14} color="textSecondaryLight" />
+          <CopyButton value={txData.to.value} color={'$textSecondaryLight'} />
           <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
         </View>
       ),

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/RemoveSigner.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/RemoveSigner.tsx
@@ -1,23 +1,26 @@
 import React, { useMemo } from 'react'
 import { YStack } from 'tamagui'
-import { TransactionHeader } from '../../TransactionHeader'
-import { ListTable } from '../../ListTable'
-import { formatRemoveSignerItems } from './utils'
 import { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useAppSelector } from '@/src/store/hooks'
 import { RootState } from '@/src/store'
 import { selectChainById } from '@/src/store/chains'
-import { getSignerName } from '../AddSigner/utils'
 
+import { formatRemoveSignerItems } from './utils'
+
+import { TransactionHeader } from '../../TransactionHeader'
+import { ListTable } from '../../ListTable'
+import { getSignerName } from '../AddSigner/utils'
+import { ParametersButton } from '../../ParametersButton'
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
 
 interface RemoveSignerProps {
   txInfo: NormalizedSettingsChangeTransaction
   executionInfo: MultisigExecutionDetails
+  txId: string
 }
 
-export function RemoveSigner({ txInfo, executionInfo }: RemoveSignerProps) {
+export function RemoveSigner({ txInfo, executionInfo, txId }: RemoveSignerProps) {
   const activeSafe = useDefinedActiveSafe()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const items = useMemo(() => formatRemoveSignerItems(txInfo, activeChain), [txInfo, activeChain])
@@ -34,7 +37,9 @@ export function RemoveSigner({ txInfo, executionInfo }: RemoveSignerProps) {
         title={newRemovedSigners}
       />
 
-      <ListTable items={items} />
+      <ListTable items={items}>
+        <ParametersButton txId={txId} />
+      </ListTable>
     </YStack>
   )
 }

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/utils.tsx
@@ -7,6 +7,7 @@ import { Identicon } from '@/src/components/Identicon'
 import { getSignerName } from '../AddSigner/utils'
 
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
+import { CopyButton } from '@/src/components/CopyButton'
 
 export const formatRemoveSignerItems = (txInfo: NormalizedSettingsChangeTransaction, chain: Chain) => {
   const newRemovedSigners = getSignerName(txInfo)
@@ -18,7 +19,7 @@ export const formatRemoveSignerItems = (txInfo: NormalizedSettingsChangeTransact
         <View flexDirection="row" alignItems="center" gap="$2">
           <Identicon address={txInfo.settingsInfo?.owner?.value} size={24} />
           <Text fontSize="$4">{newRemovedSigners}</Text>
-          <SafeFontIcon name="copy" size={14} color="textSecondaryLight" />
+          <CopyButton value={txInfo.settingsInfo?.owner?.value} color={'$textSecondaryLight'} />
           <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
         </View>
       ),

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/utils.tsx
@@ -9,6 +9,7 @@ import { ellipsis, formatValue, getLimitPrice } from '@/src/utils/formatters'
 import { TokenInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { formatAmount } from '@safe-global/utils/formatNumber'
+import { CopyButton } from '@/src/components/CopyButton'
 
 export const formatSwapOrderItems = (txInfo: OrderTransactionInfo, chain: Chain) => {
   const expiresAt = formatWithSchema(txInfo.validUntil * 1000, 'dd/MM/yyyy, HH:mm')
@@ -31,7 +32,7 @@ export const formatSwapOrderItems = (txInfo: OrderTransactionInfo, chain: Chain)
           {'uid' in txInfo && (
             <>
               <Text fontSize="$4">{ellipsis(txInfo.uid, 6)}</Text>
-              <SafeFontIcon name="copy" size={14} color="textSecondaryLight" />
+              <CopyButton value={txInfo.uid} color={'$textSecondaryLight'} />
               <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
             </>
           )}

--- a/apps/mobile/src/features/TransactionParameters/TransactionParameters.container.tsx
+++ b/apps/mobile/src/features/TransactionParameters/TransactionParameters.container.tsx
@@ -1,0 +1,42 @@
+import { useLocalSearchParams } from 'expo-router'
+import React from 'react'
+import { ScrollView, View } from 'tamagui'
+import { useTransactionsGetTransactionByIdV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+import { LargeHeaderTitle, NavBarTitle } from '@/src/components/Title'
+import { useScrollableHeader } from '@/src/navigation/useScrollableHeader'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { Alert } from '@/src/components/Alert'
+
+import { LoadingTx } from '../ConfirmTx/components/LoadingTx'
+import { TxParametersList } from './components/TxParametersList'
+
+export function TransactionParametersContainer() {
+  const { txId } = useLocalSearchParams<{ txId: string }>()
+  const activeSafe = useDefinedActiveSafe()
+
+  const { data, isFetching, isError } = useTransactionsGetTransactionByIdV1Query({
+    chainId: activeSafe.chainId,
+    id: txId,
+  })
+
+  const { handleScroll } = useScrollableHeader({
+    children: <NavBarTitle>Parameters</NavBarTitle>,
+  })
+
+  if (isError) {
+    return (
+      <View margin="$4">
+        <Alert type="error" message="Error fetching transaction parameters" />
+      </View>
+    )
+  }
+
+  return (
+    <ScrollView onScroll={handleScroll} contentContainerStyle={{ flex: 1 }}>
+      <LargeHeaderTitle paddingHorizontal="$4">Parameters</LargeHeaderTitle>
+
+      {isFetching || !data ? <LoadingTx /> : <TxParametersList txDetails={data} />}
+    </ScrollView>
+  )
+}

--- a/apps/mobile/src/features/TransactionParameters/TransactionParameters.container.tsx
+++ b/apps/mobile/src/features/TransactionParameters/TransactionParameters.container.tsx
@@ -33,7 +33,7 @@ export function TransactionParametersContainer() {
   }
 
   return (
-    <ScrollView onScroll={handleScroll} contentContainerStyle={{ flex: 1 }}>
+    <ScrollView onScroll={handleScroll}>
       <LargeHeaderTitle paddingHorizontal="$4">Parameters</LargeHeaderTitle>
 
       {isFetching || !data ? <LoadingTx /> : <TxParametersList txDetails={data} />}

--- a/apps/mobile/src/features/TransactionParameters/components/TxParametersList/TxParametersList.tsx
+++ b/apps/mobile/src/features/TransactionParameters/components/TxParametersList/TxParametersList.tsx
@@ -1,0 +1,20 @@
+import React, { useMemo } from 'react'
+import { View } from 'tamagui'
+
+import { ListTable } from '@/src/features/ConfirmTx/components/ListTable'
+import { formatParameters } from './utils'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+interface TxParametersListProps {
+  txDetails: TransactionDetails
+}
+
+export function TxParametersList({ txDetails }: TxParametersListProps) {
+  const items = useMemo(() => formatParameters({ txData: txDetails.txData }), [txDetails.txData])
+
+  return (
+    <View margin="$4">
+      <ListTable items={items} />
+    </View>
+  )
+}

--- a/apps/mobile/src/features/TransactionParameters/components/TxParametersList/formatters/arrayValue.tsx
+++ b/apps/mobile/src/features/TransactionParameters/components/TxParametersList/formatters/arrayValue.tsx
@@ -1,0 +1,35 @@
+import { ListTableItem } from '@/src/features/ConfirmTx/components/ListTable'
+import { DataDecodedParameter } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { ReactElement } from 'react'
+import { Text, View } from 'tamagui'
+import { shortenText } from '@safe-global/utils/formatters'
+import { CopyButton } from '@/src/components/CopyButton'
+
+const renderArrayValue = (value: object, index?: number): ReactElement => {
+  const displayLimit = 30
+
+  if (Array.isArray(value)) {
+    return (
+      <View key={`array-${index}`}>
+        <Text>[</Text>
+        <View marginLeft={'$2'}>{value.map(renderArrayValue)}</View>
+        <Text>]</Text>
+      </View>
+    )
+  }
+  return (
+    <View key={`value-${value}-${index}`} flexDirection="row" alignItems="center" gap="$1">
+      <Text>{shortenText(String(value), displayLimit)}</Text>
+      <CopyButton value={String(value)} color={'$textSecondaryLight'} text="Data copied." />
+    </View>
+  )
+}
+
+export const formatArrayValue = (param: DataDecodedParameter): ListTableItem => {
+  return {
+    label: param.name,
+    render: () => renderArrayValue(param.value),
+    direction: 'column',
+    alignItems: 'flex-start',
+  }
+}

--- a/apps/mobile/src/features/TransactionParameters/components/TxParametersList/formatters/singleValue.tsx
+++ b/apps/mobile/src/features/TransactionParameters/components/TxParametersList/formatters/singleValue.tsx
@@ -1,0 +1,53 @@
+import { DataDecodedParameter } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { ListTableItem } from '@/src/features/ConfirmTx/components/ListTable'
+import { shortenText } from '@safe-global/utils/formatters'
+import { Text, View } from 'tamagui'
+import { CopyButton } from '@/src/components/CopyButton'
+import { EthAddress } from '@/src/components/EthAddress'
+import { Address } from '@/src/types/address'
+import { Identicon } from '@/src/components/Identicon'
+
+export const characterDisplayLimit = 15
+
+export const DisplayValue = ({ type, value }: { type: string; value: string }) => {
+  const isLong = value.length > characterDisplayLimit
+
+  switch (type) {
+    case 'hash':
+    case 'address':
+      return (
+        <View flexDirection="row" alignItems="center" gap="$1">
+          <Identicon address={value as Address} size={24} />
+          <EthAddress address={value as Address} copy copyProps={{ color: '$textSecondaryLight' }} />
+        </View>
+      )
+    case 'rawData':
+    case 'bytes':
+      return (
+        <View flexDirection="row" alignItems="center" gap="$1">
+          <Text>{shortenText(value, characterDisplayLimit)}</Text>
+          <CopyButton value={value} color={'$textSecondaryLight'} text="Data copied." />
+        </View>
+      )
+    default:
+      return (
+        <View flexDirection="row" alignItems="center" gap="$1">
+          <Text>{isLong ? shortenText(value, characterDisplayLimit) : value}</Text>
+          {isLong && <CopyButton value={value} color={'$textSecondaryLight'} text="Data copied." />}
+        </View>
+      )
+  }
+}
+
+export const formatValueTemplate = (param: DataDecodedParameter): ListTableItem => {
+  if (param.value == undefined || typeof param.value !== 'string') {
+    return {
+      label: param.name,
+    }
+  }
+
+  return {
+    label: param.name,
+    render: () => <DisplayValue type={param.type} value={String(param.value)} />,
+  }
+}

--- a/apps/mobile/src/features/TransactionParameters/components/TxParametersList/index.ts
+++ b/apps/mobile/src/features/TransactionParameters/components/TxParametersList/index.ts
@@ -1,0 +1,1 @@
+export { TxParametersList } from './TxParametersList'

--- a/apps/mobile/src/features/TransactionParameters/components/TxParametersList/utils.tsx
+++ b/apps/mobile/src/features/TransactionParameters/components/TxParametersList/utils.tsx
@@ -1,0 +1,100 @@
+import { DataDecodedParameter, TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { ListTableItem } from '@/src/features/ConfirmTx/components/ListTable'
+import { isArrayParameter } from '@/src/utils/transaction-guards'
+import { shortenText } from '@safe-global/utils/formatters'
+import { Text, View } from 'tamagui'
+import { CopyButton } from '@/src/components/CopyButton'
+import { EthAddress } from '@/src/components/EthAddress'
+import { Address } from '@/src/types/address'
+import { Identicon } from '@/src/components/Identicon'
+interface formatParametersProps {
+  txData: TransactionDetails['txData']
+}
+
+const textDisplayLimit = 15
+
+const formatValueTemplate = (param: DataDecodedParameter): ListTableItem => {
+  if (param.value == undefined || typeof param.value !== 'string') {
+    return {
+      label: param.name,
+    }
+  }
+
+  switch (param.type) {
+    case 'hash':
+    case 'address':
+      return {
+        label: param.name,
+        render: () => (
+          <View flexDirection="row" alignItems="center" gap="$1">
+            <Identicon address={String(param.value) as Address} size={24} />
+            <EthAddress address={String(param.value) as Address} copy copyProps={{ color: '$textSecondaryLight' }} />
+          </View>
+        ),
+      }
+    case 'rawData':
+    case 'bytes':
+      return {
+        label: param.name,
+        render: () => (
+          <View flexDirection="row" alignItems="center" gap="$1">
+            <Text>{shortenText(String(param.value), textDisplayLimit)}</Text>
+            <CopyButton value={String(param.value)} color={'$textSecondaryLight'} text="Data copied." />
+          </View>
+        ),
+      }
+    default:
+      return {
+        label: param.name,
+        render: () => (
+          <View flexDirection="row" alignItems="center" gap="$1">
+            <Text>{shortenText(String(param.value), textDisplayLimit)}</Text>
+            {String(param.value).length > textDisplayLimit && (
+              <CopyButton value={String(param.value)} color={'$textSecondaryLight'} text="Data copied." />
+            )}
+          </View>
+        ),
+      }
+  }
+}
+
+const formatParameters = ({ txData }: formatParametersProps): ListTableItem[] => {
+  const items: ListTableItem[] = [
+    {
+      label: txData?.dataDecoded?.method ? 'Method' : 'Interacted with',
+      value: txData?.dataDecoded?.method || txData?.to.value,
+    },
+  ]
+
+  const parameters = txData?.dataDecoded?.parameters
+
+  if (parameters && parameters.length) {
+    const formatedParameters = parameters.reduce<ListTableItem[]>((acc, param) => {
+      const isArrayValueParam = isArrayParameter(param.type) || Array.isArray(param.value)
+
+      if (isArrayValueParam) {
+        return acc
+      }
+
+      acc.push(formatValueTemplate(param))
+
+      return acc
+    }, [])
+
+    items.push(...formatedParameters)
+  } else if (txData?.hexData) {
+    items.push({
+      label: 'Hex Data:',
+      render: () => (
+        <View flexDirection="row" alignItems="center" gap="$1">
+          <Text>{shortenText(txData?.hexData || '', textDisplayLimit)}</Text>
+          <CopyButton value={txData?.hexData || ''} color={'$textSecondaryLight'} text="Data copied." />
+        </View>
+      ),
+    })
+  }
+
+  return items
+}
+
+export { formatParameters }

--- a/apps/mobile/src/features/TransactionParameters/index.ts
+++ b/apps/mobile/src/features/TransactionParameters/index.ts
@@ -1,0 +1,1 @@
+export { TransactionParametersContainer } from './TransactionParameters.container'

--- a/apps/mobile/src/hooks/useCopyAndDispatchToast/index.ts
+++ b/apps/mobile/src/hooks/useCopyAndDispatchToast/index.ts
@@ -1,11 +1,12 @@
 import { useToastController } from '@tamagui/toast'
 import Clipboard from '@react-native-clipboard/clipboard'
 
-export const useCopyAndDispatchToast = () => {
+export const useCopyAndDispatchToast = (text = 'Address copied.') => {
   const toast = useToastController()
+
   return (value: string) => {
     Clipboard.setString(value)
-    toast.show('Address copied.', {
+    toast.show(text, {
       native: false,
       duration: 2000,
     })

--- a/apps/mobile/src/utils/transaction-guards.ts
+++ b/apps/mobile/src/utils/transaction-guards.ts
@@ -65,6 +65,7 @@ export const getBulkGroupTxHash = (group: PendingTransactionItems[]) => {
   return uniq(hashList).length === 1 ? hashList[0] : undefined
 }
 
+export const isArrayParameter = (parameter: string): boolean => /(\[\d*?])+$/.test(parameter)
 export const getTxHash = (item: TransactionQueuedItem): string => item.transaction.txHash as unknown as string
 
 export const isTransferTxInfo = (value: Transaction['txInfo']): value is TransferTransactionInfo => {


### PR DESCRIPTION
It allows user to see the transaction parameters by clicking in the "View Parameters" button, at the transaction details.

## Screenshots
<img width="502" alt="Screenshot 2025-03-07 at 15 45 45" src="https://github.com/user-attachments/assets/e42fd812-8942-47f3-ab9f-c23fdb9f5183" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
