### PR TITLE
Tests: skip NFT preview test

### DIFF
--- a/apps/web/cypress/e2e/smoke/nfts.cy.js
+++ b/apps/web/cypress/e2e/smoke/nfts.cy.js
@@ -27,7 +27,8 @@ describe.skip('[SMOKE] NFTs tests', () => {
     nfts.verifyDataInTable(nftsName, nftsAddress, nftsTokenID)
   })
 
-  it('[SMOKE] Verify NFT preview window can be opened', () => {
+  // skipped because the NFT metadata fetching is turned off on tx_service
+  it.skip('[SMOKE] Verify NFT preview window can be opened', () => {
     nfts.openActiveNFT(0)
     nfts.verifyNameInNFTModal(nftsTokenID)
     nfts.verifySelectedNetwrokSepolia()


### PR DESCRIPTION

## What it solves
The preview NFT test is skipped , because the fetching metadata for the NFTs was turned off on the back-end, so the preview is not available for now
Resolves #

## How this PR fixes it
1. The test is skipped for now till we have more details 
## How to test it
1. run smoke nft tests
2. make sure that the text is skipped
## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
