### PR TITLE
Fix(Orgs): Add links to orgs list from dashboard banner

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsCreationModal/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCreationModal/index.tsx
@@ -78,7 +78,7 @@ function OrgsCreationModal({ onClose }: { onClose: () => void }): ReactElement {
             <Button data-testid="cancel-btn" onClick={onClose}>
               Cancel
             </Button>
-            <Button type="submit" variant="contained" disabled={!formState.isValid} disableElevation>
+            <Button type="submit" variant="contained" disabled={!formState.isValid || isSubmitting} disableElevation>
               {isSubmitting ? <CircularProgress size={20} /> : 'Create organization'}
             </Button>
           </DialogActions>

--- a/apps/web/src/features/organizations/components/OrgsDashboardWidget/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsDashboardWidget/index.tsx
@@ -3,6 +3,8 @@ import Track from '@/components/common/Track'
 import OrgsCreationModal from '../OrgsCreationModal'
 import OrgsInfoModal from '../OrgsInfoModal'
 import { useState } from 'react'
+import Link from 'next/link'
+import { AppRoutes } from '@/config/routes'
 
 const gradientBg = {
   background: 'linear-gradient(225deg, rgba(95, 221, 255, 0.15) 12.5%, rgba(18, 255, 128, 0.15) 88.07%)',
@@ -36,13 +38,13 @@ const OrgsDashboardWidget = () => {
           </Track>
 
           <Track action="" category="" label="dashboard">
-            <Button variant="contained" onClick={() => setIsCreationOpen(true)}>
-              Try now
-            </Button>
+            <Link href={AppRoutes.welcome.organizations} passHref>
+              <Button variant="contained">Try now</Button>
+            </Link>
           </Track>
         </Stack>
       </Stack>
-      {isInfoOpen && <OrgsInfoModal onCreate={() => setIsCreationOpen(true)} onClose={() => setIsInfoOpen(false)} />}
+      {isInfoOpen && <OrgsInfoModal onClose={() => setIsInfoOpen(false)} />}
       {isCreationOpen && <OrgsCreationModal onClose={() => setIsCreationOpen(false)} />}
     </>
   )

--- a/apps/web/src/features/organizations/components/OrgsInfoModal/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsInfoModal/index.tsx
@@ -16,6 +16,8 @@ import CheckIcon from '@/public/images/common/check.svg'
 import CloseIcon from '@mui/icons-material/Close'
 import CreateOrgInfo from '@/public/images/orgs/create_org_info.png'
 import Image from 'next/image'
+import { AppRoutes } from '@/config/routes'
+import Link from 'next/link'
 
 const ListIcon = () => (
   <ListItemIcon
@@ -40,12 +42,7 @@ const ListIcon = () => (
   </ListItemIcon>
 )
 
-const OrgsInfoModal = ({ onClose, onCreate }: { onClose: () => void; onCreate: () => void }) => {
-  const handleCreate = () => {
-    onClose()
-    onCreate()
-  }
-
+const OrgsInfoModal = ({ onClose }: { onClose: () => void }) => {
   return (
     <Dialog open PaperProps={{ style: { width: '870px', maxWidth: '98%', borderRadius: '16px' } }} onClose={onClose}>
       <DialogContent dividers sx={{ p: 0, border: 0 }}>
@@ -87,9 +84,11 @@ const OrgsInfoModal = ({ onClose, onCreate }: { onClose: () => void; onCreate: (
             </List>
 
             <Stack gap={2} mt="auto">
-              <Button variant="contained" color="primary" onClick={handleCreate}>
-                Create an organization
-              </Button>
+              <Link href={AppRoutes.welcome.organizations} passHref legacyBehavior>
+                <Button variant="contained" color="primary">
+                  Create an organization
+                </Button>
+              </Link>
 
               <Button variant="text" color="primary" onClick={onClose}>
                 Maybe later
@@ -110,7 +109,7 @@ const OrgsInfoModal = ({ onClose, onCreate }: { onClose: () => void; onCreate: (
             right: 0,
             p: 1,
             m: 1,
-            color: 'background.paper',
+            color: '#ffffff',
           }}
         >
           <CloseIcon />


### PR DESCRIPTION
## What it solves

Resolves #5366

## How this PR fixes it

- Adds `Links` to the Try now buttons on the dashboard banner for orgs

## How to test it

1. Open a safes dashboard
2. Press on the Try now button in the banner
3. Observe being navigated to the orgs list

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
