### PR TITLE
fix(WalletConnect): ensure WC remains connected when adding Safe

### DIFF
--- a/apps/web/src/utils/wallets.ts
+++ b/apps/web/src/utils/wallets.ts
@@ -61,7 +61,7 @@ export const isSmartContractWallet = memoize(
 
 /* Check if the wallet is unlocked. */
 export const isWalletUnlocked = async (walletName: string): Promise<boolean | undefined> => {
-  if (walletName === PRIVATE_KEY_MODULE_LABEL) return true
+  if ([PRIVATE_KEY_MODULE_LABEL, WALLETCONNECT].includes(walletName)) return true
 
   const METAMASK_LIKE = ['MetaMask', 'Rabby Wallet', 'Zerion']
 


### PR DESCRIPTION
## What it solves

Resolves #4473

## How this PR fixes it

When navigating to the add Safe flow, WalletConnect disconnects because it is not deemed unlocked. This adds an early return, always flagging WalletConnect as unlocked.

## How to test it

Whilst connected via WalletConnect and with a Safe open, navigate to the flow to add a (specific) Safe. Observe WalletConnect not disconnecting. (An example video is in the issue.)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
