### PR TITLE
Feat(Orgs): Display member names

### DIFF
--- a/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
+++ b/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
@@ -103,7 +103,7 @@ const AddMembersModal = ({ onClose }: { onClose: () => void }): ReactElement => 
 
       const response = await inviteMembers({
         orgId: Number(orgId),
-        inviteUsersDto: { users: [{ address: data.address, role: data.role }] },
+        inviteUsersDto: { users: [{ address: data.address, role: data.role, name: data.name }] },
       })
       if (response.data) {
         if (router.pathname !== AppRoutes.organizations.members) {

--- a/apps/web/src/features/organizations/components/Dashboard/AcceptInviteDialog.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/AcceptInviteDialog.tsx
@@ -1,5 +1,5 @@
 import {
-  GetOrganizationResponse,
+  type GetOrganizationResponse,
   useUserOrganizationsAcceptInviteV1Mutation,
 } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useRouter } from 'next/router'

--- a/apps/web/src/features/organizations/components/Dashboard/AcceptInviteDialog.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/AcceptInviteDialog.tsx
@@ -1,0 +1,90 @@
+import {
+  GetOrganizationResponse,
+  useUserOrganizationsAcceptInviteV1Mutation,
+} from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useRouter } from 'next/router'
+import { type ReactElement, useState } from 'react'
+import { Alert, Box, Button, CircularProgress, DialogActions, DialogContent, Typography } from '@mui/material'
+import { FormProvider, useForm } from 'react-hook-form'
+import MUILink from '@mui/material/Link'
+import Link from 'next/link'
+import ModalDialog from '@/components/common/ModalDialog'
+import NameInput from '@/components/common/NameInput'
+import { AppRoutes } from '@/config/routes'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+
+function AcceptInviteDialog({ org, onClose }: { org: GetOrganizationResponse; onClose: () => void }): ReactElement {
+  const [error, setError] = useState<string>()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const router = useRouter()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { data: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
+  const [acceptInvite] = useUserOrganizationsAcceptInviteV1Mutation()
+  const memberName = org.userOrganizations.find((member) => member.user.id === currentUser?.id)?.name
+
+  const methods = useForm<{ name: string }>({ mode: 'onChange', defaultValues: { name: memberName } })
+  const { handleSubmit, formState } = methods
+
+  const onSubmit = handleSubmit(async (data) => {
+    setError(undefined)
+
+    try {
+      setIsSubmitting(true)
+      const response = await acceptInvite({ orgId: org.id, acceptInviteDto: { name: data.name } })
+
+      if (response.data) {
+        router.push({ pathname: AppRoutes.organizations.index, query: { orgId: org.id } })
+        onClose()
+      }
+
+      if (response.error) {
+        setError('Failed accepting the invite. Please try again.')
+      }
+    } catch (e) {
+      // TODO: Handle this error case
+      console.log(e)
+    } finally {
+      setIsSubmitting(false)
+    }
+  })
+
+  return (
+    <ModalDialog open onClose={onClose} dialogTitle="Accept invite" hideChainIndicator>
+      <FormProvider {...methods}>
+        <form onSubmit={onSubmit}>
+          <DialogContent sx={{ py: 2 }}>
+            <Box mb={2}>
+              <NameInput data-testid="name-input" label="Name" autoFocus name="name" required />
+            </Box>
+            <Typography variant="body2" color="text.secondary">
+              How is my data processed? Read our{' '}
+              <Link href={AppRoutes.privacy} passHref legacyBehavior>
+                <MUILink>privacy policy</MUILink>
+              </Link>
+            </Typography>
+
+            {error && (
+              <Alert severity="error" sx={{ mt: 2 }}>
+                {error}
+              </Alert>
+            )}
+          </DialogContent>
+
+          <DialogActions>
+            <Button data-testid="cancel-btn" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="contained" disabled={!formState.isValid} disableElevation>
+              {isSubmitting ? <CircularProgress size={20} /> : 'Accept invite'}
+            </Button>
+          </DialogActions>
+        </form>
+      </FormProvider>
+    </ModalDialog>
+  )
+}
+
+export default AcceptInviteDialog

--- a/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
@@ -1,25 +1,24 @@
 import { Card, Box, Stack, Button, Typography } from '@mui/material'
 import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { InitialsAvatar, OrgSummary } from '../OrgsCard'
-import {
-  useUserOrganizationsAcceptInviteV1Mutation,
-  useUserOrganizationsDeclineInviteV1Mutation,
-} from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useUserOrganizationsDeclineInviteV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useOrgSafeCount } from '@/features/organizations/hooks/useOrgSafeCount'
+import { useState } from 'react'
+import AcceptInviteDialog from '@/features/organizations/components/Dashboard/AcceptInviteDialog'
 
 type OrgListInvite = {
   org: GetOrganizationResponse
 }
 
 const OrgListInvite = ({ org }: OrgListInvite) => {
-  const [acceptInvite] = useUserOrganizationsAcceptInviteV1Mutation()
+  const [inviteOpen, setInviteOpen] = useState(false)
   const [declineInvite] = useUserOrganizationsDeclineInviteV1Mutation()
   const { id, name, userOrganizations: members } = org
   const numberOfAccounts = useOrgSafeCount(id)
   const numberOfMembers = members.length
 
   const handleAcceptInvite = () => {
-    acceptInvite({ orgId: org.id })
+    setInviteOpen(true)
   }
 
   const handleDeclineInvite = () => {
@@ -55,6 +54,7 @@ const OrgListInvite = ({ org }: OrgListInvite) => {
           </Stack>
         </Stack>
       </Card>
+      {inviteOpen && <AcceptInviteDialog org={org} onClose={() => setInviteOpen(false)} />}
     </Card>
   )
 }

--- a/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
@@ -37,7 +37,7 @@ const OrgListInvite = ({ org }: OrgListInvite) => {
       <Card sx={{ p: 2, backgroundColor: 'background.main' }}>
         <Stack direction="row" spacing={2} alignItems="center">
           <Box>
-            <InitialsAvatar orgName={name} size="large" />
+            <InitialsAvatar name={name} size="large" />
           </Box>
 
           <Box flexGrow={1}>

--- a/apps/web/src/features/organizations/components/MembersList/MemberName.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/MemberName.tsx
@@ -5,8 +5,8 @@ import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED
 const MemberName = ({ member }: { member: UserOrganization }) => {
   return (
     <Stack direction="row" spacing={1} alignItems="center" key={member.id}>
-      <InitialsAvatar size="medium" orgName={member.user.id.toString()} rounded />
-      <Typography fontSize="14px">User Id: {member.user.id}</Typography>
+      <InitialsAvatar size="medium" orgName={member.name || ''} rounded />
+      <Typography fontSize="14px">{member.name}</Typography>
     </Stack>
   )
 }

--- a/apps/web/src/features/organizations/components/MembersList/MemberName.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/MemberName.tsx
@@ -5,7 +5,7 @@ import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED
 const MemberName = ({ member }: { member: UserOrganization }) => {
   return (
     <Stack direction="row" spacing={1} alignItems="center" key={member.id}>
-      <InitialsAvatar size="medium" orgName={member.name || ''} rounded />
+      <InitialsAvatar size="medium" name={member.name || ''} rounded />
       <Typography fontSize="14px">{member.name}</Typography>
     </Stack>
   )

--- a/apps/web/src/features/organizations/components/OrgsCard/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCard/index.tsx
@@ -24,16 +24,16 @@ export function getDeterministicColor(str: string): string {
 }
 
 export const InitialsAvatar = ({
-  orgName,
+  name,
   size = 'large',
   rounded = false,
 }: {
-  orgName: string
+  name: string
   size?: 'small' | 'medium' | 'large'
   rounded?: boolean
 }) => {
-  const logoLetters = orgName.slice(0, 2)
-  const logoColor = getDeterministicColor(orgName)
+  const logoLetters = name.slice(0, 1)
+  const logoColor = getDeterministicColor(name)
   const dimensions = {
     small: { width: 24, height: 24, fontSize: '12px !important' },
     medium: { width: 32, height: 32, fontSize: '16px !important' },
@@ -107,7 +107,7 @@ const OrgsCard = ({
         <Link className={css.cardLink} href={{ pathname: AppRoutes.organizations.index, query: { orgId: id } }} />
       )}
 
-      <InitialsAvatar orgName={name} size={isCompact ? 'medium' : 'large'} />
+      <InitialsAvatar name={name} size={isCompact ? 'medium' : 'large'} />
 
       <OrgSummary
         name={name}

--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
@@ -63,7 +63,7 @@ const OrgsSidebarSelector = () => {
           className={css.orgSelectorButton}
         >
           <Box display="flex" alignItems="center" gap={1}>
-            <InitialsAvatar orgName={selectedOrg.name} size="small" />
+            <InitialsAvatar name={selectedOrg.name} size="small" />
             <Typography
               variant="body2"
               fontWeight="bold"
@@ -98,7 +98,7 @@ const OrgsSidebarSelector = () => {
               }}
             >
               <Box display="flex" alignItems="center" gap={1}>
-                <InitialsAvatar orgName={org.name} size="small" />
+                <InitialsAvatar name={org.name} size="small" />
                 <Typography variant="body2">{org.name}</Typography>
               </Box>
               {org.id === selectedOrg.id && <CheckIcon fontSize="small" color="primary" />}

--- a/packages/store/scripts/api-schema/schema.json
+++ b/packages/store/scripts/api-schema/schema.json
@@ -17,7 +17,9 @@
             }
           }
         },
-        "tags": ["about"]
+        "tags": [
+          "about"
+        ]
       }
     },
     "/v1/accounts": {
@@ -46,7 +48,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/data-types": {
@@ -68,7 +72,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/data-settings": {
@@ -99,7 +105,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "put": {
         "operationId": "accountsUpsertAccountDataSettingsV1",
@@ -138,7 +146,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}": {
@@ -166,7 +176,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "delete": {
         "operationId": "accountsDeleteAccountV1",
@@ -185,7 +197,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/address-books/{chainId}": {
@@ -221,7 +235,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "post": {
         "operationId": "addressBooksCreateAddressBookItemV1",
@@ -265,7 +281,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "delete": {
         "operationId": "addressBooksDeleteAddressBookV1",
@@ -292,7 +310,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/address-books/{chainId}/{addressBookItemId}": {
@@ -329,7 +349,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/counterfactual-safes/{chainId}/{predictedAddress}": {
@@ -373,7 +395,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "delete": {
         "operationId": "counterfactualSafesDeleteCounterfactualSafeV1",
@@ -408,7 +432,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/counterfactual-safes": {
@@ -439,7 +465,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "put": {
         "operationId": "counterfactualSafesCreateCounterfactualSafeV1",
@@ -475,7 +503,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "delete": {
         "operationId": "counterfactualSafesDeleteCounterfactualSafesV1",
@@ -494,7 +524,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/auth/nonce": {
@@ -513,7 +545,9 @@
             }
           }
         },
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/v1/auth/verify": {
@@ -535,7 +569,9 @@
             "description": "Empty response body. JWT token is set as response cookie."
           }
         },
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/v1/auth/logout": {
@@ -547,7 +583,9 @@
             "description": "Empty response body. Cookie value is removed and set to expire."
           }
         },
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/balances/{fiatCode}": {
@@ -607,7 +645,9 @@
             }
           }
         },
-        "tags": ["balances"]
+        "tags": [
+          "balances"
+        ]
       }
     },
     "/v1/balances/supported-fiat-codes": {
@@ -629,7 +669,9 @@
             }
           }
         },
-        "tags": ["balances"]
+        "tags": [
+          "balances"
+        ]
       }
     },
     "/v1/chains": {
@@ -657,7 +699,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}": {
@@ -685,7 +729,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}/about": {
@@ -713,7 +759,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}/about/backbone": {
@@ -741,7 +789,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}/about/master-copies": {
@@ -772,7 +822,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}/about/indexing": {
@@ -800,7 +852,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v2/chains/{chainId}/safes/{safeAddress}/collectibles": {
@@ -860,7 +914,9 @@
             }
           }
         },
-        "tags": ["collectibles"]
+        "tags": [
+          "collectibles"
+        ]
       }
     },
     "/v1/community/campaigns": {
@@ -888,7 +944,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/campaigns/{resourceId}": {
@@ -916,7 +974,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/campaigns/{resourceId}/activities": {
@@ -953,7 +1013,9 @@
             "description": ""
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/campaigns/{resourceId}/leaderboard": {
@@ -989,7 +1051,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/campaigns/{resourceId}/leaderboard/{safeAddress}": {
@@ -1025,7 +1089,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/eligibility": {
@@ -1054,7 +1120,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/locking/leaderboard": {
@@ -1082,7 +1150,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/locking/{safeAddress}/rank": {
@@ -1110,7 +1180,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/locking/{safeAddress}/history": {
@@ -1146,7 +1218,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/chains/{chainId}/contracts/{contractAddress}": {
@@ -1182,7 +1256,9 @@
             }
           }
         },
-        "tags": ["contracts"]
+        "tags": [
+          "contracts"
+        ]
       }
     },
     "/v1/chains/{chainId}/data-decoder": {
@@ -1220,7 +1296,9 @@
             }
           }
         },
-        "tags": ["data-decoded"]
+        "tags": [
+          "data-decoded"
+        ]
       }
     },
     "/v1/chains/{chainId}/delegates": {
@@ -1290,7 +1368,9 @@
           }
         },
         "summary": "",
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       },
       "post": {
         "deprecated": true,
@@ -1321,7 +1401,9 @@
           }
         },
         "summary": "",
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v1/chains/{chainId}/delegates/{delegateAddress}": {
@@ -1362,7 +1444,9 @@
           }
         },
         "summary": "",
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/delegates/{delegateAddress}": {
@@ -1395,7 +1479,9 @@
           }
         },
         "summary": "",
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v2/chains/{chainId}/delegates": {
@@ -1463,7 +1549,9 @@
             }
           }
         },
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       },
       "post": {
         "operationId": "delegatesPostDelegateV2",
@@ -1492,7 +1580,9 @@
             "description": ""
           }
         },
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v2/chains/{chainId}/delegates/{delegateAddress}": {
@@ -1531,7 +1621,9 @@
             "description": ""
           }
         },
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/recovery": {
@@ -1570,7 +1662,9 @@
             "description": ""
           }
         },
-        "tags": ["recovery"]
+        "tags": [
+          "recovery"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/recovery/{moduleAddress}": {
@@ -1607,7 +1701,9 @@
             "description": ""
           }
         },
-        "tags": ["recovery"]
+        "tags": [
+          "recovery"
+        ]
       }
     },
     "/v2/chains/{chainId}/safes/{address}/multisig-transactions/estimations": {
@@ -1653,7 +1749,9 @@
             }
           }
         },
-        "tags": ["estimations"]
+        "tags": [
+          "estimations"
+        ]
       }
     },
     "/v2/register/notifications": {
@@ -1675,7 +1773,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v2/chains/{chainId}/notifications/devices/{deviceUuid}/safes/{safeAddress}": {
@@ -1712,7 +1812,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       },
       "delete": {
         "operationId": "notificationsDeleteSubscriptionV2",
@@ -1747,7 +1849,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v2/chains/{chainId}/notifications/devices/{deviceUuid}": {
@@ -1776,7 +1880,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v1/chains/{chainId}/messages/{messageHash}": {
@@ -1812,7 +1918,9 @@
             }
           }
         },
-        "tags": ["messages"]
+        "tags": [
+          "messages"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/messages": {
@@ -1856,7 +1964,9 @@
             }
           }
         },
-        "tags": ["messages"]
+        "tags": [
+          "messages"
+        ]
       },
       "post": {
         "operationId": "messagesCreateMessageV1",
@@ -1893,7 +2003,9 @@
             "description": ""
           }
         },
-        "tags": ["messages"]
+        "tags": [
+          "messages"
+        ]
       }
     },
     "/v1/chains/{chainId}/messages/{messageHash}/signatures": {
@@ -1932,7 +2044,9 @@
             "description": ""
           }
         },
-        "tags": ["messages"]
+        "tags": [
+          "messages"
+        ]
       }
     },
     "/v1/register/notifications": {
@@ -1954,7 +2068,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v1/chains/{chainId}/notifications/devices/{uuid}": {
@@ -1983,7 +2099,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v1/chains/{chainId}/notifications/devices/{uuid}/safes/{safeAddress}": {
@@ -2020,7 +2138,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v1/users": {
@@ -2045,7 +2165,9 @@
             "description": "User (wallet) not found"
           }
         },
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       },
       "delete": {
         "operationId": "usersDeleteV1",
@@ -2061,7 +2183,9 @@
             "description": "User (wallet) not found"
           }
         },
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       }
     },
     "/v1/users/wallet": {
@@ -2086,7 +2210,9 @@
             "description": "Wallet already exists"
           }
         },
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       }
     },
     "/v1/users/wallet/add": {
@@ -2098,7 +2224,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Function"
+                "$ref": "#/components/schemas/SiweDto"
               }
             }
           }
@@ -2124,7 +2250,9 @@
             "description": "Wallet already exists"
           }
         },
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       }
     },
     "/v1/users/wallet/{walletAddress}": {
@@ -2154,7 +2282,9 @@
             "description": "Cannot remove the current wallet"
           }
         },
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       }
     },
     "/v1/organizations": {
@@ -2192,7 +2322,9 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       },
       "get": {
         "operationId": "organizationsGetV1",
@@ -2221,7 +2353,9 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       }
     },
     "/v1/organizations/create-with-user": {
@@ -2256,7 +2390,9 @@
             "description": "Forbidden resource"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       }
     },
     "/v1/organizations/{id}": {
@@ -2293,7 +2429,9 @@
             "description": "Organization not found. OR User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       },
       "patch": {
         "operationId": "organizationsUpdateV1",
@@ -2338,7 +2476,9 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       },
       "delete": {
         "operationId": "organizationsDeleteV1",
@@ -2366,7 +2506,9 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       }
     },
     "/v1/organizations/{organizationId}/safes": {
@@ -2403,7 +2545,9 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations-safe"]
+        "tags": [
+          "organizations-safe"
+        ]
       },
       "get": {
         "operationId": "organizationSafesGetV1",
@@ -2435,7 +2579,9 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations-safe"]
+        "tags": [
+          "organizations-safe"
+        ]
       },
       "delete": {
         "operationId": "organizationSafesDeleteV1",
@@ -2470,7 +2616,9 @@
             "description": "Organization has no Safes OR user not found."
           }
         },
-        "tags": ["organizations-safe"]
+        "tags": [
+          "organizations-safe"
+        ]
       }
     },
     "/v1/organizations/{orgId}/members/invite": {
@@ -2520,7 +2668,9 @@
             "description": "Too many invites"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       }
     },
     "/v1/organizations/{orgId}/members/accept": {
@@ -2536,6 +2686,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcceptInviteDto"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Invite accepted"
@@ -2550,7 +2710,9 @@
             "description": "User invite not pending"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       }
     },
     "/v1/organizations/{orgId}/members/decline": {
@@ -2580,7 +2742,9 @@
             "description": "User invite not pending"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       }
     },
     "/v1/organizations/{orgId}/members": {
@@ -2614,7 +2778,9 @@
             "description": "Signer or organization not found"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       }
     },
     "/v1/organizations/{orgId}/members/{userId}/role": {
@@ -2665,7 +2831,9 @@
             "description": "Cannot remove last admin"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       }
     },
     "/v1/organizations/{orgId}/members/{userId}": {
@@ -2706,7 +2874,9 @@
             "description": "Cannot remove last admin"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "organizations"
+        ]
       }
     },
     "/v1/chains/{chainId}/owners/{ownerAddress}/safes": {
@@ -2742,7 +2912,9 @@
             }
           }
         },
-        "tags": ["owners"]
+        "tags": [
+          "owners"
+        ]
       }
     },
     "/v1/owners/{ownerAddress}/safes": {
@@ -2770,7 +2942,9 @@
             }
           }
         },
-        "tags": ["owners"]
+        "tags": [
+          "owners"
+        ]
       }
     },
     "/v2/owners/{ownerAddress}/safes": {
@@ -2804,7 +2978,9 @@
             }
           }
         },
-        "tags": ["owners"]
+        "tags": [
+          "owners"
+        ]
       }
     },
     "/v1/chains/{chainId}/relay": {
@@ -2835,7 +3011,9 @@
             "description": ""
           }
         },
-        "tags": ["relay"]
+        "tags": [
+          "relay"
+        ]
       }
     },
     "/v1/chains/{chainId}/relay/{safeAddress}": {
@@ -2864,7 +3042,9 @@
             "description": ""
           }
         },
-        "tags": ["relay"]
+        "tags": [
+          "relay"
+        ]
       }
     },
     "/v1/chains/{chainId}/safe-apps": {
@@ -2911,7 +3091,9 @@
             }
           }
         },
-        "tags": ["safe-apps"]
+        "tags": [
+          "safe-apps"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}": {
@@ -2947,7 +3129,9 @@
             }
           }
         },
-        "tags": ["safes"]
+        "tags": [
+          "safes"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/nonces": {
@@ -2983,7 +3167,9 @@
             }
           }
         },
-        "tags": ["safes"]
+        "tags": [
+          "safes"
+        ]
       }
     },
     "/v1/safes": {
@@ -3046,7 +3232,9 @@
             }
           }
         },
-        "tags": ["safes"]
+        "tags": [
+          "safes"
+        ]
       }
     },
     "/v1/targeted-messaging/outreaches/{outreachId}/chains/{chainId}/safes/{safeAddress}": {
@@ -3093,7 +3281,9 @@
             "description": "Safe not targeted."
           }
         },
-        "tags": ["targeted-messaging"]
+        "tags": [
+          "targeted-messaging"
+        ]
       }
     },
     "/v1/targeted-messaging/outreaches/{outreachId}/chains/{chainId}/safes/{safeAddress}/signers/{signerAddress}/submissions": {
@@ -3145,7 +3335,9 @@
             }
           }
         },
-        "tags": ["targeted-messaging"]
+        "tags": [
+          "targeted-messaging"
+        ]
       },
       "post": {
         "operationId": "targetedMessagingCreateSubmissionV1",
@@ -3205,7 +3397,9 @@
             }
           }
         },
-        "tags": ["targeted-messaging"]
+        "tags": [
+          "targeted-messaging"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{id}": {
@@ -3241,7 +3435,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/multisig-transactions/{safeTxHash}/raw": {
@@ -3277,7 +3473,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/multisig-transactions/raw": {
@@ -3521,7 +3719,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/multisig-transactions": {
@@ -3613,7 +3813,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{safeTxHash}": {
@@ -3652,7 +3854,9 @@
             "description": ""
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/module-transactions": {
@@ -3720,7 +3924,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{safeTxHash}/confirmations": {
@@ -3766,7 +3972,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/incoming-transfers": {
@@ -3858,7 +4066,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{safeAddress}/preview": {
@@ -3904,7 +4114,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/transactions/queued": {
@@ -3956,7 +4168,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/transactions/history": {
@@ -4033,7 +4247,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{safeAddress}/propose": {
@@ -4079,7 +4295,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/transactions/creation": {
@@ -4115,7 +4333,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/creation/raw": {
@@ -4151,7 +4371,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     }
   },
@@ -4180,7 +4402,9 @@
             "nullable": true
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "CreateAccountDto": {
         "type": "object",
@@ -4192,7 +4416,10 @@
             "type": "string"
           }
         },
-        "required": ["address", "name"]
+        "required": [
+          "address",
+          "name"
+        ]
       },
       "Account": {
         "type": "object",
@@ -4211,7 +4438,11 @@
             "type": "string"
           }
         },
-        "required": ["id", "address", "name"]
+        "required": [
+          "id",
+          "address",
+          "name"
+        ]
       },
       "AccountDataType": {
         "type": "object",
@@ -4230,7 +4461,11 @@
             "type": "boolean"
           }
         },
-        "required": ["id", "name", "isActive"]
+        "required": [
+          "id",
+          "name",
+          "isActive"
+        ]
       },
       "AccountDataSetting": {
         "type": "object",
@@ -4242,7 +4477,10 @@
             "type": "boolean"
           }
         },
-        "required": ["dataTypeId", "enabled"]
+        "required": [
+          "dataTypeId",
+          "enabled"
+        ]
       },
       "UpsertAccountDataSettingDto": {
         "type": "object",
@@ -4254,7 +4492,10 @@
             "type": "boolean"
           }
         },
-        "required": ["dataTypeId", "enabled"]
+        "required": [
+          "dataTypeId",
+          "enabled"
+        ]
       },
       "UpsertAccountDataSettingsDto": {
         "type": "object",
@@ -4266,7 +4507,9 @@
             }
           }
         },
-        "required": ["accountDataSettings"]
+        "required": [
+          "accountDataSettings"
+        ]
       },
       "AddressBookItem": {
         "type": "object",
@@ -4281,7 +4524,11 @@
             "type": "string"
           }
         },
-        "required": ["id", "name", "address"]
+        "required": [
+          "id",
+          "name",
+          "address"
+        ]
       },
       "AddressBook": {
         "type": "object",
@@ -4302,7 +4549,12 @@
             }
           }
         },
-        "required": ["id", "accountId", "chainId", "data"]
+        "required": [
+          "id",
+          "accountId",
+          "chainId",
+          "data"
+        ]
       },
       "CreateAddressBookItemDto": {
         "type": "object",
@@ -4314,7 +4566,10 @@
             "type": "string"
           }
         },
-        "required": ["name", "address"]
+        "required": [
+          "name",
+          "address"
+        ]
       },
       "CounterfactualSafe": {
         "type": "object",
@@ -4403,7 +4658,9 @@
             "type": "string"
           }
         },
-        "required": ["nonce"]
+        "required": [
+          "nonce"
+        ]
       },
       "SiweDto": {
         "type": "object",
@@ -4415,17 +4672,19 @@
             "type": "string"
           }
         },
-        "required": ["message", "signature"]
+        "required": [
+          "message",
+          "signature"
+        ]
       },
-      "Token": {
+      "NativeToken": {
         "type": "object",
         "properties": {
           "address": {
             "type": "string"
           },
           "decimals": {
-            "type": "number",
-            "nullable": true
+            "type": "number"
           },
           "logoUri": {
             "type": "string"
@@ -4438,10 +4697,87 @@
           },
           "type": {
             "type": "string",
-            "enum": ["ERC721", "ERC20", "NATIVE_TOKEN", "UNKNOWN"]
+            "enum": [
+              "NATIVE_TOKEN"
+            ]
           }
         },
-        "required": ["address", "logoUri", "name", "symbol", "type"]
+        "required": [
+          "address",
+          "decimals",
+          "logoUri",
+          "name",
+          "symbol",
+          "type"
+        ]
+      },
+      "Erc20Token": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "decimals": {
+            "type": "number"
+          },
+          "logoUri": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "ERC20"
+            ]
+          }
+        },
+        "required": [
+          "address",
+          "decimals",
+          "logoUri",
+          "name",
+          "symbol",
+          "type"
+        ]
+      },
+      "Erc721Token": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "decimals": {
+            "type": "number"
+          },
+          "logoUri": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "ERC721"
+            ]
+          }
+        },
+        "required": [
+          "address",
+          "decimals",
+          "logoUri",
+          "name",
+          "symbol",
+          "type"
+        ]
       },
       "Balance": {
         "type": "object",
@@ -4456,10 +4792,25 @@
             "type": "string"
           },
           "tokenInfo": {
-            "$ref": "#/components/schemas/Token"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/NativeToken"
+              },
+              {
+                "$ref": "#/components/schemas/Erc20Token"
+              },
+              {
+                "$ref": "#/components/schemas/Erc721Token"
+              }
+            ]
           }
         },
-        "required": ["balance", "fiatBalance", "fiatConversion", "tokenInfo"]
+        "required": [
+          "balance",
+          "fiatBalance",
+          "fiatConversion",
+          "tokenInfo"
+        ]
       },
       "Balances": {
         "type": "object",
@@ -4478,7 +4829,10 @@
             }
           }
         },
-        "required": ["fiatTotal", "items"]
+        "required": [
+          "fiatTotal",
+          "items"
+        ]
       },
       "GasPriceOracle": {
         "type": "object",
@@ -4496,7 +4850,12 @@
             "type": "string"
           }
         },
-        "required": ["type", "gasParameter", "gweiFactor", "uri"]
+        "required": [
+          "type",
+          "gasParameter",
+          "gweiFactor",
+          "uri"
+        ]
       },
       "GasPriceFixed": {
         "type": "object",
@@ -4508,7 +4867,10 @@
             "type": "string"
           }
         },
-        "required": ["type", "weiValue"]
+        "required": [
+          "type",
+          "weiValue"
+        ]
       },
       "GasPriceFixedEIP1559": {
         "type": "object",
@@ -4523,7 +4885,11 @@
             "type": "string"
           }
         },
-        "required": ["type", "maxFeePerGas", "maxPriorityFeePerGas"]
+        "required": [
+          "type",
+          "maxFeePerGas",
+          "maxPriorityFeePerGas"
+        ]
       },
       "NativeCurrency": {
         "type": "object",
@@ -4541,7 +4907,12 @@
             "type": "string"
           }
         },
-        "required": ["decimals", "logoUri", "name", "symbol"]
+        "required": [
+          "decimals",
+          "logoUri",
+          "name",
+          "symbol"
+        ]
       },
       "BlockExplorerUriTemplate": {
         "type": "object",
@@ -4556,7 +4927,11 @@
             "type": "string"
           }
         },
-        "required": ["address", "api", "txHash"]
+        "required": [
+          "address",
+          "api",
+          "txHash"
+        ]
       },
       "BalancesProvider": {
         "type": "object",
@@ -4569,7 +4944,9 @@
             "type": "boolean"
           }
         },
-        "required": ["enabled"]
+        "required": [
+          "enabled"
+        ]
       },
       "ContractAddresses": {
         "type": "object",
@@ -4617,13 +4994,20 @@
         "properties": {
           "authentication": {
             "type": "string",
-            "enum": ["API_KEY_PATH", "NO_AUTHENTICATION", "UNKNOWN"]
+            "enum": [
+              "API_KEY_PATH",
+              "NO_AUTHENTICATION",
+              "UNKNOWN"
+            ]
           },
           "value": {
             "type": "string"
           }
         },
-        "required": ["authentication", "value"]
+        "required": [
+          "authentication",
+          "value"
+        ]
       },
       "Theme": {
         "type": "object",
@@ -4635,7 +5019,10 @@
             "type": "string"
           }
         },
-        "required": ["backgroundColor", "textColor"]
+        "required": [
+          "backgroundColor",
+          "textColor"
+        ]
       },
       "Chain": {
         "type": "object",
@@ -4773,7 +5160,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "AboutChain": {
         "type": "object",
@@ -4791,7 +5180,12 @@
             "type": "string"
           }
         },
-        "required": ["transactionServiceBaseUri", "name", "version", "buildNumber"]
+        "required": [
+          "transactionServiceBaseUri",
+          "name",
+          "version",
+          "buildNumber"
+        ]
       },
       "Backbone": {
         "type": "object",
@@ -4820,7 +5214,14 @@
             "type": "string"
           }
         },
-        "required": ["api_version", "host", "name", "secure", "settings", "version"]
+        "required": [
+          "api_version",
+          "host",
+          "name",
+          "secure",
+          "settings",
+          "version"
+        ]
       },
       "MasterCopy": {
         "type": "object",
@@ -4832,7 +5233,10 @@
             "type": "string"
           }
         },
-        "required": ["address", "version"]
+        "required": [
+          "address",
+          "version"
+        ]
       },
       "IndexingStatus": {
         "type": "object",
@@ -4844,7 +5248,10 @@
             "type": "boolean"
           }
         },
-        "required": ["lastSync", "synced"]
+        "required": [
+          "lastSync",
+          "synced"
+        ]
       },
       "Collectible": {
         "type": "object",
@@ -4885,7 +5292,13 @@
             "nullable": true
           }
         },
-        "required": ["address", "tokenName", "tokenSymbol", "logoUri", "id"]
+        "required": [
+          "address",
+          "tokenName",
+          "tokenSymbol",
+          "logoUri",
+          "id"
+        ]
       },
       "CollectiblePage": {
         "type": "object",
@@ -4909,7 +5322,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "ActivityMetadata": {
         "type": "object",
@@ -4924,7 +5339,11 @@
             "type": "number"
           }
         },
-        "required": ["name", "description", "maxPoints"]
+        "required": [
+          "name",
+          "description",
+          "maxPoints"
+        ]
       },
       "Campaign": {
         "type": "object",
@@ -4979,7 +5398,14 @@
             "type": "boolean"
           }
         },
-        "required": ["resourceId", "name", "description", "startDate", "endDate", "isPromoted"]
+        "required": [
+          "resourceId",
+          "name",
+          "description",
+          "startDate",
+          "endDate",
+          "isPromoted"
+        ]
       },
       "CampaignPage": {
         "type": "object",
@@ -5003,7 +5429,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "CampaignRank": {
         "type": "object",
@@ -5024,7 +5452,13 @@
             "type": "number"
           }
         },
-        "required": ["holder", "position", "boost", "totalPoints", "totalBoostedPoints"]
+        "required": [
+          "holder",
+          "position",
+          "boost",
+          "totalPoints",
+          "totalBoostedPoints"
+        ]
       },
       "CampaignRankPage": {
         "type": "object",
@@ -5048,7 +5482,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "EligibilityRequest": {
         "type": "object",
@@ -5060,7 +5496,10 @@
             "type": "string"
           }
         },
-        "required": ["requestId", "sealedData"]
+        "required": [
+          "requestId",
+          "sealedData"
+        ]
       },
       "Eligibility": {
         "type": "object",
@@ -5075,7 +5514,11 @@
             "type": "boolean"
           }
         },
-        "required": ["requestId", "isAllowed", "isVpn"]
+        "required": [
+          "requestId",
+          "isAllowed",
+          "isVpn"
+        ]
       },
       "LockingRank": {
         "type": "object",
@@ -5096,7 +5539,13 @@
             "type": "string"
           }
         },
-        "required": ["holder", "position", "lockedAmount", "unlockedAmount", "withdrawnAmount"]
+        "required": [
+          "holder",
+          "position",
+          "lockedAmount",
+          "unlockedAmount",
+          "withdrawnAmount"
+        ]
       },
       "LockingRankPage": {
         "type": "object",
@@ -5120,14 +5569,18 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "LockEventItem": {
         "type": "object",
         "properties": {
           "eventType": {
             "type": "string",
-            "enum": ["LOCKED"]
+            "enum": [
+              "LOCKED"
+            ]
           },
           "executionDate": {
             "type": "string"
@@ -5145,14 +5598,23 @@
             "type": "string"
           }
         },
-        "required": ["eventType", "executionDate", "transactionHash", "holder", "amount", "logIndex"]
+        "required": [
+          "eventType",
+          "executionDate",
+          "transactionHash",
+          "holder",
+          "amount",
+          "logIndex"
+        ]
       },
       "UnlockEventItem": {
         "type": "object",
         "properties": {
           "eventType": {
             "type": "string",
-            "enum": ["UNLOCKED"]
+            "enum": [
+              "UNLOCKED"
+            ]
           },
           "executionDate": {
             "type": "string"
@@ -5173,14 +5635,24 @@
             "type": "string"
           }
         },
-        "required": ["eventType", "executionDate", "transactionHash", "holder", "amount", "logIndex", "unlockIndex"]
+        "required": [
+          "eventType",
+          "executionDate",
+          "transactionHash",
+          "holder",
+          "amount",
+          "logIndex",
+          "unlockIndex"
+        ]
       },
       "WithdrawEventItem": {
         "type": "object",
         "properties": {
           "eventType": {
             "type": "string",
-            "enum": ["WITHDRAWN"]
+            "enum": [
+              "WITHDRAWN"
+            ]
           },
           "executionDate": {
             "type": "string"
@@ -5201,7 +5673,15 @@
             "type": "string"
           }
         },
-        "required": ["eventType", "executionDate", "transactionHash", "holder", "amount", "logIndex", "unlockIndex"]
+        "required": [
+          "eventType",
+          "executionDate",
+          "transactionHash",
+          "holder",
+          "amount",
+          "logIndex",
+          "unlockIndex"
+        ]
       },
       "LockingEventPage": {
         "type": "object",
@@ -5235,7 +5715,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "Contract": {
         "type": "object",
@@ -5260,7 +5742,13 @@
             "type": "boolean"
           }
         },
-        "required": ["address", "name", "displayName", "logoUri", "trustedForDelegateCall"]
+        "required": [
+          "address",
+          "name",
+          "displayName",
+          "logoUri",
+          "trustedForDelegateCall"
+        ]
       },
       "TransactionDataDto": {
         "type": "object",
@@ -5278,7 +5766,9 @@
             "description": "The wei amount being sent to a payable function"
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "DataDecodedParameter": {
         "type": "object",
@@ -5307,7 +5797,11 @@
             "nullable": true
           }
         },
-        "required": ["name", "type", "value"]
+        "required": [
+          "name",
+          "type",
+          "value"
+        ]
       },
       "DataDecoded": {
         "type": "object",
@@ -5323,7 +5817,9 @@
             }
           }
         },
-        "required": ["method"]
+        "required": [
+          "method"
+        ]
       },
       "Delegate": {
         "type": "object",
@@ -5342,7 +5838,11 @@
             "type": "string"
           }
         },
-        "required": ["delegate", "delegator", "label"]
+        "required": [
+          "delegate",
+          "delegator",
+          "label"
+        ]
       },
       "DelegatePage": {
         "type": "object",
@@ -5366,7 +5866,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "CreateDelegateDto": {
         "type": "object",
@@ -5388,7 +5890,12 @@
             "type": "string"
           }
         },
-        "required": ["delegate", "delegator", "signature", "label"]
+        "required": [
+          "delegate",
+          "delegator",
+          "signature",
+          "label"
+        ]
       },
       "DeleteDelegateDto": {
         "type": "object",
@@ -5403,7 +5910,11 @@
             "type": "string"
           }
         },
-        "required": ["delegate", "delegator", "signature"]
+        "required": [
+          "delegate",
+          "delegator",
+          "signature"
+        ]
       },
       "DeleteSafeDelegateDto": {
         "type": "object",
@@ -5418,7 +5929,11 @@
             "type": "string"
           }
         },
-        "required": ["delegate", "safe", "signature"]
+        "required": [
+          "delegate",
+          "safe",
+          "signature"
+        ]
       },
       "DeleteDelegateV2Dto": {
         "type": "object",
@@ -5435,7 +5950,9 @@
             "type": "string"
           }
         },
-        "required": ["signature"]
+        "required": [
+          "signature"
+        ]
       },
       "AddRecoveryModuleDto": {
         "type": "object",
@@ -5444,7 +5961,9 @@
             "type": "string"
           }
         },
-        "required": ["moduleAddress"]
+        "required": [
+          "moduleAddress"
+        ]
       },
       "GetEstimationDto": {
         "type": "object",
@@ -5463,7 +5982,11 @@
             "type": "number"
           }
         },
-        "required": ["to", "value", "operation"]
+        "required": [
+          "to",
+          "value",
+          "operation"
+        ]
       },
       "EstimationResponse": {
         "type": "object",
@@ -5478,7 +6001,11 @@
             "type": "string"
           }
         },
-        "required": ["currentNonce", "recommendedNonce", "safeTxGas"]
+        "required": [
+          "currentNonce",
+          "recommendedNonce",
+          "safeTxGas"
+        ]
       },
       "NotificationType": {
         "type": "string",
@@ -5508,11 +6035,19 @@
             }
           }
         },
-        "required": ["chainId", "address", "notificationTypes"]
+        "required": [
+          "chainId",
+          "address",
+          "notificationTypes"
+        ]
       },
       "DeviceType": {
         "type": "string",
-        "enum": ["ANDROID", "IOS", "WEB"]
+        "enum": [
+          "ANDROID",
+          "IOS",
+          "WEB"
+        ]
       },
       "UpsertSubscriptionsDto": {
         "type": "object",
@@ -5538,7 +6073,11 @@
             "nullable": true
           }
         },
-        "required": ["cloudMessagingToken", "safes", "deviceType"]
+        "required": [
+          "cloudMessagingToken",
+          "safes",
+          "deviceType"
+        ]
       },
       "AddressInfo": {
         "type": "object",
@@ -5555,7 +6094,9 @@
             "nullable": true
           }
         },
-        "required": ["value"]
+        "required": [
+          "value"
+        ]
       },
       "Message": {
         "type": "object",
@@ -5690,13 +6231,18 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["DATE_LABEL"]
+            "enum": [
+              "DATE_LABEL"
+            ]
           },
           "timestamp": {
             "type": "number"
           }
         },
-        "required": ["type", "timestamp"]
+        "required": [
+          "type",
+          "timestamp"
+        ]
       },
       "MessagePage": {
         "type": "object",
@@ -5727,7 +6273,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "CreateMessageDto": {
         "type": "object",
@@ -5748,7 +6296,10 @@
             "nullable": true
           }
         },
-        "required": ["message", "signature"]
+        "required": [
+          "message",
+          "signature"
+        ]
       },
       "UpdateMessageSignatureDto": {
         "type": "object",
@@ -5757,7 +6308,9 @@
             "type": "string"
           }
         },
-        "required": ["signature"]
+        "required": [
+          "signature"
+        ]
       },
       "SafeRegistration": {
         "type": "object",
@@ -5778,7 +6331,11 @@
             }
           }
         },
-        "required": ["chainId", "safes", "signatures"]
+        "required": [
+          "chainId",
+          "safes",
+          "signatures"
+        ]
       },
       "RegisterDeviceDto": {
         "type": "object",
@@ -5813,7 +6370,14 @@
             }
           }
         },
-        "required": ["cloudMessagingToken", "buildNumber", "bundle", "deviceType", "version", "safeRegistrations"]
+        "required": [
+          "cloudMessagingToken",
+          "buildNumber",
+          "bundle",
+          "deviceType",
+          "version",
+          "safeRegistrations"
+        ]
       },
       "UserWallet": {
         "type": "object",
@@ -5825,7 +6389,10 @@
             "type": "string"
           }
         },
-        "required": ["id", "address"]
+        "required": [
+          "id",
+          "address"
+        ]
       },
       "UserWithWallets": {
         "type": "object",
@@ -5835,7 +6402,10 @@
           },
           "status": {
             "type": "number",
-            "enum": [0, 1]
+            "enum": [
+              0,
+              1
+            ]
           },
           "wallets": {
             "type": "array",
@@ -5844,7 +6414,11 @@
             }
           }
         },
-        "required": ["id", "status", "wallets"]
+        "required": [
+          "id",
+          "status",
+          "wallets"
+        ]
       },
       "CreatedUserWithWallet": {
         "type": "object",
@@ -5853,11 +6427,9 @@
             "type": "number"
           }
         },
-        "required": ["id"]
-      },
-      "Function": {
-        "type": "object",
-        "properties": {}
+        "required": [
+          "id"
+        ]
       },
       "WalletAddedToUser": {
         "type": "object",
@@ -5866,7 +6438,9 @@
             "type": "number"
           }
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
       },
       "CreateOrganizationDto": {
         "type": "object",
@@ -5875,7 +6449,9 @@
             "type": "string"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "CreateOrganizationResponse": {
         "type": "object",
@@ -5887,7 +6463,10 @@
             "type": "number"
           }
         },
-        "required": ["name", "id"]
+        "required": [
+          "name",
+          "id"
+        ]
       },
       "UserDto": {
         "type": "object",
@@ -5897,10 +6476,16 @@
           },
           "status": {
             "type": "string",
-            "enum": ["PENDING", "ACTIVE"]
+            "enum": [
+              "PENDING",
+              "ACTIVE"
+            ]
           }
         },
-        "required": ["id", "status"]
+        "required": [
+          "id",
+          "status"
+        ]
       },
       "UserOrganizationDto": {
         "type": "object",
@@ -5910,11 +6495,21 @@
           },
           "role": {
             "type": "string",
-            "enum": ["ADMIN", "MEMBER"]
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
+          },
+          "name": {
+            "type": "string"
           },
           "status": {
             "type": "string",
-            "enum": ["INVITED", "ACTIVE", "DECLINED"]
+            "enum": [
+              "INVITED",
+              "ACTIVE",
+              "DECLINED"
+            ]
           },
           "createdAt": {
             "format": "date-time",
@@ -5928,7 +6523,15 @@
             "$ref": "#/components/schemas/UserDto"
           }
         },
-        "required": ["id", "role", "status", "createdAt", "updatedAt", "user"]
+        "required": [
+          "id",
+          "role",
+          "name",
+          "status",
+          "createdAt",
+          "updatedAt",
+          "user"
+        ]
       },
       "GetOrganizationResponse": {
         "type": "object",
@@ -5941,7 +6544,9 @@
           },
           "status": {
             "type": "string",
-            "enum": ["ACTIVE"]
+            "enum": [
+              "ACTIVE"
+            ]
           },
           "userOrganizations": {
             "type": "array",
@@ -5950,7 +6555,12 @@
             }
           }
         },
-        "required": ["id", "name", "status", "userOrganizations"]
+        "required": [
+          "id",
+          "name",
+          "status",
+          "userOrganizations"
+        ]
       },
       "UpdateOrganizationDto": {
         "type": "object",
@@ -5960,7 +6570,9 @@
           },
           "status": {
             "type": "string",
-            "enum": ["ACTIVE"]
+            "enum": [
+              "ACTIVE"
+            ]
           }
         }
       },
@@ -5971,7 +6583,9 @@
             "type": "number"
           }
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
       },
       "CreateOrganizationSafeDto": {
         "type": "object",
@@ -5983,7 +6597,10 @@
             "type": "string"
           }
         },
-        "required": ["chainId", "address"]
+        "required": [
+          "chainId",
+          "address"
+        ]
       },
       "CreateOrganizationSafesDto": {
         "type": "object",
@@ -5995,23 +6612,31 @@
             }
           }
         },
-        "required": ["safes"]
-      },
-      "GetOrganizationSafes": {
-        "type": "object",
-        "properties": {}
+        "required": [
+          "safes"
+        ]
       },
       "GetOrganizationSafeResponse": {
         "type": "object",
         "properties": {
           "safes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/GetOrganizationSafes"
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "{chainId}": [
+                "0x..."
+              ]
             }
           }
         },
-        "required": ["safes"]
+        "required": [
+          "safes"
+        ]
       },
       "DeleteOrganizationSafeDto": {
         "type": "object",
@@ -6023,7 +6648,10 @@
             "type": "string"
           }
         },
-        "required": ["chainId", "address"]
+        "required": [
+          "chainId",
+          "address"
+        ]
       },
       "DeleteOrganizationSafesDto": {
         "type": "object",
@@ -6035,7 +6663,9 @@
             }
           }
         },
-        "required": ["safes"]
+        "required": [
+          "safes"
+        ]
       },
       "InviteUserDto": {
         "type": "object",
@@ -6043,12 +6673,22 @@
           "address": {
             "type": "string"
           },
+          "name": {
+            "type": "string"
+          },
           "role": {
             "type": "string",
-            "enum": ["ADMIN", "MEMBER"]
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
           }
         },
-        "required": ["address", "role"]
+        "required": [
+          "address",
+          "name",
+          "role"
+        ]
       },
       "InviteUsersDto": {
         "type": "object",
@@ -6060,7 +6700,9 @@
             }
           }
         },
-        "required": ["users"]
+        "required": [
+          "users"
+        ]
       },
       "Invitation": {
         "type": "object",
@@ -6073,14 +6715,41 @@
           },
           "role": {
             "type": "string",
-            "enum": ["ADMIN", "MEMBER"]
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["INVITED", "ACTIVE", "DECLINED"]
+            "enum": [
+              "INVITED",
+              "ACTIVE",
+              "DECLINED"
+            ]
+          },
+          "invitedBy": {
+            "type": "string",
+            "nullable": true
           }
         },
-        "required": ["userId", "orgId", "role", "status"]
+        "required": [
+          "userId",
+          "orgId",
+          "role",
+          "status"
+        ]
+      },
+      "AcceptInviteDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
       },
       "UserOrganizationUser": {
         "type": "object",
@@ -6090,10 +6759,16 @@
           },
           "status": {
             "type": "string",
-            "enum": ["PENDING", "ACTIVE"]
+            "enum": [
+              "PENDING",
+              "ACTIVE"
+            ]
           }
         },
-        "required": ["id", "status"]
+        "required": [
+          "id",
+          "status"
+        ]
       },
       "UserOrganization": {
         "type": "object",
@@ -6103,11 +6778,25 @@
           },
           "role": {
             "type": "string",
-            "enum": ["ADMIN", "MEMBER"]
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["INVITED", "ACTIVE", "DECLINED"]
+            "enum": [
+              "INVITED",
+              "ACTIVE",
+              "DECLINED"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "invitedBy": {
+            "type": "string",
+            "nullable": true
           },
           "createdAt": {
             "format": "date-time",
@@ -6121,7 +6810,15 @@
             "$ref": "#/components/schemas/UserOrganizationUser"
           }
         },
-        "required": ["id", "role", "status", "createdAt", "updatedAt", "user"]
+        "required": [
+          "id",
+          "role",
+          "status",
+          "name",
+          "createdAt",
+          "updatedAt",
+          "user"
+        ]
       },
       "UserOrganizationsDto": {
         "type": "object",
@@ -6133,17 +6830,24 @@
             }
           }
         },
-        "required": ["members"]
+        "required": [
+          "members"
+        ]
       },
       "UpdateRoleDto": {
         "type": "object",
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["ADMIN", "MEMBER"]
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
           }
         },
-        "required": ["role"]
+        "required": [
+          "role"
+        ]
       },
       "SafeList": {
         "type": "object",
@@ -6155,7 +6859,9 @@
             }
           }
         },
-        "required": ["safes"]
+        "required": [
+          "safes"
+        ]
       },
       "RelayDto": {
         "type": "object",
@@ -6175,7 +6881,11 @@
             "description": "If specified, a gas buffer of 150k will be added on top of the expected gas usage for the transaction.\n      This is for the <a href=\"https://docs.gelato.network/developer-services/relay/quick-start/optional-parameters\" target=\"_blank\">\n      Gelato Relay execution overhead</a>, reducing the chance of the task cancelling before it is executed on-chain."
           }
         },
-        "required": ["version", "to", "data"]
+        "required": [
+          "version",
+          "to",
+          "data"
+        ]
       },
       "SafeAppProvider": {
         "type": "object",
@@ -6187,7 +6897,10 @@
             "type": "string"
           }
         },
-        "required": ["url", "name"]
+        "required": [
+          "url",
+          "name"
+        ]
       },
       "SafeAppAccessControl": {
         "type": "object",
@@ -6203,20 +6916,31 @@
             }
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "SafeAppSocialProfile": {
         "type": "object",
         "properties": {
           "platform": {
             "type": "string",
-            "enum": ["DISCORD", "GITHUB", "TWITTER", "TELEGRAM", "UNKNOWN"]
+            "enum": [
+              "DISCORD",
+              "GITHUB",
+              "TWITTER",
+              "TELEGRAM",
+              "UNKNOWN"
+            ]
           },
           "url": {
             "type": "string"
           }
         },
-        "required": ["platform", "url"]
+        "required": [
+          "platform",
+          "url"
+        ]
       },
       "SafeApp": {
         "type": "object",
@@ -6346,7 +7070,11 @@
           },
           "implementationVersionState": {
             "type": "string",
-            "enum": ["UP_TO_DATE", "OUTDATED", "UNKNOWN"]
+            "enum": [
+              "UP_TO_DATE",
+              "OUTDATED",
+              "UNKNOWN"
+            ]
           },
           "collectiblesTag": {
             "type": "string",
@@ -6385,7 +7113,10 @@
             "type": "number"
           }
         },
-        "required": ["currentNonce", "recommendedNonce"]
+        "required": [
+          "currentNonce",
+          "recommendedNonce"
+        ]
       },
       "SafeOverview": {
         "type": "object",
@@ -6416,7 +7147,14 @@
             "nullable": true
           }
         },
-        "required": ["address", "chainId", "threshold", "owners", "fiatTotal", "queued"]
+        "required": [
+          "address",
+          "chainId",
+          "threshold",
+          "owners",
+          "fiatTotal",
+          "queued"
+        ]
       },
       "TargetedSafe": {
         "type": "object",
@@ -6428,7 +7166,10 @@
             "type": "string"
           }
         },
-        "required": ["outreachId", "address"]
+        "required": [
+          "outreachId",
+          "address"
+        ]
       },
       "Submission": {
         "type": "object",
@@ -6448,7 +7189,11 @@
             "nullable": true
           }
         },
-        "required": ["outreachId", "targetedSafeId", "signerAddress"]
+        "required": [
+          "outreachId",
+          "targetedSafeId",
+          "signerAddress"
+        ]
       },
       "CreateSubmissionDto": {
         "type": "object",
@@ -6457,7 +7202,9 @@
             "type": "boolean"
           }
         },
-        "required": ["completed"]
+        "required": [
+          "completed"
+        ]
       },
       "TransactionInfo": {
         "type": "object",
@@ -6482,14 +7229,18 @@
             "nullable": true
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "CreationTransactionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["Creation"]
+            "enum": [
+              "Creation"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6517,14 +7268,20 @@
             "nullable": true
           }
         },
-        "required": ["type", "creator", "transactionHash"]
+        "required": [
+          "type",
+          "creator",
+          "transactionHash"
+        ]
       },
       "CustomTransactionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["Custom"]
+            "enum": [
+              "Custom"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6552,7 +7309,12 @@
             "nullable": true
           }
         },
-        "required": ["type", "to", "dataSize", "isCancellation"]
+        "required": [
+          "type",
+          "to",
+          "dataSize",
+          "isCancellation"
+        ]
       },
       "SettingsChange": {
         "type": "object",
@@ -6573,14 +7335,18 @@
             ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "SettingsChangeTransaction": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["SettingsChange"]
+            "enum": [
+              "SettingsChange"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6598,14 +7364,19 @@
             ]
           }
         },
-        "required": ["type", "dataDecoded"]
+        "required": [
+          "type",
+          "dataDecoded"
+        ]
       },
       "Erc20Transfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["ERC20"]
+            "enum": [
+              "ERC20"
+            ]
           },
           "tokenAddress": {
             "type": "string"
@@ -6637,14 +7408,21 @@
             "type": "boolean"
           }
         },
-        "required": ["type", "tokenAddress", "value", "imitation"]
+        "required": [
+          "type",
+          "tokenAddress",
+          "value",
+          "imitation"
+        ]
       },
       "Erc721Transfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["ERC721"]
+            "enum": [
+              "ERC721"
+            ]
           },
           "tokenAddress": {
             "type": "string"
@@ -6669,38 +7447,54 @@
             "nullable": true
           }
         },
-        "required": ["type", "tokenAddress", "tokenId"]
+        "required": [
+          "type",
+          "tokenAddress",
+          "tokenId"
+        ]
       },
       "NativeCoinTransfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NATIVE_COIN"]
+            "enum": [
+              "NATIVE_COIN"
+            ]
           },
           "value": {
             "type": "string",
             "nullable": true
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "Transfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NATIVE_COIN", "ERC20", "ERC721"]
+            "enum": [
+              "NATIVE_COIN",
+              "ERC20",
+              "ERC721"
+            ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "TransferTransactionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["Transfer"]
+            "enum": [
+              "Transfer"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6714,7 +7508,11 @@
           },
           "direction": {
             "type": "string",
-            "enum": ["INCOMING", "OUTGOING", "UNKNOWN"]
+            "enum": [
+              "INCOMING",
+              "OUTGOING",
+              "UNKNOWN"
+            ]
           },
           "transferInfo": {
             "oneOf": [
@@ -6735,7 +7533,13 @@
             ]
           }
         },
-        "required": ["type", "sender", "recipient", "direction", "transferInfo"]
+        "required": [
+          "type",
+          "sender",
+          "recipient",
+          "direction",
+          "transferInfo"
+        ]
       },
       "TokenInfo": {
         "type": "object",
@@ -6766,14 +7570,22 @@
             "description": "The token trusted status"
           }
         },
-        "required": ["address", "decimals", "name", "symbol", "trusted"]
+        "required": [
+          "address",
+          "decimals",
+          "name",
+          "symbol",
+          "trusted"
+        ]
       },
       "SwapOrderTransactionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["SwapOrder"]
+            "enum": [
+              "SwapOrder"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6785,15 +7597,31 @@
           },
           "status": {
             "type": "string",
-            "enum": ["presignaturePending", "open", "fulfilled", "cancelled", "expired", "unknown"]
+            "enum": [
+              "presignaturePending",
+              "open",
+              "fulfilled",
+              "cancelled",
+              "expired",
+              "unknown"
+            ]
           },
           "kind": {
             "type": "string",
-            "enum": ["buy", "sell", "unknown"]
+            "enum": [
+              "buy",
+              "sell",
+              "unknown"
+            ]
           },
           "orderClass": {
             "type": "string",
-            "enum": ["market", "limit", "liquidity", "unknown"]
+            "enum": [
+              "market",
+              "limit",
+              "liquidity",
+              "unknown"
+            ]
           },
           "validUntil": {
             "type": "number",
@@ -6881,7 +7709,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["SwapTransfer"]
+            "enum": [
+              "SwapTransfer"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6920,15 +7750,31 @@
           },
           "status": {
             "type": "string",
-            "enum": ["presignaturePending", "open", "fulfilled", "cancelled", "expired", "unknown"]
+            "enum": [
+              "presignaturePending",
+              "open",
+              "fulfilled",
+              "cancelled",
+              "expired",
+              "unknown"
+            ]
           },
           "kind": {
             "type": "string",
-            "enum": ["buy", "sell", "unknown"]
+            "enum": [
+              "buy",
+              "sell",
+              "unknown"
+            ]
           },
           "orderClass": {
             "type": "string",
-            "enum": ["market", "limit", "liquidity", "unknown"]
+            "enum": [
+              "market",
+              "limit",
+              "liquidity",
+              "unknown"
+            ]
           },
           "validUntil": {
             "type": "number",
@@ -7024,7 +7870,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TwapOrder"]
+            "enum": [
+              "TwapOrder"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -7033,15 +7881,31 @@
           "status": {
             "type": "string",
             "description": "The TWAP status",
-            "enum": ["presignaturePending", "open", "fulfilled", "cancelled", "expired", "unknown"]
+            "enum": [
+              "presignaturePending",
+              "open",
+              "fulfilled",
+              "cancelled",
+              "expired",
+              "unknown"
+            ]
           },
           "kind": {
             "type": "string",
-            "enum": ["buy", "sell", "unknown"]
+            "enum": [
+              "buy",
+              "sell",
+              "unknown"
+            ]
           },
           "class": {
             "type": "string",
-            "enum": ["market", "limit", "liquidity", "unknown"]
+            "enum": [
+              "market",
+              "limit",
+              "liquidity",
+              "unknown"
+            ]
           },
           "activeOrderUid": {
             "type": "string",
@@ -7157,7 +8021,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NativeStakingDeposit"]
+            "enum": [
+              "NativeStakingDeposit"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -7247,7 +8113,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NativeStakingValidatorsExit"]
+            "enum": [
+              "NativeStakingValidatorsExit"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -7304,7 +8172,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NativeStakingWithdraw"]
+            "enum": [
+              "NativeStakingWithdraw"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -7323,7 +8193,12 @@
             }
           }
         },
-        "required": ["type", "value", "tokenInfo", "validators"]
+        "required": [
+          "type",
+          "value",
+          "tokenInfo",
+          "validators"
+        ]
       },
       "TransactionData": {
         "type": "object",
@@ -7359,7 +8234,10 @@
             "nullable": true
           }
         },
-        "required": ["to", "operation"]
+        "required": [
+          "to",
+          "operation"
+        ]
       },
       "MultisigConfirmationDetails": {
         "type": "object",
@@ -7375,14 +8253,19 @@
             "type": "number"
           }
         },
-        "required": ["signer", "submittedAt"]
+        "required": [
+          "signer",
+          "submittedAt"
+        ]
       },
       "MultisigExecutionDetails": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["MULTISIG"]
+            "enum": [
+              "MULTISIG"
+            ]
           },
           "submittedAt": {
             "type": "number"
@@ -7438,12 +8321,18 @@
             }
           },
           "gasTokenInfo": {
-            "nullable": true,
-            "allOf": [
+            "oneOf": [
               {
-                "$ref": "#/components/schemas/Token"
+                "$ref": "#/components/schemas/NativeToken"
+              },
+              {
+                "$ref": "#/components/schemas/Erc20Token"
+              },
+              {
+                "$ref": "#/components/schemas/Erc721Token"
               }
-            ]
+            ],
+            "nullable": true
           },
           "trusted": {
             "type": "boolean"
@@ -7487,13 +8376,18 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["MODULE"]
+            "enum": [
+              "MODULE"
+            ]
           },
           "address": {
             "$ref": "#/components/schemas/AddressInfo"
           }
         },
-        "required": ["type", "address"]
+        "required": [
+          "type",
+          "address"
+        ]
       },
       "SafeAppInfo": {
         "type": "object",
@@ -7509,7 +8403,10 @@
             "nullable": true
           }
         },
-        "required": ["name", "url"]
+        "required": [
+          "name",
+          "url"
+        ]
       },
       "TransactionDetails": {
         "type": "object",
@@ -7565,7 +8462,13 @@
           },
           "txStatus": {
             "type": "string",
-            "enum": ["SUCCESS", "FAILED", "CANCELLED", "AWAITING_CONFIRMATIONS", "AWAITING_EXECUTION"]
+            "enum": [
+              "SUCCESS",
+              "FAILED",
+              "CANCELLED",
+              "AWAITING_CONFIRMATIONS",
+              "AWAITING_EXECUTION"
+            ]
           },
           "txData": {
             "nullable": true,
@@ -7603,7 +8506,12 @@
             "nullable": true
           }
         },
-        "required": ["txInfo", "safeAddress", "txId", "txStatus"]
+        "required": [
+          "txInfo",
+          "safeAddress",
+          "txId",
+          "txStatus"
+        ]
       },
       "TXSMultisigTransaction": {
         "type": "object",
@@ -7759,27 +8667,36 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "ModuleExecutionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["MODULE"]
+            "enum": [
+              "MODULE"
+            ]
           },
           "address": {
             "$ref": "#/components/schemas/AddressInfo"
           }
         },
-        "required": ["type", "address"]
+        "required": [
+          "type",
+          "address"
+        ]
       },
       "MultisigExecutionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["MULTISIG"]
+            "enum": [
+              "MULTISIG"
+            ]
           },
           "nonce": {
             "type": "number"
@@ -7798,7 +8715,12 @@
             }
           }
         },
-        "required": ["type", "nonce", "confirmationsRequired", "confirmationsSubmitted"]
+        "required": [
+          "type",
+          "nonce",
+          "confirmationsRequired",
+          "confirmationsSubmitted"
+        ]
       },
       "Transaction": {
         "type": "object",
@@ -7854,7 +8776,13 @@
           },
           "txStatus": {
             "type": "string",
-            "enum": ["SUCCESS", "FAILED", "CANCELLED", "AWAITING_CONFIRMATIONS", "AWAITING_EXECUTION"]
+            "enum": [
+              "SUCCESS",
+              "FAILED",
+              "CANCELLED",
+              "AWAITING_CONFIRMATIONS",
+              "AWAITING_EXECUTION"
+            ]
           },
           "executionInfo": {
             "oneOf": [
@@ -7876,24 +8804,39 @@
             ]
           }
         },
-        "required": ["txInfo", "id", "timestamp", "txStatus"]
+        "required": [
+          "txInfo",
+          "id",
+          "timestamp",
+          "txStatus"
+        ]
       },
       "MultisigTransaction": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None", "HasNext", "End"]
+            "enum": [
+              "None",
+              "HasNext",
+              "End"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "MultisigTransactionPage": {
         "type": "object",
@@ -7917,7 +8860,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "DeleteTransactionDto": {
         "type": "object",
@@ -7926,24 +8871,34 @@
             "type": "string"
           }
         },
-        "required": ["signature"]
+        "required": [
+          "signature"
+        ]
       },
       "ModuleTransaction": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None"]
+            "enum": [
+              "None"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "ModuleTransactionPage": {
         "type": "object",
@@ -7967,7 +8922,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "AddConfirmationDto": {
         "type": "object",
@@ -7976,24 +8933,34 @@
             "type": "string"
           }
         },
-        "required": ["signature"]
+        "required": [
+          "signature"
+        ]
       },
       "IncomingTransfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None"]
+            "enum": [
+              "None"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "IncomingTransferPage": {
         "type": "object",
@@ -8017,7 +8984,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "PreviewTransactionDto": {
         "type": "object",
@@ -8036,7 +9005,11 @@
             "type": "number"
           }
         },
-        "required": ["to", "value", "operation"]
+        "required": [
+          "to",
+          "value",
+          "operation"
+        ]
       },
       "TransactionPreview": {
         "type": "object",
@@ -8084,50 +9057,73 @@
             "$ref": "#/components/schemas/TransactionData"
           }
         },
-        "required": ["txInfo", "txData"]
+        "required": [
+          "txInfo",
+          "txData"
+        ]
       },
       "ConflictHeaderQueuedItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["CONFLICT_HEADER"]
+            "enum": [
+              "CONFLICT_HEADER"
+            ]
           },
           "nonce": {
             "type": "number"
           }
         },
-        "required": ["type", "nonce"]
+        "required": [
+          "type",
+          "nonce"
+        ]
       },
       "LabelQueuedItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["LABEL"]
+            "enum": [
+              "LABEL"
+            ]
           },
           "label": {
             "type": "string"
           }
         },
-        "required": ["type", "label"]
+        "required": [
+          "type",
+          "label"
+        ]
       },
       "TransactionQueuedItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None", "HasNext", "End"]
+            "enum": [
+              "None",
+              "HasNext",
+              "End"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "QueuedItemPage": {
         "type": "object",
@@ -8161,24 +9157,34 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "TransactionItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None"]
+            "enum": [
+              "None"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "TransactionItemPage": {
         "type": "object",
@@ -8209,7 +9215,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "ProposeTransactionDto": {
         "type": "object",
@@ -8311,7 +9319,12 @@
             ]
           }
         },
-        "required": ["created", "creator", "transactionHash", "factoryAddress"]
+        "required": [
+          "created",
+          "creator",
+          "transactionHash",
+          "factoryAddress"
+        ]
       },
       "TXSCreationTransaction": {
         "type": "object",

--- a/packages/store/src/gateway/AUTO_GENERATED/balances.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/balances.ts
@@ -37,19 +37,35 @@ export type BalancesGetBalancesV1ApiArg = {
 }
 export type BalancesGetSupportedFiatCodesV1ApiResponse = /** status 200  */ string[]
 export type BalancesGetSupportedFiatCodesV1ApiArg = void
-export type Token = {
+export type NativeToken = {
   address: string
-  decimals?: number | null
+  decimals: number
   logoUri: string
   name: string
   symbol: string
-  type: 'ERC721' | 'ERC20' | 'NATIVE_TOKEN' | 'UNKNOWN'
+  type: 'NATIVE_TOKEN'
+}
+export type Erc20Token = {
+  address: string
+  decimals: number
+  logoUri: string
+  name: string
+  symbol: string
+  type: 'ERC20'
+}
+export type Erc721Token = {
+  address: string
+  decimals: number
+  logoUri: string
+  name: string
+  symbol: string
+  type: 'ERC721'
 }
 export type Balance = {
   balance: string
   fiatBalance: string
   fiatConversion: string
-  tokenInfo: Token
+  tokenInfo: NativeToken | Erc20Token | Erc721Token
 }
 export type Balances = {
   fiatTotal: string

--- a/packages/store/src/gateway/AUTO_GENERATED/organizations.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/organizations.ts
@@ -76,7 +76,11 @@ const injectedRtkApi = api
         UserOrganizationsAcceptInviteV1ApiResponse,
         UserOrganizationsAcceptInviteV1ApiArg
       >({
-        query: (queryArg) => ({ url: `/v1/organizations/${queryArg.orgId}/members/accept`, method: 'POST' }),
+        query: (queryArg) => ({
+          url: `/v1/organizations/${queryArg.orgId}/members/accept`,
+          method: 'POST',
+          body: queryArg.acceptInviteDto,
+        }),
         invalidatesTags: ['organizations'],
       }),
       userOrganizationsDeclineInviteV1: build.mutation<
@@ -164,6 +168,7 @@ export type UserOrganizationsInviteUserV1ApiArg = {
 export type UserOrganizationsAcceptInviteV1ApiResponse = unknown
 export type UserOrganizationsAcceptInviteV1ApiArg = {
   orgId: number
+  acceptInviteDto: AcceptInviteDto
 }
 export type UserOrganizationsDeclineInviteV1ApiResponse = unknown
 export type UserOrganizationsDeclineInviteV1ApiArg = {
@@ -199,6 +204,7 @@ export type UserDto = {
 export type UserOrganizationDto = {
   id: number
   role: 'ADMIN' | 'MEMBER'
+  name: string
   status: 'INVITED' | 'ACTIVE' | 'DECLINED'
   createdAt: string
   updatedAt: string
@@ -224,9 +230,10 @@ export type CreateOrganizationSafeDto = {
 export type CreateOrganizationSafesDto = {
   safes: CreateOrganizationSafeDto[]
 }
-export type GetOrganizationSafes = {}
 export type GetOrganizationSafeResponse = {
-  safes: GetOrganizationSafes[]
+  safes: {
+    [key: string]: string[]
+  }
 }
 export type DeleteOrganizationSafeDto = {
   chainId: string
@@ -240,13 +247,18 @@ export type Invitation = {
   orgId: number
   role: 'ADMIN' | 'MEMBER'
   status: 'INVITED' | 'ACTIVE' | 'DECLINED'
+  invitedBy?: string | null
 }
 export type InviteUserDto = {
   address: string
+  name: string
   role: 'ADMIN' | 'MEMBER'
 }
 export type InviteUsersDto = {
   users: InviteUserDto[]
+}
+export type AcceptInviteDto = {
+  name: string
 }
 export type UserOrganizationUser = {
   id: number
@@ -256,6 +268,8 @@ export type UserOrganization = {
   id: number
   role: 'ADMIN' | 'MEMBER'
   status: 'INVITED' | 'ACTIVE' | 'DECLINED'
+  name: string
+  invitedBy?: string | null
   createdAt: string
   updatedAt: string
   user: UserOrganizationUser

--- a/packages/store/src/gateway/AUTO_GENERATED/transactions.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/transactions.ts
@@ -613,13 +613,29 @@ export type MultisigConfirmationDetails = {
   signature?: string | null
   submittedAt: number
 }
-export type Token = {
+export type NativeToken = {
   address: string
-  decimals?: number | null
+  decimals: number
   logoUri: string
   name: string
   symbol: string
-  type: 'ERC721' | 'ERC20' | 'NATIVE_TOKEN' | 'UNKNOWN'
+  type: 'NATIVE_TOKEN'
+}
+export type Erc20Token = {
+  address: string
+  decimals: number
+  logoUri: string
+  name: string
+  symbol: string
+  type: 'ERC20'
+}
+export type Erc721Token = {
+  address: string
+  decimals: number
+  logoUri: string
+  name: string
+  symbol: string
+  type: 'ERC721'
 }
 export type MultisigExecutionDetails = {
   type: 'MULTISIG'
@@ -636,7 +652,7 @@ export type MultisigExecutionDetails = {
   confirmationsRequired: number
   confirmations: MultisigConfirmationDetails[]
   rejectors: AddressInfo[]
-  gasTokenInfo?: Token | null
+  gasTokenInfo?: (NativeToken | Erc20Token | Erc721Token) | null
   trusted: boolean
   proposer?: AddressInfo | null
   proposedByDelegate?: AddressInfo | null

--- a/packages/store/src/gateway/AUTO_GENERATED/users.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/users.ts
@@ -19,7 +19,7 @@ const injectedRtkApi = api
         invalidatesTags: ['users'],
       }),
       usersAddWalletToUserV1: build.mutation<UsersAddWalletToUserV1ApiResponse, UsersAddWalletToUserV1ApiArg>({
-        query: (queryArg) => ({ url: `/v1/users/wallet/add`, method: 'POST', body: queryArg.function }),
+        query: (queryArg) => ({ url: `/v1/users/wallet/add`, method: 'POST', body: queryArg.siweDto }),
         invalidatesTags: ['users'],
       }),
       usersDeleteWalletFromUserV1: build.mutation<
@@ -41,7 +41,7 @@ export type UsersCreateWithWalletV1ApiResponse = /** status 200  */ CreatedUserW
 export type UsersCreateWithWalletV1ApiArg = void
 export type UsersAddWalletToUserV1ApiResponse = /** status 200  */ WalletAddedToUser
 export type UsersAddWalletToUserV1ApiArg = {
-  function: Function
+  siweDto: SiweDto
 }
 export type UsersDeleteWalletFromUserV1ApiResponse = unknown
 export type UsersDeleteWalletFromUserV1ApiArg = {
@@ -62,7 +62,10 @@ export type CreatedUserWithWallet = {
 export type WalletAddedToUser = {
   id: number
 }
-export type Function = {}
+export type SiweDto = {
+  message: string
+  signature: string
+}
 export const {
   useUsersGetWithWalletsV1Query,
   useLazyUsersGetWithWalletsV1Query,


### PR DESCRIPTION
## What it solves

Resolves #5260

## How this PR fixes it

- Updates RTK Queries and types
- Adds `AcceptInviteDialog` when a user accepts an invite to an org to provide their user name
- Displays the member name on the members page

## How to test it

1. Open an org
2. Observe member names are visible
3. Invite a wallet to your org and assign a name
4. Switch to that wallet and sign in on the orgs list page
5. Observe a pending invite
6. Accept the invite
7. Observe a dialog with your name prefilled
8. Submit with or without a name change
9. Observe the name is reflected in the org

## Screenshots
<img width="1265" alt="Screenshot 2025-03-12 at 14 48 40" src="https://github.com/user-attachments/assets/c29f8dbc-994d-421f-9f90-170524fcab35" />

## Checklist
<img width="1283" alt="Screenshot 2025-03-12 at 14 49 30" src="https://github.com/user-attachments/assets/89ab84ad-c557-4c3f-80c6-b40348c18fe0" />


- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
