### PR TITLE
Fix(Orgs): Signs out properly after disconnect from EOA (#5249)

### DIFF
--- a/apps/web/src/hooks/wallets/useOnboard.ts
+++ b/apps/web/src/hooks/wallets/useOnboard.ts
@@ -7,11 +7,12 @@ import useChains, { useCurrentChain } from '@/hooks/useChains'
 import ExternalStore from '@/services/ExternalStore'
 import { logError, Errors } from '@/services/exceptions'
 import { trackEvent, WALLET_EVENTS } from '@/services/analytics'
-import { useAppSelector } from '@/store'
+import { useAppSelector, useAppDispatch } from '@/store'
 import { type EnvState, selectRpc } from '@/store/settingsSlice'
 import { formatAmount } from '@/utils/formatNumber'
 import { localItem } from '@/services/local-storage/local'
 import { isWalletConnect, isWalletUnlocked } from '@/utils/wallets'
+import { setUnauthenticated } from '@/store/authSlice'
 
 export type ConnectedWallet = {
   label: string
@@ -160,6 +161,7 @@ export const useInitOnboard = () => {
   const chain = useCurrentChain()
   const onboard = useStore()
   const customRpc = useAppSelector(selectRpc)
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (configs.length > 0 && chain) {
@@ -199,13 +201,14 @@ export const useInitOnboard = () => {
       } else if (lastConnectedWallet) {
         lastConnectedWallet = ''
         saveLastWallet(lastConnectedWallet)
+        dispatch(setUnauthenticated())
       }
     })
 
     return () => {
       walletSubscription.unsubscribe()
     }
-  }, [onboard])
+  }, [onboard, dispatch])
 }
 
 export default useStore


### PR DESCRIPTION
## What it solves

Resolves #5249 

## How this PR fixes it
In `apps/web/src/store/authSlice.ts`:

The `isAuthenticated` was true even after disconnecting EOA turns out 
`setUnauthenticated()` in authSlice was not dispatched.

So In `useOnboard` wallet hook:

```
 // Track connected wallet
  useEffect(() => {
    let lastConnectedWallet = ''
    if (!onboard) return

    const walletSubscription = onboard.state.select('wallets').subscribe((wallets) => {
      const newWallet = getConnectedWallet(wallets)
      if (newWallet) {
        if (newWallet.label !== lastConnectedWallet) {
          lastConnectedWallet = newWallet.label
          saveLastWallet(lastConnectedWallet)
          trackWalletType(newWallet)
        }
      } else if (lastConnectedWallet) {
        lastConnectedWallet = ''
        saveLastWallet(lastConnectedWallet)
        dispatch(setUnauthenticated()). // dispatching setUnauthenticated() to mark isAuthenticated false resets queries
      }
    })
```



## How to test it
After loading up organizations  disconnect your EOA.

## Screen-Recording

https://github.com/user-attachments/assets/fbce47ed-cab1-4ce6-b698-ff027995f81d



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
