### PR TITLE
Fix(Signing UX): adjust CSS and wording

### DIFF
--- a/apps/web/src/components/transactions/HexEncodedData/styles.module.css
+++ b/apps/web/src/components/transactions/HexEncodedData/styles.module.css
@@ -7,4 +7,5 @@
 .encodedData button {
   padding-top: 0;
   padding-bottom: 0;
+  padding-left: 0;
 }

--- a/apps/web/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/apps/web/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -11,8 +11,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  /* Remove height of progress bar */
-  padding: calc(var(--space-3) - 6px) var(--space-3) var(--space-3);
+  padding: var(--space-3);
   border-bottom: 1px solid var(--color-border-light);
 }
 
@@ -108,15 +107,18 @@
   /* Height of transaction type title */
   margin-top: 46px;
 }
+
 @media (max-width: 1199px) {
   .backButton {
     left: 50%;
     transform: translateX(-50%);
   }
+
   .step :global(.MuiCardActions-root) {
     margin-bottom: var(--space-8);
   }
 }
+
 @media (max-width: 899.95px) {
   .widget {
     position: absolute;

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -106,9 +106,9 @@ export const ConfirmTxDetails = (props: SignOrExecuteProps) => {
       <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />
 
       <FormControlLabel
-        sx={{ mt: 2 }}
+        sx={{ mt: 2, mb: -1.3 }}
         control={<Checkbox checked={checked} onChange={handleCheckboxChange} />}
-        label="I understand what I'm signing and acknowledge that this is an irreversible action."
+        label="I understand what I'm signing and know that this is an irreversible action."
       />
 
       <SignOrExecuteFormV2

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -108,7 +108,7 @@ export const ConfirmTxDetails = (props: SignOrExecuteProps) => {
       <FormControlLabel
         sx={{ mt: 2, mb: -1.3 }}
         control={<Checkbox checked={checked} onChange={handleCheckboxChange} />}
-        label="I understand what I'm signing and know that this is an irreversible action."
+        label="I understand what I'm signing and that this is an irreversible action."
       />
 
       <SignOrExecuteFormV2


### PR DESCRIPTION
## What it solves

Adjust some margins and the acknowledgment wording to fit in one line.

<img width="590" alt="Screenshot 2025-03-21 at 07 21 30" src="https://github.com/user-attachments/assets/6acd9d2b-7caf-476c-8e64-473ac9ab1b5b" />
