### PR TITLE
fix(mobile): crash when deleting safes

### DIFF
--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/hooks/useMyAccountsSortable.ts
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/hooks/useMyAccountsSortable.ts
@@ -1,5 +1,5 @@
 import { SafesSliceItem, selectAllSafes, setSafes } from '@/src/store/safesSlice'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { DragEndParams } from 'react-native-draggable-flatlist'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -12,6 +12,10 @@ export const useMyAccountsSortable = (): useMyAccountsSortableReturn => {
   const dispatch = useDispatch()
   const safes = useSelector(selectAllSafes)
   const [sortableSafes, setSortableSafes] = useState(() => Object.values(safes))
+
+  useEffect(() => {
+    setSortableSafes(Object.values(safes))
+  }, [safes])
 
   const onDragEnd = useCallback(({ data }: DragEndParams<SafesSliceItem>) => {
     // Defer Redux update due to incompatibility issues between

--- a/apps/mobile/src/features/Assets/components/Balance/Balance.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/Balance.container.tsx
@@ -16,7 +16,7 @@ export function BalanceContainer() {
   const chains = useAppSelector(selectAllChains)
   const activeSafe = useDefinedActiveSafe()
   const activeSafeInfo = useAppSelector((state: RootState) => selectSafeInfo(state, activeSafe.address))
-  const activeSafeChains = useAppSelector((state: RootState) => getChainsByIds(state, activeSafeInfo.chains))
+  const activeSafeChains = useAppSelector((state: RootState) => getChainsByIds(state, activeSafeInfo?.chains || []))
   const copy = useCopyAndDispatchToast()
   const { data, isLoading } = useSafesGetOverviewForManyQuery<SafeOverviewResult>(
     {

--- a/apps/mobile/src/features/Share/Share.container.tsx
+++ b/apps/mobile/src/features/Share/Share.container.tsx
@@ -8,6 +8,8 @@ import { getChainsByIds } from '@/src/store/chains'
 export const ShareContainer = () => {
   const activeSafe = useDefinedActiveSafe()
   const activeSafeInfo = useAppSelector((state: RootState) => selectSafeInfo(state, activeSafe.address))
-  const safeAvailableOnChains = useAppSelector((state: RootState) => getChainsByIds(state, activeSafeInfo.chains))
+  const safeAvailableOnChains = useAppSelector((state: RootState) =>
+    getChainsByIds(state, activeSafeInfo?.chains || []),
+  )
   return <ShareView activeSafe={activeSafe} availableChains={safeAvailableOnChains} />
 }

--- a/apps/mobile/src/store/chains/index.ts
+++ b/apps/mobile/src/store/chains/index.ts
@@ -25,7 +25,7 @@ export const selectActiveChain = createSelector(
 )
 
 export const selectAllChainsIds = createSelector([selectAllChains], (chains: Chain[]) =>
-  chains.map((chain) => chain.chainId),
+  (chains || []).map((chain) => chain.chainId),
 )
 
 export const selectActiveChainCurrency = createSelector(
@@ -41,7 +41,9 @@ export const getChainsByIds = createSelector(
     (state: RootState) => state,
     (_state: RootState, chainIds: string[]) => chainIds,
   ],
-  (state, chainIds) => chainIds.map((chainId) => selectById(state, chainId)).filter(Boolean),
+  (state, chainIds) => {
+    return (chainIds || []).map((chainId) => selectById(state, chainId)).filter(Boolean)
+  },
 )
 
 export const { useGetChainsConfigQuery } = apiSliceWithChainsConfig

--- a/apps/mobile/src/store/safesSlice.ts
+++ b/apps/mobile/src/store/safesSlice.ts
@@ -45,7 +45,7 @@ export const { updateSafeInfo, setSafes, removeSafe, addSafe } = activeSafeSlice
 export const selectAllSafes = (state: RootState) => state.safes
 export const selectSafeInfo = createSelector(
   [selectAllSafes, (_state, activeSafeAddress: Address) => activeSafeAddress],
-  (safes: SafesSlice, activeSafeAddress: Address) => safes[activeSafeAddress],
+  (safes: SafesSlice, activeSafeAddress: Address): SafesSliceItem | undefined => safes[activeSafeAddress],
 )
 
 export default activeSafeSlice.reducer


### PR DESCRIPTION
## What it solves
This PR fixes 2 bugs:
- When deleting safes from my accounts view - the safe was deleted, but it was still visible in the list 
![grafik](https://github.com/user-attachments/assets/76d1f161-6c3f-4783-97bd-8743bc96b5f8)

- when deleting all the safes in the app, the final deleted safe caused the app to crash. This was due to improper assumptions about the store state. 



## How to test it
- add at least 2 safes
- try to drag and drop
- try to delete them

## Screenshots
<img src="https://github.com/user-attachments/assets/58c32bf2-8add-4e66-9906-62ab087c0922" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
