### PR TITLE
[Safenet Prototype] Add Transaction Policy Verification

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2
 }

--- a/apps/web/src/components/tx/ReviewTransaction/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransaction/ReviewTransactionContent.tsx
@@ -30,6 +30,8 @@ import { Button, CardActions, CircularProgress, Stack } from '@mui/material'
 import BatchButton from '../SignOrExecuteForm/BatchButton'
 import { TxModalContext } from '@/components/tx-flow'
 import CheckWallet from '@/components/common/CheckWallet'
+import TxPolicies from '@/features/policies/components/TxPolicies'
+import useIsPoliciesEnabled from '@/features/policies/hooks/useIsPoliciesEnabled'
 
 export type ReviewTransactionContentProps = {
   txId?: string
@@ -83,6 +85,7 @@ export const ReviewTransactionContent = ({
   const isProposer = useIsWalletProposer()
   const isProposing = isProposer && !isSafeOwner && isCreation
   const isCounterfactualSafe = !safe.deployed
+  const isPoliciesEnabled = useIsPoliciesEnabled()
 
   // Check if a Zodiac Roles mod is enabled and if the user is a member of any role that allows the transaction
   const roles = useRoles(
@@ -169,6 +172,8 @@ export const ReviewTransactionContent = ({
 
         {!isCounterfactualSafe && !props.isRejection && <BlockaidBalanceChanges />}
       </TxCard>
+
+      {isPoliciesEnabled && safeTx && <TxPolicies transaction={safeTx} />}
 
       {!isCounterfactualSafe && !props.isRejection && safeTx && <TxChecks transaction={safeTx} />}
 

--- a/apps/web/src/features/policies/components/TxPolicies.tsx
+++ b/apps/web/src/features/policies/components/TxPolicies.tsx
@@ -1,0 +1,52 @@
+import { type ReactElement } from 'react'
+import TxCard from '@/components/tx-flow/common/TxCard'
+import { Box, SvgIcon, Typography } from '@mui/material'
+import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
+import useSafeAddress from '@/hooks/useSafeAddress'
+import SuccessIcon from '@/public/images/common/success.svg'
+import AlertIcon from '@/public/images/common/alert.svg'
+
+import { useCheckTransaction } from '../hooks/useCheckTransaction'
+
+const TxChecks = ({ transaction }: { transaction: SafeTransaction }): ReactElement | null => {
+  const safe = useSafeAddress()
+  const [ok, error, loading] = useCheckTransaction({
+    safe,
+    to: transaction.data.to,
+    value: BigInt(transaction.data.value),
+    data: transaction.data.data,
+    operation: transaction.data.operation,
+  })
+
+  let status = undefined
+  if (loading) {
+    status = <>Loading...</>
+  } else if (error || !ok) {
+    status = (
+      <Box display="flex" flexDirection="column" alignItems="center" p={2} gap={2}>
+        <Box fontSize="53px">
+          <SvgIcon component={AlertIcon} inheritViewBox fontSize="inherit" />
+        </Box>
+        Transaction violates on-chain policies
+      </Box>
+    )
+  } else if (ok) {
+    status = (
+      <Box display="flex" flexDirection="column" alignItems="center" p={2} gap={2}>
+        <Box fontSize="53px">
+          <SvgIcon component={SuccessIcon} inheritViewBox fontSize="inherit" />
+        </Box>
+        Transaction secure
+      </Box>
+    )
+  }
+
+  return (
+    <TxCard>
+      <Typography variant="h5">On-Chain Policies</Typography>
+      {status}
+    </TxCard>
+  )
+}
+
+export default TxChecks

--- a/apps/web/src/features/policies/config/constants.ts
+++ b/apps/web/src/features/policies/config/constants.ts
@@ -1,0 +1,4 @@
+export const POLICY_GUARD = '0x4DeFDB4c49a24179d9575B8476b10a20Dd9B814C'
+export const POLICY_GUARD_ABI = [
+  'function checkTransaction(address safe, address to, uint256 value, bytes data, uint8 operation, bytes context) returns (address)',
+]

--- a/apps/web/src/features/policies/hooks/useCheckTransaction.ts
+++ b/apps/web/src/features/policies/hooks/useCheckTransaction.ts
@@ -1,0 +1,25 @@
+import useAsync from '@/hooks/useAsync'
+import { getPolicyGuardContract } from '../utils/contracts'
+
+export type TransactionParameters = {
+  safe: string
+  to: string
+  value: bigint
+  data: string
+  operation: number
+  context?: string
+}
+
+export const useCheckTransaction = ({ safe, to, value, data, operation, context }: TransactionParameters) => {
+  context = context ?? '0x'
+  return useAsync(async () => {
+    const policyGuard = getPolicyGuardContract()
+    try {
+      await policyGuard.checkTransaction.staticCall(safe, to, value, data, operation, context)
+      return true
+    } catch (err) {
+      console.warn(err)
+      return false
+    }
+  }, [safe, to, value, data, operation, context])
+}

--- a/apps/web/src/features/policies/hooks/useIsPoliciesEnabled.ts
+++ b/apps/web/src/features/policies/hooks/useIsPoliciesEnabled.ts
@@ -1,0 +1,14 @@
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { sameAddress } from '@/utils/addresses'
+import { POLICY_GUARD } from '../config/constants'
+
+/**
+ * Checks that the user's Safe is enabled for policies
+ * @returns {boolean} Whether the policies guard is enabled for the user's Safe
+ */
+const useIsPoliciesEnabled = () => {
+  const { safe } = useSafeInfo()
+  return sameAddress(safe.guard?.value, POLICY_GUARD)
+}
+
+export default useIsPoliciesEnabled

--- a/apps/web/src/features/policies/utils/contracts.ts
+++ b/apps/web/src/features/policies/utils/contracts.ts
@@ -1,0 +1,12 @@
+import { getSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
+import { ethers } from 'ethers'
+import { POLICY_GUARD, POLICY_GUARD_ABI } from '../config/constants'
+
+export const getPolicyGuardContract = () => {
+  const sdk = getSafeSDK()
+  if (!sdk) {
+    throw new Error('Safe SDK not found.')
+  }
+  const provider = sdk.getSafeProvider()
+  return new ethers.Contract(POLICY_GUARD, POLICY_GUARD_ABI, provider.getExternalProvider())
+}


### PR DESCRIPTION
## What it solves

This PR adds transaction policy verification to the user interface as part of the Safenet prototyping of on-chain Safe policies.

Note that it does not add the UI for re-configuring the policies to allow the transaction - I will leave that for a follow up, to keep the PRs small.

## Screenshots

![image](https://github.com/user-attachments/assets/bd50eb56-1b73-4624-ae30-425c3308dd91)

![image](https://github.com/user-attachments/assets/037b293e-cc39-4672-bfd8-790fe6efc121)

