### PR TITLE
feat: migrate flows to include new transaction receipt step

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
@@ -61,6 +61,11 @@ const TxLayoutHeader = ({
   )
 }
 
+export type TxStep = {
+  txLayoutProps: Omit<TxLayoutProps, 'children'>
+  content: ReactElement
+}
+
 type TxLayoutProps = {
   title: ReactNode
   children: ReactNode

--- a/apps/web/src/components/tx-flow/flows/AddOwner/ReviewOwner.tsx
+++ b/apps/web/src/components/tx-flow/flows/AddOwner/ReviewOwner.tsx
@@ -1,7 +1,6 @@
 import { useCurrentChain } from '@/hooks/useChains'
 import { useContext, useEffect } from 'react'
 
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { createSwapOwnerTx, createAddOwnerTx } from '@/services/tx/tx-sender'
@@ -11,8 +10,15 @@ import { SafeTxContext } from '../../SafeTxProvider'
 import type { AddOwnerFlowProps } from '.'
 import type { ReplaceOwnerFlowProps } from '../ReplaceOwner'
 import { SettingsChangeContext } from './context'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-export const ReviewOwner = ({ params }: { params: AddOwnerFlowProps | ReplaceOwnerFlowProps }) => {
+export const ReviewOwner = ({
+  params,
+  onSubmit,
+}: {
+  params: AddOwnerFlowProps | ReplaceOwnerFlowProps
+  onSubmit?: () => void
+}) => {
   const dispatch = useAppDispatch()
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
   const { safe } = useSafeInfo()
@@ -51,9 +57,14 @@ export const ReviewOwner = ({ params }: { params: AddOwnerFlowProps | ReplaceOwn
     trackEvent({ ...SETTINGS_EVENTS.SETUP.OWNERS, label: safe.owners.length })
   }
 
+  const handleSubmit = () => {
+    addAddressBookEntryAndSubmit()
+    onSubmit?.()
+  }
+
   return (
     <SettingsChangeContext.Provider value={params}>
-      <SignOrExecuteForm onSubmit={addAddressBookEntryAndSubmit} showMethodCall />
+      <ReviewTransaction onSubmit={handleSubmit} showMethodCall />
     </SettingsChangeContext.Provider>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
@@ -4,6 +4,7 @@ import { ChooseOwner, ChooseOwnerMode } from '@/components/tx-flow/flows/AddOwne
 import { ReviewOwner } from '@/components/tx-flow/flows/AddOwner/ReviewOwner'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 type Owner = {
   address: string
@@ -20,24 +21,36 @@ const FlowInner = ({ defaultValues }: { defaultValues: AddOwnerFlowProps }) => {
   const { data, step, nextStep, prevStep } = useTxStepper<AddOwnerFlowProps>(defaultValues)
 
   const steps = [
-    <ChooseOwner
-      key={0}
-      params={data}
-      onSubmit={(formData) => nextStep({ ...data, ...formData })}
-      mode={ChooseOwnerMode.ADD}
-    />,
-    <ReviewOwner key={1} params={data} />,
+    {
+      txLayoutProps: { title: 'New transaction' },
+      content: (
+        <ChooseOwner
+          key={0}
+          params={data}
+          onSubmit={(formData) => nextStep({ ...data, ...formData })}
+          mode={ChooseOwnerMode.ADD}
+        />
+      ),
+    },
+    {
+      txLayoutProps: { title: 'Confirm transaction' },
+      content: <ReviewOwner key={1} params={data} onSubmit={() => nextStep(data)} />,
+    },
+    {
+      txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+      content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+    },
   ]
 
   return (
     <TxLayout
-      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
       subtitle="Add signer"
       icon={SaveAddressIcon}
       step={step}
       onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      {steps}
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
@@ -6,6 +6,7 @@ import { ReviewOwner } from '@/components/tx-flow/flows/AddOwner/ReviewOwner'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { useMemo } from 'react'
 
 type Owner = {
   address: string
@@ -21,27 +22,30 @@ export type AddOwnerFlowProps = {
 const FlowInner = ({ defaultValues }: { defaultValues: AddOwnerFlowProps }) => {
   const { data, step, nextStep, prevStep } = useTxStepper<AddOwnerFlowProps>(defaultValues)
 
-  const steps: TxStep[] = [
-    {
-      txLayoutProps: { title: 'New transaction' },
-      content: (
-        <ChooseOwner
-          key={0}
-          params={data}
-          onSubmit={(formData) => nextStep({ ...data, ...formData })}
-          mode={ChooseOwnerMode.ADD}
-        />
-      ),
-    },
-    {
-      txLayoutProps: { title: 'Confirm transaction' },
-      content: <ReviewOwner key={1} params={data} onSubmit={() => nextStep(data)} />,
-    },
-    {
-      txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
-      content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
-    },
-  ]
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'New transaction' },
+        content: (
+          <ChooseOwner
+            key={0}
+            params={data}
+            onSubmit={(formData) => nextStep({ ...data, ...formData })}
+            mode={ChooseOwnerMode.ADD}
+          />
+        ),
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ReviewOwner key={1} params={data} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data],
+  )
 
   return (
     <TxLayout

--- a/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
@@ -1,4 +1,5 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import useTxStepper from '@/components/tx-flow/useTxStepper'
 import { ChooseOwner, ChooseOwnerMode } from '@/components/tx-flow/flows/AddOwner/ChooseOwner'
 import { ReviewOwner } from '@/components/tx-flow/flows/AddOwner/ReviewOwner'
@@ -20,7 +21,7 @@ export type AddOwnerFlowProps = {
 const FlowInner = ({ defaultValues }: { defaultValues: AddOwnerFlowProps }) => {
   const { data, step, nextStep, prevStep } = useTxStepper<AddOwnerFlowProps>(defaultValues)
 
-  const steps = [
+  const steps: TxStep[] = [
     {
       txLayoutProps: { title: 'New transaction' },
       content: (

--- a/apps/web/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryFlowReview.tsx
+++ b/apps/web/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryFlowReview.tsx
@@ -5,19 +5,21 @@ import { useContext } from 'react'
 import type { ReactElement } from 'react'
 
 import { SafeTxContext } from '../../SafeTxProvider'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { getRecoverySkipTransaction } from '@/features/recovery/services/transaction'
 import { createTx } from '@/services/tx/tx-sender'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
 import useAsync from '@/hooks/useAsync'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-const onSubmit = () => {
-  trackEvent({ ...RECOVERY_EVENTS.SUBMIT_RECOVERY_CANCEL })
-}
-
-export function CancelRecoveryFlowReview({ recovery }: { recovery: RecoveryQueueItem }): ReactElement {
+export function CancelRecoveryFlowReview({
+  recovery,
+  onSubmit,
+}: {
+  recovery: RecoveryQueueItem
+  onSubmit: () => void
+}): ReactElement {
   const web3ReadOnly = useWeb3ReadOnly()
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
 
@@ -29,8 +31,13 @@ export function CancelRecoveryFlowReview({ recovery }: { recovery: RecoveryQueue
     createTx(transaction).then(setSafeTx).catch(setSafeTxError)
   }, [setSafeTx, setSafeTxError, recovery, web3ReadOnly])
 
+  const handleSubmit = () => {
+    trackEvent({ ...RECOVERY_EVENTS.SUBMIT_RECOVERY_CANCEL })
+    onSubmit()
+  }
+
   return (
-    <SignOrExecuteForm onSubmit={onSubmit} isBatchable={false}>
+    <ReviewTransaction onSubmit={handleSubmit} isBatchable={false}>
       <Typography mb={1}>
         All actions initiated by the Recoverer will be cancelled. The current signers will remain the signers of the
         Safe Account.
@@ -41,6 +48,6 @@ export function CancelRecoveryFlowReview({ recovery }: { recovery: RecoveryQueue
         {recovery.isMalicious ? 'malicious transaction' : 'recovery proposal'}. It requires other signer signatures in
         order to be executed.
       </ErrorMessage>
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
@@ -29,7 +29,7 @@ function CancelRecoveryFlow({ recovery }: { recovery: RecoveryQueueItem }): Reac
         content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
       },
     ],
-    [nextStep],
+    [nextStep, recovery],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
@@ -2,30 +2,36 @@ import { CANCEL_RECOVERY_CATEGORY } from '@/services/analytics/events/recovery'
 import type { ReactElement } from 'react'
 
 import TxLayout from '../../common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import { CancelRecoveryFlowReview } from './CancelRecoveryFlowReview'
 import { CancelRecoveryOverview } from './CancelRecoveryOverview'
 import useTxStepper from '../../useTxStepper'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+
+const TITLE = 'Cancel Account recovery'
 
 function CancelRecoveryFlow({ recovery }: { recovery: RecoveryQueueItem }): ReactElement {
   const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, CANCEL_RECOVERY_CATEGORY)
 
-  const steps = [
-    <CancelRecoveryOverview key={0} onSubmit={() => nextStep(undefined)} />,
-    <CancelRecoveryFlowReview key={1} recovery={recovery} />,
+  const steps: TxStep[] = [
+    {
+      txLayoutProps: { title: TITLE, hideNonce: true },
+      content: <CancelRecoveryOverview key={0} onSubmit={() => nextStep(undefined)} />,
+    },
+    {
+      txLayoutProps: { title: 'Confirm transaction', subtitle: TITLE },
+      content: <CancelRecoveryFlowReview key={1} recovery={recovery} onSubmit={() => nextStep(undefined)} />,
+    },
+    {
+      txLayoutProps: { title: 'Confirm transaction details', subtitle: TITLE, fixedNonce: true },
+      content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+    },
   ]
 
-  const isIntro = step === 0
-
   return (
-    <TxLayout
-      title={isIntro ? 'Cancel Account recovery' : 'New transaction'}
-      subtitle={isIntro ? undefined : 'Cancel Account recovery'}
-      step={step}
-      hideNonce={isIntro}
-      onBack={prevStep}
-    >
-      {steps}
+    <TxLayout step={step} onBack={prevStep} {...(steps?.[step]?.txLayoutProps || {})}>
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
@@ -1,5 +1,5 @@
 import { CANCEL_RECOVERY_CATEGORY } from '@/services/analytics/events/recovery'
-import type { ReactElement } from 'react'
+import { useMemo, type ReactElement } from 'react'
 
 import TxLayout from '../../common/TxLayout'
 import type { TxStep } from '../../common/TxLayout'
@@ -14,20 +14,23 @@ const TITLE = 'Cancel Account recovery'
 function CancelRecoveryFlow({ recovery }: { recovery: RecoveryQueueItem }): ReactElement {
   const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, CANCEL_RECOVERY_CATEGORY)
 
-  const steps: TxStep[] = [
-    {
-      txLayoutProps: { title: TITLE, hideNonce: true },
-      content: <CancelRecoveryOverview key={0} onSubmit={() => nextStep(undefined)} />,
-    },
-    {
-      txLayoutProps: { title: 'Confirm transaction', subtitle: TITLE },
-      content: <CancelRecoveryFlowReview key={1} recovery={recovery} onSubmit={() => nextStep(undefined)} />,
-    },
-    {
-      txLayoutProps: { title: 'Confirm transaction details', subtitle: TITLE, fixedNonce: true },
-      content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
-    },
-  ]
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: TITLE, hideNonce: true },
+        content: <CancelRecoveryOverview key={0} onSubmit={() => nextStep(undefined)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction', subtitle: TITLE },
+        content: <CancelRecoveryFlowReview key={1} recovery={recovery} onSubmit={() => nextStep(undefined)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', subtitle: TITLE, fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep],
+  )
 
   return (
     <TxLayout step={step} onBack={prevStep} {...(steps?.[step]?.txLayoutProps || {})}>

--- a/apps/web/src/components/tx-flow/flows/ChangeThreshold/ReviewChangeThreshold.tsx
+++ b/apps/web/src/components/tx-flow/flows/ChangeThreshold/ReviewChangeThreshold.tsx
@@ -3,14 +3,14 @@ import { useContext, useEffect } from 'react'
 
 import { createUpdateThresholdTx } from '@/services/tx/tx-sender'
 import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { ChangeThresholdFlowFieldNames } from '@/components/tx-flow/flows/ChangeThreshold'
 import type { ChangeThresholdFlowProps } from '@/components/tx-flow/flows/ChangeThreshold'
 
 import { ChangeThresholdReviewContext } from './context'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-const ReviewChangeThreshold = ({ params }: { params: ChangeThresholdFlowProps }) => {
+const ReviewChangeThreshold = ({ params, onSubmit }: { params: ChangeThresholdFlowProps; onSubmit: () => void }) => {
   const { safe } = useSafeInfo()
   const newThreshold = params[ChangeThresholdFlowFieldNames.threshold]
 
@@ -20,14 +20,19 @@ const ReviewChangeThreshold = ({ params }: { params: ChangeThresholdFlowProps })
     createUpdateThresholdTx(newThreshold).then(setSafeTx).catch(setSafeTxError)
   }, [newThreshold, setSafeTx, setSafeTxError])
 
-  const onChangeThreshold = () => {
+  const trackEvents = () => {
     trackEvent({ ...SETTINGS_EVENTS.SETUP.OWNERS, label: safe.owners.length })
     trackEvent({ ...SETTINGS_EVENTS.SETUP.THRESHOLD, label: newThreshold })
   }
 
+  const handleSubmit = () => {
+    trackEvents()
+    onSubmit()
+  }
+
   return (
     <ChangeThresholdReviewContext.Provider value={{ newThreshold }}>
-      <SignOrExecuteForm onSubmit={onChangeThreshold} showMethodCall />
+      <ReviewTransaction onSubmit={handleSubmit} showMethodCall />
     </ChangeThresholdReviewContext.Provider>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/ChangeThreshold/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ChangeThreshold/index.tsx
@@ -1,9 +1,12 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '@/components/tx-flow/common/TxLayout'
 import ReviewChangeThreshold from '@/components/tx-flow/flows/ChangeThreshold/ReviewChangeThreshold'
 import useTxStepper from '@/components/tx-flow/useTxStepper'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ChooseThreshold } from '@/components/tx-flow/flows/ChangeThreshold/ChooseThreshold'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { useMemo } from 'react'
 
 export enum ChangeThresholdFlowFieldNames {
   threshold = 'threshold',
@@ -20,20 +23,33 @@ const ChangeThresholdFlow = () => {
     [ChangeThresholdFlowFieldNames.threshold]: safe.threshold,
   })
 
-  const steps = [
-    <ChooseThreshold key={0} params={data} onSubmit={(formData) => nextStep(formData)} />,
-    <ReviewChangeThreshold key={1} params={data} />,
-  ]
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'New transaction' },
+        content: <ChooseThreshold key={0} params={data} onSubmit={(formData) => nextStep(formData)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ReviewChangeThreshold key={1} params={data} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data],
+  )
 
   return (
     <TxLayout
-      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
       subtitle="Change threshold"
       icon={SaveAddressIcon}
       step={step}
       onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      {steps}
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/ConfirmBatch/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmBatch/index.tsx
@@ -46,11 +46,11 @@ const ConfirmBatchFlow = (props: ConfirmBatchProps) => {
     () => [
       {
         txLayoutProps: { title: 'Confirm batch' },
-        content: <ConfirmBatch key={0} {...props} onSubmit={() => nextStep(data)} />,
+        content: <ConfirmBatch key={0} onSubmit={() => nextStep(data)} />,
       },
       {
         txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
-        content: <ConfirmTxDetails key={1} onSubmit={() => {}} />,
+        content: <ConfirmTxDetails key={1} {...props} />,
       },
     ],
     [nextStep, data, props],

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/ConfirmProposedTx.tsx
@@ -7,17 +7,18 @@ import { useSigner } from '@/hooks/wallets/useWallet'
 import { isExecutable, isMultisigExecutionInfo, isSignableBy } from '@/utils/transaction-guards'
 import { createExistingTx } from '@/services/tx/tx-sender'
 import { SafeTxContext } from '../../SafeTxProvider'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
 type ConfirmProposedTxProps = {
   txSummary: TransactionSummary
+  onSubmit: () => void
 }
 
 const SIGN_TEXT = 'Sign this transaction.'
 const EXECUTE_TEXT = 'Submit the form to execute this transaction.'
 const SIGN_EXECUTE_TEXT = 'Sign or immediately execute this transaction.'
 
-const ConfirmProposedTx = ({ txSummary }: ConfirmProposedTxProps): ReactElement => {
+const ConfirmProposedTx = ({ txSummary, onSubmit }: ConfirmProposedTxProps): ReactElement => {
   const signer = useSigner()
   const { safe } = useSafeInfo()
   const chainId = useChainId()
@@ -39,9 +40,9 @@ const ConfirmProposedTx = ({ txSummary }: ConfirmProposedTxProps): ReactElement 
   const text = canSign ? (canExecute ? SIGN_EXECUTE_TEXT : SIGN_TEXT) : EXECUTE_TEXT
 
   return (
-    <SignOrExecuteForm txId={txId} isExecutable={canExecute} onlyExecute={!canSign} showMethodCall>
+    <ReviewTransaction onSubmit={onSubmit} txId={txId} isExecutable={canExecute} onlyExecute={!canSign} showMethodCall>
       <Typography mb={1}>{text}</Typography>
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }
 

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
@@ -1,23 +1,43 @@
 import { isSwapOrderTxInfo } from '@/utils/transaction-guards'
 import type { TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import ConfirmProposedTx from './ConfirmProposedTx'
 import { useTransactionType } from '@/hooks/useTransactionType'
 import SwapIcon from '@/public/images/common/swap.svg'
+import { useMemo } from 'react'
+import useTxStepper from '../../useTxStepper'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 const ConfirmTxFlow = ({ txSummary }: { txSummary: TransactionSummary }) => {
   const { text } = useTransactionType(txSummary)
   const isSwapOrder = isSwapOrderTxInfo(txSummary.txInfo)
+  const { data, step, nextStep, prevStep } = useTxStepper({})
+
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ConfirmProposedTx key={0} txSummary={txSummary} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={1} txId={txSummary.id} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data, txSummary],
+  )
 
   return (
     <TxLayout
-      title="Confirm transaction"
       subtitle={<>{text}&nbsp;</>}
       icon={isSwapOrder && SwapIcon}
-      step={0}
+      step={step}
+      onBack={prevStep}
       txSummary={txSummary}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      <ConfirmProposedTx txSummary={txSummary} />
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
+++ b/apps/web/src/components/tx-flow/flows/NewSpendingLimit/ReviewSpendingLimit.tsx
@@ -7,7 +7,6 @@ import { Typography, Grid, Alert } from '@mui/material'
 import SpendingLimitLabel from '@/components/common/SpendingLimitLabel'
 import { getResetTimeOptions } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
 import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import useBalances from '@/hooks/useBalances'
 import useChainId from '@/hooks/useChainId'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
@@ -17,8 +16,15 @@ import { formatVisualAmount, safeParseUnits } from '@/utils/formatters'
 import type { NewSpendingLimitFlowProps } from '.'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { SafeTxContext } from '../../SafeTxProvider'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowProps }) => {
+export const ReviewSpendingLimit = ({
+  params,
+  onSubmit,
+}: {
+  params: NewSpendingLimitFlowProps
+  onSubmit: () => void
+}) => {
   const spendingLimits = useSelector(selectSpendingLimits)
   const { safe } = useSafeInfo()
   const chainId = useChainId()
@@ -80,6 +86,8 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
       ...SETTINGS_EVENTS.SPENDING_LIMIT.RESET_PERIOD,
       label: resetTime,
     })
+
+    onSubmit()
   }
 
   const existingAmount = existingSpendingLimit
@@ -91,7 +99,7 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
     : undefined
 
   return (
-    <SignOrExecuteForm onSubmit={onFormSubmit}>
+    <ReviewTransaction onSubmit={onFormSubmit}>
       {token && (
         <SendAmountBlock amountInWei={amountInWei} tokenInfo={token.tokenInfo} title="Amount">
           {existingAmount && existingAmount !== params.amount && (
@@ -210,6 +218,6 @@ export const ReviewSpendingLimit = ({ params }: { params: NewSpendingLimitFlowPr
           </Typography>
         </Alert>
       )}
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/NewSpendingLimit/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NewSpendingLimit/index.tsx
@@ -1,10 +1,13 @@
 import TxLayout from '../../common/TxLayout'
+import type { TxStep } from '@/components/tx-flow/common/TxLayout'
 import useTxStepper from '../../useTxStepper'
 import { CreateSpendingLimit } from './CreateSpendingLimit'
 import { ReviewSpendingLimit } from './ReviewSpendingLimit'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import { TokenAmountFields } from '@/components/common/TokenAmountInput'
+import { useMemo } from 'react'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 enum Fields {
   beneficiary = 'beneficiary',
@@ -30,20 +33,35 @@ const defaultValues: NewSpendingLimitFlowProps = {
 const NewSpendingLimitFlow = () => {
   const { data, step, nextStep, prevStep } = useTxStepper<NewSpendingLimitFlowProps>(defaultValues)
 
-  const steps = [
-    <CreateSpendingLimit key={0} params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />,
-    <ReviewSpendingLimit key={1} params={data} />,
-  ]
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'New transaction' },
+        content: (
+          <CreateSpendingLimit key={0} params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />
+        ),
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ReviewSpendingLimit key={1} params={data} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data],
+  )
 
   return (
     <TxLayout
-      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
       subtitle="Spending limit"
       icon={SaveAddressIcon}
       step={step}
       onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      {steps}
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RejectTx/RejectTx.tsx
+++ b/apps/web/src/components/tx-flow/flows/RejectTx/RejectTx.tsx
@@ -1,15 +1,16 @@
 import type { ReactElement } from 'react'
 import { Typography } from '@mui/material'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { createRejectTx } from '@/services/tx/tx-sender'
 import { useContext, useEffect } from 'react'
 import { SafeTxContext } from '../../SafeTxProvider'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
 type RejectTxProps = {
   txNonce: number
+  onSubmit: () => void
 }
 
-const RejectTx = ({ txNonce }: RejectTxProps): ReactElement => {
+const RejectTx = ({ txNonce, onSubmit }: RejectTxProps): ReactElement => {
   const { setSafeTx, setSafeTxError, setNonce } = useContext(SafeTxContext)
 
   useEffect(() => {
@@ -19,7 +20,7 @@ const RejectTx = ({ txNonce }: RejectTxProps): ReactElement => {
   }, [txNonce, setNonce, setSafeTx, setSafeTxError])
 
   return (
-    <SignOrExecuteForm isBatchable={false} isRejection>
+    <ReviewTransaction isBatchable={false} onSubmit={onSubmit} isRejection>
       <Typography mb={2}>
         To reject the transaction, a separate rejection transaction will be created to replace the original one.
       </Typography>
@@ -31,7 +32,7 @@ const RejectTx = ({ txNonce }: RejectTxProps): ReactElement => {
       <Typography mb={2}>
         You will need to confirm the rejection transaction with your currently connected wallet.
       </Typography>
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }
 

--- a/apps/web/src/components/tx-flow/flows/RejectTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RejectTx/index.tsx
@@ -1,15 +1,34 @@
-import type { ReactElement } from 'react'
+import { useMemo, type ReactElement } from 'react'
 import TxLayout from '../../common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import RejectTx from './RejectTx'
+import useTxStepper from '../../useTxStepper'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 type RejectTxProps = {
   txNonce: number
 }
 
 const RejectTxFlow = ({ txNonce }: RejectTxProps): ReactElement => {
+  const { data, step, nextStep, prevStep } = useTxStepper(null)
+
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <RejectTx key={0} txNonce={txNonce} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={1} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data, txNonce],
+  )
+
   return (
-    <TxLayout title="Confirm transaction" subtitle="Reject" step={0}>
-      <RejectTx txNonce={txNonce} />
+    <TxLayout subtitle="Reject" step={step} onBack={prevStep} {...(steps?.[step]?.txLayoutProps || {})}>
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveModule/ReviewRemoveModule.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveModule/ReviewRemoveModule.tsx
@@ -1,18 +1,14 @@
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { Grid, Typography } from '@mui/material'
-import { useContext, useEffect } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 import { Errors, logError } from '@/services/exceptions'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { createRemoveModuleTx } from '@/services/tx/tx-sender'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { type RemoveModuleFlowProps } from '.'
 import EthHashInfo from '@/components/common/EthHashInfo'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-const onFormSubmit = () => {
-  trackEvent(SETTINGS_EVENTS.MODULES.REMOVE_MODULE)
-}
-
-export const ReviewRemoveModule = ({ params }: { params: RemoveModuleFlowProps }) => {
+export const ReviewRemoveModule = ({ params, onSubmit }: { params: RemoveModuleFlowProps; onSubmit: () => void }) => {
   const { setSafeTx, safeTxError, setSafeTxError } = useContext(SafeTxContext)
 
   useEffect(() => {
@@ -25,8 +21,13 @@ export const ReviewRemoveModule = ({ params }: { params: RemoveModuleFlowProps }
     }
   }, [safeTxError])
 
+  const onFormSubmit = useCallback(() => {
+    trackEvent(SETTINGS_EVENTS.MODULES.REMOVE_MODULE)
+    onSubmit()
+  }, [onSubmit])
+
   return (
-    <SignOrExecuteForm onSubmit={onFormSubmit}>
+    <ReviewTransaction onSubmit={onFormSubmit}>
       <Grid
         container
         sx={{
@@ -49,6 +50,6 @@ export const ReviewRemoveModule = ({ params }: { params: RemoveModuleFlowProps }
         After removing this module, any feature or app that uses this module might no longer work. If this Safe Account
         requires more then one signature, the module removal will have to be confirmed by other signers as well.
       </Typography>
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveModule/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveModule/index.tsx
@@ -1,14 +1,34 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import { ReviewRemoveModule } from './ReviewRemoveModule'
+import { useMemo } from 'react'
+import useTxStepper from '../../useTxStepper'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 export type RemoveModuleFlowProps = {
   address: string
 }
 
 const RemoveModuleFlow = ({ address }: RemoveModuleFlowProps) => {
+  const { data, step, nextStep, prevStep } = useTxStepper(null)
+
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ReviewRemoveModule key={0} params={{ address }} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={1} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data, address],
+  )
+
   return (
-    <TxLayout title="Confirm transaction" subtitle="Remove module">
-      <ReviewRemoveModule params={{ address }} />
+    <TxLayout subtitle="Remove module" step={step} onBack={prevStep} {...(steps?.[step]?.txLayoutProps || {})}>
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveOwner/ReviewRemoveOwner.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveOwner/ReviewRemoveOwner.tsx
@@ -1,8 +1,7 @@
-import { useContext, useEffect } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 import { Typography, Divider, Box, Paper, SvgIcon } from '@mui/material'
 import type { ReactElement } from 'react'
 
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import useAddressBook from '@/hooks/useAddressBook'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
@@ -15,8 +14,15 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { ChangeSignerSetupWarning } from '@/features/multichain/components/SignerSetupWarning/ChangeSignerSetupWarning'
 import { maybePlural } from '@/utils/formatters'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-export const ReviewRemoveOwner = ({ params }: { params: RemoveOwnerFlowProps }): ReactElement => {
+export const ReviewRemoveOwner = ({
+  params,
+  onSubmit,
+}: {
+  params: RemoveOwnerFlowProps
+  onSubmit: () => void
+}): ReactElement => {
   const addressBook = useAddressBook()
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
   const { safe } = useSafeInfo()
@@ -28,13 +34,14 @@ export const ReviewRemoveOwner = ({ params }: { params: RemoveOwnerFlowProps }):
 
   const newOwnerLength = safe.owners.length - 1
 
-  const onFormSubmit = () => {
+  const onFormSubmit = useCallback(() => {
     trackEvent({ ...SETTINGS_EVENTS.SETUP.THRESHOLD, label: safe.threshold })
     trackEvent({ ...SETTINGS_EVENTS.SETUP.OWNERS, label: safe.owners.length })
-  }
+    onSubmit()
+  }, [onSubmit, safe.threshold, safe.owners])
 
   return (
-    <SignOrExecuteForm onSubmit={onFormSubmit}>
+    <ReviewTransaction onSubmit={onFormSubmit}>
       <Paper sx={{ backgroundColor: ({ palette }) => palette.warning.background, p: 2 }}>
         <Typography color="text.secondary" mb={2} display="flex" alignItems="center">
           <SvgIcon component={MinusIcon} inheritViewBox fontSize="small" sx={{ mr: 1 }} />
@@ -60,6 +67,6 @@ export const ReviewRemoveOwner = ({ params }: { params: RemoveOwnerFlowProps }):
         </Typography>
       </Box>
       <Divider className={commonCss.nestedDivider} />
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveOwner/index.tsx
@@ -1,9 +1,12 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useTxStepper from '../../useTxStepper'
 import { ReviewRemoveOwner } from './ReviewRemoveOwner'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import { SetThreshold } from './SetThreshold'
+import { useMemo } from 'react'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 type Owner = {
   address: string
@@ -25,20 +28,35 @@ const RemoveOwnerFlow = (props: Owner) => {
 
   const { data, step, nextStep, prevStep } = useTxStepper<RemoveOwnerFlowProps>(defaultValues)
 
-  const steps = [
-    <SetThreshold key={0} params={data} onSubmit={(formData: any) => nextStep({ ...data, ...formData })} />,
-    <ReviewRemoveOwner key={1} params={data} />,
-  ]
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'New transaction' },
+        content: (
+          <SetThreshold key={0} params={data} onSubmit={(formData: any) => nextStep({ ...data, ...formData })} />
+        ),
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ReviewRemoveOwner key={1} params={data} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data],
+  )
 
   return (
     <TxLayout
-      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
       subtitle="Remove signer"
       icon={SaveAddressIcon}
       step={step}
       onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      {steps}
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveRecovery/RemoveRecoveryFlowReview.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveRecovery/RemoveRecoveryFlowReview.tsx
@@ -1,28 +1,32 @@
 import { trackEvent } from '@/services/analytics'
 import { RECOVERY_EVENTS } from '@/services/analytics/events/recovery'
 import { Typography } from '@mui/material'
-import { useContext, useEffect } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 import type { ReactElement } from 'react'
 
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { createRemoveModuleTx } from '@/services/tx/tx-sender'
 import { OwnerList } from '../../common/OwnerList'
 import { SafeTxContext } from '../../SafeTxProvider'
 import type { RecoveryFlowProps } from '.'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-const onSubmit = () => {
-  trackEvent({ ...RECOVERY_EVENTS.SUBMIT_RECOVERY_REMOVE })
-}
-
-export function RemoveRecoveryFlowReview({ delayModifier }: RecoveryFlowProps): ReactElement {
+export function RemoveRecoveryFlowReview({
+  delayModifier,
+  onSubmit,
+}: RecoveryFlowProps & { onSubmit: () => void }): ReactElement {
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
 
   useEffect(() => {
     createRemoveModuleTx(delayModifier.address).then(setSafeTx).catch(setSafeTxError)
   }, [delayModifier.address, setSafeTx, setSafeTxError])
 
+  const onFormSubmit = useCallback(() => {
+    trackEvent({ ...RECOVERY_EVENTS.SUBMIT_RECOVERY_REMOVE })
+    onSubmit()
+  }, [onSubmit])
+
   return (
-    <SignOrExecuteForm onSubmit={onSubmit}>
+    <ReviewTransaction onSubmit={onFormSubmit}>
       <Typography>
         This transaction will remove the recovery module from your Safe Account. You will no longer be able to recover
         your Safe Account once this transaction is executed.
@@ -33,6 +37,6 @@ export function RemoveRecoveryFlowReview({ delayModifier }: RecoveryFlowProps): 
         owners={delayModifier.recoverers.map((recoverer) => ({ value: recoverer }))}
         sx={{ bgcolor: ({ palette }) => `${palette.warning.background} !important` }}
       />
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveRecovery/index.tsx
@@ -1,12 +1,14 @@
 import { REMOVE_RECOVERY_CATEGORY } from '@/services/analytics/events/recovery'
-import type { ReactElement } from 'react'
+import { useMemo, type ReactElement } from 'react'
 
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import RecoveryPlus from '@/public/images/common/recovery-plus.svg'
 import useTxStepper from '../../useTxStepper'
 import { RemoveRecoveryFlowOverview } from './RemoveRecoveryFlowOverview'
 import { RemoveRecoveryFlowReview } from './RemoveRecoveryFlowReview'
 import type { RecoveryStateItem } from '@/features/recovery/services/recovery-state'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 export type RecoveryFlowProps = {
   delayModifier: RecoveryStateItem
@@ -15,20 +17,37 @@ export type RecoveryFlowProps = {
 function RemoveRecoveryFlow({ delayModifier }: RecoveryFlowProps): ReactElement {
   const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, REMOVE_RECOVERY_CATEGORY)
 
-  const steps = [
-    <RemoveRecoveryFlowOverview key={0} delayModifier={delayModifier} onSubmit={() => nextStep(undefined)} />,
-    <RemoveRecoveryFlowReview key={1} delayModifier={delayModifier} />,
-  ]
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'Remove Account recovery' },
+        content: (
+          <RemoveRecoveryFlowOverview key={0} delayModifier={delayModifier} onSubmit={() => nextStep(undefined)} />
+        ),
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: (
+          <RemoveRecoveryFlowReview key={1} delayModifier={delayModifier} onSubmit={() => nextStep(undefined)} />
+        ),
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, delayModifier],
+  )
 
   return (
     <TxLayout
-      title={step === 0 ? 'Remove Account recovery' : 'Confirm transaction'}
       subtitle="Remove Recoverer"
       icon={RecoveryPlus}
       step={step}
       onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      {steps}
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveSpendingLimit/RemoveSpendingLimit.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveSpendingLimit/RemoveSpendingLimit.tsx
@@ -1,10 +1,9 @@
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import {
   getSpendingLimitInterface,
   getDeployedSpendingLimitModuleAddress,
 } from '@/services/contracts/spendingLimitContracts'
 import useChainId from '@/hooks/useChainId'
-import { useContext, useEffect } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 import { SafeTxContext } from '../../SafeTxProvider'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { Grid, Typography } from '@mui/material'
@@ -16,12 +15,9 @@ import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmount
 import SpendingLimitLabel from '@/components/common/SpendingLimitLabel'
 import { createTx } from '@/services/tx/tx-sender'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-const onFormSubmit = () => {
-  trackEvent(SETTINGS_EVENTS.SPENDING_LIMIT.LIMIT_REMOVED)
-}
-
-export const RemoveSpendingLimit = ({ params }: { params: SpendingLimitState }) => {
+export const RemoveSpendingLimit = ({ params, onSubmit }: { params: SpendingLimitState; onSubmit: () => void }) => {
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
   const chainId = useChainId()
   const { safe } = useSafeInfo()
@@ -51,8 +47,13 @@ export const RemoveSpendingLimit = ({ params }: { params: SpendingLimitState }) 
     createTx(txParams).then(setSafeTx).catch(setSafeTxError)
   }, [chainId, params.beneficiary, params.token, setSafeTx, setSafeTxError, safe.modules])
 
+  const onFormSubmit = useCallback(() => {
+    trackEvent(SETTINGS_EVENTS.SPENDING_LIMIT.LIMIT_REMOVED)
+    onSubmit()
+  }, [onSubmit])
+
   return (
-    <SignOrExecuteForm onSubmit={onFormSubmit}>
+    <ReviewTransaction onSubmit={onFormSubmit}>
       {token && <SendAmountBlock amountInWei={amountInWei} tokenInfo={token.tokenInfo} title="Amount" />}
       <Grid
         container
@@ -105,6 +106,6 @@ export const RemoveSpendingLimit = ({ params }: { params: SpendingLimitState }) 
           />
         </Grid>
       </Grid>
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveSpendingLimit/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveSpendingLimit/index.tsx
@@ -1,12 +1,38 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import { RemoveSpendingLimit } from './RemoveSpendingLimit'
 import type { SpendingLimitState } from '@/store/spendingLimitsSlice'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
+import { useMemo } from 'react'
+import useTxStepper from '../../useTxStepper'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 const RemoveSpendingLimitFlow = ({ spendingLimit }: { spendingLimit: SpendingLimitState }) => {
+  const { data, step, nextStep, prevStep } = useTxStepper(null)
+
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <RemoveSpendingLimit params={spendingLimit} key={0} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={1} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data, spendingLimit],
+  )
+
   return (
-    <TxLayout title="Confirm transaction" subtitle="Remove spending limit" icon={SaveAddressIcon}>
-      <RemoveSpendingLimit params={spendingLimit} />
+    <TxLayout
+      subtitle="Remove spending limit"
+      icon={SaveAddressIcon}
+      step={step}
+      onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
+    >
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/ReplaceOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ReplaceOwner/index.tsx
@@ -1,4 +1,5 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import useTxStepper from '@/components/tx-flow/useTxStepper'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ReviewOwner } from '../AddOwner/ReviewOwner'
@@ -28,7 +29,7 @@ const ReplaceOwnerFlow = ({ address }: { address: string }) => {
 
   const { data, step, nextStep, prevStep } = useTxStepper<ReplaceOwnerFlowProps>(defaultValues)
 
-  const steps = [
+  const steps: TxStep[] = [
     {
       txLayoutProps: { title: 'New transaction' },
       content: (

--- a/apps/web/src/components/tx-flow/flows/ReplaceOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ReplaceOwner/index.tsx
@@ -4,6 +4,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import { ReviewOwner } from '../AddOwner/ReviewOwner'
 import { ChooseOwner, ChooseOwnerMode } from '../AddOwner/ChooseOwner'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 type Owner = {
   address: string
@@ -28,24 +29,36 @@ const ReplaceOwnerFlow = ({ address }: { address: string }) => {
   const { data, step, nextStep, prevStep } = useTxStepper<ReplaceOwnerFlowProps>(defaultValues)
 
   const steps = [
-    <ChooseOwner
-      key={0}
-      params={data}
-      onSubmit={(formData) => nextStep({ ...data, ...formData })}
-      mode={ChooseOwnerMode.REPLACE}
-    />,
-    <ReviewOwner key={1} params={data} />,
+    {
+      txLayoutProps: { title: 'New transaction' },
+      content: (
+        <ChooseOwner
+          key={0}
+          params={data}
+          onSubmit={(formData) => nextStep({ ...data, ...formData })}
+          mode={ChooseOwnerMode.REPLACE}
+        />
+      ),
+    },
+    {
+      txLayoutProps: { title: 'Confirm transaction' },
+      content: <ReviewOwner key={1} params={data} onSubmit={() => nextStep(data)} />,
+    },
+    {
+      txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+      content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+    },
   ]
 
   return (
     <TxLayout
-      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
       subtitle="Replace signer"
       icon={SaveAddressIcon}
       step={step}
       onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      {steps}
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
+++ b/apps/web/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
@@ -1,31 +1,22 @@
-import useWallet from '@/hooks/wallets/useWallet'
 import { useContext, useEffect, useMemo } from 'react'
 import type { ReactElement } from 'react'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import type { SafeAppsTxParams } from '.'
-import { trackSafeAppTxCount } from '@/services/safe-apps/track-app-usage-count'
 import { getTxOrigin } from '@/utils/transactions'
-import { createMultiSendCallOnlyTx, createTx, dispatchSafeAppsTx } from '@/services/tx/tx-sender'
-import useOnboard from '@/hooks/wallets/useOnboard'
+import { createMultiSendCallOnlyTx, createTx } from '@/services/tx/tx-sender'
 import useHighlightHiddenTab from '@/hooks/useHighlightHiddenTab'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { isTxValid } from '@/components/safe-apps/utils'
 import ErrorMessage from '@/components/tx/ErrorMessage'
-import { asError } from '@/services/exceptions/utils'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
 type ReviewSafeAppsTxProps = {
   safeAppsTx: SafeAppsTxParams
-  onSubmit?: (txId: string, safeTxHash: string) => void
+  onSubmit: () => void
 }
 
-const ReviewSafeAppsTx = ({
-  safeAppsTx: { txs, requestId, params, appId, app },
-  onSubmit,
-}: ReviewSafeAppsTxProps): ReactElement => {
-  const onboard = useOnboard()
-  const wallet = useWallet()
-  const { safeTx, setSafeTx, safeTxError, setSafeTxError, setTxOrigin } = useContext(SafeTxContext)
+const ReviewSafeAppsTx = ({ safeAppsTx: { txs, params, app }, onSubmit }: ReviewSafeAppsTxProps): ReactElement => {
+  const { setSafeTx, safeTxError, setSafeTxError, setTxOrigin } = useContext(SafeTxContext)
 
   useHighlightHiddenTab()
 
@@ -51,32 +42,18 @@ const ReviewSafeAppsTx = ({
     createSafeTx().then(setSafeTx).catch(setSafeTxError)
   }, [txs, setSafeTx, setSafeTxError, params])
 
-  const handleSubmit = async (txId: string) => {
-    if (!safeTx || !onboard || !wallet?.provider) return
-    trackSafeAppTxCount(Number(appId))
-
-    let safeTxHash = ''
-    try {
-      safeTxHash = await dispatchSafeAppsTx(safeTx, requestId, wallet.provider, txId)
-    } catch (error) {
-      setSafeTxError(asError(error))
-    }
-
-    onSubmit?.(txId, safeTxHash)
-  }
-
   const origin = useMemo(() => getTxOrigin(app), [app])
   const error = !isTxValid(txs)
 
   return (
-    <SignOrExecuteForm onSubmit={handleSubmit} origin={origin} showMethodCall>
+    <ReviewTransaction onSubmit={onSubmit} origin={origin} showMethodCall>
       {error ? (
         <ErrorMessage error={safeTxError}>
           This Safe App initiated a transaction which cannot be processed. Please get in touch with the developer of
           this Safe App for more information.
         </ErrorMessage>
       ) : null}
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }
 

--- a/apps/web/src/components/tx-flow/flows/SafeAppsTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SafeAppsTx/index.tsx
@@ -1,8 +1,18 @@
 import type { BaseTransaction, RequestId, SendTransactionRequestParams } from '@safe-global/safe-apps-sdk'
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import type { SafeAppData } from '@safe-global/safe-gateway-typescript-sdk'
 import ReviewSafeAppsTx from './ReviewSafeAppsTx'
 import { AppTitle } from '@/components/tx-flow/flows/SignMessage'
+import useTxStepper from '../../useTxStepper'
+import { useCallback, useContext, useMemo } from 'react'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { asError } from '@/services/exceptions/utils'
+import { SafeTxContext } from '../../SafeTxProvider'
+import useWallet from '@/hooks/wallets/useWallet'
+import useOnboard from '@/hooks/wallets/useOnboard'
+import { dispatchSafeAppsTx } from '@/services/tx/tx-sender'
+import { trackSafeAppTxCount } from '@/services/safe-apps/track-app-usage-count'
 
 export type SafeAppsTxParams = {
   appId?: string
@@ -19,13 +29,49 @@ const SafeAppsTxFlow = ({
   data: SafeAppsTxParams
   onSubmit?: (txId: string, safeTxHash: string) => void
 }) => {
+  const { safeTx, setSafeTxError } = useContext(SafeTxContext)
+  const onboard = useOnboard()
+  const wallet = useWallet()
+  const { step, nextStep, prevStep } = useTxStepper(null)
+
+  const handleSubmit = useCallback(
+    async (txId: string) => {
+      if (!safeTx || !onboard || !wallet?.provider) return
+      trackSafeAppTxCount(Number(data.appId))
+
+      let safeTxHash = ''
+      try {
+        safeTxHash = await dispatchSafeAppsTx(safeTx, data.requestId, wallet.provider, txId)
+      } catch (error) {
+        setSafeTxError(asError(error))
+      }
+
+      onSubmit?.(txId, safeTxHash)
+    },
+    [safeTx, data, onboard, wallet, setSafeTxError, onSubmit],
+  )
+
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ReviewSafeAppsTx key={0} safeAppsTx={data} onSubmit={() => nextStep(null)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={1} onSubmit={handleSubmit} />,
+      },
+    ],
+    [nextStep, data, handleSubmit],
+  )
   return (
     <TxLayout
-      title="Confirm transaction"
       subtitle={<AppTitle name={data.app?.name} logoUri={data.app?.iconUrl} txs={data.txs} />}
-      step={0}
+      step={step}
+      onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      <ReviewSafeAppsTx safeAppsTx={data} onSubmit={onSubmit} />
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/index.tsx
@@ -7,6 +7,7 @@ import AssetsIcon from '@/public/images/sidebar/assets.svg'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import { TokenAmountFields } from '@/components/common/TokenAmountInput'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { useMemo } from 'react'
 
 export enum TokenTransferType {
   multiSig = 'multiSig',
@@ -44,27 +45,30 @@ const TokenTransferFlow = ({ txNonce, ...params }: TokenTransferFlowProps) => {
     ...params,
   })
 
-  const steps: TxStep[] = [
-    {
-      txLayoutProps: { title: 'New transaction' },
-      content: (
-        <CreateTokenTransfer
-          key={0}
-          params={data}
-          txNonce={txNonce}
-          onSubmit={(formData) => nextStep({ ...data, ...formData })}
-        />
-      ),
-    },
-    {
-      txLayoutProps: { title: 'Confirm transaction' },
-      content: <ReviewTokenTx key={1} params={data} txNonce={txNonce} onSubmit={() => nextStep(data)} />,
-    },
-    {
-      txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
-      content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
-    },
-  ]
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'New transaction' },
+        content: (
+          <CreateTokenTransfer
+            key={0}
+            params={data}
+            txNonce={txNonce}
+            onSubmit={(formData) => nextStep({ ...data, ...formData })}
+          />
+        ),
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ReviewTokenTx key={1} params={data} txNonce={txNonce} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data, txNonce],
+  )
 
   return (
     <TxLayout

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/index.tsx
@@ -1,4 +1,5 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import useTxStepper from '../../useTxStepper'
 import CreateTokenTransfer from './CreateTokenTransfer'
 import ReviewTokenTx from '@/components/tx-flow/flows/TokenTransfer/ReviewTokenTx'
@@ -43,7 +44,7 @@ const TokenTransferFlow = ({ txNonce, ...params }: TokenTransferFlowProps) => {
     ...params,
   })
 
-  const steps = [
+  const steps: TxStep[] = [
     {
       txLayoutProps: { title: 'New transaction' },
       content: (

--- a/apps/web/src/components/tx-flow/flows/UpdateSafe/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpdateSafe/index.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '@/components/tx-flow/common/TxLayout'
 import { UpdateSafeReview } from './UpdateSafeReview'
 import SettingsIcon from '@/public/images/sidebar/settings.svg'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
@@ -8,7 +9,7 @@ import useTxStepper from '../../useTxStepper'
 const UpdateSafeFlow = () => {
   const { data, step, nextStep, prevStep } = useTxStepper({})
 
-  const steps = useMemo(
+  const steps = useMemo<TxStep[]>(
     () => [
       {
         txLayoutProps: { title: 'Review transaction' },
@@ -19,7 +20,7 @@ const UpdateSafeFlow = () => {
         content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
       },
     ],
-    [nextStep],
+    [nextStep, data],
   )
 
   return (

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -6,10 +6,11 @@ import ExternalLink from '@/components/common/ExternalLink'
 import { useContext, useState } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import SignOrExecuteFormV2 from '../SignOrExecuteForm/SignOrExecuteFormV2'
+import type { SubmitCallback } from '../SignOrExecuteForm/SignOrExecuteFormV2'
 import useTxPreview from '../confirmation-views/useTxPreview'
 
 type ConfirmTxDetailsProps = {
-  onSubmit: () => void
+  onSubmit: SubmitCallback
   txId?: string
 }
 

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignFormV2.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignFormV2.tsx
@@ -140,7 +140,7 @@ export const SignFormV2 = ({
           {/* Submit button */}
           <CheckWallet checkNetwork={!submitDisabled}>
             {(isOk) => (
-              <Tooltip title={tooltip} placement="top">
+              <Tooltip title={isOk ? tooltip : undefined} placement="top">
                 <span>
                   <Button
                     data-testid="sign-btn"


### PR DESCRIPTION
## What it solves

Resolves #5303 

## How this PR fixes it

This PR migrates the following flows to the new structure and adds the transaction receipt step as final step:
- AddOwner
- CancelRecovery
- ChangeThreshold
- ConfirmBatch
- ConfirmTx
- NewSpendingLimit
- RejectTx
- RemoveModule
- RemoveOwner
- RemoveRecovery
- RemoveSpendingLimit
- ReplaceOwner
- SafeAppsTx
- UpsertRecovery

## How to test it
Check all the listed flows above that they show the new transaction receipt step at the end.
