### PR TITLE
Feat(Orgs): Dont show chain prefix for multichain safes (#5267)

### DIFF
--- a/apps/web/src/features/organizations/components/AddAccounts/SafesList.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/SafesList.tsx
@@ -100,7 +100,7 @@ const SafesList = ({ safes }: { safes: AllSafeItems }) => {
                   sx={{ mr: 2 }}
                 />
                 <Box className={css.safeRow}>
-                  <EthHashInfo address={safe.address} copyAddress={false} />
+                  <EthHashInfo address={safe.address} copyAddress={false} showPrefix={false} />
                   <Box sx={{ justifySelf: 'flex-start' }}>
                     <MultichainIndicator safes={safe.safes} />
                   </Box>


### PR DESCRIPTION
## What it solves

Resolves #5267 

## How this PR fixes it
In `apps/web/src/features/organizations/components/AddAccounts/SafesList.tsx`
Marks showPrefix prop in `<EthHashInfo />` component to false if its a multichain safe

## How to test it
1. Open Organizations (Create an organization if not already present)
2. Add Accounts to organization

## Screenshots
![Capture-2025-03-13-004111](https://github.com/user-attachments/assets/06f89c53-22a9-4d88-b93f-38bfede6624a)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
