### PR TITLE
fix(mobile): don’t use location APIs

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -74,6 +74,7 @@ export default {
         {
           cameraPermissionText: 'Safe{Wallet} needs access to your Camera to scan QR Codes.',
           enableCodeScanner: true,
+          enableLocation: false
         },
       ],
       ['./expo-plugins/withDrawableAssets.js', './assets/android/drawable'],


### PR DESCRIPTION
## What it solves
Vision Camera is including location APIs, needed to properly tag an image, but since we don’t take images, we don’t need this.

Resolves #
This should put an end to "ITMS-90683: Missing purpose string in Info.plist" email that we get from apple.

## How to test it
Merge this, publish a release and wait for the mail...

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
