### PR TITLE
Fix(Orgs): Adjust send token buttons style within spaces

### DIFF
--- a/apps/web/src/features/spaces/components/SafeAccounts/SendTransactionButton.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SendTransactionButton.tsx
@@ -64,7 +64,7 @@ const SendTransactionButton = ({ safe }: { safe: SafeOverview }) => {
   return (
     <Tooltip placement="top" title={canSend ? 'Send tokens' : 'You are not a signer of this Safe Account'}>
       <span>
-        <IconButton className={css.sendButton} size="small" onClick={onNewTxClick} disabled={!canSend}>
+        <IconButton className={css.sendButton} size="medium" onClick={onNewTxClick} disabled={!canSend}>
           <ArrowOutwardIcon />
         </IconButton>
       </span>

--- a/apps/web/src/features/spaces/components/SafeAccounts/styles.module.css
+++ b/apps/web/src/features/spaces/components/SafeAccounts/styles.module.css
@@ -1,6 +1,6 @@
 
 .sendButton {
-    background-color: var(--color-text-disabled);
+    background-color: var(--color-background-main);
     border-radius: 3px;
     margin: 0 var(--space-1);
 }
@@ -11,5 +11,8 @@
 
 .sendButton:global(.Mui-disabled) {
     background-color: var(--color-background-main);
-    opacity: 0.6;
+}
+
+.sendButton:global(.Mui-disabled) svg path {
+    fill: var(--color-border-main);
 }


### PR DESCRIPTION
## What it solves

Resolves #5386

## How this PR fixes it

- Makes the buttons slightly larger
- Changes the background color and disabled color in light and dark mode according to Figma

## How to test it

1. Open a space with safe accounts
2. Compare the send token button design with Figma
3. Switch to a wallet thats not an owner of that safe
4. Compare the disabled button design with Figma

## Screenshots

Light mode not disabled
<img width="565" alt="Screenshot 2025-03-31 at 12 23 19" src="https://github.com/user-attachments/assets/6e4a5dc2-aa89-4654-832a-39a30f5f9483" />

Dark mode not disabled
<img width="557" alt="Screenshot 2025-03-31 at 12 23 40" src="https://github.com/user-attachments/assets/a17c29b5-1e51-49dd-af5b-caee38b24b6c" />

Light mode disabled
<img width="630" alt="Screenshot 2025-03-31 at 12 24 19" src="https://github.com/user-attachments/assets/ccf87807-819e-4468-bd62-12f2a0725a5d" />

Dark mode disabled
<img width="649" alt="Screenshot 2025-03-31 at 12 24 02" src="https://github.com/user-attachments/assets/5df983d3-d30d-44bb-81a1-29c11b32cddf" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
