### PR TITLE
Tests: Add advanced details tests

### DIFF
--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -77,12 +77,14 @@ const txHexData = '[data-testid="tx-hex-data"]'
 const txStack = '[data-testid="tx-stack"]'
 const txOperation = '[data-testid="tx-operation"]'
 const nonceFld = '[data-testid="nonce-fld"]'
+const txHexDataRow = '[data-testid="tx-hexData"]'
 
 const viewTransactionBtn = 'View transaction'
 const transactionDetailsTitle = 'Transaction details'
 const QueueLabel = 'needs to be executed first'
 const TransactionSummary = 'Send '
 const transactionsPerHrStr = 'free transactions left today'
+const txHashesStr = 'Transaction hashes'
 
 const maxAmountBtnStr = 'Max'
 const nextBtnStr = 'Next'
@@ -139,6 +141,14 @@ export const advancedDetailsViewOptions = {
   grid: 'grid',
 }
 
+export function checkHashesExist(count) {
+  cy.contains(txHashesStr).next().within(() => {
+    main.verifyElementsCount(txHexDataRow, count)
+    cy.get(txHexDataRow).each(($el) => {
+      cy.wrap($el).invoke('text').should('match', /0x[a-fA-F0-9]{64}/)
+    })
+  })
+}
 export function clickOnReplaceTxOption() {
   cy.get(replaceChoiceBtn).find('button').click()
 }

--- a/apps/web/cypress/e2e/pages/owners.pages.js
+++ b/apps/web/cypress/e2e/pages/owners.pages.js
@@ -135,10 +135,9 @@ export function getAddressToBeRemoved() {
 }
 
 export function openReplaceOwnerWindow(index) {
-  cy.wait(3000) // Need to wait for the SDK to be initialized
   const minimumCount = index === 0 ? 1 : index
   main.verifyMinimumElementsCount(replaceOwnerBtn, minimumCount)
-  cy.get(replaceOwnerBtn).eq(index).click({ force: true })
+  cy.get(replaceOwnerBtn).eq(index).should('be.enabled').click({ force: true })
   cy.get(newOwnerName).should('be.visible')
   cy.get(newOwnerAddress).should('be.visible')
 }

--- a/apps/web/cypress/e2e/regression/tx_history_2.cy.js
+++ b/apps/web/cypress/e2e/regression/tx_history_2.cy.js
@@ -163,4 +163,15 @@ describe('Tx history tests 2', () => {
     createTx.clickOnTransactionItemByName(typeUntrustedToken.summaryTitle, typeUntrustedToken.summaryTxInfo)
     createTx.verifyAddressNotCopied(0, typeUntrustedToken.senderAddress)
   })
+
+  it('Verify tx hashes are grouped in advanced details', () => {
+    createTx.clickOnTransactionItemByName(typeDisableOwner.title)
+    createTx.verifyExpandedDetails([
+      typeDisableOwner.description,
+      typeDisableOwner.address,
+      typeDisableOwner.transactionHash,
+    ])
+    createTx.clickOnAdvancedDetails()
+    createTx.checkHashesExist(3)
+  })
 })

--- a/apps/web/src/components/tx/DecodedTx/index.test.tsx
+++ b/apps/web/src/components/tx/DecodedTx/index.test.tsx
@@ -164,7 +164,9 @@ describe('DecodedTx', () => {
 
       expect(toField).toBeInTheDocument()
       if (toField) {
-        const address = within(toField.parentElement!.parentElement!).queryByText('0x474e5Ded6b5D078163BFB8F6dBa355C3aA5478C8')
+        const address = within(toField.parentElement!.parentElement!).queryByText(
+          '0x474e5Ded6b5D078163BFB8F6dBa355C3aA5478C8',
+        )
         expect(address).toBeInTheDocument()
       }
 

--- a/apps/web/src/components/tx/DecodedTx/index.test.tsx
+++ b/apps/web/src/components/tx/DecodedTx/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@/tests/test-utils'
+import { fireEvent, render, within } from '@/tests/test-utils'
 import { type SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import DecodedTx from '.'
 import { waitFor } from '@testing-library/react'
@@ -158,8 +158,28 @@ describe('DecodedTx', () => {
     fireEvent.click(result.getByText('Advanced details'))
 
     await waitFor(() => {
+      const toField = result.queryByText('to:')
+      const dataField = result.queryByText('data:')
+      const valueField = result.queryByText('value:')
+
+      expect(toField).toBeInTheDocument()
+      if (toField) {
+        const address = within(toField.parentElement!.parentElement!).queryByText('0x474e5Ded6b5D078163BFB8F6dBa355C3aA5478C8')
+        expect(address).toBeInTheDocument()
+      }
+
+      expect(dataField).toBeInTheDocument()
+      if (dataField) {
+        const value = within(dataField.parentElement!.parentElement!).queryByText('0x')
+        expect(value).toBeInTheDocument()
+      }
+
+      expect(valueField).toBeInTheDocument()
+      if (valueField) {
+        const value = within(valueField.parentElement!.parentElement!).queryByText('40737664983361196')
+        expect(value).toBeInTheDocument()
+      }
       expect(result.queryAllByText('safeTxGas:').length).toBeGreaterThan(0)
-      expect(result.queryAllByText('data:').length).toBeGreaterThan(0)
     })
   })
 


### PR DESCRIPTION
## How this PR fixes it

- Add automation tests to cover new advanced details functionality
- Replace waiter in owner replace button with 'should.be.enabled' check

## How to test it

- Run Cypress and jest tests and observe outcome

