### PR TITLE
Fix(Orgs): Use correct space id when deleting space

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
@@ -15,9 +15,10 @@ import CheckIcon from '@/public/images/common/check.svg'
 import CloseIcon from '@/public/images/common/close.svg'
 import css from './styles.module.css'
 import { AppRoutes } from '@/config/routes'
-import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
+import { showNotification } from '@/store/notificationsSlice'
+import { useAppDispatch } from '@/store'
 
 const ListIcon = ({ variant }: { variant: 'success' | 'danger' }) => {
   const Icon = variant === 'success' ? CheckIcon : CloseIcon
@@ -31,17 +32,28 @@ const ListIcon = ({ variant }: { variant: 'success' | 'danger' }) => {
 
 const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefined; onClose: () => void }) => {
   const [error, setError] = useState<string>()
-  const spaceId = useCurrentSpaceId()
   const router = useRouter()
+  const dispatch = useAppDispatch()
   const [deleteSpace] = useSpacesDeleteV1Mutation()
 
   const onDelete = async () => {
+    if (!space) return
+
     setError(undefined)
 
     try {
-      await deleteSpace({ id: Number(spaceId) })
+      await deleteSpace({ id: space.id })
 
       onClose()
+
+      dispatch(
+        showNotification({
+          message: `Successfully deleted space ${space.name}.`,
+          variant: 'success',
+          groupKey: 'delete-space-success',
+        }),
+      )
+
       router.push({ pathname: AppRoutes.welcome.spaces })
     } catch (e) {
       console.error(e)

--- a/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
@@ -12,10 +12,8 @@ import { isAuthenticated } from '@/store/authSlice'
 export const useSpaceSafes = () => {
   const spaceId = useCurrentSpaceId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { currentData, isLoading } = useSpaceSafesGetV1Query(
-    { spaceId: Number(spaceId) },
-    { skip: !isUserSignedIn },
-  )
+  const { currentData, isLoading } = useSpaceSafesGetV1Query({ spaceId: Number(spaceId) }, { skip: !isUserSignedIn })
+
   const allSafeNames = useAppSelector(selectAllAddressBooks)
   const safeItems = currentData ? _buildSafeItems(currentData.safes, allSafeNames) : []
   const safes = useAllSafesGrouped(safeItems)


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/8

## How this PR fixes it

- Uses the `space` parameter that is passed to the dialog instead of using the `useCurrentSpaceId` hook which doesn't work outside of a space e.g. on the space list view

## How to test it

1. Go to the space list view
2. Delete a space from there
3. Observe a success message

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
