### PR TITLE
Fix(Orgs): Highlight current user in member list

### DIFF
--- a/apps/web/src/features/spaces/components/MembersList/MemberName.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/MemberName.tsx
@@ -10,8 +10,13 @@ const MemberName = ({ member }: { member: UserOrganization }) => {
   return (
     <Stack direction="row" spacing={1} alignItems="center" key={member.id}>
       <InitialsAvatar size="medium" name={member.name || ''} rounded />
-      <Typography fontSize="14px">
-        {member.name} {isCurrentUser ? '(you)' : ''}
+      <Typography variant="body2">
+        {member.name}{' '}
+        {isCurrentUser && (
+          <Typography variant="body2" component="span" color="text.secondary" ml={1}>
+            you
+          </Typography>
+        )}
       </Typography>
     </Stack>
   )

--- a/apps/web/src/features/spaces/components/MembersList/MemberName.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/MemberName.tsx
@@ -1,12 +1,18 @@
 import InitialsAvatar from '../InitialsAvatar'
 import { Stack, Typography } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 
 const MemberName = ({ member }: { member: UserOrganization }) => {
+  const { currentData: user } = useUsersGetWithWalletsV1Query()
+  const isCurrentUser = member.user.id === user?.id
+
   return (
     <Stack direction="row" spacing={1} alignItems="center" key={member.id}>
       <InitialsAvatar size="medium" name={member.name || ''} rounded />
-      <Typography fontSize="14px">{member.name}</Typography>
+      <Typography fontSize="14px">
+        {member.name} {isCurrentUser ? '(you)' : ''}
+      </Typography>
     </Stack>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves #5433 

## How this PR fixes it

- Checks for the current member when rendering the member name and highlights them with `(you)`

## How to test it

1. Open an org
2. Go to the member list
3. Observe a `(you)` next to your member name

## Screenshots

<img width="469" alt="Screenshot 2025-03-20 at 14 30 24" src="https://github.com/user-attachments/assets/ea9b4c77-1379-4984-a0e4-f14115172ad5" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
