### PR TITLE
Fix(Orgs): Don't duplicate safes when adding manually

### DIFF
--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -120,7 +120,7 @@ const AddAccounts = () => {
   })
 
   const handleAddSafe = (data: AddManuallyFormValues) => {
-    const alreadyExists = manualSafes.some((safe) => safe.address === data.address && safe.chainId === data.chainId)
+    const alreadyExists = allSafes.some((safe) => safe.address === data.address)
 
     const newSafeItem: SafeItem = {
       ...data,


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/7

## How this PR fixes it

- Checks the manual safe to be added against all safes instead of just the manually added ones

## How to test it

1. Open an org
2. Go to add safe accounts
3. Add safe manually thats already in the list
4. Observe no new entry and the existing entry is checked
5. Add a manual safe thats part of a multichain setup
6. Observe the correct multichain safe is checked and there is no duplicate

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
