### PR TITLE
fix(Nested Safes): only allow adding nested Safe for deployed Safes

### DIFF
--- a/apps/web/src/components/settings/NestedSafesList/index.tsx
+++ b/apps/web/src/components/settings/NestedSafesList/index.tsx
@@ -92,19 +92,21 @@ export function NestedSafesList(): ReactElement | null {
               </Typography>
             )}
 
-            <CheckWallet>
-              {(isOk) => (
-                <Button
-                  onClick={() => setTxFlow(<CreateNestedSafe />)}
-                  variant="text"
-                  startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
-                  disabled={!isOk}
-                  sx={{ mb: 3 }}
-                >
-                  Add nested Safe
-                </Button>
-              )}
-            </CheckWallet>
+            {safe.deployed && (
+              <CheckWallet>
+                {(isOk) => (
+                  <Button
+                    onClick={() => setTxFlow(<CreateNestedSafe />)}
+                    variant="text"
+                    startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}
+                    disabled={!isOk}
+                    sx={{ mb: 3 }}
+                  >
+                    Add nested Safe
+                  </Button>
+                )}
+              </CheckWallet>
+            )}
 
             {rows && rows.length > 0 && <EnhancedTable rows={rows} headCells={[]} />}
           </Grid2>

--- a/apps/web/src/components/sidebar/NestedSafesButton/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesButton/index.tsx
@@ -7,6 +7,7 @@ import NestedSafesIcon from '@/public/images/sidebar/nested-safes-icon.svg'
 import { NestedSafesPopover } from '@/components/sidebar/NestedSafesPopover'
 import { useGetOwnedSafesQuery } from '@/store/slices'
 import { useHasFeature } from '@/hooks/useChains'
+import useSafeInfo from '@/hooks/useSafeInfo'
 import { FEATURES } from '@/utils/chains'
 
 import headerCss from '@/components/sidebar/SidebarHeader/styles.module.css'
@@ -20,11 +21,12 @@ export function NestedSafesButton({
   safeAddress: string
 }): ReactElement | null {
   const isEnabled = useHasFeature(FEATURES.NESTED_SAFES)
+  const { safe } = useSafeInfo()
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const { data } = useGetOwnedSafesQuery(isEnabled && safeAddress ? { chainId, ownerAddress: safeAddress } : skipToken)
   const nestedSafes = data?.safes ?? []
 
-  if (!isEnabled) {
+  if (!isEnabled || !safe.deployed) {
     return null
   }
 

--- a/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
@@ -10,6 +10,7 @@ import { NestedSafesList } from '@/components/sidebar/NestedSafesList'
 import { NestedSafeInfo } from '@/components/sidebar/NestedSafeInfo'
 import Track from '@/components/common/Track'
 import { NESTED_SAFE_EVENTS } from '@/services/analytics/events/nested-safes'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 export function NestedSafesPopover({
   anchorEl,
@@ -22,6 +23,7 @@ export function NestedSafesPopover({
   nestedSafes: Array<string>
   hideCreationButton?: boolean
 }): ReactElement {
+  const { safe } = useSafeInfo()
   const { setTxFlow } = useContext(TxModalContext)
 
   const onAdd = () => {
@@ -75,7 +77,7 @@ export function NestedSafesPopover({
             <NestedSafesList onClose={onClose} nestedSafes={nestedSafes} />
           </Box>
         )}
-        {!hideCreationButton && (
+        {safe.deployed && !hideCreationButton && (
           <Track {...NESTED_SAFE_EVENTS.ADD}>
             <Button variant="contained" sx={{ width: '100%', mt: 3 }} onClick={onAdd}>
               <SvgIcon component={AddIcon} inheritViewBox fontSize="small" />

--- a/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
@@ -10,7 +10,6 @@ import { NestedSafesList } from '@/components/sidebar/NestedSafesList'
 import { NestedSafeInfo } from '@/components/sidebar/NestedSafeInfo'
 import Track from '@/components/common/Track'
 import { NESTED_SAFE_EVENTS } from '@/services/analytics/events/nested-safes'
-import useSafeInfo from '@/hooks/useSafeInfo'
 
 export function NestedSafesPopover({
   anchorEl,
@@ -23,7 +22,6 @@ export function NestedSafesPopover({
   nestedSafes: Array<string>
   hideCreationButton?: boolean
 }): ReactElement {
-  const { safe } = useSafeInfo()
   const { setTxFlow } = useContext(TxModalContext)
 
   const onAdd = () => {
@@ -77,7 +75,7 @@ export function NestedSafesPopover({
             <NestedSafesList onClose={onClose} nestedSafes={nestedSafes} />
           </Box>
         )}
-        {safe.deployed && !hideCreationButton && (
+        {!hideCreationButton && (
           <Track {...NESTED_SAFE_EVENTS.ADD}>
             <Button variant="contained" sx={{ width: '100%', mt: 3 }} onClick={onAdd}>
               <SvgIcon component={AddIcon} inheritViewBox fontSize="small" />


### PR DESCRIPTION
## What it solves

Resolves #5075

## How this PR fixes it

Only deployed Safes can add nested Safes. This hides the creation buttons (in the sidebar and settings) if the current Safe is not deployed.

## How to test it

In a counterfactual Safe, observe no "Add nested Safe" button in the sidebar popover or settings.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
