### PR TITLE
Fix(Orgs): Reset orgs cache when signing out

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
@@ -12,6 +12,8 @@ import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
 import OrgsCreationModal from '../OrgsCreationModal'
 import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
 
 const OrgsSidebarSelector = () => {
   const [isCreationModalOpen, setIsCreationModalOpen] = useState(false)
@@ -19,7 +21,8 @@ const OrgsSidebarSelector = () => {
   const router = useRouter()
   const open = Boolean(anchorEl)
   const orgId = useCurrentOrgId()
-  const { data: orgs } = useOrganizationsGetV1Query()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { data: orgs } = useOrganizationsGetV1Query(undefined, { skip: !isUserSignedIn })
   const selectedOrg = orgs?.find((org) => org.id === Number(orgId))
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/apps/web/src/features/organizations/hooks/useOrgSafes.tsx
+++ b/apps/web/src/features/organizations/hooks/useOrgSafes.tsx
@@ -8,6 +8,7 @@ import { getComparator } from '@/features/myAccounts/utils/utils'
 import { useMemo } from 'react'
 import type { SafeItem } from '@/features/myAccounts/hooks/useAllSafes'
 import { selectAllAddressBooks, type AddressBookState } from '@/store/addressBookSlice'
+import { isAuthenticated } from '@/store/authSlice'
 
 function _buildSafeItems(safes: Record<string, string[]>, allSafeNames: AddressBookState): SafeItem[] {
   const result: SafeItem[] = []
@@ -34,7 +35,8 @@ function _buildSafeItems(safes: Record<string, string[]>, allSafeNames: AddressB
 
 export const useOrgSafes = () => {
   const orgId = useCurrentOrgId()
-  const { data } = useOrganizationSafesGetV1Query({ organizationId: Number(orgId) })
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { data } = useOrganizationSafesGetV1Query({ organizationId: Number(orgId) }, { skip: !isUserSignedIn })
   const allSafeNames = useAppSelector(selectAllAddressBooks)
   // @ts-ignore TODO: Fix type issue
   const safeItems = data ? _buildSafeItems(data.safes, allSafeNames) : []

--- a/apps/web/src/store/authSlice.ts
+++ b/apps/web/src/store/authSlice.ts
@@ -1,5 +1,6 @@
-import type { RootState } from '@/store/index'
+import type { listenerMiddlewareInstance, RootState } from '@/store/index'
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import { cgwClient } from '@safe-global/store/gateway/cgwClient'
 
 type AuthPayload = {
   sessionExpiresAt: number | null
@@ -27,4 +28,13 @@ export const { setAuthenticated, setUnauthenticated } = authSlice.actions
 
 export const isAuthenticated = (state: RootState): boolean => {
   return !!state.auth.sessionExpiresAt && state.auth.sessionExpiresAt > Date.now()
+}
+
+export const authListener = (listenerMiddleware: typeof listenerMiddlewareInstance) => {
+  listenerMiddleware.startListening({
+    actionCreator: authSlice.actions.setUnauthenticated,
+    effect: async (_action, { dispatch }) => {
+      dispatch(cgwClient.util.resetApiState())
+    },
+  })
 }

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -21,6 +21,7 @@ import {
   swapOrderStatusListener,
   txHistoryListener,
   txQueueListener,
+  authListener,
 } from './slices'
 import * as slices from './slices'
 import * as hydrate from './useHydrateStore'
@@ -94,7 +95,14 @@ const middleware: Middleware<{}, RootState>[] = [
   slices.gatewayApi.middleware,
 ]
 
-const listeners = [safeMessagesListener, txHistoryListener, txQueueListener, swapOrderListener, swapOrderStatusListener]
+const listeners = [
+  safeMessagesListener,
+  txHistoryListener,
+  txQueueListener,
+  swapOrderListener,
+  swapOrderStatusListener,
+  authListener,
+]
 
 export const _hydrationReducer: typeof rootReducer = (state, action) => {
   if (action.type === hydrate.HYDRATE_ACTION) {


### PR DESCRIPTION
## What it solves

Resolves #5249

## How this PR fixes it

- Adds a listener on the `auth` slice to reset `cgwClient` data when disconnected

## How to test it

1. Open an org
2. Observe safe accounts are visible
3. Disconnect wallet
4. Observe no safe accounts are visible

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
