### PR TITLE
feat(Signing UX): adds receipt step to NftTransferFlow + RemoveGuardFlow

### DIFF
--- a/apps/web/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
+++ b/apps/web/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
@@ -5,9 +5,9 @@ import { createNftTransferParams } from '@/services/tx/tokenTransferParams'
 import type { NftTransferParams } from '.'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import { createMultiSendCallOnlyTx, createTx } from '@/services/tx/tx-sender'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { SafeTxContext } from '../../SafeTxProvider'
 import { NftItems } from '@/components/tx-flow/flows/NftTransfer/SendNftBatch'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
 type ReviewNftBatchProps = {
   params: NftTransferParams
@@ -39,7 +39,7 @@ const ReviewNftBatch = ({ params, onSubmit, txNonce }: ReviewNftBatchProps): Rea
   }, [safeAddress, params, setSafeTx, setSafeTxError])
 
   return (
-    <SignOrExecuteForm onSubmit={onSubmit}>
+    <ReviewTransaction onSubmit={onSubmit}>
       <Grid
         container
         sx={{
@@ -63,7 +63,7 @@ const ReviewNftBatch = ({ params, onSubmit, txNonce }: ReviewNftBatchProps): Rea
         </Grid>
       </Grid>
       <SendToBlock address={params.recipient} />
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }
 

--- a/apps/web/src/components/tx-flow/flows/NftTransfer/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NftTransfer/index.tsx
@@ -1,9 +1,12 @@
 import type { SafeCollectibleResponse } from '@safe-global/safe-gateway-typescript-sdk'
 import NftIcon from '@/public/images/common/nft.svg'
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '@/components/tx-flow/common/TxLayout'
 import useTxStepper from '../../useTxStepper'
 import SendNftBatch from './SendNftBatch'
 import ReviewNftBatch from './ReviewNftBatch'
+import { useMemo } from 'react'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 export type NftTransferParams = {
   recipient: string
@@ -25,21 +28,33 @@ const NftTransferFlow = ({ txNonce, ...params }: NftTransferFlowProps) => {
     ...params,
   })
 
-  const steps = [
-    <SendNftBatch key={0} params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />,
-
-    <ReviewNftBatch key={1} params={data} txNonce={txNonce} onSubmit={() => null} />,
-  ]
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'New transaction' },
+        content: <SendNftBatch key={0} params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ReviewNftBatch key={1} params={data} txNonce={txNonce} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data, txNonce],
+  )
 
   return (
     <TxLayout
-      title={step === 0 ? 'New transaction' : 'Confirm transaction'}
       subtitle="Send NFTs"
       icon={NftIcon}
       step={step}
       onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      {steps}
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveGuard/ReviewRemoveGuard.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveGuard/ReviewRemoveGuard.tsx
@@ -1,18 +1,14 @@
-import { useContext, useEffect } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 import { Typography } from '@mui/material'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { Errors, logError } from '@/services/exceptions'
 import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
 import { createRemoveGuardTx } from '@/services/tx/tx-sender'
 import { type RemoveGuardFlowProps } from '.'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-const onFormSubmit = () => {
-  trackEvent(SETTINGS_EVENTS.MODULES.REMOVE_GUARD)
-}
-
-export const ReviewRemoveGuard = ({ params }: { params: RemoveGuardFlowProps }) => {
+export const ReviewRemoveGuard = ({ params, onSubmit }: { params: RemoveGuardFlowProps; onSubmit: () => void }) => {
   const { setSafeTx, safeTxError, setSafeTxError } = useContext(SafeTxContext)
 
   useEffect(() => {
@@ -25,8 +21,13 @@ export const ReviewRemoveGuard = ({ params }: { params: RemoveGuardFlowProps }) 
     }
   }, [safeTxError])
 
+  const onFormSubmit = useCallback(() => {
+    trackEvent(SETTINGS_EVENTS.MODULES.REMOVE_GUARD)
+    onSubmit()
+  }, [onSubmit])
+
   return (
-    <SignOrExecuteForm onSubmit={onFormSubmit}>
+    <ReviewTransaction onSubmit={onFormSubmit}>
       <Typography sx={({ palette }) => ({ color: palette.primary.light })}>Transaction guard</Typography>
 
       <EthHashInfo address={params.address} showCopyButton hasExplorer shortAddress={false} />
@@ -35,6 +36,6 @@ export const ReviewRemoveGuard = ({ params }: { params: RemoveGuardFlowProps }) 
         Once the transaction guard has been removed, checks by the transaction guard will not be conducted before or
         after any subsequent transactions.
       </Typography>
-    </SignOrExecuteForm>
+    </ReviewTransaction>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/RemoveGuard/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveGuard/index.tsx
@@ -1,5 +1,9 @@
 import TxLayout from '@/components/tx-flow/common/TxLayout'
+import type { TxStep } from '../../common/TxLayout'
 import { ReviewRemoveGuard } from '@/components/tx-flow/flows/RemoveGuard/ReviewRemoveGuard'
+import useTxStepper from '../../useTxStepper'
+import { useMemo } from 'react'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 // TODO: This can possibly be combined with the remove module type
 export type RemoveGuardFlowProps = {
@@ -7,9 +11,25 @@ export type RemoveGuardFlowProps = {
 }
 
 const RemoveGuardFlow = ({ address }: RemoveGuardFlowProps) => {
+  const { data, step, nextStep, prevStep } = useTxStepper(null)
+
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <ReviewRemoveGuard key={0} params={{ address }} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data, address],
+  )
+
   return (
-    <TxLayout title="Confirm transaction" subtitle="Remove guard">
-      <ReviewRemoveGuard params={{ address }} />
+    <TxLayout subtitle="Remove guard" step={step} onBack={prevStep} {...(steps?.[step]?.txLayoutProps || {})}>
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }


### PR DESCRIPTION
## What it solves

Adds the new transaction receipt step to the following flows:
* NftTransferFlow
* RemoveGuardFlow

**Note**: I haven't been able to test it yet, because I'm missing a Safe that has the conditions for both flows (holds an NFT or has a guard defined).