### PR TITLE
fix(Spending limits): rename disabled spending limit text

### DIFF
--- a/apps/web/src/components/settings/SpendingLimits/index.tsx
+++ b/apps/web/src/components/settings/SpendingLimits/index.tsx
@@ -68,7 +68,7 @@ const SpendingLimits = () => {
               {!spendingLimits.length && !spendingLimitsLoading && <NoSpendingLimits />}
             </Box>
           ) : (
-            <Typography>The spending limit module is not yet available on this chain.</Typography>
+            <Typography>The spending limit feature is not yet available on this chain.</Typography>
           )}
         </Grid>
       </Grid>


### PR DESCRIPTION
## What it solves

Resolves confusing text

## How this PR fixes it

When the spending limits _feature_ is disabled, but a module remains activated, a message and module are shown. This is for security reasons: allowing an owner to disable the module:

![image](https://github.com/user-attachments/assets/4bc992b1-7432-450b-937a-30bc7e91ccd7)

However, the message is unclear because the _module_ is available but it states that it isn't. As such, this renames _module_ to _feature_.

## How to test it

1. Ensuring the spending limits feature is disabled, observe the new message.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
