### PR TITLE
Feat(Orgs): Allow deletion of members by Admins

### DIFF
--- a/apps/web/src/features/organizations/components/MembersList/RemoveMemberModal.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/RemoveMemberModal.tsx
@@ -25,9 +25,8 @@ const RemoveMemberDialog = ({
 
       if (error) {
         throw error
-      } else {
-        handleClose()
       }
+      handleClose()
     } catch (e) {
       setErrorMessage('An unexpected error occurred while removing the member.')
     }

--- a/apps/web/src/features/organizations/components/MembersList/RemoveMemberModal.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/RemoveMemberModal.tsx
@@ -1,0 +1,50 @@
+import ModalDialog from '@/components/common/ModalDialog'
+import { DialogContent, DialogActions, Button, Typography } from '@mui/material'
+import type { UserOrganizationUser } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useUserOrganizationsRemoveUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
+import { useState } from 'react'
+
+const RemoveMemberDialog = ({ member, handleClose }: { member: UserOrganizationUser; handleClose: () => void }) => {
+  const orgId = useCurrentOrgId()
+  const [deleteMember] = useUserOrganizationsRemoveUserV1Mutation()
+  const [errorMessage, setErrorMessage] = useState<string>('')
+
+  const handleConfirm = async () => {
+    setErrorMessage('')
+    try {
+      const { error } = await deleteMember({ orgId: Number(orgId), userId: member.id })
+
+      if (error) {
+        throw error
+      }
+    } catch (e) {
+      setErrorMessage('An unexpected error occurred while removing the member.')
+    }
+  }
+
+  return (
+    <ModalDialog open onClose={handleClose} dialogTitle="Remove member" hideChainIndicator>
+      <DialogContent sx={{ p: '24px !important' }}>
+        {/* TODO: use name here instead of ID as soon as it's available */}
+        <Typography>Are you sure you want to remove {`${member.id}`} from this organization?</Typography>
+        {errorMessage && (
+          <Typography mt={1} color="error.main">
+            {errorMessage}
+          </Typography>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button data-testid="cancel-btn" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button data-testid="delete-btn" onClick={handleConfirm} variant="danger" disableElevation>
+          Remove
+        </Button>
+      </DialogActions>
+    </ModalDialog>
+  )
+}
+
+export default RemoveMemberDialog

--- a/apps/web/src/features/organizations/components/MembersList/RemoveMemberModal.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/RemoveMemberModal.tsx
@@ -1,11 +1,19 @@
 import ModalDialog from '@/components/common/ModalDialog'
 import { DialogContent, DialogActions, Button, Typography } from '@mui/material'
-import type { UserOrganizationUser } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useUserOrganizationsRemoveUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
+import ErrorMessage from '@/components/tx/ErrorMessage'
 import { useState } from 'react'
 
-const RemoveMemberDialog = ({ member, handleClose }: { member: UserOrganizationUser; handleClose: () => void }) => {
+const RemoveMemberDialog = ({
+  userId,
+  memberName,
+  handleClose,
+}: {
+  userId: number
+  memberName: string
+  handleClose: () => void
+}) => {
   const orgId = useCurrentOrgId()
   const [deleteMember] = useUserOrganizationsRemoveUserV1Mutation()
   const [errorMessage, setErrorMessage] = useState<string>('')
@@ -13,10 +21,12 @@ const RemoveMemberDialog = ({ member, handleClose }: { member: UserOrganizationU
   const handleConfirm = async () => {
     setErrorMessage('')
     try {
-      const { error } = await deleteMember({ orgId: Number(orgId), userId: member.id })
+      const { error } = await deleteMember({ orgId: Number(orgId), userId })
 
       if (error) {
         throw error
+      } else {
+        handleClose()
       }
     } catch (e) {
       setErrorMessage('An unexpected error occurred while removing the member.')
@@ -27,12 +37,10 @@ const RemoveMemberDialog = ({ member, handleClose }: { member: UserOrganizationU
     <ModalDialog open onClose={handleClose} dialogTitle="Remove member" hideChainIndicator>
       <DialogContent sx={{ p: '24px !important' }}>
         {/* TODO: use name here instead of ID as soon as it's available */}
-        <Typography>Are you sure you want to remove {`${member.id}`} from this organization?</Typography>
-        {errorMessage && (
-          <Typography mt={1} color="error.main">
-            {errorMessage}
-          </Typography>
-        )}
+        <Typography>
+          Are you sure you want to remove <b>{`${memberName}`}</b> from this organization?
+        </Typography>
+        {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
       </DialogContent>
 
       <DialogActions>

--- a/apps/web/src/features/organizations/components/MembersList/RemoveMemberModal.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/RemoveMemberModal.tsx
@@ -36,7 +36,6 @@ const RemoveMemberDialog = ({
   return (
     <ModalDialog open onClose={handleClose} dialogTitle="Remove member" hideChainIndicator>
       <DialogContent sx={{ p: '24px !important' }}>
-        {/* TODO: use name here instead of ID as soon as it's available */}
         <Typography>
           Are you sure you want to remove <b>{`${memberName}`}</b> from this organization?
         </Typography>

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -9,7 +9,6 @@ import MemberName from './MemberName'
 import RemoveMemberDialog from './RemoveMemberModal'
 import { useState } from 'react'
 import { useIsAdmin } from '@/features/organizations/hooks/useIsAdmin'
-import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 
 const headCells = [
   {
@@ -39,25 +38,8 @@ const EditButton = () => {
     </Tooltip>
   )
 }
-const MenuButtons = ({
-  member,
-  editOnly,
-  disableDelete,
-}: {
-  member: UserOrganization
-  editOnly: boolean
-  disableDelete: boolean
-}) => {
+const MenuButtons = ({ member, disableDelete }: { member: UserOrganization; disableDelete: boolean }) => {
   const [openRemoveMemberDialog, setOpenRemoveMemberDialog] = useState(false)
-
-  if (editOnly) {
-    return (
-      <div className={tableCss.actions}>
-        <EditButton />
-      </div>
-    )
-  }
-
   return (
     <div className={tableCss.actions}>
       <EditButton />
@@ -81,13 +63,11 @@ const MenuButtons = ({
 }
 
 const MembersList = ({ members }: { members: UserOrganization[] }) => {
-  const { data: currentUser } = useUsersGetWithWalletsV1Query()
   const isAdmin = useIsAdmin()
   const adminCount = members.filter((member) => member.role === MemberRole.ADMIN).length
 
   const rows = members.map((member) => {
     const isLastAdmin = adminCount === 1 && member.role === MemberRole.ADMIN
-    const isOwnEntry = member.user.id === currentUser?.id
     return {
       cells: {
         name: {
@@ -107,10 +87,7 @@ const MembersList = ({ members }: { members: UserOrganization[] }) => {
         actions: {
           rawValue: '',
           sticky: true,
-          content:
-            isAdmin || isOwnEntry ? (
-              <MenuButtons member={member} editOnly={!isAdmin && isOwnEntry} disableDelete={isAdmin && isLastAdmin} />
-            ) : null,
+          content: isAdmin ? <MenuButtons member={member} disableDelete={isAdmin && isLastAdmin} /> : null,
         },
       },
     }

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -6,6 +6,8 @@ import DeleteIcon from '@/public/images/common/delete.svg'
 import EnhancedTable from '@/components/common/EnhancedTable'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import MemberName from './MemberName'
+import RemoveMemberDialog from './RemoveMemberModal'
+import { useState } from 'react'
 
 const headCells = [
   {
@@ -25,6 +27,30 @@ const headCells = [
     sticky: true,
   },
 ]
+
+const MenuButtons = ({ member }: { member: UserOrganization }) => {
+  const [openRemoveMemberDialog, setOpenRemoveMemberDialog] = useState(false)
+
+  return (
+    <div className={tableCss.actions}>
+      <Tooltip title="Edit entry" placement="top">
+        <IconButton disabled={member.role !== MemberRole.ADMIN} onClick={() => {}} size="small">
+          <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <IconButton
+        disabled={member.role !== MemberRole.ADMIN}
+        onClick={() => setOpenRemoveMemberDialog(true)}
+        size="small"
+      >
+        <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
+      </IconButton>
+      {openRemoveMemberDialog && (
+        <RemoveMemberDialog member={member.user} handleClose={() => setOpenRemoveMemberDialog(false)} />
+      )}
+    </div>
+  )
+}
 
 const MembersList = ({ members }: { members: UserOrganization[] }) => {
   const rows = members.map((member) => {
@@ -47,22 +73,12 @@ const MembersList = ({ members }: { members: UserOrganization[] }) => {
         actions: {
           rawValue: '',
           sticky: true,
-          content: (
-            <div className={tableCss.actions}>
-              <Tooltip title="Edit entry" placement="top">
-                <IconButton onClick={() => {}} size="small">
-                  <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
-                </IconButton>
-              </Tooltip>
-              <IconButton onClick={() => {}} size="small">
-                <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
-              </IconButton>
-            </div>
-          ),
+          content: <MenuButtons member={member} />,
         },
       },
     }
   })
+
   if (!rows.length) {
     return null
   }

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Chip, IconButton, SvgIcon, Tooltip } from '@mui/material'
+import { Chip, IconButton, SvgIcon, Tooltip } from '@mui/material'
 import { type UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import EditIcon from '@/public/images/common/edit.svg'
 import { MemberRole } from '../AddMembersModal'
@@ -54,13 +54,13 @@ const MenuButtons = ({
           </IconButton>
         </Tooltip>
       )}
-      <Box width={12}>
-        {showDelete && (
-          <IconButton onClick={() => setOpenRemoveMemberDialog(true)} size="small">
-            <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
-          </IconButton>
-        )}
-      </Box>
+      <IconButton
+        onClick={() => setOpenRemoveMemberDialog(true)}
+        size="small"
+        sx={{ visibility: showDelete ? 'visible' : 'hidden' }}
+      >
+        <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
+      </IconButton>
       {openRemoveMemberDialog && (
         <RemoveMemberDialog member={member.user} handleClose={() => setOpenRemoveMemberDialog(false)} />
       )}

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -1,4 +1,4 @@
-import { Chip, IconButton, SvgIcon, Tooltip } from '@mui/material'
+import { Box, Chip, IconButton, SvgIcon, Tooltip } from '@mui/material'
 import { type UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import EditIcon from '@/public/images/common/edit.svg'
 import { MemberRole } from '../AddMembersModal'
@@ -30,37 +30,49 @@ const headCells = [
   },
 ]
 
+const EditButton = () => {
+  return (
+    <Tooltip title="Edit member name" placement="top">
+      <IconButton onClick={() => {}} size="small">
+        <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  )
+}
 const MenuButtons = ({
   member,
-  showEdit,
-  showDelete,
+  editOnly,
+  disableDelete,
 }: {
   member: UserOrganization
-  showEdit: boolean
-  showDelete: boolean
+  editOnly: boolean
+  disableDelete: boolean
 }) => {
   const [openRemoveMemberDialog, setOpenRemoveMemberDialog] = useState(false)
 
-  if (!showEdit && !showDelete) {
-    return null
+  if (editOnly) {
+    return (
+      <div className={tableCss.actions}>
+        <EditButton />
+      </div>
+    )
   }
 
   return (
     <div className={tableCss.actions}>
-      {showEdit && (
-        <Tooltip title="Edit member name" placement="top">
-          <IconButton onClick={() => {}} size="small">
-            <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
+      <EditButton />
+      <Tooltip title={disableDelete ? 'Cannot remove last admin' : 'Remove member'} placement="top">
+        <Box component="span">
+          <IconButton disabled={disableDelete} onClick={() => setOpenRemoveMemberDialog(true)} size="small">
+            <SvgIcon
+              component={DeleteIcon}
+              inheritViewBox
+              color={disableDelete ? 'disabled' : 'error'}
+              fontSize="small"
+            />
           </IconButton>
-        </Tooltip>
-      )}
-      <IconButton
-        onClick={() => setOpenRemoveMemberDialog(true)}
-        size="small"
-        sx={{ visibility: showDelete ? 'visible' : 'hidden' }}
-      >
-        <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
-      </IconButton>
+        </Box>
+      </Tooltip>
       {openRemoveMemberDialog && (
         <RemoveMemberDialog member={member.user} handleClose={() => setOpenRemoveMemberDialog(false)} />
       )}
@@ -97,7 +109,7 @@ const MembersList = ({ members }: { members: UserOrganization[] }) => {
           sticky: true,
           content:
             isAdmin || isOwnEntry ? (
-              <MenuButtons member={member} showEdit={isAdmin || isOwnEntry} showDelete={isAdmin && !isLastAdmin} />
+              <MenuButtons member={member} editOnly={!isAdmin && isOwnEntry} disableDelete={isAdmin && isLastAdmin} />
             ) : null,
         },
       },

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -56,7 +56,11 @@ const MenuButtons = ({ member, disableDelete }: { member: UserOrganization; disa
         </Box>
       </Tooltip>
       {openRemoveMemberDialog && (
-        <RemoveMemberDialog member={member.user} handleClose={() => setOpenRemoveMemberDialog(false)} />
+        <RemoveMemberDialog
+          userId={member.user.id}
+          memberName={member.name}
+          handleClose={() => setOpenRemoveMemberDialog(false)}
+        />
       )}
     </div>
   )

--- a/apps/web/src/features/organizations/hooks/useIsAdmin.ts
+++ b/apps/web/src/features/organizations/hooks/useIsAdmin.ts
@@ -1,0 +1,13 @@
+import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { useUserOrganizationsGetUsersV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { MemberRole } from '@/features/organizations/components/AddMembersModal'
+
+export const useIsAdmin = () => {
+  const orgId = useCurrentOrgId()
+  const { data: user } = useUsersGetWithWalletsV1Query()
+  const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
+  const currentMembership = data?.members.find((member) => member.user.id === user?.id)
+
+  return currentMembership?.role === MemberRole.ADMIN
+}


### PR DESCRIPTION
## What it solves

Resolves [5294](https://github.com/safe-global/safe-wallet-monorepo/issues/5294)

## How this PR fixes it
- Adds a confirmation dialogue when deleting members of an org
- Hides the member list action buttons when the current member is not an admin.
- Disables the delete button for the last admin in an org

## How to test it
- Open an org where you are an admin.
- You should see the option to delete other member of the org. If there are no other admins in the org, you should not be able to delete your own entry in the list.
- Click delete on one of the members. You should see a confirmation dialog.
- Clicking confirm should close the dialog and remove the chosen member from the members list.
- If you open the org as a non-admin, you should not be able to edit or delete the entries in the list.

## Screenshots
Admin view:
![image](https://github.com/user-attachments/assets/93e2d109-ac4f-424a-b10f-10c7016c1d99)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
