### PR TITLE
Refactor: replace @safe-global/safe-gateway-typescript-sdk imports

### DIFF
--- a/codemods/convert-safe-gateway-typescript-sdk.js
+++ b/codemods/convert-safe-gateway-typescript-sdk.js
@@ -1,0 +1,231 @@
+
+/**
+ * jscodeshift transformer to update @safe-global/safe-gateway-typescript-sdk imports to @safe-global/store imports.
+ * 
+ * The scripts modifies import declarations, type references and type assertions across the codebase.
+ * 
+ * To use the script run
+ * 
+ * jscodeshift -t codemods/convert-safe-gateway-typescript-sdk.js apps/web/src --extensions=tsx --parser=tsx
+ * and
+ * jscodeshift -t codemods/convert-safe-gateway-typescript-sdk.js apps/web/src --extensions=ts --parser=ts
+ * 
+ * This way the changes are applied to both TypeScript and JSX files.
+ */
+
+const importMapping = {
+  // safe info
+  SafeInfo: { module: '@safe-global/store/gateway/AUTO_GENERATED/safes', newName: 'SafeState' },
+  SafeOverview: { module: '@safe-global/store/gateway/AUTO_GENERATED/safes', newName: 'SafeOverview' },
+  ImplementationVersionState: { module: '@safe-global/store/gateway/types', newName: 'ImplementationVersionState' },
+  // safe apps
+  SafeAppAccessPolicyTypes: { module: '@safe-global/store/gateway/types', newName: 'SafeAppAccessPolicyTypes' },
+  SafeAppNoRestrictionsPolicy: { module: '@safe-global/store/gateway/types', newName: 'SafeAppNoRestrictionsPolicy' },
+  SafeAppDomainAllowlistPolicy: { module: '@safe-global/store/gateway/types', newName: 'SafeAppDomainAllowlistPolicy' },
+  SafeAppsAccessControlPolicies: { module: '@safe-global/store/gateway/types', newName: 'SafeAppsAccessControlPolicies' },
+  SafeAppProvider: { module: '@safe-global/store/gateway/AUTO_GENERATED/safe-apps', newName: 'SafeAppProvider' },
+  SafeAppFeatures: { module: '@safe-global/store/gateway/types', newName: 'SafeAppFeatures' },
+  SafeAppSocialProfile: { module: '@safe-global/store/gateway/AUTO_GENERATED/safe-apps', newName: 'SafeAppSocialProfile' },
+  SafeAppSocialPlatforms: { module: '@safe-global/store/gateway/types', newName: 'SafeAppSocialPlatforms' },
+  SafeAppData: { module: '@safe-global/store/gateway/AUTO_GENERATED/safe-apps', newName: 'SafeApp' },
+  SafeAppsResponse: { module: '@safe-global/store/gateway/AUTO_GENERATED/safe-apps', newName: 'SafeAppsGetSafeAppsV1ApiResponse' },
+
+  // common
+  SafeBalanceResponse: { module: '@safe-global/store/gateway/AUTO_GENERATED/balances', newName: 'BalancesGetBalancesV1ApiResponse' },
+  TokenType: { module: '@safe-global/store/gateway/types', newName: 'TokenType' },
+  AddressEx: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'AddressInfo' },
+  // transactions
+  Operation: { module: '@safe-global/store/gateway/types', newName: 'Operation' },
+  // don't know what is this?
+  // InternalTransaction: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'InternalTransaction' },
+  Parameter: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'DataDecodedParameter' },
+  DataDecoded: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'DataDecoded' },
+
+  TransactionStatus: { module: '@safe-global/store/gateway/types', newName: 'TransactionStatus' },
+  TransferDirection: { module: '@safe-global/store/gateway/types', newName: 'TransferDirection' },
+  TransactionTokenType: { module: '@safe-global/store/gateway/types', newName: 'TransactionTokenType' },
+  SettingsInfoType: { module: '@safe-global/store/gateway/types', newName: 'SettingsInfoType' },
+  TransactionInfoType: { module: '@safe-global/store/gateway/types', newName: 'TransactionInfoType' },
+  ConflictType: { module: '@safe-global/store/gateway/types', newName: 'ConflictType' },
+  TransactionListItemType: { module: '@safe-global/store/gateway/types', newName: 'TransactionListItemType' },
+  DetailedExecutionInfoType: { module: '@safe-global/store/gateway/types', newName: 'DetailedExecutionInfoType' },
+
+  Erc20Transfer: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'Erc20Transfer' },
+  Erc721Transfer: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'Erc721Transfer' },
+  NativeCoinTransfer: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'NativeCoinTransfer' },
+  TransferInfo: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TransferInfo' },
+  Transfer: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TransferTransactionInfo' },
+  SetFallbackHandler: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'SetFallbackHandler' },
+  TransferInfo: { module: '@safe-global/store/gateway/types', newName: 'TransferInfo' },
+  SettingsChange: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'SettingsChangeTransaction' },
+  Custom: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'CustomTransactionInfo' },
+  MultiSend: { module: '@safe-global/store/gateway/types', newName: 'MultiSend' },
+  Cancellation: { module: '@safe-global/store/gateway/types', newName: 'Cancellation' },
+  Creation: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'CreationTransactionInfo' },
+  Order: { module: '@safe-global/store/gateway/types', newName: 'OrderTransactionInfo' },
+  StakingTxInfo: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'StakingTxInfo' },
+  OrderToken: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TokenInfo' },
+  SwapOrder: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'SwapOrderTransactionInfo' },
+  SwapTransferOrder: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'SwapTransferTransactionInfo' },
+  TwapOrder: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TwapOrderTransactionInfo' },
+  StakingTxDepositInfo: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'NativeStakingDepositTransactionInfo' },
+  StakingTxExitInfo: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'NativeStakingValidatorsExitTransactionInfo' },
+  StakingTxWithdrawInfo: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'NativeStakingWithdrawTransactionInfo' },
+
+  StakingTxInfo: { module: '@safe-global/store/gateway/types', newName: 'StakingTxInfo' },
+  TransactionInfo: { module: '@safe-global/store/gateway/types', newName: 'TransactionInfo' },
+  ModuleExecutionInfo: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'ModuleExecutionInfo' },
+  MultisigExecutionInfo: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'MultisigExecutionInfo' },
+  ExecutionInfo: { module: '@safe-global/store/gateway/types', newName: 'ExecutionInfo' },
+  TransactionSummary: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'Transaction' },
+  Transaction: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TransactionItem' },
+  IncomingTransfer: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'IncomingTransfer' },
+  ModuleTransaction: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'ModuleTransaction' },
+  MultisigTransaction: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'MultisigTransaction' },
+
+  DateLabel: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'DateLabel' },
+  LabelValue: { module: '@safe-global/store/gateway/types', newName: 'LabelValue' },
+  // not sure
+  // Label: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'Label' },
+  ConflictHeader: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'ConflictHeaderQueuedItem' },
+  // not sure
+  // TransactionListItem: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TransactionListItem' },
+  TransactionListPage: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TransactionItemPage' },
+  MultisigTransactionRequest: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'ProposeTransactionDto' },
+  SafeAppInfo: { module: '@safe-global/store/gateway/AUTO_GENERATED/safe-apps', newName: 'SafeAppInfo' },
+  TransactionData: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TransactionData' },
+  ModuleExecutionDetails: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'ModuleExecutionDetails' },
+  MultisigConfirmation: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'MultisigConfirmationDetails' },
+  MultisigExecutionDetails: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'MultisigExecutionDetails' },
+  DetailedExecutionInfo: { module: '@safe-global/store/gateway/types', newName: 'DetailedExecutionInfo' },
+  TransactionDetails: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TransactionDetails' },
+  TransactionPreview: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TransactionPreview' },
+  // not sure
+  // SafeTransactionEstimationRequest
+  // SafeTransactionEstimation
+  // NoncesResponse
+  SafeIncomingTransfersResponse: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'IncomingTransferPage' },
+  SafeModuleTransactionsResponse: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'ModuleTransactionPage' },
+  SafeMultisigTransactionsResponse: { module: '@safe-global/store/gateway/AUTO_GENERATED/transactions', newName: 'TxsMultisigTransactionPage' },
+
+  // Chains 
+  RPC_AUTHENTICATION: { module: '@safe-global/store/gateway/types', newName: 'RPC_AUTHENTICATION' },
+  RpcUri: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'RpcUri' },
+  BlockExplorerUriTemplate: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'BlockExplorerUriTemplate' },
+  NativeCurrency: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'NativeCurrency' },
+  Theme: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'Theme' },
+  GAS_PRICE_TYPE: { module: '@safe-global/store/gateway/types', newName: 'GAS_PRICE_TYPE' },
+  GasPriceOracle: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'GasPriceOracle' },
+  GasPriceFixed: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'GasPriceFixed' },
+  GasPriceFixedEip1559: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'GasPriceFixedEip1559' },
+  GasPriceUnknown: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'GasPriceUnknown' },
+  GasPrice: { module: '@safe-global/store/gateway/types', newName: 'GasPrice' },
+  FEATURES: { module: '@safe-global/store/gateway/types', newName: 'FEATURES' },
+  ChainInfo: { module: '@safe-global/store/gateway/types', newName: 'ChainInfo' },
+  ChainListResponse: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'ChainPage' },
+  ChainIndexingStatus: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'IndexingStatus' },
+  MasterCopyReponse: { module: '@safe-global/store/gateway/AUTO_GENERATED/chains', newName: 'ChainsGetMasterCopiesV1ApiResponse' },
+
+  // Data Decoded
+
+
+  // Messages
+  SafeMessageListItemType: { module: '@safe-global/store/gateway/types', newName: 'SafeMessageListItemType' },
+  SafeMessageDateLabel: { module: '@safe-global/store/gateway/AUTO_GENERATED/messages', newName: 'DateLabel' },
+  SafeMessageStatus: { module: '@safe-global/store/gateway/types', newName: 'SafeMessageStatus' },
+  TypedDataDomain: { module: '@safe-global/store/gateway/AUTO_GENERATED/messages', newName: 'TypedDataDomain' },
+  TypedDataTypes: { module: '@safe-global/store/gateway/AUTO_GENERATED/messages', newName: 'TypedDataParameter' },
+  TypedMessageTypes: { module: '@safe-global/store/gateway/types', newName: 'TypedMessageTypes' },
+  EIP712TypedData: { module: '@safe-global/store/gateway/AUTO_GENERATED/messages', newName: 'TypedData' },
+  SafeMessage: { module: '@safe-global/store/gateway/AUTO_GENERATED/messages', newName: 'MessageItem' },
+  SafeMessageListItem: { module: '@safe-global/store/gateway/types', newName: 'SafeMessageListItem' },
+  SafeMessageListPage: { module: '@safe-global/store/gateway/AUTO_GENERATED/messages', newName: 'MessagePage' },
+  ProposeSafeMessageRequest: { module: '@safe-global/store/gateway/AUTO_GENERATED/messages', newName: 'CreateMessageDto' },
+  ConfirmSafeMessageRequest: { module: '@safe-global/store/gateway/AUTO_GENERATED/messages', newName: 'UpdateMessageSignatureDto' },
+
+  // Notifications
+  DeviceType: { module: '@safe-global/store/gateway/types', newName: 'DeviceType' },
+  SafeRegistration: { module: '@safe-global/store/gateway/AUTO_GENERATED/notifications', newName: 'SafeRegistration' },
+  RegisterDeviceDto: { module: '@safe-global/store/gateway/AUTO_GENERATED/notifications', newName: 'RegisterDeviceDto' },
+
+
+  // RelayTransactionRequest
+  RelayTransactionRequest: { module: '@safe-global/store/gateway/types', newName: 'RelayDto' },
+  RelayTransactionResponse: { module: '@safe-global/store/gateway/types', newName: 'RelayRelayV1ApiResponse' },
+  RelayCountResponse: { module: '@safe-global/store/gateway/types', newName: 'RelaysRemaining' },
+
+};
+
+export default function transformer(file, api) {
+  if (!file.source.includes('@safe-global/safe-gateway-typescript-sdk')) {
+    return file.source;
+  }
+
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const newImportsMap = new Map();
+  const importsToRemove = [];
+
+  root.find(j.ImportDeclaration, { source: { value: '@safe-global/safe-gateway-typescript-sdk' } })
+    .forEach(path => {
+      const baseImportKind = path.node.importKind || 'value';
+      const transformedSpecifiers = [];
+
+      path.node.specifiers.forEach(specifier => {
+        if (specifier.type !== 'ImportSpecifier') return;
+
+        const importedName = specifier.imported.name;
+        const mapping = importMapping[importedName];
+        if (!mapping) return;
+
+        const specifierImportKind = specifier.importKind || baseImportKind;
+        const key = `${mapping.module}|${specifierImportKind}`;
+        if (!newImportsMap.has(key)) newImportsMap.set(key, []);
+
+        const localName = specifier.local.name !== importedName ? specifier.local.name : undefined;
+        if (localName) {
+          newImportsMap.get(key).push(
+            j.importSpecifier(j.identifier(mapping.newName), j.identifier(localName))
+          );
+        } else {
+          newImportsMap.get(key).push(j.importSpecifier(j.identifier(mapping.newName)));
+        }
+
+        transformedSpecifiers.push(specifier);
+      });
+
+      if (transformedSpecifiers.length === path.node.specifiers.length) {
+        importsToRemove.push(path);
+      } else {
+        path.node.specifiers = path.node.specifiers.filter(spec => !transformedSpecifiers.includes(spec));
+      }
+    });
+
+  importsToRemove.forEach(p => j(p).remove());
+
+  newImportsMap.forEach((specifiers, key) => {
+    const [module, importKind] = key.split('|');
+    const importDecl = j.importDeclaration(specifiers, j.literal(module));
+    if (importKind === 'type') importDecl.importKind = 'type';
+    root.get().node.program.body.unshift(importDecl);
+  });
+
+  // Replace types in angle-bracket assertions according to importMapping
+  root.find(j.TSTypeAssertion).forEach(path => {
+    const typeName = path.node.typeAnnotation.typeName?.name
+    if (typeName && importMapping[typeName]) {
+      path.node.typeAnnotation.typeName.name = importMapping[typeName].newName
+    }
+  })
+
+  // Replace type references according to importMapping
+  root.find(j.TSTypeReference).forEach(path => {
+    const typeName = path.node.typeName?.name
+    if (typeName && importMapping[typeName]) {
+      path.node.typeName.name = importMapping[typeName].newName
+    }
+  })
+
+  return root.toSource({ quote: 'single', trailingComma: true });
+}

--- a/packages/store/scripts/api-schema/schema.json
+++ b/packages/store/scripts/api-schema/schema.json
@@ -17,7 +17,9 @@
             }
           }
         },
-        "tags": ["about"]
+        "tags": [
+          "about"
+        ]
       }
     },
     "/v1/accounts": {
@@ -46,7 +48,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/data-types": {
@@ -68,7 +72,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/data-settings": {
@@ -99,7 +105,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "put": {
         "operationId": "accountsUpsertAccountDataSettingsV1",
@@ -138,7 +146,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}": {
@@ -166,7 +176,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "delete": {
         "operationId": "accountsDeleteAccountV1",
@@ -185,7 +197,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/address-books/{chainId}": {
@@ -221,7 +235,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "post": {
         "operationId": "addressBooksCreateAddressBookItemV1",
@@ -265,7 +281,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "delete": {
         "operationId": "addressBooksDeleteAddressBookV1",
@@ -292,7 +310,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/address-books/{chainId}/{addressBookItemId}": {
@@ -329,7 +349,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/counterfactual-safes/{chainId}/{predictedAddress}": {
@@ -373,7 +395,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "delete": {
         "operationId": "counterfactualSafesDeleteCounterfactualSafeV1",
@@ -408,7 +432,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/accounts/{address}/counterfactual-safes": {
@@ -439,7 +465,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "put": {
         "operationId": "counterfactualSafesCreateCounterfactualSafeV1",
@@ -475,7 +503,9 @@
             }
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       },
       "delete": {
         "operationId": "counterfactualSafesDeleteCounterfactualSafesV1",
@@ -494,7 +524,9 @@
             "description": ""
           }
         },
-        "tags": ["accounts"]
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/v1/auth/nonce": {
@@ -513,7 +545,9 @@
             }
           }
         },
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/v1/auth/verify": {
@@ -535,7 +569,23 @@
             "description": "Empty response body. JWT token is set as response cookie."
           }
         },
-        "tags": ["auth"]
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/v1/auth/logout": {
+      "post": {
+        "operationId": "authLogoutV1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Empty response body. Cookie value is removed and set to expire."
+          }
+        },
+        "tags": [
+          "auth"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/balances/{fiatCode}": {
@@ -595,7 +645,9 @@
             }
           }
         },
-        "tags": ["balances"]
+        "tags": [
+          "balances"
+        ]
       }
     },
     "/v1/balances/supported-fiat-codes": {
@@ -617,7 +669,9 @@
             }
           }
         },
-        "tags": ["balances"]
+        "tags": [
+          "balances"
+        ]
       }
     },
     "/v1/chains": {
@@ -645,7 +699,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}": {
@@ -673,7 +729,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}/about": {
@@ -701,7 +759,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}/about/backbone": {
@@ -729,7 +789,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}/about/master-copies": {
@@ -760,7 +822,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v1/chains/{chainId}/about/indexing": {
@@ -788,7 +852,9 @@
             }
           }
         },
-        "tags": ["chains"]
+        "tags": [
+          "chains"
+        ]
       }
     },
     "/v2/chains/{chainId}/safes/{safeAddress}/collectibles": {
@@ -848,7 +914,9 @@
             }
           }
         },
-        "tags": ["collectibles"]
+        "tags": [
+          "collectibles"
+        ]
       }
     },
     "/v1/community/campaigns": {
@@ -876,7 +944,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/campaigns/{resourceId}": {
@@ -904,7 +974,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/campaigns/{resourceId}/activities": {
@@ -941,7 +1013,9 @@
             "description": ""
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/campaigns/{resourceId}/leaderboard": {
@@ -977,7 +1051,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/campaigns/{resourceId}/leaderboard/{safeAddress}": {
@@ -1013,7 +1089,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/eligibility": {
@@ -1042,7 +1120,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/locking/leaderboard": {
@@ -1070,7 +1150,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/locking/{safeAddress}/rank": {
@@ -1098,7 +1180,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/community/locking/{safeAddress}/history": {
@@ -1134,7 +1218,9 @@
             }
           }
         },
-        "tags": ["community"]
+        "tags": [
+          "community"
+        ]
       }
     },
     "/v1/chains/{chainId}/contracts/{contractAddress}": {
@@ -1170,7 +1256,9 @@
             }
           }
         },
-        "tags": ["contracts"]
+        "tags": [
+          "contracts"
+        ]
       }
     },
     "/v1/chains/{chainId}/data-decoder": {
@@ -1208,7 +1296,9 @@
             }
           }
         },
-        "tags": ["data-decoded"]
+        "tags": [
+          "data-decoded"
+        ]
       }
     },
     "/v1/chains/{chainId}/delegates": {
@@ -1278,7 +1368,9 @@
           }
         },
         "summary": "",
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       },
       "post": {
         "deprecated": true,
@@ -1309,7 +1401,9 @@
           }
         },
         "summary": "",
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v1/chains/{chainId}/delegates/{delegateAddress}": {
@@ -1350,7 +1444,9 @@
           }
         },
         "summary": "",
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/delegates/{delegateAddress}": {
@@ -1383,7 +1479,9 @@
           }
         },
         "summary": "",
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v2/chains/{chainId}/delegates": {
@@ -1451,7 +1549,9 @@
             }
           }
         },
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       },
       "post": {
         "operationId": "delegatesPostDelegateV2",
@@ -1480,7 +1580,9 @@
             "description": ""
           }
         },
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v2/chains/{chainId}/delegates/{delegateAddress}": {
@@ -1519,7 +1621,9 @@
             "description": ""
           }
         },
-        "tags": ["delegates"]
+        "tags": [
+          "delegates"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/recovery": {
@@ -1558,7 +1662,9 @@
             "description": ""
           }
         },
-        "tags": ["recovery"]
+        "tags": [
+          "recovery"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/recovery/{moduleAddress}": {
@@ -1595,7 +1701,9 @@
             "description": ""
           }
         },
-        "tags": ["recovery"]
+        "tags": [
+          "recovery"
+        ]
       }
     },
     "/v2/chains/{chainId}/safes/{address}/multisig-transactions/estimations": {
@@ -1641,7 +1749,9 @@
             }
           }
         },
-        "tags": ["estimations"]
+        "tags": [
+          "estimations"
+        ]
       }
     },
     "/v2/register/notifications": {
@@ -1663,7 +1773,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v2/chains/{chainId}/notifications/devices/{deviceUuid}/safes/{safeAddress}": {
@@ -1700,7 +1812,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       },
       "delete": {
         "operationId": "notificationsDeleteSubscriptionV2",
@@ -1735,7 +1849,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v2/chains/{chainId}/notifications/devices/{deviceUuid}": {
@@ -1764,7 +1880,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v1/chains/{chainId}/messages/{messageHash}": {
@@ -1800,7 +1918,9 @@
             }
           }
         },
-        "tags": ["messages"]
+        "tags": [
+          "messages"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/messages": {
@@ -1844,7 +1964,9 @@
             }
           }
         },
-        "tags": ["messages"]
+        "tags": [
+          "messages"
+        ]
       },
       "post": {
         "operationId": "messagesCreateMessageV1",
@@ -1881,7 +2003,9 @@
             "description": ""
           }
         },
-        "tags": ["messages"]
+        "tags": [
+          "messages"
+        ]
       }
     },
     "/v1/chains/{chainId}/messages/{messageHash}/signatures": {
@@ -1920,7 +2044,9 @@
             "description": ""
           }
         },
-        "tags": ["messages"]
+        "tags": [
+          "messages"
+        ]
       }
     },
     "/v1/register/notifications": {
@@ -1942,7 +2068,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v1/chains/{chainId}/notifications/devices/{uuid}": {
@@ -1971,7 +2099,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v1/chains/{chainId}/notifications/devices/{uuid}/safes/{safeAddress}": {
@@ -2008,7 +2138,9 @@
             "description": ""
           }
         },
-        "tags": ["notifications"]
+        "tags": [
+          "notifications"
+        ]
       }
     },
     "/v1/users": {
@@ -2033,7 +2165,9 @@
             "description": "User (wallet) not found"
           }
         },
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       },
       "delete": {
         "operationId": "usersDeleteV1",
@@ -2049,7 +2183,9 @@
             "description": "User (wallet) not found"
           }
         },
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       }
     },
     "/v1/users/wallet": {
@@ -2074,22 +2210,25 @@
             "description": "Wallet already exists"
           }
         },
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       }
     },
-    "/v1/users/wallet/{walletAddress}": {
+    "/v1/users/wallet/add": {
       "post": {
         "operationId": "usersAddWalletToUserV1",
-        "parameters": [
-          {
-            "name": "walletAddress",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SiweDto"
+              }
             }
           }
-        ],
+        },
         "responses": {
           "200": {
             "description": "",
@@ -2102,7 +2241,7 @@
             }
           },
           "401": {
-            "description": "Signer address not provided"
+            "description": "Signer address not provided OR invalid message/signature"
           },
           "404": {
             "description": "User not found"
@@ -2111,8 +2250,12 @@
             "description": "Wallet already exists"
           }
         },
-        "tags": ["users"]
-      },
+        "tags": [
+          "users"
+        ]
+      }
+    },
+    "/v1/users/wallet/{walletAddress}": {
       "delete": {
         "operationId": "usersDeleteWalletFromUserV1",
         "parameters": [
@@ -2139,30 +2282,32 @@
             "description": "Cannot remove the current wallet"
           }
         },
-        "tags": ["users"]
+        "tags": [
+          "users"
+        ]
       }
     },
-    "/v1/organizations": {
+    "/v1/spaces": {
       "post": {
-        "operationId": "organizationsCreateV1",
+        "operationId": "spacesCreateV1",
         "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateOrganizationDto"
+                "$ref": "#/components/schemas/CreateSpaceDto"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Organizations created",
+            "description": "Space created",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateOrganizationResponse"
+                  "$ref": "#/components/schemas/CreateSpaceResponse"
                 }
               }
             }
@@ -2177,20 +2322,22 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       },
       "get": {
-        "operationId": "organizationsGetV1",
+        "operationId": "spacesGetV1",
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Organizations found",
+            "description": "Spaces found",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/GetOrganizationResponse"
+                    "$ref": "#/components/schemas/GetSpaceResponse"
                   }
                 }
               }
@@ -2206,30 +2353,32 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       }
     },
-    "/v1/organizations/create-with-user": {
+    "/v1/spaces/create-with-user": {
       "post": {
-        "operationId": "organizationsCreateWithUserV1",
+        "operationId": "spacesCreateWithUserV1",
         "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateOrganizationDto"
+                "$ref": "#/components/schemas/CreateSpaceDto"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Organizations created",
+            "description": "Space created",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateOrganizationResponse"
+                  "$ref": "#/components/schemas/CreateSpaceResponse"
                 }
               }
             }
@@ -2241,12 +2390,14 @@
             "description": "Forbidden resource"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       }
     },
-    "/v1/organizations/{id}": {
+    "/v1/spaces/{id}": {
       "get": {
-        "operationId": "organizationsGetOneV1",
+        "operationId": "spacesGetOneV1",
         "parameters": [
           {
             "name": "id",
@@ -2259,11 +2410,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Organization found",
+            "description": "Space found",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GetOrganizationResponse"
+                  "$ref": "#/components/schemas/GetSpaceResponse"
                 }
               }
             }
@@ -2275,13 +2426,15 @@
             "description": "Forbidden resource"
           },
           "404": {
-            "description": "Organization not found. OR User not found."
+            "description": "Space not found. OR User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       },
       "patch": {
-        "operationId": "organizationsUpdateV1",
+        "operationId": "spacesUpdateV1",
         "parameters": [
           {
             "name": "id",
@@ -2297,18 +2450,18 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateOrganizationDto"
+                "$ref": "#/components/schemas/UpdateSpaceDto"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Organization updated",
+            "description": "Space updated",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateOrganizationResponse"
+                  "$ref": "#/components/schemas/UpdateSpaceResponse"
                 }
               }
             }
@@ -2323,10 +2476,12 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       },
       "delete": {
-        "operationId": "organizationsDeleteV1",
+        "operationId": "spacesDeleteV1",
         "parameters": [
           {
             "name": "id",
@@ -2339,7 +2494,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Organization deleted"
+            "description": "Spaces deleted"
           },
           "401": {
             "description": "Signer address not provided OR User is unauthorized"
@@ -2351,15 +2506,17 @@
             "description": "User not found."
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       }
     },
-    "/v1/organizations/{orgId}/members/invite": {
+    "/v1/spaces/{spaceId}/safes": {
       "post": {
-        "operationId": "userOrganizationsInviteUserV1",
+        "operationId": "spaceSafesCreateV1",
         "parameters": [
           {
-            "name": "orgId",
+            "name": "spaceId",
             "required": true,
             "in": "path",
             "schema": {
@@ -2372,10 +2529,117 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "array",
-                "items": {
-                  "type": "string"
+                "$ref": "#/components/schemas/CreateSpaceSafesDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Safes created successfully"
+          },
+          "401": {
+            "description": "User unauthorize OR signer address not provided"
+          },
+          "404": {
+            "description": "User not found."
+          }
+        },
+        "tags": [
+          "spaces"
+        ]
+      },
+      "get": {
+        "operationId": "spaceSafesGetV1",
+        "parameters": [
+          {
+            "name": "spaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Safes fetched successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSpaceSafeResponse"
                 }
+              }
+            }
+          },
+          "401": {
+            "description": "User unauthorized OR signer address not provided"
+          },
+          "404": {
+            "description": "User not found."
+          }
+        },
+        "tags": [
+          "spaces"
+        ]
+      },
+      "delete": {
+        "operationId": "spaceSafesDeleteV1",
+        "parameters": [
+          {
+            "name": "spaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteSpaceSafesDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Safes deleted successfully"
+          },
+          "401": {
+            "description": "User unauthorized OR signer address not provided"
+          },
+          "404": {
+            "description": "Space has no Safes OR user not found."
+          }
+        },
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/v1/spaces/{spaceId}/members/invite": {
+      "post": {
+        "operationId": "membersInviteUserV1",
+        "parameters": [
+          {
+            "name": "spaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InviteUsersDto"
               }
             }
           }
@@ -2404,15 +2668,17 @@
             "description": "Too many invites"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       }
     },
-    "/v1/organizations/{orgId}/members/accept": {
+    "/v1/spaces/{spaceId}/members/accept": {
       "post": {
-        "operationId": "userOrganizationsAcceptInviteV1",
+        "operationId": "membersAcceptInviteV1",
         "parameters": [
           {
-            "name": "orgId",
+            "name": "spaceId",
             "required": true,
             "in": "path",
             "schema": {
@@ -2420,6 +2686,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcceptInviteDto"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Invite accepted"
@@ -2428,21 +2704,23 @@
             "description": "Signer not authorized"
           },
           "404": {
-            "description": "Signer, organization or membership not found"
+            "description": "Signer, space or membership not found"
           },
           "409": {
             "description": "User invite not pending"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       }
     },
-    "/v1/organizations/{orgId}/members/decline": {
+    "/v1/spaces/{spaceId}/members/decline": {
       "post": {
-        "operationId": "userOrganizationsDeclineInviteV1",
+        "operationId": "membersDeclineInviteV1",
         "parameters": [
           {
-            "name": "orgId",
+            "name": "spaceId",
             "required": true,
             "in": "path",
             "schema": {
@@ -2458,21 +2736,23 @@
             "description": "Signer not authorized"
           },
           "404": {
-            "description": "Signer, organization or membership not found"
+            "description": "Signer, space or membership not found"
           },
           "409": {
             "description": "User invite not pending"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       }
     },
-    "/v1/organizations/{orgId}/members": {
+    "/v1/spaces/{spaceId}/members": {
       "get": {
-        "operationId": "userOrganizationsGetUsersV1",
+        "operationId": "membersGetUsersV1",
         "parameters": [
           {
-            "name": "orgId",
+            "name": "spaceId",
             "required": true,
             "in": "path",
             "schema": {
@@ -2482,11 +2762,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Organization and members list",
+            "description": "Space and members list",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserOrganizationsDto"
+                  "$ref": "#/components/schemas/MembersDto"
                 }
               }
             }
@@ -2495,18 +2775,20 @@
             "description": "Signer not authorized"
           },
           "404": {
-            "description": "Signer or organization not found"
+            "description": "Signer or space not found"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       }
     },
-    "/v1/organizations/{orgId}/members/{userId}/role": {
+    "/v1/spaces/{spaceId}/members/{userId}/role": {
       "patch": {
-        "operationId": "userOrganizationsUpdateRoleV1",
+        "operationId": "membersUpdateRoleV1",
         "parameters": [
           {
-            "name": "orgId",
+            "name": "spaceId",
             "required": true,
             "in": "path",
             "schema": {
@@ -2522,6 +2804,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRoleDto"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Role updated"
@@ -2533,21 +2825,23 @@
             "description": "Signer not authorized"
           },
           "404": {
-            "description": "Signer, organization or signer/user-to-update membership not found"
+            "description": "Signer, space or signer/user-to-update membership not found"
           },
           "409": {
             "description": "Cannot remove last admin"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       }
     },
-    "/v1/organizations/{orgId}/members/{userId}": {
+    "/v1/spaces/{spaceId}/members/{userId}": {
       "delete": {
-        "operationId": "userOrganizationsRemoveUserV1",
+        "operationId": "membersRemoveUserV1",
         "parameters": [
           {
-            "name": "orgId",
+            "name": "spaceId",
             "required": true,
             "in": "path",
             "schema": {
@@ -2574,13 +2868,15 @@
             "description": "Signer not authorized"
           },
           "404": {
-            "description": "Signer or organization not found"
+            "description": "Signer or space not found"
           },
           "409": {
             "description": "Cannot remove last admin"
           }
         },
-        "tags": ["organizations"]
+        "tags": [
+          "spaces"
+        ]
       }
     },
     "/v1/chains/{chainId}/owners/{ownerAddress}/safes": {
@@ -2616,7 +2912,9 @@
             }
           }
         },
-        "tags": ["owners"]
+        "tags": [
+          "owners"
+        ]
       }
     },
     "/v1/owners/{ownerAddress}/safes": {
@@ -2644,7 +2942,9 @@
             }
           }
         },
-        "tags": ["owners"]
+        "tags": [
+          "owners"
+        ]
       }
     },
     "/v2/owners/{ownerAddress}/safes": {
@@ -2678,7 +2978,9 @@
             }
           }
         },
-        "tags": ["owners"]
+        "tags": [
+          "owners"
+        ]
       }
     },
     "/v1/chains/{chainId}/relay": {
@@ -2705,11 +3007,20 @@
           }
         },
         "responses": {
-          "201": {
-            "description": ""
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Relay"
+                }
+              }
+            }
           }
         },
-        "tags": ["relay"]
+        "tags": [
+          "relay"
+        ]
       }
     },
     "/v1/chains/{chainId}/relay/{safeAddress}": {
@@ -2735,10 +3046,19 @@
         ],
         "responses": {
           "200": {
-            "description": ""
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RelaysRemaining"
+                }
+              }
+            }
           }
         },
-        "tags": ["relay"]
+        "tags": [
+          "relay"
+        ]
       }
     },
     "/v1/chains/{chainId}/safe-apps": {
@@ -2785,7 +3105,9 @@
             }
           }
         },
-        "tags": ["safe-apps"]
+        "tags": [
+          "safe-apps"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}": {
@@ -2821,7 +3143,9 @@
             }
           }
         },
-        "tags": ["safes"]
+        "tags": [
+          "safes"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/nonces": {
@@ -2857,7 +3181,9 @@
             }
           }
         },
-        "tags": ["safes"]
+        "tags": [
+          "safes"
+        ]
       }
     },
     "/v1/safes": {
@@ -2920,7 +3246,9 @@
             }
           }
         },
-        "tags": ["safes"]
+        "tags": [
+          "safes"
+        ]
       }
     },
     "/v1/targeted-messaging/outreaches/{outreachId}/chains/{chainId}/safes/{safeAddress}": {
@@ -2967,7 +3295,9 @@
             "description": "Safe not targeted."
           }
         },
-        "tags": ["targeted-messaging"]
+        "tags": [
+          "targeted-messaging"
+        ]
       }
     },
     "/v1/targeted-messaging/outreaches/{outreachId}/chains/{chainId}/safes/{safeAddress}/signers/{signerAddress}/submissions": {
@@ -3019,7 +3349,9 @@
             }
           }
         },
-        "tags": ["targeted-messaging"]
+        "tags": [
+          "targeted-messaging"
+        ]
       },
       "post": {
         "operationId": "targetedMessagingCreateSubmissionV1",
@@ -3079,7 +3411,9 @@
             }
           }
         },
-        "tags": ["targeted-messaging"]
+        "tags": [
+          "targeted-messaging"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{id}": {
@@ -3115,7 +3449,293 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/v1/chains/{chainId}/multisig-transactions/{safeTxHash}/raw": {
+      "get": {
+        "operationId": "transactionsGetDomainMultisigTransactionBySafeTxHashV1",
+        "parameters": [
+          {
+            "name": "chainId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "safeTxHash",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TXSMultisigTransaction"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/v1/chains/{chainId}/safes/{safeAddress}/multisig-transactions/raw": {
+      "get": {
+        "operationId": "transactionsGetDomainMultisigTransactionsV1",
+        "parameters": [
+          {
+            "name": "chainId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "safeAddress",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "failed",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "modified__lt",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "modified__gt",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "modified__lte",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "modified__gte",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nonce__lt",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "nonce__gt",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "nonce__lte",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "nonce__gte",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "nonce",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "safe_tx_hash",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "value__lt",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "value__gt",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "value",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "executed",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "has_confirmations",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "trusted",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "execution_date__gte",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "execution_date__lte",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "submission_date__gte",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "submission_date__lte",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "transaction_hash",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ordering",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TXSMultisigTransactionPage"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/multisig-transactions": {
@@ -3207,7 +3827,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{safeTxHash}": {
@@ -3246,7 +3868,9 @@
             "description": ""
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/module-transactions": {
@@ -3314,7 +3938,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{safeTxHash}/confirmations": {
@@ -3360,7 +3986,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/incoming-transfers": {
@@ -3452,7 +4080,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{safeAddress}/preview": {
@@ -3498,7 +4128,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/transactions/queued": {
@@ -3550,7 +4182,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/transactions/history": {
@@ -3627,7 +4261,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/transactions/{safeAddress}/propose": {
@@ -3673,7 +4309,9 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
       }
     },
     "/v1/chains/{chainId}/safes/{safeAddress}/transactions/creation": {
@@ -3709,7 +4347,47 @@
             }
           }
         },
-        "tags": ["transactions"]
+        "tags": [
+          "transactions"
+        ]
+      }
+    },
+    "/v1/chains/{chainId}/safes/{safeAddress}/creation/raw": {
+      "get": {
+        "operationId": "transactionsGetDomainCreationTransactionV1",
+        "parameters": [
+          {
+            "name": "chainId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "safeAddress",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TXSCreationTransaction"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "transactions"
+        ]
       }
     }
   },
@@ -3738,7 +4416,9 @@
             "nullable": true
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
       "CreateAccountDto": {
         "type": "object",
@@ -3750,7 +4430,10 @@
             "type": "string"
           }
         },
-        "required": ["address", "name"]
+        "required": [
+          "address",
+          "name"
+        ]
       },
       "Account": {
         "type": "object",
@@ -3769,7 +4452,11 @@
             "type": "string"
           }
         },
-        "required": ["id", "address", "name"]
+        "required": [
+          "id",
+          "address",
+          "name"
+        ]
       },
       "AccountDataType": {
         "type": "object",
@@ -3788,7 +4475,11 @@
             "type": "boolean"
           }
         },
-        "required": ["id", "name", "isActive"]
+        "required": [
+          "id",
+          "name",
+          "isActive"
+        ]
       },
       "AccountDataSetting": {
         "type": "object",
@@ -3800,7 +4491,10 @@
             "type": "boolean"
           }
         },
-        "required": ["dataTypeId", "enabled"]
+        "required": [
+          "dataTypeId",
+          "enabled"
+        ]
       },
       "UpsertAccountDataSettingDto": {
         "type": "object",
@@ -3812,7 +4506,10 @@
             "type": "boolean"
           }
         },
-        "required": ["dataTypeId", "enabled"]
+        "required": [
+          "dataTypeId",
+          "enabled"
+        ]
       },
       "UpsertAccountDataSettingsDto": {
         "type": "object",
@@ -3824,7 +4521,9 @@
             }
           }
         },
-        "required": ["accountDataSettings"]
+        "required": [
+          "accountDataSettings"
+        ]
       },
       "AddressBookItem": {
         "type": "object",
@@ -3839,7 +4538,11 @@
             "type": "string"
           }
         },
-        "required": ["id", "name", "address"]
+        "required": [
+          "id",
+          "name",
+          "address"
+        ]
       },
       "AddressBook": {
         "type": "object",
@@ -3860,7 +4563,12 @@
             }
           }
         },
-        "required": ["id", "accountId", "chainId", "data"]
+        "required": [
+          "id",
+          "accountId",
+          "chainId",
+          "data"
+        ]
       },
       "CreateAddressBookItemDto": {
         "type": "object",
@@ -3872,7 +4580,10 @@
             "type": "string"
           }
         },
-        "required": ["name", "address"]
+        "required": [
+          "name",
+          "address"
+        ]
       },
       "CounterfactualSafe": {
         "type": "object",
@@ -3961,7 +4672,9 @@
             "type": "string"
           }
         },
-        "required": ["nonce"]
+        "required": [
+          "nonce"
+        ]
       },
       "SiweDto": {
         "type": "object",
@@ -3973,17 +4686,19 @@
             "type": "string"
           }
         },
-        "required": ["message", "signature"]
+        "required": [
+          "message",
+          "signature"
+        ]
       },
-      "Token": {
+      "NativeToken": {
         "type": "object",
         "properties": {
           "address": {
             "type": "string"
           },
           "decimals": {
-            "type": "number",
-            "nullable": true
+            "type": "number"
           },
           "logoUri": {
             "type": "string"
@@ -3996,10 +4711,87 @@
           },
           "type": {
             "type": "string",
-            "enum": ["ERC721", "ERC20", "NATIVE_TOKEN", "UNKNOWN"]
+            "enum": [
+              "NATIVE_TOKEN"
+            ]
           }
         },
-        "required": ["address", "logoUri", "name", "symbol", "type"]
+        "required": [
+          "address",
+          "decimals",
+          "logoUri",
+          "name",
+          "symbol",
+          "type"
+        ]
+      },
+      "Erc20Token": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "decimals": {
+            "type": "number"
+          },
+          "logoUri": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "ERC20"
+            ]
+          }
+        },
+        "required": [
+          "address",
+          "decimals",
+          "logoUri",
+          "name",
+          "symbol",
+          "type"
+        ]
+      },
+      "Erc721Token": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "decimals": {
+            "type": "number"
+          },
+          "logoUri": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "ERC721"
+            ]
+          }
+        },
+        "required": [
+          "address",
+          "decimals",
+          "logoUri",
+          "name",
+          "symbol",
+          "type"
+        ]
       },
       "Balance": {
         "type": "object",
@@ -4014,10 +4806,25 @@
             "type": "string"
           },
           "tokenInfo": {
-            "$ref": "#/components/schemas/Token"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/NativeToken"
+              },
+              {
+                "$ref": "#/components/schemas/Erc20Token"
+              },
+              {
+                "$ref": "#/components/schemas/Erc721Token"
+              }
+            ]
           }
         },
-        "required": ["balance", "fiatBalance", "fiatConversion", "tokenInfo"]
+        "required": [
+          "balance",
+          "fiatBalance",
+          "fiatConversion",
+          "tokenInfo"
+        ]
       },
       "Balances": {
         "type": "object",
@@ -4036,7 +4843,10 @@
             }
           }
         },
-        "required": ["fiatTotal", "items"]
+        "required": [
+          "fiatTotal",
+          "items"
+        ]
       },
       "GasPriceOracle": {
         "type": "object",
@@ -4054,7 +4864,12 @@
             "type": "string"
           }
         },
-        "required": ["type", "gasParameter", "gweiFactor", "uri"]
+        "required": [
+          "type",
+          "gasParameter",
+          "gweiFactor",
+          "uri"
+        ]
       },
       "GasPriceFixed": {
         "type": "object",
@@ -4066,7 +4881,10 @@
             "type": "string"
           }
         },
-        "required": ["type", "weiValue"]
+        "required": [
+          "type",
+          "weiValue"
+        ]
       },
       "GasPriceFixedEIP1559": {
         "type": "object",
@@ -4081,7 +4899,11 @@
             "type": "string"
           }
         },
-        "required": ["type", "maxFeePerGas", "maxPriorityFeePerGas"]
+        "required": [
+          "type",
+          "maxFeePerGas",
+          "maxPriorityFeePerGas"
+        ]
       },
       "NativeCurrency": {
         "type": "object",
@@ -4099,7 +4921,12 @@
             "type": "string"
           }
         },
-        "required": ["decimals", "logoUri", "name", "symbol"]
+        "required": [
+          "decimals",
+          "logoUri",
+          "name",
+          "symbol"
+        ]
       },
       "BlockExplorerUriTemplate": {
         "type": "object",
@@ -4114,7 +4941,11 @@
             "type": "string"
           }
         },
-        "required": ["address", "api", "txHash"]
+        "required": [
+          "address",
+          "api",
+          "txHash"
+        ]
       },
       "BalancesProvider": {
         "type": "object",
@@ -4127,7 +4958,9 @@
             "type": "boolean"
           }
         },
-        "required": ["enabled"]
+        "required": [
+          "enabled"
+        ]
       },
       "ContractAddresses": {
         "type": "object",
@@ -4175,13 +5008,20 @@
         "properties": {
           "authentication": {
             "type": "string",
-            "enum": ["API_KEY_PATH", "NO_AUTHENTICATION", "UNKNOWN"]
+            "enum": [
+              "API_KEY_PATH",
+              "NO_AUTHENTICATION",
+              "UNKNOWN"
+            ]
           },
           "value": {
             "type": "string"
           }
         },
-        "required": ["authentication", "value"]
+        "required": [
+          "authentication",
+          "value"
+        ]
       },
       "Theme": {
         "type": "object",
@@ -4193,7 +5033,10 @@
             "type": "string"
           }
         },
-        "required": ["backgroundColor", "textColor"]
+        "required": [
+          "backgroundColor",
+          "textColor"
+        ]
       },
       "Chain": {
         "type": "object",
@@ -4331,7 +5174,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "AboutChain": {
         "type": "object",
@@ -4349,7 +5194,12 @@
             "type": "string"
           }
         },
-        "required": ["transactionServiceBaseUri", "name", "version", "buildNumber"]
+        "required": [
+          "transactionServiceBaseUri",
+          "name",
+          "version",
+          "buildNumber"
+        ]
       },
       "Backbone": {
         "type": "object",
@@ -4378,7 +5228,14 @@
             "type": "string"
           }
         },
-        "required": ["api_version", "host", "name", "secure", "settings", "version"]
+        "required": [
+          "api_version",
+          "host",
+          "name",
+          "secure",
+          "settings",
+          "version"
+        ]
       },
       "MasterCopy": {
         "type": "object",
@@ -4390,7 +5247,10 @@
             "type": "string"
           }
         },
-        "required": ["address", "version"]
+        "required": [
+          "address",
+          "version"
+        ]
       },
       "IndexingStatus": {
         "type": "object",
@@ -4402,7 +5262,10 @@
             "type": "boolean"
           }
         },
-        "required": ["lastSync", "synced"]
+        "required": [
+          "lastSync",
+          "synced"
+        ]
       },
       "Collectible": {
         "type": "object",
@@ -4443,7 +5306,13 @@
             "nullable": true
           }
         },
-        "required": ["address", "tokenName", "tokenSymbol", "logoUri", "id"]
+        "required": [
+          "address",
+          "tokenName",
+          "tokenSymbol",
+          "logoUri",
+          "id"
+        ]
       },
       "CollectiblePage": {
         "type": "object",
@@ -4467,7 +5336,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "ActivityMetadata": {
         "type": "object",
@@ -4482,7 +5353,11 @@
             "type": "number"
           }
         },
-        "required": ["name", "description", "maxPoints"]
+        "required": [
+          "name",
+          "description",
+          "maxPoints"
+        ]
       },
       "Campaign": {
         "type": "object",
@@ -4537,7 +5412,14 @@
             "type": "boolean"
           }
         },
-        "required": ["resourceId", "name", "description", "startDate", "endDate", "isPromoted"]
+        "required": [
+          "resourceId",
+          "name",
+          "description",
+          "startDate",
+          "endDate",
+          "isPromoted"
+        ]
       },
       "CampaignPage": {
         "type": "object",
@@ -4561,7 +5443,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "CampaignRank": {
         "type": "object",
@@ -4582,7 +5466,13 @@
             "type": "number"
           }
         },
-        "required": ["holder", "position", "boost", "totalPoints", "totalBoostedPoints"]
+        "required": [
+          "holder",
+          "position",
+          "boost",
+          "totalPoints",
+          "totalBoostedPoints"
+        ]
       },
       "CampaignRankPage": {
         "type": "object",
@@ -4606,7 +5496,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "EligibilityRequest": {
         "type": "object",
@@ -4618,7 +5510,10 @@
             "type": "string"
           }
         },
-        "required": ["requestId", "sealedData"]
+        "required": [
+          "requestId",
+          "sealedData"
+        ]
       },
       "Eligibility": {
         "type": "object",
@@ -4633,7 +5528,11 @@
             "type": "boolean"
           }
         },
-        "required": ["requestId", "isAllowed", "isVpn"]
+        "required": [
+          "requestId",
+          "isAllowed",
+          "isVpn"
+        ]
       },
       "LockingRank": {
         "type": "object",
@@ -4654,7 +5553,13 @@
             "type": "string"
           }
         },
-        "required": ["holder", "position", "lockedAmount", "unlockedAmount", "withdrawnAmount"]
+        "required": [
+          "holder",
+          "position",
+          "lockedAmount",
+          "unlockedAmount",
+          "withdrawnAmount"
+        ]
       },
       "LockingRankPage": {
         "type": "object",
@@ -4678,14 +5583,18 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "LockEventItem": {
         "type": "object",
         "properties": {
           "eventType": {
             "type": "string",
-            "enum": ["LOCKED"]
+            "enum": [
+              "LOCKED"
+            ]
           },
           "executionDate": {
             "type": "string"
@@ -4703,14 +5612,23 @@
             "type": "string"
           }
         },
-        "required": ["eventType", "executionDate", "transactionHash", "holder", "amount", "logIndex"]
+        "required": [
+          "eventType",
+          "executionDate",
+          "transactionHash",
+          "holder",
+          "amount",
+          "logIndex"
+        ]
       },
       "UnlockEventItem": {
         "type": "object",
         "properties": {
           "eventType": {
             "type": "string",
-            "enum": ["UNLOCKED"]
+            "enum": [
+              "UNLOCKED"
+            ]
           },
           "executionDate": {
             "type": "string"
@@ -4731,14 +5649,24 @@
             "type": "string"
           }
         },
-        "required": ["eventType", "executionDate", "transactionHash", "holder", "amount", "logIndex", "unlockIndex"]
+        "required": [
+          "eventType",
+          "executionDate",
+          "transactionHash",
+          "holder",
+          "amount",
+          "logIndex",
+          "unlockIndex"
+        ]
       },
       "WithdrawEventItem": {
         "type": "object",
         "properties": {
           "eventType": {
             "type": "string",
-            "enum": ["WITHDRAWN"]
+            "enum": [
+              "WITHDRAWN"
+            ]
           },
           "executionDate": {
             "type": "string"
@@ -4759,7 +5687,15 @@
             "type": "string"
           }
         },
-        "required": ["eventType", "executionDate", "transactionHash", "holder", "amount", "logIndex", "unlockIndex"]
+        "required": [
+          "eventType",
+          "executionDate",
+          "transactionHash",
+          "holder",
+          "amount",
+          "logIndex",
+          "unlockIndex"
+        ]
       },
       "LockingEventPage": {
         "type": "object",
@@ -4793,7 +5729,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "Contract": {
         "type": "object",
@@ -4818,7 +5756,13 @@
             "type": "boolean"
           }
         },
-        "required": ["address", "name", "displayName", "logoUri", "trustedForDelegateCall"]
+        "required": [
+          "address",
+          "name",
+          "displayName",
+          "logoUri",
+          "trustedForDelegateCall"
+        ]
       },
       "TransactionDataDto": {
         "type": "object",
@@ -4836,7 +5780,9 @@
             "description": "The wei amount being sent to a payable function"
           }
         },
-        "required": ["data"]
+        "required": [
+          "data"
+        ]
       },
       "DataDecodedParameter": {
         "type": "object",
@@ -4865,7 +5811,11 @@
             "nullable": true
           }
         },
-        "required": ["name", "type", "value"]
+        "required": [
+          "name",
+          "type",
+          "value"
+        ]
       },
       "DataDecoded": {
         "type": "object",
@@ -4881,7 +5831,9 @@
             }
           }
         },
-        "required": ["method"]
+        "required": [
+          "method"
+        ]
       },
       "Delegate": {
         "type": "object",
@@ -4900,7 +5852,11 @@
             "type": "string"
           }
         },
-        "required": ["delegate", "delegator", "label"]
+        "required": [
+          "delegate",
+          "delegator",
+          "label"
+        ]
       },
       "DelegatePage": {
         "type": "object",
@@ -4924,7 +5880,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "CreateDelegateDto": {
         "type": "object",
@@ -4946,7 +5904,12 @@
             "type": "string"
           }
         },
-        "required": ["delegate", "delegator", "signature", "label"]
+        "required": [
+          "delegate",
+          "delegator",
+          "signature",
+          "label"
+        ]
       },
       "DeleteDelegateDto": {
         "type": "object",
@@ -4961,7 +5924,11 @@
             "type": "string"
           }
         },
-        "required": ["delegate", "delegator", "signature"]
+        "required": [
+          "delegate",
+          "delegator",
+          "signature"
+        ]
       },
       "DeleteSafeDelegateDto": {
         "type": "object",
@@ -4976,7 +5943,11 @@
             "type": "string"
           }
         },
-        "required": ["delegate", "safe", "signature"]
+        "required": [
+          "delegate",
+          "safe",
+          "signature"
+        ]
       },
       "DeleteDelegateV2Dto": {
         "type": "object",
@@ -4993,7 +5964,9 @@
             "type": "string"
           }
         },
-        "required": ["signature"]
+        "required": [
+          "signature"
+        ]
       },
       "AddRecoveryModuleDto": {
         "type": "object",
@@ -5002,7 +5975,9 @@
             "type": "string"
           }
         },
-        "required": ["moduleAddress"]
+        "required": [
+          "moduleAddress"
+        ]
       },
       "GetEstimationDto": {
         "type": "object",
@@ -5021,7 +5996,11 @@
             "type": "number"
           }
         },
-        "required": ["to", "value", "operation"]
+        "required": [
+          "to",
+          "value",
+          "operation"
+        ]
       },
       "EstimationResponse": {
         "type": "object",
@@ -5036,7 +6015,11 @@
             "type": "string"
           }
         },
-        "required": ["currentNonce", "recommendedNonce", "safeTxGas"]
+        "required": [
+          "currentNonce",
+          "recommendedNonce",
+          "safeTxGas"
+        ]
       },
       "NotificationType": {
         "type": "string",
@@ -5066,11 +6049,19 @@
             }
           }
         },
-        "required": ["chainId", "address", "notificationTypes"]
+        "required": [
+          "chainId",
+          "address",
+          "notificationTypes"
+        ]
       },
       "DeviceType": {
         "type": "string",
-        "enum": ["ANDROID", "IOS", "WEB"]
+        "enum": [
+          "ANDROID",
+          "IOS",
+          "WEB"
+        ]
       },
       "UpsertSubscriptionsDto": {
         "type": "object",
@@ -5096,7 +6087,75 @@
             "nullable": true
           }
         },
-        "required": ["cloudMessagingToken", "safes", "deviceType"]
+        "required": [
+          "cloudMessagingToken",
+          "safes",
+          "deviceType"
+        ]
+      },
+      "TypedDataParameter": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ]
+      },
+      "TypedDataDomain": {
+        "type": "object",
+        "properties": {
+          "chainId": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "salt": {
+            "type": "string"
+          },
+          "verifyingContract": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "TypedData": {
+        "type": "object",
+        "properties": {
+          "domain": {
+            "$ref": "#/components/schemas/TypedDataDomain"
+          },
+          "primaryType": {
+            "type": "string"
+          },
+          "types": {
+            "type": "object",
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/TypedDataParameter"
+              },
+              "type": "array"
+            }
+          },
+          "message": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "domain",
+          "primaryType",
+          "types",
+          "message"
+        ]
       },
       "AddressInfo": {
         "type": "object",
@@ -5113,7 +6172,24 @@
             "nullable": true
           }
         },
-        "required": ["value"]
+        "required": [
+          "value"
+        ]
+      },
+      "MessageConfirmation": {
+        "type": "object",
+        "properties": {
+          "owner": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "signature": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "owner",
+          "signature"
+        ]
       },
       "Message": {
         "type": "object",
@@ -5122,7 +6198,11 @@
             "type": "string"
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "NEEDS_CONFIRMATION",
+              "CONFIRMED"
+            ]
           },
           "logoUri": {
             "type": "string",
@@ -5133,7 +6213,14 @@
             "nullable": true
           },
           "message": {
-            "type": "object"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/TypedData"
+              }
+            ]
           },
           "creationTimestamp": {
             "type": "number"
@@ -5153,7 +6240,7 @@
           "confirmations": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/MessageConfirmation"
             }
           },
           "preparedSignature": {
@@ -5184,7 +6271,11 @@
             "type": "string"
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "NEEDS_CONFIRMATION",
+              "CONFIRMED"
+            ]
           },
           "logoUri": {
             "type": "string",
@@ -5195,7 +6286,14 @@
             "nullable": true
           },
           "message": {
-            "type": "object"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/TypedData"
+              }
+            ]
           },
           "creationTimestamp": {
             "type": "number"
@@ -5215,7 +6313,7 @@
           "confirmations": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/MessageConfirmation"
             }
           },
           "preparedSignature": {
@@ -5227,7 +6325,10 @@
             "nullable": true
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "MESSAGE"
+            ]
           }
         },
         "required": [
@@ -5248,13 +6349,18 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["DATE_LABEL"]
+            "enum": [
+              "DATE_LABEL"
+            ]
           },
           "timestamp": {
             "type": "number"
           }
         },
-        "required": ["type", "timestamp"]
+        "required": [
+          "type",
+          "timestamp"
+        ]
       },
       "MessagePage": {
         "type": "object",
@@ -5285,13 +6391,22 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "CreateMessageDto": {
         "type": "object",
         "properties": {
           "message": {
-            "type": "object"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/TypedData"
+              }
+            ]
           },
           "safeAppId": {
             "type": "number",
@@ -5306,7 +6421,10 @@
             "nullable": true
           }
         },
-        "required": ["message", "signature"]
+        "required": [
+          "message",
+          "signature"
+        ]
       },
       "UpdateMessageSignatureDto": {
         "type": "object",
@@ -5315,7 +6433,9 @@
             "type": "string"
           }
         },
-        "required": ["signature"]
+        "required": [
+          "signature"
+        ]
       },
       "SafeRegistration": {
         "type": "object",
@@ -5336,7 +6456,11 @@
             }
           }
         },
-        "required": ["chainId", "safes", "signatures"]
+        "required": [
+          "chainId",
+          "safes",
+          "signatures"
+        ]
       },
       "RegisterDeviceDto": {
         "type": "object",
@@ -5371,7 +6495,14 @@
             }
           }
         },
-        "required": ["cloudMessagingToken", "buildNumber", "bundle", "deviceType", "version", "safeRegistrations"]
+        "required": [
+          "cloudMessagingToken",
+          "buildNumber",
+          "bundle",
+          "deviceType",
+          "version",
+          "safeRegistrations"
+        ]
       },
       "UserWallet": {
         "type": "object",
@@ -5383,7 +6514,10 @@
             "type": "string"
           }
         },
-        "required": ["id", "address"]
+        "required": [
+          "id",
+          "address"
+        ]
       },
       "UserWithWallets": {
         "type": "object",
@@ -5393,7 +6527,10 @@
           },
           "status": {
             "type": "number",
-            "enum": [0, 1]
+            "enum": [
+              0,
+              1
+            ]
           },
           "wallets": {
             "type": "array",
@@ -5402,7 +6539,11 @@
             }
           }
         },
-        "required": ["id", "status", "wallets"]
+        "required": [
+          "id",
+          "status",
+          "wallets"
+        ]
       },
       "CreatedUserWithWallet": {
         "type": "object",
@@ -5411,7 +6552,9 @@
             "type": "number"
           }
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
       },
       "WalletAddedToUser": {
         "type": "object",
@@ -5420,18 +6563,22 @@
             "type": "number"
           }
         },
-        "required": ["id"]
+        "required": [
+          "id"
+        ]
       },
-      "CreateOrganizationDto": {
+      "CreateSpaceDto": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           }
         },
-        "required": ["name"]
+        "required": [
+          "name"
+        ]
       },
-      "CreateOrganizationResponse": {
+      "CreateSpaceResponse": {
         "type": "object",
         "properties": {
           "name": {
@@ -5441,7 +6588,10 @@
             "type": "number"
           }
         },
-        "required": ["name", "id"]
+        "required": [
+          "name",
+          "id"
+        ]
       },
       "UserDto": {
         "type": "object",
@@ -5451,100 +6601,18 @@
           },
           "status": {
             "type": "string",
-            "enum": ["PENDING", "ACTIVE"]
+            "enum": [
+              "PENDING",
+              "ACTIVE"
+            ]
           }
         },
-        "required": ["id", "status"]
+        "required": [
+          "id",
+          "status"
+        ]
       },
-      "UserOrganizationsDto": {
-        "type": "object",
-        "properties": {
-          "members": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/UserOrganization"
-            }
-          }
-        },
-        "required": ["members"]
-      },
-      "GetOrganizationResponse": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "number"
-          },
-          "name": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": ["ACTIVE"]
-          },
-          "userOrganizations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/UserOrganizationsDto"
-            }
-          }
-        },
-        "required": ["id", "name", "status", "userOrganizations"]
-      },
-      "UpdateOrganizationDto": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string",
-            "enum": ["ACTIVE"]
-          }
-        }
-      },
-      "UpdateOrganizationResponse": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "number"
-          }
-        },
-        "required": ["id"]
-      },
-      "Invitation": {
-        "type": "object",
-        "properties": {
-          "userId": {
-            "type": "number"
-          },
-          "orgId": {
-            "type": "number"
-          },
-          "role": {
-            "type": "string",
-            "enum": ["ADMIN", "MEMBER"]
-          },
-          "status": {
-            "type": "string",
-            "enum": ["INVITED", "ACTIVE", "DECLINED"]
-          }
-        },
-        "required": ["userId", "orgId", "role", "status"]
-      },
-      "UserOrganizationUser": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "number"
-          },
-          "status": {
-            "type": "string",
-            "enum": ["PENDING", "ACTIVE"]
-          }
-        },
-        "required": ["id", "status"]
-      },
-      "UserOrganization": {
+      "MemberDto": {
         "type": "object",
         "properties": {
           "id": {
@@ -5552,11 +6620,24 @@
           },
           "role": {
             "type": "string",
-            "enum": ["ADMIN", "MEMBER"]
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "invitedBy": {
+            "type": "string"
           },
           "status": {
             "type": "string",
-            "enum": ["INVITED", "ACTIVE", "DECLINED"]
+            "enum": [
+              "INVITED",
+              "ACTIVE",
+              "DECLINED"
+            ]
           },
           "createdAt": {
             "format": "date-time",
@@ -5567,10 +6648,339 @@
             "type": "string"
           },
           "user": {
-            "$ref": "#/components/schemas/UserOrganizationUser"
+            "$ref": "#/components/schemas/UserDto"
           }
         },
-        "required": ["id", "role", "status", "createdAt", "updatedAt", "user"]
+        "required": [
+          "id",
+          "role",
+          "name",
+          "invitedBy",
+          "status",
+          "createdAt",
+          "updatedAt",
+          "user"
+        ]
+      },
+      "GetSpaceResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE"
+            ]
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MemberDto"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "status",
+          "members"
+        ]
+      },
+      "UpdateSpaceDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE"
+            ]
+          }
+        }
+      },
+      "UpdateSpaceResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "CreateSpaceSafeDto": {
+        "type": "object",
+        "properties": {
+          "chainId": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "chainId",
+          "address"
+        ]
+      },
+      "CreateSpaceSafesDto": {
+        "type": "object",
+        "properties": {
+          "safes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CreateSpaceSafeDto"
+            }
+          }
+        },
+        "required": [
+          "safes"
+        ]
+      },
+      "GetSpaceSafeResponse": {
+        "type": "object",
+        "properties": {
+          "safes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "example": {
+              "{chainId}": [
+                "0x..."
+              ]
+            }
+          }
+        },
+        "required": [
+          "safes"
+        ]
+      },
+      "DeleteSpaceSafeDto": {
+        "type": "object",
+        "properties": {
+          "chainId": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "chainId",
+          "address"
+        ]
+      },
+      "DeleteSpaceSafesDto": {
+        "type": "object",
+        "properties": {
+          "safes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeleteSpaceSafeDto"
+            }
+          }
+        },
+        "required": [
+          "safes"
+        ]
+      },
+      "InviteUserDto": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
+          }
+        },
+        "required": [
+          "address",
+          "name",
+          "role"
+        ]
+      },
+      "InviteUsersDto": {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InviteUserDto"
+            }
+          }
+        },
+        "required": [
+          "users"
+        ]
+      },
+      "Invitation": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "spaceId": {
+            "type": "number"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "INVITED",
+              "ACTIVE",
+              "DECLINED"
+            ]
+          },
+          "invitedBy": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "userId",
+          "name",
+          "spaceId",
+          "role",
+          "status"
+        ]
+      },
+      "AcceptInviteDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "MemberUser": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "ACTIVE"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "status"
+        ]
+      },
+      "Member": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "INVITED",
+              "ACTIVE",
+              "DECLINED"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "invitedBy": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/MemberUser"
+          }
+        },
+        "required": [
+          "id",
+          "role",
+          "status",
+          "name",
+          "createdAt",
+          "updatedAt",
+          "user"
+        ]
+      },
+      "MembersDto": {
+        "type": "object",
+        "properties": {
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Member"
+            }
+          }
+        },
+        "required": [
+          "members"
+        ]
+      },
+      "UpdateRoleDto": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
+          }
+        },
+        "required": [
+          "role"
+        ]
       },
       "SafeList": {
         "type": "object",
@@ -5582,7 +6992,9 @@
             }
           }
         },
-        "required": ["safes"]
+        "required": [
+          "safes"
+        ]
       },
       "RelayDto": {
         "type": "object",
@@ -5602,7 +7014,37 @@
             "description": "If specified, a gas buffer of 150k will be added on top of the expected gas usage for the transaction.\n      This is for the <a href=\"https://docs.gelato.network/developer-services/relay/quick-start/optional-parameters\" target=\"_blank\">\n      Gelato Relay execution overhead</a>, reducing the chance of the task cancelling before it is executed on-chain."
           }
         },
-        "required": ["version", "to", "data"]
+        "required": [
+          "version",
+          "to",
+          "data"
+        ]
+      },
+      "Relay": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "taskId"
+        ]
+      },
+      "RelaysRemaining": {
+        "type": "object",
+        "properties": {
+          "remaining": {
+            "type": "number"
+          },
+          "limit": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "remaining",
+          "limit"
+        ]
       },
       "SafeAppProvider": {
         "type": "object",
@@ -5614,7 +7056,10 @@
             "type": "string"
           }
         },
-        "required": ["url", "name"]
+        "required": [
+          "url",
+          "name"
+        ]
       },
       "SafeAppAccessControl": {
         "type": "object",
@@ -5630,20 +7075,31 @@
             }
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "SafeAppSocialProfile": {
         "type": "object",
         "properties": {
           "platform": {
             "type": "string",
-            "enum": ["DISCORD", "GITHUB", "TWITTER", "TELEGRAM", "UNKNOWN"]
+            "enum": [
+              "DISCORD",
+              "GITHUB",
+              "TWITTER",
+              "TELEGRAM",
+              "UNKNOWN"
+            ]
           },
           "url": {
             "type": "string"
           }
         },
-        "required": ["platform", "url"]
+        "required": [
+          "platform",
+          "url"
+        ]
       },
       "SafeApp": {
         "type": "object",
@@ -5773,7 +7229,11 @@
           },
           "implementationVersionState": {
             "type": "string",
-            "enum": ["UP_TO_DATE", "OUTDATED", "UNKNOWN"]
+            "enum": [
+              "UP_TO_DATE",
+              "OUTDATED",
+              "UNKNOWN"
+            ]
           },
           "collectiblesTag": {
             "type": "string",
@@ -5812,7 +7272,10 @@
             "type": "number"
           }
         },
-        "required": ["currentNonce", "recommendedNonce"]
+        "required": [
+          "currentNonce",
+          "recommendedNonce"
+        ]
       },
       "SafeOverview": {
         "type": "object",
@@ -5843,7 +7306,14 @@
             "nullable": true
           }
         },
-        "required": ["address", "chainId", "threshold", "owners", "fiatTotal", "queued"]
+        "required": [
+          "address",
+          "chainId",
+          "threshold",
+          "owners",
+          "fiatTotal",
+          "queued"
+        ]
       },
       "TargetedSafe": {
         "type": "object",
@@ -5855,7 +7325,10 @@
             "type": "string"
           }
         },
-        "required": ["outreachId", "address"]
+        "required": [
+          "outreachId",
+          "address"
+        ]
       },
       "Submission": {
         "type": "object",
@@ -5875,7 +7348,11 @@
             "nullable": true
           }
         },
-        "required": ["outreachId", "targetedSafeId", "signerAddress"]
+        "required": [
+          "outreachId",
+          "targetedSafeId",
+          "signerAddress"
+        ]
       },
       "CreateSubmissionDto": {
         "type": "object",
@@ -5884,7 +7361,9 @@
             "type": "boolean"
           }
         },
-        "required": ["completed"]
+        "required": [
+          "completed"
+        ]
       },
       "TransactionInfo": {
         "type": "object",
@@ -5909,14 +7388,18 @@
             "nullable": true
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "CreationTransactionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["Creation"]
+            "enum": [
+              "Creation"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -5944,14 +7427,20 @@
             "nullable": true
           }
         },
-        "required": ["type", "creator", "transactionHash"]
+        "required": [
+          "type",
+          "creator",
+          "transactionHash"
+        ]
       },
       "CustomTransactionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["Custom"]
+            "enum": [
+              "Custom"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -5979,7 +7468,178 @@
             "nullable": true
           }
         },
-        "required": ["type", "to", "dataSize", "isCancellation"]
+        "required": [
+          "type",
+          "to",
+          "dataSize",
+          "isCancellation"
+        ]
+      },
+      "AddOwner": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "ADD_OWNER"
+            ]
+          },
+          "owner": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "threshold": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "type",
+          "owner",
+          "threshold"
+        ]
+      },
+      "ChangeMasterCopy": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "CHANGE_MASTER_COPY"
+            ]
+          },
+          "implementation": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "implementation"
+        ]
+      },
+      "ChangeThreshold": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "CHANGE_THRESHOLD"
+            ]
+          },
+          "threshold": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "type",
+          "threshold"
+        ]
+      },
+      "DeleteGuard": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "DELETE_GUARD"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "DisableModule": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "DISABLE_MODULE"
+            ]
+          },
+          "module": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "module"
+        ]
+      },
+      "EnableModule": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "ENABLE_MODULE"
+            ]
+          },
+          "module": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "module"
+        ]
+      },
+      "RemoveOwner": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "REMOVE_OWNER"
+            ]
+          },
+          "owner": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "threshold": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "type",
+          "owner",
+          "threshold"
+        ]
+      },
+      "SetFallbackHandler": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SET_FALLBACK_HANDLER"
+            ]
+          },
+          "handler": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "handler"
+        ]
+      },
+      "SetGuard": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SET_GUARD"
+            ]
+          },
+          "guard": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "guard"
+        ]
       },
       "SettingsChange": {
         "type": "object",
@@ -6000,14 +7660,40 @@
             ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
+      },
+      "SwapOwner": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SWAP_OWNER"
+            ]
+          },
+          "oldOwner": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "newOwner": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "oldOwner",
+          "newOwner"
+        ]
       },
       "SettingsChangeTransaction": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["SettingsChange"]
+            "enum": [
+              "SettingsChange"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6017,22 +7703,54 @@
             "$ref": "#/components/schemas/DataDecoded"
           },
           "settingsInfo": {
-            "nullable": true,
-            "allOf": [
+            "oneOf": [
               {
-                "$ref": "#/components/schemas/SettingsChange"
+                "$ref": "#/components/schemas/AddOwner"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeMasterCopy"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeThreshold"
+              },
+              {
+                "$ref": "#/components/schemas/DeleteGuard"
+              },
+              {
+                "$ref": "#/components/schemas/DisableModule"
+              },
+              {
+                "$ref": "#/components/schemas/EnableModule"
+              },
+              {
+                "$ref": "#/components/schemas/RemoveOwner"
+              },
+              {
+                "$ref": "#/components/schemas/SetFallbackHandler"
+              },
+              {
+                "$ref": "#/components/schemas/SetGuard"
+              },
+              {
+                "$ref": "#/components/schemas/SwapOwner"
               }
             ]
           }
         },
-        "required": ["type", "dataDecoded"]
+        "required": [
+          "type",
+          "dataDecoded",
+          "settingsInfo"
+        ]
       },
       "Erc20Transfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["ERC20"]
+            "enum": [
+              "ERC20"
+            ]
           },
           "tokenAddress": {
             "type": "string"
@@ -6064,14 +7782,21 @@
             "type": "boolean"
           }
         },
-        "required": ["type", "tokenAddress", "value", "imitation"]
+        "required": [
+          "type",
+          "tokenAddress",
+          "value",
+          "imitation"
+        ]
       },
       "Erc721Transfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["ERC721"]
+            "enum": [
+              "ERC721"
+            ]
           },
           "tokenAddress": {
             "type": "string"
@@ -6096,38 +7821,54 @@
             "nullable": true
           }
         },
-        "required": ["type", "tokenAddress", "tokenId"]
+        "required": [
+          "type",
+          "tokenAddress",
+          "tokenId"
+        ]
       },
       "NativeCoinTransfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NATIVE_COIN"]
+            "enum": [
+              "NATIVE_COIN"
+            ]
           },
           "value": {
             "type": "string",
             "nullable": true
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "Transfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NATIVE_COIN", "ERC20", "ERC721"]
+            "enum": [
+              "NATIVE_COIN",
+              "ERC20",
+              "ERC721"
+            ]
           }
         },
-        "required": ["type"]
+        "required": [
+          "type"
+        ]
       },
       "TransferTransactionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["Transfer"]
+            "enum": [
+              "Transfer"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6141,7 +7882,11 @@
           },
           "direction": {
             "type": "string",
-            "enum": ["INCOMING", "OUTGOING", "UNKNOWN"]
+            "enum": [
+              "INCOMING",
+              "OUTGOING",
+              "UNKNOWN"
+            ]
           },
           "transferInfo": {
             "oneOf": [
@@ -6162,7 +7907,13 @@
             ]
           }
         },
-        "required": ["type", "sender", "recipient", "direction", "transferInfo"]
+        "required": [
+          "type",
+          "sender",
+          "recipient",
+          "direction",
+          "transferInfo"
+        ]
       },
       "TokenInfo": {
         "type": "object",
@@ -6193,14 +7944,22 @@
             "description": "The token trusted status"
           }
         },
-        "required": ["address", "decimals", "name", "symbol", "trusted"]
+        "required": [
+          "address",
+          "decimals",
+          "name",
+          "symbol",
+          "trusted"
+        ]
       },
       "SwapOrderTransactionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["SwapOrder"]
+            "enum": [
+              "SwapOrder"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6212,15 +7971,31 @@
           },
           "status": {
             "type": "string",
-            "enum": ["presignaturePending", "open", "fulfilled", "cancelled", "expired", "unknown"]
+            "enum": [
+              "presignaturePending",
+              "open",
+              "fulfilled",
+              "cancelled",
+              "expired",
+              "unknown"
+            ]
           },
           "kind": {
             "type": "string",
-            "enum": ["buy", "sell", "unknown"]
+            "enum": [
+              "buy",
+              "sell",
+              "unknown"
+            ]
           },
           "orderClass": {
             "type": "string",
-            "enum": ["market", "limit", "liquidity", "unknown"]
+            "enum": [
+              "market",
+              "limit",
+              "liquidity",
+              "unknown"
+            ]
           },
           "validUntil": {
             "type": "number",
@@ -6308,7 +8083,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["SwapTransfer"]
+            "enum": [
+              "SwapTransfer"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6347,15 +8124,31 @@
           },
           "status": {
             "type": "string",
-            "enum": ["presignaturePending", "open", "fulfilled", "cancelled", "expired", "unknown"]
+            "enum": [
+              "presignaturePending",
+              "open",
+              "fulfilled",
+              "cancelled",
+              "expired",
+              "unknown"
+            ]
           },
           "kind": {
             "type": "string",
-            "enum": ["buy", "sell", "unknown"]
+            "enum": [
+              "buy",
+              "sell",
+              "unknown"
+            ]
           },
           "orderClass": {
             "type": "string",
-            "enum": ["market", "limit", "liquidity", "unknown"]
+            "enum": [
+              "market",
+              "limit",
+              "liquidity",
+              "unknown"
+            ]
           },
           "validUntil": {
             "type": "number",
@@ -6446,12 +8239,78 @@
           "owner"
         ]
       },
+      "DurationAuto": {
+        "type": "object",
+        "properties": {
+          "durationType": {
+            "type": "string",
+            "enum": [
+              "AUTO"
+            ]
+          }
+        },
+        "required": [
+          "durationType"
+        ]
+      },
+      "DurationLimit": {
+        "type": "object",
+        "properties": {
+          "durationType": {
+            "type": "string",
+            "enum": [
+              "LIMIT_DURATION"
+            ]
+          },
+          "duration": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "durationType",
+          "duration"
+        ]
+      },
+      "StartTimeAtMining": {
+        "type": "object",
+        "properties": {
+          "startType": {
+            "type": "string",
+            "enum": [
+              "AT_MINING_TIME"
+            ]
+          }
+        },
+        "required": [
+          "startType"
+        ]
+      },
+      "StartTimeAtEpoch": {
+        "type": "object",
+        "properties": {
+          "startType": {
+            "type": "string",
+            "enum": [
+              "AT_EPOCH"
+            ]
+          },
+          "epoch": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "startType",
+          "epoch"
+        ]
+      },
       "TwapOrderTransactionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TwapOrder"]
+            "enum": [
+              "TwapOrder"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6460,15 +8319,31 @@
           "status": {
             "type": "string",
             "description": "The TWAP status",
-            "enum": ["presignaturePending", "open", "fulfilled", "cancelled", "expired", "unknown"]
+            "enum": [
+              "presignaturePending",
+              "open",
+              "fulfilled",
+              "cancelled",
+              "expired",
+              "unknown"
+            ]
           },
           "kind": {
             "type": "string",
-            "enum": ["buy", "sell", "unknown"]
+            "enum": [
+              "buy",
+              "sell",
+              "unknown"
+            ]
           },
           "class": {
             "type": "string",
-            "enum": ["market", "limit", "liquidity", "unknown"]
+            "enum": [
+              "market",
+              "limit",
+              "liquidity",
+              "unknown"
+            ]
           },
           "activeOrderUid": {
             "type": "string",
@@ -6551,12 +8426,26 @@
             "description": "The duration of the TWAP interval"
           },
           "durationOfPart": {
-            "type": "object",
-            "description": "Whether the TWAP is valid for the entire interval or not"
+            "description": "Whether the TWAP is valid for the entire interval or not",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DurationAuto"
+              },
+              {
+                "$ref": "#/components/schemas/DurationLimit"
+              }
+            ]
           },
           "startTime": {
-            "type": "object",
-            "description": "The start time of the TWAP"
+            "description": "The start time of the TWAP",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/StartTimeAtMining"
+              },
+              {
+                "$ref": "#/components/schemas/StartTimeAtEpoch"
+              }
+            ]
           }
         },
         "required": [
@@ -6584,7 +8473,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NativeStakingDeposit"]
+            "enum": [
+              "NativeStakingDeposit"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6674,7 +8565,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NativeStakingValidatorsExit"]
+            "enum": [
+              "NativeStakingValidatorsExit"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6731,7 +8624,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["NativeStakingWithdraw"]
+            "enum": [
+              "NativeStakingWithdraw"
+            ]
           },
           "humanDescription": {
             "type": "string",
@@ -6750,7 +8645,12 @@
             }
           }
         },
-        "required": ["type", "value", "tokenInfo", "validators"]
+        "required": [
+          "type",
+          "value",
+          "tokenInfo",
+          "validators"
+        ]
       },
       "TransactionData": {
         "type": "object",
@@ -6786,7 +8686,10 @@
             "nullable": true
           }
         },
-        "required": ["to", "operation"]
+        "required": [
+          "to",
+          "operation"
+        ]
       },
       "MultisigConfirmationDetails": {
         "type": "object",
@@ -6802,14 +8705,19 @@
             "type": "number"
           }
         },
-        "required": ["signer", "submittedAt"]
+        "required": [
+          "signer",
+          "submittedAt"
+        ]
       },
       "MultisigExecutionDetails": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["MULTISIG"]
+            "enum": [
+              "MULTISIG"
+            ]
           },
           "submittedAt": {
             "type": "number"
@@ -6865,12 +8773,18 @@
             }
           },
           "gasTokenInfo": {
-            "nullable": true,
-            "allOf": [
+            "oneOf": [
               {
-                "$ref": "#/components/schemas/Token"
+                "$ref": "#/components/schemas/NativeToken"
+              },
+              {
+                "$ref": "#/components/schemas/Erc20Token"
+              },
+              {
+                "$ref": "#/components/schemas/Erc721Token"
               }
-            ]
+            ],
+            "nullable": true
           },
           "trusted": {
             "type": "boolean"
@@ -6914,13 +8828,18 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["MODULE"]
+            "enum": [
+              "MODULE"
+            ]
           },
           "address": {
             "$ref": "#/components/schemas/AddressInfo"
           }
         },
-        "required": ["type", "address"]
+        "required": [
+          "type",
+          "address"
+        ]
       },
       "SafeAppInfo": {
         "type": "object",
@@ -6936,7 +8855,10 @@
             "nullable": true
           }
         },
-        "required": ["name", "url"]
+        "required": [
+          "name",
+          "url"
+        ]
       },
       "TransactionDetails": {
         "type": "object",
@@ -6992,7 +8914,13 @@
           },
           "txStatus": {
             "type": "string",
-            "enum": ["SUCCESS", "FAILED", "CANCELLED", "AWAITING_CONFIRMATIONS", "AWAITING_EXECUTION"]
+            "enum": [
+              "SUCCESS",
+              "FAILED",
+              "CANCELLED",
+              "AWAITING_CONFIRMATIONS",
+              "AWAITING_EXECUTION"
+            ]
           },
           "txData": {
             "nullable": true,
@@ -7030,27 +8958,197 @@
             "nullable": true
           }
         },
-        "required": ["txInfo", "safeAddress", "txId", "txStatus"]
+        "required": [
+          "txInfo",
+          "safeAddress",
+          "txId",
+          "txStatus"
+        ]
+      },
+      "TXSMultisigTransaction": {
+        "type": "object",
+        "properties": {
+          "safe": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          },
+          "dataDecoded": {
+            "type": "object"
+          },
+          "operation": {
+            "type": "number"
+          },
+          "gasToken": {
+            "type": "object"
+          },
+          "safeTxGas": {
+            "type": "object"
+          },
+          "baseGas": {
+            "type": "object"
+          },
+          "gasPrice": {
+            "type": "object"
+          },
+          "proposer": {
+            "type": "object"
+          },
+          "proposedByDelegate": {
+            "type": "object"
+          },
+          "refundReceiver": {
+            "type": "object"
+          },
+          "nonce": {
+            "type": "number"
+          },
+          "executionDate": {
+            "type": "object"
+          },
+          "submissionDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "modified": {
+            "type": "object"
+          },
+          "blockNumber": {
+            "type": "object"
+          },
+          "transactionHash": {
+            "type": "object"
+          },
+          "safeTxHash": {
+            "type": "string"
+          },
+          "executor": {
+            "type": "object"
+          },
+          "isExecuted": {
+            "type": "boolean"
+          },
+          "isSuccessful": {
+            "type": "object"
+          },
+          "ethGasPrice": {
+            "type": "object"
+          },
+          "gasUsed": {
+            "type": "object"
+          },
+          "fee": {
+            "type": "object"
+          },
+          "origin": {
+            "type": "object"
+          },
+          "confirmationsRequired": {
+            "type": "number"
+          },
+          "confirmations": {
+            "type": "object"
+          },
+          "signatures": {
+            "type": "object"
+          },
+          "trusted": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "safe",
+          "to",
+          "value",
+          "data",
+          "dataDecoded",
+          "operation",
+          "gasToken",
+          "safeTxGas",
+          "baseGas",
+          "gasPrice",
+          "proposer",
+          "proposedByDelegate",
+          "refundReceiver",
+          "nonce",
+          "executionDate",
+          "submissionDate",
+          "modified",
+          "blockNumber",
+          "transactionHash",
+          "safeTxHash",
+          "executor",
+          "isExecuted",
+          "isSuccessful",
+          "ethGasPrice",
+          "gasUsed",
+          "fee",
+          "origin",
+          "confirmationsRequired",
+          "confirmations",
+          "signatures",
+          "trusted"
+        ]
+      },
+      "TXSMultisigTransactionPage": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number",
+            "nullable": true
+          },
+          "next": {
+            "type": "string",
+            "nullable": true
+          },
+          "previous": {
+            "type": "string",
+            "nullable": true
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TXSMultisigTransaction"
+            }
+          }
+        },
+        "required": [
+          "results"
+        ]
       },
       "ModuleExecutionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["MODULE"]
+            "enum": [
+              "MODULE"
+            ]
           },
           "address": {
             "$ref": "#/components/schemas/AddressInfo"
           }
         },
-        "required": ["type", "address"]
+        "required": [
+          "type",
+          "address"
+        ]
       },
       "MultisigExecutionInfo": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["MULTISIG"]
+            "enum": [
+              "MULTISIG"
+            ]
           },
           "nonce": {
             "type": "number"
@@ -7069,7 +9167,12 @@
             }
           }
         },
-        "required": ["type", "nonce", "confirmationsRequired", "confirmationsSubmitted"]
+        "required": [
+          "type",
+          "nonce",
+          "confirmationsRequired",
+          "confirmationsSubmitted"
+        ]
       },
       "Transaction": {
         "type": "object",
@@ -7125,7 +9228,13 @@
           },
           "txStatus": {
             "type": "string",
-            "enum": ["SUCCESS", "FAILED", "CANCELLED", "AWAITING_CONFIRMATIONS", "AWAITING_EXECUTION"]
+            "enum": [
+              "SUCCESS",
+              "FAILED",
+              "CANCELLED",
+              "AWAITING_CONFIRMATIONS",
+              "AWAITING_EXECUTION"
+            ]
           },
           "executionInfo": {
             "oneOf": [
@@ -7147,24 +9256,39 @@
             ]
           }
         },
-        "required": ["txInfo", "id", "timestamp", "txStatus"]
+        "required": [
+          "txInfo",
+          "id",
+          "timestamp",
+          "txStatus"
+        ]
       },
       "MultisigTransaction": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None", "HasNext", "End"]
+            "enum": [
+              "None",
+              "HasNext",
+              "End"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "MultisigTransactionPage": {
         "type": "object",
@@ -7188,7 +9312,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "DeleteTransactionDto": {
         "type": "object",
@@ -7197,24 +9323,34 @@
             "type": "string"
           }
         },
-        "required": ["signature"]
+        "required": [
+          "signature"
+        ]
       },
       "ModuleTransaction": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None"]
+            "enum": [
+              "None"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "ModuleTransactionPage": {
         "type": "object",
@@ -7238,33 +9374,45 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "AddConfirmationDto": {
         "type": "object",
         "properties": {
-          "signedSafeTxHash": {
+          "signature": {
             "type": "string"
           }
         },
-        "required": ["signedSafeTxHash"]
+        "required": [
+          "signature"
+        ]
       },
       "IncomingTransfer": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None"]
+            "enum": [
+              "None"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "IncomingTransferPage": {
         "type": "object",
@@ -7288,7 +9436,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "PreviewTransactionDto": {
         "type": "object",
@@ -7307,7 +9457,11 @@
             "type": "number"
           }
         },
-        "required": ["to", "value", "operation"]
+        "required": [
+          "to",
+          "value",
+          "operation"
+        ]
       },
       "TransactionPreview": {
         "type": "object",
@@ -7355,50 +9509,73 @@
             "$ref": "#/components/schemas/TransactionData"
           }
         },
-        "required": ["txInfo", "txData"]
+        "required": [
+          "txInfo",
+          "txData"
+        ]
       },
       "ConflictHeaderQueuedItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["CONFLICT_HEADER"]
+            "enum": [
+              "CONFLICT_HEADER"
+            ]
           },
           "nonce": {
             "type": "number"
           }
         },
-        "required": ["type", "nonce"]
+        "required": [
+          "type",
+          "nonce"
+        ]
       },
       "LabelQueuedItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["LABEL"]
+            "enum": [
+              "LABEL"
+            ]
           },
           "label": {
             "type": "string"
           }
         },
-        "required": ["type", "label"]
+        "required": [
+          "type",
+          "label"
+        ]
       },
       "TransactionQueuedItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None", "HasNext", "End"]
+            "enum": [
+              "None",
+              "HasNext",
+              "End"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "QueuedItemPage": {
         "type": "object",
@@ -7432,24 +9609,34 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "TransactionItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["TRANSACTION"]
+            "enum": [
+              "TRANSACTION"
+            ]
           },
           "transaction": {
             "$ref": "#/components/schemas/Transaction"
           },
           "conflictType": {
             "type": "string",
-            "enum": ["None"]
+            "enum": [
+              "None"
+            ]
           }
         },
-        "required": ["type", "transaction", "conflictType"]
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
       },
       "TransactionItemPage": {
         "type": "object",
@@ -7480,7 +9667,9 @@
             }
           }
         },
-        "required": ["results"]
+        "required": [
+          "results"
+        ]
       },
       "ProposeTransactionDto": {
         "type": "object",
@@ -7582,7 +9771,52 @@
             ]
           }
         },
-        "required": ["created", "creator", "transactionHash", "factoryAddress"]
+        "required": [
+          "created",
+          "creator",
+          "transactionHash",
+          "factoryAddress"
+        ]
+      },
+      "TXSCreationTransaction": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "transactionHash": {
+            "type": "string"
+          },
+          "factoryAddress": {
+            "type": "string"
+          },
+          "masterCopy": {
+            "type": "object"
+          },
+          "setupData": {
+            "type": "object"
+          },
+          "saltNonce": {
+            "type": "object"
+          },
+          "dataDecoded": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "created",
+          "creator",
+          "transactionHash",
+          "factoryAddress",
+          "masterCopy",
+          "setupData",
+          "saltNonce",
+          "dataDecoded"
+        ]
       }
     }
   }

--- a/packages/store/src/gateway/AUTO_GENERATED/auth.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/auth.ts
@@ -14,6 +14,10 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/v1/auth/verify`, method: 'POST', body: queryArg.siweDto }),
         invalidatesTags: ['auth'],
       }),
+      authLogoutV1: build.mutation<AuthLogoutV1ApiResponse, AuthLogoutV1ApiArg>({
+        query: () => ({ url: `/v1/auth/logout`, method: 'POST' }),
+        invalidatesTags: ['auth'],
+      }),
     }),
     overrideExisting: false,
   })
@@ -24,6 +28,8 @@ export type AuthVerifyV1ApiResponse = unknown
 export type AuthVerifyV1ApiArg = {
   siweDto: SiweDto
 }
+export type AuthLogoutV1ApiResponse = unknown
+export type AuthLogoutV1ApiArg = void
 export type AuthNonce = {
   nonce: string
 }
@@ -31,4 +37,5 @@ export type SiweDto = {
   message: string
   signature: string
 }
-export const { useAuthGetNonceV1Query, useLazyAuthGetNonceV1Query, useAuthVerifyV1Mutation } = injectedRtkApi
+export const { useAuthGetNonceV1Query, useLazyAuthGetNonceV1Query, useAuthVerifyV1Mutation, useAuthLogoutV1Mutation } =
+  injectedRtkApi

--- a/packages/store/src/gateway/AUTO_GENERATED/balances.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/balances.ts
@@ -37,19 +37,35 @@ export type BalancesGetBalancesV1ApiArg = {
 }
 export type BalancesGetSupportedFiatCodesV1ApiResponse = /** status 200  */ string[]
 export type BalancesGetSupportedFiatCodesV1ApiArg = void
-export type Token = {
+export type NativeToken = {
   address: string
-  decimals?: number | null
+  decimals: number
   logoUri: string
   name: string
   symbol: string
-  type: 'ERC721' | 'ERC20' | 'NATIVE_TOKEN' | 'UNKNOWN'
+  type: 'NATIVE_TOKEN'
+}
+export type Erc20Token = {
+  address: string
+  decimals: number
+  logoUri: string
+  name: string
+  symbol: string
+  type: 'ERC20'
+}
+export type Erc721Token = {
+  address: string
+  decimals: number
+  logoUri: string
+  name: string
+  symbol: string
+  type: 'ERC721'
 }
 export type Balance = {
   balance: string
   fiatBalance: string
   fiatConversion: string
-  tokenInfo: Token
+  tokenInfo: NativeToken | Erc20Token | Erc721Token
 }
 export type Balances = {
   fiatTotal: string

--- a/packages/store/src/gateway/AUTO_GENERATED/messages.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/messages.ts
@@ -68,41 +68,64 @@ export type MessagesUpdateMessageSignatureV1ApiArg = {
   messageHash: string
   updateMessageSignatureDto: UpdateMessageSignatureDto
 }
+export type TypedDataDomain = {
+  chainId?: number
+  name?: string
+  salt?: string
+  verifyingContract?: string
+  version?: string
+}
+export type TypedDataParameter = {
+  name: string
+  type: string
+}
+export type TypedData = {
+  domain: TypedDataDomain
+  primaryType: string
+  types: {
+    [key: string]: TypedDataParameter[]
+  }
+  message: object
+}
 export type AddressInfo = {
   value: string
   name?: string | null
   logoUri?: string | null
 }
+export type MessageConfirmation = {
+  owner: AddressInfo
+  signature: string
+}
 export type Message = {
   messageHash: string
-  status: string
+  status: 'NEEDS_CONFIRMATION' | 'CONFIRMED'
   logoUri?: string | null
   name?: string | null
-  message: object
+  message: string | TypedData
   creationTimestamp: number
   modifiedTimestamp: number
   confirmationsSubmitted: number
   confirmationsRequired: number
   proposedBy: AddressInfo
-  confirmations: string[]
+  confirmations: MessageConfirmation[]
   preparedSignature?: string | null
   origin?: string | null
 }
 export type MessageItem = {
   messageHash: string
-  status: string
+  status: 'NEEDS_CONFIRMATION' | 'CONFIRMED'
   logoUri?: string | null
   name?: string | null
-  message: object
+  message: string | TypedData
   creationTimestamp: number
   modifiedTimestamp: number
   confirmationsSubmitted: number
   confirmationsRequired: number
   proposedBy: AddressInfo
-  confirmations: string[]
+  confirmations: MessageConfirmation[]
   preparedSignature?: string | null
   origin?: string | null
-  type: string
+  type: 'MESSAGE'
 }
 export type DateLabel = {
   type: 'DATE_LABEL'
@@ -115,7 +138,7 @@ export type MessagePage = {
   results: (MessageItem | DateLabel)[]
 }
 export type CreateMessageDto = {
-  message: object
+  message: string | TypedData
   safeAppId?: number | null
   signature: string
   origin?: string | null

--- a/packages/store/src/gateway/AUTO_GENERATED/relay.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/relay.ts
@@ -18,15 +18,18 @@ const injectedRtkApi = api
     overrideExisting: false,
   })
 export { injectedRtkApi as cgwApi }
-export type RelayRelayV1ApiResponse = unknown
+export type RelayRelayV1ApiResponse = /** status 200  */ Relay
 export type RelayRelayV1ApiArg = {
   chainId: string
   relayDto: RelayDto
 }
-export type RelayGetRelaysRemainingV1ApiResponse = unknown
+export type RelayGetRelaysRemainingV1ApiResponse = /** status 200  */ RelaysRemaining
 export type RelayGetRelaysRemainingV1ApiArg = {
   chainId: string
   safeAddress: string
+}
+export type Relay = {
+  taskId: string
 }
 export type RelayDto = {
   version: string
@@ -36,6 +39,10 @@ export type RelayDto = {
           This is for the <a href="https://docs.gelato.network/developer-services/relay/quick-start/optional-parameters" target="_blank">
           Gelato Relay execution overhead</a>, reducing the chance of the task cancelling before it is executed on-chain. */
   gasLimit?: string | null
+}
+export type RelaysRemaining = {
+  remaining: number
+  limit: number
 }
 export const { useRelayRelayV1Mutation, useRelayGetRelaysRemainingV1Query, useLazyRelayGetRelaysRemainingV1Query } =
   injectedRtkApi

--- a/packages/store/src/gateway/AUTO_GENERATED/transactions.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/transactions.ts
@@ -13,6 +13,52 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/v1/chains/${queryArg.chainId}/transactions/${queryArg.id}` }),
         providesTags: ['transactions'],
       }),
+      transactionsGetDomainMultisigTransactionBySafeTxHashV1: build.query<
+        TransactionsGetDomainMultisigTransactionBySafeTxHashV1ApiResponse,
+        TransactionsGetDomainMultisigTransactionBySafeTxHashV1ApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/v1/chains/${queryArg.chainId}/multisig-transactions/${queryArg.safeTxHash}/raw`,
+        }),
+        providesTags: ['transactions'],
+      }),
+      transactionsGetDomainMultisigTransactionsV1: build.query<
+        TransactionsGetDomainMultisigTransactionsV1ApiResponse,
+        TransactionsGetDomainMultisigTransactionsV1ApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/v1/chains/${queryArg.chainId}/safes/${queryArg.safeAddress}/multisig-transactions/raw`,
+          params: {
+            failed: queryArg.failed,
+            modified__lt: queryArg.modifiedLt,
+            modified__gt: queryArg.modifiedGt,
+            modified__lte: queryArg.modifiedLte,
+            modified__gte: queryArg.modifiedGte,
+            nonce__lt: queryArg.nonceLt,
+            nonce__gt: queryArg.nonceGt,
+            nonce__lte: queryArg.nonceLte,
+            nonce__gte: queryArg.nonceGte,
+            nonce: queryArg.nonce,
+            safe_tx_hash: queryArg.safeTxHash,
+            to: queryArg.to,
+            value__lt: queryArg.valueLt,
+            value__gt: queryArg.valueGt,
+            value: queryArg.value,
+            executed: queryArg.executed,
+            has_confirmations: queryArg.hasConfirmations,
+            trusted: queryArg.trusted,
+            execution_date__gte: queryArg.executionDateGte,
+            execution_date__lte: queryArg.executionDateLte,
+            submission_date__gte: queryArg.submissionDateGte,
+            submission_date__lte: queryArg.submissionDateLte,
+            transaction_hash: queryArg.transactionHash,
+            ordering: queryArg.ordering,
+            limit: queryArg.limit,
+            offset: queryArg.offset,
+          },
+        }),
+        providesTags: ['transactions'],
+      }),
       transactionsGetMultisigTransactionsV1: build.query<
         TransactionsGetMultisigTransactionsV1ApiResponse,
         TransactionsGetMultisigTransactionsV1ApiArg
@@ -146,6 +192,13 @@ const injectedRtkApi = api
         }),
         providesTags: ['transactions'],
       }),
+      transactionsGetDomainCreationTransactionV1: build.query<
+        TransactionsGetDomainCreationTransactionV1ApiResponse,
+        TransactionsGetDomainCreationTransactionV1ApiArg
+      >({
+        query: (queryArg) => ({ url: `/v1/chains/${queryArg.chainId}/safes/${queryArg.safeAddress}/creation/raw` }),
+        providesTags: ['transactions'],
+      }),
     }),
     overrideExisting: false,
   })
@@ -154,6 +207,43 @@ export type TransactionsGetTransactionByIdV1ApiResponse = /** status 200  */ Tra
 export type TransactionsGetTransactionByIdV1ApiArg = {
   chainId: string
   id: string
+}
+export type TransactionsGetDomainMultisigTransactionBySafeTxHashV1ApiResponse =
+  /** status 200  */ TxsMultisigTransaction
+export type TransactionsGetDomainMultisigTransactionBySafeTxHashV1ApiArg = {
+  chainId: string
+  safeTxHash: string
+}
+export type TransactionsGetDomainMultisigTransactionsV1ApiResponse = /** status 200  */ TxsMultisigTransactionPage
+export type TransactionsGetDomainMultisigTransactionsV1ApiArg = {
+  chainId: string
+  safeAddress: string
+  failed?: boolean
+  modifiedLt?: string
+  modifiedGt?: string
+  modifiedLte?: string
+  modifiedGte?: string
+  nonceLt?: number
+  nonceGt?: number
+  nonceLte?: number
+  nonceGte?: number
+  nonce?: number
+  safeTxHash?: string
+  to?: string
+  valueLt?: number
+  valueGt?: number
+  value?: number
+  executed?: boolean
+  hasConfirmations?: boolean
+  trusted?: boolean
+  executionDateGte?: string
+  executionDateLte?: string
+  submissionDateGte?: string
+  submissionDateLte?: string
+  transactionHash?: string
+  ordering?: string
+  limit?: number
+  offset?: number
 }
 export type TransactionsGetMultisigTransactionsV1ApiResponse = /** status 200  */ MultisigTransactionPage
 export type TransactionsGetMultisigTransactionsV1ApiArg = {
@@ -234,6 +324,11 @@ export type TransactionsGetCreationTransactionV1ApiArg = {
   chainId: string
   safeAddress: string
 }
+export type TransactionsGetDomainCreationTransactionV1ApiResponse = /** status 200  */ TxsCreationTransaction
+export type TransactionsGetDomainCreationTransactionV1ApiArg = {
+  chainId: string
+  safeAddress: string
+}
 export type AddressInfo = {
   value: string
   name?: string | null
@@ -268,24 +363,63 @@ export type DataDecoded = {
   method: string
   parameters?: DataDecodedParameter[] | null
 }
-export type SettingsChange = {
-  type:
-    | 'ADD_OWNER'
-    | 'CHANGE_MASTER_COPY'
-    | 'CHANGE_THRESHOLD'
-    | 'DELETE_GUARD'
-    | 'DISABLE_MODULE'
-    | 'ENABLE_MODULE'
-    | 'REMOVE_OWNER'
-    | 'SET_FALLBACK_HANDLER'
-    | 'SET_GUARD'
-    | 'SWAP_OWNER'
+export type AddOwner = {
+  type: 'ADD_OWNER'
+  owner: AddressInfo
+  threshold: number
+}
+export type ChangeMasterCopy = {
+  type: 'CHANGE_MASTER_COPY'
+  implementation: AddressInfo
+}
+export type ChangeThreshold = {
+  type: 'CHANGE_THRESHOLD'
+  threshold: number
+}
+export type DeleteGuard = {
+  type: 'DELETE_GUARD'
+}
+export type DisableModule = {
+  type: 'DISABLE_MODULE'
+  module: AddressInfo
+}
+export type EnableModule = {
+  type: 'ENABLE_MODULE'
+  module: AddressInfo
+}
+export type RemoveOwner = {
+  type: 'REMOVE_OWNER'
+  owner: AddressInfo
+  threshold: number
+}
+export type SetFallbackHandler = {
+  type: 'SET_FALLBACK_HANDLER'
+  handler: AddressInfo
+}
+export type SetGuard = {
+  type: 'SET_GUARD'
+  guard: AddressInfo
+}
+export type SwapOwner = {
+  type: 'SWAP_OWNER'
+  oldOwner: AddressInfo
+  newOwner: AddressInfo
 }
 export type SettingsChangeTransaction = {
   type: 'SettingsChange'
   humanDescription?: string | null
   dataDecoded: DataDecoded
-  settingsInfo?: SettingsChange | null
+  settingsInfo:
+    | AddOwner
+    | ChangeMasterCopy
+    | ChangeThreshold
+    | DeleteGuard
+    | DisableModule
+    | EnableModule
+    | RemoveOwner
+    | SetFallbackHandler
+    | SetGuard
+    | SwapOwner
 }
 export type Erc20Transfer = {
   type: 'ERC20'
@@ -405,6 +539,20 @@ export type SwapTransferTransactionInfo = {
   /** The App Data for this order */
   fullAppData?: object | null
 }
+export type DurationAuto = {
+  durationType: 'AUTO'
+}
+export type DurationLimit = {
+  durationType: 'LIMIT_DURATION'
+  duration: string
+}
+export type StartTimeAtMining = {
+  startType: 'AT_MINING_TIME'
+}
+export type StartTimeAtEpoch = {
+  startType: 'AT_EPOCH'
+  epoch: number
+}
 export type TwapOrderTransactionInfo = {
   type: 'TwapOrder'
   humanDescription?: string | null
@@ -446,9 +594,9 @@ export type TwapOrderTransactionInfo = {
   /** The duration of the TWAP interval */
   timeBetweenParts: number
   /** Whether the TWAP is valid for the entire interval or not */
-  durationOfPart: object
+  durationOfPart: DurationAuto | DurationLimit
   /** The start time of the TWAP */
-  startTime: object
+  startTime: StartTimeAtMining | StartTimeAtEpoch
 }
 export type NativeStakingDepositTransactionInfo = {
   type: 'NativeStakingDeposit'
@@ -518,13 +666,29 @@ export type MultisigConfirmationDetails = {
   signature?: string | null
   submittedAt: number
 }
-export type Token = {
+export type NativeToken = {
   address: string
-  decimals?: number | null
+  decimals: number
   logoUri: string
   name: string
   symbol: string
-  type: 'ERC721' | 'ERC20' | 'NATIVE_TOKEN' | 'UNKNOWN'
+  type: 'NATIVE_TOKEN'
+}
+export type Erc20Token = {
+  address: string
+  decimals: number
+  logoUri: string
+  name: string
+  symbol: string
+  type: 'ERC20'
+}
+export type Erc721Token = {
+  address: string
+  decimals: number
+  logoUri: string
+  name: string
+  symbol: string
+  type: 'ERC721'
 }
 export type MultisigExecutionDetails = {
   type: 'MULTISIG'
@@ -541,7 +705,7 @@ export type MultisigExecutionDetails = {
   confirmationsRequired: number
   confirmations: MultisigConfirmationDetails[]
   rejectors: AddressInfo[]
-  gasTokenInfo?: Token | null
+  gasTokenInfo?: (NativeToken | Erc20Token | Erc721Token) | null
   trusted: boolean
   proposer?: AddressInfo | null
   proposedByDelegate?: AddressInfo | null
@@ -576,6 +740,45 @@ export type TransactionDetails = {
   txHash?: string | null
   safeAppInfo?: SafeAppInfo | null
   note?: string | null
+}
+export type TxsMultisigTransaction = {
+  safe: string
+  to: string
+  value: string
+  data: object
+  dataDecoded: object
+  operation: number
+  gasToken: object
+  safeTxGas: object
+  baseGas: object
+  gasPrice: object
+  proposer: object
+  proposedByDelegate: object
+  refundReceiver: object
+  nonce: number
+  executionDate: object
+  submissionDate: string
+  modified: object
+  blockNumber: object
+  transactionHash: object
+  safeTxHash: string
+  executor: object
+  isExecuted: boolean
+  isSuccessful: object
+  ethGasPrice: object
+  gasUsed: object
+  fee: object
+  origin: object
+  confirmationsRequired: number
+  confirmations: object
+  signatures: object
+  trusted: boolean
+}
+export type TxsMultisigTransactionPage = {
+  count?: number | null
+  next?: string | null
+  previous?: string | null
+  results: TxsMultisigTransaction[]
 }
 export type MultisigExecutionInfo = {
   type: 'MULTISIG'
@@ -633,7 +836,7 @@ export type ModuleTransactionPage = {
   results: ModuleTransaction[]
 }
 export type AddConfirmationDto = {
-  signedSafeTxHash: string
+  signature: string
 }
 export type IncomingTransfer = {
   type: 'TRANSACTION'
@@ -726,9 +929,23 @@ export type CreationTransaction = {
   saltNonce?: string | null
   dataDecoded?: DataDecoded | null
 }
+export type TxsCreationTransaction = {
+  created: string
+  creator: string
+  transactionHash: string
+  factoryAddress: string
+  masterCopy: object
+  setupData: object
+  saltNonce: object
+  dataDecoded: object
+}
 export const {
   useTransactionsGetTransactionByIdV1Query,
   useLazyTransactionsGetTransactionByIdV1Query,
+  useTransactionsGetDomainMultisigTransactionBySafeTxHashV1Query,
+  useLazyTransactionsGetDomainMultisigTransactionBySafeTxHashV1Query,
+  useTransactionsGetDomainMultisigTransactionsV1Query,
+  useLazyTransactionsGetDomainMultisigTransactionsV1Query,
   useTransactionsGetMultisigTransactionsV1Query,
   useLazyTransactionsGetMultisigTransactionsV1Query,
   useTransactionsDeleteTransactionV1Mutation,
@@ -745,4 +962,6 @@ export const {
   useTransactionsProposeTransactionV1Mutation,
   useTransactionsGetCreationTransactionV1Query,
   useLazyTransactionsGetCreationTransactionV1Query,
+  useTransactionsGetDomainCreationTransactionV1Query,
+  useLazyTransactionsGetDomainCreationTransactionV1Query,
 } = injectedRtkApi

--- a/packages/store/src/gateway/types.ts
+++ b/packages/store/src/gateway/types.ts
@@ -8,11 +8,112 @@ import {
   ModuleExecutionInfo,
   MultisigExecutionInfo,
   AddressInfo,
+  TransferTransactionInfo,
+  TransactionDetails,
+  NativeStakingDepositTransactionInfo,
+  NativeStakingValidatorsExitTransactionInfo,
+  NativeStakingWithdrawTransactionInfo,
+  ModuleExecutionDetails,
+  MultisigExecutionDetails
 } from './AUTO_GENERATED/transactions'
 import { SafeOverview } from './AUTO_GENERATED/safes'
+import { Chain } from './AUTO_GENERATED/chains';
+import { MessagePage, TypedData } from './AUTO_GENERATED/messages';
 
 export type ExecutionInfo = ModuleExecutionInfo | MultisigExecutionInfo
 
+// safe messages
+export enum SafeMessageListItemType {
+  DATE_LABEL = "DATE_LABEL",
+  MESSAGE = "MESSAGE"
+}
+export enum SafeMessageStatus {
+  NEEDS_CONFIRMATION = "NEEDS_CONFIRMATION",
+  CONFIRMED = "CONFIRMED"
+}
+export type TypedMessageTypes = TypedData['types']
+
+export type SafeMessageListItem = MessagePage['results'][number]
+
+
+// notifications
+export enum DeviceType {
+  ANDROID = "ANDROID",
+  IOS = "IOS",
+  WEB = "WEB"
+}
+
+// Chains
+export enum RPC_AUTHENTICATION {
+  API_KEY_PATH = "API_KEY_PATH",
+  NO_AUTHENTICATION = "NO_AUTHENTICATION",
+  UNKNOWN = "UNKNOWN"
+}
+
+export enum GAS_PRICE_TYPE {
+  ORACLE = "ORACLE",
+  FIXED = "FIXED",
+  FIXED_1559 = "FIXED1559",
+  UNKNOWN = "UNKNOWN"
+}
+
+export type GasPrice = Chain['gasPrice']
+
+export enum FEATURES {
+  ERC721 = "ERC721",
+  SAFE_APPS = "SAFE_APPS",
+  CONTRACT_INTERACTION = "CONTRACT_INTERACTION",
+  DOMAIN_LOOKUP = "DOMAIN_LOOKUP",
+  SPENDING_LIMIT = "SPENDING_LIMIT",
+  EIP1559 = "EIP1559",
+  SAFE_TX_GAS_OPTIONAL = "SAFE_TX_GAS_OPTIONAL",
+  TX_SIMULATION = "TX_SIMULATION",
+  EIP1271 = "EIP1271"
+}
+
+export type ChainInfo = Omit<Chain, 'features'> & {
+  features: FEATURES[]
+}
+
+// Safe info
+export enum ImplementationVersionState {
+  UP_TO_DATE = "UP_TO_DATE",
+  OUTDATED = "OUTDATED",
+  UNKNOWN = "UNKNOWN"
+}
+
+// Safe apps
+export enum SafeAppAccessPolicyTypes {
+  NoRestrictions = "NO_RESTRICTIONS",
+  DomainAllowlist = "DOMAIN_ALLOWLIST"
+}
+
+export type SafeAppNoRestrictionsPolicy = {
+  type: SafeAppAccessPolicyTypes.NoRestrictions;
+};
+export type SafeAppDomainAllowlistPolicy = {
+  type: SafeAppAccessPolicyTypes.DomainAllowlist;
+  value: string[];
+};
+export type SafeAppsAccessControlPolicies = SafeAppNoRestrictionsPolicy | SafeAppDomainAllowlistPolicy
+
+export enum SafeAppFeatures {
+  BATCHED_TRANSACTIONS = "BATCHED_TRANSACTIONS"
+}
+
+export enum SafeAppSocialPlatforms {
+  TWITTER = "TWITTER",
+  GITHUB = "GITHUB",
+  DISCORD = "DISCORD",
+  TELEGRAM = "TELEGRAM"
+}
+
+
+// Transactions
+export enum Operation {
+  CALL = 0,
+  DELEGATE = 1
+}
 export enum TransactionStatus {
   AWAITING_CONFIRMATIONS = 'AWAITING_CONFIRMATIONS',
   AWAITING_EXECUTION = 'AWAITING_EXECUTION',
@@ -25,6 +126,13 @@ export enum TransferDirection {
   INCOMING = 'INCOMING',
   OUTGOING = 'OUTGOING',
   UNKNOWN = 'UNKNOWN',
+}
+
+export enum TokenType {
+  ERC20 = "ERC20",
+  ERC721 = "ERC721",
+  NATIVE_TOKEN = "NATIVE_TOKEN",
+  UNKNOWN = "UNKNOWN"
 }
 
 export enum TransactionTokenType {
@@ -74,6 +182,18 @@ export enum DetailedExecutionInfoType {
   MODULE = 'MODULE',
 }
 
+export type TransferInfo = TransferTransactionInfo['transferInfo']
+export type StakingTxInfo = NativeStakingDepositTransactionInfo | NativeStakingValidatorsExitTransactionInfo | NativeStakingWithdrawTransactionInfo;
+export type TransactionInfo = TransactionDetails['txInfo']
+
+export type DetailedExecutionInfo = ModuleExecutionDetails | MultisigExecutionDetails;
+
+
+export enum LabelValue {
+  Queued = "Queued",
+  Next = "Next"
+}
+
 export type Cancellation = CustomTransactionInfo & {
   isCancellation: true
 }
@@ -88,6 +208,11 @@ export type MultiSend = CustomTransactionInfo & {
 export type SafeOverviewResult = { data: SafeOverview[]; error: unknown; isLoading: boolean }
 
 export type OrderTransactionInfo = SwapOrderTransactionInfo | TwapOrderTransactionInfo | SwapTransferTransactionInfo
+
+export enum StartTimeValue {
+  AT_MINING_TIME = "AT_MINING_TIME",
+  AT_EPOCH = "AT_EPOCH"
+}
 
 export type PendingTransactionItems = QueuedItemPage['results'][number]
 export type HistoryTransactionItems = TransactionItemPage['results'][number]

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../config/tsconfig/confs/base.json",
   "compilerOptions": {
+    "baseUrl": "./"
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
## What it solves
This is an attempt to refactor the code to use the new @safe-global/store package instead of @safe-global/safe-gateway-typescript-sdk.

The codemod is at the moment not complete. 
I'm not sure how to map the data-decoded types and few other. 

to execute the script one needs to have jscoodeshift installed globaly and then one can run

```
jscodeshift -t codemods/convert-safe-gateway-typescript-sdk.js apps/web/src --extensions=tsx --parser=tsx
jscodeshift -t codemods/convert-safe-gateway-typescript-sdk.js apps/web/src --extensions=ts --parser=ts
```

Prettier and lint are not happy with the newly generated code, so running those commands with --fix is necessary to reduce the amount of errors. 

Resolves #

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
