### PR TITLE
Fix(Orgs): Hide settings page for non admins

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsSettings/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSettings/index.tsx
@@ -27,7 +27,7 @@ import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
 import { isAuthenticated } from '@/store/authSlice'
-import { useIsInvited } from '@/features/organizations/hooks/useOrgMembers'
+import { useIsAdmin, useIsInvited } from '@/features/organizations/hooks/useOrgMembers'
 import PreviewInvite from '@/features/organizations/components/InviteBanner/PreviewInvite'
 import css from './styles.module.css'
 
@@ -47,6 +47,7 @@ type OrganizationFormData = {
 
 const OrgsSettings = () => {
   const [deleteOrgOpen, setDeleteOrgOpen] = useState(false)
+  const isAdmin = useIsAdmin()
   const router = useRouter()
   const dispatch = useAppDispatch()
   const orgId = useCurrentOrgId()
@@ -120,7 +121,7 @@ const OrgsSettings = () => {
                   slotProps={{ inputLabel: { shrink: true } }}
                 />
 
-                <Button variant="contained" type="submit" sx={{ mt: 2 }} disabled={!isNameChanged}>
+                <Button variant="contained" type="submit" sx={{ mt: 2 }} disabled={!isNameChanged || !isAdmin}>
                   Save
                 </Button>
               </form>
@@ -140,6 +141,7 @@ const OrgsSettings = () => {
               onClick={() => {
                 setDeleteOrgOpen(true)
               }}
+              disabled={!isAdmin}
             >
               Delete organization
             </Button>

--- a/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarNavigation/config.tsx
@@ -15,6 +15,7 @@ export type DynamicNavItem = {
   href: string
   tag?: ReactElement
   disabled?: boolean
+  adminOnly?: boolean
 }
 
 export const navItems: DynamicNavItem[] = [
@@ -51,5 +52,6 @@ export const navItems: DynamicNavItem[] = [
     label: 'Settings',
     icon: <SvgIcon component={SettingsIcon} inheritViewBox />,
     href: AppRoutes.organizations.settings,
+    adminOnly: true,
   },
 ]

--- a/apps/web/src/features/organizations/components/OrgsSidebarNavigation/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsSidebarNavigation/index.tsx
@@ -8,17 +8,22 @@ import {
   SidebarListItemIcon,
   SidebarListItemText,
 } from '@/components/sidebar/SidebarList'
+import { useCurrentOrgId } from '@/features/organizations/hooks/useCurrentOrgId'
+import { useIsAdmin } from '@/features/organizations/hooks/useOrgMembers'
 import { navItems } from './config'
-import { useCurrentOrgId } from '../../hooks/useCurrentOrgId'
 
 const Navigation = (): ReactElement => {
   const router = useRouter()
   const orgId = useCurrentOrgId()
+  const isAdmin = useIsAdmin()
 
   return (
     <SidebarList>
       {navItems.map((item) => {
+        const hideItem = item.adminOnly && !isAdmin
         const isSelected = router.pathname === item.href
+
+        if (hideItem) return null
 
         return (
           <div key={item.label}>


### PR DESCRIPTION
## What it solves

Resolves #5315

## How this PR fixes it
- Disables all buttons on the settings page for non admins
- hides the settings page in the sidebar for non admins

## How to test it
- sign in to an org as a non member
- See that the settings page is not in the sidebar menu
- go to the settings page directly `/organizations/settings?orgId={orgId}`
- see that all the buttons are disabled

## Screenshots
![image](https://github.com/user-attachments/assets/34a2cce1-0150-4ab2-878e-200157b0fdb8)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
