### PR TITLE
Fix(Orgs): hide add members button on dashboard members list for non admins

### DIFF
--- a/apps/web/src/features/spaces/components/Dashboard/DashboardMembersList.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/DashboardMembersList.tsx
@@ -1,4 +1,4 @@
-import { Paper, Button, Box } from '@mui/material'
+import { Paper, Button, Box, Stack } from '@mui/material'
 import type { UserOrganization } from '@safe-global/store/gateway/AUTO_GENERATED/organizations'
 import PlusIcon from '@/public/images/common/plus.svg'
 import { useState } from 'react'
@@ -6,25 +6,31 @@ import AddMembersModal from '../AddMembersModal'
 import MemberName from '../MembersList/MemberName'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
+import { useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
 
 const DashboardMembersList = ({ members }: { members: UserOrganization[] }) => {
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
+  const isAdmin = useIsAdmin()
 
   return (
     <>
       <Paper sx={{ p: 2, borderRadius: '8px' }}>
-        {members.map((member) => (
-          <Box mb={2} key={member.id}>
-            <MemberName key={member.id} member={member} />
+        <Stack spacing={2}>
+          {members.map((member) => (
+            <Box key={member.id}>
+              <MemberName key={member.id} member={member} />
+            </Box>
+          ))}
+        </Stack>
+        {isAdmin && (
+          <Box display="flex" justifyContent="center" mt={2}>
+            <Track {...SPACE_EVENTS.ADD_MEMBER_MODAL} label={SPACE_LABELS.space_dashboard}>
+              <Button size="small" variant="text" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>
+                Add member
+              </Button>
+            </Track>
           </Box>
-        ))}
-        <Box display="flex" justifyContent="center">
-          <Track {...SPACE_EVENTS.ADD_MEMBER_MODAL} label={SPACE_LABELS.space_dashboard}>
-            <Button size="small" variant="text" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>
-              Add member
-            </Button>
-          </Track>
-        </Box>
+        )}
       </Paper>
       {openAddMembersModal && <AddMembersModal onClose={() => setOpenAddMembersModal(false)} />}
     </>


### PR DESCRIPTION
## What it solves

Resolves [#5400](https://github.com/safe-global/safe-wallet-monorepo/issues/5400)

## How this PR fixes it
- Hides the add members button in the members list if you are not an admin

## How to test it
- Go to the dashboard of a space where you are a non admin member
- If the members list is shown, it should not have a button for adding members.

## Screenshots
![image](https://github.com/user-attachments/assets/befe65f5-5c26-4d64-9dac-6516dbf9097c)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
