### PR TITLE
fix(web): notification registration was failing

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -13,6 +13,24 @@ const withPWA = withPWAInit({
   dest: 'public',
   workboxOptions: {
     mode: 'production',
+    exclude: [
+      // Some users report bad-precaching-responses. We exclude the problematic files.
+      // https://github.com/shadowwalker/next-pwa/issues/424#issuecomment-1332258575
+      ({ asset }) => {
+        // Add here any file that fails pre-caching
+        const excludeList = [
+          // Default Serwist https://serwist.pages.dev/docs/next/configuring/exclude
+          /\.map$/,
+          /^manifest.*\.js$/,
+          /^server\//,
+          /^(((app-)?build-manifest|react-loadable-manifest|dynamic-css-manifest)\.json)$/,
+        ]
+        if (excludeList.some(r => r.test(asset.name))) {
+          return true
+        }
+        return false
+      },
+    ],
   },
   reloadOnOnline: false,
   /* Do not precache anything */


### PR DESCRIPTION

## What it solves
Some users were getting a „code 633: Notification (un-)registration faield“ when trying to register for push notifications. This seems to be caused by an error coming from the service worker happening right before that: „uncaught (in promise) bad-precaching-response: … dynamic-css-manifest.json status 404

## How this PR fixes it
It excludes some files that were never generated. 

## How to test it
Most of the time this happens in private mode. 
- start a session in private mode
- try to register for push notifications

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
