### PR TITLE
fix(mobile): display properly formatted amounts in queue and history

### DIFF
--- a/apps/mobile/src/components/TokenAmount/TokenAmount.tsx
+++ b/apps/mobile/src/components/TokenAmount/TokenAmount.tsx
@@ -1,0 +1,36 @@
+import { type ReactElement } from 'react'
+import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
+import { TransferDirection } from '@safe-global/store/gateway/types'
+import { Text } from 'tamagui'
+import { TransferTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+const PRECISION = 20
+
+export const TokenAmount = ({
+  value,
+  decimals,
+  tokenSymbol,
+  direction,
+  preciseAmount,
+}: {
+  value: string
+  decimals?: number | null
+  tokenSymbol?: string
+  direction?: TransferTransactionInfo['direction']
+  preciseAmount?: boolean
+}): ReactElement => {
+  const sign = direction === TransferDirection.OUTGOING ? '-' : ''
+  const amount =
+    decimals !== undefined && decimals !== null
+      ? formatVisualAmount(value, decimals, preciseAmount ? PRECISION : undefined)
+      : value
+
+  return (
+    <Text fontWeight={700}>
+      {sign}
+      {amount} {tokenSymbol}
+    </Text>
+  )
+}
+
+export default TokenAmount

--- a/apps/mobile/src/components/TokenAmount/TokenAmount.tsx
+++ b/apps/mobile/src/components/TokenAmount/TokenAmount.tsx
@@ -1,10 +1,20 @@
 import { type ReactElement } from 'react'
 import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
 import { TransferDirection } from '@safe-global/store/gateway/types'
-import { Text } from 'tamagui'
+import { Text, TextProps } from 'tamagui'
 import { TransferTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
 const PRECISION = 20
+
+interface TokenAmountProps {
+  value: string
+  decimals?: number | null
+  tokenSymbol?: string
+  direction?: TransferTransactionInfo['direction']
+  preciseAmount?: boolean
+  textProps?: TextProps
+  displayPositiveSign?: boolean
+}
 
 export const TokenAmount = ({
   value,
@@ -12,23 +22,27 @@ export const TokenAmount = ({
   tokenSymbol,
   direction,
   preciseAmount,
-}: {
-  value: string
-  decimals?: number | null
-  tokenSymbol?: string
-  direction?: TransferTransactionInfo['direction']
-  preciseAmount?: boolean
-}): ReactElement => {
-  const sign = direction === TransferDirection.OUTGOING ? '-' : ''
-  const amount =
-    decimals !== undefined && decimals !== null
-      ? formatVisualAmount(value, decimals, preciseAmount ? PRECISION : undefined)
-      : value
+  textProps,
+  displayPositiveSign,
+}: TokenAmountProps): ReactElement => {
+  const getSign = (): string => {
+    if (direction === TransferDirection.OUTGOING) {
+      return '-'
+    }
+    return displayPositiveSign ? '+' : ''
+  }
+
+  const formatAmount = (): string => {
+    if (decimals === undefined || decimals === null) {
+      return value
+    }
+    return formatVisualAmount(value, decimals, preciseAmount ? PRECISION : undefined)
+  }
 
   return (
-    <Text fontWeight={700}>
-      {sign}
-      {amount} {tokenSymbol}
+    <Text fontWeight={700} {...textProps}>
+      {getSign()}
+      {formatAmount()} {tokenSymbol}
     </Text>
   )
 }

--- a/apps/mobile/src/components/TokenAmount/index.ts
+++ b/apps/mobile/src/components/TokenAmount/index.ts
@@ -1,0 +1,1 @@
+export { TokenAmount } from './TokenAmount'

--- a/apps/mobile/src/components/transactions-list/Card/TxTokenCard/TxTokenCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxTokenCard/TxTokenCard.tsx
@@ -7,7 +7,7 @@ import { TransferDirection } from '@safe-global/store/gateway/types'
 import { TransferTransactionInfo, Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { Logo } from '@/src/components/Logo'
 import { useTokenDetails } from '@/src/hooks/useTokenDetails'
-
+import { TokenAmount } from '@/src/components/TokenAmount'
 interface TxTokenCardProps {
   bordered?: boolean
   txStatus: Transaction['txStatus']
@@ -21,15 +21,16 @@ export function TxTokenCard({ bordered, inQueue, txStatus, executionInfo, txInfo
   const isSendTx = isOutgoingTransfer(txInfo)
   const icon = isSendTx ? 'transaction-outgoing' : 'transaction-incoming'
   const type = isSendTx ? (isTxQueued(txStatus) ? 'Send' : 'Sent') : 'Received'
-  const { logoUri, name, value, tokenSymbol } = useTokenDetails(txInfo)
+  const { logoUri, name, value, tokenSymbol, decimals } = useTokenDetails(txInfo)
   const isERC721 = isERC721Transfer(txInfo.transferInfo)
   const isOutgoing = txInfo.direction === TransferDirection.OUTGOING
 
+  console.log('is send tx', isSendTx, value, decimals)
   return (
     <SafeListItem
       inQueue={inQueue}
       executionInfo={executionInfo}
-      label={name}
+      label={inQueue ? <TokenAmount value={value} decimals={decimals} tokenSymbol={tokenSymbol} preciseAmount /> : name}
       icon={icon}
       type={type}
       onPress={onPress}

--- a/apps/mobile/src/components/transactions-list/Card/TxTokenCard/TxTokenCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxTokenCard/TxTokenCard.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Text, View } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { isERC721Transfer, isOutgoingTransfer, isTxQueued } from '@/src/utils/transaction-guards'
-import { ellipsis } from '@/src/utils/formatters'
 import { TransferDirection } from '@safe-global/store/gateway/types'
 import { TransferTransactionInfo, Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { Logo } from '@/src/components/Logo'
@@ -25,7 +24,6 @@ export function TxTokenCard({ bordered, inQueue, txStatus, executionInfo, txInfo
   const isERC721 = isERC721Transfer(txInfo.transferInfo)
   const isOutgoing = txInfo.direction === TransferDirection.OUTGOING
 
-  console.log('is send tx', isSendTx, value, decimals)
   return (
     <SafeListItem
       inQueue={inQueue}
@@ -38,8 +36,16 @@ export function TxTokenCard({ bordered, inQueue, txStatus, executionInfo, txInfo
       leftNode={<Logo logoUri={logoUri} accessibilityLabel={name} />}
       rightNode={
         <View maxWidth="34%">
-          <Text color={isOutgoing ? '$color' : '$primary'} textAlign="right">
-            {isOutgoing ? '-' : '+'} {ellipsis(value, 8)} {!isERC721 && tokenSymbol}
+          <Text>
+            <TokenAmount
+              value={value}
+              decimals={decimals}
+              tokenSymbol={!isERC721 ? tokenSymbol : ''}
+              direction={txInfo.direction}
+              preciseAmount
+              displayPositiveSign
+              textProps={{ color: isOutgoing ? '$color' : '$primary', textAlign: 'right', fontWeight: 400 }}
+            />
           </Text>
         </View>
       }

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/TransactionHeader.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/TransactionHeader.tsx
@@ -14,7 +14,7 @@ interface TransactionHeaderProps {
   badgeIcon: IconName
   badgeThemeName?: BadgeThemeTypes
   badgeColor: string
-  title: string
+  title: string | React.ReactNode
   isIdenticon?: boolean
   submittedAt: number
 }
@@ -45,7 +45,7 @@ export function TransactionHeader({
       )}
 
       <View alignItems="center" gap="$1">
-        <H3 fontWeight={600}>{title}</H3>
+        {typeof title === 'string' ? <H3 fontWeight={600}>{title}</H3> : title}
         <Text color="$textSecondaryLight">
           {date} at {time}
         </Text>

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '@/src/components/Container'
-import { View, YStack, Text, Button } from 'tamagui'
+import { View, YStack, Text, Button, H3 } from 'tamagui'
 import Share from 'react-native-share'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Logo } from '@/src/components/Logo'
@@ -18,6 +18,7 @@ import { RootState } from '@/src/store'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { Address } from '@/src/types/address'
 import Logger from '@/src/utils/logger'
+import { TokenAmount } from '@/src/components/TokenAmount'
 interface TokenTransferProps {
   txInfo: TransferTransactionInfo
   executionInfo: MultisigExecutionDetails
@@ -27,7 +28,7 @@ interface TokenTransferProps {
 export function TokenTransfer({ txInfo, executionInfo, executedAt }: TokenTransferProps) {
   const activeSafe = useDefinedActiveSafe()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
-  const { value, tokenSymbol, logoUri } = useTokenDetails(txInfo)
+  const { value, tokenSymbol, logoUri, decimals } = useTokenDetails(txInfo)
 
   const recipientAddress = txInfo.recipient.value as Address
 
@@ -48,7 +49,17 @@ export function TokenTransfer({ txInfo, executionInfo, executedAt }: TokenTransf
         badgeIcon="transaction-outgoing"
         badgeThemeName="badge_error"
         badgeColor="$error"
-        title={`-${value} ${tokenSymbol}`}
+        title={
+          <H3 fontWeight={600}>
+            <TokenAmount
+              value={value}
+              decimals={decimals}
+              tokenSymbol={tokenSymbol}
+              direction={txInfo.direction}
+              preciseAmount
+            />
+          </H3>
+        }
         submittedAt={executionInfo?.submittedAt || executedAt}
       />
 

--- a/apps/mobile/src/features/PendingTx/components/PendingTxList/PendingTxList.container.tsx
+++ b/apps/mobile/src/features/PendingTx/components/PendingTxList/PendingTxList.container.tsx
@@ -34,7 +34,12 @@ export function PendingTxListContainer({
     children: (
       <>
         <NavBarTitle paddingRight={5}>Pending transactions</NavBarTitle>
-        <Badge content={`${amount}${hasMore ? '+' : ''}`} circleSize={'$6'} fontSize={10} />
+        <Badge
+          content={`${amount}${hasMore ? '+' : ''}`}
+          circleSize={'$6'}
+          fontSize={10}
+          themeName="badge_warning_variant2"
+        />
       </>
     ),
   })

--- a/apps/mobile/src/features/PendingTx/utils.tsx
+++ b/apps/mobile/src/features/PendingTx/utils.tsx
@@ -38,8 +38,8 @@ export const groupPendingTxs = (list: PendingTransactionItems[]) => {
     pointer: -1,
     amount: 0,
     sections: [
-      { title: 'Ready to execute', data: [] },
-      { title: 'Confirmation needed', data: [] },
+      { title: 'Next', data: [] },
+      { title: 'In queue', data: [] },
     ],
   }
 

--- a/apps/mobile/src/hooks/useTokenDetails/useTokenDetails.ts
+++ b/apps/mobile/src/hooks/useTokenDetails/useTokenDetails.ts
@@ -1,6 +1,5 @@
 import { selectActiveChainCurrency } from '@/src/store/chains'
 import { useAppSelector } from '@/src/store/hooks'
-import { formatValue } from '@/src/utils/formatters'
 import { isERC20Transfer, isERC721Transfer, isNativeTokenTransfer } from '@/src/utils/transaction-guards'
 import { TransferTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { ellipsis } from '@safe-global/utils/utils/formatters'
@@ -20,7 +19,7 @@ export const useTokenDetails = (txInfo: TransferTransactionInfo): tokenDetails =
 
   if (isNativeTokenTransfer(transfer) && nativeCurrency) {
     return {
-      value: formatValue(transfer.value || '0', nativeCurrency.decimals),
+      value: transfer.value || '0',
       // take it from the native currency slice
       decimals: nativeCurrency.decimals,
       tokenSymbol: nativeCurrency.symbol,
@@ -31,7 +30,7 @@ export const useTokenDetails = (txInfo: TransferTransactionInfo): tokenDetails =
 
   if (isERC20Transfer(transfer)) {
     return {
-      value: formatValue(transfer.value, transfer.decimals || 18),
+      value: transfer.value || '0',
       decimals: transfer.decimals || undefined,
       logoUri: transfer.logoUri || undefined,
       tokenSymbol: ellipsis((transfer.tokenSymbol || 'Unknown Token').trim(), 6),


### PR DESCRIPTION
## What it solves
The amounts displayed for sent/receive events were not properly formatted. In addition to that renamed the queue sectiosn to "next" and "in queue" as the old section titles were misleading.


## How to test it
Inspect transfer events in the queue and history. They should be properly formatted.

## Screenshots
<img src="https://github.com/user-attachments/assets/0270f20c-b21e-4f59-ad8b-dd85a26c4f61" width="150" />
<img src="https://github.com/user-attachments/assets/b5f6fca1-4197-41cf-8af9-ba726b31bd4d" width="150" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
