### PR TITLE
fix(WalletConnect): update EIP-5792 implementation

### DIFF
--- a/apps/web/src/services/safe-wallet-provider/index.test.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.test.ts
@@ -520,9 +520,9 @@ describe('SafeWalletProvider', () => {
 
         const params = [
           {
-            chainId: 1,
+            chainId: '0x1',
             version: '1.0',
-            from: faker.finance.ethereumAddress(),
+            from: safe.safeAddress,
             calls: [
               { data: '0x123', to: faker.finance.ethereumAddress(), value: '0x123' },
               { data: '0x456', to: faker.finance.ethereumAddress(), value: '0x1' },
@@ -570,7 +570,7 @@ describe('SafeWalletProvider', () => {
 
         const params = [
           {
-            chainId: 1,
+            chainId: '0x1',
             version: '1.0',
             from: safe.safeAddress,
             calls: [

--- a/apps/web/src/services/safe-wallet-provider/index.test.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.test.ts
@@ -656,18 +656,20 @@ describe('SafeWalletProvider', () => {
           id: 1,
           jsonrpc: '2.0',
           result: {
+            id: params[0],
+            chainId: '0x1',
             receipts: [
               {
                 blockHash: receipt.blockHash,
                 blockNumber: receipt.blockNumber,
-                chainId: '0x1',
                 gasUsed: receipt.gasUsed,
                 logs: receipt.logs,
                 status: '0x1',
                 transactionHash: '0x123',
               },
             ],
-            status: 'CONFIRMED',
+            status: 200,
+            version: '1.0',
           },
         })
       })
@@ -708,18 +710,20 @@ describe('SafeWalletProvider', () => {
           id: 1,
           jsonrpc: '2.0',
           result: {
+            chainId: '0x1',
+            id: params[0],
             receipts: [
               {
                 blockHash: numberToHex(Number(receipt.blockHash)),
                 blockNumber: numberToHex(Number(receipt.blockNumber)),
-                chainId: '0x1',
                 gasUsed: numberToHex(receipt.gasUsed),
                 logs: receipt.logs,
                 status: '0x1',
                 transactionHash: '0x123',
               },
             ],
-            status: 'CONFIRMED',
+            status: 200,
+            version: '1.0',
           },
         })
       })
@@ -748,7 +752,10 @@ describe('SafeWalletProvider', () => {
           id: 1,
           jsonrpc: '2.0',
           result: {
-            status: 'PENDING',
+            chainId: '0x1',
+            id: params[0],
+            status: 100,
+            version: '1.0',
           },
         })
       })
@@ -783,7 +790,10 @@ describe('SafeWalletProvider', () => {
           id: 1,
           jsonrpc: '2.0',
           result: {
-            status: 'PENDING',
+            chainId: '0x1',
+            id: params[0],
+            status: 100,
+            version: '1.0',
           },
         })
       })

--- a/apps/web/src/services/safe-wallet-provider/index.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.ts
@@ -363,6 +363,14 @@ export class SafeWalletProvider {
   // EIP-5792
   // @see https://eips.ethereum.org/EIPS/eip-5792
   async wallet_sendCalls(bundle: SendCallsParams, appInfo: AppInfo): Promise<SendCallsResult> {
+    if (bundle.chainId !== numberToHex(this.safe.chainId)) {
+      throw new Error(`Safe is not on chain ${this.safe.chainId}`)
+    }
+
+    if (bundle.from !== this.safe.safeAddress) {
+      throw Error('Invalid from address')
+    }
+
     const txs = bundle.calls.map((call) => {
       if (!call.to && !call.value && !call.data) {
         throw new RpcError(RpcErrorCode.INVALID_PARAMS, 'Invalid call parameters.')

--- a/apps/web/src/services/safe-wallet-provider/index.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.ts
@@ -12,6 +12,48 @@ type SafeSettings = {
   offChainSigning?: boolean
 }
 
+type Capability = {
+  [key: string]: unknown
+  optional?: boolean
+}
+
+type SendCallsParams = {
+  version: '1.0'
+  id?: string
+  from?: `0x${string}`
+  chainId: `0x${string}`
+  calls: Array<{
+    to?: `0x${string}`
+    data?: `0x${string}`
+    value?: `0x${string}`
+    capabilities?: Record<string, Capability>
+  }>
+  capabilities?: Record<string, Capability>
+}
+
+type SendCallsResult = {
+  id: string
+  capabilities?: Record<string, any>
+}
+
+type GetCallsParams = `0x${string}`
+
+type GetCallsResult = {
+  version: string
+  id: `0x${string}`
+  chainId: `0x${string}`
+  status: number // See "Status Codes"
+  receipts?: Array<{
+    logs: TransactionReceipt['logs']
+    status: `0x${string}` // Hex 1 or 0 for success or failure, respectively
+    blockHash: `0x${string}`
+    blockNumber: `0x${string}`
+    gasUsed: `0x${string}`
+    transactionHash: `0x${string}`
+  }>
+  capabilities?: Record<string, any>
+}
+
 type GetCapabilitiesResult = Record<`0x${string}`, Record<string, any>>
 
 export type AppInfo = {
@@ -54,16 +96,19 @@ export enum RpcErrorCode {
 }
 
 enum BundleStatus {
-  PENDING = 'PENDING',
-  CONFIRMED = 'CONFIRMED',
+  PENDING = 100, // Batch has been received by the wallet but has not completed execution onchain (pending)
+  CONFIRMED = 200, // Batch has been included onchain without reverts, receipts array contains info of all calls (confirmed)
+  OFFCHAIN_FAILURE = 400, // Batch has not been included onchain and wallet will not retry (offchain failure)
+  REVERTED = 500, // Batch reverted completely and only changes related to gas charge may have been included onchain (chain rules failure)
+  PARTIALLY_REVERTED = 600, // Batch reverted partially and some changes related to batch calls may have been included onchain (partial chain rules failure)
 }
 
 const BundleTxStatuses: Record<TransactionStatus, BundleStatus> = {
   [TransactionStatus.AWAITING_CONFIRMATIONS]: BundleStatus.PENDING,
   [TransactionStatus.AWAITING_EXECUTION]: BundleStatus.PENDING,
-  [TransactionStatus.CANCELLED]: BundleStatus.CONFIRMED,
-  [TransactionStatus.FAILED]: BundleStatus.CONFIRMED,
   [TransactionStatus.SUCCESS]: BundleStatus.CONFIRMED,
+  [TransactionStatus.CANCELLED]: BundleStatus.OFFCHAIN_FAILURE,
+  [TransactionStatus.FAILED]: BundleStatus.REVERTED,
 }
 
 class RpcError extends Error {
@@ -137,22 +182,11 @@ export class SafeWalletProvider {
       // EIP-5792
       // @see https://eips.ethereum.org/EIPS/eip-5792
       case 'wallet_sendCalls': {
-        return this.wallet_sendCalls(
-          ...(params as [
-            {
-              version: string
-              chainId: string
-              from: string
-              calls: Array<{ data: string; to?: string; value?: string }>
-              capabilities?: Record<string, any> | undefined
-            },
-          ]),
-          appInfo,
-        )
+        return this.wallet_sendCalls(...(params as [SendCallsParams]), appInfo)
       }
 
       case 'wallet_getCallsStatus': {
-        return this.wallet_getCallsStatus(...(params as [string]))
+        return this.wallet_getCallsStatus(...(params as [GetCallsParams]))
       }
 
       case 'wallet_showCallsStatus': {
@@ -328,14 +362,7 @@ export class SafeWalletProvider {
 
   // EIP-5792
   // @see https://eips.ethereum.org/EIPS/eip-5792
-  async wallet_sendCalls(
-    bundle: {
-      chainId: string
-      from: string
-      calls: Array<{ data?: string; to?: string; value?: string }>
-    },
-    appInfo: AppInfo,
-  ): Promise<string> {
+  async wallet_sendCalls(bundle: SendCallsParams, appInfo: AppInfo): Promise<SendCallsResult> {
     const txs = bundle.calls.map((call) => {
       if (!call.to && !call.value && !call.data) {
         throw new RpcError(RpcErrorCode.INVALID_PARAMS, 'Invalid call parameters.')
@@ -363,20 +390,9 @@ export class SafeWalletProvider {
       appInfo,
     )
 
-    return safeTxHash
+    return { id: safeTxHash }
   }
-  async wallet_getCallsStatus(safeTxHash: string): Promise<{
-    status: BundleStatus
-    receipts?: Array<{
-      logs: TransactionReceipt['logs']
-      status: `0x${string}` // Hex 1 or 0 for success or failure, respectively
-      chainId: `0x${string}`
-      blockHash: `0x${string}`
-      blockNumber: `0x${string}`
-      gasUsed: `0x${string}`
-      transactionHash: `0x${string}`
-    }>
-  }> {
+  async wallet_getCallsStatus(safeTxHash: GetCallsParams): Promise<GetCallsResult> {
     let tx: TransactionDetails | undefined
 
     try {
@@ -387,19 +403,22 @@ export class SafeWalletProvider {
       throw new Error('Transaction not found')
     }
 
-    const status = BundleTxStatuses[tx.txStatus]
+    const result: GetCallsResult = {
+      version: '1.0',
+      id: safeTxHash,
+      chainId: numberToHex(this.safe.chainId),
+      status: BundleTxStatuses[tx.txStatus],
+    }
 
     if (!tx.txHash) {
-      return {
-        status,
-      }
+      return result
     }
 
     const receipt = await (this.sdk.proxy('eth_getTransactionReceipt', [
       tx.txHash,
     ]) as Promise<TransactionReceipt | null>)
     if (!receipt) {
-      return { status }
+      return result
     }
 
     const calls = tx.txData?.dataDecoded?.parameters?.[0].valueDecoded?.length ?? 1
@@ -408,20 +427,16 @@ export class SafeWalletProvider {
     const blockNumber = Number(receipt.blockNumber)
     const gasUsed = Number(receipt.gasUsed)
 
-    const receipts = Array.from({ length: calls }, () => ({
+    result.receipts = Array.from({ length: calls }, () => ({
       logs: receipt.logs,
       status: numberToHex(tx.txStatus === TransactionStatus.SUCCESS ? 1 : 0),
-      chainId: numberToHex(this.safe.chainId),
       blockHash: receipt.blockHash as `0x${string}`,
       blockNumber: numberToHex(blockNumber),
       gasUsed: numberToHex(gasUsed),
       transactionHash: tx.txHash as `0x${string}`,
     }))
 
-    return {
-      status,
-      receipts,
-    }
+    return result
   }
   async wallet_showCallsStatus(txHash: string): Promise<null> {
     this.sdk.showTxStatus(txHash)


### PR DESCRIPTION
## What it solves

Propagates https://github.com/safe-global/safe-apps-sdk/pull/637 fix.

This updates our EIP-5792 implementation to align with [recent changes](https://github.com/ethereum/EIPs/pull/8826) to the `wallet_sendCalls` and `wallet_getCallsStatus` methods. The request and response objects changed meaning requests would fail.

## How this PR fixes it

Explicit types have been added for the respective methods and the logic for handling requests adjusted.

## How to test it

Using a DApp that supports the latest implementation of EIP-5792, send a batch call and then get the status of it sequentially throughout its lifecycle.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
