### PR TITLE
fix: AuthState background in dark mode

### DIFF
--- a/apps/web/src/features/spaces/components/Dashboard/styles.module.css
+++ b/apps/web/src/features/spaces/components/Dashboard/styles.module.css
@@ -6,13 +6,16 @@
   justify-content: center;
 }
 
+.contentWrapper {
+  position: relative;
+  z-index: 1;
+}
+
 .contentInner {
   background-color: var(--color-background-paper);
   max-width: 500px;
   padding: var(--space-5);
   border-radius: var(--space-1);
-  position: relative;
-  z-index: 1;
 }
 
 .contentBg {

--- a/apps/web/src/features/spaces/components/SignedOutState/index.tsx
+++ b/apps/web/src/features/spaces/components/SignedOutState/index.tsx
@@ -7,19 +7,21 @@ import Image from 'next/image'
 const SignedOutState = () => {
   return (
     <Box className={css.content}>
-      <Box textAlign="center" className={css.contentInner}>
+      <Box textAlign="center" className={css.contentWrapper}>
+        <Box className={css.contentInner}>
+          <Typography fontWeight={700} mb={2}>
+            Sign in to see content
+          </Typography>
+
+          <Typography color="text.secondary" mb={2}>
+            To view and interact with spaces, you need to sign in with the wallet, that is a member of the space. Sign
+            in to continue.
+          </Typography>
+
+          <SignInButton />
+        </Box>
+
         <Image src={SkeletonBG} alt="" className={css.contentBg} />
-
-        <Typography fontWeight={700} mb={2}>
-          Sign in to see content
-        </Typography>
-
-        <Typography color="text.secondary" mb={2}>
-          To view and interact with spaces, you need to sign in with the wallet, that is a member of the space. Sign in
-          to continue.
-        </Typography>
-
-        <SignInButton />
       </Box>
     </Box>
   )

--- a/apps/web/src/features/spaces/components/UnauthorizedState/index.tsx
+++ b/apps/web/src/features/spaces/components/UnauthorizedState/index.tsx
@@ -9,21 +9,23 @@ import SkeletonBG from '@/public/images/spaces/skeleton_bg.png'
 const UnauthorizedState = () => {
   return (
     <Box className={css.content}>
-      <Box textAlign="center" className={css.contentInner}>
+      <Box textAlign="center" className={css.contentWrapper}>
+        <Box className={css.contentInner}>
+          <Typography fontWeight={700} mb={2}>
+            You don’t have permissions to this page
+          </Typography>
+
+          <Typography color="text.secondary" mb={2}>
+            Sorry, you don’t have permissions to view this page, as your wallet is not a member of the space. Try to
+            sign in with a different wallet or go back to the overview.
+          </Typography>
+
+          <Link href={AppRoutes.welcome.spaces} passHref>
+            <Button variant="outlined">Back to overview</Button>
+          </Link>
+        </Box>
+
         <Image src={SkeletonBG} alt="" className={css.contentBg} />
-
-        <Typography fontWeight={700} mb={2}>
-          You don’t have permissions to this page
-        </Typography>
-
-        <Typography color="text.secondary" mb={2}>
-          Sorry, you don’t have permissions to view this page, as your wallet is not a member of the space. Try to sign
-          in with a different wallet or go back to the overview.
-        </Typography>
-
-        <Link href={AppRoutes.welcome.spaces} passHref>
-          <Button variant="outlined">Back to overview</Button>
-        </Link>
       </Box>
     </Box>
   )


### PR DESCRIPTION
## What it solves

Fixes the background of the `AuthState` component in dark mode

## How this PR fixes it

- Adds the image layer behind the content background layer

## How to test it

1. Open an org
2. Disconnect your wallet
3. Observe the sign out / unauthorized screen in dark mode

## Screenshots

<img width="929" alt="Screenshot 2025-03-24 at 15 09 53" src="https://github.com/user-attachments/assets/ef49d745-a56a-4e06-8f0e-f7d77b628af0" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
