### PR TITLE
fix: Disable edit button for last admin

### DIFF
--- a/apps/web/src/features/spaces/components/AddMembersModal/index.tsx
+++ b/apps/web/src/features/spaces/components/AddMembersModal/index.tsx
@@ -109,7 +109,9 @@ const AddMembersModal = ({ onClose }: { onClose: () => void }): ReactElement => 
         onClose()
       }
       if (response.error) {
-        setError('Invite failed. Please try again.')
+        // @ts-ignore
+        const errorMessage = response.error?.data?.message || 'Invite failed. Please try again.'
+        setError(errorMessage)
       }
     } catch (e) {
       console.error(e)

--- a/apps/web/src/features/spaces/components/MembersList/index.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.tsx
@@ -32,15 +32,17 @@ const headCells = [
   },
 ]
 
-const EditButton = ({ member }: { member: Member }) => {
+const EditButton = ({ member, disabled }: { member: Member; disabled: boolean }) => {
   const [open, setOpen] = useState(false)
 
   return (
     <>
-      <Tooltip title="Edit member" placement="top">
-        <IconButton onClick={() => setOpen(true)} size="small">
-          <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
-        </IconButton>
+      <Tooltip title={disabled ? 'Cannot edit role of last admin' : 'Edit member'} placement="top">
+        <Box component="span">
+          <IconButton onClick={() => setOpen(true)} size="small" disabled={disabled}>
+            <SvgIcon component={EditIcon} inheritViewBox color="border" fontSize="small" />
+          </IconButton>
+        </Box>
       </Tooltip>
       {open && <EditMemberDialog member={member} handleClose={() => setOpen(false)} />}
     </>
@@ -95,6 +97,8 @@ const MembersList = ({ members }: { members: Member[] }) => {
     const isLastAdmin = adminCount === 1 && member.role === MemberRole.ADMIN
     const isInvite = member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED
     const isDeclined = member.status === MemberStatus.DECLINED
+    const isDisabled = isAdmin && isLastAdmin && !isInvite
+
     return {
       cells: {
         name: {
@@ -123,8 +127,8 @@ const MembersList = ({ members }: { members: Member[] }) => {
           sticky: true,
           content: isAdmin ? (
             <div className={tableCss.actions}>
-              {!isInvite && <EditButton member={member} />}
-              <RemoveMemberButton member={member} disabled={isAdmin && isLastAdmin && !isInvite} isInvite={isInvite} />
+              {!isInvite && <EditButton member={member} disabled={isDisabled} />}
+              <RemoveMemberButton member={member} disabled={isDisabled} isInvite={isInvite} />
             </div>
           ) : null,
         },


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/40
Resolves https://github.com/safe-global/safe-wallet-monorepo/issues/5274

## How this PR fixes it

- Disables the edit button for last admin and adjusts the tooltip
- Shows a more meaningful error message when trying to invite an existing member

## How to test it

1. Open an org
2. Go to the members list
3. If there is only one admin the edit button is disabled with a custom tooltip
4. Try to invite an existing member
5. Observe a meaningful error message

## Screenshots
<img width="749" alt="Screenshot 2025-03-24 at 11 22 37" src="https://github.com/user-attachments/assets/8ec19f08-ffec-46c0-b1c0-6c45f351f15d" />
<img width="640" alt="Screenshot 2025-03-24 at 11 23 00" src="https://github.com/user-attachments/assets/85eae23d-6243-4aff-90ea-b3288787d078" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
