### PR TITLE
fix(Nested Safes): trigger validation of Nested Safe asset on change

### DIFF
--- a/apps/web/src/components/tx-flow/flows/CreateNestedSafe/SetupNestedSafe.tsx
+++ b/apps/web/src/components/tx-flow/flows/CreateNestedSafe/SetupNestedSafe.tsx
@@ -210,7 +210,7 @@ function AssetInputs({ name }: { name: SetupNestedSafeFormFields.assets }) {
 
                 <Controller
                   name={`${name}.${index}.${SetupNestedSafeFormAssetFields.tokenAddress}`}
-                  rules={{ required: true }}
+                  rules={{ required: true, deps: [`${name}.${index}.${SetupNestedSafeFormAssetFields.amount}`] }}
                   render={({ field }) => {
                     return (
                       <TextField


### PR DESCRIPTION
## What it solves

Resolves #5148

## How this PR fixes it

This add validation dependency of asset-to-fund amounts to the asset. When an asset is changed, the amount is revalidated.

## How to test it

1. Ensure a to-be-parent Safe has >1 asset of differing amounts: A and B.
2. Open the Nested Safe creation flow.
3. Select the token with smaller amount and enter an amount above that held, but below that of the other token
4. Change the token and observe the amount validation clearing.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
