### PR TITLE
Chore(web): Update nextjs to v15.2.3 and integrity patch

### DIFF
--- a/.yarn/patches/next-npm-15.2.3-06a6671f62.patch
+++ b/.yarn/patches/next-npm-15.2.3-06a6671f62.patch
@@ -1,13 +1,13 @@
 diff --git a/dist/client/route-loader.js b/dist/client/route-loader.js
-index 5b9774a..cb9e8af 100644
+index 888fc23e628cd87fbbf60742aeaaea37b9703f6e..93cc6e0fd3316445dbb55ac618dd9421aeeae19c 100644
 --- a/dist/client/route-loader.js
 +++ b/dist/client/route-loader.js
-@@ -116,6 +116,12 @@ function appendScript(src, script) {
+@@ -124,6 +124,12 @@ function appendScript(src, script) {
          // 3. Finally, set the source and inject into the DOM in case the child
          //    must be appended for fetching to start.
          script.src = src;
 +
-+        // Set integrity if we have a matching hash
++	     // Set integrity if we have a matching hash
 +        const hashManifest = window.__CHUNK_SRI_MANIFEST || {};
 +        if (hashManifest[src]) {
 +            script.integrity = hashManifest[src];

--- a/apps/web/docs/update-patch.md
+++ b/apps/web/docs/update-patch.md
@@ -1,0 +1,19 @@
+# Update yarn patches
+
+You can find all patches that are currently applied inside the `.yarn/patches` directory. The name of the package that the patch applies to can be found in the file name of the patch.
+
+Following are the steps to update a patch in case an update to the dependency needs to be done:
+
+1. Go to the `package.json` of where the dependency is located and change the version manually 
+   1. e.g. `"next": "patch:next@15.1.2#../../.yarn/patches/next-npm-15.1.2-24e7411703.patch"` -> `"next": "15.2.3"`
+2. Run `yarn install` to update the dependency
+3. Run `yarn patch <package-name>` e.g. `yarn patch next@npm:15.2.3`
+4. Follow the instructions from your CLI
+   1. This will generate a temporary directory with files of that dependency
+   2. Navigate to that directory and do the necessary changes
+   3. Run `yarn patch-commit -s <path to temporary directory>`
+5. Check the generated patch file inside `.yarn/patches` and make sure it contains the expected changes
+6. Update the dependency inside `package.json`
+   1. e.g. `"next": "patch:next@15.2.3#../../.yarn/patches/next-npm-15.2.3-06a6671f62.patch"`
+7. Run `yarn install` to update the dependency and lock file
+8. Go to the package directory inside `node_modules` and check that the patch is applied

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -76,7 +76,7 @@
     "idb-keyval": "^6.2.1",
     "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",
-    "next": "patch:next@15.1.2#../../.yarn/patches/next-npm-15.1.2-24e7411703.patch",
+    "next": "patch:next@15.2.3#../../.yarn/patches/next-npm-15.2.3-06a6671f62.patch",
     "papaparse": "^5.3.2",
     "qrcode.react": "^3.1.0",
     "react": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5752,6 +5752,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/env@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/env@npm:15.2.3"
+  checksum: 10/976f9e85b7e4e1b4bce16c06c4528a1febfce3ae20e7935440900bc4befd650257bf5a71c94b6c9391e251c6ee6080c868c759c1becaacddd25b280751013b2c
+  languageName: node
+  linkType: hard
+
 "@next/eslint-plugin-next@npm:15.1.1":
   version: 15.1.1
   resolution: "@next/eslint-plugin-next@npm:15.1.1"
@@ -5785,9 +5792,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-darwin-arm64@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-darwin-arm64@npm:15.2.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-darwin-x64@npm:15.1.2":
   version: 15.1.2
   resolution: "@next/swc-darwin-x64@npm:15.1.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-x64@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-darwin-x64@npm:15.2.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -5799,9 +5820,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-arm64-gnu@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-linux-arm64-gnu@npm:15.2.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-arm64-musl@npm:15.1.2":
   version: 15.1.2
   resolution: "@next/swc-linux-arm64-musl@npm:15.1.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-musl@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-linux-arm64-musl@npm:15.2.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -5813,9 +5848,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-x64-gnu@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-linux-x64-gnu@npm:15.2.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-x64-musl@npm:15.1.2":
   version: 15.1.2
   resolution: "@next/swc-linux-x64-musl@npm:15.1.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-musl@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-linux-x64-musl@npm:15.2.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -5827,9 +5876,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-win32-arm64-msvc@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-win32-arm64-msvc@npm:15.2.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-win32-x64-msvc@npm:15.1.2":
   version: 15.1.2
   resolution: "@next/swc-win32-x64-msvc@npm:15.1.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-x64-msvc@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-win32-x64-msvc@npm:15.2.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7738,7 +7801,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     mockdate: "npm:^3.0.5"
     msw: "npm:^2.7.3"
-    next: "patch:next@15.1.2#../../.yarn/patches/next-npm-15.1.2-24e7411703.patch"
+    next: "patch:next@15.2.3#../../.yarn/patches/next-npm-15.2.3-06a6671f62.patch"
     papaparse: "npm:^5.3.2"
     prettier: "npm:^3.3.3"
     qrcode.react: "npm:^3.1.0"
@@ -24668,7 +24731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:*, next@npm:15.1.2":
+"next@npm:*":
   version: 15.1.2
   resolution: "next@npm:15.1.2"
   dependencies:
@@ -24729,19 +24792,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@patch:next@15.1.2#../../.yarn/patches/next-npm-15.1.2-24e7411703.patch::locator=%40safe-global%2Fweb%40workspace%3Aapps%2Fweb":
-  version: 15.1.2
-  resolution: "next@patch:next@npm%3A15.1.2#../../.yarn/patches/next-npm-15.1.2-24e7411703.patch::version=15.1.2&hash=f62d10&locator=%40safe-global%2Fweb%40workspace%3Aapps%2Fweb"
+"next@npm:15.2.3":
+  version: 15.2.3
+  resolution: "next@npm:15.2.3"
   dependencies:
-    "@next/env": "npm:15.1.2"
-    "@next/swc-darwin-arm64": "npm:15.1.2"
-    "@next/swc-darwin-x64": "npm:15.1.2"
-    "@next/swc-linux-arm64-gnu": "npm:15.1.2"
-    "@next/swc-linux-arm64-musl": "npm:15.1.2"
-    "@next/swc-linux-x64-gnu": "npm:15.1.2"
-    "@next/swc-linux-x64-musl": "npm:15.1.2"
-    "@next/swc-win32-arm64-msvc": "npm:15.1.2"
-    "@next/swc-win32-x64-msvc": "npm:15.1.2"
+    "@next/env": "npm:15.2.3"
+    "@next/swc-darwin-arm64": "npm:15.2.3"
+    "@next/swc-darwin-x64": "npm:15.2.3"
+    "@next/swc-linux-arm64-gnu": "npm:15.2.3"
+    "@next/swc-linux-arm64-musl": "npm:15.2.3"
+    "@next/swc-linux-x64-gnu": "npm:15.2.3"
+    "@next/swc-linux-x64-musl": "npm:15.2.3"
+    "@next/swc-win32-arm64-msvc": "npm:15.2.3"
+    "@next/swc-win32-x64-msvc": "npm:15.2.3"
     "@swc/counter": "npm:0.1.3"
     "@swc/helpers": "npm:0.5.15"
     busboy: "npm:1.6.0"
@@ -24786,7 +24849,68 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10/a0dd97b75d435cc539094231e8e064269e07df7cc65a2714bf19be0459e57d7d578303082bb543cdb5ea8c25ebee7003212eaeedaac1253336583e090a742161
+  checksum: 10/91714227d09ad1a41340bfa10a2ad212fa372d5d6255dd14cc47cccb4795a04c8ac08a8b10998d2d7bf90eeca46668091d4a0398ec11224310fd96a484bca867
+  languageName: node
+  linkType: hard
+
+"next@patch:next@15.2.3#../../.yarn/patches/next-npm-15.2.3-06a6671f62.patch::locator=%40safe-global%2Fweb%40workspace%3Aapps%2Fweb":
+  version: 15.2.3
+  resolution: "next@patch:next@npm%3A15.2.3#../../.yarn/patches/next-npm-15.2.3-06a6671f62.patch::version=15.2.3&hash=f475b4&locator=%40safe-global%2Fweb%40workspace%3Aapps%2Fweb"
+  dependencies:
+    "@next/env": "npm:15.2.3"
+    "@next/swc-darwin-arm64": "npm:15.2.3"
+    "@next/swc-darwin-x64": "npm:15.2.3"
+    "@next/swc-linux-arm64-gnu": "npm:15.2.3"
+    "@next/swc-linux-arm64-musl": "npm:15.2.3"
+    "@next/swc-linux-x64-gnu": "npm:15.2.3"
+    "@next/swc-linux-x64-musl": "npm:15.2.3"
+    "@next/swc-win32-arm64-msvc": "npm:15.2.3"
+    "@next/swc-win32-x64-msvc": "npm:15.2.3"
+    "@swc/counter": "npm:0.1.3"
+    "@swc/helpers": "npm:0.5.15"
+    busboy: "npm:1.6.0"
+    caniuse-lite: "npm:^1.0.30001579"
+    postcss: "npm:8.4.31"
+    sharp: "npm:^0.33.5"
+    styled-jsx: "npm:5.1.6"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
+    babel-plugin-react-compiler: "*"
+    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+    sharp:
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 10/e9d99d89e310f2f378bba828a076edc7ab02e3f2927aea35ce16c4c5d0462387d7b561a199dd8793bc99cc240b5c8820a976d2fae8b7123d18e7ecce2dbaf1a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-monorepo/security/dependabot/107

## How this PR fixes it

- Updates next to v15.2.3
- Updates the integrity-hash patch
- Adds a document to explain the patch update process

## How to test it

- Deployment should work and the integrity hashes should still be generated

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
