### PR TITLE
Fix(Orgs): Update member name sort value

### DIFF
--- a/apps/web/src/features/organizations/components/Members/InvitesList.tsx
+++ b/apps/web/src/features/organizations/components/Members/InvitesList.tsx
@@ -46,7 +46,7 @@ const InvitesList = ({ invitedMembers }: { invitedMembers: UserOrganization[] })
     return {
       cells: {
         name: {
-          rawValue: member.user.id,
+          rawValue: member.name,
           content: (
             <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
               <MemberName member={member} />

--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -83,7 +83,7 @@ const MembersList = ({ members }: { members: UserOrganization[] }) => {
     return {
       cells: {
         name: {
-          rawValue: member.user.id,
+          rawValue: member.name,
           content: <MemberName member={member} />,
         },
         role: {


### PR DESCRIPTION
## What it solves

Resolves #5344 

## How this PR fixes it

- The table rawValue for the name column was still using the `member.user.id` instead of `member.name`

## How to test it

1. Open an org with a couple of members
2. Sort members by name
3. Members should be sorted alphabetically 

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
