### PR TITLE
fix(Signing UX): allow non-owner execution in transaction review

### DIFF
--- a/apps/web/src/components/tx/ReviewTransaction/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransaction/ReviewTransactionContent.tsx
@@ -222,7 +222,7 @@ export const ReviewTransactionContent = ({
             )}
 
             {/* Continue button */}
-            <CheckWallet checkNetwork={!submitDisabled}>
+            <CheckWallet allowNonOwner={props.onlyExecute} checkNetwork={!submitDisabled}>
               {(isOk) => (
                 <Button
                   data-testid="continue-sign-btn"


### PR DESCRIPTION
## What it solves

Allow to continue to the transaction receipt step if connected wallet is not an owner of the Safe.
