### PR TITLE
feat(Signing UX): always show hashes on receipt

### DIFF
--- a/apps/web/src/components/transactions/HexEncodedData/styles.module.css
+++ b/apps/web/src/components/transactions/HexEncodedData/styles.module.css
@@ -7,4 +7,5 @@
 .encodedData button {
   padding-top: 0;
   padding-bottom: 0;
+  padding-left: 0;
 }

--- a/apps/web/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/SafeTxHashDataRow/index.tsx
@@ -4,7 +4,6 @@ import { TxDataRow, generateDataRowValue } from '../TxDataRow'
 import { type SafeTransactionData, type SafeVersion } from '@safe-global/safe-core-sdk-types'
 import { calculateSafeTransactionHash } from '@safe-global/protocol-kit/dist/src/utils'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import useChainId from '@/hooks/useChainId'
 import { getDomainHash, getSafeTxMessageHash } from '@/utils/safe-hashes'
 
 export const SafeTxHashDataRow = ({
@@ -14,40 +13,14 @@ export const SafeTxHashDataRow = ({
   safeTxData: SafeTransactionData
   safeTxHash?: string
 }) => {
-  const { safe, safeAddress } = useSafeInfo()
-  const chainId = useChainId()
-  const safeVersion = safe.version as SafeVersion
-
-  const computedSafeTxHash = useMemo(() => {
-    if (safeTxHash) return safeTxHash
-    if (!safe.version) return
-    try {
-      return calculateSafeTransactionHash(safeAddress, safeTxData, safe.version, BigInt(safe.chainId))
-    } catch {
-      return
-    }
-  }, [safe.chainId, safe.version, safeAddress, safeTxData, safeTxHash])
-
-  const domainHash = useMemo(() => {
-    try {
-      return getDomainHash({ chainId, safeAddress, safeVersion })
-    } catch {
-      return ''
-    }
-  }, [chainId, safeAddress, safeVersion])
-
-  const messageHash = useMemo(() => {
-    try {
-      return getSafeTxMessageHash({ safeVersion, safeTxData })
-    } catch {
-      return ''
-    }
-  }, [safeTxData, safeVersion])
+  const domainHash = useDomainHash()
+  const messageHash = useMessageHash({ safeTxData })
+  const computedSafeTxHash = useSafeTxHash({ safeTxData, safeTxHash })
 
   return (
     <Stack gap={1}>
       <TxDataRow datatestid="tx-domain-hash" title="Domain hash:">
-        {generateDataRowValue(domainHash, 'rawData')}
+        {generateDataRowValue(domainHash ?? '', 'rawData')}
       </TxDataRow>
       {messageHash && (
         <TxDataRow datatestid="tx-message-hash" title="Message hash:">
@@ -55,8 +28,62 @@ export const SafeTxHashDataRow = ({
         </TxDataRow>
       )}
       <TxDataRow datatestid="tx-safe-hash" title="safeTxHash:">
-        {generateDataRowValue(computedSafeTxHash, 'rawData')}
+        {generateDataRowValue(computedSafeTxHash ?? '', 'rawData')}
       </TxDataRow>
     </Stack>
   )
+}
+
+export function useDomainHash(): string | null {
+  const { safe, safeAddress } = useSafeInfo()
+
+  return useMemo(() => {
+    if (!safe.version) {
+      return null
+    }
+    try {
+      return getDomainHash({ chainId: safe.chainId, safeAddress, safeVersion: safe.version as SafeVersion })
+    } catch {
+      return null
+    }
+  }, [safe.chainId, safe.version, safeAddress])
+}
+
+export function useMessageHash({ safeTxData }: { safeTxData: SafeTransactionData }): string | null {
+  const { safe } = useSafeInfo()
+
+  return useMemo(() => {
+    if (!safe.version) {
+      return null
+    }
+    try {
+      return getSafeTxMessageHash({ safeVersion: safe.version as SafeVersion, safeTxData })
+    } catch {
+      return null
+    }
+  }, [safe.version, safeTxData])
+}
+
+export function useSafeTxHash({
+  safeTxData,
+  safeTxHash,
+}: {
+  safeTxData: SafeTransactionData
+  safeTxHash?: string
+}): string | null {
+  const { safe, safeAddress } = useSafeInfo()
+
+  return useMemo(() => {
+    if (safeTxHash) {
+      return safeTxHash
+    }
+    if (!safe.version) {
+      return null
+    }
+    try {
+      return calculateSafeTransactionHash(safeAddress, safeTxData, safe.version, BigInt(safe.chainId))
+    } catch {
+      return null
+    }
+  }, [safeTxData, safe.chainId, safe.version, safeAddress, safeTxHash])
 }

--- a/apps/web/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/apps/web/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -11,8 +11,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  /* Remove height of progress bar */
-  padding: calc(var(--space-3) - 6px) var(--space-3) var(--space-3);
+  padding: var(--space-3);
   border-bottom: 1px solid var(--color-border-light);
 }
 
@@ -108,15 +107,18 @@
   /* Height of transaction type title */
   margin-top: 46px;
 }
+
 @media (max-width: 1199px) {
   .backButton {
     left: 50%;
     transform: translateX(-50%);
   }
+
   .step :global(.MuiCardActions-root) {
     margin-bottom: var(--space-8);
   }
 }
+
 @media (max-width: 899.95px) {
   .widget {
     position: absolute;

--- a/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
@@ -46,11 +46,14 @@ const TxDetailsRow = ({
 )
 
 const ContentWrapper = ({ children }: { children: ReactElement | ReactElement[] }) => (
-  <Box sx={{ maxHeight: '750px', overflowY: 'auto', px: 2 }}>{children}</Box>
+  <Box sx={{ maxHeight: '550px', overflowY: 'auto', px: 2 }}>{children}</Box>
 )
 
 export const TxDetails = ({ safeTx, txData, showHashes: _showHashes }: TxDetailsProps) => {
   const [showHashes, setShowHashes] = useState(_showHashes)
+  const safeTxHash = useSafeTxHash({ safeTxData: safeTx.data })
+  const domainHash = useDomainHash()
+  const messageHash = useMessageHash({ safeTxData: safeTx.data })
 
   const toInfo = txData?.addressInfoIndex?.[safeTx.data.to] || txData?.to
   const toName = toInfo?.name || (toInfo && 'displayName' in toInfo ? String(toInfo.displayName || '') : undefined)
@@ -160,13 +163,35 @@ export const TxDetails = ({ safeTx, txData, showHashes: _showHashes }: TxDetails
                     display="inline-flex"
                     alignItems="center"
                     color="primary.light"
+                    sx={{ cursor: 'pointer' }}
                   >
-                    Show transaction hashes{' '}
-                    <ExpandMoreIcon sx={{ transform: !showHashes ? 'rotate(180deg)' : undefined }} />
+                    Transaction hashes <ExpandMoreIcon sx={{ transform: !showHashes ? 'rotate(180deg)' : undefined }} />
                   </Typography>
                 </Button>
 
-                {!showHashes && <TxDetailsHashes safeTx={safeTx} />}
+                {showHashes && domainHash && (
+                  <TxDetailsRow label="Domain hash">
+                    <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
+                      <HexEncodedData hexData={domainHash} limit={66} highlightFirstBytes={false} />
+                    </Typography>
+                  </TxDetailsRow>
+                )}
+
+                {showHashes && messageHash && (
+                  <TxDetailsRow label="Message hash">
+                    <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
+                      <HexEncodedData hexData={messageHash} limit={66} highlightFirstBytes={false} />
+                    </Typography>
+                  </TxDetailsRow>
+                )}
+
+                {showHashes && safeTxHash && (
+                  <TxDetailsRow label="safeTxHash">
+                    <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
+                      <HexEncodedData hexData={safeTxHash} limit={66} highlightFirstBytes={false} />
+                    </Typography>
+                  </TxDetailsRow>
+                )}
               </Stack>
             </ContentWrapper>
           ),
@@ -193,29 +218,5 @@ export const TxDetails = ({ safeTx, txData, showHashes: _showHashes }: TxDetails
         },
       ]}
     </PaperViewToggle>
-  )
-}
-
-function TxDetailsHashes({ safeTx }: Pick<TxDetailsProps, 'safeTx'>) {
-  const safeTxHash = useSafeTxHash({ safeTxData: safeTx.data })
-  const domainHash = useDomainHash()
-  const messageHash = useMessageHash({ safeTxData: safeTx.data })
-
-  return (
-    <>
-      {[
-        ['Domain hash', domainHash] as const,
-        ['Message hash', messageHash] as const,
-        ['safeTxHash', safeTxHash] as const,
-      ].map(([label, hash]) => {
-        return (
-          <TxDetailsRow label={label} key={hash}>
-            <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
-              {hash}
-            </Typography>
-          </TxDetailsRow>
-        )
-      })}
-    </>
   )
 }

--- a/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/TxDetails.tsx
@@ -49,8 +49,8 @@ const ContentWrapper = ({ children }: { children: ReactElement | ReactElement[] 
   <Box sx={{ maxHeight: '550px', overflowY: 'auto', px: 2 }}>{children}</Box>
 )
 
-export const TxDetails = ({ safeTx, txData, showHashes: _showHashes }: TxDetailsProps) => {
-  const [showHashes, setShowHashes] = useState(_showHashes)
+export const TxDetails = ({ safeTx, txData, showHashes }: TxDetailsProps) => {
+  const [expandHashes, setExpandHashes] = useState(showHashes)
   const safeTxHash = useSafeTxHash({ safeTxData: safeTx.data })
   const domainHash = useDomainHash()
   const messageHash = useMessageHash({ safeTxData: safeTx.data })
@@ -156,7 +156,7 @@ export const TxDetails = ({ safeTx, txData, showHashes: _showHashes }: TxDetails
 
                 <TxDetailsRow label="Nonce">{safeTx.data.nonce}</TxDetailsRow>
 
-                <Button onClick={() => setShowHashes(!showHashes)} sx={{ all: 'unset' }}>
+                <Button onClick={() => setExpandHashes(!expandHashes)} sx={{ all: 'unset' }}>
                   <Typography
                     variant="body2"
                     fontWeight={700}
@@ -165,11 +165,12 @@ export const TxDetails = ({ safeTx, txData, showHashes: _showHashes }: TxDetails
                     color="primary.light"
                     sx={{ cursor: 'pointer' }}
                   >
-                    Transaction hashes <ExpandMoreIcon sx={{ transform: !showHashes ? 'rotate(180deg)' : undefined }} />
+                    Transaction hashes{' '}
+                    <ExpandMoreIcon sx={expandHashes ? { transform: 'rotate(180deg)' } : undefined} />
                   </Typography>
                 </Button>
 
-                {showHashes && domainHash && (
+                {expandHashes && domainHash && (
                   <TxDetailsRow label="Domain hash">
                     <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
                       <HexEncodedData hexData={domainHash} limit={66} highlightFirstBytes={false} />
@@ -177,7 +178,7 @@ export const TxDetails = ({ safeTx, txData, showHashes: _showHashes }: TxDetails
                   </TxDetailsRow>
                 )}
 
-                {showHashes && messageHash && (
+                {expandHashes && messageHash && (
                   <TxDetailsRow label="Message hash">
                     <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
                       <HexEncodedData hexData={messageHash} limit={66} highlightFirstBytes={false} />
@@ -185,7 +186,7 @@ export const TxDetails = ({ safeTx, txData, showHashes: _showHashes }: TxDetails
                   </TxDetailsRow>
                 )}
 
-                {showHashes && safeTxHash && (
+                {expandHashes && safeTxHash && (
                   <TxDetailsRow label="safeTxHash">
                     <Typography variant="body2" width="100%" sx={{ wordWrap: 'break-word' }}>
                       <HexEncodedData hexData={safeTxHash} limit={66} highlightFirstBytes={false} />

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -106,9 +106,9 @@ export const ConfirmTxDetails = (props: SignOrExecuteProps) => {
       <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />
 
       <FormControlLabel
-        sx={{ mt: 2 }}
+        sx={{ mt: 2, mb: -1.3 }}
         control={<Checkbox checked={checked} onChange={handleCheckboxChange} />}
-        label="I understand what I'm signing and acknowledge that this is an irreversible action."
+        label="I understand what I'm signing and that this is an irreversible action."
       />
 
       <SignOrExecuteFormV2

--- a/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
@@ -337,6 +337,52 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="MuiGrid-root MuiGrid-container css-1m1clne-MuiGrid-root"
+                          >
+                            <div
+                              class="MuiGrid-root MuiGrid-item css-p1l0hx-MuiGrid-root"
+                              data-testid="tx-row-title"
+                              style="word-break: break-word;"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                              >
+                                safeTxHash:
+                              </p>
+                            </div>
+                            <div
+                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+                              data-testid="tx-data-row"
+                            >
+                              <div
+                                class="encodedData MuiBox-root css-0"
+                                data-testid="tx-hexData"
+                              >
+                                <span
+                                  aria-label="Copy to clipboard"
+                                  class=""
+                                  data-mui-internal-clone-element="true"
+                                  style="cursor: pointer;"
+                                >
+                                  <button
+                                    aria-label="Copy to clipboard"
+                                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <mock-icon
+                                      aria-hidden=""
+                                      class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                                      data-testid="copy-btn-icon"
+                                      focusable="false"
+                                    />
+                                  </button>
+                                </span>
+                                 
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
@@ -337,6 +337,52 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                               </div>
                             </div>
                           </div>
+                          <div
+                            class="MuiGrid-root MuiGrid-container css-1m1clne-MuiGrid-root"
+                          >
+                            <div
+                              class="MuiGrid-root MuiGrid-item css-p1l0hx-MuiGrid-root"
+                              data-testid="tx-row-title"
+                              style="word-break: break-word;"
+                            >
+                              <p
+                                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                              >
+                                safeTxHash:
+                              </p>
+                            </div>
+                            <div
+                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+                              data-testid="tx-data-row"
+                            >
+                              <div
+                                class="encodedData MuiBox-root css-0"
+                                data-testid="tx-hexData"
+                              >
+                                <span
+                                  aria-label="Copy to clipboard"
+                                  class=""
+                                  data-mui-internal-clone-element="true"
+                                  style="cursor: pointer;"
+                                >
+                                  <button
+                                    aria-label="Copy to clipboard"
+                                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                                    tabindex="0"
+                                    type="button"
+                                  >
+                                    <mock-icon
+                                      aria-hidden=""
+                                      class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                                      data-testid="copy-btn-icon"
+                                      focusable="false"
+                                    />
+                                  </button>
+                                </span>
+                                 
+                              </div>
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## What it solves

Resolves #5417

## How this PR fixes it

There is no common display of hashes (domain, message, Safe) in wallets and our receipt screen currently shows them depending on whether a hardware wallet is connect. We should instead always show them.

This adjusts the receipt screen to include a collapsable section, displaying the hashes when opened. It is opened by default if a hardware wallet is connected, however.

## How to test it

With the receipt screen open, observe the new section that can be opened/closed on click. If a hardware wallet is connected, it should be open by default.

## Screenshots

![image](https://github.com/user-attachments/assets/cd8ea540-47ee-44b7-80e0-354d06695415)

![image](https://github.com/user-attachments/assets/ce6ffb16-9df8-483e-8801-7230d355a2aa)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
