### PR TITLE
Tests: Enable data signing

### DIFF
--- a/apps/web/cypress/e2e/happypath_2/add_owner.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/add_owner.cy.js
@@ -23,7 +23,7 @@ describe('Happy path Add Owners tests', () => {
     cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
   })
 
-  it.skip(
+  it(
     'Verify creation, confirmation and deletion of Add owner tx. GA tx_confirm',
     { defaultCommandTimeout: 30000 },
     () => {

--- a/apps/web/cypress/e2e/happypath_2/proposers.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/proposers.cy.js
@@ -20,7 +20,7 @@ describe('Happy path Proposers tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  it.skip('Verify that editing a proposer is only possible for the proposer created by the creator', () => {
+  it('Verify that editing a proposer is only possible for the proposer created by the creator', () => {
     cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_31)
     wallet.connectSigner(signer3)
     cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })
@@ -39,7 +39,7 @@ describe('Happy path Proposers tests', () => {
     proposer.checkProposerData([proposerName2])
   })
 
-  it.skip('Verify a proposer can be added', () => {
+  it('Verify a proposer can be added', () => {
     cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_32)
     wallet.connectSigner(signer)
     cy.contains(owner.safeAccountNonceStr, { timeout: 10000 })

--- a/apps/web/cypress/e2e/happypath_2/swaps.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/swaps.cy.js
@@ -29,7 +29,7 @@ describe('Happy path Swaps tests', () => {
     iframeSelector = `iframe[src*="${constants.swapWidget}"]`
   })
 
-  it.skip(
+  it(
     'Verify an order can be created, signed by second signer and deleted. GA tx_confirm, tx_created',
     { defaultCommandTimeout: 60000 },
     () => {
@@ -68,6 +68,7 @@ describe('Happy path Swaps tests', () => {
         swaps.clickOnExceeFeeChkbox()
         swaps.clickOnSwapBtn()
         swaps.clickOnSwapBtn()
+        swaps.confirmPriceImpact()
       })
       create_tx.changeNonce(0)
       create_tx.clickOnSignTransactionBtn()

--- a/apps/web/src/services/private-key-module/index.ts
+++ b/apps/web/src/services/private-key-module/index.ts
@@ -116,10 +116,26 @@ const PrivateKeyModule = (chainId: ChainInfo['chainId'], rpcUri: ChainInfo['rpcU
               // @ts-ignore
               eth_signTypedData_v4: async ({ params }) => {
                 const [, typedData] = params
+
+                let parsedTypedData
+                try {
+                  parsedTypedData = JSON.parse(typedData)
+                } catch (error: unknown) {
+                  if (error instanceof Error) {
+                    throw new Error('Failed to parse typedData: ' + error.message)
+                  } else {
+                    throw new Error('Failed to parse typedData: Unknown error')
+                  }
+                }
+
+                if (!parsedTypedData || !parsedTypedData.domain || !parsedTypedData.types || !parsedTypedData.message) {
+                  throw new Error('Invalid parameters for eth_signTypedData_v4')
+                }
+
                 return await wallet.signTypedData(
-                  typedData.domain,
-                  { [typedData.primaryType]: typedData.types[typedData.primaryType] },
-                  typedData.message,
+                  parsedTypedData.domain,
+                  { [parsedTypedData.primaryType]: parsedTypedData.types[parsedTypedData.primaryType] },
+                  parsedTypedData.message,
                 )
               },
 


### PR DESCRIPTION
## How this PR fixes it

- Introduced a try-catch block to parse the typedData JSON string to allow catching of parsing errors.
- Added respective error messages
- Updated the method to use the parsed typedData for signing, ensuring that the correct structure is utilized when calling wallet.signTypedData.
- Re-enabled skipped tests in happy path that required signing

## How to test it

- Run Cypress tests and observe outcome