### PR TITLE
Fix(Orgs): Don't list declined spaces in the selector

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceSidebarSelector/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarSelector/index.tsx
@@ -16,6 +16,8 @@ import { isAuthenticated } from '@/store/authSlice'
 import { SPACE_LABELS } from '@/services/analytics/events/spaces'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { getNonDeclinedSpaces } from '@/features/spaces/utils'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 
 const SpaceSidebarSelector = () => {
   const [isCreationModalOpen, setIsCreationModalOpen] = useState(false)
@@ -24,8 +26,11 @@ const SpaceSidebarSelector = () => {
   const open = Boolean(anchorEl)
   const spaceId = useCurrentSpaceId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
   const { currentData: spaces } = useSpacesGetV1Query(undefined, { skip: !isUserSignedIn })
   const selectedSpace = spaces?.find((space) => space.id === Number(spaceId))
+
+  const nonDeclinedSpaces = getNonDeclinedSpaces(currentUser, spaces || [])
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget)
@@ -88,7 +93,7 @@ const SpaceSidebarSelector = () => {
 
           <Divider sx={{ mb: 1 }} />
 
-          {spaces?.map((space) => (
+          {nonDeclinedSpaces.map((space) => (
             <MenuItem
               key={space.id}
               onClick={() => handleSelectSpace(space)}

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -7,7 +7,7 @@ import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import { Box, Button, Card, Grid2, Link, Typography } from '@mui/material'
 import { type GetSpaceResponse, useSpacesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import { type UserWithWallets, useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 import SpaceListInvite from '../InviteBanner'
 import { useState } from 'react'
 import css from './styles.module.css'
@@ -16,6 +16,7 @@ import useWallet from '@/hooks/wallets/useWallet'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 import SpaceInfoModal from '../SpaceInfoModal'
+import { filterSpacesByStatus } from '@/features/spaces/utils'
 
 const AddSpaceButton = ({ disabled }: { disabled: boolean }) => {
   const [openCreationModal, setOpenCreationModal] = useState<boolean>(false)
@@ -87,16 +88,6 @@ const NoSpacesState = () => {
       {openCreationModal && <SpaceCreationModal onClose={() => setOpenCreationModal(false)} />}
     </>
   )
-}
-
-const filterSpacesByStatus = (
-  currentUser: UserWithWallets | undefined,
-  spaces: GetSpaceResponse[],
-  status: MemberStatus,
-) => {
-  return spaces.filter((space) => {
-    return space.members.some((member) => member.user.id === currentUser?.id && member.status === status)
-  })
 }
 
 const SpacesList = () => {

--- a/apps/web/src/features/spaces/utils.ts
+++ b/apps/web/src/features/spaces/utils.ts
@@ -1,7 +1,27 @@
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import type { SerializedError } from '@reduxjs/toolkit'
+import type { UserWithWallets } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { MemberStatus } from '@/features/spaces/hooks/useSpaceMembers'
 
 // TODO: Currently also checks for 404 because the /v1/spaces/<orgId> endpoint does not return 401
 export const isUnauthorized = (error: FetchBaseQueryError | SerializedError | undefined) => {
   return error && 'status' in error && (error.status === 401 || error.status === 404)
+}
+
+export const filterSpacesByStatus = (
+  currentUser: UserWithWallets | undefined,
+  spaces: GetSpaceResponse[],
+  status: MemberStatus,
+) => {
+  return spaces.filter((space) => {
+    return space.members.some((member) => member.user.id === currentUser?.id && member.status === status)
+  })
+}
+
+export const getNonDeclinedSpaces = (currentUser: UserWithWallets | undefined, spaces: GetSpaceResponse[]) => {
+  const pendingInvites = filterSpacesByStatus(currentUser, spaces || [], MemberStatus.INVITED)
+  const activeSpaces = filterSpacesByStatus(currentUser, spaces || [], MemberStatus.ACTIVE)
+
+  return [...pendingInvites, ...activeSpaces]
 }


### PR DESCRIPTION
## What it solves

Resolves #5424

## How this PR fixes it

- Filters declined spaces from the selector

## How to test it

1. Decline the invite to a space
2. Create a new space
3. Observe the declined space is not showing up in the selector

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
