### PR TITLE
fix: Add unsafe-inline to script-src CSP

### DIFF
--- a/apps/web/src/config/securityHeaders.ts
+++ b/apps/web/src/config/securityHeaders.ts
@@ -11,7 +11,7 @@ import { CYPRESS_MNEMONIC, IS_PRODUCTION } from '@/config/constants'
 export const ContentSecurityPolicy = `
  default-src 'self';
  connect-src 'self' *;
- script-src 'self' https://*.getbeamer.com https://www.googletagmanager.com https://*.ingest.sentry.io https://sentry.io ${
+ script-src 'self' 'unsafe-inline' https://*.getbeamer.com https://www.googletagmanager.com https://*.ingest.sentry.io https://sentry.io ${
    !IS_PRODUCTION || CYPRESS_MNEMONIC
      ? "'unsafe-eval'" // Dev server and cypress need unsafe-eval
      : "'wasm-unsafe-eval'"


### PR DESCRIPTION
## What it solves

Follow-up on #5201 

## How this PR fixes it

- Turns out GA still inserts an inline script to initialize the dataLayer with some configs which was being blocked

## How to test it

1. Open the app
2. Observe no inline errors in the console
3. Click around
4. Events are sent to GA

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
