### PR TITLE
fix(CGW SDK): only include `credentials` for specific routes

### DIFF
--- a/packages/store/src/gateway/cgwClient.test.ts
+++ b/packages/store/src/gateway/cgwClient.test.ts
@@ -1,4 +1,5 @@
 import type { FetchArgs, BaseQueryApi } from '@reduxjs/toolkit/query/react'
+import * as cgwClient from './cgwClient'
 
 describe('dynamicBaseQuery', () => {
   const api: BaseQueryApi = {
@@ -11,57 +12,85 @@ describe('dynamicBaseQuery', () => {
     type: 'query',
   }
 
+  const mockRawBaseQuery = jest.spyOn(cgwClient, 'rawBaseQuery')
+
   beforeEach(() => {
-    jest.clearAllMocks()
+    jest.resetAllMocks()
   })
 
   it('throws an error if baseUrl is not set', async () => {
-    jest.isolateModules(async () => {
-      const { dynamicBaseQuery } = await import('./cgwClient')
-      // Note: We do NOT set baseUrl here, so it remains null by default.
-      await expect(dynamicBaseQuery('/test', api, {})).rejects.toThrow(
-        'baseUrl not set. Call setBaseUrl before using the cgwClient',
-      )
-    })
+    // Note: We do NOT set baseUrl here, so it remains null by default.
+    await expect(cgwClient.dynamicBaseQuery('/test', api, {})).rejects.toThrow(
+      'baseUrl not set. Call setBaseUrl before using the cgwClient',
+    )
   })
 
   it('calls rawBaseQuery with correct url when baseUrl is set and args is a string', async () => {
-    jest.isolateModules(async () => {
-      // Re-import a fresh instance of the module
-      const { dynamicBaseQuery, setBaseUrl, rawBaseQuery } = await import('./cgwClient')
-      // Mock rawBaseQuery
-      const mockRawBaseQuery = jest.fn().mockResolvedValue({ data: 'stringResult' })
-      Object.assign(rawBaseQuery, mockRawBaseQuery)
+    mockRawBaseQuery.mockResolvedValue({ data: 'stringResult' })
+    // Set the baseUrl
+    cgwClient.setBaseUrl('http://example.com')
 
-      // Set the baseUrl
-      setBaseUrl('http://example.com')
+    const result = await cgwClient.dynamicBaseQuery('/test', api, {})
 
-      const result = await dynamicBaseQuery('/test', api, {})
-
-      expect(mockRawBaseQuery).toHaveBeenCalledWith('http://example.com//test', api)
-      expect(result).toEqual({ data: 'stringResult' })
-    })
+    expect(mockRawBaseQuery).toHaveBeenCalledWith(
+      {
+        method: 'GET',
+        url: 'http://example.com/test',
+        credentials: 'omit',
+      },
+      api,
+      {},
+    )
+    expect(result).toEqual({ data: 'stringResult' })
   })
 
   it('calls rawBaseQuery with correct url when baseUrl is set and args is FetchArgs', async () => {
-    jest.isolateModules(async () => {
-      const { dynamicBaseQuery, setBaseUrl, rawBaseQuery } = await import('./cgwClient')
-      const mockRawBaseQuery = jest.fn().mockResolvedValue({ data: 'objectResult' })
-      Object.assign(rawBaseQuery, mockRawBaseQuery)
+    mockRawBaseQuery.mockResolvedValue({ data: 'objectResult' })
+    cgwClient.setBaseUrl('http://example.com')
 
-      setBaseUrl('http://example.com')
+    const args: FetchArgs = { url: 'endpoint', method: 'POST', body: { hello: 'world' } }
+    const extraOptions = { extra: 'options' }
 
-      const args: FetchArgs = { url: 'endpoint', method: 'POST', body: { hello: 'world' } }
-      const extraOptions = { credentials: 'include' }
+    const result = await cgwClient.dynamicBaseQuery(args, api, extraOptions)
 
-      const result = await dynamicBaseQuery(args, api, extraOptions)
+    expect(mockRawBaseQuery).toHaveBeenCalledWith(
+      {
+        url: 'http://example.comendpoint',
+        method: 'POST',
+        body: { hello: 'world' },
+        credentials: 'omit',
+      },
+      api,
+      extraOptions,
+    )
+    expect(result).toEqual({ data: 'objectResult' })
+  })
 
-      expect(mockRawBaseQuery).toHaveBeenCalledWith(
-        { url: 'http://example.com//endpoint', method: 'POST', body: { hello: 'world' } },
-        api,
-        extraOptions,
-      )
-      expect(result).toEqual({ data: 'objectResult' })
-    })
+  it.each([
+    '/v1/auth',
+    '/v2/register/notifications',
+    `/v2/chains/1/notifications/devices/${crypto.randomUUID()}/safes/0x0000000000000000000000000000000000000000`,
+    '/v2/chains/1/notifications/devices/0x0000000000000000000000000000000000000000',
+  ])('calls rawBaseQuery with credentials for %s', async (url) => {
+    const mockRawBaseQuery = jest.spyOn(cgwClient, 'rawBaseQuery')
+    mockRawBaseQuery.mockResolvedValue({ data: 'objectResult' })
+    cgwClient.setBaseUrl('http://example.com')
+
+    const args: FetchArgs = { url, method: 'POST', body: { hello: 'world' } }
+    const extraOptions = { credentials: 'include' }
+
+    const result = await cgwClient.dynamicBaseQuery(args, api, extraOptions)
+
+    expect(mockRawBaseQuery).toHaveBeenCalledWith(
+      {
+        url: `http://example.com${url}`,
+        method: 'POST',
+        body: { hello: 'world' },
+        credentials: 'include',
+      },
+      api,
+      extraOptions,
+    )
+    expect(result).toEqual({ data: 'objectResult' })
   })
 })

--- a/packages/store/src/gateway/cgwClient.ts
+++ b/packages/store/src/gateway/cgwClient.ts
@@ -1,6 +1,16 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
 
+const CREDENTIAL_ROUTES = [
+  /^\/v1\/auth/,
+  /^\/v2\/register\/notifications$/,
+  /^\/v2\/chains\/[^\/]+\/notifications\/devices/,
+]
+
+export function isCredentialRoute(url: string) {
+  return CREDENTIAL_ROUTES.some((route) => url.match(route))
+}
+
 let baseUrl: null | string = null
 export const setBaseUrl = (url: string) => {
   baseUrl = url
@@ -11,7 +21,6 @@ export const getBaseUrl = () => {
 }
 export const rawBaseQuery = fetchBaseQuery({
   baseUrl: '/',
-  credentials: 'include',
   headers: {
     'Content-Type': 'application/json',
     Accept: 'application/json',
@@ -32,7 +41,13 @@ export const dynamicBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBas
 
   const urlEnd = typeof args === 'string' ? args : args.url
   const adjustedUrl = `${resolvedBaseUrl}${urlEnd}`
-  const adjustedArgs = typeof args === 'string' ? adjustedUrl : { ...args, url: adjustedUrl }
+  const shouldIncludeCredentials = isCredentialRoute(urlEnd)
+  const adjustedArgs = {
+    ...(typeof args === 'string' ? { method: 'GET' } : args),
+    url: adjustedUrl,
+    // Conditionally set credentials based on your pattern, e.g. if URL starts with /auth
+    credentials: shouldIncludeCredentials ? ('include' as RequestCredentials) : ('omit' as RequestCredentials),
+  }
 
   return rawBaseQuery(adjustedArgs, api, extraOptions)
 }

--- a/packages/store/src/gateway/cgwClient.ts
+++ b/packages/store/src/gateway/cgwClient.ts
@@ -24,7 +24,6 @@ export const rawBaseQuery = fetchBaseQuery({
   headers: {
     'Content-Type': 'application/json',
     Accept: 'application/json',
-    'Set-Cookie': 'HttpOnly;Secure;SameSite=None',
   },
 })
 


### PR DESCRIPTION
## What it solves

Resolves addition of `credentials` to every request

## How this PR fixes it

The `dynamicBaseQuery` of the store now only includes `credentials` for the following routes:

- `/v1/auth/*`
- `/v2/register/notifications`
- `/v2/chains/:chainId/notifications/devices/*`

Note: these will need to be adjusted should we require `credentials` on other routes, or if we restrict domains for the Client Gateway.

## How to test it

Interaction with the app should be as expected, and mobile registration for notifications should still work.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
