### PR TITLE
Fix(Orgs): re-trigger validation of safe address when chain id changes

### DIFF
--- a/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
@@ -78,7 +78,7 @@ const AddManually = ({ handleAddSafe }: { handleAddSafe: (data: AddManuallyFormV
     if (address) {
       trigger('address')
     }
-  }, [chainId, trigger, watch])
+  }, [address, chainId, trigger])
 
   return (
     <>

--- a/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/AddManually.tsx
@@ -8,7 +8,7 @@ import useChains from '@/hooks/useChains'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { Button, DialogActions, DialogContent, MenuItem, Select, Stack, Box } from '@mui/material'
 import { getSafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 
 export type AddManuallyFormValues = {
@@ -28,9 +28,10 @@ const AddManually = ({ handleAddSafe }: { handleAddSafe: (data: AddManuallyFormV
     },
   })
 
-  const { handleSubmit, watch, register, reset, formState } = formMethods
+  const { handleSubmit, watch, register, reset, formState, trigger } = formMethods
 
   const chainId = watch('chainId')
+  const address = watch('address')
   const selectedChain = configs.find((chain) => chain.chainId === chainId)
 
   const onSubmit = handleSubmit((data) => {
@@ -71,6 +72,13 @@ const AddManually = ({ handleAddSafe }: { handleAddSafe: (data: AddManuallyFormV
   )
 
   const chainIdField = register('chainId')
+
+  // Re-validate when chainId changes
+  useEffect(() => {
+    if (address) {
+      trigger('address')
+    }
+  }, [chainId, trigger, watch])
 
   return (
     <>


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-monorepo/issues/5275#issuecomment-2724543297

## How this PR fixes it
- re triggers validation of the address input in the add account modal when the selected chain is changed.

## How to test it
- go to the add address modal. 
- Click add manually
- paste the address of a safe that exists on the currently selected chain. No validation error should be shown and the submit button enabled
- change the chain. A validation error should show and the submit should be disabled.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
