### PR TITLE
Fix(Orgs): disable buttons on dashboard for non admins

### DIFF
--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -123,7 +123,7 @@ const AddAccounts = () => {
 
   return (
     <>
-      <Tooltip title={!isAdmin ? 'You need an Admin role to add accounts' : ''} placement="top">
+      <Tooltip title={!isAdmin ? 'You need to be an Admin to add accounts' : ''} placement="top">
         <Box component="span">
           <Button variant="contained" onClick={() => setOpen(true)} disabled={!isAdmin}>
             Add accounts

--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -123,7 +123,7 @@ const AddAccounts = () => {
 
   return (
     <>
-      <Tooltip title={!isAdmin ? 'Only admins can add accounts' : ''} placement="top">
+      <Tooltip title={!isAdmin ? 'You need an Admin role to add accounts' : ''} placement="top">
         <Box component="span">
           <Button variant="contained" onClick={() => setOpen(true)} disabled={!isAdmin}>
             Add accounts

--- a/apps/web/src/features/organizations/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/organizations/components/AddAccounts/index.tsx
@@ -23,10 +23,12 @@ import {
   InputAdornment,
   SvgIcon,
   TextField,
+  Tooltip,
   Typography,
 } from '@mui/material'
 import React, { useCallback, useMemo, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
+import { useIsAdmin } from '../../hooks/useOrgMembers'
 
 export type AddAccountsFormValues = {
   selectedSafes: Record<string, boolean>
@@ -37,6 +39,7 @@ function getSelectedSafes(safes: AddAccountsFormValues['selectedSafes']) {
 }
 
 const AddAccounts = () => {
+  const isAdmin = useIsAdmin()
   const [open, setOpen] = useState<boolean>(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [error, setError] = useState<string>()
@@ -120,9 +123,14 @@ const AddAccounts = () => {
 
   return (
     <>
-      <Button variant="contained" onClick={() => setOpen(true)}>
-        Add accounts
-      </Button>
+      <Tooltip title={!isAdmin ? 'Only admins can add accounts' : ''} placement="top">
+        <Box component="span">
+          <Button variant="contained" onClick={() => setOpen(true)} disabled={!isAdmin}>
+            Add accounts
+          </Button>
+        </Box>
+      </Tooltip>
+
       <ModalDialog open={open} fullScreen hideChainIndicator PaperProps={{ sx: { backgroundColor: '#f4f4f4' } }}>
         <DialogContent sx={{ display: 'flex', alignItems: 'center' }}>
           <Container fixed maxWidth="sm" disableGutters>

--- a/apps/web/src/features/organizations/components/Dashboard/MembersCard.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/MembersCard.tsx
@@ -21,7 +21,7 @@ const MembersCard = () => {
           <Box className={css.iconBG}>
             <SvgIcon component={MemberIcon} inheritViewBox />
           </Box>
-          <Tooltip title={isButtonDisabled ? 'Only admins can add members' : ''} placement="top">
+          <Tooltip title={isButtonDisabled ? 'You need an Admin role to add members' : ''} placement="top">
             <Box component="span" sx={{ position: 'absolute', top: 0, right: 0 }}>
               <Button
                 onClick={handleInviteClick}

--- a/apps/web/src/features/organizations/components/Dashboard/MembersCard.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/MembersCard.tsx
@@ -21,7 +21,7 @@ const MembersCard = () => {
           <Box className={css.iconBG}>
             <SvgIcon component={MemberIcon} inheritViewBox />
           </Box>
-          <Tooltip title={isButtonDisabled ? 'You need an Admin role to add members' : ''} placement="top">
+          <Tooltip title={isButtonDisabled ? 'You need to be an Admin to add members' : ''} placement="top">
             <Box component="span" sx={{ position: 'absolute', top: 0, right: 0 }}>
               <Button
                 onClick={handleInviteClick}

--- a/apps/web/src/features/organizations/components/Dashboard/MembersCard.tsx
+++ b/apps/web/src/features/organizations/components/Dashboard/MembersCard.tsx
@@ -1,11 +1,14 @@
 import css from '@/features/organizations/components/Dashboard/styles.module.css'
 import MemberIcon from '@/public/images/orgs/member.svg'
-import { Typography, Paper, Box, Button, SvgIcon } from '@mui/material'
+import { Typography, Paper, Box, Button, SvgIcon, Tooltip } from '@mui/material'
 import { useState } from 'react'
+import { useIsAdmin } from '@/features/organizations/hooks/useOrgMembers'
 import AddMembersModal from '../AddMembersModal'
 
 const MembersCard = () => {
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
+  const isAdmin = useIsAdmin()
+  const isButtonDisabled = !isAdmin
 
   const handleInviteClick = () => {
     setOpenAddMembersModal(true)
@@ -18,20 +21,19 @@ const MembersCard = () => {
           <Box className={css.iconBG}>
             <SvgIcon component={MemberIcon} inheritViewBox />
           </Box>
-
-          <Button
-            onClick={handleInviteClick}
-            variant="outlined"
-            size="compact"
-            sx={{
-              position: 'absolute',
-              top: 0,
-              right: 0,
-            }}
-            aria-label="Invite team members"
-          >
-            Add members
-          </Button>
+          <Tooltip title={isButtonDisabled ? 'Only admins can add members' : ''} placement="top">
+            <Box component="span" sx={{ position: 'absolute', top: 0, right: 0 }}>
+              <Button
+                onClick={handleInviteClick}
+                variant={isButtonDisabled ? 'contained' : 'outlined'}
+                size="compact"
+                aria-label="Invite team members"
+                disabled={isButtonDisabled}
+              >
+                Add members
+              </Button>
+            </Box>
+          </Tooltip>
         </Box>
         <Box>
           <Typography variant="body1" color="text.primary" fontWeight={700} mb={1}>


### PR DESCRIPTION
## What it solves

Resolves [#5400](https://github.com/safe-global/safe-wallet-monorepo/issues/5400)

## How this PR fixes it
- diables the buttons for non admins
- adds tooltips to explain why

## How to test it
view the dashboard page as a non admin (normal member or invited member)
see that the add member and accounts buttons are disabled with a tootlip to explain why

## Screenshots
![image](https://github.com/user-attachments/assets/b7b77b12-6e7f-41d5-9434-eb4e9b2b338b)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
