### PR TITLE
Feat(Tx details): show "Unverified contract" for unknown contracts

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -3,16 +3,31 @@ import useChainId from '@/hooks/useChainId'
 import { getContract } from '@safe-global/safe-gateway-typescript-sdk'
 import EthHashInfo from '../EthHashInfo'
 import type { EthHashInfoProps } from '../EthHashInfo/SrcEthHashInfo'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 
-const NamedAddressInfo = ({ address, name, customAvatar, ...props }: EthHashInfoProps) => {
+function useAddressName(address: string, name?: string | null, customAvatar?: string) {
   const chainId = useChainId()
-  const [contract] = useAsync(
+  const web3 = useWeb3ReadOnly()
+
+  const [contract, error] = useAsync(
     () => (!name && !customAvatar ? getContract(chainId, address) : undefined),
     [address, chainId, name, customAvatar],
   )
 
-  const finalName = name || contract?.displayName || contract?.name
-  const finalAvatar = customAvatar || contract?.logoUri
+  const [isUnverifiedContract] = useAsync<boolean>(async () => {
+    if (!error) return false // Only check via RPC if getContract returned an error
+    const code = await web3?.getCode(address)
+    return code !== '0x'
+  }, [address, web3, error])
+
+  return {
+    name: name || contract?.displayName || contract?.name || (isUnverifiedContract ? 'Unverified contract' : undefined),
+    avatar: customAvatar || contract?.logoUri,
+  }
+}
+
+const NamedAddressInfo = ({ address, name, customAvatar, ...props }: EthHashInfoProps) => {
+  const { name: finalName, avatar: finalAvatar } = useAddressName(address, name, customAvatar)
 
   return <EthHashInfo address={address} name={finalName} customAvatar={finalAvatar} {...props} />
 }

--- a/apps/web/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/Transfer/index.tsx
@@ -1,4 +1,4 @@
-import EthHashInfo from '@/components/common/EthHashInfo'
+import NamedAddressInfo from '@/components/common/NamedAddressInfo'
 import { TransferTx } from '@/components/transactions/TxInfo'
 import { isTxQueued } from '@/utils/transaction-guards'
 import type { TransactionStatus, Transfer } from '@safe-global/safe-gateway-typescript-sdk'
@@ -42,7 +42,7 @@ const TransferTxInfo = ({ txInfo, txStatus, trusted, imitation }: TransferTxInfo
       <TransferTxInfoMain txInfo={txInfo} txStatus={txStatus} trusted={trusted} imitation={imitation} />
 
       <Box display="flex" alignItems="center" width="100%">
-        <EthHashInfo
+        <NamedAddressInfo
           address={address.value}
           name={address.name}
           customAvatar={address.logoUri}
@@ -52,7 +52,7 @@ const TransferTxInfo = ({ txInfo, txStatus, trusted, imitation }: TransferTxInfo
           trusted={trusted && !imitation}
         >
           <TransferActions address={address.value} txInfo={txInfo} trusted={trusted} />
-        </EthHashInfo>
+        </NamedAddressInfo>
       </Box>
       {imitation && <ImitationTransactionWarning />}
     </Box>


### PR DESCRIPTION
Resolves #5557.

Show "Unverified contact" for unknown contracts in tx details in history and queue.

<img width="697" alt="Screenshot 2025-03-26 at 15 13 11" src="https://github.com/user-attachments/assets/98ba7468-9771-455a-a60a-fe879eb9d648" />

## How to test it

* Go to some safe with lots of spam txs (e.g. [this one](https://unverified_contract--walletweb.review.5afe.dev/transactions/history?safe=eth:0x220866b1a2219f40e72f5c628b65d54268ca3a9d))
* Unhide suspicious txs
* Observe that the address is marked as "Unverified contract"