### PR TITLE
Fix(Orgs): Nested safe breadcrumbs, add breadcrumb analytics events

### DIFF
--- a/apps/web/src/components/common/NestedSafeBreadcrumbs/index.tsx
+++ b/apps/web/src/components/common/NestedSafeBreadcrumbs/index.tsx
@@ -5,22 +5,30 @@ import type { ReactElement } from 'react'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useParentSafe } from '@/hooks/useParentSafe'
 import { BreadcrumbItem } from '@/components/common/Breadcrumbs/BreadcrumbItem'
+import { formatPrefixedAddress } from '@safe-global/utils/utils/addresses'
+import { useChain } from '@/hooks/useChains'
 
 export function NestedSafeBreadcrumbs(): ReactElement | null {
-  const { pathname } = useRouter()
+  const { pathname, query } = useRouter()
   const { safeAddress } = useSafeInfo()
   const parentSafe = useParentSafe()
+  const currentChain = useChain(parentSafe?.chainId || '')
 
   if (!parentSafe) {
     return null
   }
+
+  const prefixedAddress = formatPrefixedAddress(parentSafe.address.value, currentChain?.shortName)
 
   return (
     <>
       <BreadcrumbItem
         title="Parent Safe"
         address={parentSafe.address.value}
-        href={{ pathname, query: { safe: parentSafe.address.value } }}
+        href={{
+          pathname,
+          query: { ...query, safe: prefixedAddress },
+        }}
       />
       <Typography variant="body2">/</Typography>
       <BreadcrumbItem title="Nested Safe" address={safeAddress} />

--- a/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
@@ -3,17 +3,7 @@ import type { SafeListProps } from '@/features/myAccounts/components/SafesList'
 import SpaceSafeContextMenu from '@/features/spaces/components/SafeAccounts/SpaceSafeContextMenu'
 import { type SafeOverview } from '@safe-global/safe-gateway-typescript-sdk'
 import { useMemo, useRef } from 'react'
-import {
-  ListItemButton,
-  Box,
-  Typography,
-  IconButton,
-  SvgIcon,
-  Skeleton,
-  useTheme,
-  useMediaQuery,
-  ListItem,
-} from '@mui/material'
+import { ListItemButton, Box, Typography, IconButton, SvgIcon, Skeleton, useTheme, useMediaQuery } from '@mui/material'
 import Link from 'next/link'
 import Track from '@/components/common/Track'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS, PIN_SAFE_LABELS, trackEvent } from '@/services/analytics'
@@ -76,7 +66,11 @@ const SingleAccountItem = ({
 
   const dispatch = useAppDispatch()
 
-  const trackingLabel = isWelcomePage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
+  const trackingLabel = isWelcomePage
+    ? OVERVIEW_LABELS.login_page
+    : isSpaceSafe
+      ? OVERVIEW_LABELS.space_page
+      : OVERVIEW_LABELS.sidebar
 
   const getHref = useGetHref(router)
 
@@ -288,12 +282,7 @@ const SingleAccountItem = ({
     </>
   )
 
-  return isSpaceSafe ? (
-    <ListItem component="div" ref={elementRef} className={css.listItem}>
-      <Box className={css.safeLink}>{content}</Box>
-      {actions}
-    </ListItem>
-  ) : (
+  return (
     <ListItemButton
       ref={elementRef}
       data-testid="safe-list-item"

--- a/apps/web/src/features/myAccounts/hooks/useGetHref.ts
+++ b/apps/web/src/features/myAccounts/hooks/useGetHref.ts
@@ -2,6 +2,7 @@ import { AppRoutes } from '@/config/routes'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { type NextRouter } from 'next/router'
 import { useCallback } from 'react'
+import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
 
 /**
  * Navigate to the dashboard when selecting a safe on the welcome page,
@@ -9,16 +10,22 @@ import { useCallback } from 'react'
  * otherwise keep the current route
  */
 export const useGetHref = (router: NextRouter) => {
+  const isSpacePage = useIsSpaceRoute()
   const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
   const isSingleTxPage = router.pathname === AppRoutes.transactions.tx
 
   return useCallback(
     (chain: ChainInfo, address: string) => {
       return {
-        pathname: isWelcomePage ? AppRoutes.home : isSingleTxPage ? AppRoutes.transactions.history : router.pathname,
+        pathname:
+          isWelcomePage || isSpacePage
+            ? AppRoutes.home
+            : isSingleTxPage
+              ? AppRoutes.transactions.history
+              : router.pathname,
         query: { ...router.query, safe: `${chain.shortName}:${address}` },
       }
     },
-    [isSingleTxPage, isWelcomePage, router.pathname, router.query],
+    [isSingleTxPage, isWelcomePage, isSpacePage, router.pathname, router.query],
   )
 }

--- a/apps/web/src/features/spaces/components/SpaceBreadcrumbs/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceBreadcrumbs/index.tsx
@@ -14,6 +14,8 @@ import { useParentSafe } from '@/hooks/useParentSafe'
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
+import Track from '@/components/common/Track'
+import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 
 const SpaceBreadcrumbs = () => {
   const isSpacesFeatureEnabled = useHasFeature(FEATURES.SPACES)
@@ -31,20 +33,24 @@ const SpaceBreadcrumbs = () => {
 
   return (
     <>
-      <Link href={{ pathname: AppRoutes.welcome.spaces }} passHref>
-        <IconButton size="small">
-          <SvgIcon component={SpaceIcon} inheritViewBox sx={{ fill: 'none' }} fontSize="small" color="primary" />
-        </IconButton>
-      </Link>
+      <Track {...SPACE_EVENTS.OPEN_SPACE_LIST_PAGE} label={SPACE_LABELS.space_breadcrumbs}>
+        <Link href={{ pathname: AppRoutes.welcome.spaces }} passHref>
+          <IconButton size="small">
+            <SvgIcon component={SpaceIcon} inheritViewBox sx={{ fill: 'none' }} fontSize="small" color="primary" />
+          </IconButton>
+        </Link>
+      </Track>
 
       <Typography variant="body2">/</Typography>
 
-      <Link href={{ pathname: AppRoutes.spaces.index, query: { spaceId } }} passHref className={css.spaceName}>
-        <InitialsAvatar name={space.name} size="xsmall" />
-        <Typography variant="body2" fontWeight="bold">
-          {space.name}
-        </Typography>
-      </Link>
+      <Track {...SPACE_EVENTS.OPEN_SPACE_DASHBOARD} label={SPACE_LABELS.space_breadcrumbs}>
+        <Link href={{ pathname: AppRoutes.spaces.index, query: { spaceId } }} passHref className={css.spaceName}>
+          <InitialsAvatar name={space.name} size="xsmall" />
+          <Typography variant="body2" fontWeight="bold">
+            {space.name}
+          </Typography>
+        </Link>
+      </Track>
 
       <Typography variant="body2">/</Typography>
 

--- a/apps/web/src/services/analytics/events/overview.ts
+++ b/apps/web/src/services/analytics/events/overview.ts
@@ -209,4 +209,5 @@ export enum OVERVIEW_LABELS {
   login_page = 'login_page',
   settings = 'settings',
   space_list_page = 'space_list_page',
+  space_page = 'space_page',
 }

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -15,6 +15,10 @@ export const SPACE_EVENTS = {
     action: 'Open space list page',
     category: SPACE_CATEGORY,
   },
+  OPEN_SPACE_DASHBOARD: {
+    action: 'Open space dashboard',
+    category: SPACE_CATEGORY,
+  },
   CREATE_SPACE_MODAL: {
     action: 'Open create space dialog',
     category: SPACE_CATEGORY,
@@ -144,4 +148,5 @@ export enum SPACE_LABELS {
   member_list = 'member_list',
   invite_list = 'invite_list',
   add_accounts_modal = 'add_accounts_modal',
+  space_breadcrumbs = 'space_breadcrumbs',
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/58

## How this PR fixes it

- Fixes the parent safe link in the nested safe breadcrumbs by including the chain prefix in the pathname
- Includes all other query params in the parent safe link as well
- Adds two new analytics events to the space breadcrumbs when navigating to a space or to the space list
- Adds a link to the safe when clicking a safe item in spaces

## How to test it

1. Open a nested safe so that the breadcrumbs are visible
2. Add a spaceId parameter to the url
3. Observe the spaces breadcrumbs also appear
4. Press the parent safe button
5. Observe the spaceId stays in the url and the breadcrumbs are still visible
6. Press the space button and the space overview button
7. Observe analytics events for both

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
