### PR TITLE
Feat(Signing UX): show full to address

### DIFF
--- a/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -62,12 +62,16 @@ const SrcEthHashInfo = ({
   const identicon = <Identicon address={address} size={avatarSize} />
   const shouldCopyPrefix = shouldPrefix && copyPrefix
 
-  const highlightedAddress = highlight4bytes ? <>
-    {address.slice(0, 2)}
-    <b>{address.slice(2, 6)}</b>
-    {address.slice(6, -4)}
-    <b>{address.slice(-4)}</b>
-  </> : address
+  const highlightedAddress = highlight4bytes ? (
+    <>
+      {address.slice(0, 2)}
+      <b>{address.slice(2, 6)}</b>
+      {address.slice(6, -4)}
+      <b>{address.slice(-4)}</b>
+    </>
+  ) : (
+    address
+  )
 
   const addressElement = (
     <>

--- a/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -31,6 +31,7 @@ export type EthHashInfoProps = {
   trusted?: boolean
   ExplorerButtonProps?: ExplorerButtonProps
   isAddressBookName?: boolean
+  highlight4bytes?: boolean
 }
 
 const stopPropagation = (e: SyntheticEvent) => e.stopPropagation()
@@ -53,6 +54,7 @@ const SrcEthHashInfo = ({
   children,
   trusted = true,
   isAddressBookName = false,
+  highlight4bytes = false,
 }: EthHashInfoProps): ReactElement => {
   const shouldPrefix = isAddress(address)
   const theme = useTheme()
@@ -60,10 +62,17 @@ const SrcEthHashInfo = ({
   const identicon = <Identicon address={address} size={avatarSize} />
   const shouldCopyPrefix = shouldPrefix && copyPrefix
 
+  const highlightedAddress = highlight4bytes ? <>
+    {address.slice(0, 2)}
+    <b>{address.slice(2, 6)}</b>
+    {address.slice(6, -4)}
+    <b>{address.slice(-4)}</b>
+  </> : address
+
   const addressElement = (
     <>
       {showPrefix && shouldPrefix && prefix && <b>{prefix}:</b>}
-      <span>{shortAddress || isMobile ? shortenAddress(address) : address}</span>
+      <span>{shortAddress || isMobile ? shortenAddress(address) : highlightedAddress}</span>
     </>
   )
 

--- a/apps/web/src/components/common/PaperViewToggle/index.tsx
+++ b/apps/web/src/components/common/PaperViewToggle/index.tsx
@@ -1,7 +1,8 @@
 import { ToggleButtonGroup } from '@/components/common/ToggleButtonGroup'
 import { Box, Paper, Stack, Typography } from '@mui/material'
 import { isString } from 'lodash'
-import React, { ReactElement, useState } from 'react'
+import type { ReactElement } from 'react'
+import React, { useState } from 'react'
 
 type PaperViewToggleProps = {
   children: {

--- a/apps/web/src/components/common/ToggleButtonGroup/index.tsx
+++ b/apps/web/src/components/common/ToggleButtonGroup/index.tsx
@@ -60,8 +60,8 @@ export const ToggleButtonGroup = ({ value = 0, children, onChange }: ToggleButto
       aria-label="text alignment"
     >
       {children.map(({ tooltip, icon }, index) => (
-        <ToggleButton value={index}>
-          <Tooltip key={index} title={tooltip} placement="top">
+        <ToggleButton key={index} value={index}>
+          <Tooltip title={tooltip} placement="top">
             {icon}
           </Tooltip>
         </ToggleButton>

--- a/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
@@ -8,6 +8,7 @@ import type { ReactElement, ReactNode } from 'react'
 import { isNumber, isString } from 'lodash'
 import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk/dist/types/transactions'
 import NamedAddressInfo from '@/components/common/NamedAddressInfo'
+import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 
 type TxDetailsProps = {
   safeTx: SafeTransaction
@@ -99,8 +100,8 @@ export const TxDetails = ({ safeTx, txData }: TxDetailsProps) => {
                 <TxDetailsRow label="Value">{safeTx.data.value}</TxDetailsRow>
 
                 <TxDetailsRow label="Data" direction={safeTx.data.data === '0x' ? 'row' : 'column'}>
-                  <Typography variant="body2" sx={{ wordWrap: 'break-word' }}>
-                    {safeTx.data.data}
+                  <Typography variant="body2">
+                    <HexEncodedData hexData={safeTx.data.data} limit={66} />
                   </Typography>
                 </TxDetailsRow>
 

--- a/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
@@ -1,12 +1,13 @@
-import { Box, Divider, Stack, StackProps, Typography } from '@mui/material'
+import { Box, Chip, Divider, Stack, StackProps, Typography } from '@mui/material'
 import { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { PaperViewToggle } from '../../common/PaperViewToggle'
 import TableRowsRoundedIcon from '@mui/icons-material/TableRowsRounded'
 import DataObjectIcon from '@mui/icons-material/DataObject'
 import EthHashInfo from '@/components/common/EthHashInfo'
-import { ReactElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
 import { isNumber, isString } from 'lodash'
 import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk/dist/types/transactions'
+import NamedAddressInfo from '@/components/common/NamedAddressInfo'
 
 type TxDetailsProps = {
   safeTx: SafeTransaction
@@ -19,7 +20,7 @@ const TxDetailsRow = ({
   direction = 'row',
 }: {
   label: string
-  children: string | number | ReactElement
+  children: ReactNode
   direction?: StackProps['direction']
 }) => (
   <Stack
@@ -37,6 +38,8 @@ const TxDetailsRow = ({
 )
 
 export const TxDetails = ({ safeTx, txData }: TxDetailsProps) => {
+  const toInfo = txData?.addressInfoIndex?.[safeTx.data.to] || txData?.to
+
   const ContentWrapper = ({ children }: { children: ReactElement | ReactElement[] }) => (
     <Box sx={{ maxHeight: '500px', overflowY: 'scroll' }}>{children}</Box>
   )
@@ -59,7 +62,27 @@ export const TxDetails = ({ safeTx, txData }: TxDetailsProps) => {
                 <TxDetailsRow label="Primary type">SafeTx</TxDetailsRow>
 
                 <TxDetailsRow label="To">
-                  <Typography variant="body2" width="100%" sx={{ '& *': { whiteSpace: 'normal', wordWrap: "break-word", alignItems: 'flex-start !important' } }}>
+                  <Chip
+                    sx={{ backgroundColor: 'background.paper', height: 'unset', '& > *': { p: 0.5 } }}
+                    label={
+                      <NamedAddressInfo
+                        address={safeTx.data.to}
+                        name={toInfo?.name}
+                        customAvatar={toInfo?.logoUri}
+                        avatarSize={20}
+                        showAvatar
+                        onlyName
+                      />
+                    }
+                  ></Chip>
+
+                  <Typography
+                    variant="body2"
+                    width="100%"
+                    sx={{
+                      '& *': { whiteSpace: 'normal', wordWrap: 'break-word', alignItems: 'flex-start !important' },
+                    }}
+                  >
                     <EthHashInfo
                       address={safeTx.data.to}
                       avatarSize={20}

--- a/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
@@ -1,13 +1,13 @@
-import { Box, Chip, Divider, Stack, StackProps, Typography } from '@mui/material'
-import { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import type { StackProps } from '@mui/material'
+import { Box, Chip, Divider, Stack, Typography } from '@mui/material'
+import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { PaperViewToggle } from '../../common/PaperViewToggle'
 import TableRowsRoundedIcon from '@mui/icons-material/TableRowsRounded'
 import DataObjectIcon from '@mui/icons-material/DataObject'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import type { ReactElement, ReactNode } from 'react'
 import { isNumber, isString } from 'lodash'
-import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk/dist/types/transactions'
-import NamedAddressInfo from '@/components/common/NamedAddressInfo'
+import { Operation, type TransactionData } from '@safe-global/safe-gateway-typescript-sdk/dist/types/transactions'
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 
 type TxDetailsProps = {
@@ -42,7 +42,7 @@ export const TxDetails = ({ safeTx, txData }: TxDetailsProps) => {
   const toInfo = txData?.addressInfoIndex?.[safeTx.data.to] || txData?.to
 
   const ContentWrapper = ({ children }: { children: ReactElement | ReactElement[] }) => (
-    <Box sx={{ maxHeight: '500px', overflowY: 'scroll' }}>{children}</Box>
+    <Box sx={{ maxHeight: '550px', overflowY: 'scroll' }}>{children}</Box>
   )
 
   return (
@@ -63,19 +63,21 @@ export const TxDetails = ({ safeTx, txData }: TxDetailsProps) => {
                 <TxDetailsRow label="Primary type">SafeTx</TxDetailsRow>
 
                 <TxDetailsRow label="To">
-                  <Chip
-                    sx={{ backgroundColor: 'background.paper', height: 'unset', '& > *': { p: 0.5 } }}
-                    label={
-                      <NamedAddressInfo
-                        address={safeTx.data.to}
-                        name={toInfo?.name}
-                        customAvatar={toInfo?.logoUri}
-                        avatarSize={20}
-                        showAvatar
-                        onlyName
-                      />
-                    }
-                  ></Chip>
+                  {toInfo?.name || toInfo?.logoUri ? (
+                    <Chip
+                      sx={{ backgroundColor: 'background.paper', height: 'unset', '& > *': { p: 0.5 } }}
+                      label={
+                        <EthHashInfo
+                          address={safeTx.data.to}
+                          name={toInfo?.name}
+                          customAvatar={toInfo?.logoUri}
+                          showAvatar={!!toInfo?.logoUri}
+                          avatarSize={20}
+                          onlyName
+                        />
+                      }
+                    ></Chip>
+                  ) : null}
 
                   <Typography
                     variant="body2"
@@ -105,7 +107,9 @@ export const TxDetails = ({ safeTx, txData }: TxDetailsProps) => {
                   </Typography>
                 </TxDetailsRow>
 
-                <TxDetailsRow label="Operation">{safeTx.data.operation}</TxDetailsRow>
+                <TxDetailsRow label="Operation">
+                  {safeTx.data.operation} ({Operation[safeTx.data.operation].toLowerCase()})
+                </TxDetailsRow>
 
                 <TxDetailsRow label="SafeTxGas">{safeTx.data.safeTxGas}</TxDetailsRow>
 

--- a/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
@@ -6,9 +6,11 @@ import DataObjectIcon from '@mui/icons-material/DataObject'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { ReactElement } from 'react'
 import { isNumber, isString } from 'lodash'
+import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk/dist/types/transactions'
 
 type TxDetailsProps = {
   safeTx: SafeTransaction
+  txData?: TransactionData
 }
 
 const TxDetailsRow = ({
@@ -34,7 +36,7 @@ const TxDetailsRow = ({
   </Stack>
 )
 
-export const TxDetails = ({ safeTx }: TxDetailsProps) => {
+export const TxDetails = ({ safeTx, txData }: TxDetailsProps) => {
   const ContentWrapper = ({ children }: { children: ReactElement | ReactElement[] }) => (
     <Box sx={{ maxHeight: '500px', overflowY: 'scroll' }}>{children}</Box>
   )
@@ -57,15 +59,16 @@ export const TxDetails = ({ safeTx }: TxDetailsProps) => {
                 <TxDetailsRow label="Primary type">SafeTx</TxDetailsRow>
 
                 <TxDetailsRow label="To">
-                  <Typography variant="body2">
+                  <Typography variant="body2" width="100%" sx={{ '& *': { whiteSpace: 'normal', wordWrap: "break-word", alignItems: 'flex-start !important' } }}>
                     <EthHashInfo
                       address={safeTx.data.to}
-                      avatarSize={15}
+                      avatarSize={20}
                       showPrefix={false}
                       showName={false}
                       shortAddress={false}
                       hasExplorer
-                      showAvatar={false}
+                      showAvatar
+                      highlight4bytes
                     />
                   </Typography>
                 </TxDetailsRow>

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -1,6 +1,6 @@
 import TxCard from '@/components/tx-flow/common/TxCard'
 import { Button, Checkbox, Divider, FormControlLabel, Grid2 as Grid, Stack, StepIcon, Typography } from '@mui/material'
-import { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxDetails } from './TxDetails'
 import SignForm from '../SignOrExecuteForm/SignForm'

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -13,7 +13,7 @@ type ConfirmTxDetailsProps = {
   txData?: TransactionData
 }
 
-export const ConfirmTxDetails = ({ safeTx }: ConfirmTxDetailsProps) => {
+export const ConfirmTxDetails = ({ safeTx, txData }: ConfirmTxDetailsProps) => {
   const [checked, setChecked] = useState(false)
 
   const steps = [

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -6,9 +6,11 @@ import { TxDetails } from './TxDetails'
 import SignForm from '../SignOrExecuteForm/SignForm'
 import ExternalLink from '@/components/common/ExternalLink'
 import { useState } from 'react'
+import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
 
 type ConfirmTxDetailsProps = {
   safeTx: SafeTransaction
+  txData?: TransactionData
 }
 
 export const ConfirmTxDetails = ({ safeTx }: ConfirmTxDetailsProps) => {
@@ -57,7 +59,7 @@ export const ConfirmTxDetails = ({ safeTx }: ConfirmTxDetailsProps) => {
           </Stack>
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <TxDetails safeTx={safeTx} />
+          <TxDetails safeTx={safeTx} txData={txData} />
         </Grid>
       </Grid>
 

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
@@ -34,6 +34,7 @@ import { SignerForm } from './SignerForm'
 import { useSigner } from '@/hooks/wallets/useWallet'
 import { trackTxEvents } from './tracking'
 import { TxNoteForm, encodeTxNote, trackAddNote } from '@/features/tx-notes'
+import { ConfirmTxDetails } from '../ConfirmTxDetails'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -176,6 +177,8 @@ export const SignOrExecuteForm = ({
 
   return (
     <>
+      {safeTx && <ConfirmTxDetails safeTx={safeTx} txData={props.txDetails?.txData || props.txPreview?.txData} />}
+
       <TxCard>
         {props.children}
 

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
@@ -34,7 +34,6 @@ import { SignerForm } from './SignerForm'
 import { useSigner } from '@/hooks/wallets/useWallet'
 import { trackTxEvents } from './tracking'
 import { TxNoteForm, encodeTxNote, trackAddNote } from '@/features/tx-notes'
-import { ConfirmTxDetails } from '../ConfirmTxDetails'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 
@@ -177,8 +176,6 @@ export const SignOrExecuteForm = ({
 
   return (
     <>
-      {safeTx && <ConfirmTxDetails safeTx={safeTx} txData={props.txDetails?.txData || props.txPreview?.txData} />}
-
       <TxCard>
         {props.children}
 


### PR DESCRIPTION
* Show the full `to` address with a blockie avatar
* Show name and icon in a chip above
* Add "Show more" to the `data` field
* Make the receipt taller to fit the nonce field at the bottom
* Add operation type (call or delegate call)

![Screenshot 2025-03-12 at 11 32 57](https://github.com/user-attachments/assets/db6b91b8-61c3-4451-82c9-7849aaa8e5f8)
