### PR TITLE
Tests: Update cy tests 

### DIFF
--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -119,6 +119,7 @@ export const txDetailsStr = 'Transaction details'
 export const settingsStr = 'Settings'
 export const assetsStr = 'Assets'
 export const topAssetsStr = 'Top assets'
+export const getStartedStr = 'Get started'
 
 export const txNoteWarningMessage = 'The notes are publicly visible, do not share any private or sensitive details'
 export const recordedTxNote = 'Tx note one'

--- a/apps/web/cypress/e2e/pages/sidebar.pages.js
+++ b/apps/web/cypress/e2e/pages/sidebar.pages.js
@@ -634,7 +634,7 @@ export function checkNetworksInRange(expectedString, expectedCount, direction = 
 
   return cy
     .get(startSelector)
-  [traversalMethod](endSelector, 'li')
+    [traversalMethod](endSelector, 'li')
     .then((liElements) => {
       expect(liElements.length).to.equal(expectedCount)
       const optionTexts = [...liElements].map((li) => li.innerText)

--- a/apps/web/cypress/e2e/pages/sidebar.pages.js
+++ b/apps/web/cypress/e2e/pages/sidebar.pages.js
@@ -634,7 +634,7 @@ export function checkNetworksInRange(expectedString, expectedCount, direction = 
 
   return cy
     .get(startSelector)
-    [traversalMethod](endSelector, 'li')
+  [traversalMethod](endSelector, 'li')
     .then((liElements) => {
       expect(liElements.length).to.equal(expectedCount)
       const optionTexts = [...liElements].map((li) => li.innerText)

--- a/apps/web/cypress/e2e/pages/swaps.pages.js
+++ b/apps/web/cypress/e2e/pages/swaps.pages.js
@@ -231,7 +231,7 @@ export function clickOnConfirmSwapBtn() {
 export function clickOnExceeFeeChkbox() {
   cy.wait(1000)
   cy.get(exceedFeesChkbox)
-    .should(() => { })
+    .should(() => {})
     .then(($button) => {
       if (!$button.length) {
         return
@@ -253,7 +253,7 @@ export function verifyReviewOrderBtnIsVisible() {
 export function clickOnReviewOrderBtn() {
   cy.get('button')
     .contains(swapAnywayStrBtn)
-    .should(() => { })
+    .should(() => {})
     .then(($button) => {
       if (!$button.length) {
         return
@@ -267,7 +267,7 @@ export function placeTwapOrder() {
   cy.wait(3000)
   cy.get('button')
     .contains(acceptStrBtn)
-    .should(() => { })
+    .should(() => {})
     .then(($button) => {
       if (!$button.length) {
         return
@@ -280,7 +280,7 @@ export function placeTwapOrder() {
 export function confirmPriceImpact() {
   cy.wait(3000)
   cy.get(confirmPriceImpactInput)
-    .should(() => { })
+    .should(() => {})
     .then(($input) => {
       if ($input.length) {
         cy.wrap($input).type('confirm')
@@ -480,7 +480,7 @@ export function verifyRecipientAlertIsDisplayed() {
 export function closeIntroTwapModal() {
   cy.get('button')
     .contains(unlockTwapOrdersStrBtn)
-    .should(() => { })
+    .should(() => {})
     .then(($button) => {
       if (!$button.length) {
         return

--- a/apps/web/cypress/e2e/pages/swaps.pages.js
+++ b/apps/web/cypress/e2e/pages/swaps.pages.js
@@ -231,7 +231,7 @@ export function clickOnConfirmSwapBtn() {
 export function clickOnExceeFeeChkbox() {
   cy.wait(1000)
   cy.get(exceedFeesChkbox)
-    .should(() => {})
+    .should(() => { })
     .then(($button) => {
       if (!$button.length) {
         return
@@ -253,41 +253,40 @@ export function verifyReviewOrderBtnIsVisible() {
 export function clickOnReviewOrderBtn() {
   cy.get('button')
     .contains(swapAnywayStrBtn)
-    .should(() => {})
+    .should(() => { })
     .then(($button) => {
       if (!$button.length) {
         return
       }
       cy.wrap($button).click()
     })
-  cy.get(reviewTwapBtn).click()
+  cy.get(reviewTwapBtn).should('be.enabled').click()
 }
 
 export function placeTwapOrder() {
   cy.wait(3000)
   cy.get('button')
     .contains(acceptStrBtn)
-    .should(() => {})
+    .should(() => { })
     .then(($button) => {
       if (!$button.length) {
         return
       }
       cy.wrap($button).click()
     })
-  cy.contains(placeTwapOrderStrBtn).click()
+  cy.get('button').contains(placeTwapOrderStrBtn).should('be.enabled').click()
 }
 
 export function confirmPriceImpact() {
   cy.wait(3000)
   cy.get(confirmPriceImpactInput)
-    .should(() => {})
+    .should(() => { })
     .then(($input) => {
-      if (!$input.length) {
-        return
+      if ($input.length) {
+        cy.wrap($input).type('confirm')
+        cy.get(confirmPriceImpactBtn).should('be.enabled').click()
       }
-      cy.wrap($input).type('confirm')
     })
-  cy.get(confirmPriceImpactBtn).should('be.enabled').click()
 }
 
 export function placeLimitOrder() {
@@ -481,7 +480,7 @@ export function verifyRecipientAlertIsDisplayed() {
 export function closeIntroTwapModal() {
   cy.get('button')
     .contains(unlockTwapOrdersStrBtn)
-    .should(() => {})
+    .should(() => { })
     .then(($button) => {
       if (!$button.length) {
         return

--- a/apps/web/cypress/e2e/prodhealthcheck/multichain_network.cy.js
+++ b/apps/web/cypress/e2e/prodhealthcheck/multichain_network.cy.js
@@ -18,13 +18,6 @@ describe('[PROD] Multichain add network tests', () => {
     staticSafes = await getSafes(CATEGORIES.static)
   })
 
-  beforeEach(() => {
-    cy.visit(constants.prodbaseUrl + constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
-    cy.contains(createTx.settingsStr, { timeout: 10000 })
-    closeSecurityNotice()
-    acceptCookies2()
-  })
-
   // TODO: Unskip after next release
   it.skip('Verify that zkSync network is not available as add network option for safes from other networks', () => {
     cy.visit(constants.prodbaseUrl + constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
@@ -37,17 +30,22 @@ describe('[PROD] Multichain add network tests', () => {
   })
 
   // Limitation: zkSync network does not support private key. Test might be flaky.
-  it('Verify that it is not possible to add networks for the zkSync safes', () => {
-    wallet.connectSigner(signer)
+  // Unskip after networkSelectorItem is released
+  it.skip('Verify that it is not possible to add networks for the zkSync safes', () => {
     cy.visit(constants.prodbaseUrl + constants.setupUrl + staticSafes.ZKSYNC_STATIC_SAFE_29)
+    cy.contains(createTx.settingsStr, { timeout: 10000 })
+    closeSecurityNotice()
+    wallet.connectSigner(signer)
     sideBar.openSidebar()
     create_wallet.openNetworkSelector()
     cy.contains(sideBar.addingNetworkNotPossibleStr)
   })
 
   it('Verify that zkSync network is not available during multichain safe creation', () => {
-    wallet.connectSigner(signer)
     cy.visit(constants.prodbaseUrl + constants.welcomeUrl + '?chain=sep')
+    cy.contains(createTx.getStartedStr, { timeout: 10000 })
+    closeSecurityNotice()
+    wallet.connectSigner(signer)
     create_wallet.clickOnContinueWithWalletBtn()
     create_wallet.clickOnCreateNewSafeBtn()
     create_wallet.selectMultiNetwork(1, constants.networks.polygon.toLowerCase())
@@ -55,8 +53,10 @@ describe('[PROD] Multichain add network tests', () => {
   })
 
   it('Verify that zkSync network is available as part of single safe creation flow ', () => {
-    wallet.connectSigner(signer)
     cy.visit(constants.prodbaseUrl + constants.welcomeUrl + '?chain=sep')
+    cy.contains(createTx.getStartedStr, { timeout: 10000 })
+    closeSecurityNotice()
+    wallet.connectSigner(signer)
     create_wallet.clickOnContinueWithWalletBtn()
     create_wallet.clickOnCreateNewSafeBtn()
     create_wallet.clearNetworkInput(1)
@@ -64,15 +64,19 @@ describe('[PROD] Multichain add network tests', () => {
     cy.contains('li', constants.networks.zkSync).should('not.have.attr', 'aria-disabled', 'true')
   })
 
-  it('Verify list of available networks for the safe deployed on one network with mastercopy 1.3.0', () => {
+  // Unskip after networkSelectorItem is released
+  it.skip('Verify list of available networks for the safe deployed on one network with mastercopy 1.3.0', () => {
     const safe = 'eth:0x55d93DF21332615D48EA0c0144c7b1D176F3e7cb'
     cy.visit(constants.prodbaseUrl + constants.setupUrl + safe)
+    cy.contains(createTx.settingsStr, { timeout: 10000 })
+    closeSecurityNotice()
     create_wallet.openNetworkSelector()
     sideBar.clickOnShowAllNetworksStrBtn()
     sideBar.checkNetworkDisabled([constants.networks.zkSync, constants.networks.gnosisChiado])
   })
 
-  it('Verify list of available networks for the safe deployed on one network with mastercopy 1.4.1', () => {
+  // Unskip after networkSelectorItem is released
+  it.skip('Verify list of available networks for the safe deployed on one network with mastercopy 1.4.1', () => {
     cy.visit(constants.prodbaseUrl + constants.setupUrl + staticSafes.MATIC_STATIC_SAFE_28)
     create_wallet.openNetworkSelector()
     sideBar.clickOnShowAllNetworksStrBtn()

--- a/apps/web/cypress/e2e/prodhealthcheck/tokens.cy.js
+++ b/apps/web/cypress/e2e/prodhealthcheck/tokens.cy.js
@@ -10,8 +10,7 @@ const FIAT_AMOUNT_COLUMN = 2
 let staticSafes = []
 
 describe('[PROD] Prod tokens tests', () => {
-  const domain = window.location.hostname
-  const value = domain === new URL(constants.prodbaseUrl).hostname ? assets.fiatRegex : '--'
+  const value = '--'
 
   before(async () => {
     staticSafes = await getSafes(CATEGORIES.static)

--- a/apps/web/cypress/e2e/regression/swaps.cy.js
+++ b/apps/web/cypress/e2e/regression/swaps.cy.js
@@ -112,7 +112,12 @@ describe('Swaps tests', () => {
       swaps.clickOnExceeFeeChkbox()
       swaps.clickOnSwapBtn()
       swaps.clickOnSwapBtn()
-      swaps.confirmPriceImpact()
+
+      cy.get(swaps.confirmPriceImpact).then(($input) => {
+        if ($input.length) {
+          swaps.confirmPriceImpact()
+        }
+      })
     })
 
     swaps.verifyOrderDetails(limitPrice, swapOrder.expiry2Mins, slippage, swapOrder.interactWith, orderID, widgetFee)

--- a/apps/web/cypress/e2e/regression/swaps_2.cy.js
+++ b/apps/web/cypress/e2e/regression/swaps_2.cy.js
@@ -63,7 +63,11 @@ describe('Swaps 2 tests', () => {
         swaps.clickOnSwapBtn()
         swaps.checkOutputCurrencyPreviewValue(value)
         swaps.clickOnSwapBtn()
-        swaps.confirmPriceImpact()
+        cy.get(swaps.confirmPriceImpact).then(($input) => {
+          if ($input.length) {
+            swaps.confirmPriceImpact()
+          }
+        })
       })
       swaps.checkTokenBlockValue(1, tokenValue)
     },

--- a/apps/web/cypress/e2e/regression/tokens.cy.js
+++ b/apps/web/cypress/e2e/regression/tokens.cy.js
@@ -11,8 +11,7 @@ const FIAT_AMOUNT_COLUMN = 2
 let staticSafes = []
 
 describe('Tokens tests', () => {
-  const domain = window.location.hostname
-  const value = domain === new URL(constants.prodbaseUrl).hostname ? assets.fiatRegex : '--'
+  const value = '--'
 
   before(async () => {
     staticSafes = await getSafes(CATEGORIES.static)

--- a/apps/web/cypress/e2e/regression/twaps_history.cy.js
+++ b/apps/web/cypress/e2e/regression/twaps_history.cy.js
@@ -43,7 +43,11 @@ describe('Twaps history tests', { defaultCommandTimeout: 30000 }, () => {
         cy.wrap(formData).as('twapFormData')
         swaps.clickOnReviewOrderBtn()
         swaps.placeTwapOrder()
-        swaps.confirmPriceImpact()
+        cy.get(swaps.confirmPriceImpact).then(($input) => {
+          if ($input.length) {
+            swaps.confirmPriceImpact()
+          }
+        })
       })
     })
 


### PR DESCRIPTION
## How this PR fixes it

- Network selector is now can be accessed only with data-tested. Since it is not available on prod yet, some multi-chain tests are skipped.
- Updated steps in multi-chain tests to handle security modal.
- Removed domain condition in tests to always check ‘--’ in non-native tokens.
- Updated logic in swap/twap tests to handle confirm price impact modal.

## How to test it

- Run Cypress tests and observe outcome.
