### PR TITLE
Fix(Orgs): Add signed out state to every orgs view

### DIFF
--- a/apps/web/src/features/organizations/components/Dashboard/index.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/index.tsx
@@ -1,8 +1,7 @@
 import MembersCard from '@/features/organizations/components/Dashboard/MembersCard'
 import NewFeaturesCard from '@/features/organizations/components/Dashboard/NewFeaturesCard'
 import OrgsCTACard from '@/features/organizations/components/Dashboard/OrgsCTACard'
-import { Box, Grid2, Stack, Typography } from '@mui/material'
-import SignInButton from '@/features/organizations/components/SignInButton'
+import { Grid2, Stack, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid2'
 import { useOrgSafes } from '@/features/organizations/hooks/useOrgSafes'
 import SafesList from '@/features/myAccounts/components/SafesList'
@@ -17,25 +16,7 @@ import { Link } from '@mui/material'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import DashboardMembersList from '@/features/organizations/components/Dashboard/DashboardMembersList'
 import { useOrgMembers } from '@/features/organizations/hooks/useOrgMembers'
-import css from './styles.module.css'
-
-const SignedOutState = () => {
-  return (
-    <Box className={css.content}>
-      <Box textAlign="center" p={3}>
-        <Typography variant="h2" fontWeight={700} mb={1}>
-          Sign in to see your organization
-        </Typography>
-
-        <Typography variant="body2" mb={2} color="primary.light">
-          Description
-        </Typography>
-
-        <SignInButton />
-      </Box>
-    </Box>
-  )
-}
+import SignedOutState from '@/features/organizations/components/SignedOutState'
 
 const ViewAllLink = ({ url }: { url: LinkProps['href'] }) => {
   return (

--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -7,14 +7,20 @@ import InvitesList from './InvitesList'
 import SearchIcon from '@/public/images/common/search.svg'
 import { useMembersSearch } from '../../hooks/useMembersSearch'
 import { useOrgMembers } from '../../hooks/useOrgMembers'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
+import SignedOutState from '@/features/organizations/components/SignedOutState'
 
 const OrganizationMembers = () => {
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
+  const isUserSignedIn = useAppSelector(isAuthenticated)
   const { activeMembers, invitedMembers } = useOrgMembers()
 
   const filteredMembers = useMembersSearch(activeMembers, searchQuery)
   const filteredInvites = useMembersSearch(invitedMembers, searchQuery)
+
+  if (!isUserSignedIn) return <SignedOutState />
 
   return (
     <>

--- a/apps/web/src/features/organizations/components/OrgsSettings/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSettings/index.tsx
@@ -2,7 +2,7 @@ import ModalDialog from '@/components/common/ModalDialog'
 import { AppRoutes } from '@/config/routes'
 import CheckIcon from '@/public/images/common/check.svg'
 import CloseIcon from '@/public/images/common/close.svg'
-import { useAppDispatch } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import {
   Button,
@@ -27,6 +27,8 @@ import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import css from './styles.module.css'
 import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
+import { isAuthenticated } from '@/store/authSlice'
+import SignedOutState from '@/features/organizations/components/SignedOutState'
 
 const ListIcon = ({ variant }: { variant: 'success' | 'danger' }) => {
   const Icon = variant === 'success' ? CheckIcon : CloseIcon
@@ -47,7 +49,8 @@ const OrgsSettings = () => {
   const router = useRouter()
   const dispatch = useAppDispatch()
   const orgId = useCurrentOrgId()
-  const { data: org } = useOrganizationsGetOneV1Query({ id: Number(orgId) })
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { data: org } = useOrganizationsGetOneV1Query({ id: Number(orgId) }, { skip: !isUserSignedIn })
   const [updateOrg] = useOrganizationsUpdateV1Mutation()
   const [deleteOrg] = useOrganizationsDeleteV1Mutation()
 
@@ -89,6 +92,8 @@ const OrgsSettings = () => {
       console.log(e)
     }
   }
+
+  if (!isUserSignedIn) return <SignedOutState />
 
   return (
     <div>

--- a/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
@@ -7,13 +7,19 @@ import { useState } from 'react'
 import SafesList from '@/features/myAccounts/components/SafesList'
 import { useOrgSafes } from '@/features/organizations/hooks/useOrgSafes'
 import { useSafesSearch } from '@/features/myAccounts/hooks/useSafesSearch'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
+import SignedOutState from '@/features/organizations/components/SignedOutState'
 
 const OrganizationSafeAccounts = () => {
   const [searchQuery, setSearchQuery] = useState('')
+  const isUserSignedIn = useAppSelector(isAuthenticated)
   const allSafes = useOrgSafes()
   const filteredSafes = useSafesSearch(allSafes, searchQuery)
 
   const safes = searchQuery ? filteredSafes : allSafes
+
+  if (!isUserSignedIn) return <SignedOutState />
 
   return (
     <>

--- a/apps/web/src/features/organizations/components/SignedOutState/index.tsx
+++ b/apps/web/src/features/organizations/components/SignedOutState/index.tsx
@@ -1,0 +1,23 @@
+import { Box, Typography } from '@mui/material'
+import css from '@/features/organizations/components/Dashboard/styles.module.css'
+import SignInButton from '@/features/organizations/components/SignInButton'
+
+const SignedOutState = () => {
+  return (
+    <Box className={css.content}>
+      <Box textAlign="center" p={3}>
+        <Typography variant="h2" fontWeight={700} mb={1}>
+          Sign in to see your organization
+        </Typography>
+
+        <Typography variant="body2" mb={2} color="primary.light">
+          Description
+        </Typography>
+
+        <SignInButton />
+      </Box>
+    </Box>
+  )
+}
+
+export default SignedOutState

--- a/apps/web/src/features/organizations/hooks/useOrgMembers.tsx
+++ b/apps/web/src/features/organizations/hooks/useOrgMembers.tsx
@@ -1,5 +1,7 @@
 import { useUserOrganizationsGetUsersV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useCurrentOrgId } from './useCurrentOrgId'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
 
 export enum MemberStatus {
   INVITED = 'INVITED',
@@ -9,7 +11,8 @@ export enum MemberStatus {
 
 export const useOrgMembers = () => {
   const orgId = useCurrentOrgId()
-  const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) }, { skip: !isUserSignedIn })
 
   const invitedMembers =
     data?.members.filter(


### PR DESCRIPTION
## What it solves

Resolves #5252

## How this PR fixes it

- Extracts `SignedOutState` into its own file
- Uses that component on every view if user is not signed in

## How to test it

1. Open an org
2. Disconnect your wallet
3. Navigate through each page
4. Observe the sign in view

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
