### PR TITLE
fix(mobile): display coming soon for non-implemented features

### DIFF
--- a/apps/mobile/src/config/constants.ts
+++ b/apps/mobile/src/config/constants.ts
@@ -9,6 +9,9 @@ export const isTestingEnv = process.env.NODE_ENV === 'test'
 export const isStorybookEnv = Constants?.expoConfig?.extra?.storybookEnabled === 'true'
 export const POLLING_INTERVAL = 15_000
 
+export const COMING_SOON_MESSAGE = 'This feature is coming soon.'
+export const COMING_SOON_TITLE = 'Coming soon'
+
 export const GATEWAY_URL_PRODUCTION =
   process.env.EXPO_PUBLIC_GATEWAY_URL_PRODUCTION || 'https://safe-client.safe.global'
 export const GATEWAY_URL_STAGING = process.env.EXPO_PUBLIC_GATEWAY_URL_STAGING || 'https://safe-client.staging.5afe.dev'

--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
@@ -1,10 +1,10 @@
 import { Badge } from '@/src/components/Badge'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import React from 'react'
-import { TouchableOpacity } from 'react-native'
+import { Alert, TouchableOpacity } from 'react-native'
 import { styled, Text, View } from 'tamagui'
 import { Link } from 'expo-router'
-
+import { COMING_SOON_MESSAGE, COMING_SOON_TITLE } from '@/src/config/constants'
 const MyAccountsFooterContainer = styled(View, {
   borderTopWidth: 1,
   borderTopColor: '$colorSecondary',
@@ -21,7 +21,9 @@ const MyAccountsButton = styled(View, {
 })
 
 export function MyAccountsFooter() {
-  const onJoinAccountClick = () => null
+  const onJoinAccountClick = () => {
+    Alert.alert(COMING_SOON_TITLE, COMING_SOON_MESSAGE)
+  }
   return (
     <MyAccountsFooterContainer paddingBottom={'$7'}>
       <Link href={'/(import-accounts)'} asChild>

--- a/apps/mobile/src/features/GetStarted/GetStarted.tsx
+++ b/apps/mobile/src/features/GetStarted/GetStarted.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { BlurView } from 'expo-blur'
 import crashlytics from '@react-native-firebase/crashlytics'
 import { Alert } from 'react-native'
+import { COMING_SOON_MESSAGE, COMING_SOON_TITLE } from '@/src/config/constants'
 
 export const GetStarted = () => {
   const router = useRouter()
@@ -22,7 +23,7 @@ export const GetStarted = () => {
   }, [])
 
   const onPressJoinAccount = useCallback(() => {
-    Alert.alert('Coming soon', 'This feature is not yet available.')
+    Alert.alert(COMING_SOON_TITLE, COMING_SOON_MESSAGE)
   }, [])
 
   return (

--- a/apps/mobile/src/features/Notifications/NotificationsCenter.container.tsx
+++ b/apps/mobile/src/features/Notifications/NotificationsCenter.container.tsx
@@ -1,12 +1,13 @@
+import { COMING_SOON_MESSAGE, COMING_SOON_TITLE } from '@/src/config/constants'
 import React from 'react'
 import { H3, Text, View } from 'tamagui'
 
 export const NotificationsCenterContainer = () => {
   return (
     <View flex={1} alignItems="center" justifyContent="center">
-      <H3 fontWeight={600}>Coming soon</H3>
+      <H3 fontWeight={600}>{COMING_SOON_TITLE}</H3>
       <Text textAlign="center" color="$colorSecondary" width="70%" fontSize="$4">
-        This feature is coming soon.
+        {COMING_SOON_MESSAGE}
       </Text>
     </View>
   )

--- a/apps/mobile/src/features/Signer/Signer.container.tsx
+++ b/apps/mobile/src/features/Signer/Signer.container.tsx
@@ -12,6 +12,7 @@ import { SubmitHandler, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { FormValues } from '@/src/features/Signer/types'
 import { formSchema } from '@/src/features/Signer/schema'
+import { COMING_SOON_MESSAGE, COMING_SOON_TITLE } from '@/src/config/constants'
 
 export const SignerContainer = () => {
   const navigation = useNavigation()
@@ -31,7 +32,7 @@ export const SignerContainer = () => {
   }, [address, activeChain])
 
   const onPressDelete = useCallback(() => {
-    Alert.alert('Coming soon', 'This feature is not available yet')
+    Alert.alert(COMING_SOON_TITLE, COMING_SOON_MESSAGE)
   }, [])
 
   // Initialize the form with React Hook Form and Zod schema resolver


### PR DESCRIPTION
## What it solves
Ads a "coming soon" alert for joining a safe. Also abstracted the title and description for "coming soon" to a constant that we can now reuse everywhere where we need this. (our descriptions were always slightly different everywhere)

## How to test it
Pressing "join new acocunt" under "My accounts" shoudl trigger an Alert.

## Screenshots
![grafik](https://github.com/user-attachments/assets/8358e97b-ea01-48e6-9617-94ef18fc8c1b)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
