### PR TITLE
Fix(Balances): add skipPollingIfUnfocused to polled queries

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/index.tsx
@@ -184,6 +184,7 @@ const TxDetails = ({
     { chainId, txId: txSummary.id },
     {
       pollingInterval: isOpenSwapOrder(txSummary.txInfo) ? POLLING_INTERVAL : undefined,
+      skipPollingIfUnfocused: true,
     },
   )
 

--- a/apps/web/src/hooks/loadables/useLoadBalances.ts
+++ b/apps/web/src/hooks/loadables/useLoadBalances.ts
@@ -42,6 +42,7 @@ const useLoadBalances = () => {
     {
       skip: !isReady,
       pollingInterval: POLLING_INTERVAL,
+      skipPollingIfUnfocused: true,
     },
   )
 

--- a/apps/web/src/hooks/loadables/useLoadBalances.ts
+++ b/apps/web/src/hooks/loadables/useLoadBalances.ts
@@ -43,6 +43,7 @@ const useLoadBalances = () => {
       skip: !isReady,
       pollingInterval: POLLING_INTERVAL,
       skipPollingIfUnfocused: true,
+      refetchOnFocus: true,
     },
   )
 

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -29,6 +29,7 @@ import { safePassApi } from './api/safePass'
 import { version as termsVersion } from '@/markdown/terms/version'
 import { cgwClient, setBaseUrl } from '@safe-global/store/gateway/cgwClient'
 import { GATEWAY_URL } from '@/config/gateway'
+import { setupListeners } from '@reduxjs/toolkit/query'
 
 const rootReducer = combineReducers({
   [slices.chainsSlice.name]: slices.chainsSlice.reducer,
@@ -141,6 +142,8 @@ export const makeStore = (
   if (!options?.skipBroadcast) {
     listenToBroadcast(store)
   }
+
+  setupListeners(store.dispatch)
 
   return store
 }


### PR DESCRIPTION
## What it solves

We're seeing a 3x increase in balances requests after migrating the Balances fetching to RTK Query.
@compojoom's hypothesis is that it's because the old `useIntervalCounter` polling was being suspended in a background tab and the query wasn't.

## How to test

* Open the Console -> Network and filter by `balances`
* Observe that balances are polled every 15s
* Go to another tab, wait for 1 minute
* Come back to the Safe tab
* Observe that there's just one new request, not 4+