### PR TITLE
Fix(Orgs): add declined chip back to invites list

### DIFF
--- a/apps/web/src/features/organizations/components/MembersList/index.tsx
+++ b/apps/web/src/features/organizations/components/MembersList/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Chip, IconButton, SvgIcon, Tooltip } from '@mui/material'
+import { Box, Chip, IconButton, Stack, SvgIcon, Tooltip } from '@mui/material'
 import { type UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import EditIcon from '@/public/images/common/edit.svg'
 import DeleteIcon from '@/public/images/common/delete.svg'
@@ -87,11 +87,19 @@ const MembersList = ({ members }: { members: UserOrganization[] }) => {
   const rows = members.map((member) => {
     const isLastAdmin = adminCount === 1 && member.role === MemberRole.ADMIN
     const isInvite = member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED
+    const isDeclined = member.status === MemberStatus.DECLINED
     return {
       cells: {
         name: {
           rawValue: member.name,
-          content: <MemberName member={member} />,
+          content: (
+            <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
+              <MemberName member={member} />
+              {isDeclined && (
+                <Chip label="Declined" size="small" sx={{ backgroundColor: 'error.light', borderRadius: 0.5 }} />
+              )}
+            </Stack>
+          ),
         },
         role: {
           rawValue: member.role,


### PR DESCRIPTION
## What it solves
The chip was accidentally removed during a refactor in a previous PR

## How this PR fixes it
Adds the chip back in when a member in the invites list has declined the invite.

## How to test it
- Invite a user to an org
- decline the invite
- from the inviter wallet, view the pending invites list

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
