### PR TITLE
feat(mobile): display safe address next to network

### DIFF
--- a/apps/mobile/src/components/Dropdown/DropdownLabel.tsx
+++ b/apps/mobile/src/components/Dropdown/DropdownLabel.tsx
@@ -9,6 +9,7 @@ type DropdownLabelProps = {
     fontSize?: '$4' | '$5' | GetThemeValueForKey<'fontSize'>
     fontWeight: 400 | 500 | 600
   }
+  displayDropDownIcon?: boolean
   onPress?: () => void
 }
 const defaultLabelProps = {
@@ -16,7 +17,13 @@ const defaultLabelProps = {
   fontWeight: 400,
 } as const
 
-export const DropdownLabel = ({ label, leftNode, onPress, labelProps = defaultLabelProps }: DropdownLabelProps) => {
+export const DropdownLabel = ({
+  label,
+  displayDropDownIcon = true,
+  leftNode,
+  onPress,
+  labelProps = defaultLabelProps,
+}: DropdownLabelProps) => {
   return (
     <View testID="dropdown-label-view" onPress={onPress} flexDirection="row" columnGap="$2">
       {leftNode}
@@ -27,9 +34,11 @@ export const DropdownLabel = ({ label, leftNode, onPress, labelProps = defaultLa
         </Text>
       </View>
 
-      <View paddingTop={'$1'}>
-        <SafeFontIcon testID="dropdown-arrow" name="chevron-down" size={16} />
-      </View>
+      {displayDropDownIcon && (
+        <View paddingTop={'$1'}>
+          <SafeFontIcon testID="dropdown-arrow" name="chevron-down" size={16} />
+        </View>
+      )}
     </View>
   )
 }

--- a/apps/mobile/src/features/Assets/components/Balance/Balance.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/Balance.container.tsx
@@ -7,15 +7,17 @@ import { RootState } from '@/src/store'
 import { selectSafeInfo } from '@/src/store/safesSlice'
 import { useAppSelector } from '@/src/store/hooks'
 import { useSafesGetOverviewForManyQuery } from '@safe-global/store/gateway/safes'
-import React from 'react'
+import React, { useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { useCopyAndDispatchToast } from '@/src/hooks/useCopyAndDispatchToast'
 
 export function BalanceContainer() {
   const chains = useAppSelector(selectAllChains)
   const activeSafe = useDefinedActiveSafe()
   const activeSafeInfo = useAppSelector((state: RootState) => selectSafeInfo(state, activeSafe.address))
   const activeSafeChains = useAppSelector((state: RootState) => getChainsByIds(state, activeSafeInfo.chains))
+  const copy = useCopyAndDispatchToast()
   const { data, isLoading } = useSafesGetOverviewForManyQuery<SafeOverviewResult>(
     {
       safes: chains.map((chain) => makeSafeId(chain.chainId, activeSafe.address)),
@@ -31,13 +33,20 @@ export function BalanceContainer() {
   const activeChain = useSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const balance = data?.find((chain) => chain.chainId === activeSafe.chainId)
 
+  const onPressAddressCopy = useCallback(() => {
+    console.log('onPressAddressCopy')
+    copy(activeSafe.address)
+  }, [activeSafe.address])
+
   return (
     <Balance
       chainName={activeChain?.chainName}
       chains={activeSafeChains}
       isLoading={isLoading}
       activeChainId={activeSafe.chainId}
+      safeAddress={activeSafe.address}
       balanceAmount={balance?.fiatTotal || ''}
+      onPressAddressCopy={onPressAddressCopy}
     />
   )
 }

--- a/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Spinner, View } from 'tamagui'
+import { Spinner, View, XStack, Text } from 'tamagui'
 
 import { Alert } from '@/src/components/Alert'
 import { DropdownLabel } from '@/src/components/Dropdown'
@@ -9,31 +9,54 @@ import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { ChainsDisplay } from '@/src/components/ChainsDisplay'
 import { useRouter } from 'expo-router'
 import { shouldDisplayPreciseBalance } from '@/src/utils/balance'
+import { shortenAddress } from '@safe-global/utils/formatters'
+import { TouchableOpacity } from 'react-native'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 
 interface BalanceProps {
   activeChainId: string
+  safeAddress: string
   isLoading: boolean
   chains: Chain[]
   balanceAmount: string
   chainName: string
+  onPressAddressCopy: () => void
 }
 
-export function Balance({ activeChainId, chains, isLoading, balanceAmount, chainName }: BalanceProps) {
+export function Balance({
+  activeChainId,
+  chains,
+  isLoading,
+  balanceAmount,
+  chainName,
+  safeAddress,
+  onPressAddressCopy,
+}: BalanceProps) {
   const router = useRouter()
 
   return (
     <View>
       <View marginBottom="$4">
         {activeChainId && (
-          <View paddingBottom={'$4'}>
+          <XStack paddingBottom={'$4'} alignItems={'center'}>
             <DropdownLabel
               label={chainName}
               leftNode={<ChainsDisplay activeChainId={activeChainId} chains={chains} max={1} />}
               onPress={() => {
                 router.push('/networks-sheet')
               }}
+              labelProps={{ fontWeight: 600 }}
+              displayDropDownIcon={chains.length > 1}
             />
-          </View>
+            <TouchableOpacity onPress={onPressAddressCopy}>
+              <XStack alignItems={'center'} paddingLeft={'$1'}>
+                <Text color={'$colorSecondary'}>{shortenAddress(safeAddress)}</Text>
+                <View paddingLeft={'$1'}>
+                  <SafeFontIcon name={'copy'} size={13} color={'$colorSecondary'} />
+                </View>
+              </XStack>
+            </TouchableOpacity>
+          </XStack>
         )}
 
         {isLoading ? (


### PR DESCRIPTION
## What it solves
Display the safe’s address next to the network selection dropdown. If the safe is not available on multiple networks we don’t display the arrow down icon.

https://www.figma.com/design/yVshG47sZRM7ztI66bDII4/New-Mobile-App?node-id=3521-19078&m=dev

## Screenshots
<img src="https://github.com/user-attachments/assets/67ee0bdc-7d56-4464-b7be-0a583a977462" width="150" />
<img src="https://github.com/user-attachments/assets/467d2b0b-7fe5-4482-8c7b-858b9543947c" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
