### PR TITLE
Tests: Update set value method

### DIFF
--- a/apps/web/cypress/e2e/pages/swaps.pages.js
+++ b/apps/web/cypress/e2e/pages/swaps.pages.js
@@ -354,17 +354,19 @@ export function setInputValue(value) {
   cy.get(inputCurrencyInput).within(() => {
     cy.get('input')
       .should('be.visible')
+      .should('not.be.disabled')
       .clear()
       .wait(3000)
-      .clear()
+      .invoke('val', '')
+      .trigger('input')
       .then(($input) => {
         if ($input.val() !== '') {
-          cy.wrap($input).clear()
+          cy.wrap($input).clear().invoke('val', '').trigger('input');
         }
       })
       .should('have.value', '')
-      .type(value, { force: true })
-  })
+      .type(value, { force: true });
+  });
 }
 
 export function setOutputValue(value) {


### PR DESCRIPTION
## How this PR fixes it

- Some Twap tests failed due to flakiness in setting input value. The updated method aims to fix it.

## How to test it

- Run Twap tests and observe outcome
