### PR TITLE
Fix(Orgs): keep button size consistent when submitting

### DIFF
--- a/apps/web/src/features/organizations/components/OrgsCreationModal/index.tsx
+++ b/apps/web/src/features/organizations/components/OrgsCreationModal/index.tsx
@@ -32,11 +32,11 @@ function OrgsCreationModal({ onClose }: { onClose: () => void }): ReactElement {
       }
 
       if (response.error) {
-        setError('Failed creating the organization. Please try again.')
+        throw response.error
       }
     } catch (e) {
-      // TODO: Handle this error case
-      console.log(e)
+      // TODO: Show more specific error message
+      setError('Failed creating the organization. Please try again.')
     } finally {
       setIsSubmitting(false)
     }
@@ -78,7 +78,13 @@ function OrgsCreationModal({ onClose }: { onClose: () => void }): ReactElement {
             <Button data-testid="cancel-btn" onClick={onClose}>
               Cancel
             </Button>
-            <Button type="submit" variant="contained" disabled={!formState.isValid || isSubmitting} disableElevation>
+            <Button
+              type="submit"
+              variant="contained"
+              disabled={!formState.isValid || isSubmitting}
+              disableElevation
+              sx={{ minWidth: '200px' }}
+            >
               {isSubmitting ? <CircularProgress size={20} /> : 'Create organization'}
             </Button>
           </DialogActions>


### PR DESCRIPTION
## What it solves

Resolves: Org creation button was changing size in it's loading state

## How this PR fixes it
- keeps the button size consistent when submitting the form.
- Also removes a console log and replaces it with an error message shown to the user.

## How to test it
- Open the org creation modal
- when the submit button is pressed, it should not jump or change size. The loading circle should show but the button size should be consistent.


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
