### PR TITLE
feat(nextjs): sri support

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,4 +1,5 @@
-import path from 'path'
+// @ts-check
+import path from 'node:path'
 import withBundleAnalyzer from '@next/bundle-analyzer'
 import withPWAInit from '@ducanh2912/next-pwa'
 import remarkGfm from 'remark-gfm'
@@ -17,12 +18,13 @@ const withPWA = withPWAInit({
   reloadOnOnline: false,
   /* Do not precache anything */
   publicExcludes: ['**/*'],
-  buildExcludes: [/./],
+ // buildExcludes: [/./],
   customWorkerSrc: SERVICE_WORKERS_PATH,
   // Prefer InjectManifest for Web Push
+  // @ts-ignore
   swSrc: `${SERVICE_WORKERS_PATH}/index.ts`,
+  disable: false
 })
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export', // static site export
@@ -33,7 +35,8 @@ const nextConfig = {
   },
 
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
-  reactStrictMode: false,
+  reactStrictMode: true,
+  poweredByHeader: false,
   productionBrowserSourceMaps: true,
   eslint: {
     dirs: ['src', 'cypress'],
@@ -47,7 +50,17 @@ const nextConfig = {
       '@sentry/react',
       '@gnosis.pm/zodiac',
     ],
+    sri: {
+      algorithm: 'sha384',
+    },
+
   },
+  deploymentId: 'web',
+  bundlePagesRouterDependencies: true,
+//  generateBuildId: async () => {
+    // This could be anything, using the latest git hash
+  //  return process.env.GIT_HASH
+ // },
   webpack(config, { dev }) {
     config.module.rules.push({
       test: /\.svg$/i,
@@ -103,13 +116,11 @@ const nextConfig = {
 }
 const withMDX = createMDX({
   extension: /\.(md|mdx)?$/,
-  jsx: true,
   options: {
     remarkPlugins: [remarkFrontmatter, [remarkMdxFrontmatter, { name: 'metadata' }], remarkHeadingId, remarkGfm],
     rehypePlugins: [],
   },
 })
-
 export default withBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 })(withPWA(withMDX(nextConfig)))


### PR DESCRIPTION
# SRI Hash Support

> [!IMPORTANT]
> Please do not merge this just yet, I am opening it to get feedback first!

## Background

Currently safe ui uses a post-process workflow for inserting the SRI hash, this has some potential issues. NextJS v15 has experimental support for SRI support, however I am proposing a different way of doing this that will actually be of better benefit. 

```
safe-wallet-monorepo/apps/web/scripts/integrity-hashes.cjs
```

There is support for it in NextJS now, but Let me suggest a better way of doing this.

### SRI Import Map

> read more here: <https://shopify.engineering/shipping-support-for-module-script-integrity-in-chrome-safari>

https://github.com/sambacha/sri-import-map#how-it-works

This library uses the import map specification to associate module URLs with their integrity hashes:

```json
{
  "imports": {
    "square": "./module/shapes/square.js"
  },
  "integrity": {
    "./module/shapes/square.js": "sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"
  }
}
```

#### During the build process, the NextJS plugin:

Identifies modules to be included in the import map
Calculates SHA-384 integrity hashes for each module
Generates an import map with integrity information
Optionally updates security headers in Vercel configuration


#### At runtime, the client-side library:

Loads the import map
Verifies module integrity before execution
Prevents execution of compromised modules



## NextJS SRI config flag

Use the nextjs experimental flag,

```js
    sri: {
      algorithm: 'sha384',
    },
```



### NextJS SRI Issue

Currently webpack chunks loaded via flight runtime do not get integrity
hashes. This was previously unobservable in this test because these scripts
are inserted by the webpack runtime and immediately removed from the document.
However with the advent of preinitialization of chunks used during SSR there are
some script tags for flight loaded chunks that will be part of the initial HTML
but do not have integrity hashes. Flight does not currently support a way to
provide integrity hashes for these chunks. When this is addressed in React upstream
we can revisit this tests assertions and start to ensure it actually applies to
all SSR'd scripts. For now we will look for known entrypoint scripts and assume
everything else in the <head> is part of flight loaded chunks

> source: <https://github.com/vercel/next.js/pull/73891/files#diff-3c2194b9775dc490d232fd610c84e85bf320eac7a0a38dc4968d38cc67ae0cb1R153-R163>