### PR TITLE
feat(web): clear pending txs

### DIFF
--- a/apps/web/src/components/settings/ClearPendingTxs/index.test.tsx
+++ b/apps/web/src/components/settings/ClearPendingTxs/index.test.tsx
@@ -1,0 +1,104 @@
+import React, { act } from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { ClearPendingTxs } from '../ClearPendingTxs'
+import { render } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import { PendingStatus, PendingTxType } from '@/store/pendingTxsSlice'
+import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
+
+const safeAddress = faker.finance.ethereumAddress()
+
+describe('ClearPendingTxs', () => {
+  it('clear single transaction', () => {
+    render(<ClearPendingTxs />, {
+      initialReduxState: {
+        pendingTxs: {
+          ['0x123']: {
+            chainId: '1',
+            safeAddress,
+            nonce: 0,
+            data: faker.string.hexadecimal({ length: 64 }),
+            to: faker.finance.ethereumAddress(),
+            status: PendingStatus.PROCESSING,
+            txHash: faker.string.hexadecimal({ length: 64 }),
+            signerAddress: faker.finance.ethereumAddress(),
+            submittedAt: Date.now(),
+            signerNonce: 0,
+            txType: PendingTxType.CUSTOM_TX,
+          },
+        },
+        safeInfo: {
+          data: extendedSafeInfoBuilder()
+            .with({ address: { value: safeAddress } })
+            .with({ chainId: '1' })
+            .build(),
+          loading: false,
+        },
+      },
+    })
+    expect(screen.getByText('Clear 1 transaction')).toBeInTheDocument()
+    act(() => {
+      fireEvent.click(screen.getByText('Clear 1 transaction'))
+    })
+    expect(screen.getByText('No pending transactions')).toBeInTheDocument()
+  })
+  it('clear multiple transactions', () => {
+    render(<ClearPendingTxs />, {
+      initialReduxState: {
+        pendingTxs: {
+          ['0x123']: {
+            chainId: '1',
+            safeAddress,
+            nonce: 0,
+            data: faker.string.hexadecimal({ length: 64 }),
+            to: faker.finance.ethereumAddress(),
+            status: PendingStatus.PROCESSING,
+            txHash: faker.string.hexadecimal({ length: 64 }),
+            signerAddress: faker.finance.ethereumAddress(),
+            submittedAt: Date.now(),
+            signerNonce: 0,
+            txType: PendingTxType.CUSTOM_TX,
+          },
+          ['0x234']: {
+            chainId: '1',
+            safeAddress,
+            nonce: 1,
+            data: faker.string.hexadecimal({ length: 64 }),
+            to: faker.finance.ethereumAddress(),
+            status: PendingStatus.PROCESSING,
+            txHash: faker.string.hexadecimal({ length: 64 }),
+            signerAddress: faker.finance.ethereumAddress(),
+            submittedAt: Date.now(),
+            signerNonce: 0,
+            txType: PendingTxType.CUSTOM_TX,
+          },
+          ['0x345']: {
+            chainId: '100',
+            safeAddress,
+            nonce: 0,
+            data: faker.string.hexadecimal({ length: 64 }),
+            to: faker.finance.ethereumAddress(),
+            status: PendingStatus.PROCESSING,
+            txHash: faker.string.hexadecimal({ length: 64 }),
+            signerAddress: faker.finance.ethereumAddress(),
+            submittedAt: Date.now(),
+            signerNonce: 0,
+            txType: PendingTxType.CUSTOM_TX,
+          },
+        },
+        safeInfo: {
+          data: extendedSafeInfoBuilder()
+            .with({ address: { value: safeAddress } })
+            .with({ chainId: '1' })
+            .build(),
+          loading: false,
+        },
+      },
+    })
+    expect(screen.getByText('Clear 2 transactions')).toBeInTheDocument()
+    act(() => {
+      fireEvent.click(screen.getByText('Clear 2 transactions'))
+    })
+    expect(screen.getByText('No pending transactions')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/settings/ClearPendingTxs/index.tsx
+++ b/apps/web/src/components/settings/ClearPendingTxs/index.tsx
@@ -1,0 +1,42 @@
+import { usePendingTxIds } from '@/hooks/usePendingTxs'
+import { useAppDispatch } from '@/store'
+import { clearPendingTx } from '@/store/pendingTxsSlice'
+import { Stack, Typography, Box, Button, Alert } from '@mui/material'
+import { useCallback } from 'react'
+
+export const ClearPendingTxs = () => {
+  const pendingTxIds = usePendingTxIds()
+  const pendingTxCount = pendingTxIds.length
+  const dispatch = useAppDispatch()
+
+  const clearPendingTxs = useCallback(() => {
+    pendingTxIds.forEach((txId) => {
+      dispatch(clearPendingTx({ txId }))
+    })
+  }, [dispatch, pendingTxIds])
+  return (
+    <Stack spacing={2}>
+      <Typography>Clear this Safe&apos;s pending transactions.</Typography>
+      <Alert severity="warning">
+        <Typography>
+          This action does not delete any transactions but only resets their local state. It does not stop any pending
+          transactions from executing. If you want to cancel a execution you have to do this in your connected wallet.
+        </Typography>
+      </Alert>
+      <Box>
+        {pendingTxCount > 0 ? (
+          <Button
+            variant="text"
+            color="error"
+            onClick={clearPendingTxs}
+            sx={{ backgroundColor: ({ palette }) => palette.error.background }}
+          >
+            Clear {pendingTxCount} transaction{pendingTxCount > 1 ? 's' : ''}
+          </Button>
+        ) : (
+          <Typography variant="body2">No pending transactions</Typography>
+        )}
+      </Box>
+    </Stack>
+  )
+}

--- a/apps/web/src/components/settings/DataManagement/index.tsx
+++ b/apps/web/src/components/settings/DataManagement/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Paper, Grid, Typography, Button, SvgIcon, Box } from '@mui/material'
+import { Paper, Grid, Typography, Button, SvgIcon, Box, Stack } from '@mui/material'
 
 import FileIcon from '@/public/images/settings/data/file.svg'
 import ExportIcon from '@/public/images/common/export.svg'
@@ -18,6 +18,7 @@ import { selectAllVisitedSafes, visitedSafesSlice } from '@/store/visitedSafesSl
 import css from './styles.module.css'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
+import { ClearPendingTxs } from '../ClearPendingTxs'
 
 const getExportFileName = () => {
   const today = new Date().toISOString().slice(0, 10)
@@ -111,7 +112,7 @@ const DataManagement = () => {
         </Grid>
       </Paper>
 
-      <Paper sx={{ p: 4 }}>
+      <Paper sx={{ p: 4, mb: 2 }}>
         <Grid container spacing={3}>
           <Grid item sm={4} xs={12}>
             <Typography variant="h4" fontWeight={700}>
@@ -131,6 +132,20 @@ const DataManagement = () => {
               setFileName={setImportFileName}
             />
           )}
+        </Grid>
+      </Paper>
+
+      <Paper sx={{ p: 4 }}>
+        <Grid container spacing={3}>
+          <Grid item sm={4} xs={12}>
+            <Typography variant="h4" fontWeight={700}>
+              Pending transactions
+            </Typography>
+          </Grid>
+
+          <Grid data-testid="clear-pending-tx-section" item container xs>
+            <ClearPendingTxs />
+          </Grid>
         </Grid>
       </Paper>
     </>

--- a/apps/web/src/hooks/usePendingTxs.ts
+++ b/apps/web/src/hooks/usePendingTxs.ts
@@ -17,7 +17,7 @@ import {
 import useSafeInfo from './useSafeInfo'
 import { shallowEqual } from 'react-redux'
 
-const usePendingTxIds = (): Array<TransactionSummary['id']> => {
+export const usePendingTxIds = (): Array<TransactionSummary['id']> => {
   const { safe, safeAddress } = useSafeInfo()
   const { chainId } = safe
   return useAppSelector((state) => selectPendingTxIdsBySafe(state, chainId, safeAddress), shallowEqual)


### PR DESCRIPTION
## What it solves

Resolves #5326 

## How this PR fixes it
- Adds new section for clearing the pending transactions to the _Data_ tab of the _settings_ page
- New button that triggers action to clear pending transactions of the **currently opened** Safe.

## How to test it
- Queue a transaction and fully sign it
- Execute the transaction with a too low gas price (e.g. 0.0001 Max Fee on Sepolia)
- Go to the Settings / Data page 
- Button should show one pending transaction
- Clearing the pending transaction should reset the transactions state to being executable again.

## Screenshots
![Screenshot 2025-03-14 at 09 17 42](https://github.com/user-attachments/assets/492a572f-b694-4c89-b800-75231f0e9a19)

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
