### PR TITLE
fix(History filters): don't parse/format filter values

### DIFF
--- a/apps/web/src/components/transactions/TxFilterForm/index.tsx
+++ b/apps/web/src/components/transactions/TxFilterForm/index.tsx
@@ -191,9 +191,7 @@ const TxFilterForm = ({ toggleFilter }: { toggleFilter: () => void }): ReactElem
                               className={inputCss.input}
                               label={
                                 fieldState.error?.message ||
-                                (isIncomingFilter
-                                  ? 'Amount (with decimals)'
-                                  : `Amount (only ${chain?.nativeCurrency.symbol || 'ETH'})`)
+                                (isIncomingFilter ? 'Amount' : `Amount (only ${chain?.nativeCurrency.symbol || 'ETH'})`)
                               }
                               error={!!fieldState.error}
                               {...field}

--- a/apps/web/src/utils/__tests__/tx-history-filter.test.ts
+++ b/apps/web/src/utils/__tests__/tx-history-filter.test.ts
@@ -242,7 +242,7 @@ describe('tx-history-filter', () => {
           filter: {
             to: '0x1234567890123456789012345678901234567890',
             execution_date__gte: '1969-12-31T23:00:00.000Z',
-            value: '123000000000000000000',
+            value: '123',
             nonce: '123',
           },
         })
@@ -293,7 +293,7 @@ describe('tx-history-filter', () => {
           type: 'Outgoing' as TxFilterType,
           filter: {
             execution_date__gte: '1970-01-01T00:00:00.000Z',
-            value: '123000000000000000000',
+            value: '123',
             nonce: '123',
           },
         })


### PR DESCRIPTION
## What it solves

Partially resolves https://github.com/safe-global/safe-client-gateway/issues/2340

## How this PR fixes it

We format/parse the `value` for incoming/outgoing filters because the Client Gateway requires "raw" values. When https://github.com/safe-global/safe-client-gateway/pull/2485 is merged, this value parsing will happen on the Client Gateway.

This removes the client-side format/parse accordingly.

## How to test it

Filter incoming/outgoing and observe the value "as is" in the request.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
