### PR TITLE
Fix(Orgs): Only list owned accounts when adding to space

### DIFF
--- a/apps/web/src/features/multichain/utils/utils.ts
+++ b/apps/web/src/features/multichain/utils/utils.ts
@@ -30,6 +30,10 @@ export const isMultiChainSafeItem = (safe: SafeItem | MultiChainSafeItem): safe 
   return false
 }
 
+export const isSafeItem = (safe: SafeItem | MultiChainSafeItem): safe is SafeItem => {
+  return !isMultiChainSafeItem(safe)
+}
+
 const areOwnersMatching = (owners1: string[], owners2: string[]) =>
   owners1.length === owners2.length && owners1.every((owner) => owners2.some((owner2) => sameAddress(owner, owner2)))
 

--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -120,6 +120,7 @@ const AddAccounts = () => {
   }
 
   const handleClose = () => {
+    setError(undefined)
     setSearchQuery('')
     setValue('selectedSafes', {}) // Reset doesn't seem to work consistently with an object
     setOpen(false)

--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -8,7 +8,7 @@ import SearchIcon from '@/public/images/common/search.svg'
 import { useOrganizationSafesCreateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import debounce from 'lodash/debounce'
 import css from './styles.module.css'
-import { type AllSafeItems, useAllSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGrouped'
+import { type AllSafeItems, useOwnedSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGrouped'
 import { getComparator } from '@/features/myAccounts/utils/utils'
 import { useAppSelector } from '@/store'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
@@ -49,7 +49,7 @@ const AddAccounts = () => {
   const [manualSafes, setManualSafes] = useState<SafeItems>([])
 
   const { orderBy } = useAppSelector(selectOrderByPreference)
-  const safes = useAllSafesGrouped()
+  const safes = useOwnedSafesGrouped()
   const sortComparator = getComparator(orderBy)
   const [addSafesToSpace] = useOrganizationSafesCreateV1Mutation()
   const spaceId = useCurrentSpaceId()

--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -39,6 +39,7 @@ export type AddAccountsFormValues = {
   selectedSafes: Record<string, boolean>
 }
 
+// TODO: Refactor this and combine logic with whats in SafesList
 function getSelectedSafes(safes: AddAccountsFormValues['selectedSafes'], spaceSafes: AllSafeItems) {
   return Object.entries(safes).filter(
     ([key, isSelected]) =>

--- a/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
@@ -1,37 +1,13 @@
 import { useOrganizationSafesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import { useCurrentSpaceId } from 'src/features/spaces/hooks/useCurrentSpaceId'
-import type { AllSafeItems } from '@/features/myAccounts/hooks/useAllSafesGrouped'
+import { _buildSafeItems, type AllSafeItems } from '@/features/myAccounts/hooks/useAllSafesGrouped'
 import { useAllSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGrouped'
 import { useAppSelector } from '@/store'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import { getComparator } from '@/features/myAccounts/utils/utils'
 import { useMemo } from 'react'
-import type { SafeItem } from '@/features/myAccounts/hooks/useAllSafes'
-import { selectAllAddressBooks, type AddressBookState } from '@/store/addressBookSlice'
+import { selectAllAddressBooks } from '@/store/addressBookSlice'
 import { isAuthenticated } from '@/store/authSlice'
-
-function _buildSafeItems(safes: Record<string, string[]>, allSafeNames: AddressBookState): SafeItem[] {
-  const result: SafeItem[] = []
-
-  for (const chainId in safes) {
-    const addresses = safes[chainId]
-
-    addresses.forEach((address) => {
-      const name = allSafeNames[chainId]?.[address]
-
-      result.push({
-        chainId,
-        address,
-        isReadOnly: false,
-        isPinned: false,
-        lastVisited: 0,
-        name,
-      })
-    })
-  }
-
-  return result
-}
 
 export const useSpaceSafes = () => {
   const spaceId = useCurrentSpaceId()


### PR DESCRIPTION
## What it solves

Resolves #5425 

## How this PR fixes it

- Adds a new hook `useOwnedSafesGrouped` and uses that instead of `useAllSafesGrouped` within spaces

## How to test it

1. Create an undeployed safe
2. Observe it is listed under accounts
1. Open a space
3. Add safe accounts
4. Observe the undeployed safe is not showing up in the list

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
