### PR TITLE
Feat(Orgs): add link to org from invite card

### DIFF
--- a/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
@@ -1,10 +1,12 @@
-import { Card, Box, Stack, Button, Typography } from '@mui/material'
+import { Card, Box, Stack, Button, Typography, Link as MUILink } from '@mui/material'
 import type { GetOrganizationResponse } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { InitialsAvatar, OrgSummary } from '../OrgsCard'
 import { useUserOrganizationsDeclineInviteV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useOrgSafeCount } from '@/features/organizations/hooks/useOrgSafeCount'
 import { useState } from 'react'
 import AcceptInviteDialog from '@/features/organizations/components/Dashboard/AcceptInviteDialog'
+import Link from 'next/link'
+import { AppRoutes } from '@/config/routes'
 
 type OrgListInvite = {
   org: GetOrganizationResponse
@@ -17,11 +19,15 @@ const OrgListInvite = ({ org }: OrgListInvite) => {
   const numberOfAccounts = useOrgSafeCount(id)
   const numberOfMembers = members.length
 
-  const handleAcceptInvite = () => {
+  const handleAcceptInvite = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
     setInviteOpen(true)
   }
 
-  const handleDeclineInvite = () => {
+  const handleDeclineInvite = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
     declineInvite({ orgId: org.id })
   }
 
@@ -34,26 +40,30 @@ const OrgListInvite = ({ org }: OrgListInvite) => {
         </Typography>
       </Typography>
 
-      <Card sx={{ p: 2, backgroundColor: 'background.main' }}>
-        <Stack direction="row" spacing={2} alignItems="center">
-          <Box>
-            <InitialsAvatar name={name} size="large" />
-          </Box>
+      <Link href={{ pathname: AppRoutes.organizations.index, query: { orgId: id } }} passHref legacyBehavior>
+        <MUILink underline="none" sx={{ display: 'block' }}>
+          <Card sx={{ p: 2, backgroundColor: 'background.main', '&:hover': { backgroundColor: 'background.light' } }}>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Box>
+                <InitialsAvatar name={name} size="large" />
+              </Box>
 
-          <Box flexGrow={1}>
-            <OrgSummary name={name} numberOfAccounts={numberOfAccounts} numberOfMembers={numberOfMembers} />
-          </Box>
+              <Box flexGrow={1}>
+                <OrgSummary name={name} numberOfAccounts={numberOfAccounts} numberOfMembers={numberOfMembers} />
+              </Box>
 
-          <Stack direction="row" spacing={1}>
-            <Button variant="contained" onClick={handleAcceptInvite} size="small" sx={{ px: 2, py: 0.5 }}>
-              Accept
-            </Button>
-            <Button variant="outlined" onClick={handleDeclineInvite} size="small" sx={{ px: 2, py: 0.5 }}>
-              Decline
-            </Button>
-          </Stack>
-        </Stack>
-      </Card>
+              <Stack direction="row" spacing={1}>
+                <Button variant="contained" onClick={handleAcceptInvite} size="small" sx={{ px: 2, py: 0.5 }}>
+                  Accept
+                </Button>
+                <Button variant="outlined" onClick={handleDeclineInvite} size="small" sx={{ px: 2, py: 0.5 }}>
+                  Decline
+                </Button>
+              </Stack>
+            </Stack>
+          </Card>
+        </MUILink>
+      </Link>
       {inviteOpen && <AcceptInviteDialog org={org} onClose={() => setInviteOpen(false)} />}
     </Card>
   )


### PR DESCRIPTION
## What it solves

Resolves [5145](https://github.com/safe-global/safe-wallet-monorepo/issues/5145)

## How this PR fixes it
- Makes the org invite link to the org.

## How to test it
- go to the orgs list for a user who has been invited to an org. 
- Click on the org. It should link to the org dashboard.
- Clicking on invite or accept should complete the chosen action without triggering the link to the org dashboard.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
