### PR TITLE
Feat(Signing UX): add receipt to the UpdateSafe flow

### DIFF
--- a/apps/web/src/components/tx-flow/flows/UpdateSafe/UpdateSafeReview.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpdateSafe/UpdateSafeReview.tsx
@@ -4,10 +4,10 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import { createUpdateSafeTxs } from '@/services/tx/safeUpdateParams'
 import { createMultiSendCallOnlyTx, createTx } from '@/services/tx/tx-sender'
 import { SafeTxContext } from '../../SafeTxProvider'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import useAsync from '@/hooks/useAsync'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-export const UpdateSafeReview = () => {
+export const UpdateSafeReview = ({ onSubmit }: { onSubmit: () => void }) => {
   const { safe, safeLoaded } = useSafeInfo()
   const chain = useCurrentChain()
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
@@ -21,5 +21,5 @@ export const UpdateSafeReview = () => {
     safeTxPromise.then(setSafeTx).catch(setSafeTxError)
   }, [safe, safeLoaded, chain, setSafeTx, setSafeTxError])
 
-  return <SignOrExecuteForm />
+  return <ReviewTransaction onSubmit={onSubmit} />
 }

--- a/apps/web/src/components/tx-flow/flows/UpdateSafe/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpdateSafe/index.tsx
@@ -1,11 +1,36 @@
+import { useMemo } from 'react'
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import { UpdateSafeReview } from './UpdateSafeReview'
 import SettingsIcon from '@/public/images/sidebar/settings.svg'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import useTxStepper from '../../useTxStepper'
 
 const UpdateSafeFlow = () => {
+  const { data, step, nextStep, prevStep } = useTxStepper({})
+
+  const steps = useMemo(
+    () => [
+      {
+        txLayoutProps: { title: 'Review transaction' },
+        content: <UpdateSafeReview key={1} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep],
+  )
+
   return (
-    <TxLayout title="Confirm transaction" subtitle="Update Safe Account version" icon={SettingsIcon}>
-      <UpdateSafeReview />
+    <TxLayout
+      subtitle="Update Safe Account version"
+      icon={SettingsIcon}
+      step={step}
+      onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
+    >
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
@@ -108,7 +108,8 @@ export const TxDetails = ({ safeTx, txData }: TxDetailsProps) => {
                 </TxDetailsRow>
 
                 <TxDetailsRow label="Operation">
-                  {safeTx.data.operation} ({Operation[safeTx.data.operation].toLowerCase()})
+                  {safeTx.data.operation} (
+                  {(Number(safeTx.data.operation) as Operation) === Operation.CALL ? 'call' : 'delegate call'})
                 </TxDetailsRow>
 
                 <TxDetailsRow label="SafeTxGas">{safeTx.data.safeTxGas}</TxDetailsRow>

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -3,18 +3,18 @@ import { Checkbox, Divider, FormControlLabel, Grid2 as Grid, Stack, StepIcon, Ty
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxDetails } from './TxDetails'
 import ExternalLink from '@/components/common/ExternalLink'
-import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
 import { useContext, useState } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import SignOrExecuteForm from '../SignOrExecuteForm/SignOrExecuteFormNew'
+import useTxPreview from '../confirmation-views/useTxPreview'
 
 type ConfirmTxDetailsProps = {
-  txData?: TransactionData
   onSubmit: () => void
 }
 
-export const ConfirmTxDetails = ({ txData, onSubmit }: ConfirmTxDetailsProps) => {
+export const ConfirmTxDetails = ({ onSubmit }: ConfirmTxDetailsProps) => {
   const { safeTx } = useContext(SafeTxContext)
+  const [txPreview] = useTxPreview(safeTx?.data)
   const [checked, setChecked] = useState(false)
 
   const steps = [
@@ -60,7 +60,7 @@ export const ConfirmTxDetails = ({ txData, onSubmit }: ConfirmTxDetailsProps) =>
           </Stack>
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <TxDetails safeTx={safeTx} txData={txData} />
+          <TxDetails safeTx={safeTx} txData={txPreview?.txData} />
         </Grid>
       </Grid>
 

--- a/apps/web/src/components/tx/ReviewTransaction/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransaction/ReviewTransactionContent.tsx
@@ -1,6 +1,7 @@
 import { useIsWalletProposer } from '@/hooks/useProposers'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { type ReactElement, type ReactNode, useState, useContext, useCallback, SyntheticEvent } from 'react'
+import type { SyntheticEvent } from 'react'
+import { type ReactElement, type ReactNode, useState, useContext, useCallback } from 'react'
 import madProps from '@/utils/mad-props'
 import ExecuteCheckbox from '../ExecuteCheckbox'
 import { useImmediatelyExecutable, useValidateNonce, useTxActions } from '../SignOrExecuteForm/hooks'


### PR DESCRIPTION
Add a receipt step to the Safe upgrade flow.

<img width="710" alt="Screenshot 2025-03-12 at 14 38 28" src="https://github.com/user-attachments/assets/6859d0f1-b618-48b4-89e8-5b4bb5929947" />