### PR TITLE
Fix(Orgs): update snapshots for unit tests after theme update

### DIFF
--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
@@ -357,7 +357,7 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
         Transaction checks
       </h5>
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-c7us71-MuiPaper-root-MuiAlert-root"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-8hu1mc-MuiPaper-root-MuiAlert-root"
         role="alert"
         style="--Paper-shadow: none;"
       >
@@ -690,7 +690,7 @@ exports[`SignOrExecute should display an error screen 1`] = `
         Transaction checks
       </h5>
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-c7us71-MuiPaper-root-MuiAlert-root"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorInfo MuiAlert-standardInfo MuiAlert-standard css-8hu1mc-MuiPaper-root-MuiAlert-root"
         role="alert"
         style="--Paper-shadow: none;"
       >


### PR DESCRIPTION
## What it solves

Unit tests were failing after https://github.com/safe-global/safe-wallet-monorepo/pull/5340 was merged, which updated on of the palette colors, causing some of the auto generated css class names to change.

## How this PR fixes it
- updates the unit test snapshots with the new palette color change.

## How to test it
- run tests

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
