### PR TITLE
Feat(Orgs): Add send tokens flow to orgs view

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
@@ -44,6 +44,7 @@ import { skipToken } from '@reduxjs/toolkit/query'
 import { defaultSafeInfo, showNotification, useGetSafeOverviewQuery } from '@/store/slices'
 import FiatValue from '@/components/common/FiatValue'
 import { AccountInfoChips } from '../AccountInfoChips'
+import SendTransactionButton from '@/features/organizations/components/SafeAccounts/SendTransactionButton'
 
 type AccountItemProps = {
   safeItem: SafeItem
@@ -251,7 +252,10 @@ const SingleAccountItem = ({
           )}
 
           {isOrgSafe ? (
-            <OrgSafeContextMenu safeItem={safeItem} />
+            <>
+              {safeOverview && <SendTransactionButton safe={safeOverview} />}
+              <OrgSafeContextMenu safeItem={safeItem} />
+            </>
           ) : (
             <SafeListContextMenu
               name={name}

--- a/apps/web/src/features/organizations/components/SafeAccounts/SendTransactionButton.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccounts/SendTransactionButton.tsx
@@ -1,0 +1,59 @@
+import { useContext } from 'react'
+import { IconButton, Tooltip } from '@mui/material'
+import { useRouter } from 'next/router'
+import ArrowOutwardIcon from '@/public/images/transactions/outgoing.svg'
+import css from './styles.module.css'
+import { TxModalContext } from '@/components/tx-flow'
+import { TokenTransferFlow } from '@/components/tx-flow/flows'
+import { networks } from '@safe-global/protocol-kit/dist/src/utils/eip-3770/config'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import useWallet from '@/hooks/wallets/useWallet'
+import { isOwner } from '@/utils/transaction-guards'
+import type { AddressEx } from '@safe-global/safe-gateway-typescript-sdk'
+
+type Chains = Record<string, string>
+
+const chains = networks.reduce<Chains>((result, { shortName, chainId }) => {
+  result[chainId.toString()] = shortName.toString()
+  return result
+}, {})
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+const SendTransactionButton = ({ safe }: { safe: SafeOverview }) => {
+  const router = useRouter()
+  const wallet = useWallet()
+  const canSend = isOwner(safe.owners as AddressEx[], wallet?.address)
+
+  const { setTxFlow } = useContext(TxModalContext)
+
+  const onNewTxClick = async () => {
+    const shortname = chains[safe.chainId]
+
+    await router.replace({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        safe: `${shortname}:${safe.address.value}`,
+        chain: shortname,
+      },
+    })
+
+    // Otherwise the tx flow immediately closes again
+    await sleep(500)
+
+    setTxFlow(<TokenTransferFlow />, undefined, false)
+  }
+
+  return (
+    <Tooltip placement="top" title={canSend ? 'Send tokens' : 'You are not a signer of this Safe Account'}>
+      <span>
+        <IconButton className={css.sendButton} size="small" onClick={onNewTxClick} disabled={!canSend}>
+          <ArrowOutwardIcon />
+        </IconButton>
+      </span>
+    </Tooltip>
+  )
+}
+
+export default SendTransactionButton

--- a/apps/web/src/features/organizations/components/SafeAccounts/SendTransactionButton.tsx
+++ b/apps/web/src/features/organizations/components/SafeAccounts/SendTransactionButton.tsx
@@ -27,7 +27,7 @@ const SendTransactionButton = ({ safe }: { safe: SafeOverview }) => {
 
   const { setTxFlow } = useContext(TxModalContext)
 
-  const onNewTxClick = async () => {
+  const setActiveSafe = async () => {
     const shortname = chains[safe.chainId]
 
     await router.replace({
@@ -38,11 +38,26 @@ const SendTransactionButton = ({ safe }: { safe: SafeOverview }) => {
         chain: shortname,
       },
     })
+  }
 
-    // Otherwise the tx flow immediately closes again
+  const resetActiveSafe = async () => {
+    await router.replace({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        safe: undefined,
+        chain: undefined,
+      },
+    })
+  }
+
+  const onNewTxClick = async () => {
+    await setActiveSafe()
+
+    // TODO: Otherwise the tx flow immediately closes again (still does sometimes)
     await sleep(500)
 
-    setTxFlow(<TokenTransferFlow />, undefined, false)
+    setTxFlow(<TokenTransferFlow />, resetActiveSafe, false)
   }
 
   return (

--- a/apps/web/src/features/organizations/components/SafeAccounts/styles.module.css
+++ b/apps/web/src/features/organizations/components/SafeAccounts/styles.module.css
@@ -1,0 +1,15 @@
+
+.sendButton {
+    background-color: var(--color-text-disabled);
+    border-radius: 3px;
+    margin: 0 var(--space-1);
+}
+
+.sendButton svg path {
+    fill: var(--color-primary-main);
+}
+
+.sendButton:global(.Mui-disabled) {
+    background-color: var(--color-background-main);
+    opacity: 0.6;
+}


### PR DESCRIPTION
## What it solves

Resolves #5386

## How this PR fixes it

- Adds a send button next to safe items
- Opens the send token flow
- Displays the correct tokens and balances for the safe that is used

## How to test it

1. Open an org
2. Add safe accounts
3. Observe a send icon next to each safe account
4. Press the button
5. Observe the send token flow opening with the correct balances and tokens showing

## Screenshots
<img width="844" alt="Screenshot 2025-03-18 at 13 38 13" src="https://github.com/user-attachments/assets/c6bd1bce-f2d7-41f4-b610-d4cded434f33" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
