### PR TITLE
Fix(Orgs): added safes are shown on the org accounts list

### DIFF
--- a/apps/web/src/features/organizations/hooks/useOrgSafes.tsx
+++ b/apps/web/src/features/organizations/hooks/useOrgSafes.tsx
@@ -37,7 +37,7 @@ export const useOrgSafes = () => {
   const { data } = useOrganizationSafesGetV1Query({ organizationId: Number(orgId) })
   const allSafeNames = useAppSelector(selectAllAddressBooks)
   // @ts-ignore TODO: Fix type issue
-  const safeItems = data ? _buildSafeItems(data.safes, allSafeNames) : undefined
+  const safeItems = data ? _buildSafeItems(data.safes, allSafeNames) : []
   const safes = useAllSafesGrouped(safeItems)
   const { orderBy } = useAppSelector(selectOrderByPreference)
   const sortComparator = getComparator(orderBy)


### PR DESCRIPTION

## What it solves

Resolves [#5231](https://github.com/safe-global/safe-wallet-monorepo/issues/5231)

## How this PR fixes it
- Sends an empty array to `useAllSafesGrouped` instead of undefined so that the fallback (added safes) is not used.

## How to test it
- Go to the accounts page for an org
- Refresh the page
- See that the added safes are not shown briefly before the page has finished loading.
