### PR TITLE
feat(Signing UX): tracking

### DIFF
--- a/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
@@ -7,6 +7,7 @@ import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import { useMemo } from 'react'
+import { EventCategory } from '@/services/analytics'
 
 type Owner = {
   address: string
@@ -20,7 +21,7 @@ export type AddOwnerFlowProps = {
 }
 
 const FlowInner = ({ defaultValues }: { defaultValues: AddOwnerFlowProps }) => {
-  const { data, step, nextStep, prevStep } = useTxStepper<AddOwnerFlowProps>(defaultValues)
+  const { data, step, nextStep, prevStep } = useTxStepper<AddOwnerFlowProps>(defaultValues, EventCategory.ADD_OWNER)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/AddOwner/index.tsx
@@ -7,7 +7,7 @@ import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import { useMemo } from 'react'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 type Owner = {
   address: string
@@ -21,7 +21,7 @@ export type AddOwnerFlowProps = {
 }
 
 const FlowInner = ({ defaultValues }: { defaultValues: AddOwnerFlowProps }) => {
-  const { data, step, nextStep, prevStep } = useTxStepper<AddOwnerFlowProps>(defaultValues, EventCategory.ADD_OWNER)
+  const { data, step, nextStep, prevStep } = useTxStepper<AddOwnerFlowProps>(defaultValues, TxFlowType.ADD_OWNER)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
@@ -1,6 +1,4 @@
-import { CANCEL_RECOVERY_CATEGORY } from '@/services/analytics/events/recovery'
 import { useMemo, type ReactElement } from 'react'
-
 import TxLayout from '../../common/TxLayout'
 import type { TxStep } from '../../common/TxLayout'
 import { CancelRecoveryFlowReview } from './CancelRecoveryFlowReview'
@@ -8,11 +6,12 @@ import { CancelRecoveryOverview } from './CancelRecoveryOverview'
 import useTxStepper from '../../useTxStepper'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 const TITLE = 'Cancel Account recovery'
 
 function CancelRecoveryFlow({ recovery }: { recovery: RecoveryQueueItem }): ReactElement {
-  const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, CANCEL_RECOVERY_CATEGORY)
+  const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, EventCategory.CANCEL_RECOVERY)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
@@ -6,12 +6,12 @@ import { CancelRecoveryOverview } from './CancelRecoveryOverview'
 import useTxStepper from '../../useTxStepper'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 const TITLE = 'Cancel Account recovery'
 
 function CancelRecoveryFlow({ recovery }: { recovery: RecoveryQueueItem }): ReactElement {
-  const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, EventCategory.CANCEL_RECOVERY)
+  const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, TxFlowType.CANCEL_RECOVERY)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/ChangeThreshold/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ChangeThreshold/index.tsx
@@ -7,6 +7,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import { ChooseThreshold } from '@/components/tx-flow/flows/ChangeThreshold/ChooseThreshold'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import { useMemo } from 'react'
+import { EventCategory } from '@/services/analytics'
 
 export enum ChangeThresholdFlowFieldNames {
   threshold = 'threshold',
@@ -19,9 +20,12 @@ export type ChangeThresholdFlowProps = {
 const ChangeThresholdFlow = () => {
   const { safe } = useSafeInfo()
 
-  const { data, step, nextStep, prevStep } = useTxStepper<ChangeThresholdFlowProps>({
-    [ChangeThresholdFlowFieldNames.threshold]: safe.threshold,
-  })
+  const { data, step, nextStep, prevStep } = useTxStepper<ChangeThresholdFlowProps>(
+    {
+      [ChangeThresholdFlowFieldNames.threshold]: safe.threshold,
+    },
+    EventCategory.CHANGE_THRESHOLD,
+  )
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/ChangeThreshold/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ChangeThreshold/index.tsx
@@ -7,7 +7,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import { ChooseThreshold } from '@/components/tx-flow/flows/ChangeThreshold/ChooseThreshold'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import { useMemo } from 'react'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 export enum ChangeThresholdFlowFieldNames {
   threshold = 'threshold',
@@ -24,7 +24,7 @@ const ChangeThresholdFlow = () => {
     {
       [ChangeThresholdFlowFieldNames.threshold]: safe.threshold,
     },
-    EventCategory.CHANGE_THRESHOLD,
+    TxFlowType.CHANGE_THRESHOLD,
   )
 
   const steps = useMemo<TxStep[]>(

--- a/apps/web/src/components/tx-flow/flows/ConfirmBatch/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmBatch/index.tsx
@@ -12,6 +12,7 @@ import { maybePlural } from '@/utils/formatters'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import useTxStepper from '../../useTxStepper'
 import ReviewTransaction from '@/components/tx/ReviewTransaction'
+import { EventCategory } from '@/services/analytics'
 
 type ConfirmBatchProps = {
   onSubmit: () => void
@@ -40,20 +41,20 @@ const ConfirmBatch = ({ onSubmit }: ConfirmBatchProps): ReactElement => {
 
 const ConfirmBatchFlow = (props: ConfirmBatchProps) => {
   const { length } = useDraftBatch()
-  const { data, step, nextStep, prevStep } = useTxStepper({})
+  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.CONFIRM_BATCH)
 
   const steps = useMemo<TxStep[]>(
     () => [
       {
         txLayoutProps: { title: 'Confirm batch' },
-        content: <ConfirmBatch key={0} onSubmit={() => nextStep(data)} />,
+        content: <ConfirmBatch key={0} onSubmit={() => nextStep(undefined)} />,
       },
       {
         txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
         content: <ConfirmTxDetails key={1} {...props} />,
       },
     ],
-    [nextStep, data, props],
+    [nextStep, props],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/flows/ConfirmBatch/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmBatch/index.tsx
@@ -12,7 +12,7 @@ import { maybePlural } from '@/utils/formatters'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import useTxStepper from '../../useTxStepper'
 import ReviewTransaction from '@/components/tx/ReviewTransaction'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 type ConfirmBatchProps = {
   onSubmit: () => void
@@ -41,7 +41,7 @@ const ConfirmBatch = ({ onSubmit }: ConfirmBatchProps): ReactElement => {
 
 const ConfirmBatchFlow = (props: ConfirmBatchProps) => {
   const { length } = useDraftBatch()
-  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.CONFIRM_BATCH)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, TxFlowType.CONFIRM_BATCH)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
@@ -11,11 +11,12 @@ import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import { isExecutable, isMultisigExecutionInfo, isSignableBy } from '@/utils/transaction-guards'
 import { useSigner } from '@/hooks/wallets/useWallet'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { EventCategory } from '@/services/analytics'
 
 const ConfirmTxFlow = ({ txSummary }: { txSummary: TransactionSummary }) => {
   const { text } = useTransactionType(txSummary)
   const isSwapOrder = isSwapOrderTxInfo(txSummary.txInfo)
-  const { data, step, nextStep, prevStep } = useTxStepper({})
+  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.CONFIRM_TX)
   const signer = useSigner()
   const { safe } = useSafeInfo()
 
@@ -33,14 +34,14 @@ const ConfirmTxFlow = ({ txSummary }: { txSummary: TransactionSummary }) => {
     () => [
       {
         txLayoutProps: { title: 'Confirm transaction' },
-        content: <ConfirmProposedTx key={0} txNonce={txNonce} onSubmit={() => nextStep(data)} {...commonProps} />,
+        content: <ConfirmProposedTx key={0} txNonce={txNonce} onSubmit={() => nextStep(undefined)} {...commonProps} />,
       },
       {
         txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
         content: <ConfirmTxDetails key={1} onSubmit={() => {}} {...commonProps} />,
       },
     ],
-    [nextStep, data, commonProps, txNonce],
+    [nextStep, commonProps, txNonce],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
@@ -11,12 +11,12 @@ import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import { isExecutable, isMultisigExecutionInfo, isSignableBy } from '@/utils/transaction-guards'
 import { useSigner } from '@/hooks/wallets/useWallet'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 const ConfirmTxFlow = ({ txSummary }: { txSummary: TransactionSummary }) => {
   const { text } = useTransactionType(txSummary)
   const isSwapOrder = isSwapOrderTxInfo(txSummary.txInfo)
-  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.CONFIRM_TX)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, TxFlowType.CONFIRM_TX)
   const signer = useSigner()
   const { safe } = useSafeInfo()
 

--- a/apps/web/src/components/tx-flow/flows/NewSpendingLimit/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NewSpendingLimit/index.tsx
@@ -8,7 +8,7 @@ import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants
 import { TokenAmountFields } from '@/components/common/TokenAmountInput'
 import { useMemo } from 'react'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 enum Fields {
   beneficiary = 'beneficiary',
@@ -34,7 +34,7 @@ const defaultValues: NewSpendingLimitFlowProps = {
 const NewSpendingLimitFlow = () => {
   const { data, step, nextStep, prevStep } = useTxStepper<NewSpendingLimitFlowProps>(
     defaultValues,
-    EventCategory.SETUP_SPENDING_LIMIT,
+    TxFlowType.SETUP_SPENDING_LIMIT,
   )
 
   const steps = useMemo<TxStep[]>(

--- a/apps/web/src/components/tx-flow/flows/NewSpendingLimit/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NewSpendingLimit/index.tsx
@@ -8,6 +8,7 @@ import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants
 import { TokenAmountFields } from '@/components/common/TokenAmountInput'
 import { useMemo } from 'react'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 enum Fields {
   beneficiary = 'beneficiary',
@@ -31,7 +32,10 @@ const defaultValues: NewSpendingLimitFlowProps = {
 }
 
 const NewSpendingLimitFlow = () => {
-  const { data, step, nextStep, prevStep } = useTxStepper<NewSpendingLimitFlowProps>(defaultValues)
+  const { data, step, nextStep, prevStep } = useTxStepper<NewSpendingLimitFlowProps>(
+    defaultValues,
+    EventCategory.SETUP_SPENDING_LIMIT,
+  )
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/NftTransfer/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NftTransfer/index.tsx
@@ -7,7 +7,7 @@ import SendNftBatch from './SendNftBatch'
 import ReviewNftBatch from './ReviewNftBatch'
 import { useMemo } from 'react'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 export type NftTransferParams = {
   recipient: string
@@ -29,7 +29,7 @@ const NftTransferFlow = ({ txNonce, ...params }: NftTransferFlowProps) => {
       ...defaultParams,
       ...params,
     },
-    EventCategory.NFT_TRANSFER,
+    TxFlowType.NFT_TRANSFER,
   )
 
   const steps = useMemo<TxStep[]>(

--- a/apps/web/src/components/tx-flow/flows/NftTransfer/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NftTransfer/index.tsx
@@ -7,6 +7,7 @@ import SendNftBatch from './SendNftBatch'
 import ReviewNftBatch from './ReviewNftBatch'
 import { useMemo } from 'react'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 export type NftTransferParams = {
   recipient: string
@@ -23,10 +24,13 @@ const defaultParams: NftTransferParams = {
 }
 
 const NftTransferFlow = ({ txNonce, ...params }: NftTransferFlowProps) => {
-  const { data, step, nextStep, prevStep } = useTxStepper<NftTransferParams>({
-    ...defaultParams,
-    ...params,
-  })
+  const { data, step, nextStep, prevStep } = useTxStepper<NftTransferParams>(
+    {
+      ...defaultParams,
+      ...params,
+    },
+    EventCategory.NFT_TRANSFER,
+  )
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/RecoverAccount/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RecoverAccount/index.tsx
@@ -5,7 +5,7 @@ import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import useTxStepper from '../../useTxStepper'
 import { RecoverAccountFlowReview } from './RecoverAccountFlowReview'
 import { RecoverAccountFlowSetup } from './RecoverAccountFlowSetup'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 export enum RecoverAccountFlowFields {
   owners = 'owners',
@@ -24,7 +24,7 @@ function RecoverAccountFlow(): ReactElement {
       [RecoverAccountFlowFields.owners]: [{ value: '' }],
       [RecoverAccountFlowFields.threshold]: '1',
     },
-    EventCategory.START_RECOVERY,
+    TxFlowType.START_RECOVERY,
   )
 
   const steps = [

--- a/apps/web/src/components/tx-flow/flows/RecoverAccount/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RecoverAccount/index.tsx
@@ -1,12 +1,11 @@
-import { START_RECOVERY_CATEGORY } from '@/services/analytics/events/recovery'
 import type { ReactElement } from 'react'
 import type { AddressEx } from '@safe-global/safe-gateway-typescript-sdk'
-
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import useTxStepper from '../../useTxStepper'
 import { RecoverAccountFlowReview } from './RecoverAccountFlowReview'
 import { RecoverAccountFlowSetup } from './RecoverAccountFlowSetup'
+import { EventCategory } from '@/services/analytics'
 
 export enum RecoverAccountFlowFields {
   owners = 'owners',
@@ -25,7 +24,7 @@ function RecoverAccountFlow(): ReactElement {
       [RecoverAccountFlowFields.owners]: [{ value: '' }],
       [RecoverAccountFlowFields.threshold]: '1',
     },
-    START_RECOVERY_CATEGORY,
+    EventCategory.START_RECOVERY,
   )
 
   const steps = [

--- a/apps/web/src/components/tx-flow/flows/RejectTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RejectTx/index.tsx
@@ -4,14 +4,14 @@ import type { TxStep } from '../../common/TxLayout'
 import RejectTx from './RejectTx'
 import useTxStepper from '../../useTxStepper'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 type RejectTxProps = {
   txNonce: number
 }
 
 const RejectTxFlow = ({ txNonce }: RejectTxProps): ReactElement => {
-  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.REJECT_TX)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, TxFlowType.REJECT_TX)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/RejectTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RejectTx/index.tsx
@@ -4,26 +4,27 @@ import type { TxStep } from '../../common/TxLayout'
 import RejectTx from './RejectTx'
 import useTxStepper from '../../useTxStepper'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 type RejectTxProps = {
   txNonce: number
 }
 
 const RejectTxFlow = ({ txNonce }: RejectTxProps): ReactElement => {
-  const { data, step, nextStep, prevStep } = useTxStepper(null)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.REJECT_TX)
 
   const steps = useMemo<TxStep[]>(
     () => [
       {
         txLayoutProps: { title: 'Confirm transaction' },
-        content: <RejectTx key={0} txNonce={txNonce} onSubmit={() => nextStep(data)} />,
+        content: <RejectTx key={0} txNonce={txNonce} onSubmit={() => nextStep(undefined)} />,
       },
       {
         txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
         content: <ConfirmTxDetails key={1} onSubmit={() => {}} isRejection />,
       },
     ],
-    [nextStep, data, txNonce],
+    [nextStep, txNonce],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/flows/RemoveGuard/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveGuard/index.tsx
@@ -4,6 +4,7 @@ import { ReviewRemoveGuard } from '@/components/tx-flow/flows/RemoveGuard/Review
 import useTxStepper from '../../useTxStepper'
 import { useMemo } from 'react'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 // TODO: This can possibly be combined with the remove module type
 export type RemoveGuardFlowProps = {
@@ -11,20 +12,20 @@ export type RemoveGuardFlowProps = {
 }
 
 const RemoveGuardFlow = ({ address }: RemoveGuardFlowProps) => {
-  const { data, step, nextStep, prevStep } = useTxStepper(null)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.REMOVE_GUARD)
 
   const steps = useMemo<TxStep[]>(
     () => [
       {
         txLayoutProps: { title: 'Confirm transaction' },
-        content: <ReviewRemoveGuard key={0} params={{ address }} onSubmit={() => nextStep(data)} />,
+        content: <ReviewRemoveGuard key={0} params={{ address }} onSubmit={() => nextStep(undefined)} />,
       },
       {
         txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
         content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
       },
     ],
-    [nextStep, data, address],
+    [nextStep, address],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/flows/RemoveGuard/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveGuard/index.tsx
@@ -4,7 +4,7 @@ import { ReviewRemoveGuard } from '@/components/tx-flow/flows/RemoveGuard/Review
 import useTxStepper from '../../useTxStepper'
 import { useMemo } from 'react'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 // TODO: This can possibly be combined with the remove module type
 export type RemoveGuardFlowProps = {
@@ -12,7 +12,7 @@ export type RemoveGuardFlowProps = {
 }
 
 const RemoveGuardFlow = ({ address }: RemoveGuardFlowProps) => {
-  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.REMOVE_GUARD)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, TxFlowType.REMOVE_GUARD)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/RemoveModule/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveModule/index.tsx
@@ -4,26 +4,27 @@ import { ReviewRemoveModule } from './ReviewRemoveModule'
 import { useMemo } from 'react'
 import useTxStepper from '../../useTxStepper'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 export type RemoveModuleFlowProps = {
   address: string
 }
 
 const RemoveModuleFlow = ({ address }: RemoveModuleFlowProps) => {
-  const { data, step, nextStep, prevStep } = useTxStepper(null)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.REMOVE_MODULE)
 
   const steps = useMemo<TxStep[]>(
     () => [
       {
         txLayoutProps: { title: 'Confirm transaction' },
-        content: <ReviewRemoveModule key={0} params={{ address }} onSubmit={() => nextStep(data)} />,
+        content: <ReviewRemoveModule key={0} params={{ address }} onSubmit={() => nextStep(undefined)} />,
       },
       {
         txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
         content: <ConfirmTxDetails key={1} onSubmit={() => {}} />,
       },
     ],
-    [nextStep, data, address],
+    [nextStep, address],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/flows/RemoveModule/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveModule/index.tsx
@@ -4,14 +4,14 @@ import { ReviewRemoveModule } from './ReviewRemoveModule'
 import { useMemo } from 'react'
 import useTxStepper from '../../useTxStepper'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 export type RemoveModuleFlowProps = {
   address: string
 }
 
 const RemoveModuleFlow = ({ address }: RemoveModuleFlowProps) => {
-  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.REMOVE_MODULE)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, TxFlowType.REMOVE_MODULE)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/RemoveOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveOwner/index.tsx
@@ -7,7 +7,7 @@ import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import { SetThreshold } from './SetThreshold'
 import { useMemo } from 'react'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 type Owner = {
   address: string
@@ -27,10 +27,7 @@ const RemoveOwnerFlow = (props: Owner) => {
     threshold: Math.min(safe.threshold, safe.owners.length - 1),
   }
 
-  const { data, step, nextStep, prevStep } = useTxStepper<RemoveOwnerFlowProps>(
-    defaultValues,
-    EventCategory.REMOVE_OWNER,
-  )
+  const { data, step, nextStep, prevStep } = useTxStepper<RemoveOwnerFlowProps>(defaultValues, TxFlowType.REMOVE_OWNER)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/RemoveOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveOwner/index.tsx
@@ -7,6 +7,7 @@ import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import { SetThreshold } from './SetThreshold'
 import { useMemo } from 'react'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 type Owner = {
   address: string
@@ -26,7 +27,10 @@ const RemoveOwnerFlow = (props: Owner) => {
     threshold: Math.min(safe.threshold, safe.owners.length - 1),
   }
 
-  const { data, step, nextStep, prevStep } = useTxStepper<RemoveOwnerFlowProps>(defaultValues)
+  const { data, step, nextStep, prevStep } = useTxStepper<RemoveOwnerFlowProps>(
+    defaultValues,
+    EventCategory.REMOVE_OWNER,
+  )
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/RemoveRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveRecovery/index.tsx
@@ -7,14 +7,14 @@ import { RemoveRecoveryFlowOverview } from './RemoveRecoveryFlowOverview'
 import { RemoveRecoveryFlowReview } from './RemoveRecoveryFlowReview'
 import type { RecoveryStateItem } from '@/features/recovery/services/recovery-state'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 export type RecoveryFlowProps = {
   delayModifier: RecoveryStateItem
 }
 
 function RemoveRecoveryFlow({ delayModifier }: RecoveryFlowProps): ReactElement {
-  const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, EventCategory.REMOVE_RECOVERY)
+  const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, TxFlowType.REMOVE_RECOVERY)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/RemoveRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveRecovery/index.tsx
@@ -1,6 +1,4 @@
-import { REMOVE_RECOVERY_CATEGORY } from '@/services/analytics/events/recovery'
 import { useMemo, type ReactElement } from 'react'
-
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import type { TxStep } from '../../common/TxLayout'
 import RecoveryPlus from '@/public/images/common/recovery-plus.svg'
@@ -9,13 +7,14 @@ import { RemoveRecoveryFlowOverview } from './RemoveRecoveryFlowOverview'
 import { RemoveRecoveryFlowReview } from './RemoveRecoveryFlowReview'
 import type { RecoveryStateItem } from '@/features/recovery/services/recovery-state'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 export type RecoveryFlowProps = {
   delayModifier: RecoveryStateItem
 }
 
 function RemoveRecoveryFlow({ delayModifier }: RecoveryFlowProps): ReactElement {
-  const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, REMOVE_RECOVERY_CATEGORY)
+  const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, EventCategory.REMOVE_RECOVERY)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/RemoveSpendingLimit/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveSpendingLimit/index.tsx
@@ -6,22 +6,23 @@ import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import { useMemo } from 'react'
 import useTxStepper from '../../useTxStepper'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 const RemoveSpendingLimitFlow = ({ spendingLimit }: { spendingLimit: SpendingLimitState }) => {
-  const { data, step, nextStep, prevStep } = useTxStepper(null)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.REMOVE_SPENDING_LIMIT)
 
   const steps = useMemo<TxStep[]>(
     () => [
       {
         txLayoutProps: { title: 'Confirm transaction' },
-        content: <RemoveSpendingLimit params={spendingLimit} key={0} onSubmit={() => nextStep(data)} />,
+        content: <RemoveSpendingLimit params={spendingLimit} key={0} onSubmit={() => nextStep(undefined)} />,
       },
       {
         txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
         content: <ConfirmTxDetails key={1} onSubmit={() => {}} />,
       },
     ],
-    [nextStep, data, spendingLimit],
+    [nextStep, spendingLimit],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/flows/RemoveSpendingLimit/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RemoveSpendingLimit/index.tsx
@@ -6,10 +6,10 @@ import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import { useMemo } from 'react'
 import useTxStepper from '../../useTxStepper'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 const RemoveSpendingLimitFlow = ({ spendingLimit }: { spendingLimit: SpendingLimitState }) => {
-  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.REMOVE_SPENDING_LIMIT)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, TxFlowType.REMOVE_SPENDING_LIMIT)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/ReplaceOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ReplaceOwner/index.tsx
@@ -6,7 +6,7 @@ import { ReviewOwner } from '../AddOwner/ReviewOwner'
 import { ChooseOwner, ChooseOwnerMode } from '../AddOwner/ChooseOwner'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 type Owner = {
   address: string
@@ -30,7 +30,7 @@ const ReplaceOwnerFlow = ({ address }: { address: string }) => {
 
   const { data, step, nextStep, prevStep } = useTxStepper<ReplaceOwnerFlowProps>(
     defaultValues,
-    EventCategory.REPLACE_OWNER,
+    TxFlowType.REPLACE_OWNER,
   )
 
   const steps: TxStep[] = [

--- a/apps/web/src/components/tx-flow/flows/ReplaceOwner/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ReplaceOwner/index.tsx
@@ -6,6 +6,7 @@ import { ReviewOwner } from '../AddOwner/ReviewOwner'
 import { ChooseOwner, ChooseOwnerMode } from '../AddOwner/ChooseOwner'
 import SaveAddressIcon from '@/public/images/common/save-address.svg'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 type Owner = {
   address: string
@@ -27,7 +28,10 @@ const ReplaceOwnerFlow = ({ address }: { address: string }) => {
     threshold: safe.threshold,
   }
 
-  const { data, step, nextStep, prevStep } = useTxStepper<ReplaceOwnerFlowProps>(defaultValues)
+  const { data, step, nextStep, prevStep } = useTxStepper<ReplaceOwnerFlowProps>(
+    defaultValues,
+    EventCategory.REPLACE_OWNER,
+  )
 
   const steps: TxStep[] = [
     {

--- a/apps/web/src/components/tx-flow/flows/SafeAppsTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SafeAppsTx/index.tsx
@@ -8,6 +8,7 @@ import useTxStepper from '../../useTxStepper'
 import { useMemo } from 'react'
 import { getTxOrigin } from '@/utils/transactions'
 import { ConfirmSafeAppsTxDetails } from './ConfirmSafeAppsTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 export type SafeAppsTxParams = {
   appId?: string
@@ -24,7 +25,7 @@ const SafeAppsTxFlow = ({
   data: SafeAppsTxParams
   onSubmit?: (txId: string, safeTxHash: string) => void
 }) => {
-  const { step, nextStep, prevStep } = useTxStepper(null)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.SAFE_APPS_TX)
 
   const origin = useMemo(() => getTxOrigin(data.app), [data.app])
 
@@ -32,7 +33,7 @@ const SafeAppsTxFlow = ({
     () => [
       {
         txLayoutProps: { title: 'Confirm transaction' },
-        content: <ReviewSafeAppsTx key={0} safeAppsTx={data} origin={origin} onSubmit={() => nextStep(null)} />,
+        content: <ReviewSafeAppsTx key={0} safeAppsTx={data} origin={origin} onSubmit={() => nextStep(undefined)} />,
       },
       {
         txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },

--- a/apps/web/src/components/tx-flow/flows/SafeAppsTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SafeAppsTx/index.tsx
@@ -8,7 +8,7 @@ import useTxStepper from '../../useTxStepper'
 import { useMemo } from 'react'
 import { getTxOrigin } from '@/utils/transactions'
 import { ConfirmSafeAppsTxDetails } from './ConfirmSafeAppsTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 export type SafeAppsTxParams = {
   appId?: string
@@ -25,7 +25,7 @@ const SafeAppsTxFlow = ({
   data: SafeAppsTxParams
   onSubmit?: (txId: string, safeTxHash: string) => void
 }) => {
-  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.SAFE_APPS_TX)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, TxFlowType.SAFE_APPS_TX)
 
   const origin = useMemo(() => getTxOrigin(data.app), [data.app])
 

--- a/apps/web/src/components/tx-flow/flows/SignMessageOnChain/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SignMessageOnChain/index.tsx
@@ -7,10 +7,10 @@ import ReviewSignMessageOnChain, {
 import { useMemo } from 'react'
 import useTxStepper from '../../useTxStepper'
 import { ConfirmSignMessageOnChainDetails } from './ConfirmSignMessageOnChainDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 const SignMessageOnChainFlow = ({ props }: { props: Omit<SignMessageOnChainProps, 'onSubmit'> }) => {
-  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.SIGN_MESSAGE_ON_CHAIN)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, TxFlowType.SIGN_MESSAGE_ON_CHAIN)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/SignMessageOnChain/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SignMessageOnChain/index.tsx
@@ -7,22 +7,23 @@ import ReviewSignMessageOnChain, {
 import { useMemo } from 'react'
 import useTxStepper from '../../useTxStepper'
 import { ConfirmSignMessageOnChainDetails } from './ConfirmSignMessageOnChainDetails'
+import { EventCategory } from '@/services/analytics'
 
 const SignMessageOnChainFlow = ({ props }: { props: Omit<SignMessageOnChainProps, 'onSubmit'> }) => {
-  const { data, step, nextStep, prevStep } = useTxStepper(null)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.SIGN_MESSAGE_ON_CHAIN)
 
   const steps = useMemo<TxStep[]>(
     () => [
       {
         txLayoutProps: { title: 'Confirm message' },
-        content: <ReviewSignMessageOnChain {...props} key={0} onSubmit={() => nextStep(data)} />,
+        content: <ReviewSignMessageOnChain {...props} key={0} onSubmit={() => nextStep(undefined)} />,
       },
       {
         txLayoutProps: { title: 'Confirm message details', fixedNonce: true },
         content: <ConfirmSignMessageOnChainDetails requestId={props.requestId} key={1} />,
       },
     ],
-    [nextStep, data, props],
+    [nextStep, props],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/index.tsx
@@ -8,6 +8,7 @@ import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants
 import { TokenAmountFields } from '@/components/common/TokenAmountInput'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import { useMemo } from 'react'
+import { EventCategory } from '@/services/analytics'
 
 export enum TokenTransferType {
   multiSig = 'multiSig',
@@ -40,10 +41,13 @@ const defaultParams: TokenTransferParams = {
 }
 
 const TokenTransferFlow = ({ txNonce, ...params }: TokenTransferFlowProps) => {
-  const { data, step, nextStep, prevStep } = useTxStepper<TokenTransferParams>({
-    ...defaultParams,
-    ...params,
-  })
+  const { data, step, nextStep, prevStep } = useTxStepper<TokenTransferParams>(
+    {
+      ...defaultParams,
+      ...params,
+    },
+    EventCategory.TOKEN_TRANSFER,
+  )
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/index.tsx
@@ -8,7 +8,7 @@ import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants
 import { TokenAmountFields } from '@/components/common/TokenAmountInput'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import { useMemo } from 'react'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 export enum TokenTransferType {
   multiSig = 'multiSig',
@@ -46,7 +46,7 @@ const TokenTransferFlow = ({ txNonce, ...params }: TokenTransferFlowProps) => {
       ...defaultParams,
       ...params,
     },
-    EventCategory.TOKEN_TRANSFER,
+    TxFlowType.TOKEN_TRANSFER,
   )
 
   const steps = useMemo<TxStep[]>(

--- a/apps/web/src/components/tx-flow/flows/UpdateSafe/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpdateSafe/index.tsx
@@ -5,10 +5,10 @@ import { UpdateSafeReview } from './UpdateSafeReview'
 import SettingsIcon from '@/public/images/sidebar/settings.svg'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import useTxStepper from '../../useTxStepper'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 const UpdateSafeFlow = () => {
-  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.UPDATE_SAFE)
+  const { step, nextStep, prevStep } = useTxStepper(undefined, TxFlowType.UPDATE_SAFE)
 
   const steps = useMemo<TxStep[]>(
     () => [

--- a/apps/web/src/components/tx-flow/flows/UpdateSafe/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpdateSafe/index.tsx
@@ -5,22 +5,23 @@ import { UpdateSafeReview } from './UpdateSafeReview'
 import SettingsIcon from '@/public/images/sidebar/settings.svg'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import useTxStepper from '../../useTxStepper'
+import { EventCategory } from '@/services/analytics'
 
 const UpdateSafeFlow = () => {
-  const { data, step, nextStep, prevStep } = useTxStepper({})
+  const { step, nextStep, prevStep } = useTxStepper(undefined, EventCategory.UPDATE_SAFE)
 
   const steps = useMemo<TxStep[]>(
     () => [
       {
         txLayoutProps: { title: 'Review transaction' },
-        content: <UpdateSafeReview key={0} onSubmit={() => nextStep(data)} />,
+        content: <UpdateSafeReview key={0} onSubmit={() => nextStep(undefined)} />,
       },
       {
         txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
         content: <ConfirmTxDetails key={1} onSubmit={() => {}} />,
       },
     ],
-    [nextStep, data],
+    [nextStep],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/flows/UpsertRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpsertRecovery/index.tsx
@@ -1,6 +1,4 @@
-import { SETUP_RECOVERY_CATEGORY } from '@/services/analytics/events/recovery'
 import { useMemo, type ReactElement } from 'react'
-
 import TxLayout from '@/components/tx-flow/common/TxLayout'
 import type { TxStep } from '../../common/TxLayout'
 import RecoveryPlus from '@/public/images/common/recovery-plus.svg'
@@ -11,6 +9,7 @@ import { UpsertRecoveryFlowIntro as UpsertRecoveryFlowIntro } from './UpsertReco
 import { DAY_IN_SECONDS } from './useRecoveryPeriods'
 import type { RecoveryState } from '@/features/recovery/services/recovery-state'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { EventCategory } from '@/services/analytics'
 
 export enum UpsertRecoveryFlowFields {
   recoverer = 'recoverer',
@@ -37,7 +36,7 @@ function UpsertRecoveryFlow({ delayModifier }: { delayModifier?: RecoveryState[n
       [UpsertRecoveryFlowFields.customDelay]: '',
       [UpsertRecoveryFlowFields.expiry]: delayModifier?.expiry?.toString() ?? '0',
     },
-    SETUP_RECOVERY_CATEGORY,
+    EventCategory.SETUP_RECOVERY,
   )
 
   const steps = useMemo<TxStep[]>(

--- a/apps/web/src/components/tx-flow/flows/UpsertRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpsertRecovery/index.tsx
@@ -9,7 +9,7 @@ import { UpsertRecoveryFlowIntro as UpsertRecoveryFlowIntro } from './UpsertReco
 import { DAY_IN_SECONDS } from './useRecoveryPeriods'
 import type { RecoveryState } from '@/features/recovery/services/recovery-state'
 import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
-import { EventCategory } from '@/services/analytics'
+import { TxFlowType } from '@/services/analytics'
 
 export enum UpsertRecoveryFlowFields {
   recoverer = 'recoverer',
@@ -36,7 +36,7 @@ function UpsertRecoveryFlow({ delayModifier }: { delayModifier?: RecoveryState[n
       [UpsertRecoveryFlowFields.customDelay]: '',
       [UpsertRecoveryFlowFields.expiry]: delayModifier?.expiry?.toString() ?? '0',
     },
-    EventCategory.SETUP_RECOVERY,
+    TxFlowType.SETUP_RECOVERY,
   )
 
   const steps = useMemo<TxStep[]>(

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -9,7 +9,7 @@ import SignOrExecuteFormV2 from '../SignOrExecuteForm/SignOrExecuteFormV2'
 import type { SignOrExecuteProps } from '../SignOrExecuteForm/SignOrExecuteFormV2'
 import useTxPreview from '../confirmation-views/useTxPreview'
 import Track from '@/components/common/Track'
-import { MODALS_EVENTS } from '@/services/analytics'
+import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 import useWallet from '@/hooks/wallets/useWallet'
 import { isHardwareWallet, isLedgerLive } from '@/utils/wallets'
 
@@ -73,8 +73,9 @@ export const ConfirmTxDetails = (props: SignOrExecuteProps) => {
   const showHashes = wallet ? isHardwareWallet(wallet) || isLedgerLive(wallet) : false
   const steps = showHashes ? HardwareWalletStep : InfoSteps
 
-  const handleCheckboxChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    setChecked(event.target.checked)
+  const handleCheckboxChange = useCallback(({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+    trackEvent({ ...MODALS_EVENTS.CONFIRM_SIGN_CHECKBOX, label: checked })
+    setChecked(checked)
   }, [])
 
   if (!safeTx) {

--- a/apps/web/src/services/analytics/events/modals.ts
+++ b/apps/web/src/services/analytics/events/modals.ts
@@ -100,6 +100,11 @@ export const MODALS_EVENTS = {
     category: MODALS_CATEGORY,
     event: EventType.CLICK,
   },
+  CONFIRM_SIGN_CHECKBOX: {
+    action: 'Confirm sign checkbox',
+    category: MODALS_CATEGORY,
+    event: EventType.CLICK,
+  },
 }
 
 export enum MODAL_NAVIGATION {

--- a/apps/web/src/services/analytics/events/recovery.ts
+++ b/apps/web/src/services/analytics/events/recovery.ts
@@ -1,11 +1,5 @@
 import { EventType } from '@/services/analytics'
 
-// These are used for the generic stepper flow events (Next, Back)
-export const SETUP_RECOVERY_CATEGORY = 'setup-recovery'
-export const START_RECOVERY_CATEGORY = 'propose-recovery'
-export const REMOVE_RECOVERY_CATEGORY = 'remove-recovery'
-export const CANCEL_RECOVERY_CATEGORY = 'cancel-recovery'
-
 const RECOVERY_CATEGORY = 'recovery'
 
 export const RECOVERY_EVENTS = {

--- a/apps/web/src/services/analytics/types.ts
+++ b/apps/web/src/services/analytics/types.ts
@@ -44,8 +44,24 @@ export enum AnalyticsUserProperties {
 
 // These are used for the generic stepper flow events (Next, Back)
 export enum EventCategory {
-  SETUP_RECOVERY = 'setup-recovery',
-  START_RECOVERY = 'propose-recovery',
-  REMOVE_RECOVERY = 'remove-recovery',
+  ADD_OWNER = 'add-owner',
   CANCEL_RECOVERY = 'cancel-recovery',
+  CHANGE_THRESHOLD = 'change-threshold',
+  CONFIRM_BATCH = 'confirm-batch',
+  CONFIRM_TX = 'confirm-tx',
+  NFT_TRANSFER = 'nft-transfer',
+  REJECT_TX = 'reject-tx',
+  REMOVE_GUARD = 'remove-guard',
+  REMOVE_MODULE = 'remove-module',
+  REMOVE_OWNER = 'remove-owner',
+  REMOVE_RECOVERY = 'remove-recovery',
+  REMOVE_SPENDING_LIMIT = 'remove-spending-limit',
+  REPLACE_OWNER = 'replace-owner',
+  SAFE_APPS_TX = 'safe-apps-tx',
+  SETUP_RECOVERY = 'setup-recovery',
+  SETUP_SPENDING_LIMIT = 'setup-spending-limit',
+  SIGN_MESSAGE_ON_CHAIN = 'sign-message-on-chain',
+  START_RECOVERY = 'propose-recovery',
+  TOKEN_TRANSFER = 'token-transfer',
+  UPDATE_SAFE = 'update-safe',
 }

--- a/apps/web/src/services/analytics/types.ts
+++ b/apps/web/src/services/analytics/types.ts
@@ -43,7 +43,7 @@ export enum AnalyticsUserProperties {
 }
 
 // These are used for the generic stepper flow events (Next, Back)
-export enum EventCategory {
+export enum TxFlowType {
   ADD_OWNER = 'add-owner',
   CANCEL_RECOVERY = 'cancel-recovery',
   CHANGE_THRESHOLD = 'change-threshold',

--- a/apps/web/src/services/analytics/types.ts
+++ b/apps/web/src/services/analytics/types.ts
@@ -41,3 +41,11 @@ export enum AnalyticsUserProperties {
   WALLET_LABEL = 'walletLabel',
   WALLET_ADDRESS = 'walletAddress',
 }
+
+// These are used for the generic stepper flow events (Next, Back)
+export enum EventCategory {
+  SETUP_RECOVERY = 'setup-recovery',
+  START_RECOVERY = 'propose-recovery',
+  REMOVE_RECOVERY = 'remove-recovery',
+  CANCEL_RECOVERY = 'cancel-recovery',
+}


### PR DESCRIPTION
## What it solves

Resolves #5283 

Add tracking for the following events:
* User checks the checkbox "I understand what I will sign ... "
* User clicks on external link to the article about how to perform basic transaction checks
* User navigates back or next on any transaction flow