### PR TITLE
fix: error in migration tx check

### DIFF
--- a/apps/web/src/utils/__tests__/safe-migrations.test.ts
+++ b/apps/web/src/utils/__tests__/safe-migrations.test.ts
@@ -38,6 +38,15 @@ describe('isMigrateL2SingletonCall', () => {
       } as TransactionData),
     ).toBeTruthy()
   })
+
+  it('should return false for null data', () => {
+    expect(
+      isMigrateL2SingletonCall({
+        hexData: null,
+        to: { value: safeMigrationAddress },
+      } as TransactionData),
+    ).toBeFalsy()
+  })
 })
 
 describe('createUpdateMigration', () => {

--- a/apps/web/src/utils/safe-migrations.ts
+++ b/apps/web/src/utils/safe-migrations.ts
@@ -86,6 +86,7 @@ export const isMigrateL2SingletonCall = (txData: TransactionData): boolean => {
 
   return (
     txData.hexData !== undefined &&
+    txData.hexData !== null &&
     txData.hexData.startsWith(safeMigrationInterface.getFunction('migrateL2Singleton').selector) &&
     sameAddress(txData.to.value, safeMigrationAddress)
   )


### PR DESCRIPTION
## What this PR fixes
Fixes safe-migrations.ts:
`hexData` can be `null` (even though not declared in type)

## How to test it
- Create a tx without tx data, e.g. a native transfer

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
