### PR TITLE
Fix(Orgs): Show balances for org safe accounts

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
@@ -282,7 +282,7 @@ const SingleAccountItem = ({
   )
 
   return isOrgSafe ? (
-    <ListItem className={css.listItem}>
+    <ListItem component="div" ref={elementRef} className={css.listItem}>
       <Box className={css.safeLink}>{content}</Box>
       {actions}
     </ListItem>


### PR DESCRIPTION
## What it solves

Resolves #5236

## How this PR fixes it

- Adds the missing `elementRef` to the list item

## How to test it

1. Open an org
2. Add a safe account
3. Observe the balance is visible

## Screenshots
<img width="1281" alt="Screenshot 2025-03-10 at 14 53 29" src="https://github.com/user-attachments/assets/f8f6216b-f0a6-48b8-b6c0-176153363548" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
