### PR TITLE
refactor(utils): move signTxServiceMessage function back to web package

### DIFF
--- a/.github/workflows/package-utils-unit-tests.yml
+++ b/.github/workflows/package-utils-unit-tests.yml
@@ -1,0 +1,37 @@
+name: Package @safe-global/utils unit tests
+on:
+  pull_request:
+    paths:
+      - packages/utils/**
+      - packages/store/**
+  push:
+    branches:
+      - main
+    paths:
+      - packages/**
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  eslint:
+    permissions:
+      checks: write
+      pull-requests: read
+      statuses: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/yarn
+
+      - name: Annotations and coverage report
+        uses: ArtiomTr/jest-coverage-report-action@v2.3.1
+        with:
+          skip-step: install
+          annotations: failed-tests
+          package-manager: yarn
+          test-script: yarn test
+          working-directory: packages/utils
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-utils-unit-tests.yml
+++ b/.github/workflows/package-utils-unit-tests.yml
@@ -26,12 +26,15 @@ jobs:
 
       - uses: ./.github/actions/yarn
 
-      - name: Annotations and coverage report
-        uses: ArtiomTr/jest-coverage-report-action@v2.3.1
+      # Run tests with coverage
+      - name: Run Jest tests with coverage
+        run: |
+          yarn workspace @safe-global/utils test:coverage --coverageReporters=text --coverageReporters=json-summary | tee ./coverage.txt && exit ${PIPESTATUS[0]}
+
+      - name: Jest Coverage Comment
+        uses: MishaKav/jest-coverage-comment@v1
         with:
-          skip-step: install
-          annotations: failed-tests
-          package-manager: yarn
-          test-script: yarn test
-          working-directory: packages/utils
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          title: Package @safe-global/utils coverage
+          coverage-summary-path: ./coverage/coverage-summary.json
+          coverage-title: Coverage
+          coverage-path: ./coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # testing
 /coverage
+/packages/utils/coverage
 
 # next.js
 **/.next/

--- a/apps/web/src/utils/gateway.ts
+++ b/apps/web/src/utils/gateway.ts
@@ -1,6 +1,32 @@
 import type { JsonRpcSigner } from 'ethers'
 import { deleteTransaction } from '@safe-global/safe-gateway-typescript-sdk'
-import { signTxServiceMessage } from '@safe-global/utils/utils/gateway'
+import { signTypedData } from './web3'
+
+export const signTxServiceMessage = async (
+  chainId: string,
+  safeAddress: string,
+  safeTxHash: string,
+  signer: JsonRpcSigner,
+): Promise<string> => {
+  return await signTypedData(signer, {
+    types: {
+      DeleteRequest: [
+        { name: 'safeTxHash', type: 'bytes32' },
+        { name: 'totp', type: 'uint256' },
+      ],
+    },
+    domain: {
+      name: 'Safe Transaction Service',
+      version: '1.0',
+      chainId,
+      verifyingContract: safeAddress,
+    },
+    message: {
+      safeTxHash,
+      totp: Math.floor(Date.now() / 3600e3),
+    },
+  })
+}
 
 export const deleteTx = async ({
   chainId,

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -2,4 +2,6 @@ const preset = require('../../config/test/presets/jest-preset')
 
 module.exports = {
   ...preset,
+  collectCoverage: true,
+  collectCoverageFrom: ['<rootDir>/src/**/*.ts']
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,8 @@
   "description": "A collection of utility functions used across the Safe apps",
   "version": "1.0.0",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/utils/src/features/swap/helpers/__tests__/utils.test.ts
+++ b/packages/utils/src/features/swap/helpers/__tests__/utils.test.ts
@@ -8,8 +8,11 @@ import {
   isSettingTwapFallbackHandler,
   TWAP_FALLBACK_HANDLER,
 } from '../utils'
-import type { DataDecoded, TwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
-import { type SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
+import type {
+  DataDecoded,
+  TwapOrderTransactionInfo as TwapOrder,
+  SwapOrderTransactionInfo as SwapOrder,
+} from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
 describe('Swap helpers', () => {
   test('sellAmount bigger than buyAmount', () => {

--- a/packages/utils/src/utils/gateway.ts
+++ b/packages/utils/src/utils/gateway.ts
@@ -1,6 +1,4 @@
 import { type Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import type { JsonRpcSigner } from 'ethers'
-import { signTypedData } from '@safe-global/web/src/utils/web3'
 
 export const _replaceTemplate = (uri: string, data: Record<string, string>): string => {
   // Template syntax returned from gateway is {{this}}
@@ -26,29 +24,4 @@ export const getExplorerLink = (
   const title = `View on ${new URL(href).hostname}`
 
   return { href, title }
-}
-export const signTxServiceMessage = async (
-  chainId: string,
-  safeAddress: string,
-  safeTxHash: string,
-  signer: JsonRpcSigner,
-): Promise<string> => {
-  return await signTypedData(signer, {
-    types: {
-      DeleteRequest: [
-        { name: 'safeTxHash', type: 'bytes32' },
-        { name: 'totp', type: 'uint256' },
-      ],
-    },
-    domain: {
-      name: 'Safe Transaction Service',
-      version: '1.0',
-      chainId,
-      verifyingContract: safeAddress,
-    },
-    message: {
-      safeTxHash,
-      totp: Math.floor(Date.now() / 3600e3),
-    },
-  })
 }


### PR DESCRIPTION
## What it solves
This functions needs signTypeData from the web utils/web3 helper. Unfortunately if I move the helper to the utils package it drags with itself the typedData dependency from the safe-gateway-typescript-sdk. If I don’t move the function the mobile app can’t be build because the @safe-global/web package has a stream dependency from nodejs which cannot be resolved by the metro bundler. Until we ditch the safe-gateway-typescript-sdk this type will live in apps/web package.


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
