### PR TITLE
Fix(Orgs): display a max of 5 safes on the dashboard page

### DIFF
--- a/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardMembersList.tsx
@@ -5,14 +5,13 @@ import { useState } from 'react'
 import AddMembersModal from '../AddMembersModal'
 import MemberName from '../MembersList/MemberName'
 
-const DashboardMembersList = ({ members, displayLimit }: { members: UserOrganization[]; displayLimit: number }) => {
+const DashboardMembersList = ({ members }: { members: UserOrganization[] }) => {
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
-  const membersToDisplay = members.slice(0, displayLimit)
 
   return (
     <>
       <Paper sx={{ p: 2, borderRadius: '8px' }}>
-        {membersToDisplay.map((member) => (
+        {members.map((member) => (
           <Box mb={2} key={member.id}>
             <MemberName key={member.id} member={member} />
           </Box>

--- a/apps/web/src/features/organizations/components/Dashboard/index.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/index.tsx
@@ -85,7 +85,6 @@ const OrganizationsDashboard = () => {
                 <Typography variant="h5">Safe Accounts ({safes.length})</Typography>
                 {orgId && <ViewAllLink url={{ pathname: AppRoutes.organizations.safeAccounts, query: { orgId } }} />}
               </Stack>
-              {/* TODO: Set a max length for dashboard safes. */}
               <SafesList safes={safesToDisplay} isOrgSafe />
             </Grid>
             <Grid size={{ xs: 12, md: 4 }}>

--- a/apps/web/src/features/organizations/components/Dashboard/index.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/index.tsx
@@ -56,11 +56,16 @@ const ViewAllLink = ({ url }: { url: LinkProps['href'] }) => {
   )
 }
 
+const DASHBOARD_LIST_DISPLAY_LIMIT = 5
+
 const OrganizationsDashboard = () => {
   const safes = useOrgSafes()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const orgId = useCurrentOrgId()
   const { activeMembers } = useOrgMembers()
+
+  const safesToDisplay = safes.slice(0, DASHBOARD_LIST_DISPLAY_LIMIT)
+  const membersToDisplay = activeMembers.slice(0, DASHBOARD_LIST_DISPLAY_LIMIT)
 
   if (!isUserSignedIn) {
     return <SignedOutState />
@@ -81,14 +86,14 @@ const OrganizationsDashboard = () => {
                 {orgId && <ViewAllLink url={{ pathname: AppRoutes.organizations.safeAccounts, query: { orgId } }} />}
               </Stack>
               {/* TODO: Set a max length for dashboard safes. */}
-              <SafesList safes={safes} isOrgSafe />
+              <SafesList safes={safesToDisplay} isOrgSafe />
             </Grid>
             <Grid size={{ xs: 12, md: 4 }}>
               <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
                 <Typography variant="h5">Members ({activeMembers.length})</Typography>
                 {orgId && <ViewAllLink url={{ pathname: AppRoutes.organizations.members, query: { orgId } }} />}
               </Stack>
-              <DashboardMembersList members={activeMembers} displayLimit={5} />
+              <DashboardMembersList members={membersToDisplay} />
             </Grid>
           </Grid>
         </>


### PR DESCRIPTION
## What it solves

Resolves [5254](https://github.com/safe-global/safe-wallet-monorepo/issues/5254)

## How this PR fixes it
Set a limit of 5 for the accounts list on the dashboard

## How to test it
- Open the dashboard page for an org with more than 5 safes.
- Check that only 5 safes are displayed.
- Check that the full number of safes is displayed in the title count.

## Screenshots
![image](https://github.com/user-attachments/assets/58cae5ae-067e-4fe4-bb68-67efe7e36ea9)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
