### PR TITLE
Fix(Signing UX): scroll inside the receipt

### DIFF
--- a/apps/web/src/components/common/PaperViewToggle/index.tsx
+++ b/apps/web/src/components/common/PaperViewToggle/index.tsx
@@ -29,9 +29,9 @@ export const PaperViewToggle = ({ children, activeView = 0 }: PaperViewTogglePro
   const Content = ({ index }: { index: number }) => children?.[index]?.content || null
 
   return (
-    <Paper sx={{ backgroundColor: 'background.main', padding: 2 }}>
+    <Paper sx={{ backgroundColor: 'background.main', py: 2 }}>
       <Stack spacing={2}>
-        <Stack direction="row-reverse" justifyContent="space-between">
+        <Stack direction="row-reverse" justifyContent="space-between" px={2}>
           <ToggleButtonGroup onChange={onChangeView}>{children}</ToggleButtonGroup>
           <Title index={active} />
         </Stack>

--- a/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
@@ -42,7 +42,7 @@ export const TxDetails = ({ safeTx, txData }: TxDetailsProps) => {
   const toInfo = txData?.addressInfoIndex?.[safeTx.data.to] || txData?.to
 
   const ContentWrapper = ({ children }: { children: ReactElement | ReactElement[] }) => (
-    <Box sx={{ maxHeight: '550px', overflowY: 'scroll' }}>{children}</Box>
+    <Box sx={{ maxHeight: '550px', overflowY: 'auto', px: 2 }}>{children}</Box>
   )
 
   return (


### PR DESCRIPTION
Fix the CSS of the container to place the scrollbar to the left-most edge of it.

<img width="594" alt="Screenshot 2025-03-13 at 11 27 32" src="https://github.com/user-attachments/assets/8cacde8c-ff51-475a-8ac6-4db89d0f61f2" />
