### PR TITLE
Fix(Orgs): Hide buttons for non admins

### DIFF
--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -1,5 +1,5 @@
 import EnhancedTable from '@/components/common/EnhancedTable'
-import { Button, Chip, IconButton, Stack, SvgIcon } from '@mui/material'
+import { Chip, IconButton, Stack, SvgIcon } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useUserOrganizationsRemoveUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
@@ -8,6 +8,7 @@ import { MemberRole } from '../AddMembersModal'
 import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
 import { MemberStatus } from '@/features/organizations/hooks/useOrgMembers'
 import MemberName from '../MembersList/MemberName'
+import { useIsAdmin } from '@/features/organizations/hooks/useIsAdmin'
 
 const headCells = [
   {
@@ -31,7 +32,7 @@ const headCells = [
 const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] }) => {
   const [deleteInvite] = useUserOrganizationsRemoveUserV1Mutation()
   const currentOrgId = useCurrentOrgId()
-
+  const isAdmin = useIsAdmin()
   const handleDeleteInvite = async (invitedId: number) => {
     try {
       await deleteInvite({ orgId: Number(currentOrgId), userId: invitedId })
@@ -69,16 +70,15 @@ const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] })
           rawValue: '',
           sticky: true,
           content: (
-            <div className={tableCss.actions}>
-              {isDeclined && (
-                <Button variant="outlined" size="small" sx={{ px: 2, py: 0.5, mr: 1 }} onClick={() => {}}>
-                  Resend
-                </Button>
+            <>
+              {isAdmin && (
+                <div className={tableCss.actions}>
+                  <IconButton onClick={() => handleDeleteInvite(member.user.id)} size="small">
+                    <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
+                  </IconButton>
+                </div>
               )}
-              <IconButton onClick={() => handleDeleteInvite(member.user.id)} size="small">
-                <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />
-              </IconButton>
-            </div>
+            </>
           ),
         },
       },

--- a/apps/web/src/features/organizations/components/Members/index.tsx
+++ b/apps/web/src/features/organizations/components/Members/index.tsx
@@ -2,21 +2,22 @@ import PlusIcon from '@/public/images/common/plus.svg'
 import { Button, InputAdornment, Stack, SvgIcon, TextField, Typography } from '@mui/material'
 import AddMembersModal from '@/features/organizations/components/AddMembersModal'
 import { useState } from 'react'
-import MembersList from '../MembersList'
+import MembersList from '@/features/organizations/components/MembersList'
 import InvitesList from './InvitesList'
 import SearchIcon from '@/public/images/common/search.svg'
-import { useMembersSearch } from '../../hooks/useMembersSearch'
-import { useOrgMembers } from '../../hooks/useOrgMembers'
+import { useMembersSearch } from '@/features/organizations/hooks/useMembersSearch'
+import { useOrgMembers } from '@/features/organizations/hooks/useOrgMembers'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import SignedOutState from '@/features/organizations/components/SignedOutState'
+import { useIsAdmin } from '@/features/organizations/hooks/useIsAdmin'
 
 const OrganizationMembers = () => {
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { activeMembers, invitedMembers } = useOrgMembers()
-
+  const isAdmin = useIsAdmin()
   const filteredMembers = useMembersSearch(activeMembers, searchQuery)
   const filteredInvites = useMembersSearch(invitedMembers, searchQuery)
 
@@ -46,9 +47,11 @@ const OrganizationMembers = () => {
           }}
           size="small"
         />
-        <Button variant="contained" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>
-          Add member
-        </Button>
+        {isAdmin && (
+          <Button variant="contained" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>
+            Add member
+          </Button>
+        )}
       </Stack>
       <>
         {searchQuery && !filteredMembers.length && !filteredInvites.length && (

--- a/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
@@ -10,12 +10,14 @@ import { useSafesSearch } from '@/features/myAccounts/hooks/useSafesSearch'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import SignedOutState from '@/features/organizations/components/SignedOutState'
+import { useIsAdmin } from '@/features/organizations/hooks/useIsAdmin'
 
 const OrganizationSafeAccounts = () => {
   const [searchQuery, setSearchQuery] = useState('')
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const allSafes = useOrgSafes()
   const filteredSafes = useSafesSearch(allSafes, searchQuery)
+  const isAdmin = useIsAdmin()
 
   const safes = searchQuery ? filteredSafes : allSafes
 
@@ -46,7 +48,7 @@ const OrganizationSafeAccounts = () => {
           size="small"
         />
 
-        <AddAccounts />
+        {isAdmin && <AddAccounts />}
       </Stack>
 
       {/* TODO: Fix the condition once data is ready */}


### PR DESCRIPTION
## What it solves

partially Resolves [#5315](https://github.com/safe-global/safe-wallet-monorepo/issues/5315)
note: the admin page will be tackled separately once there are designs for it

## How this PR fixes it
For non admin users:
- Hides the add members button on the members page
- Hide the delete invited member button on the members page
- Hides the add accounts button on the accounts page

## How to test it
- open an org as a non admin user.
- Check that the buttons mentioned above are not visible
- Change to an admin user
- Check that the buttons are visible

## Screenshots
![image](https://github.com/user-attachments/assets/045187fc-c832-445b-b252-860c456f251f)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
