### PR TITLE
feat(Nested Safes): show identicon of Nested Safe-to-be-created

### DIFF
--- a/apps/web/src/components/tx/confirmation-views/NestedSafeCreation/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/NestedSafeCreation/index.tsx
@@ -37,7 +37,7 @@ export function NestedSafeCreation({ txData }: { txData: TransactionData }): Rea
           shortAddress={false}
           hasExplorer
           showCopyButton
-          showAvatar={false}
+          showAvatar
         />
       </div>
     </Box>


### PR DESCRIPTION
## What it solves

Resolves #5150

## How this PR fixes it

The identicon of the Nested Safe-to-be-created is now shown on the confirmation view of the transaction flow.

## How to test it

1. Open the flow to create a Nested Safe.
2. On the review screen, observe the identicon of the Nested Safe-to-be-created.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
