### PR TITLE
Feat(Orgs): allow adding users from fresh org dashboard

### DIFF
--- a/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
+++ b/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
@@ -22,6 +22,8 @@ import css from './styles.module.css'
 import { useUserOrganizationsInviteUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 import NameInput from '@/components/common/NameInput'
+import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
 
 export enum MemberRole {
   ADMIN = 'ADMIN',
@@ -73,6 +75,7 @@ const RoleMenuItem = ({
 
 const AddMembersModal = ({ onClose }: { onClose: () => void }): ReactElement => {
   const orgId = useCurrentOrgId()
+  const router = useRouter()
   const [error, setError] = useState<string>()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [inviteMembers] = useUserOrganizationsInviteUserV1Mutation()
@@ -103,6 +106,9 @@ const AddMembersModal = ({ onClose }: { onClose: () => void }): ReactElement => 
         inviteUsersDto: { users: [{ address: data.address, role: data.role }] },
       })
       if (response.data) {
+        if (router.pathname !== AppRoutes.organizations.members) {
+          router.push({ pathname: AppRoutes.organizations.members, query: { orgId } })
+        }
         onClose()
       }
       if (response.error) {

--- a/apps/web/src/features/organizations/components/Dashboard/MembersCard.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/MembersCard.tsx
@@ -1,44 +1,50 @@
 import css from '@/features/organizations/components/Dashboard/styles.module.css'
 import MemberIcon from '@/public/images/orgs/member.svg'
 import { Typography, Paper, Box, Button, SvgIcon } from '@mui/material'
+import { useState } from 'react'
+import AddMembersModal from '../AddMembersModal'
 
 const MembersCard = () => {
+  const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
+
   const handleInviteClick = () => {
-    // TODO: Implement invite functionality
-    console.log('Invite clicked')
+    setOpenAddMembersModal(true)
   }
 
   return (
-    <Paper sx={{ p: 3, borderRadius: '12px' }}>
-      <Box position="relative" width={1}>
-        <Box className={css.iconBG}>
-          <SvgIcon component={MemberIcon} inheritViewBox />
-        </Box>
+    <>
+      <Paper sx={{ p: 3, borderRadius: '12px' }}>
+        <Box position="relative" width={1}>
+          <Box className={css.iconBG}>
+            <SvgIcon component={MemberIcon} inheritViewBox />
+          </Box>
 
-        <Button
-          onClick={handleInviteClick}
-          variant="outlined"
-          size="compact"
-          sx={{
-            position: 'absolute',
-            top: 0,
-            right: 0,
-          }}
-          aria-label="Invite team members"
-        >
-          Add members
-        </Button>
-      </Box>
-      <Box>
-        <Typography variant="body1" color="text.primary" fontWeight={700} mb={1}>
-          Add members
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          Invite team members to help manage your Safe Accounts. You can add both Safe Account signers and external
-          collaborators.
-        </Typography>
-      </Box>
-    </Paper>
+          <Button
+            onClick={handleInviteClick}
+            variant="outlined"
+            size="compact"
+            sx={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+            }}
+            aria-label="Invite team members"
+          >
+            Add members
+          </Button>
+        </Box>
+        <Box>
+          <Typography variant="body1" color="text.primary" fontWeight={700} mb={1}>
+            Add members
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Invite team members to help manage your Safe Accounts. You can add both Safe Account signers and external
+            collaborators.
+          </Typography>
+        </Box>
+      </Paper>
+      {openAddMembersModal && <AddMembersModal onClose={() => setOpenAddMembersModal(false)} />}
+    </>
   )
 }
 


### PR DESCRIPTION
## What it solves

Resolves #5265

## How this PR fixes it
- Clicking the add members button on the members dashboard card will open the add member modal.
- Redirect to the members page when a member has been successfully invited.

## How to test it
- Go to the dashboard of a newly created org
- Click `Add members`
- The add members modal should open. On submission, you should be redrected to the members page so you can see the invited user in the list.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
