### PR TITLE
Fix: validation on address input being triggered on load

### DIFF
--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -64,11 +64,6 @@ const AddressInput = ({
   const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
   const { address, resolverError, resolving } = useNameResolver(isDomainLookupEnabled ? watchedValue : '')
 
-  // Re-validate when chainId changes
-  useEffect(() => {
-    trigger(address)
-  }, [currentChain?.chainId, trigger, address])
-
   // errors[name] doesn't work with nested field names like 'safe.address', need to use the lodash get
   const fieldError = resolverError || get(errors, name)
 

--- a/apps/web/src/components/new-safe/load/steps/SetAddressStep/index.tsx
+++ b/apps/web/src/components/new-safe/load/steps/SetAddressStep/index.tsx
@@ -21,7 +21,7 @@ import { useMnemonicSafeName } from '@/hooks/useMnemonicName'
 import { useAddressResolver } from '@/hooks/useAddressResolver'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import AddressInput from '@/components/common/AddressInput'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { getSafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import useChainId from '@/hooks/useChainId'
 import { useAppSelector } from '@/store'
@@ -57,6 +57,7 @@ const SetAddressStep = ({ data, onSubmit, onBack }: StepRenderProps<LoadSafeForm
     formState: { errors, isValid },
     watch,
     getValues,
+    trigger,
   } = formMethods
 
   const safeAddress = watch(Field.address)
@@ -65,6 +66,13 @@ const SetAddressStep = ({ data, onSubmit, onBack }: StepRenderProps<LoadSafeForm
 
   // Address book, ENS, mnemonic
   const fallbackName = name || ens || randomName
+
+  // Re-validate when chainId changes
+  useEffect(() => {
+    if (safeAddress) {
+      trigger(Field.address)
+    }
+  }, [currentChainId, trigger, safeAddress])
 
   const validateSafeAddress = async (address: string) => {
     if (addedSafes && Object.keys(addedSafes).includes(address)) {


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-monorepo/pull/5187#issuecomment-2720305035

## How this PR fixes it
- only triggers validation on chain change if the address is present.

## How to test it
- Go anywhere that address input is used and see that validation is not triggered on load


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
