### PR TITLE
Fix(Orgs): Update orgs list when signing in

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -95,7 +95,7 @@ const filterOrgsByStatus = (
 // todo: replace with real data
 const OrgsList = () => {
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { data: currentUser } = useUsersGetWithWalletsV1Query()
+  const { data: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
   const { data: organizations } = useOrganizationsGetV1Query(undefined, { skip: !isUserSignedIn })
 
   const pendingInvites = filterOrgsByStatus(currentUser, organizations || [], MemberStatus.INVITED)


### PR DESCRIPTION
## What it solves

Small fix when signing in on the orgs list page. Previously it would try to fetch user info without the cookie which resulted in an empty orgs list after signing in.

## How this PR fixes it

- Skip the user info fetch if the user is not signed in

## How to test it

1. Go to the orgs list page
2. Sign in
3. Observe your orgs showing up without having to reload

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
