### PR TITLE
Fix(Orgs): Show error when trying to add same safe to org

### DIFF
--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -13,6 +13,7 @@ import { getComparator } from '@/features/myAccounts/utils/utils'
 import { useAppSelector } from '@/store'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import {
+  Alert,
   Box,
   Button,
   Card,
@@ -38,6 +39,7 @@ function getSelectedSafes(safes: AddAccountsFormValues['selectedSafes']) {
 const AddAccounts = () => {
   const [open, setOpen] = useState<boolean>(false)
   const [searchQuery, setSearchQuery] = useState('')
+  const [error, setError] = useState<string>()
   const [manualSafes, setManualSafes] = useState<SafeItems>([])
 
   const { orderBy } = useAppSelector(selectOrderByPreference)
@@ -80,12 +82,14 @@ const AddAccounts = () => {
       })
 
       if (result.error) {
-        // TODO: Handle error message
+        // TODO: Add error handler and display more specific error
+        setError('Something went wrong adding one or more Safe Accounts')
+        return
       }
+
+      handleClose()
     } catch (e) {
       console.log(e)
-    } finally {
-      handleClose()
     }
   })
 
@@ -169,6 +173,13 @@ const AddAccounts = () => {
                   <Box p={2}>
                     <AddManually handleAddSafe={handleAddSafe} />
                   </Box>
+
+                  {error && (
+                    <Alert severity="error" sx={{ m: 2, mt: 0 }}>
+                      {error}
+                    </Alert>
+                  )}
+
                   <DialogActions>
                     <Button onClick={handleClose}>Cancel</Button>
                     <Button variant="contained" disabled={selectedSafesLength === 0} type="submit">


### PR DESCRIPTION
## What it solves

Resolves #5242

## How this PR fixes it

- Shows an error and keeps the dialog open

## How to test it

1. Open an org
2. Add a safe account
3. Try to add the same safe account again
4. Observe an error message

## Screenshots
<img width="634" alt="Screenshot 2025-03-18 at 14 25 10" src="https://github.com/user-attachments/assets/5a78e700-7af4-4b3b-a7fc-c97360e33e7b" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
