### PR TITLE
Fix(mobile): Use CGW for signing transactions

### DIFF
--- a/apps/mobile/src/features/Assets/components/NFTs/NFTs.container.tsx
+++ b/apps/mobile/src/features/Assets/components/NFTs/NFTs.container.tsx
@@ -13,6 +13,7 @@ import { Fallback } from '../Fallback'
 import { NFTItem } from './NFTItem'
 import { useInfiniteScroll } from '@/src/hooks/useInfiniteScroll'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { Spinner } from 'tamagui'
 
 export function NFTsContainer() {
   const activeSafe = useDefinedActiveSafe()
@@ -34,15 +35,16 @@ export function NFTsContainer() {
     data,
   })
 
-  if (isFetching || !list?.length || error) {
+  if (!list?.results.length || error) {
     return <Fallback loading={isFetching || !list} hasError={!!error} />
   }
 
   return (
     <SafeTab.FlatList<Collectible>
       onEndReached={onEndReached}
-      data={list}
+      data={list?.results}
       renderItem={NFTItem}
+      ListFooterComponent={isFetching ? <Spinner size="small" /> : undefined}
       keyExtractor={(item) => item.id}
     />
   )

--- a/apps/mobile/src/features/ChangeSignerSheet/ChangeSignerSheet.container.tsx
+++ b/apps/mobile/src/features/ChangeSignerSheet/ChangeSignerSheet.container.tsx
@@ -32,10 +32,9 @@ export const ChangeSignerSheetContainer = () => {
     id: txId,
   })
 
-  const storedSigners = useMemo(
-    () => extractAppSigners(signers, txDetails?.detailedExecutionInfo as MultisigExecutionDetails),
-    [txDetails, signers],
-  )
+  const detailedExecutionInfo = txDetails?.detailedExecutionInfo as MultisigExecutionDetails
+
+  const storedSigners = useMemo(() => extractAppSigners(signers, detailedExecutionInfo), [txDetails, signers])
 
   const { data, isLoading } = useGetBalancesQuery({
     addresses: storedSigners?.map((item) => item.value) || [],
@@ -47,11 +46,15 @@ export const ChangeSignerSheetContainer = () => {
       return []
     }
 
-    return storedSigners?.map((item) => ({
+    const availableSigners = storedSigners.filter((signer) => {
+      return !detailedExecutionInfo?.confirmations?.some((confirmation) => confirmation.signer.value === signer.value)
+    })
+
+    return availableSigners?.map((item) => ({
       ...item,
       balance: data[item.value],
     }))
-  }, [data, storedSigners])
+  }, [data, storedSigners, detailedExecutionInfo])
 
   const onSignerPress = (signer: SignerInfo, onClose: () => void) => () => {
     if (activeSigner.value !== signer.value) {

--- a/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignTransaction.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignTransaction.tsx
@@ -6,27 +6,44 @@ import { selectChainById } from '@/src/store/chains'
 import { RootState } from '@/src/store'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { useLocalSearchParams } from 'expo-router'
-import { useLazySignTransactionQuery } from '@/src/store/signersBalance'
 import { getPrivateKey } from '@/src/hooks/useSign/useSign'
 import SignError from './SignError'
 import SignSuccess from './SignSuccess'
+import { signTx } from '@/src/services/tx/tx-sender/sign'
+import { useTransactionsAddConfirmationV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import logger from '@/src/utils/logger'
 
 export function SignTransaction() {
   const { txId, signerAddress } = useLocalSearchParams<{ txId: string; signerAddress: string }>()
   const activeSafe = useDefinedActiveSafe()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
 
-  const [trigger, { isFetching, data, isError }] = useLazySignTransactionQuery()
+  const [addConfirmation, { isLoading, data, isError }] = useTransactionsAddConfirmationV1Mutation()
 
   const sign = useCallback(async () => {
-    const privateKey = await getPrivateKey(signerAddress)
+    try {
+      const privateKey = await getPrivateKey(signerAddress)
 
-    trigger({
-      chain: activeChain as ChainInfo,
-      activeSafe,
-      txId,
-      privateKey,
-    })
+      const signedTx = await signTx({
+        chain: activeChain as ChainInfo,
+        activeSafe,
+        txId,
+        privateKey,
+      })
+
+      // Now call the mutation with the signed transaction data
+      await addConfirmation({
+        chainId: activeSafe.chainId,
+        safeTxHash: signedTx.safeTransactionHash,
+        addConfirmationDto: {
+          // TODO: we need to add this signature type in the auto generated types, because it was included recently in CGW
+          // @ts-ignore
+          signature: signedTx.signature,
+        },
+      })
+    } catch (error) {
+      logger.error('Error signing transaction:', error)
+    }
   }, [activeChain, activeSafe, txId, signerAddress])
 
   useLayoutEffect(() => {
@@ -37,7 +54,7 @@ export function SignTransaction() {
     return <SignError onRetryPress={sign} />
   }
 
-  if (isFetching || !data) {
+  if (isLoading || !data) {
     return <LoadingScreen title="Signing transaction..." description="It may take a few seconds..." />
   }
 

--- a/apps/mobile/src/features/ConfirmTx/hooks/useTxSigner/useTxSigner.ts
+++ b/apps/mobile/src/features/ConfirmTx/hooks/useTxSigner/useTxSigner.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo } from 'react'
+import { useLayoutEffect, useMemo } from 'react'
 import { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { selectActiveSigner, setActiveSigner } from '@/src/store/activeSignerSlice'
 import { useAppSelector, useAppDispatch } from '@/src/store/hooks'

--- a/apps/mobile/src/features/ConfirmTx/hooks/useTxSigner/useTxSigner.ts
+++ b/apps/mobile/src/features/ConfirmTx/hooks/useTxSigner/useTxSigner.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useLayoutEffect, useMemo } from 'react'
 import { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { selectActiveSigner, setActiveSigner } from '@/src/store/activeSignerSlice'
 import { useAppSelector, useAppDispatch } from '@/src/store/hooks'
@@ -18,19 +18,37 @@ export const useTxSigner = (detailedExecutionInfo?: MultisigExecutionDetails) =>
     () => appSigners.find((signer) => signer.value === activeSigner?.value),
     [appSigners, activeSigner],
   )
+
   const hasSigned = useMemo(() => {
     return detailedExecutionInfo?.confirmations?.some(
       (confirmation) => confirmation.signer.value === activeSigner?.value,
     )
   }, [detailedExecutionInfo, activeSigner])
 
-  // Changes the active signer if there are app signers and the active signer is not in the app signers
-  // because it can be a signer of that safe but in a different chain
-  useEffect(() => {
+  const proposedSigner = useMemo(() => {
+    const signers = appSigners.filter((signer) => {
+      return !detailedExecutionInfo?.confirmations?.some((confirmation) => confirmation.signer.value === signer?.value)
+    })
+
+    return signers?.find((signer) =>
+      detailedExecutionInfo?.signers?.some((executionSigner) => executionSigner.value === signer?.value),
+    )
+  }, [appSigners, activeSigner, detailedExecutionInfo])
+
+  useLayoutEffect(() => {
+    if (proposedSigner && activeTxSigner?.value !== proposedSigner.value && hasSigned) {
+      dispatch(setActiveSigner({ safeAddress: activeSafe.address, signer: proposedSigner }))
+      return
+    }
+  }, [proposedSigner, activeTxSigner, hasSigned])
+
+  useLayoutEffect(() => {
+    // Changes the active signer if there are app signers and the active signer is not in the app signers
+    // because it can be a signer of that safe but in a different chain
     if (appSigners.length > 0 && !activeTxSigner) {
       dispatch(setActiveSigner({ safeAddress: activeSafe.address, signer: appSigners[0] }))
     }
-  }, [activeTxSigner, appSigners])
+  }, [activeTxSigner, appSigners, proposedSigner])
 
   return { activeSigner, hasSigned }
 }

--- a/apps/mobile/src/features/PendingTx/utils.tsx
+++ b/apps/mobile/src/features/PendingTx/utils.tsx
@@ -4,6 +4,7 @@ import {
   getTxHash,
   isConflictHeaderListItem,
   isLabelListItem,
+  isMultisigExecutionInfo,
   isTransactionListItem,
 } from '@/src/utils/transaction-guards'
 import { groupBulkTxs } from '@/src/utils/transactions'
@@ -150,10 +151,24 @@ export const keyExtractor = (item: PendingTransactionItems | TransactionQueuedIt
       return txGroupHash + index
     }
 
+    if (isTransactionListItem(item[0]) && isMultisigExecutionInfo(item[0].transaction.executionInfo)) {
+      return getTxHash(item[0]) + item[0].transaction.executionInfo.confirmationsSubmitted + index
+    }
+
     if (isTransactionListItem(item[0])) {
       return getTxHash(item[0]) + index
     }
+
     return String(index)
   }
-  return String(index)
+
+  if (isTransactionListItem(item) && isMultisigExecutionInfo(item.transaction.executionInfo)) {
+    return item.transaction.id + item.transaction.executionInfo.confirmationsSubmitted
+  }
+
+  if (isTransactionListItem(item)) {
+    return item.transaction.id
+  }
+
+  return String(item)
 }

--- a/apps/mobile/src/hooks/useInfiniteScroll/useInfiniteScroll.ts
+++ b/apps/mobile/src/hooks/useInfiniteScroll/useInfiniteScroll.ts
@@ -2,7 +2,7 @@ import { selectActiveSafe } from '@/src/store/activeSafeSlice'
 import { useCallback, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 
-type TUseInfiniteScrollData<J> = { results: J[]; prev?: string | null; next?: string | null }
+type TUseInfiniteScrollData<J> = { results: J[]; previous?: string | null; next?: string | null }
 
 type TUseInfiniteScrollConfig<T, J> = {
   refetch: () => void
@@ -12,10 +12,10 @@ type TUseInfiniteScrollConfig<T, J> = {
 
 export const useInfiniteScroll = <T, J>({ refetch, setPageUrl, data }: TUseInfiniteScrollConfig<T, J>) => {
   const activeSafe = useSelector(selectActiveSafe)
-  const [list, setList] = useState<J[]>([])
+  const [list, setList] = useState<T & TUseInfiniteScrollData<J>>()
 
   useEffect(() => {
-    setList([])
+    setList(undefined)
   }, [activeSafe])
 
   useEffect(() => {
@@ -23,12 +23,16 @@ export const useInfiniteScroll = <T, J>({ refetch, setPageUrl, data }: TUseInfin
       return
     }
 
-    if (!data.prev) {
-      setList(data.results)
-      return
-    }
+    setList((prev) => {
+      if (prev?.previous === data.previous) {
+        return data
+      }
 
-    setList((prev) => (prev ? [...prev, ...data.results] : data.results))
+      return {
+        ...data,
+        results: [...(prev?.results || []), ...data.results],
+      }
+    })
   }, [data])
 
   const onEndReached = useCallback(() => {

--- a/apps/mobile/src/hooks/usePendingTxs/index.ts
+++ b/apps/mobile/src/hooks/usePendingTxs/index.ts
@@ -36,7 +36,7 @@ const usePendingTxs = () => {
     data,
   })
 
-  const pendingTxs = useMemo(() => groupPendingTxs(list || []), [list])
+  const pendingTxs = useMemo(() => groupPendingTxs(list?.results || []), [list])
 
   return {
     hasMore: Boolean(data?.next),

--- a/apps/mobile/src/services/tx/tx-sender/create.ts
+++ b/apps/mobile/src/services/tx/tx-sender/create.ts
@@ -13,7 +13,7 @@ interface CreateTxParams {
   chain: ChainInfo
 }
 
-export const createExistingTx = async ({ activeSafe, txId, privateKey, txDetails, chain }: CreateTxParams) => {
+export const proposeTx = async ({ activeSafe, txId, privateKey, txDetails, chain }: CreateTxParams) => {
   // Get the tx details from the backend if not provided
   txDetails = txDetails || (await getTransactionDetails(activeSafe.chainId, txId))
 

--- a/apps/mobile/src/services/tx/tx-sender/sign.ts
+++ b/apps/mobile/src/services/tx/tx-sender/sign.ts
@@ -1,20 +1,8 @@
-import Safe, { buildSignatureBytes, EthSafeSignature, SigningMethod } from '@safe-global/protocol-kit'
-import SafeTransaction from '@safe-global/protocol-kit/dist/src/utils/transactions/SafeTransaction'
-import { ethers } from 'ethers'
-import SafeApiKit from '@safe-global/api-kit'
+import { SigningMethod } from '@safe-global/protocol-kit'
 import { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { createConnectedWallet } from '@/src/services/web3'
 import { createExistingTx } from '@/src/services/tx/tx-sender'
 import { SafeInfo } from '@/src/types/address'
-import { SafeMultisigTransactionResponse } from '@safe-global/types-kit/dist/src/types'
-
-type sendSignedTxParameters = {
-  safeTx: SafeTransaction
-  signatures: Record<string, string>
-  protocolKit: Safe
-  wallet: ethers.Wallet
-  apiKit: SafeApiKit
-}
 
 export type signTxParams = {
   chain: ChainInfo
@@ -28,7 +16,10 @@ export const signTx = async ({
   activeSafe,
   txId,
   privateKey,
-}: signTxParams): Promise<SafeMultisigTransactionResponse> => {
+}: signTxParams): Promise<{
+  signature: string
+  safeTransactionHash: string
+}> => {
   if (!chain) {
     throw new Error('Active chain not found')
   }
@@ -37,56 +28,29 @@ export const signTx = async ({
   }
 
   const { protocolKit, wallet } = await createConnectedWallet(privateKey, activeSafe, chain)
-  const { safeTx, signatures } = await createExistingTx({
+  const { safeTx } = await createExistingTx({
     activeSafe,
     txId,
     chain,
     privateKey,
   })
 
-  const apiKit = new SafeApiKit({
-    chainId: BigInt(activeSafe.chainId),
-  })
-
   if (!safeTx) {
     throw new Error('Safe transaction not found')
   }
 
-  const safeTransactionHash = await sendSignedTx({
-    safeTx,
-    signatures,
-    protocolKit,
-    wallet,
-    apiKit,
-  })
-  const signedTransaction = await apiKit.getTransaction(safeTransactionHash)
+  const signedSafeTx = await protocolKit.signTransaction(safeTx, SigningMethod.ETH_SIGN_TYPED_DATA_V4)
 
-  return signedTransaction
-}
-
-export const sendSignedTx = async ({
-  safeTx,
-  signatures,
-  protocolKit,
-  wallet,
-  apiKit,
-}: sendSignedTxParameters): Promise<string> => {
-  const signedSafeTx = await protocolKit.signTransaction(safeTx, SigningMethod.ETH_SIGN)
-
-  Object.entries(signatures).forEach(([signer, data]) => {
-    signedSafeTx.addSignature({
-      signer,
-      data,
-      staticPart: () => data,
-      dynamicPart: () => '',
-      isContractSignature: false,
-    })
-  })
   const safeTransactionHash = await protocolKit.getTransactionHash(signedSafeTx)
 
-  const signature = signedSafeTx.getSignature(wallet.address) as EthSafeSignature
+  const signature = signedSafeTx.getSignature(wallet.address)?.data
 
-  await apiKit.confirmTransaction(safeTransactionHash, buildSignatureBytes([signature]))
+  if (!signature) {
+    throw new Error('Signature not found')
+  }
 
-  return safeTransactionHash
+  return {
+    signature,
+    safeTransactionHash,
+  }
 }

--- a/apps/mobile/src/services/tx/tx-sender/sign.ts
+++ b/apps/mobile/src/services/tx/tx-sender/sign.ts
@@ -1,7 +1,7 @@
 import { SigningMethod } from '@safe-global/protocol-kit'
 import { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { createConnectedWallet } from '@/src/services/web3'
-import { createExistingTx } from '@/src/services/tx/tx-sender'
+import { proposeTx } from '@/src/services/tx/tx-sender'
 import { SafeInfo } from '@/src/types/address'
 
 export type signTxParams = {
@@ -28,7 +28,7 @@ export const signTx = async ({
   }
 
   const { protocolKit, wallet } = await createConnectedWallet(privateKey, activeSafe, chain)
-  const { safeTx } = await createExistingTx({
+  const { safeTx } = await proposeTx({
     activeSafe,
     txId,
     chain,

--- a/apps/mobile/src/store/signersBalance.ts
+++ b/apps/mobile/src/store/signersBalance.ts
@@ -1,8 +1,6 @@
 import { createApi } from '@reduxjs/toolkit/query/react'
 import { createWeb3ReadOnly } from '../services/web3'
 import { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import { signTx, signTxParams } from '@/src/services/tx/tx-sender/sign'
-import { SafeMultisigTransactionResponse } from '@safe-global/types-kit/dist/src/types'
 
 const noopBaseQuery = async () => ({ data: null })
 
@@ -38,27 +36,9 @@ export const web3API = createApi({
         }
       },
     }),
-    signTransaction: builder.query<SafeMultisigTransactionResponse, signTxParams>({
-      async queryFn({ chain, activeSafe, txId, privateKey }) {
-        try {
-          const signedTx = await signTx({
-            chain,
-            activeSafe,
-            txId,
-            privateKey,
-          })
-
-          return { data: signedTx }
-        } catch (error) {
-          return createBadRequestError(
-            `Failed to sign transaction: ${error instanceof Error ? error.message : 'Unknown error'}`,
-          )
-        }
-      },
-    }),
   }),
 })
 
 // Export hooks for usage in functional components, which are
 // auto-generated based on the defined endpoints
-export const { useGetBalancesQuery, useLazySignTransactionQuery } = web3API
+export const { useGetBalancesQuery } = web3API


### PR DESCRIPTION
## What it solves
We were using api-kit for signing transactions, which stop working some weeks ago due to the server being down. After talking to @iamacook he mentioned that we actually should be using CGW for signing transactions, since that is the reason it was designed for.

## How this PR fixes it
It removes the lazy query we were using and uses the `addConfirmation` mutation instead.

## How to test it
- Add any wallet with a pending transaction
- go to your pending transactions
- click in the transaction that is pending
- click in the "Confirm" button

#### Available testing video
https://github.com/user-attachments/assets/27111040-055a-4eae-a2e8-b2a5ea4fe3ee

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
