### PR TITLE
Fix(Orgs): show empty orgs list state when user account is not found

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -117,7 +117,7 @@ const OrgsList = () => {
 
         {isUserSignedIn ? (
           <Grid2 container spacing={2} flexWrap="wrap">
-            {currentUser && activeOrganizations.length > 0 ? (
+            {activeOrganizations.length > 0 ? (
               activeOrganizations.map((org) => (
                 <Grid2 size={6} key={org.name}>
                   <OrgsCard org={org} />

--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -48,7 +48,7 @@ const InfoModal = () => {
   )
 }
 
-const EmptyState = () => {
+const SignedOutState = () => {
   const wallet = useWallet()
 
   return (
@@ -115,9 +115,9 @@ const OrgsList = () => {
             <OrgListInvite key={invitingOrg.id} org={invitingOrg} />
           ))}
 
-        {isUserSignedIn && organizations ? (
+        {isUserSignedIn ? (
           <Grid2 container spacing={2} flexWrap="wrap">
-            {activeOrganizations.length > 0 ? (
+            {currentUser && activeOrganizations.length > 0 ? (
               activeOrganizations.map((org) => (
                 <Grid2 size={6} key={org.name}>
                   <OrgsCard org={org} />
@@ -128,7 +128,7 @@ const OrgsList = () => {
             )}
           </Grid2>
         ) : (
-          <EmptyState />
+          <SignedOutState />
         )}
       </Box>
     </Box>


### PR DESCRIPTION
## What it solves
[5234](https://github.com/safe-global/safe-wallet-monorepo/issues/5234)

## How this PR fixes it
Shows the empty orgs list if no user account is found for the signed in wallet address.

## How to test it
- go to /welcome/organizations using a wallet with no account
- click connect and then sign in.
- You should be shown the "no orgs" state.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
