### PR TITLE
fix(mobile): update tx can’t be executed text

### DIFF
--- a/apps/mobile/src/config/constants.ts
+++ b/apps/mobile/src/config/constants.ts
@@ -20,3 +20,6 @@ export const GATEWAY_URL = isProduction ? GATEWAY_URL_PRODUCTION : GATEWAY_URL_S
  */
 export const ONBOARDING_VERSION = 'v1'
 export const INFURA_TOKEN = process.env.EXPO_PUBLIC_INFURA_TOKEN || ''
+
+export const SAFE_WEB_URL = 'https://app.safe.global'
+export const SAFE_WEB_TRANSACTIONS_URL = `${SAFE_WEB_URL}/transactions/tx?safe=:safeAddressWithChainPrefix&id=:txId`

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmTxForm/ConfirmTxForm.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmTxForm/ConfirmTxForm.tsx
@@ -23,7 +23,7 @@ export function ConfirmTxForm({
   const activeSafe = useDefinedActiveSafe()
 
   if (hasSigned) {
-    return <AlreadySigned />
+    return <AlreadySigned txId={txId} safeAddress={activeSafe.address} chainId={activeSafe.chainId} />
   }
 
   if (hasEnoughConfirmations) {

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/AlreadySigned.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/AlreadySigned.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { render, fireEvent } from '@/src/tests/test-utils'
+import { AlreadySigned } from './AlreadySigned'
+import { Linking } from 'react-native'
+import { GATEWAY_URL, SAFE_WEB_TRANSACTIONS_URL } from '@/src/config/constants'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/src/tests/server'
+import { apiSliceWithChainsConfig } from '@safe-global/store/gateway/chains'
+import { makeStore } from '@/src/store'
+
+// Mock Linking
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  openURL: jest.fn(),
+}))
+
+describe('AlreadySigned', () => {
+  const mockProps = {
+    txId: 'test-tx-id',
+    safeAddress: '0x123',
+    chainId: '1',
+  }
+
+  const mockChain = {
+    shortName: 'eth',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/chains`, () => {
+        return HttpResponse.json({
+          results: [
+            {
+              chainId: '1',
+              shortName: 'eth',
+            },
+          ],
+        })
+      }),
+    )
+  })
+
+  const renderWithStore = async (ui: React.ReactElement) => {
+    const store = makeStore()
+    await store.dispatch(apiSliceWithChainsConfig.endpoints.getChainsConfig.initiate())
+    return render(ui, { initialStore: store.getState() })
+  }
+
+  it('renders correctly with all required elements', async () => {
+    const { getByText } = await renderWithStore(<AlreadySigned {...mockProps} />)
+
+    expect(getByText('This transaction can be executed in the web app only.')).toBeTruthy()
+    expect(getByText('Go to Web app')).toBeTruthy()
+    expect(getByText('Confirm')).toBeTruthy()
+  })
+
+  it('opens web app URL when "Go to Web app" is pressed', async () => {
+    const { getByText } = await renderWithStore(<AlreadySigned {...mockProps} />)
+
+    const expectedUrl = SAFE_WEB_TRANSACTIONS_URL.replace(
+      ':safeAddressWithChainPrefix',
+      `${mockChain.shortName}:${mockProps.safeAddress}`,
+    ).replace(':txId', mockProps.txId)
+
+    fireEvent.press(getByText('Go to Web app'))
+    expect(Linking.openURL).toHaveBeenCalledWith(expectedUrl)
+  })
+
+  it('matches snapshot', async () => {
+    const { toJSON } = await renderWithStore(<AlreadySigned {...mockProps} />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+})

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/AlreadySigned.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/AlreadySigned.tsx
@@ -1,16 +1,45 @@
 import { SafeButton } from '@/src/components/SafeButton'
-import React from 'react'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { SAFE_WEB_TRANSACTIONS_URL } from '@/src/config/constants'
+import { selectChainById } from '@/src/store/chains'
+import { useAppSelector } from '@/src/store/hooks'
+import React, { useCallback } from 'react'
+import { Linking, TouchableOpacity } from 'react-native'
 import { Text, View, YStack } from 'tamagui'
 
-export function AlreadySigned() {
+type Props = {
+  txId: string
+  safeAddress: string
+  chainId: string
+}
+
+export function AlreadySigned({ txId, safeAddress, chainId }: Props) {
+  const chain = useAppSelector((state) => selectChainById(state, chainId))
+  const onPressGoToWebApp = useCallback(() => {
+    const url = SAFE_WEB_TRANSACTIONS_URL.replace(
+      ':safeAddressWithChainPrefix',
+      `${chain?.shortName}:${safeAddress}`,
+    ).replace(':txId', txId)
+
+    Linking.openURL(url)
+  }, [txId, safeAddress, chainId])
+
   return (
     <YStack justifyContent="center" gap="$4" alignItems="center" paddingHorizontal={'$4'}>
       <Text fontSize="$4" fontWeight={400} textAlign="center" color="$textSecondaryLight">
-        You have already signed this transaction.
+        This transaction can be executed in the web app only.
       </Text>
+      <TouchableOpacity onPress={onPressGoToWebApp}>
+        <View flexDirection="row" alignItems="center" gap="$2">
+          <Text fontSize="$4" fontWeight={700} textAlign="center" color="$color">
+            Go to Web app
+          </Text>
+          <SafeFontIcon name="external-link" size={16} color="$color" />
+        </View>
+      </TouchableOpacity>
 
       <View height={50} width="100%">
-        <SafeButton height="100%" rounded fullscreen fontWeight={600} disabled>
+        <SafeButton height="100%" rounded fullscreen fontWeight={600} disabled testID="confirm-button">
           Confirm
         </SafeButton>
       </View>

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/__snapshots__/AlreadySigned.test.tsx.snap
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/__snapshots__/AlreadySigned.test.tsx.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlreadySigned matches snapshot 1`] = `
+<View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flexDirection": "column",
+        "gap": 16,
+        "justifyContent": "center",
+        "paddingLeft": 16,
+        "paddingRight": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "#A1A3A7",
+          "fontSize": 16,
+          "fontWeight": 400,
+          "textAlign": "center",
+        }
+      }
+      suppressHighlighting={true}
+    >
+      This transaction can be executed in the web app only.
+    </Text>
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "opacity": 1,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 8,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#121312",
+              "fontSize": 16,
+              "fontWeight": 700,
+              "textAlign": "center",
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Go to Web app
+        </Text>
+        <Text
+          allowFontScaling={false}
+          selectable={false}
+          style={
+            [
+              {
+                "color": "#121312",
+                "fontSize": 16,
+              },
+              undefined,
+              {
+                "fontFamily": "SafeIcons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+              {},
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "height": 50,
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        focusVisibleStyle={
+          {
+            "borderColor": "$background",
+          }
+        }
+        lineHeight={20}
+        pointerEvents="none"
+        role="button"
+        style={
+          {
+            "alignItems": "center",
+            "backgroundColor": "#7878801F",
+            "borderBottomColor": "transparent",
+            "borderBottomLeftRadius": 8,
+            "borderBottomRightRadius": 8,
+            "borderBottomWidth": 1,
+            "borderLeftColor": "transparent",
+            "borderLeftWidth": 1,
+            "borderRightColor": "transparent",
+            "borderRightWidth": 1,
+            "borderStyle": "solid",
+            "borderTopColor": "transparent",
+            "borderTopLeftRadius": 8,
+            "borderTopRightRadius": 8,
+            "borderTopWidth": 1,
+            "bottom": 0,
+            "color": "#636669",
+            "flexDirection": "row",
+            "flexWrap": "nowrap",
+            "fontWeight": 600,
+            "height": "100%",
+            "justifyContent": "center",
+            "left": 0,
+            "marginBottom": 0,
+            "marginLeft": 0,
+            "marginRight": 0,
+            "marginTop": 0,
+            "paddingBottom": 14,
+            "paddingLeft": 20,
+            "paddingRight": 20,
+            "paddingTop": 14,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+        testID="confirm-button"
+      >
+        <Text
+          lineBreakMode="clip"
+          numberOfLines={1}
+          style={
+            {
+              "color": "#636669",
+              "flexGrow": 0,
+              "flexShrink": 1,
+              "fontFamily": "DMSans-SemiBold",
+              "fontSize": 14,
+              "letterSpacing": -0.1,
+              "lineHeight": 15.400000000000002,
+              "userSelect": "none",
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Confirm
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
+`;


### PR DESCRIPTION
## What it solves
Updated the "can't execute tx in mobile wallet" text and added a proper link to the transaction.

## How to test it
Sign a transaction. Afterwards you should be displayed: "This transaction can be executed in the web app only. Go to web app". The link should lead you directly to the transaction in the web app.
 
## Screenshots
<img src="https://github.com/user-attachments/assets/0305164e-67e7-4f78-b0e8-7962496d09dc" width="150" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
