### PR TITLE
Feat(web): fixed signer selector issue for nested-safe with same EOA owner (#5204)

### DIFF
--- a/apps/web/src/hooks/wallets/useSelectAvailableSigner.ts
+++ b/apps/web/src/hooks/wallets/useSelectAvailableSigner.ts
@@ -18,7 +18,7 @@ export const useSelectAvailableSigner = () => {
     (tx: SafeTransaction | undefined, safe: SafeInfo) => {
       const availableSigners = getAvailableSigners(wallet, nestedSafeOwners, safe, tx)
 
-      if (safe.owners.some((owner) => sameAddress(owner.value, wallet?.address))) {
+      if (safe.owners.some((owner) => sameAddress(owner.value, wallet?.address)) && safe.threshold === 1) {
         return
       } else if (!signer || !availableSigners.some((available) => sameAddress(available, signer.address))) {
         setSignerAddress?.(availableSigners[0])

--- a/apps/web/src/hooks/wallets/useSelectAvailableSigner.ts
+++ b/apps/web/src/hooks/wallets/useSelectAvailableSigner.ts
@@ -18,7 +18,9 @@ export const useSelectAvailableSigner = () => {
     (tx: SafeTransaction | undefined, safe: SafeInfo) => {
       const availableSigners = getAvailableSigners(wallet, nestedSafeOwners, safe, tx)
 
-      if (!signer || !availableSigners.some((available) => sameAddress(available, signer.address))) {
+      if (safe.owners.some((owner) => sameAddress(owner.value, wallet?.address))) {
+        return
+      } else if (!signer || !availableSigners.some((available) => sameAddress(available, signer.address))) {
         setSignerAddress?.(availableSigners[0])
       }
     },


### PR DESCRIPTION
## What it solves

Resolves #5204 

## How this PR fixes it
This PR fixes an issue where switching from a Safe account to an EOA (Externally Owned Account) would revert back to the Safe account when the EOA had already signed a transaction.

The root cause was in the [useSelectAvailableSigner](https://github.com/safe-global/safe-wallet-monorepo/blob/18cfd62f2cce1b632cb4ac777b68f58e29428159/apps/web/src/hooks/wallets/useSelectAvailableSigner.ts#L19) hook, which automatically selects a signer for transactions. When an EOA had already signed a transaction, it would get filtered out from the available signers list, causing the hook to automatically select a different signer (reverting back to the Safe account).

Now we changed the [useSelectAvailableSigner](https://github.com/chiranjeev13/safe-wallet-monorepo/blob/bb6835f935dc353b524638a8d34134f6fbbb91b7/apps/web/src/hooks/wallets/useSelectAvailableSigner.ts#L21) hook to
```
if (safe.owners.some((owner) => sameAddress(owner.value, wallet?.address))  && safe.threshold === 1) {
        return
      } else if (!signer || !availableSigners.some((available) => sameAddress(available, signer.address))) {
        setSignerAddress?.(availableSigners[0])
      }
```
This check ensures that:
If the connected wallet (EOA) is an owner of the Safe, we respect that choice and don't automatically change the signer even if it has already signed the tx but want to execute it using the EOA(if the safe threshold is 1 cause if more than 1 it will count the signer in even if it has already signed).

## How to test it
1. Have a SafeA owned by a SafeB
2. Have an EOA that owns both safeA and safeB
3. Go to safeA 1/x and sign a tx so it remains in queue
4. Connect with the EOA and try to execute the tx
5. In the form, try to pick the signer and the nested-safe
## Screen-Recording

https://github.com/user-attachments/assets/6b0ace2a-f8a0-487f-8a04-2b2b1bb71961



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
