### PR TITLE
Feat(Orgs): Show aggregated balance on dashboard

### DIFF
--- a/apps/web/src/features/myAccounts/hooks/useAllSafesGrouped.ts
+++ b/apps/web/src/features/myAccounts/hooks/useAllSafesGrouped.ts
@@ -6,6 +6,7 @@ import { type AddressBookState, selectAllAddressBooks } from '@/store/addressBoo
 import useWallet from '@/hooks/wallets/useWallet'
 import useAllOwnedSafes from '@/features/myAccounts/hooks/useAllOwnedSafes'
 import { useAppSelector } from '@/store'
+import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
 
 export type MultiChainSafeItem = {
   address: string
@@ -51,6 +52,10 @@ export function _buildSafeItems(safes: Record<string, string[]>, allSafeNames: A
   }
 
   return result
+}
+
+export function flattenSafeItems(items: Array<SafeItem | MultiChainSafeItem>): SafeItem[] {
+  return items.flatMap((item) => (isMultiChainSafeItem(item) ? item.safes : [item]))
 }
 
 export const _getMultiChainAccounts = (safes: SafeItems): MultiChainSafeItem[] => {

--- a/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
@@ -34,12 +34,13 @@ function aggregateFiatTotalsByChainId(items: SafeOverview[]): FiatTotalByChain[]
 }
 
 function getTopFiatTotals(chainTotals: FiatTotalByChain[]): FiatTotalByChain[] {
-  if (chainTotals.length <= 5) {
+  const MAX_NETWORKS = 5
+  if (chainTotals.length <= MAX_NETWORKS) {
     return chainTotals
   }
 
-  const topFour = chainTotals.slice(0, 4)
-  const rest = chainTotals.slice(4)
+  const topTotals = chainTotals.slice(0, MAX_NETWORKS - 1)
+  const rest = chainTotals.slice(MAX_NETWORKS - 1)
 
   const otherTotal = rest.reduce((sum, item) => sum + item.total, 0)
 
@@ -48,7 +49,7 @@ function getTopFiatTotals(chainTotals: FiatTotalByChain[]): FiatTotalByChain[] {
     total: otherTotal,
   }
 
-  return [...topFour, otherItem]
+  return [...topTotals, otherItem]
 }
 
 const AggregatedBalanceByChain = ({ fiatTotalByChain }: { fiatTotalByChain: FiatTotalByChain }) => {

--- a/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
@@ -117,7 +117,8 @@ const AggregatedBalanceSkeleton = () => {
   return (
     <Card sx={{ p: 2, mb: 2 }}>
       <Skeleton variant="rounded" width={100} height={20} sx={{ mb: 1 }} />
-      <Skeleton variant="rounded" width={160} height={40} />
+      <Skeleton variant="rounded" width={160} height={40} sx={{ mb: 3 }} />
+      <Skeleton variant="rounded" width={200} height={58} />
     </Card>
   )
 }

--- a/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
@@ -1,0 +1,125 @@
+import { useChain } from '@/hooks/useChains'
+import { Card, Grid2, Skeleton, Stack, Typography } from '@mui/material'
+import css from '@/features/spaces/components/Dashboard/styles.module.css'
+import FiatValue from '@/components/common/FiatValue'
+import { type AllSafeItems, flattenSafeItems } from '@/features/myAccounts/hooks/useAllSafesGrouped'
+import { useAppSelector } from '@/store'
+import { selectCurrency } from '@/store/settingsSlice'
+import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
+import type { SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
+
+type FiatTotalByChain = {
+  chainId: string
+  total: number
+}
+
+function aggregateFiatTotalsByChainId(items: SafeOverview[]): FiatTotalByChain[] {
+  const totals: Record<string, number> = {}
+
+  for (const item of items) {
+    const fiatValue = Number(item.fiatTotal) || 0
+    totals[item.chainId] = (totals[item.chainId] || 0) + fiatValue
+  }
+
+  const result = Object.entries(totals).map(([chainId, total]) => {
+    return {
+      chainId,
+      total,
+    }
+  })
+
+  result.sort((a, b) => b.total - a.total)
+
+  return result
+}
+
+function getTopFiatTotals(chainTotals: FiatTotalByChain[]): FiatTotalByChain[] {
+  if (chainTotals.length <= 5) {
+    return chainTotals
+  }
+
+  const topFour = chainTotals.slice(0, 4)
+  const rest = chainTotals.slice(4)
+
+  const otherTotal = rest.reduce((sum, item) => sum + item.total, 0)
+
+  const otherItem: FiatTotalByChain = {
+    chainId: 'Other',
+    total: otherTotal,
+  }
+
+  return [...topFour, otherItem]
+}
+
+const AggregatedBalanceByChain = ({ fiatTotalByChain }: { fiatTotalByChain: FiatTotalByChain }) => {
+  const chain = useChain(fiatTotalByChain.chainId)
+
+  return (
+    <Stack>
+      <div className={css.chainIndicator}>
+        <Typography component="span" className={css.chainIndicatorColor} bgcolor={chain?.theme.backgroundColor} />
+      </div>
+
+      <Typography variant="body2" color="primary.light" fontWeight="700" mt={0.5}>
+        {chain?.chainName || fiatTotalByChain.chainId}
+      </Typography>
+
+      <Typography variant="h3" fontWeight="700">
+        <FiatValue value={fiatTotalByChain.total.toString()} maxLength={20} precise />
+      </Typography>
+    </Stack>
+  )
+}
+
+const AggregatedBalance = ({ safes }: { safes: AllSafeItems }) => {
+  const currency = useAppSelector(selectCurrency)
+  const safeItems = flattenSafeItems(safes)
+
+  const { data: safeOverviews, isLoading } = useGetMultipleSafeOverviewsQuery({ safes: safeItems, currency })
+  const aggregatedBalance = safeOverviews ? safeOverviews.reduce((prev, next) => prev + Number(next.fiatTotal), 0) : 0
+  const fiatTotalByChainId = safeOverviews ? aggregateFiatTotalsByChainId(safeOverviews) : []
+  const topTotals = getTopFiatTotals(fiatTotalByChainId)
+
+  if (isLoading) return <AggregatedBalanceSkeleton />
+
+  return (
+    <Card sx={{ p: 2, mb: 2 }}>
+      <Typography variant="body2" fontWeight="bold" mb={1} color="primary.light">
+        Aggregated balance
+      </Typography>
+      <Typography
+        component="div"
+        variant="h1"
+        sx={{
+          fontSize: 44,
+          lineHeight: '40px',
+        }}
+      >
+        <FiatValue value={aggregatedBalance.toString()} maxLength={20} precise />
+      </Typography>
+
+      {topTotals && (
+        <Grid2 container mt={3} spacing={2}>
+          {topTotals.map((fiatTotal) => {
+            return (
+              <Grid2 key={fiatTotal.chainId} size={{ xs: 12, md: 'grow' }} maxWidth={{ xs: 1, md: '20%' }}>
+                <AggregatedBalanceByChain fiatTotalByChain={fiatTotal} />
+              </Grid2>
+            )
+          })}
+        </Grid2>
+      )}
+    </Card>
+  )
+}
+
+const AggregatedBalanceSkeleton = () => {
+  return (
+    <Card sx={{ p: 2, mb: 2 }}>
+      <Skeleton variant="rounded" width={100} height={20} sx={{ mb: 1 }} />
+      <Skeleton variant="rounded" width={160} height={40} />
+    </Card>
+  )
+}
+
+export default AggregatedBalance

--- a/apps/web/src/features/spaces/components/Dashboard/DashboardMembersList.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/DashboardMembersList.tsx
@@ -1,4 +1,4 @@
-import { Paper, Button, Box, Stack } from '@mui/material'
+import { Button, Box, Stack } from '@mui/material'
 import type { Member } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import PlusIcon from '@/public/images/common/plus.svg'
 import { useState } from 'react'
@@ -14,24 +14,22 @@ const DashboardMembersList = ({ members }: { members: Member[] }) => {
 
   return (
     <>
-      <Paper sx={{ p: 2, borderRadius: '8px' }}>
-        <Stack spacing={2}>
-          {members.map((member) => (
-            <Box key={member.id}>
-              <MemberName key={member.id} member={member} />
-            </Box>
-          ))}
-        </Stack>
-        {isAdmin && (
-          <Box display="flex" justifyContent="center" mt={2}>
-            <Track {...SPACE_EVENTS.ADD_MEMBER_MODAL} label={SPACE_LABELS.space_dashboard}>
-              <Button size="small" variant="text" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>
-                Add member
-              </Button>
-            </Track>
+      <Stack spacing={2}>
+        {members.map((member) => (
+          <Box key={member.id}>
+            <MemberName key={member.id} member={member} />
           </Box>
-        )}
-      </Paper>
+        ))}
+      </Stack>
+      {isAdmin && (
+        <Box display="flex" justifyContent="center" mt={2}>
+          <Track {...SPACE_EVENTS.ADD_MEMBER_MODAL} label={SPACE_LABELS.space_dashboard}>
+            <Button size="small" variant="text" startIcon={<PlusIcon />} onClick={() => setOpenAddMembersModal(true)}>
+              Add member
+            </Button>
+          </Track>
+        </Box>
+      )}
       {openAddMembersModal && <AddMembersModal onClose={() => setOpenAddMembersModal(false)} />}
     </>
   )

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -1,7 +1,7 @@
 import MembersCard from '@/features/spaces/components/Dashboard/MembersCard'
 import NewFeaturesCard from '@/features/spaces/components/Dashboard/NewFeaturesCard'
 import SpacesCTACard from '@/features/spaces/components/Dashboard/SpacesCTACard'
-import { Grid2, Stack, Typography } from '@mui/material'
+import { Card, Grid2, Stack, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid2'
 import { useSpaceSafes } from '@/features/spaces/hooks/useSpaceSafes'
 import SafesList from '@/features/myAccounts/components/SafesList'
@@ -17,6 +17,7 @@ import { useSpaceMembersByStatus, useIsInvited } from '@/features/spaces/hooks/u
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
+import AggregatedBalance from '@/features/spaces/components/Dashboard/AggregatedBalances'
 
 const ViewAllLink = ({ url }: { url: LinkProps['href'] }) => {
   return (
@@ -54,33 +55,39 @@ const SpaceDashboard = () => {
 
       {safes.length > 0 ? (
         <>
-          <Typography variant="h1" fontWeight={700} mb={4}>
-            Dashboard
-          </Typography>
+          <Grid container>
+            <Grid size={12}>
+              <AggregatedBalance safes={safes} />
+            </Grid>
+          </Grid>
 
           <Grid container spacing={3}>
             <Grid size={{ xs: 12, md: 8 }}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
-                <Typography variant="h5">Safe Accounts ({safes.length})</Typography>
-                {spaceId && (
-                  <Track {...SPACE_EVENTS.VIEW_ALL_ACCOUNTS}>
-                    <ViewAllLink url={{ pathname: AppRoutes.spaces.safeAccounts, query: { spaceId } }} />
-                  </Track>
-                )}
-              </Stack>
-              <SafesList safes={safesToDisplay} isSpaceSafe />
+              <Card sx={{ p: 2 }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+                  <Typography variant="h5">Safe Accounts ({safes.length})</Typography>
+                  {spaceId && (
+                    <Track {...SPACE_EVENTS.VIEW_ALL_ACCOUNTS}>
+                      <ViewAllLink url={{ pathname: AppRoutes.spaces.safeAccounts, query: { spaceId } }} />
+                    </Track>
+                  )}
+                </Stack>
+                <SafesList safes={safesToDisplay} isSpaceSafe />
+              </Card>
             </Grid>
             <Grid size={{ xs: 12, md: 4 }}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
-                <Typography variant="h5">Members ({activeMembers.length})</Typography>
+              <Card sx={{ p: 2 }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+                  <Typography variant="h5">Members ({activeMembers.length})</Typography>
 
-                {spaceId && (
-                  <Track {...SPACE_EVENTS.VIEW_ALL_MEMBERS}>
-                    <ViewAllLink url={{ pathname: AppRoutes.spaces.members, query: { spaceId } }} />
-                  </Track>
-                )}
-              </Stack>
-              <DashboardMembersList members={membersToDisplay} />
+                  {spaceId && (
+                    <Track {...SPACE_EVENTS.VIEW_ALL_MEMBERS}>
+                      <ViewAllLink url={{ pathname: AppRoutes.spaces.members, query: { spaceId } }} />
+                    </Track>
+                  )}
+                </Stack>
+                <DashboardMembersList members={membersToDisplay} />
+              </Card>
             </Grid>
           </Grid>
         </>

--- a/apps/web/src/features/spaces/components/Dashboard/styles.module.css
+++ b/apps/web/src/features/spaces/components/Dashboard/styles.module.css
@@ -39,3 +39,17 @@
   max-width: 100%;
   height: auto;
 }
+
+.chainIndicator {
+  width: 100%;
+  height: 4px;
+  background-color: var(--color-background-main);
+  border-radius: 5px;
+}
+
+.chainIndicatorColor {
+  width: 100%;
+  display: block;
+  height: 100%;
+  border-radius: 5px;
+}


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/19

## How this PR fixes it

- Adds aggregated balances to the dashboard

## How to test it

1. Open a space with some safe accounts
2. Go to the dashboard
3. Observe aggregated balances showing

## Screenshots
<img width="1274" alt="Screenshot 2025-03-21 at 15 53 09" src="https://github.com/user-attachments/assets/fa014c90-95c3-4ffb-b584-ae9166245add" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
