### PR TITLE
Fix(Web): Only fetch owned nested safes if menu is opened

### DIFF
--- a/apps/web/src/components/sidebar/SafeListContextMenu/index.tsx
+++ b/apps/web/src/components/sidebar/SafeListContextMenu/index.tsx
@@ -57,14 +57,13 @@ const SafeListContextMenu = ({
   undeployedSafe: boolean
   onClose?: () => void
 }): ReactElement => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const isNestedSafesEnabled = useHasFeature(FEATURES.NESTED_SAFES)
   const { data: nestedSafes } = useGetOwnedSafesQuery(
-    isNestedSafesEnabled && address ? { chainId, ownerAddress: address } : skipToken,
+    isNestedSafesEnabled && address && anchorEl ? { chainId, ownerAddress: address } : skipToken,
   )
   const addressBook = useAddressBook()
   const hasName = address in addressBook
-
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const [open, setOpen] = useState<typeof defaultOpen>(defaultOpen)
 
   const trackingLabel =


### PR DESCRIPTION
## What it solves

Part of #5508 

## How this PR fixes it

- Only fetches the nested owned safes if the context menu is mounted. This reduces the number of requests on the accounts page significantly.

## How to test it

1. Open the accounts page
2. Connect a wallet that owns a few safes
3. Observe no requests to get safes for every safe that the wallet owns
4. Press the three-dot menu next to a safe item in the list
5. Observe the request happens then
6. Close the context menu and open it again
7. Observe no additional request (Redux cache kicking in)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
