### PR TITLE
Fix(Orgs): Send credentials when logging out

### DIFF
--- a/packages/store/src/gateway/cgwClient.ts
+++ b/packages/store/src/gateway/cgwClient.ts
@@ -1,7 +1,7 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
 
-const CREDENTIAL_ROUTES = ['/v1/organizations', '/v1/auth/verify', '/v1/users']
+const CREDENTIAL_ROUTES = ['/v1/organizations', '/v1/auth/verify', '/v1/auth/logout', '/v1/users']
 
 let baseUrl: null | string = null
 export const setBaseUrl = (url: string) => {


### PR DESCRIPTION
## What it solves

Resolves #5226 

## How this PR fixes it

- Adds the `/v1/auth/logout` endpoint to the list of routes where credentials should be included

## How to test it

1. Open an org
2. Disconnect your wallet
3. Observe the `access_token` cookie is deleted

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
