### PR TITLE
feat(Signing UX): receipt screen for CreateNestedSafe + MigrateSafeL2 flows

### DIFF
--- a/apps/web/src/components/tx-flow/flows/CreateNestedSafe/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/CreateNestedSafe/index.tsx
@@ -1,32 +1,75 @@
-import type { ReactElement } from 'react'
+import { useMemo, useState, type ReactElement } from 'react'
 
 import NestedSafeIcon from '@/public/images/sidebar/nested-safes-icon.svg'
-import TxLayout from '@/components/tx-flow/common/TxLayout'
+import TxLayout, { type TxStep } from '@/components/tx-flow/common/TxLayout'
 import useTxStepper from '@/components/tx-flow/useTxStepper'
 import { ReviewNestedSafe } from '@/components/tx-flow/flows/CreateNestedSafe/ReviewNestedSafe'
 import { SetUpNestedSafe } from '@/components/tx-flow/flows/CreateNestedSafe/SetupNestedSafe'
 import type { SetupNestedSafeForm } from '@/components/tx-flow/flows/CreateNestedSafe/SetupNestedSafe'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
+import { useAppDispatch } from '@/store'
+import { upsertAddressBookEntries } from '@/store/addressBookSlice'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 export function CreateNestedSafe(): ReactElement {
+  const dispatch = useAppDispatch()
+  const { safe } = useSafeInfo()
+  const [predictedSafeAddress, setPredictedSafeAddress] = useState<string | undefined>()
+
   const { data, step, nextStep, prevStep } = useTxStepper<SetupNestedSafeForm>({
     name: '',
     assets: [],
   })
 
-  const steps = [
-    <SetUpNestedSafe key={0} params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />,
-    <ReviewNestedSafe key={1} params={data} />,
-  ]
+  const handleSubmit = () => {
+    if (!predictedSafeAddress) {
+      return
+    }
+    dispatch(
+      upsertAddressBookEntries({
+        chainIds: [safe.chainId],
+        address: predictedSafeAddress,
+        name: data.name,
+      }),
+    )
+  }
+
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'Set up Nested Safe' },
+        content: <SetUpNestedSafe key={0} params={data} onSubmit={(formData) => nextStep({ ...data, ...formData })} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm Nested Safe' },
+        content: (
+          <ReviewNestedSafe
+            key={1}
+            params={data}
+            onSubmit={(predictedSafeAddress) => {
+              setPredictedSafeAddress(predictedSafeAddress)
+              nextStep(data)
+            }}
+          />
+        ),
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={2} onSubmit={handleSubmit} />,
+      },
+    ],
+    [nextStep, data],
+  )
 
   return (
     <TxLayout
-      title={step === 0 ? 'Set up Nested Safe' : 'Confirm Nested Safe'}
       subtitle="Create a Nested Safe"
       icon={NestedSafeIcon}
       step={step}
       onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
     >
-      {steps}
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/MigrateSafeL2/MigrateSafeL2Review.tsx
+++ b/apps/web/src/components/tx-flow/flows/MigrateSafeL2/MigrateSafeL2Review.tsx
@@ -2,12 +2,12 @@ import { useContext, useEffect } from 'react'
 import { useCurrentChain } from '@/hooks/useChains'
 import { createTx } from '@/services/tx/tx-sender'
 import { SafeTxContext } from '../../SafeTxProvider'
-import SignOrExecuteForm from '@/components/tx/SignOrExecuteForm'
 import { createMigrateToL2 } from '@/utils/safe-migrations'
 import { Box, Typography } from '@mui/material'
 import ErrorMessage from '@/components/tx/ErrorMessage'
+import ReviewTransaction from '@/components/tx/ReviewTransaction'
 
-export const MigrateSafeL2Review = () => {
+export const MigrateSafeL2Review = ({ onSubmit }: { onSubmit: () => void }) => {
   const chain = useCurrentChain()
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
 
@@ -20,7 +20,7 @@ export const MigrateSafeL2Review = () => {
 
   return (
     <Box>
-      <SignOrExecuteForm>
+      <ReviewTransaction onSubmit={onSubmit}>
         <ErrorMessage level="warning" title="Migration transaction">
           <Typography>
             When executing this transaction, it will not get indexed and appear in the history due to the current
@@ -29,7 +29,7 @@ export const MigrateSafeL2Review = () => {
             indexed as usual, and there will be no further restrictions.
           </Typography>
         </ErrorMessage>
-      </SignOrExecuteForm>
+      </ReviewTransaction>
     </Box>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/MigrateSafeL2/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/MigrateSafeL2/index.tsx
@@ -1,11 +1,36 @@
-import TxLayout from '@/components/tx-flow/common/TxLayout'
+import TxLayout, { type TxStep } from '@/components/tx-flow/common/TxLayout'
 import { MigrateSafeL2Review } from './MigrateSafeL2Review'
 import SettingsIcon from '@/public/images/sidebar/settings.svg'
+import { useMemo } from 'react'
+import useTxStepper from '../../useTxStepper'
+import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 
 const MigrateSafeL2Flow = () => {
+  const { data, step, nextStep, prevStep } = useTxStepper(undefined)
+
+  const steps = useMemo<TxStep[]>(
+    () => [
+      {
+        txLayoutProps: { title: 'Confirm transaction' },
+        content: <MigrateSafeL2Review key={0} onSubmit={() => nextStep(data)} />,
+      },
+      {
+        txLayoutProps: { title: 'Confirm transaction details', fixedNonce: true },
+        content: <ConfirmTxDetails key={1} onSubmit={() => {}} />,
+      },
+    ],
+    [nextStep, data],
+  )
+
   return (
-    <TxLayout title="Confirm transaction" subtitle="Update Safe Account base contract" icon={SettingsIcon}>
-      <MigrateSafeL2Review />
+    <TxLayout
+      subtitle="Update Safe Account base contract"
+      icon={SettingsIcon}
+      step={step}
+      onBack={prevStep}
+      {...(steps?.[step]?.txLayoutProps || {})}
+    >
+      {steps.map(({ content }) => content)}
     </TxLayout>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves #5496 

Adds the transaction receipt screen to the **CreateNestedSafe** and **MigrateSafeL2** flows.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
