### PR TITLE
feat(mobile): unify fiat amount display

### DIFF
--- a/apps/mobile/src/components/Fiat/Fiat.tsx
+++ b/apps/mobile/src/components/Fiat/Fiat.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import { H1, View } from 'tamagui'
+import { H1, H2, View, XStack } from 'tamagui'
 import { formatCurrency, formatCurrencyPrecise } from '@safe-global/utils/formatNumber'
 
 interface FiatProps {
@@ -18,9 +18,9 @@ export const Fiat = ({ value, currency, maxLength, precise }: FiatProps) => {
     return formatCurrencyPrecise(value, currency)
   }, [value, currency])
 
-  const [whole, decimals, endCurrency] = useMemo(() => {
-    const match = (preciseFiat ?? '').match(/(.+)(\D\d+)(\D+)?$/)
-    return match ? match.slice(1) : ['', preciseFiat, '', '']
+  const [symbol, whole, decimals, endCurrency] = useMemo(() => {
+    const match = (preciseFiat ?? '').match(/(\D+)?(.+)(\D\d+)(\D+)?$/)
+    return match ? match.slice(1) : ['', '', preciseFiat, '', '']
   }, [preciseFiat])
 
   if (fiat == null) {
@@ -30,15 +30,18 @@ export const Fiat = ({ value, currency, maxLength, precise }: FiatProps) => {
   return (
     <View flexDirection="row" alignItems="center" testID={'fiat-balance-display'}>
       {precise ? (
-        <H1 fontWeight="600">
-          {whole}
+        <XStack>
+          <H2 fontWeight={'600'} alignSelf={'flex-end'} marginBottom={'$2'}>
+            {symbol}
+          </H2>
+          <H1 fontWeight="600">{whole}</H1>
           {decimals && (
             <H1 fontWeight={600} color="$textSecondaryDark">
               {decimals}
             </H1>
           )}
-          {endCurrency}
-        </H1>
+          <H1 fontWeight={600}>{endCurrency}</H1>
+        </XStack>
       ) : (
         <H1 fontWeight="600">{fiat}</H1>
       )}

--- a/apps/mobile/src/components/transactions-list/Card/AccountCard/AccountCard.test.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/AccountCard/AccountCard.test.tsx
@@ -8,19 +8,20 @@ import { ellipsis } from '@/src/utils/formatters'
 describe('AccountCard', () => {
   it('should render the account card with only one chain provided', () => {
     const accountName = 'This is my account'
+    const balance = '758.932'
     const container = render(
       <AccountCard
         name={accountName}
         chains={mockedChains as unknown as Chain[]}
         owners={5}
-        balance={mockedActiveSafeInfo.fiatTotal}
+        balance={balance}
         address={mockedActiveSafeInfo.address.value as Address}
         threshold={2}
       />,
     )
     expect(container.getByTestId('threshold-info-badge')).toBeVisible()
     expect(container.getByText('2/5')).toBeDefined()
-    expect(container.getByText(`$${mockedActiveSafeInfo.fiatTotal}`)).toBeDefined()
+    expect(container.getByText(`$ 758.93`)).toBeDefined()
     expect(container.getByText(accountName)).toBeDefined()
   })
 
@@ -39,7 +40,7 @@ describe('AccountCard', () => {
     )
     expect(container.getByTestId('threshold-info-badge')).toBeVisible()
     expect(container.getByText('2/5')).toBeDefined()
-    expect(container.getByText(`$${ellipsis(longBalance, 14)}`)).toBeDefined()
+    expect(container.getByText(`$ 21,312,321,3...`)).toBeDefined()
     expect(container.getByText(ellipsis(longAccountName, 18))).toBeDefined()
   })
 })

--- a/apps/mobile/src/components/transactions-list/Card/AccountCard/AccountCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/AccountCard/AccountCard.tsx
@@ -6,6 +6,8 @@ import { IdenticonWithBadge } from '@/src/features/Settings/components/Identicon
 import { Address } from '@/src/types/address'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { ChainsDisplay } from '@/src/components/ChainsDisplay'
+import { shouldDisplayPreciseBalance } from '@/src/utils/balance'
+import { formatCurrency, formatCurrencyPrecise } from '@safe-global/utils/formatNumber'
 
 interface AccountCardProps {
   name: string | Address
@@ -30,6 +32,10 @@ export function AccountCard({
   threshold,
   rightNode,
 }: AccountCardProps) {
+  const formattedBalance = shouldDisplayPreciseBalance(balance, 8)
+    ? formatCurrencyPrecise(balance, 'usd')
+    : formatCurrency(balance, 'usd')
+
   return (
     <SafeListItem
       spaced={spaced}
@@ -39,7 +45,7 @@ export function AccountCard({
             {ellipsis(name, 18)}
           </Text>
           <Text fontSize="$4" color="$colorSecondary" fontWeight={400}>
-            ${ellipsis(balance, 14)}
+            {ellipsis(formattedBalance, 14)}
           </Text>
         </View>
       }

--- a/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.test.tsx
+++ b/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.test.tsx
@@ -65,7 +65,7 @@ describe('AccountItem', () => {
 
     expect(screen.getByText('Test Account')).toBeTruthy()
     expect(screen.getByText('1/1')).toBeTruthy()
-    expect(screen.getByText('$1000')).toBeTruthy()
+    expect(screen.getByText('$ 1,000.00')).toBeTruthy()
   })
 
   it('shows active state when account is selected', () => {

--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccounts.container.test.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccounts.container.test.tsx
@@ -79,7 +79,7 @@ describe('MyAccountsContainer', () => {
 
     expect(screen.getByText('Test Safe')).toBeTruthy()
     expect(screen.getByText('1/1')).toBeTruthy()
-    expect(screen.getByText('$1000')).toBeTruthy()
+    expect(screen.getByText('$ 1,000.00')).toBeTruthy()
   })
 
   it('calls onClose when account is selected', () => {

--- a/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
@@ -8,6 +8,7 @@ import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 
 import { ChainsDisplay } from '@/src/components/ChainsDisplay'
 import { useRouter } from 'expo-router'
+import { shouldDisplayPreciseBalance } from '@/src/utils/balance'
 
 interface BalanceProps {
   activeChainId: string
@@ -38,7 +39,7 @@ export function Balance({ activeChainId, chains, isLoading, balanceAmount, chain
         {isLoading ? (
           <Spinner />
         ) : balanceAmount ? (
-          <Fiat value={balanceAmount} currency="usd" precise={balanceAmount.length < 6} />
+          <Fiat value={balanceAmount} currency="usd" precise={shouldDisplayPreciseBalance(balanceAmount)} />
         ) : (
           <Alert type="error" message="error while getting the balance of your wallet" />
         )}

--- a/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.test.tsx
+++ b/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.test.tsx
@@ -48,7 +48,7 @@ describe('TokensContainer', () => {
     // Then check for content
     const ethText = await screen.findByText('Ethereum')
     const ethAmount = await screen.findByText('1 ETH')
-    const ethValue = await screen.findByText('$ 2,000')
+    const ethValue = await screen.findByText('$ 2,000.00')
 
     expect(ethText).toBeTruthy()
     expect(ethAmount).toBeTruthy()

--- a/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
@@ -10,8 +10,9 @@ import { selectActiveSafe } from '@/src/store/activeSafeSlice'
 import { Balance, useBalancesGetBalancesV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
 import { Fallback } from '../Fallback'
 import { skipToken } from '@reduxjs/toolkit/query'
-import { formatCurrency } from '@safe-global/utils/formatNumber'
+import { formatCurrency, formatCurrencyPrecise } from '@safe-global/utils/formatNumber'
 import { formatVisualAmount } from '@safe-global/utils/formatters'
+import { shouldDisplayPreciseBalance } from '@/src/utils/balance'
 
 export function TokensContainer() {
   const activeSafe = useSelector(selectActiveSafe)
@@ -32,6 +33,7 @@ export function TokensContainer() {
   )
 
   const renderItem: ListRenderItem<Balance> = React.useCallback(({ item }) => {
+    const fiatBalance = item.fiatBalance
     return (
       <AssetsCard
         name={item.tokenInfo.name}
@@ -39,7 +41,9 @@ export function TokensContainer() {
         description={`${formatVisualAmount(item.balance, item.tokenInfo.decimals as number)} ${item.tokenInfo.symbol}`}
         rightNode={
           <Text fontSize="$4" fontWeight={400} color="$color">
-            {formatCurrency(item.fiatBalance, 'usd')}
+            {shouldDisplayPreciseBalance(fiatBalance, 7)
+              ? formatCurrencyPrecise(fiatBalance, 'usd')
+              : formatCurrency(fiatBalance, 'usd')}
           </Text>
         }
       />

--- a/apps/mobile/src/features/NetworksSheet/NetworksSheet.container.tsx
+++ b/apps/mobile/src/features/NetworksSheet/NetworksSheet.container.tsx
@@ -10,7 +10,8 @@ import { SafeOverviewResult } from '@safe-global/store/gateway/types'
 import { makeSafeId } from '@/src/utils/formatters'
 import { POLLING_INTERVAL } from '@/src/config/constants'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
-import { formatCurrency } from '@safe-global/utils/formatNumber'
+import { formatCurrency, formatCurrencyPrecise } from '@safe-global/utils/formatNumber'
+import { shouldDisplayPreciseBalance } from '@/src/utils/balance'
 
 export const NetworksSheetContainer = () => {
   const dispatch = useAppDispatch()
@@ -46,7 +47,11 @@ export const NetworksSheetContainer = () => {
             onClose()
           }}
           activeChain={activeChain}
-          fiatTotal={formatCurrency(item.fiatTotal, 'usd')}
+          fiatTotal={
+            shouldDisplayPreciseBalance(item.fiatTotal, 8)
+              ? formatCurrencyPrecise(item.fiatTotal, 'usd')
+              : formatCurrency(item.fiatTotal, 'usd')
+          }
           chains={chains}
           chainId={item.chainId}
           key={item.chainId}

--- a/apps/mobile/src/utils/balance.test.ts
+++ b/apps/mobile/src/utils/balance.test.ts
@@ -1,0 +1,20 @@
+import { shouldDisplayPreciseBalance } from './balance'
+
+describe('shouldDisplayPreciseBalance', () => {
+  it('returns true for balance amounts with less than 8 digits before the decimal point', () => {
+    expect(shouldDisplayPreciseBalance('210.2122')).toBe(true)
+    expect(shouldDisplayPreciseBalance('5.2213')).toBe(true)
+    expect(shouldDisplayPreciseBalance('1234567.89')).toBe(true)
+  })
+
+  it('returns false for balance amounts with 8 or more digits before the decimal point', () => {
+    expect(shouldDisplayPreciseBalance('83892893298.3838')).toBe(false)
+    expect(shouldDisplayPreciseBalance('12345678.1234')).toBe(false)
+    expect(shouldDisplayPreciseBalance('10000000.00')).toBe(false)
+  })
+
+  it('handles balance amounts without a decimal point', () => {
+    expect(shouldDisplayPreciseBalance('1234567')).toBe(true)
+    expect(shouldDisplayPreciseBalance('12345678')).toBe(false)
+  })
+})

--- a/apps/mobile/src/utils/balance.ts
+++ b/apps/mobile/src/utils/balance.ts
@@ -1,0 +1,3 @@
+export const shouldDisplayPreciseBalance = (balanceAmount: string, integerPartLength = 8) => {
+  return balanceAmount.split('.')[0].length < integerPartLength
+}


### PR DESCRIPTION
## What it solves
After adding the polyfill for the Intl.numberFormat class we didn't use the correct functions to display the fiat numbers across the app. 
Based on the available screen estate we either display a precise amount or a rounded value.

## Screenshots
<img src="https://github.com/user-attachments/assets/c84a8800-0a02-4d68-9cb9-6effd3384a59" width="150" />
<img src="https://github.com/user-attachments/assets/8367fcf7-8407-4915-a142-0ff1a728dc29" width="150" />
<img src="https://github.com/user-attachments/assets/a4e028c4-7a0f-4826-ae8c-469e2aadc863" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
