### PR TITLE
Fix(Orgs): Redirect user to accounts page if spaces feature is turned off

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceBreadcrumbs/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceBreadcrumbs/index.tsx
@@ -12,8 +12,11 @@ import { BreadcrumbItem } from '@/components/common/Breadcrumbs/BreadcrumbItem'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useParentSafe } from '@/hooks/useParentSafe'
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@/utils/chains'
 
 const SpaceBreadcrumbs = () => {
+  const isSpacesFeatureEnabled = useHasFeature(FEATURES.SPACES)
   const { pathname } = useRouter()
   const spaceId = useCurrentSpaceId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
@@ -22,7 +25,7 @@ const SpaceBreadcrumbs = () => {
   const parentSafe = useParentSafe()
   const isSpaceRoute = pathname.startsWith(AppRoutes.spaces.index)
 
-  if (!isUserSignedIn || !spaceId || isSpaceRoute || !space) {
+  if (!isUserSignedIn || !spaceId || isSpaceRoute || !space || !isSpacesFeatureEnabled) {
     return null
   }
 

--- a/apps/web/src/pages/welcome/spaces.tsx
+++ b/apps/web/src/pages/welcome/spaces.tsx
@@ -2,15 +2,29 @@ import type { NextPage } from 'next'
 import Head from 'next/head'
 import SpacesList from '@/features/spaces/components/SpacesList'
 import { BRAND_NAME } from '@/config/constants'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@/utils/chains'
+import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
+import { useEffect } from 'react'
 
 const Spaces: NextPage = () => {
+  const router = useRouter()
+  const isSpacesFeatureEnabled = useHasFeature(FEATURES.SPACES)
+
+  useEffect(() => {
+    if (!isSpacesFeatureEnabled) {
+      router.push({ pathname: AppRoutes.welcome.accounts })
+    }
+  }, [isSpacesFeatureEnabled, router])
+
   return (
     <>
       <Head>
         <title>{`${BRAND_NAME} – Spaces`}</title>
       </Head>
 
-      <SpacesList />
+      {isSpacesFeatureEnabled && <SpacesList />}
     </>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves #5230

## How this PR fixes it

- Redirects user from `/welcome/spaces` to `/welcome/accounts` if Spaces feature is turned off
- Redirects user from `/spaces/*` to `/welcome/accounts` if Spaces feature is turned off
- Only displays the spaces breadcrumbs if the feature is turned on

## How to test it

1. Turn off the feature flag
2. Navigate to the above mentioned pages
3. Observe being redirected to the accounts page
4. Open a safe and add a spaceId query param to the url
5. Observe no breadcrumbs are showing

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
