### PR TITLE
Fix(Orgs): Don't close modal when adding safes manually

### DIFF
--- a/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
@@ -35,10 +35,10 @@ const AddManually = ({ handleAddSafe }: { handleAddSafe: (data: AddManuallyFormV
 
   const onSubmit = handleSubmit((data) => {
     handleAddSafe(data)
-    setAddManuallyOpen(false)
+    onClose()
   })
 
-  const onCancel = () => {
+  const onClose = () => {
     reset()
     setAddManuallyOpen(false)
   }
@@ -77,9 +77,14 @@ const AddManually = ({ handleAddSafe }: { handleAddSafe: (data: AddManuallyFormV
       <Button size="compact" onClick={() => setAddManuallyOpen(true)}>
         + Add manually
       </Button>
-      <ModalDialog open={addManuallyOpen} dialogTitle="Add safe account" onClose={onCancel} hideChainIndicator>
+      <ModalDialog open={addManuallyOpen} dialogTitle="Add safe account" onClose={onClose} hideChainIndicator>
         <FormProvider {...formMethods}>
-          <form onSubmit={onSubmit}>
+          <form
+            onSubmit={(e) => {
+              e.stopPropagation()
+              return onSubmit(e)
+            }}
+          >
             <DialogContent>
               <Stack direction="row" spacing={2}>
                 <AddressInput
@@ -108,7 +113,7 @@ const AddManually = ({ handleAddSafe }: { handleAddSafe: (data: AddManuallyFormV
               </Stack>
             </DialogContent>
             <DialogActions>
-              <Button onClick={onCancel}>Cancel</Button>
+              <Button onClick={onClose}>Cancel</Button>
               <Button variant="contained" disabled={!formState.isValid} type="submit">
                 Add
               </Button>

--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -91,7 +91,6 @@ const AddAccounts = () => {
 
   const handleAddSafe = (data: AddManuallyFormValues) => {
     const alreadyExists = manualSafes.some((safe) => safe.address === data.address && safe.chainId === data.chainId)
-    if (alreadyExists) return
 
     const newSafeItem: SafeItem = {
       ...data,
@@ -100,7 +99,10 @@ const AddAccounts = () => {
       lastVisited: 0,
       name: '',
     }
-    setManualSafes((prev) => [newSafeItem, ...prev])
+
+    if (!alreadyExists) {
+      setManualSafes((prev) => [newSafeItem, ...prev])
+    }
 
     const safeId = getSafeId(newSafeItem)
     setValue(`selectedSafes.${safeId}`, true, { shouldValidate: true })


### PR DESCRIPTION
## What it solves

Resolves #5259 

## How this PR fixes it

- Call `e.stopPropagation()` when submitting the add manually form
- Adjust `handleAddSafe` to deal with already manually added safes

## How to test it

1. Open an org
2. Add a safe manually
3. Submit the add manually form
4. Observe it shows up in the list of safes and the number updates to 1
5. Submit that form
6. Observe it shows up in the safe accounts list

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
