### PR TITLE
Revert "fix(web): appUrl query was getting lost while switching network in safeApp "

### DIFF
--- a/apps/web/src/components/common/NetworkSelector/index.tsx
+++ b/apps/web/src/components/common/NetworkSelector/index.tsx
@@ -81,7 +81,6 @@ export const getNetworkLink = (router: NextRouter, safeAddress: string, networkS
     safe?: string
     chain?: string
     safeViewRedirectURL?: string
-    appUrl?: string
   }
 
   const route = {
@@ -91,10 +90,6 @@ export const getNetworkLink = (router: NextRouter, safeAddress: string, networkS
 
   if (router.query?.safeViewRedirectURL) {
     route.query.safeViewRedirectURL = router.query?.safeViewRedirectURL.toString()
-  }
-
-  if (router.query?.appUrl) {
-    route.query.appUrl = router.query.appUrl.toString()
   }
 
   return route

--- a/apps/web/src/pages/apps/open.tsx
+++ b/apps/web/src/pages/apps/open.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { useCallback, useEffect } from 'react'
-import { Box, CircularProgress, Typography } from '@mui/material'
+import { useCallback } from 'react'
+import { Box, CircularProgress } from '@mui/material'
 
 import { useSafeAppUrl } from '@/hooks/safe-apps/useSafeAppUrl'
 import { useSafeApps } from '@/hooks/safe-apps/useSafeApps'
@@ -15,7 +15,7 @@ import { useBrowserPermissions } from '@/hooks/safe-apps/permissions'
 import useChainId from '@/hooks/useChainId'
 import { AppRoutes } from '@/config/routes'
 import { getOrigin } from '@/components/safe-apps/utils'
-import { useCurrentChain, useHasFeature } from '@/hooks/useChains'
+import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
 
 const SafeApps: NextPage = () => {
@@ -26,7 +26,6 @@ const SafeApps: NextPage = () => {
   const safeAppData = allSafeApps.find((app) => app.url === appUrl)
   const { safeApp, isLoading } = useSafeAppFromManifest(appUrl || '', chainId, safeAppData)
   const isSafeAppsEnabled = useHasFeature(FEATURES.SAFE_APPS)
-  const currentChain = useCurrentChain()
 
   const { addPermissions, getPermissions, getAllowedFeaturesList } = useBrowserPermissions()
   const origin = getOrigin(appUrl)
@@ -52,19 +51,6 @@ const SafeApps: NextPage = () => {
       query: { safe: router.query.safe },
     })
   }, [router])
-
-  useEffect(() => {
-    if (!remoteSafeAppsLoading && !isLoading && safeApp.chainIds.length === 0) {
-      const timer = setTimeout(() => {
-        router.push({
-          pathname: AppRoutes.apps.index,
-          query: { safe: router.query.safe },
-        })
-      }, 3000)
-
-      return () => clearTimeout(timer)
-    }
-  }, [remoteSafeAppsLoading, isLoading, safeApp.chainIds.length, router, router.query.safe])
 
   // appUrl is required to be present
   if (!isSafeAppsEnabled || !appUrl || !router.isReady) return null
@@ -97,26 +83,6 @@ const SafeApps: NextPage = () => {
   if (isLoading) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" height="100%">
-        <CircularProgress />
-      </Box>
-    )
-  }
-
-  if (!remoteSafeAppsLoading && !isLoading && safeApp.chainIds.length === 0) {
-    return (
-      <Box
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        justifyContent="center"
-        height="100%"
-        textAlign="center"
-        p={2}
-      >
-        <Typography variant="body1" gutterBottom>
-          {currentChain?.chainName} is not supported in this app. <br />
-          Redirecting to home page
-        </Typography>
         <CircularProgress />
       </Box>
     )


### PR DESCRIPTION
Reverts #5081

Resolves #5350.

It broke the use case when you want to test an unlisted Safe App, e.g. running on localhost.