### PR TITLE
Fix(Signing UX v2): Ledger Live detection

### DIFF
--- a/apps/web/src/utils/wallets.ts
+++ b/apps/web/src/utils/wallets.ts
@@ -8,7 +8,7 @@ import { PRIVATE_KEY_MODULE_LABEL } from '@/services/private-key-module'
 import { type JsonRpcProvider } from 'ethers'
 
 const WALLETCONNECT = 'WalletConnect'
-const WC_LEDGER = 'Ledger'
+const WC_LEDGER = 'Ledger Wallet'
 
 const isWCRejection = (err: Error): boolean => {
   return /rejected/.test(err?.message)


### PR DESCRIPTION
## What it solves

Ledger Live's WalletConnect peer name is `Ledger Wallet`, not just `Ledger`.