### PR TITLE
feat(mobile): Safes can have a name now

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -129,6 +129,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.26.3",
     "@eslint/js": "^9.18.0",
+    "@faker-js/faker": "^9.0.3",
     "@gorhom/bottom-sheet": "^5.1.1",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/datetimepicker": "8.2.0",

--- a/apps/mobile/src/app/(import-accounts)/form.tsx
+++ b/apps/mobile/src/app/(import-accounts)/form.tsx
@@ -7,7 +7,7 @@ import { useModalStyle } from '@/src/navigation/hooks/useModalStyle'
 function ImportAccountFormScreen() {
   const modalStyle = useModalStyle()
   return (
-    <View style={modalStyle} paddingHorizontal={'$4'}>
+    <View style={modalStyle}>
       <ImportAccountFormContainer />
     </View>
   )

--- a/apps/mobile/src/components/Dropdown/DropdownLabel.tsx
+++ b/apps/mobile/src/components/Dropdown/DropdownLabel.tsx
@@ -22,7 +22,7 @@ export const DropdownLabel = ({ label, leftNode, onPress, labelProps = defaultLa
       {leftNode}
 
       <View justifyContent={'center'}>
-        <Text fontSize={labelProps.fontSize} fontWeight={labelProps.fontWeight}>
+        <Text fontSize={labelProps.fontSize} fontWeight={labelProps.fontWeight} numberOfLines={1} maxWidth={170}>
           {label}
         </Text>
       </View>

--- a/apps/mobile/src/components/SafeInput/SafeInput.tsx
+++ b/apps/mobile/src/components/SafeInput/SafeInput.tsx
@@ -41,7 +41,7 @@ export function SafeInput({
   return (
     <Theme name={`input_${getInputThemeName(hasError, success)}`}>
       <StyledInputContainer minHeight={height} testID="safe-input">
-        {left}
+        {left ? <View paddingLeft={'$3'}>{left}</View> : null}
 
         <StyledInput
           {...props}
@@ -49,11 +49,12 @@ export function SafeInput({
           flex={1}
           // maxHeight={height}
           autoCapitalize="none"
+          paddingHorizontal={'$3'}
           // keyboardType={'ascii-capable'}
           autoCorrect={false}
           placeholder={placeholder}
         />
-        {right}
+        {right ? <View paddingHorizontal={'$3'}>{right}</View> : null}
       </StyledInputContainer>
       {hasError && <ErrorDisplay error={error} />}
     </Theme>

--- a/apps/mobile/src/components/SafeInput/styled.ts
+++ b/apps/mobile/src/components/SafeInput/styled.ts
@@ -1,12 +1,11 @@
 import { Input, styled, View } from 'tamagui'
 
 export const StyledInputContainer = styled(View, {
-  borderWidth: 2,
+  borderWidth: 1,
   borderRadius: '$4',
   borderColor: '$borderColor',
   flex: 1,
   flexDirection: 'row',
-  paddingHorizontal: '$3',
   alignItems: 'center',
   justifyContent: 'center',
   marginBottom: '$3',
@@ -15,7 +14,7 @@ export const StyledInputContainer = styled(View, {
   variants: {
     error: {
       true: {
-        borderWidth: 2,
+        borderWidth: 1,
       },
     },
   },
@@ -26,4 +25,8 @@ export const StyledInput = styled(Input, {
   placeholderTextColor: '$placeholderColor',
   backgroundColor: '$inputBackgroundColor',
   borderWidth: 0,
+
+  style: {
+    padding: 0,
+  },
 })

--- a/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.test.tsx
+++ b/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.test.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { render, screen, fireEvent } from '@/src/tests/test-utils'
 import { AccountItem } from './AccountItem'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { faker } from '@faker-js/faker'
+import { shortenAddress } from '@/src/utils/formatters'
 
 jest.mock('expo-router', () => ({
   useNavigation: () => ({
@@ -12,9 +14,9 @@ jest.mock('expo-router', () => ({
 }))
 
 const mockAccount = {
-  address: { value: '0x123' as `0x${string}`, name: 'Test Account' },
+  address: { value: faker.finance.ethereumAddress() as `0x${string}`, name: 'Test Account' },
   threshold: 1,
-  owners: [{ value: '0x456' as `0x${string}` }],
+  owners: [{ value: faker.finance.ethereumAddress() as `0x${string}` }],
   fiatTotal: '1000',
   chainId: '1',
   queued: 0,
@@ -63,7 +65,32 @@ describe('AccountItem', () => {
       />,
     )
 
-    expect(screen.getByText('Test Account')).toBeTruthy()
+    expect(screen.getByText(shortenAddress(mockAccount.address.value))).toBeTruthy()
+    expect(screen.getByText('1/1')).toBeTruthy()
+    expect(screen.getByText('$1000')).toBeTruthy()
+  })
+
+  it('renders account details correctly when a contact for the address exists', () => {
+    render(
+      <AccountItem
+        account={mockAccount}
+        chains={mockChains as unknown as Chain[]}
+        activeAccount="0x789"
+        onSelect={mockOnSelect}
+      />,
+      {
+        initialStore: {
+          addressBook: {
+            contacts: {
+              [mockAccount.address.value]: { name: 'Test Safe', value: mockAccount.address.value },
+            },
+            selectedContact: null,
+          },
+        },
+      },
+    )
+
+    expect(screen.getByText('Test Safe')).toBeTruthy()
     expect(screen.getByText('1/1')).toBeTruthy()
     expect(screen.getByText('$1000')).toBeTruthy()
   })

--- a/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.tsx
+++ b/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.tsx
@@ -9,6 +9,8 @@ import { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { shortenAddress } from '@/src/utils/formatters'
 import { RenderItemParams } from 'react-native-draggable-flatlist'
 import { useEditAccountItem } from './hooks/useEditAccountItem'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectContactByAddress } from '@/src/store/addressBookSlice'
 
 interface AccountItemProps {
   chains: Chain[]
@@ -30,7 +32,7 @@ const getRightNodeLayout = (isEdit: boolean, isActive: boolean) => {
 export function AccountItem({ account, drag, chains, isDragging, activeAccount, onSelect }: AccountItemProps) {
   const { isEdit, deleteSafe } = useEditAccountItem()
   const isActive = activeAccount === account.address.value
-
+  const contact = useAppSelector(selectContactByAddress(account.address.value))
   const handleChainSelect = () => {
     onSelect(account.address.value)
   }
@@ -75,7 +77,7 @@ export function AccountItem({ account, drag, chains, isDragging, activeAccount, 
           }
           threshold={account.threshold}
           owners={account.owners.length}
-          name={account.address.name || shortenAddress(account.address.value)}
+          name={contact ? contact.name : shortenAddress(account.address.value)}
           address={account.address.value as Address}
           balance={account.fiatTotal}
           chains={isEdit ? undefined : chains}

--- a/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
+++ b/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
@@ -10,6 +10,7 @@ import { Link, useRouter } from 'expo-router'
 import { DropdownLabel } from '@/src/components/Dropdown/DropdownLabel'
 import { selectAppNotificationStatus } from '@/src/store/notificationsSlice'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { selectContactByAddress } from '@/src/store/addressBookSlice'
 
 const dropdownLabelProps = {
   fontSize: '$5',
@@ -20,6 +21,7 @@ export const Navbar = () => {
   const insets = useSafeAreaInsets()
   const router = useRouter()
   const activeSafe = useDefinedActiveSafe()
+  const contact = useAppSelector(selectContactByAddress(activeSafe.address))
   const isAppNotificationEnabled = useAppSelector(selectAppNotificationStatus)
 
   const handleNotificationAccess = () => {
@@ -41,7 +43,7 @@ export const Navbar = () => {
         backgroundColor={'$background'}
       >
         <DropdownLabel
-          label={shortenAddress(activeSafe.address)}
+          label={contact ? contact.name : shortenAddress(activeSafe.address)}
           labelProps={dropdownLabelProps}
           leftNode={<Identicon address={activeSafe.address} size={30} />}
           onPress={() => {

--- a/apps/mobile/src/features/ImportReadOnly/AddSignersForm.container.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/AddSignersForm.container.tsx
@@ -12,9 +12,10 @@ import { selectSigners } from '@/src/store/signersSlice'
 import { SignerSection } from '@/src/features/Signers/components/SignersList/SignersList'
 import { extractChainsFromSafes, extractSignersFromSafes } from '@/src/features/ImportReadOnly/helpers/safes'
 import { AddSignersFormView } from '@/src/features/ImportReadOnly/components/AddSignersFormView'
+import { upsertContact } from '@/src/store/addressBookSlice'
 
 export const AddSignersFormContainer = () => {
-  const params = useLocalSearchParams<{ safeAddress: string }>()
+  const params = useLocalSearchParams<{ safeAddress: string; safeName: string }>()
   const dispatch = useAppDispatch()
   const chainIds = useAppSelector(selectAllChainsIds)
   const appSigners = useAppSelector(selectSigners)
@@ -41,6 +42,7 @@ export const AddSignersFormContainer = () => {
       return
     }
     const hasActiveSafe = !!activeSafe
+    dispatch(upsertContact({ value: params.safeAddress, name: params.safeName }))
     dispatch(addSafe({ SafeInfo: currentData[0], chains: safeAvailableOnChains }))
     dispatch(
       setActiveSafe({

--- a/apps/mobile/src/features/ImportReadOnly/components/ImportAccountFormView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/ImportAccountFormView.tsx
@@ -12,31 +12,31 @@ import { useScrollableHeader } from '@/src/navigation/useScrollableHeader'
 import { NavBarTitle } from '@/src/components/Title'
 import { useModalStyle } from '@/src/navigation/hooks/useModalStyle'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { type Control, Controller, type FieldErrors, FieldNamesMarkedBoolean } from 'react-hook-form'
+import type { FormValues } from '@/src/features/ImportReadOnly/types'
+import { parsePrefixedAddress } from '@safe-global/utils/addresses'
 
 type LazyQueryResult = ReturnType<typeof useLazySafesGetOverviewForManyQuery>[1]
 
 type ImportAccountFormViewProps = {
-  safeAddress: string
-  onChangeText: (text: string) => void
-  error: string | undefined
   canContinue: boolean
-  addressWithoutPrefix: string | undefined
   result: LazyQueryResult
   isEnteredAddressValid: boolean
-  safeExists: boolean
   onContinue: () => void
+  control: Control<FormValues>
+  errors: FieldErrors<FormValues>
+  dirtyFields: FieldNamesMarkedBoolean<FormValues>
+  isFormValid: boolean
 }
 
 export const ImportAccountFormView: React.FC<ImportAccountFormViewProps> = ({
-  safeAddress,
-  onChangeText,
-  error,
   canContinue,
-  addressWithoutPrefix,
   result,
   isEnteredAddressValid,
-  safeExists,
   onContinue,
+  control,
+  errors,
+  dirtyFields,
 }) => {
   const modalStyle = useModalStyle()
   const { top } = useSafeAreaInsets()
@@ -55,43 +55,80 @@ export const ImportAccountFormView: React.FC<ImportAccountFormViewProps> = ({
       style={{ flex: 1 }}
       keyboardVerticalOffset={modalStyle.paddingBottom + top}
     >
-      <ScrollView paddingBottom={'$4'} onScroll={handleScroll} flex={1}>
+      <ScrollView
+        paddingBottom={'$4'}
+        onScroll={handleScroll}
+        flex={1}
+        contentContainerStyle={{ paddingBottom: '$9', paddingHorizontal: '$4' }}
+      >
         <LargeHeaderTitle marginBottom={'$4'}>Import Safe account</LargeHeaderTitle>
-        <Text marginBottom={'$4'}>Paste the address of an account you want to import.</Text>
-        <SafeInput
-          value={safeAddress}
-          onChangeText={onChangeText}
-          multiline={true}
-          placeholder="Paste address..."
-          error={error && error.length > 0 ? error : undefined}
-          success={canContinue}
-          left={
-            addressWithoutPrefix ? (
-              <Identicon address={addressWithoutPrefix as `0x${string}`} size={32} />
-            ) : (
-              <View width={32} />
-            )
-          }
-          right={
-            result?.data?.length && !error ? (
-              <SafeFontIcon name={'check-filled'} size={20} color={'$success'} testID={'success-icon'} />
-            ) : (
-              <View width={20} />
-            )
-          }
-        />
+        <Text>Paste the address of an account you want to import.</Text>
+        <View marginTop={'$4'}>
+          <Controller
+            control={control}
+            name="name"
+            render={({ field: { onChange, value } }) => {
+              return (
+                <SafeInput
+                  value={value}
+                  onChangeText={onChange}
+                  multiline={true}
+                  autoFocus={true}
+                  placeholder="Enter safe name here"
+                  error={errors.name?.message}
+                  success={dirtyFields.name && !errors.name}
+                />
+              )
+            }}
+          />
+        </View>
 
-        <VerificationStatus
-          isLoading={result.isLoading}
-          data={result.data}
-          isEnteredAddressValid={isEnteredAddressValid}
-        />
+        <View marginTop={'$4'}>
+          <Controller
+            control={control}
+            name="safeAddress"
+            render={({ field: { onChange, value } }) => {
+              const addressWithoutPrefix = parsePrefixedAddress(value).address
+              return (
+                <SafeInput
+                  value={value}
+                  onChangeText={onChange}
+                  multiline={true}
+                  placeholder="Paste address..."
+                  error={errors.safeAddress?.message}
+                  success={dirtyFields.safeAddress && !errors.safeAddress}
+                  left={
+                    addressWithoutPrefix ? (
+                      <Identicon address={addressWithoutPrefix as `0x${string}`} size={32} />
+                    ) : null
+                  }
+                  right={
+                    result?.data?.length && !errors.safeAddress ? (
+                      <SafeFontIcon name={'check-filled'} size={20} color={'$success'} testID={'success-icon'} />
+                    ) : (
+                      <View width={20} />
+                    )
+                  }
+                />
+              )
+            }}
+          />
+        </View>
+
+        {!errors.safeAddress && (
+          <VerificationStatus
+            isLoading={result.isLoading}
+            data={result.data}
+            isEnteredAddressValid={isEnteredAddressValid}
+          />
+        )}
       </ScrollView>
       <SafeButton
         primary
         onPress={onContinue}
-        disabled={!isEnteredAddressValid || !safeExists}
+        disabled={!canContinue}
         testID={'continue-button'}
+        marginHorizontal={'$4'}
       >
         Continue
       </SafeButton>

--- a/apps/mobile/src/features/ImportReadOnly/schema.ts
+++ b/apps/mobile/src/features/ImportReadOnly/schema.ts
@@ -1,0 +1,18 @@
+import { isValidAddress } from '@safe-global/utils/validation'
+import { parsePrefixedAddress } from '@safe-global/utils/addresses'
+import { z } from 'zod'
+
+export const formSchema = z.object({
+  name: z.string().nonempty('Name is required').max(30, 'Name is too long'),
+  safeAddress: z
+    .string()
+    .nonempty('Safe address is required')
+    .refine(
+      (value) => {
+        return isValidAddress(parsePrefixedAddress(value).address)
+      },
+      {
+        message: 'Invalid address format',
+      },
+    ),
+})

--- a/apps/mobile/src/features/ImportReadOnly/types.ts
+++ b/apps/mobile/src/features/ImportReadOnly/types.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod'
+import { formSchema } from '@/src/features/ImportReadOnly/schema'
+
+export type FormValues = z.infer<typeof formSchema>

--- a/apps/mobile/src/features/Settings/Settings.container.tsx
+++ b/apps/mobile/src/features/Settings/Settings.container.tsx
@@ -3,6 +3,8 @@ import { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { Settings } from './Settings'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useCallback, useState } from 'react'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectContactByAddress } from '@/src/store/addressBookSlice'
 
 export const SettingsContainer = () => {
   const { chainId, address } = useDefinedActiveSafe()
@@ -10,6 +12,7 @@ export const SettingsContainer = () => {
     chainId: chainId,
     safeAddress: address,
   })
+  const contact = useAppSelector(selectContactByAddress(address))
   const [displayDevMenu, setDisplayDevMenu] = useState(false)
   const [tappedCount, setTappedCount] = useState(0)
   const onImplementationTap = useCallback(() => {
@@ -20,6 +23,12 @@ export const SettingsContainer = () => {
   }, [tappedCount, setTappedCount, setDisplayDevMenu])
 
   return (
-    <Settings address={address} data={data} displayDevMenu={displayDevMenu} onImplementationTap={onImplementationTap} />
+    <Settings
+      address={address}
+      data={data}
+      displayDevMenu={displayDevMenu}
+      onImplementationTap={onImplementationTap}
+      contact={contact}
+    />
   )
 }

--- a/apps/mobile/src/features/Settings/Settings.tsx
+++ b/apps/mobile/src/features/Settings/Settings.tsx
@@ -11,15 +11,17 @@ import { router } from 'expo-router'
 import { IdenticonWithBadge } from '@/src/features/Settings/components/IdenticonWithBadge'
 
 import { Navbar } from '@/src/features/Settings/components/Navbar/Navbar'
+import { type Contact } from '@/src/store/addressBookSlice'
 
 interface SettingsProps {
   data: SafeState
   address: `0x${string}`
   displayDevMenu: boolean
   onImplementationTap: () => void
+  contact: Contact | null
 }
 
-export const Settings = ({ address, data, onImplementationTap, displayDevMenu }: SettingsProps) => {
+export const Settings = ({ address, data, onImplementationTap, displayDevMenu, contact }: SettingsProps) => {
   const { owners = [], threshold, implementation } = data
 
   return (
@@ -42,8 +44,8 @@ export const Settings = ({ address, data, onImplementationTap, displayDevMenu }:
                   address={address}
                   badgeContent={owners.length ? `${threshold}/${owners.length}` : ''}
                 />
-                <H2 color="$foreground" fontWeight={600}>
-                  My DAO
+                <H2 color="$foreground" fontWeight={600} numberOfLines={1}>
+                  {contact?.name || 'Unnamed Safe'}
                 </H2>
                 <View>
                   <EthAddress
@@ -53,12 +55,6 @@ export const Settings = ({ address, data, onImplementationTap, displayDevMenu }:
                       color: '$colorSecondary',
                     }}
                   />
-                </View>
-
-                <View>
-                  <Skeleton>
-                    <Text color="$primary">saaafe.xyz</Text>
-                  </Skeleton>
                 </View>
               </YStack>
 
@@ -165,7 +161,7 @@ export const Settings = ({ address, data, onImplementationTap, displayDevMenu }:
 
                 {displayDevMenu && (
                   <View backgroundColor="$backgroundDark" padding="$4" borderRadius="$3" gap={'$2'}>
-                    <Text color="$foreground">Developer stuff</Text>
+                    <Text color="$foreground">Developer</Text>
                     <View backgroundColor={'$background'} borderRadius={'$3'}>
                       <Pressable
                         style={({ pressed }) => [{ opacity: pressed ? 0.5 : 1.0 }]}

--- a/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
@@ -8,11 +8,12 @@ import { useCopyAndDispatchToast } from '@/src/hooks/useCopyAndDispatchToast'
 import { useToastController } from '@tamagui/toast'
 import { selectChainById } from '@/src/store/chains'
 import { RootState } from '@/src/store'
-import { useAppSelector } from '@/src/store/hooks'
+import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useEditAccountItem } from '@/src/features/AccountsSheet/AccountItem/hooks/useEditAccountItem'
 import { type Address } from '@/src/types/address'
 import { useRouter } from 'expo-router'
+import { selectContactByAddress, upsertContact } from '@/src/store/addressBookSlice'
 
 type Props = {
   safeAddress: string | undefined
@@ -21,22 +22,15 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
   const toast = useToastController()
   const activeSafe = useDefinedActiveSafe()
   const { deleteSafe } = useEditAccountItem()
+  const dispatch = useAppDispatch()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const copyAndDispatchToast = useCopyAndDispatchToast()
+  const contact = useAppSelector(selectContactByAddress(activeSafe.address))
   const theme = useTheme()
   const color = theme.color?.get()
   const router = useRouter()
   const colorError = 'red'
 
-  const toBeImplemented = () => {
-    toast.show('This feature is not implemented yet.', {
-      native: true,
-      duration: 2000,
-      burntOptions: {
-        preset: 'error',
-      },
-    })
-  }
   if (!safeAddress) {
     return null
   }
@@ -44,11 +38,12 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
   return (
     <Menu
       onPressAction={({ nativeEvent }) => {
-        console.warn(JSON.stringify(nativeEvent))
-
         if (nativeEvent.event === 'rename') {
-          console.log('rename')
-          toBeImplemented()
+          Alert.prompt('Rename safe', 'Enter a new name for the safe', (newName) => {
+            if (newName) {
+              dispatch(upsertContact({ ...contact, value: safeAddress, name: newName }))
+            }
+          })
         }
 
         if (nativeEvent.event === 'explorer') {

--- a/apps/mobile/src/features/Share/components/ShareView.test.tsx
+++ b/apps/mobile/src/features/Share/components/ShareView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent, waitFor } from '@testing-library/react-native'
+import { render, fireEvent, waitFor } from '@/src/tests/test-utils'
 import { ShareView } from './ShareView'
 import Share from 'react-native-share'
 import { useCopyAndDispatchToast } from '@/src/hooks/useCopyAndDispatchToast'
@@ -36,15 +36,19 @@ describe('ShareView', () => {
     jest.clearAllMocks()
   })
 
-  it('renders null when activeSafe is null', () => {
-    const { toJSON } = render(<ShareView activeSafe={null} availableChains={[]} />)
-    expect(toJSON()).toBeNull()
-  })
-
   it('renders safe address and chain names when activeSafe is provided', () => {
     const activeSafe = { address: '0x123', chainId: '1' } as SafeInfo
     const availableChains = [{ chainName: 'Ethereum' }, { chainName: 'Polygon' }] as Chain[]
-    const { getByText } = render(<ShareView activeSafe={activeSafe} availableChains={availableChains} />)
+    const { getByText } = render(<ShareView activeSafe={activeSafe} availableChains={availableChains} />, {
+      initialStore: {
+        addressBook: {
+          contacts: {
+            [activeSafe.address]: { name: 'Test Safe', value: activeSafe.address },
+          },
+          selectedContact: null,
+        },
+      },
+    })
     expect(getByText(activeSafe.address)).toBeTruthy()
     // Check that the chains text is rendered as expected.
     expect(getByText(/Ethereum and Polygon/)).toBeTruthy()

--- a/apps/mobile/src/features/Share/components/ShareView.tsx
+++ b/apps/mobile/src/features/Share/components/ShareView.tsx
@@ -13,17 +13,17 @@ import { ToastViewport } from '@tamagui/toast'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { ChainsDisplay } from '@/src/components/ChainsDisplay'
 import { getAvailableChainsNames } from '@/src/utils/chains'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectContactByAddress } from '@/src/store/addressBookSlice'
 
 type ShareViewProps = {
-  activeSafe: SafeInfo | null
+  activeSafe: SafeInfo
   availableChains: Chain[]
 }
 
 export const ShareView = ({ activeSafe, availableChains }: ShareViewProps) => {
   const copyAndDispatchToast = useCopyAndDispatchToast()
-  if (!activeSafe) {
-    return null
-  }
+  const contact = useAppSelector(selectContactByAddress(activeSafe.address))
 
   const safeAddress = activeSafe.address
 
@@ -45,7 +45,7 @@ export const ShareView = ({ activeSafe, availableChains }: ShareViewProps) => {
     <>
       <YStack flex={1}>
         <YStack flex={1} justifyContent={'flex-end'} alignItems={'center'} marginBottom={'$6'}>
-          <H3 fontWeight={600}>Safe title</H3>
+          <H3 fontWeight={600}>{contact ? contact.name : 'Unnamed safe'}</H3>
         </YStack>
         <YStack flex={3} alignItems={'center'}>
           <Container marginHorizontal={'$10'}>

--- a/apps/mobile/src/store/addressBookSlice.ts
+++ b/apps/mobile/src/store/addressBookSlice.ts
@@ -3,7 +3,9 @@ import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transacti
 
 import { RootState } from '.'
 
-export type Contact = AddressInfo
+export type Contact = Omit<AddressInfo, 'name'> & {
+  name: string
+}
 
 interface AddressBookState {
   contacts: Record<string, Contact>
@@ -78,6 +80,6 @@ export const selectAllContacts = createSelector(selectAddressBookState, (address
 })
 
 export const selectContactByAddress = (address: string) =>
-  createSelector(selectAddressBookState, (addressBook): AddressInfo | null => addressBook.contacts[address] || null)
+  createSelector(selectAddressBookState, (addressBook): Contact | null => addressBook.contacts[address] || null)
 
 export default addressBookSlice.reducer

--- a/apps/mobile/src/tests/test-utils.tsx
+++ b/apps/mobile/src/tests/test-utils.tsx
@@ -5,6 +5,9 @@ import { makeStore, rootReducer } from '../store'
 import { PortalProvider } from 'tamagui'
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet'
 import { configureStore } from '@reduxjs/toolkit'
+import { FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE } from 'redux-persist'
+import { cgwClient } from '@safe-global/store/gateway/cgwClient'
+import { web3API } from '@/src/store/signersBalance'
 
 export type RootState = ReturnType<typeof rootReducer>
 type getProvidersArgs = (initialStoreState?: Partial<RootState>) => React.FC<{ children: React.ReactNode }>
@@ -14,6 +17,12 @@ const getProviders: getProvidersArgs = (initialStoreState) =>
     const store = initialStoreState
       ? configureStore({
           reducer: rootReducer,
+          middleware: (getDefaultMiddleware) =>
+            getDefaultMiddleware({
+              serializableCheck: {
+                ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+              },
+            }).concat(cgwClient.middleware, web3API.middleware),
           preloadedState: initialStoreState,
         })
       : makeStore()

--- a/yarn.lock
+++ b/yarn.lock
@@ -7307,6 +7307,7 @@ __metadata:
     "@ethersproject/shims": "npm:^5.7.0"
     "@expo/config-plugins": "npm:^9.0.10"
     "@expo/vector-icons": "npm:^14.0.2"
+    "@faker-js/faker": "npm:^9.0.3"
     "@formatjs/intl-getcanonicallocales": "npm:^2.5.4"
     "@formatjs/intl-locale": "npm:^4.2.10"
     "@formatjs/intl-numberformat": "npm:^8.15.3"


### PR DESCRIPTION
## What it solves
With this PR safes added to the mobile app can have names.

Resolves  https://github.com/safe-global/safe-wallet-mobile/issues/62

## How this PR fixes it
During account import there is a field to enter the safe name. You can change that Safe name later in the Safe's settings. 
During the import the safe is created as a contact in the address book. We look for that contact everywhere where we need to display the safe name. (we could later optimise this and make it a hook)

## How to test it
Look at the added video

## Screenshots

https://github.com/user-attachments/assets/95a97367-e0c8-4be6-9f50-2fd943e61216

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
