### PR TITLE
Fix(Orgs): Trim NameInput values

### DIFF
--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -26,7 +26,11 @@ const NameInput = ({
       required={required}
       className={inputCss.input}
       onKeyDown={(e) => e.stopPropagation()}
-      {...register(name, { maxLength: 50, required })}
+      {...register(name, {
+        maxLength: 50,
+        required,
+        setValueAs: (value) => value.trim(),
+      })}
     />
   )
 }


### PR DESCRIPTION
## What it solves

Resolves #5346

## How this PR fixes it

- Trims the input value in `NameInput` so that empty spaces are not allowed

## How to test it

1. Open an org
2. Add a member
3. Try adding empty spaces as the member name
4. Form should display an error and not let you submit

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
