### PR TITLE
Feat(web): detect official IPFS deployments

### DIFF
--- a/apps/web/src/config/constants.ts
+++ b/apps/web/src/config/constants.ts
@@ -107,7 +107,7 @@ export const TWITTER_URL = 'https://twitter.com/safe'
 // Legal
 export const IS_OFFICIAL_HOST = process.env.NEXT_PUBLIC_IS_OFFICIAL_HOST === 'true'
 export const OFFICIAL_HOSTS = /app\.safe\.global|.+\.5afe\.dev|localhost:3000/
-export const IPFS_HOStS = /\.ipfs\.dweb\.link|\.ipfs\.w3s\.link|\.ipfs\.inbrowser\.link/
+export const IPFS_HOSTS = /\.ipfs\.dweb\.link|\.ipfs\.w3s\.link|\.ipfs\.inbrowser\.link/
 export const BRAND_NAME = process.env.NEXT_PUBLIC_BRAND_NAME || (IS_OFFICIAL_HOST ? 'Safe{Wallet}' : 'Wallet fork')
 export const BRAND_LOGO = process.env.NEXT_PUBLIC_BRAND_LOGO || ''
 

--- a/apps/web/src/config/constants.ts
+++ b/apps/web/src/config/constants.ts
@@ -107,6 +107,7 @@ export const TWITTER_URL = 'https://twitter.com/safe'
 // Legal
 export const IS_OFFICIAL_HOST = process.env.NEXT_PUBLIC_IS_OFFICIAL_HOST === 'true'
 export const OFFICIAL_HOSTS = /app\.safe\.global|.+\.5afe\.dev|localhost:3000/
+export const IPFS_HOStS = /\.ipfs\.dweb\.link|\.ipfs\.w3s\.link|\.ipfs\.inbrowser\.link/
 export const BRAND_NAME = process.env.NEXT_PUBLIC_BRAND_NAME || (IS_OFFICIAL_HOST ? 'Safe{Wallet}' : 'Wallet fork')
 export const BRAND_LOGO = process.env.NEXT_PUBLIC_BRAND_LOGO || ''
 

--- a/apps/web/src/hooks/useIsOfficialHost.ts
+++ b/apps/web/src/hooks/useIsOfficialHost.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { IPFS_HOStS, IS_OFFICIAL_HOST, OFFICIAL_HOSTS } from '@/config/constants'
+import { IPFS_HOSTS, IS_OFFICIAL_HOST, OFFICIAL_HOSTS } from '@/config/constants'
 import { version } from '../../../../package.json'
 import useAsync from './useAsync'
 
@@ -21,7 +21,7 @@ async function isOfficialIpfs(): Promise<boolean> {
 }
 
 function isIpfs() {
-  return IPFS_HOStS.test(window.location.host)
+  return IPFS_HOSTS.test(window.location.host)
 }
 
 export const useIsOfficialHost = (): boolean => {

--- a/apps/web/src/hooks/useIsOfficialHost.ts
+++ b/apps/web/src/hooks/useIsOfficialHost.ts
@@ -1,9 +1,39 @@
 import { useMemo } from 'react'
-import { IS_OFFICIAL_HOST, OFFICIAL_HOSTS } from '@/config/constants'
+import { IPFS_HOStS, IS_OFFICIAL_HOST, OFFICIAL_HOSTS } from '@/config/constants'
+import { version } from '../../../../package.json'
+import useAsync from './useAsync'
+
+const GITHUB_API_URL = 'https://api.github.com/repos/5afe/safe-wallet-ipfs/releases/tags/'
+
+async function getGithubRelease(version: string) {
+  const resp = await fetch(`${GITHUB_API_URL}/v${version}`, {
+    headers: {
+      Accept: 'application/vnd.github.v3+json',
+    },
+  })
+  if (!resp.ok) return false
+  return await resp.json()
+}
+
+async function isOfficialIpfs(): Promise<boolean> {
+  const data = await getGithubRelease(version)
+  return data.body.includes(window.location.host)
+}
+
+function isIpfs() {
+  return IPFS_HOStS.test(window.location.host)
+}
 
 export const useIsOfficialHost = (): boolean => {
-  return useMemo(
+  const isOfficialHost = useMemo(
     () => IS_OFFICIAL_HOST && (typeof window === 'undefined' || OFFICIAL_HOSTS.test(window.location.host)),
     [],
   )
+
+  const [isTrustedIpfs = false] = useAsync<boolean>(() => {
+    if (isOfficialHost || !isIpfs()) return
+    return isOfficialIpfs()
+  }, [isOfficialHost])
+
+  return isOfficialHost || isTrustedIpfs
 }


### PR DESCRIPTION
## What it solves

Display the Safe Wallet logo, as well as Terms and Privacy links in the footer for official IPFS deployments.

To detect such a deployment:

* We check the page host
* If it's one of the IPFS domains, get the version of the app
* Fetch the release notes for this version from our [IPFS repo](https://github.com/5afe/safe-wallet-ipfs/releases/tag/v1.53.0)
* If the current host matches the links in the release, it's an official deployment
