### PR TITLE
Fix(Orgs): Display selected safes number, reset form state on cancel

### DIFF
--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -85,7 +85,7 @@ const AddAccounts = () => {
     } catch (e) {
       console.log(e)
     } finally {
-      setOpen(false)
+      handleClose()
     }
   })
 
@@ -106,7 +106,7 @@ const AddAccounts = () => {
     setValue(`selectedSafes.${safeId}`, true, { shouldValidate: true })
   }
 
-  const handleCancel = () => {
+  const handleClose = () => {
     setSearchQuery('')
     reset()
     setOpen(false)
@@ -168,7 +168,7 @@ const AddAccounts = () => {
                     <AddManually handleAddSafe={handleAddSafe} />
                   </Box>
                   <DialogActions>
-                    <Button onClick={handleCancel}>Cancel</Button>
+                    <Button onClick={handleClose}>Cancel</Button>
                     <Button variant="contained" disabled={selectedSafesLength === 0} type="submit">
                       Add Accounts ({selectedSafesLength})
                     </Button>

--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -31,6 +31,10 @@ export type AddAccountsFormValues = {
   selectedSafes: Record<string, boolean>
 }
 
+function getSelectedSafes(safes: AddAccountsFormValues['selectedSafes']) {
+  return Object.entries(safes).filter(([address, isSelected]) => isSelected && !address.startsWith('multichain_'))
+}
+
 const AddAccounts = () => {
   const [open, setOpen] = useState<boolean>(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -58,18 +62,16 @@ const AddAccounts = () => {
     },
   })
 
-  const { handleSubmit, watch, setValue } = formMethods
+  const { handleSubmit, watch, setValue, reset } = formMethods
 
   const selectedSafes = watch(`selectedSafes`)
-  const selectedSafesLength = Object.values(selectedSafes).filter(Boolean).length
+  const selectedSafesLength = getSelectedSafes(selectedSafes).length
 
   const onSubmit = handleSubmit(async (data) => {
-    const safesToAdd = Object.entries(data.selectedSafes)
-      .filter(([address, isSelected]) => isSelected && !address.startsWith('multichain_'))
-      .map(([key]) => {
-        const [chainId, address] = key.split(':')
-        return { chainId, address }
-      })
+    const safesToAdd = getSelectedSafes(data.selectedSafes).map(([key]) => {
+      const [chainId, address] = key.split(':')
+      return { chainId, address }
+    })
 
     try {
       const result = await addSafesToOrg({
@@ -102,6 +104,12 @@ const AddAccounts = () => {
 
     const safeId = getSafeId(newSafeItem)
     setValue(`selectedSafes.${safeId}`, true, { shouldValidate: true })
+  }
+
+  const handleCancel = () => {
+    setSearchQuery('')
+    reset()
+    setOpen(false)
   }
 
   return (
@@ -160,7 +168,7 @@ const AddAccounts = () => {
                     <AddManually handleAddSafe={handleAddSafe} />
                   </Box>
                   <DialogActions>
-                    <Button onClick={() => setOpen(false)}>Cancel</Button>
+                    <Button onClick={handleCancel}>Cancel</Button>
                     <Button variant="contained" disabled={selectedSafesLength === 0} type="submit">
                       Add Accounts ({selectedSafesLength})
                     </Button>

--- a/apps/web/src/store/authSlice.ts
+++ b/apps/web/src/store/authSlice.ts
@@ -33,7 +33,7 @@ export const isAuthenticated = (state: RootState): boolean => {
 export const authListener = (listenerMiddleware: typeof listenerMiddlewareInstance) => {
   listenerMiddleware.startListening({
     actionCreator: authSlice.actions.setUnauthenticated,
-    effect: async (_action, { dispatch }) => {
+    effect: (_action, { dispatch }) => {
       dispatch(cgwClient.util.resetApiState())
     },
   })


### PR DESCRIPTION
## What it solves

Resolves #5140 
Resolves #5253

## How this PR fixes it

- Filters out elements starting with `multichain_` in the selectedSafes object
- Resets form state and search query when cancelling the form

## How to test it

1. Open an org
2. Go to the safe accounts page
3. Add account
4. Select multichain accounts
5. Observe the correct number is displayed in the submit form
6. Cancel the form
7. Reopen it
8. Observe the form state is reset

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
