### PR TITLE
Feat(Orgs): Edit member role

### DIFF
--- a/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
+++ b/apps/web/src/features/organizations/components/AddMembersModal/index.tsx
@@ -36,7 +36,7 @@ type MemberField = {
   role: MemberRole
 }
 
-const RoleMenuItem = ({
+export const RoleMenuItem = ({
   role,
   hasDescription = false,
   selected = false,

--- a/apps/web/src/features/organizations/components/MembersList/EditMemberDialog.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/EditMemberDialog.tsx
@@ -1,0 +1,121 @@
+import ModalDialog from '@/components/common/ModalDialog'
+import { DialogContent, DialogActions, Button, Typography, Select, MenuItem, Stack } from '@mui/material'
+import {
+  type UserOrganization,
+  useUserOrganizationsUpdateRoleV1Mutation,
+} from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
+import ErrorMessage from '@/components/tx/ErrorMessage'
+import { useState } from 'react'
+import NameInput from '@/components/common/NameInput'
+import { Controller, FormProvider, useForm } from 'react-hook-form'
+import { MemberRole, RoleMenuItem } from '@/features/organizations/components/AddMembersModal'
+
+type MemberField = {
+  name: string
+  role: UserOrganization['role']
+}
+
+const EditMemberDialog = ({ member, handleClose }: { member: UserOrganization; handleClose: () => void }) => {
+  const orgId = useCurrentOrgId()
+  const [editMember] = useUserOrganizationsUpdateRoleV1Mutation()
+  const [error, setError] = useState<string>()
+
+  const methods = useForm<MemberField>({
+    mode: 'onChange',
+    defaultValues: {
+      name: member.name,
+      role: member.role,
+    },
+  })
+
+  const { handleSubmit, control, formState } = methods
+
+  const onSubmit = handleSubmit(async (data) => {
+    setError(undefined)
+
+    if (!orgId) {
+      setError('Something went wrong. Please try again.')
+      return
+    }
+
+    try {
+      const { error } = await editMember({
+        orgId: Number(orgId),
+        userId: member.user.id,
+        updateRoleDto: {
+          role: data.role,
+        },
+      })
+
+      if (error) {
+        throw error
+      }
+      handleClose()
+    } catch (e) {
+      setError('An unexpected error occurred while editing the member.')
+    }
+  })
+
+  // TODO: Change this once it is possible to edit a members name
+  const isEditNameDisabled = true
+
+  return (
+    <ModalDialog open onClose={handleClose} dialogTitle="Edit member" hideChainIndicator>
+      <FormProvider {...methods}>
+        <form onSubmit={onSubmit}>
+          <DialogContent sx={{ p: '24px !important' }}>
+            <Typography mb={2}>
+              Edit the role of <b>{`${member.name}`}</b> in this organization.
+            </Typography>
+
+            {/* TODO: Check if its possible to extract this to be reused in add/edit member */}
+            <Stack direction="row" spacing={2} alignItems="center">
+              <NameInput name="name" label="Name" required disabled={isEditNameDisabled} />
+
+              <Controller
+                control={control}
+                name="role"
+                render={({ field: { value, onChange, ...field } }) => (
+                  <Select
+                    {...field}
+                    value={value}
+                    onChange={onChange}
+                    required
+                    sx={{ minWidth: '150px', py: 0.5 }}
+                    renderValue={(role) => <RoleMenuItem role={role as MemberRole} />}
+                  >
+                    <MenuItem value={MemberRole.ADMIN}>
+                      <RoleMenuItem role={MemberRole.ADMIN} hasDescription selected={value === MemberRole.ADMIN} />
+                    </MenuItem>
+                    <MenuItem value={MemberRole.MEMBER}>
+                      <RoleMenuItem role={MemberRole.MEMBER} hasDescription selected={value === MemberRole.MEMBER} />
+                    </MenuItem>
+                  </Select>
+                )}
+              />
+            </Stack>
+            {error && <ErrorMessage>{error}</ErrorMessage>}
+          </DialogContent>
+
+          <DialogActions>
+            <Button data-testid="cancel-btn" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              data-testid="delete-btn"
+              variant="danger"
+              disableElevation
+              disabled={!formState.isDirty}
+            >
+              Update
+            </Button>
+          </DialogActions>
+        </form>
+      </FormProvider>
+    </ModalDialog>
+  )
+}
+
+export default EditMemberDialog

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -9,6 +9,7 @@ import MemberName from './MemberName'
 import RemoveMemberDialog from './RemoveMemberModal'
 import { useState } from 'react'
 import { useIsAdmin } from '@/features/organizations/hooks/useIsAdmin'
+import EditMemberDialog from '@/features/organizations/components/MembersList/EditMemberDialog'
 
 const headCells = [
   {
@@ -29,20 +30,27 @@ const headCells = [
   },
 ]
 
-const EditButton = () => {
+const EditButton = ({ member }: { member: UserOrganization }) => {
+  const [open, setOpen] = useState(false)
+
   return (
-    <Tooltip title="Edit member name" placement="top">
-      <IconButton onClick={() => {}} size="small">
-        <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
-      </IconButton>
-    </Tooltip>
+    <>
+      <Tooltip title="Edit member" placement="top">
+        <IconButton onClick={() => setOpen(true)} size="small">
+          <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      {open && <EditMemberDialog member={member} handleClose={() => setOpen(false)} />}
+    </>
   )
 }
+
 const MenuButtons = ({ member, disableDelete }: { member: UserOrganization; disableDelete: boolean }) => {
   const [openRemoveMemberDialog, setOpenRemoveMemberDialog] = useState(false)
+
   return (
     <div className={tableCss.actions}>
-      <EditButton />
+      <EditButton member={member} />
       <Tooltip title={disableDelete ? 'Cannot remove last admin' : 'Remove member'} placement="top">
         <Box component="span">
           <IconButton disabled={disableDelete} onClick={() => setOpenRemoveMemberDialog(true)} size="small">


### PR DESCRIPTION
## What it solves

Resolves #5312 

## How this PR fixes it

- Adds a new `EditMemberDialog` component

## How to test it

1. Open an org with members
2. Go to the members page
3. Edit one of them as an admin
4. Update their role and submit
5. Observe the role changing

## Screenshots
<img width="679" alt="Screenshot 2025-03-13 at 13 53 30" src="https://github.com/user-attachments/assets/57ef4591-428e-4cc6-b5c5-5f16c8254e03" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
