### PR TITLE
fix: prevent "Add Nested Safe" button being off-screen

### DIFF
--- a/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
@@ -42,7 +42,17 @@ export function NestedSafesPopover({
         vertical: 'top',
         horizontal: 'left',
       }}
-      slotProps={{ paper: { sx: { width: '300px' } } }}
+      slotProps={{
+        paper: {
+          sx: {
+            width: '300px',
+            maxHeight: '590px',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          },
+        },
+      }}
     >
       <ModalDialogTitle
         hideChainIndicator
@@ -51,11 +61,17 @@ export function NestedSafesPopover({
       >
         Nested Safes
       </ModalDialogTitle>
-      <Stack p={3} pt={2} display="flex" flexDirection="column" maxHeight="590px">
+      <Stack p={3} pt={2} display="flex" flexDirection="column" flex={1} overflow="hidden">
         {nestedSafes.length === 0 ? (
           <NestedSafeInfo />
         ) : (
-          <Box sx={{ overflowX: 'hidden' }}>
+          <Box
+            sx={{
+              overflowX: 'hidden',
+              overflowY: 'auto',
+              flex: 1,
+            }}
+          >
             <NestedSafesList onClose={onClose} nestedSafes={nestedSafes} />
           </Box>
         )}


### PR DESCRIPTION
## What it solves

Resolves #5149

## How this PR fixes it

The maximum height of what was only set to the list is now on the `Popover` of the Nested Safe list.

## How to test it

Ensuring the current Safe owns many Nested Safes, open the Nested Safe list in the sidbar on a small resolution. Observe the "Add Nested Safe" button still present on screen.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
