### PR TITLE
Feat(mobile): transaction actions flow

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -69,6 +69,8 @@ function RootLayout() {
                         <Stack.Screen name="notifications" options={{ headerShown: true, title: '' }} />
 
                         <Stack.Screen name="transaction-parameters" options={{ headerShown: true, title: '' }} />
+                        <Stack.Screen name="transaction-actions" options={{ headerShown: true, title: '' }} />
+                        <Stack.Screen name="action-details" options={{ headerShown: true, title: '' }} />
 
                         <Stack.Screen name="signers" options={{ headerShown: false }} />
                         <Stack.Screen name="import-signers" options={{ headerShown: false }} />

--- a/apps/mobile/src/app/action-details.tsx
+++ b/apps/mobile/src/app/action-details.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+import { ActionDetailsContainer } from '@/src/features/ActionDetails'
+
+function ActionDetails() {
+  return (
+    <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
+      <ActionDetailsContainer />
+    </SafeAreaView>
+  )
+}
+
+export default ActionDetails

--- a/apps/mobile/src/app/transaction-actions.tsx
+++ b/apps/mobile/src/app/transaction-actions.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+import { TransactionActionsContainer } from '@/src/features/TransactionActions'
+
+function TransactionActions() {
+  return (
+    <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
+      <TransactionActionsContainer />
+    </SafeAreaView>
+  )
+}
+
+export default TransactionActions

--- a/apps/mobile/src/components/EncodedData/EncodedData.tsx
+++ b/apps/mobile/src/components/EncodedData/EncodedData.tsx
@@ -1,0 +1,23 @@
+import React, { useReducer } from 'react'
+import { Text } from 'tamagui'
+import { TouchableOpacity } from 'react-native'
+
+interface EncodedDataProps {
+  data: string
+}
+
+export function EncodedData({ data }: EncodedDataProps) {
+  const [truncated, toggleTruncate] = useReducer((state: boolean) => !state, true)
+
+  return (
+    <>
+      <Text numberOfLines={truncated ? 5 : undefined} ellipsizeMode="tail">
+        {data}
+      </Text>
+
+      <TouchableOpacity onPress={toggleTruncate}>
+        <Text fontWeight={600}>{truncated ? 'Show more' : 'Show less'}</Text>
+      </TouchableOpacity>
+    </>
+  )
+}

--- a/apps/mobile/src/components/EncodedData/index.ts
+++ b/apps/mobile/src/components/EncodedData/index.ts
@@ -1,0 +1,1 @@
+export { EncodedData } from './EncodedData'

--- a/apps/mobile/src/features/ActionDetails/ActionDetails.container.tsx
+++ b/apps/mobile/src/features/ActionDetails/ActionDetails.container.tsx
@@ -1,0 +1,45 @@
+import { useLocalSearchParams } from 'expo-router'
+import React, { useMemo } from 'react'
+import { ScrollView } from 'tamagui'
+import { useTransactionsGetTransactionByIdV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+import { LargeHeaderTitle, NavBarTitle } from '@/src/components/Title'
+import { useScrollableHeader } from '@/src/navigation/useScrollableHeader'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { Alert } from '@/src/components/Alert'
+
+import { LoadingTx } from '../ConfirmTx/components/LoadingTx'
+import ActionsDetails from './ActionsDetails'
+
+export function ActionDetailsContainer() {
+  const { txId, action, actionName } = useLocalSearchParams<{ txId: string; actionName: string; action: string }>()
+  const parsedAction = useMemo(() => JSON.parse(action), [action])
+  const activeSafe = useDefinedActiveSafe()
+
+  const { data, isFetching, isError } = useTransactionsGetTransactionByIdV1Query({
+    chainId: activeSafe.chainId,
+    id: txId,
+  })
+
+  const { handleScroll } = useScrollableHeader({
+    children: <NavBarTitle>{actionName}</NavBarTitle>,
+  })
+
+  if (isError) {
+    return <Alert type="error" message="Error fetching action details" />
+  }
+
+  if (isFetching || !data) {
+    return <LoadingTx />
+  }
+
+  return (
+    <ScrollView onScroll={handleScroll}>
+      <LargeHeaderTitle paddingHorizontal="$4" marginBottom="$6">
+        {actionName}
+      </LargeHeaderTitle>
+
+      <ActionsDetails txDetails={data} action={parsedAction} />
+    </ScrollView>
+  )
+}

--- a/apps/mobile/src/features/ActionDetails/ActionsDetails.tsx
+++ b/apps/mobile/src/features/ActionDetails/ActionsDetails.tsx
@@ -1,0 +1,18 @@
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { ActionValueDecoded } from '@safe-global/store/gateway/types'
+import React, { useMemo } from 'react'
+import { ListTable } from '../ConfirmTx/components/ListTable'
+import { formatActionDetails } from './utils'
+import { View } from 'tamagui'
+
+function ActionsDetails({ txDetails, action }: { txDetails: TransactionDetails; action: ActionValueDecoded }) {
+  const items = useMemo(() => txDetails && formatActionDetails({ txData: txDetails.txData, action }), [txDetails])
+
+  return (
+    <View paddingHorizontal="$4">
+      <ListTable items={items} />
+    </View>
+  )
+}
+
+export default ActionsDetails

--- a/apps/mobile/src/features/ActionDetails/index.ts
+++ b/apps/mobile/src/features/ActionDetails/index.ts
@@ -1,0 +1,1 @@
+export { ActionDetailsContainer } from './ActionDetails.container'

--- a/apps/mobile/src/features/ActionDetails/utils.tsx
+++ b/apps/mobile/src/features/ActionDetails/utils.tsx
@@ -1,0 +1,113 @@
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { ActionValueDecoded, AddressInfoIndex } from '@safe-global/store/gateway/types'
+import { getActionName } from '../TransactionActions/components/TxActionsList'
+import { Badge } from '@/src/components/Badge'
+import { CircleProps, View, Text } from 'tamagui'
+import { ListTableItem } from '../ConfirmTx/components/ListTable'
+import { Logo } from '@/src/components/Logo'
+import { ellipsis } from '@/src/utils/formatters'
+import { CopyButton } from '@/src/components/CopyButton'
+import { Identicon } from '@/src/components/Identicon'
+import { Address } from '@/src/types/address'
+import { EthAddress } from '@/src/components/EthAddress'
+import { EncodedData } from '@/src/components/EncodedData/EncodedData'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+
+const badgeProps: CircleProps = { borderRadius: '$2', paddingHorizontal: '$2', paddingVertical: '$1' }
+
+type formatActionDetailsReturn = {
+  txData: TransactionDetails['txData']
+  action: ActionValueDecoded
+}
+
+const getContractCall = (action: ActionValueDecoded, addressInfoIndex?: AddressInfoIndex) => {
+  return addressInfoIndex?.[action.to]
+}
+
+const TxOptions = ({ value }: { value: string }) => {
+  return (
+    <View flexDirection="row" alignItems="center">
+      <CopyButton value={value} color={'$textSecondaryLight'} />
+      <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+    </View>
+  )
+}
+
+export const formatActionDetails = ({ txData, action }: formatActionDetailsReturn): ListTableItem[] => {
+  if (!txData) {
+    return []
+  }
+
+  let columns: ListTableItem[] = []
+
+  const contractCall = getContractCall(action, txData.addressInfoIndex as AddressInfoIndex)
+
+  if (action.dataDecoded?.method) {
+    columns.push({
+      label: 'Call',
+      render: () => (
+        <Badge
+          circleProps={badgeProps}
+          themeName="badge_background"
+          fontSize={12}
+          circular={false}
+          content={getActionName(action)}
+        />
+      ),
+    })
+  } else {
+    columns.push({
+      label: 'Interacted with',
+      render: () => (
+        <View flexDirection="row" alignItems="center" gap="$2">
+          <Identicon address={action.to as Address} size={24} />
+          <EthAddress copy copyProps={{ color: '$textSecondaryLight' }} address={action.to as Address} />
+          <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+        </View>
+      ),
+    })
+  }
+
+  if (contractCall) {
+    columns.push({
+      label: 'Contract',
+      render: () => (
+        <View flexDirection="row" alignItems="center" gap="$2">
+          {txData.to.logoUri ? (
+            <Logo logoUri={txData.to.logoUri} size="$6" />
+          ) : (
+            <Identicon address={txData.to.value as Address} size={24} />
+          )}
+          <Text fontSize="$4">{ellipsis(txData.to.name || txData.to.value, 16)}</Text>
+          <TxOptions value={txData.to.value} />
+        </View>
+      ),
+    })
+  }
+
+  if (action.dataDecoded) {
+    columns = [
+      ...columns,
+      ...action.dataDecoded.parameters.map((param) => ({
+        label: param.name,
+        render: () => {
+          if (param.type === 'address') {
+            return <EthAddress copy copyProps={{ color: '$textSecondaryLight' }} address={param.value as Address} />
+          }
+
+          return <Text>{param.value}</Text>
+        },
+      })),
+    ]
+  } else if (action.data) {
+    columns = [
+      ...columns,
+      {
+        label: 'Data',
+        render: () => <EncodedData data={action.data} />,
+      },
+    ]
+  }
+
+  return columns
+}

--- a/apps/mobile/src/features/ConfirmTx/components/ListTable/ListTable.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ListTable/ListTable.tsx
@@ -23,6 +23,8 @@ export function ListTable({ items, children }: ListTableProps) {
           alignItems={item.alignItems || 'center'}
           flexDirection={item.direction || 'row'}
           justifyContent="space-between"
+          gap={'$2'}
+          flexWrap="wrap"
         >
           <Text color="$textSecondaryLight" fontSize="$4">
             {item.label}

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
@@ -12,6 +12,7 @@ import { SafeListItem } from '@/src/components/SafeListItem'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Badge } from '@/src/components/Badge'
 import { ParametersButton } from '../../ParametersButton'
+import { router } from 'expo-router'
 
 interface ContractProps {
   txInfo: CustomTransactionInfo
@@ -23,6 +24,13 @@ export function Contract({ txInfo, executionInfo, txId }: ContractProps) {
   const activeSafe = useDefinedActiveSafe()
   const chain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const items = useMemo(() => formatContractItems(txInfo, chain), [txInfo, chain])
+
+  const handleViewActions = () => {
+    router.push({
+      pathname: '/transaction-actions',
+      params: { txId },
+    })
+  }
 
   return (
     <YStack gap="$4">
@@ -49,6 +57,7 @@ export function Contract({ txInfo, executionInfo, txId }: ContractProps) {
               <SafeFontIcon name={'chevron-right'} />
             </View>
           }
+          onPress={handleViewActions}
         />
       )}
     </YStack>

--- a/apps/mobile/src/features/TransactionActions/TransactionActions.container.tsx
+++ b/apps/mobile/src/features/TransactionActions/TransactionActions.container.tsx
@@ -1,0 +1,42 @@
+import { useLocalSearchParams } from 'expo-router'
+import React from 'react'
+import { ScrollView, View } from 'tamagui'
+import { useTransactionsGetTransactionByIdV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+import { LargeHeaderTitle, NavBarTitle } from '@/src/components/Title'
+import { useScrollableHeader } from '@/src/navigation/useScrollableHeader'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { Alert } from '@/src/components/Alert'
+
+import { LoadingTx } from '../ConfirmTx/components/LoadingTx'
+import { TxActionsList } from './components/TxActionsList'
+
+export function TransactionActionsContainer() {
+  const { txId } = useLocalSearchParams<{ txId: string }>()
+  const activeSafe = useDefinedActiveSafe()
+
+  const { data, isFetching, isError } = useTransactionsGetTransactionByIdV1Query({
+    chainId: activeSafe.chainId,
+    id: txId,
+  })
+
+  const { handleScroll } = useScrollableHeader({
+    children: <NavBarTitle>Actions</NavBarTitle>,
+  })
+
+  if (isError) {
+    return (
+      <View margin="$4">
+        <Alert type="error" message="Error fetching transaction actions" />
+      </View>
+    )
+  }
+
+  return (
+    <ScrollView onScroll={handleScroll}>
+      <LargeHeaderTitle paddingHorizontal="$4">Actions</LargeHeaderTitle>
+
+      {isFetching || !data ? <LoadingTx /> : <TxActionsList txDetails={data} />}
+    </ScrollView>
+  )
+}

--- a/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
+++ b/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
@@ -1,0 +1,73 @@
+import React, { useMemo } from 'react'
+import { Text, View, YStack } from 'tamagui'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { ActionValueDecoded, AddressInfoIndex } from '@safe-global/store/gateway/types'
+import { shortenAddress } from '@safe-global/utils/formatters'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { router } from 'expo-router'
+import { useLocalSearchParams } from 'expo-router'
+import { Container } from '@/src/components/Container'
+
+interface TxActionsListProps {
+  txDetails: TransactionDetails
+}
+
+export const getActionName = (action: ActionValueDecoded, addressInfoIndex?: AddressInfoIndex): string => {
+  const contractName = (addressInfoIndex as AddressInfoIndex)?.[action.to]?.name
+  let name = shortenAddress(action.to)
+
+  if (action.dataDecoded) {
+    name = action.dataDecoded.method
+  }
+
+  return contractName ? `${contractName}: ${name}` : action.dataDecoded?.method || 'contract interaction'
+}
+
+export function TxActionsList({ txDetails }: TxActionsListProps) {
+  const { txId } = useLocalSearchParams<{ txId: string }>()
+
+  const { dataDecoded, addressInfoIndex } = txDetails.txData || {}
+
+  const onActionPress = (action: ActionValueDecoded) => {
+    router.push({
+      pathname: '/action-details',
+      params: {
+        txId,
+        actionName: getActionName(action, addressInfoIndex as AddressInfoIndex),
+        action: JSON.stringify(action),
+      },
+    })
+  }
+
+  const transaction = dataDecoded?.parameters?.find((action) => action.name === 'transactions' && action.valueDecoded)
+  const actions = useMemo(() => {
+    return Array.isArray(transaction?.valueDecoded) ? transaction?.valueDecoded : [transaction?.valueDecoded]
+  }, [transaction])
+
+  return (
+    <YStack gap="$2" padding="$4">
+      {actions?.map((action, index) => (
+        <Container
+          key={`${getActionName(action, addressInfoIndex as AddressInfoIndex)}-${index}`}
+          padding="$42"
+          gap="$5"
+          borderRadius="$3"
+          onPress={() => onActionPress(action)}
+        >
+          <View alignItems="center" flexDirection="row" justifyContent="space-between" gap={'$2'} flexWrap="wrap">
+            <View flexDirection="row" alignItems="center" gap={'$3'} maxWidth="90%">
+              <SafeFontIcon name="transaction-contract" color="$colorSecondary" size={18} />
+              <Text marginRight={'$2'}>{index + 1}</Text>
+
+              <Text fontSize="$4" flexShrink={1} flexWrap="wrap">
+                {getActionName(action, addressInfoIndex as AddressInfoIndex)}
+              </Text>
+            </View>
+
+            <SafeFontIcon name="chevron-right" size={18} />
+          </View>
+        </Container>
+      ))}
+    </YStack>
+  )
+}

--- a/apps/mobile/src/features/TransactionActions/index.ts
+++ b/apps/mobile/src/features/TransactionActions/index.ts
@@ -1,0 +1,1 @@
+export { TransactionActionsContainer } from './TransactionActions.container'

--- a/packages/store/src/gateway/types.ts
+++ b/packages/store/src/gateway/types.ts
@@ -7,7 +7,7 @@ import {
   SwapTransferTransactionInfo,
   ModuleExecutionInfo,
   MultisigExecutionInfo,
-  Transaction,
+  AddressInfo,
 } from './AUTO_GENERATED/transactions'
 import { SafeOverview } from './AUTO_GENERATED/safes'
 
@@ -91,5 +91,23 @@ export type OrderTransactionInfo = SwapOrderTransactionInfo | TwapOrderTransacti
 
 export type PendingTransactionItems = QueuedItemPage['results'][number]
 export type HistoryTransactionItems = TransactionItemPage['results'][number]
+
+// TODO: fix CGW DataDecodedParameter type. The decodedValue is typed only as an object or object[] there.
+export type ActionValueDecoded = {
+  data: string
+  dataDecoded: {
+    method: string
+    parameters: {
+      name: string
+      type: string
+      value: string
+    }[]
+  }
+  operation: number
+  to: string
+  value: string
+}
+
+export type AddressInfoIndex = Record<string, AddressInfo>
 
 export type { BalancesGetSupportedFiatCodesV1ApiResponse as FiatCurrencies } from './AUTO_GENERATED/balances'


### PR DESCRIPTION
## What it solves
It create all the missing screens for the transaction actions.

## How to test it
- Go to any pending tx that has actions
- Click in the actions section
- You should be redirected to the actions list and inside of it, click in any of the item
- You should be redirected to the action details

## Video

https://github.com/user-attachments/assets/57bf4364-f2a1-406d-9d79-b071c094baeb



## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
