### PR TITLE
fix: Show who invited you to their org

### DIFF
--- a/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
@@ -7,6 +7,8 @@ import { useState } from 'react'
 import AcceptInviteDialog from '@/features/organizations/components/Dashboard/AcceptInviteDialog'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import EthHashInfo from '@/components/common/EthHashInfo'
 
 type OrgListInvite = {
   org: GetOrganizationResponse
@@ -14,10 +16,14 @@ type OrgListInvite = {
 
 const OrgListInvite = ({ org }: OrgListInvite) => {
   const [inviteOpen, setInviteOpen] = useState(false)
+  const { currentData: currentUser } = useUsersGetWithWalletsV1Query()
   const [declineInvite] = useUserOrganizationsDeclineInviteV1Mutation()
   const { id, name, userOrganizations: members } = org
   const numberOfAccounts = useOrgSafeCount(id)
   const numberOfMembers = members.length
+
+  // @ts-ignore TODO: Need to fix the type once available
+  const invitedBy = org.userOrganizations.find((member) => member.user.id === currentUser.id)?.invitedBy
 
   const handleAcceptInvite = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -37,6 +43,19 @@ const OrgListInvite = ({ org }: OrgListInvite) => {
         You were invited to join{' '}
         <Typography component="span" variant="h4" fontWeight={700} color="primary.main">
           {name}
+        </Typography>{' '}
+        by
+        <Typography
+          component="span"
+          variant="h4"
+          fontWeight={700}
+          color="primary.main"
+          position="relative"
+          top="4px"
+          ml="6px"
+          display="inline-block"
+        >
+          {invitedBy && <EthHashInfo address={invitedBy} avatarSize={24} showName={false} showPrefix={false} />}
         </Typography>
       </Typography>
 

--- a/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/DashboardInvite.tsx
@@ -43,20 +43,25 @@ const OrgListInvite = ({ org }: OrgListInvite) => {
         You were invited to join{' '}
         <Typography component="span" variant="h4" fontWeight={700} color="primary.main">
           {name}
-        </Typography>{' '}
-        by
-        <Typography
-          component="span"
-          variant="h4"
-          fontWeight={700}
-          color="primary.main"
-          position="relative"
-          top="4px"
-          ml="6px"
-          display="inline-block"
-        >
-          {invitedBy && <EthHashInfo address={invitedBy} avatarSize={24} showName={false} showPrefix={false} />}
         </Typography>
+        {invitedBy && (
+          <>
+            {' '}
+            by
+            <Typography
+              component="span"
+              variant="h4"
+              fontWeight={700}
+              color="primary.main"
+              position="relative"
+              top="4px"
+              ml="6px"
+              display="inline-block"
+            >
+              <EthHashInfo address={invitedBy} avatarSize={24} showName={false} showPrefix={false} />
+            </Typography>
+          </>
+        )}
       </Typography>
 
       <Link href={{ pathname: AppRoutes.organizations.index, query: { orgId: id } }} passHref legacyBehavior>


### PR DESCRIPTION
## What it solves

Resolves #5337

## How this PR fixes it

- Adds the `invitedBy` value as an `EthHashInfo` to the pending invite card

## How to test it

1. Get invited to an org
2. Go to the orgs list page and sign in
3. Observe the address of the inviter is visible

## Screenshots
<img width="877" alt="Screenshot 2025-03-14 at 12 04 40" src="https://github.com/user-attachments/assets/91835b5e-ed3a-4d2c-8d20-56b9663ebc30" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
