### PR TITLE
Fix(Orgs): add not found state for accounts search

### DIFF
--- a/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
@@ -49,7 +49,7 @@ const OrganizationSafeAccounts = () => {
         <AddAccounts />
       </Stack>
 
-      {searchQuery && !filteredSafes.length ? (
+      {searchQuery && filteredSafes.length === 0 ? (
         <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">
           Found 0 results
         </Typography>

--- a/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccounts/index.tsx
@@ -49,8 +49,15 @@ const OrganizationSafeAccounts = () => {
         <AddAccounts />
       </Stack>
 
-      {/* TODO: Fix the condition once data is ready */}
-      {safes.length === 0 ? <EmptySafeAccounts /> : <SafesList safes={safes} isOrgSafe />}
+      {searchQuery && !filteredSafes.length ? (
+        <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">
+          Found 0 results
+        </Typography>
+      ) : safes.length === 0 ? (
+        <EmptySafeAccounts />
+      ) : (
+        <SafesList safes={safes} isOrgSafe />
+      )}
     </>
   )
 }

--- a/apps/web/src/features/organizations/hooks/useMembersSearch.ts
+++ b/apps/web/src/features/organizations/hooks/useMembersSearch.ts
@@ -6,7 +6,7 @@ const useMembersSearch = (members: UserOrganization[], query: string): UserOrgan
   const fuse = useMemo(
     () =>
       new Fuse(members, {
-        keys: [{ name: 'user.id' }],
+        keys: [{ name: 'name' }],
         threshold: 0.2,
         findAllMatches: true,
         ignoreLocation: true,


### PR DESCRIPTION
## What it solves

Resolves: https://github.com/safe-global/safe-wallet-monorepo/issues/5255
Resolves: members search not working

## How this PR fixes it
- When no results are found from the search, display ` Found 0 results` instead of the no safes placeholder
- also fixes members search. Changes it so it searches by member name instead of member ID

## How to test it
1.
- go to the accounts page.
- type in the search bra untill there are no matching results
- see that there is a state for this case
2.
- Go to the members search.
- Type the name of one of the members in either of the two lists.
- Check that it filters the lists as expected.

## Screenshots
![image](https://github.com/user-attachments/assets/81c38924-6890-4ad2-adb0-0d867bf7d1be)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
