### PR TITLE
Fix(mobile): infinite scroll cache invalidation duplicates the list data

### DIFF
--- a/apps/mobile/src/features/Assets/components/NFTs/NFTs.container.tsx
+++ b/apps/mobile/src/features/Assets/components/NFTs/NFTs.container.tsx
@@ -13,6 +13,7 @@ import { Fallback } from '../Fallback'
 import { NFTItem } from './NFTItem'
 import { useInfiniteScroll } from '@/src/hooks/useInfiniteScroll'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { Spinner } from 'tamagui'
 
 export function NFTsContainer() {
   const activeSafe = useDefinedActiveSafe()
@@ -34,15 +35,16 @@ export function NFTsContainer() {
     data,
   })
 
-  if (isFetching || !list?.length || error) {
+  if (!list?.results.length || error) {
     return <Fallback loading={isFetching || !list} hasError={!!error} />
   }
 
   return (
     <SafeTab.FlatList<Collectible>
       onEndReached={onEndReached}
-      data={list}
+      data={list?.results}
       renderItem={NFTItem}
+      ListFooterComponent={isFetching ? <Spinner size="small" /> : undefined}
       keyExtractor={(item) => item.id}
     />
   )

--- a/apps/mobile/src/features/PendingTx/utils.tsx
+++ b/apps/mobile/src/features/PendingTx/utils.tsx
@@ -4,6 +4,7 @@ import {
   getTxHash,
   isConflictHeaderListItem,
   isLabelListItem,
+  isMultisigExecutionInfo,
   isTransactionListItem,
 } from '@/src/utils/transaction-guards'
 import { groupBulkTxs } from '@/src/utils/transactions'
@@ -150,10 +151,24 @@ export const keyExtractor = (item: PendingTransactionItems | TransactionQueuedIt
       return txGroupHash + index
     }
 
+    if (isTransactionListItem(item[0]) && isMultisigExecutionInfo(item[0].transaction.executionInfo)) {
+      return getTxHash(item[0]) + item[0].transaction.executionInfo.confirmationsSubmitted + index
+    }
+
     if (isTransactionListItem(item[0])) {
       return getTxHash(item[0]) + index
     }
+
     return String(index)
   }
-  return String(index)
+
+  if (isTransactionListItem(item) && isMultisigExecutionInfo(item.transaction.executionInfo)) {
+    return item.transaction.id + item.transaction.executionInfo.confirmationsSubmitted
+  }
+
+  if (isTransactionListItem(item)) {
+    return item.transaction.id
+  }
+
+  return String(item)
 }

--- a/apps/mobile/src/hooks/useInfiniteScroll/useInfiniteScroll.ts
+++ b/apps/mobile/src/hooks/useInfiniteScroll/useInfiniteScroll.ts
@@ -2,7 +2,7 @@ import { selectActiveSafe } from '@/src/store/activeSafeSlice'
 import { useCallback, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 
-type TUseInfiniteScrollData<J> = { results: J[]; prev?: string | null; next?: string | null }
+type TUseInfiniteScrollData<J> = { results: J[]; previous?: string | null; next?: string | null }
 
 type TUseInfiniteScrollConfig<T, J> = {
   refetch: () => void
@@ -12,10 +12,10 @@ type TUseInfiniteScrollConfig<T, J> = {
 
 export const useInfiniteScroll = <T, J>({ refetch, setPageUrl, data }: TUseInfiniteScrollConfig<T, J>) => {
   const activeSafe = useSelector(selectActiveSafe)
-  const [list, setList] = useState<J[]>([])
+  const [list, setList] = useState<T & TUseInfiniteScrollData<J>>()
 
   useEffect(() => {
-    setList([])
+    setList(undefined)
   }, [activeSafe])
 
   useEffect(() => {
@@ -23,12 +23,16 @@ export const useInfiniteScroll = <T, J>({ refetch, setPageUrl, data }: TUseInfin
       return
     }
 
-    if (!data.prev) {
-      setList(data.results)
-      return
-    }
+    setList((prev) => {
+      if (prev?.previous === data.previous) {
+        return data
+      }
 
-    setList((prev) => (prev ? [...prev, ...data.results] : data.results))
+      return {
+        ...data,
+        results: [...(prev?.results || []), ...data.results],
+      }
+    })
   }, [data])
 
   const onEndReached = useCallback(() => {

--- a/apps/mobile/src/hooks/usePendingTxs/index.ts
+++ b/apps/mobile/src/hooks/usePendingTxs/index.ts
@@ -36,7 +36,7 @@ const usePendingTxs = () => {
     data,
   })
 
-  const pendingTxs = useMemo(() => groupPendingTxs(list || []), [list])
+  const pendingTxs = useMemo(() => groupPendingTxs(list?.results || []), [list])
 
   return {
     hasMore: Boolean(data?.next),


### PR DESCRIPTION
## What it solves
The `useInfiniteScroll` hook is duplicating the `list` data every time the useEffect is triggered. The reason why it is happening is because we do not check if the consumer component is really going to the next page or just refetching the list data again.

## How this PR fixes it
Now we're comparing the previous url of the data with the previous url of the list, if both are the same, we just set whatever is in the data, otherwise we concatenate the data with the previous data, just like before.

## How to test it
- This issue is only reproducible within the Signer functionality, since before we were not invalidating the pending transactions data.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
