### PR TITLE
feat(mobile): add „read-only“ account block

### DIFF
--- a/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
+++ b/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
@@ -3,6 +3,7 @@ import { BalanceContainer } from '../Balance'
 import { PendingTransactions } from '@/src/components/StatusBanners/PendingTransactions'
 import { View } from 'tamagui'
 import { StyledAssetsHeader } from './styles'
+import { ReadOnlyContainer } from '../ReadOnly/ReadOnly.container'
 
 interface AssetsHeaderProps {
   amount: number
@@ -25,6 +26,10 @@ export function AssetsHeader({ amount, isLoading, onPendingTransactionsPress, ha
       </View>
 
       <BalanceContainer />
+
+      <View marginBottom="$4">
+        <ReadOnlyContainer />
+      </View>
     </StyledAssetsHeader>
   )
 }

--- a/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.container.test.tsx
+++ b/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.container.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@/src/tests/test-utils'
+import { ReadOnlyContainer } from './ReadOnly.container'
+import { RootState } from '@/src/store'
+import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+
+describe('ReadOnlyContainer', () => {
+  const mockSafeAddress = '0x123'
+  const mockSigners: Record<string, AddressInfo> = {
+    '0x456': { value: '0x456', name: 'Signer 1' },
+    '0x789': { value: '0x789', name: 'Signer 2' },
+  }
+
+  const mockSafeInfo: SafeOverview = {
+    address: { value: mockSafeAddress },
+    chainId: '1',
+    owners: [{ value: '0x456' }, { value: '0x789' }],
+    threshold: 2,
+    fiatTotal: '0',
+    queued: 0,
+  }
+
+  const createInitialState = (signers: Record<string, AddressInfo>, safeInfo: SafeOverview): Partial<RootState> => ({
+    safes: {
+      [mockSafeAddress]: {
+        SafeInfo: safeInfo,
+        chains: ['1'],
+      },
+    },
+    signers: signers,
+    activeSafe: {
+      address: mockSafeAddress,
+      chainId: '1',
+    },
+  })
+
+  it('should render read-only message when there are no signers', () => {
+    const initialState = createInitialState(
+      {},
+      {
+        ...mockSafeInfo,
+      },
+    )
+    render(<ReadOnlyContainer />, { initialStore: initialState })
+
+    expect(screen.getByText('This is a read-only account')).toBeTruthy()
+  })
+
+  it("should render read-only message when signers don't match owners", () => {
+    const initialState = createInitialState(mockSigners, {
+      ...mockSafeInfo,
+      owners: [{ value: '0x345' }],
+    })
+    render(<ReadOnlyContainer />, { initialStore: initialState })
+
+    expect(screen.getByText('This is a read-only account')).toBeTruthy()
+  })
+
+  it('should not render read-only message when there are signers', () => {
+    const initialState = createInitialState(mockSigners, mockSafeInfo)
+    render(<ReadOnlyContainer />, { initialStore: initialState })
+
+    expect(screen.queryByText('This is a read-only account')).toBeNull()
+  })
+})

--- a/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.container.tsx
+++ b/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.container.tsx
@@ -1,0 +1,17 @@
+import { useSelector } from 'react-redux'
+import { RootState } from '@/src/store'
+import { selectSafeInfo } from '@/src/store/safesSlice'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { selectSigners } from '@/src/store/signersSlice'
+import { getSafeSigners } from '@/src/utils/signer'
+import { ReadOnly } from './ReadOnly'
+
+export const ReadOnlyContainer = () => {
+  const activeSafe = useDefinedActiveSafe()
+  const safeInfo = useSelector((state: RootState) => selectSafeInfo(state, activeSafe?.address))
+  const signers = useSelector(selectSigners)
+
+  const safeSigners = safeInfo?.SafeInfo ? getSafeSigners(safeInfo.SafeInfo, signers) : []
+
+  return <ReadOnly signers={safeSigners} />
+}

--- a/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.tsx
+++ b/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.tsx
@@ -1,0 +1,20 @@
+import { Container } from '@/src/components/Container'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { View, Text } from 'tamagui'
+
+export const ReadOnly = ({ signers }: { signers: string[] }) => {
+  if (signers.length === 0) {
+    return (
+      <Container padding="$2" justifyContent="center" alignItems="center" backgroundColor="$backgroundSecondary">
+        <View flexDirection="row" alignItems="center" gap="$2">
+          <SafeFontIcon name="eye-n" size={20} color="$colorLight" />
+          <Text color="$colorLight" fontWeight={600}>
+            This is a read-only account
+          </Text>
+        </View>
+      </Container>
+    )
+  }
+
+  return null
+}

--- a/apps/mobile/src/utils/signer.test.ts
+++ b/apps/mobile/src/utils/signer.test.ts
@@ -1,0 +1,40 @@
+import { getSafeSigners } from './signer'
+import { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+describe('getSafeSigners', () => {
+  const mockSafeInfo: SafeOverview = {
+    owners: [{ value: '0x123' }, { value: '0x456' }, { value: '0x789' }],
+    address: { value: '0x123' },
+    chainId: '1',
+    threshold: 2,
+    fiatTotal: '0',
+    queued: 0,
+  } as SafeOverview
+
+  const mockSigners: Record<string, AddressInfo> = {
+    '0x123': { value: '0x123' },
+    '0x789': { value: '0x789' },
+  }
+
+  it('should return only the owners that exist in signers', () => {
+    const result = getSafeSigners(mockSafeInfo, mockSigners)
+    expect(result).toEqual(['0x123', '0x789'])
+  })
+
+  it('should return empty array when no owners match signers', () => {
+    const emptySigners: Record<string, AddressInfo> = {}
+    const result = getSafeSigners(mockSafeInfo, emptySigners)
+    expect(result).toEqual([])
+  })
+
+  it('should handle case when all owners are signers', () => {
+    const allSigners: Record<string, AddressInfo> = {
+      '0x123': { value: '0x123' },
+      '0x456': { value: '0x456' },
+      '0x789': { value: '0x789' },
+    }
+    const result = getSafeSigners(mockSafeInfo, allSigners)
+    expect(result).toEqual(['0x123', '0x456', '0x789'])
+  })
+})

--- a/apps/mobile/src/utils/signer.ts
+++ b/apps/mobile/src/utils/signer.ts
@@ -1,0 +1,7 @@
+import { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+export const getSafeSigners = (SafeInfo: SafeOverview, signers: Record<string, AddressInfo>) => {
+  const owners = SafeInfo.owners.map((owner) => owner.value)
+  return owners.filter((owner) => signers[owner])
+}


### PR DESCRIPTION
## What it solves
Displays a "this is a read-only account" if there is no signer imported for the safe. 

## How to test it
You should see a "this is a read-only acocunt" in safe's where you haven't imported a signer.

## Screenshots
<img src="https://github.com/user-attachments/assets/a85122a2-b41e-46b4-8bc7-8b2e9ea21cc3" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
