### PR TITLE
Fix(Orgs): Use currentData instead of data for fetching org data in RTK

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsList/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsList/index.tsx
@@ -95,8 +95,8 @@ const filterOrgsByStatus = (
 // todo: replace with real data
 const OrgsList = () => {
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { data: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
-  const { data: organizations } = useOrganizationsGetV1Query(undefined, { skip: !isUserSignedIn })
+  const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
+  const { currentData: organizations } = useOrganizationsGetV1Query(undefined, { skip: !isUserSignedIn })
 
   const pendingInvites = filterOrgsByStatus(currentUser, organizations || [], MemberStatus.INVITED)
   const activeOrganizations = filterOrgsByStatus(currentUser, organizations || [], MemberStatus.ACTIVE)

--- a/apps/web/src/features/organizations/components/OrgsSettings/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSettings/index.tsx
@@ -50,7 +50,7 @@ const OrgsSettings = () => {
   const dispatch = useAppDispatch()
   const orgId = useCurrentOrgId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { data: org } = useOrganizationsGetOneV1Query({ id: Number(orgId) }, { skip: !isUserSignedIn })
+  const { currentData: org } = useOrganizationsGetOneV1Query({ id: Number(orgId) }, { skip: !isUserSignedIn })
   const [updateOrg] = useOrganizationsUpdateV1Mutation()
   const [deleteOrg] = useOrganizationsDeleteV1Mutation()
 

--- a/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarSelector/index.tsx
@@ -22,7 +22,7 @@ const OrgsSidebarSelector = () => {
   const open = Boolean(anchorEl)
   const orgId = useCurrentOrgId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { data: orgs } = useOrganizationsGetV1Query(undefined, { skip: !isUserSignedIn })
+  const { currentData: orgs } = useOrganizationsGetV1Query(undefined, { skip: !isUserSignedIn })
   const selectedOrg = orgs?.find((org) => org.id === Number(orgId))
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/apps/web/src/features/organizations/hooks/useIsAdmin.ts
+++ b/apps/web/src/features/organizations/hooks/useIsAdmin.ts
@@ -5,9 +5,9 @@ import { MemberRole } from '@/features/organizations/components/AddMembersModal'
 
 export const useIsAdmin = () => {
   const orgId = useCurrentOrgId()
-  const { data: user } = useUsersGetWithWalletsV1Query()
-  const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
-  const currentMembership = data?.members.find((member) => member.user.id === user?.id)
+  const { currentData: user } = useUsersGetWithWalletsV1Query()
+  const { currentData } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) })
+  const currentMembership = currentData?.members.find((member) => member.user.id === user?.id)
 
   return currentMembership?.role === MemberRole.ADMIN
 }

--- a/apps/web/src/features/organizations/hooks/useOrgMembers.tsx
+++ b/apps/web/src/features/organizations/hooks/useOrgMembers.tsx
@@ -12,13 +12,13 @@ export enum MemberStatus {
 export const useOrgMembers = () => {
   const orgId = useCurrentOrgId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { data } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) }, { skip: !isUserSignedIn })
+  const { currentData } = useUserOrganizationsGetUsersV1Query({ orgId: Number(orgId) }, { skip: !isUserSignedIn })
 
   const invitedMembers =
-    data?.members.filter(
+    currentData?.members.filter(
       (member) => member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED,
     ) || []
-  const activeMembers = data?.members.filter((member) => member.status === MemberStatus.ACTIVE) || []
+  const activeMembers = currentData?.members.filter((member) => member.status === MemberStatus.ACTIVE) || []
 
   return { activeMembers, invitedMembers }
 }

--- a/apps/web/src/features/organizations/hooks/useOrgSafeCount.tsx
+++ b/apps/web/src/features/organizations/hooks/useOrgSafeCount.tsx
@@ -4,9 +4,8 @@ import { useOrganizationSafesGetV1Query } from '@safe-global/store/gateway/AUTO_
 
 export const useOrgSafeCount = (orgId: number): number => {
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { data } = useOrganizationSafesGetV1Query({ organizationId: orgId }, { skip: !isUserSignedIn })
-  const safes = data?.safes || {}
-  // @ts-ignore TODO: Fix type issue
-  const numberOfAccounts: number = Object.values(safes).reduce((acc, safesOnChain) => acc + safesOnChain.length, 0)
-  return numberOfAccounts
+  const { currentData } = useOrganizationSafesGetV1Query({ organizationId: orgId }, { skip: !isUserSignedIn })
+  const safes = currentData?.safes || {}
+
+  return Object.values(safes).reduce((acc, safesOnChain) => acc + safesOnChain.length, 0)
 }

--- a/apps/web/src/features/organizations/hooks/useOrgSafes.tsx
+++ b/apps/web/src/features/organizations/hooks/useOrgSafes.tsx
@@ -36,10 +36,9 @@ function _buildSafeItems(safes: Record<string, string[]>, allSafeNames: AddressB
 export const useOrgSafes = () => {
   const orgId = useCurrentOrgId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { data } = useOrganizationSafesGetV1Query({ organizationId: Number(orgId) }, { skip: !isUserSignedIn })
+  const { currentData } = useOrganizationSafesGetV1Query({ organizationId: Number(orgId) }, { skip: !isUserSignedIn })
   const allSafeNames = useAppSelector(selectAllAddressBooks)
-  // @ts-ignore TODO: Fix type issue
-  const safeItems = data ? _buildSafeItems(data.safes, allSafeNames) : []
+  const safeItems = currentData ? _buildSafeItems(currentData.safes, allSafeNames) : []
   const safes = useAllSafesGrouped(safeItems)
   const { orderBy } = useAppSelector(selectOrderByPreference)
   const sortComparator = getComparator(orderBy)


### PR DESCRIPTION
## What it solves

Resolves #5319

## How this PR fixes it

- Uses `currentData` instead of `data` for all RTK Queries in Orgs

## How to test it

1. Open an org with safe accounts
2. Go to the safe accounts page
3. Disconnect your wallet
4. Connect and sign in with a different wallet thats not part of the org
5. Observe no safe accounts are visible

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
