### PR TITLE
Fix(Orgs/Web): network tooltip position issue fixed for multichain safes (#5257)

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -50,23 +50,25 @@ import { getComparator } from '@/features/myAccounts/utils/utils'
 
 export const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
   return (
-    <Tooltip
-      title={
-        <Box data-testid="multichain-tooltip">
-          <Typography fontSize="14px">Multichain account on:</Typography>
-          {safes.map((safeItem) => (
-            <Box key={safeItem.chainId} sx={{ p: '4px 0px' }}>
-              <ChainIndicator chainId={safeItem.chainId} />
-            </Box>
-          ))}
+    <Box className={css.multiChains}>
+      <Tooltip
+        title={
+          <Box data-testid="multichain-tooltip">
+            <Typography fontSize="14px">Multichain account on:</Typography>
+            {safes.map((safeItem) => (
+              <Box key={safeItem.chainId} sx={{ p: '4px 0px' }}>
+                <ChainIndicator chainId={safeItem.chainId} />
+              </Box>
+            ))}
+          </Box>
+        }
+        arrow
+      >
+        <Box>
+          <NetworkLogosList networks={safes} showHasMore />
         </Box>
-      }
-      arrow
-    >
-      <Box className={css.multiChains}>
-        <NetworkLogosList networks={safes} showHasMore />
-      </Box>
-    </Tooltip>
+      </Tooltip>
+    </Box>
   )
 }
 


### PR DESCRIPTION
## What it solves

Resolves #5257 

## How this PR fixes it

The tooltip component actually refs to its parent component the problem with the old code was that the tooltip was referring to this css component and was opening according to this component :
 https://github.com/safe-global/safe-wallet-monorepo/blob/d793477e27d1cc60e31e99e564c8fd0370dfbad7/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx#L265
 
 Fix:
 Now we are wrapping the Tooltip with the box component which was earlier inside the tooltip component so now it refers to `css.multiChains` which contains the network elements:

```
<Box className={css.multiChains}>
      <Tooltip
        title={
          <Box data-testid="multichain-tooltip">
            <Typography fontSize="14px">Multichain account on:</Typography>
            {safes.map((safeItem) => (
              <Box key={safeItem.chainId} sx={{ p: '4px 0px' }}>
                <ChainIndicator chainId={safeItem.chainId} />
              </Box>
            ))}
          </Box>
        }
        arrow
      >
        <Box>
          <NetworkLogosList networks={safes} showHasMore />
        </Box>
      </Tooltip>
    </Box>
```

## How to test it
Hover over network icons of multichain safes in:
- Orgs/Safe Accounts
- Welcome/Safe Accounts
- Sidebar/Safe Accounts

## Screenshots
<img width="1368" alt="Screenshot 2025-03-14 at 3 54 29 PM" src="https://github.com/user-attachments/assets/106ee9b1-9d20-4ed6-a937-d3925b6433a7" />
<img width="1352" alt="Screenshot 2025-03-14 at 3 56 11 PM" src="https://github.com/user-attachments/assets/e5b1f211-fa7b-4f24-a8d8-a21d0d061929" />
<img width="1361" alt="Screenshot 2025-03-14 at 4 29 54 PM" src="https://github.com/user-attachments/assets/33c0ceb6-59a9-410a-b70a-995729c85c40" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
