### PR TITLE
Fix(Spaces): add missing tracking event and remove misfiring events

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -47,6 +47,7 @@ import { addOrUpdateSafe, pinSafe, selectAllAddedSafes, unpinSafe } from '@/stor
 import { defaultSafeInfo } from '@/store/safeInfoSlice'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import { getComparator } from '@/features/myAccounts/utils/utils'
+import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
 
 export const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
   return (
@@ -77,6 +78,7 @@ function useMultiAccountItemData(multiSafeAccountItem: MultiChainSafeItem) {
 
   const router = useRouter()
   const isWelcomePage = router.pathname === AppRoutes.welcome.accounts
+  const isSpaceRoute = useIsSpaceRoute()
   const safeAddress = useSafeAddress()
   const isCurrentSafe = sameAddress(safeAddress, address)
 
@@ -134,6 +136,7 @@ function useMultiAccountItemData(multiSafeAccountItem: MultiChainSafeItem) {
     isReadOnly,
     isWelcomePage,
     deployedChainIds,
+    isSpaceRoute,
   }
 }
 
@@ -232,6 +235,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = fal
     isReadOnly,
     isWelcomePage,
     deployedChainIds,
+    isSpaceRoute,
   } = useMultiAccountItemData(multiSafeAccountItem)
   const { addToPinnedList, removeFromPinnedList } = usePinActions(address, name, sortedSafes, safeOverviews)
 
@@ -240,7 +244,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = fal
 
   const toggleExpand = () => {
     setExpanded((prev) => {
-      if (!prev) {
+      if (!prev && !isSpaceRoute) {
         trackEvent({ ...OVERVIEW_EVENTS.EXPAND_MULTI_SAFE, label: trackingLabel })
       }
       return !prev

--- a/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
@@ -2,9 +2,10 @@ import Track from '@/components/common/Track'
 import { AppRoutes } from '@/config/routes'
 import css from '@/features/myAccounts/styles.module.css'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
-import { Chip, Link, Stack, Typography } from '@mui/material'
+import { Chip, Stack, Typography } from '@mui/material'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
+import Link from 'next/link'
 
 const AccountsNavigation = () => {
   const router = useRouter()

--- a/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
@@ -1,4 +1,3 @@
-import Track from '@/components/common/Track'
 import { AppRoutes } from '@/config/routes'
 import css from '@/features/myAccounts/styles.module.css'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
@@ -6,12 +5,19 @@ import { Chip, Stack, Typography } from '@mui/material'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
+import { trackEvent } from '@/services/analytics'
 
 const AccountsNavigation = () => {
   const router = useRouter()
 
   const isActiveNavigation = (pathname: string) => {
     return router.pathname === pathname
+  }
+
+  const trackOpenSpaces = () => {
+    if (isActiveNavigation(AppRoutes.welcome.spaces)) {
+      trackEvent({ ...SPACE_EVENTS.OPEN_SPACE_LIST_PAGE, label: SPACE_LABELS.accounts_page })
+    }
   }
 
   return (
@@ -26,15 +32,14 @@ const AccountsNavigation = () => {
       </Typography>
 
       <Typography variant="h1" fontWeight={700} className={css.title}>
-        <Track {...SPACE_EVENTS.OPEN_SPACE_LIST_PAGE} label={SPACE_LABELS.accounts_page}>
-          <Link
-            href={AppRoutes.welcome.spaces}
-            className={classNames(css.link, { [css.active]: isActiveNavigation(AppRoutes.welcome.spaces) })}
-          >
-            Spaces
-            <Chip label="Beta" size="small" sx={{ ml: 1, fontWeight: 'normal', borderRadius: '4px' }} />
-          </Link>
-        </Track>
+        <Link
+          onClick={trackOpenSpaces}
+          href={AppRoutes.welcome.spaces}
+          className={classNames(css.link, { [css.active]: isActiveNavigation(AppRoutes.welcome.spaces) })}
+        >
+          Spaces
+          <Chip label="Beta" size="small" sx={{ ml: 1, fontWeight: 'normal', borderRadius: '4px' }} />
+        </Link>
       </Typography>
     </Stack>
   )

--- a/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
@@ -14,7 +14,7 @@ const AccountsNavigation = () => {
     return router.pathname === pathname
   }
 
-  const trackOpenSpaces = () => {
+  const trackSpacesClick = () => {
     if (isActiveNavigation(AppRoutes.welcome.spaces)) {
       trackEvent({ ...SPACE_EVENTS.OPEN_SPACE_LIST_PAGE, label: SPACE_LABELS.accounts_page })
     }
@@ -33,7 +33,7 @@ const AccountsNavigation = () => {
 
       <Typography variant="h1" fontWeight={700} className={css.title}>
         <Link
-          onClick={trackOpenSpaces}
+          onClick={trackSpacesClick}
           href={AppRoutes.welcome.spaces}
           className={classNames(css.link, { [css.active]: isActiveNavigation(AppRoutes.welcome.spaces) })}
         >

--- a/apps/web/src/features/spaces/components/SpaceCard/SpaceContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCard/SpaceContextMenu.tsx
@@ -12,6 +12,8 @@ import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED
 import css from './styles.module.css'
 import DeleteSpaceDialog from '@/features/spaces/components/SpaceSettings/DeleteSpaceDialog'
 import UpdateSpaceDialog from '@/features/spaces/components/SpaceSettings/UpdateSpaceDialog'
+import Track from '@/components/common/Track'
+import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 
 enum ModalType {
   RENAME = 'rename',
@@ -57,12 +59,14 @@ const SpaceContextMenu = ({ space }: { space: GetSpaceResponse }) => {
           <ListItemText>Rename</ListItemText>
         </MenuItem>
 
-        <MenuItem onClick={(e) => handleOpenModal(e, ModalType.REMOVE)}>
-          <ListItemIcon>
-            <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" color="error" />
-          </ListItemIcon>
-          <ListItemText>Remove</ListItemText>
-        </MenuItem>
+        <Track {...SPACE_EVENTS.DELETE_SPACE_MODAL} label={SPACE_LABELS.space_dashboard_card}>
+          <MenuItem onClick={(e) => handleOpenModal(e, ModalType.REMOVE)}>
+            <ListItemIcon>
+              <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" color="error" />
+            </ListItemIcon>
+            <ListItemText>Remove</ListItemText>
+          </MenuItem>
+        </Track>
       </ContextMenu>
 
       {open[ModalType.RENAME] && <UpdateSpaceDialog space={space} onClose={handleCloseModal} />}

--- a/apps/web/src/features/spaces/components/SpaceCard/SpaceContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCard/SpaceContextMenu.tsx
@@ -59,7 +59,7 @@ const SpaceContextMenu = ({ space }: { space: GetSpaceResponse }) => {
           <ListItemText>Rename</ListItemText>
         </MenuItem>
 
-        <Track {...SPACE_EVENTS.DELETE_SPACE_MODAL} label={SPACE_LABELS.space_dashboard_card}>
+        <Track {...SPACE_EVENTS.DELETE_SPACE_MODAL} label={SPACE_LABELS.space_context_menu}>
           <MenuItem onClick={(e) => handleOpenModal(e, ModalType.REMOVE)}>
             <ListItemIcon>
               <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" color="error" />

--- a/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
@@ -19,6 +19,8 @@ import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { trackEvent } from '@/services/analytics'
 
 const ListIcon = ({ variant }: { variant: 'success' | 'danger' }) => {
   const Icon = variant === 'success' ? CheckIcon : CloseIcon
@@ -40,6 +42,7 @@ const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undef
     if (!space) return
 
     setError(undefined)
+    trackEvent({ ...SPACE_EVENTS.DELETE_SPACE })
 
     try {
       await deleteSpace({ id: space.id })

--- a/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
@@ -42,13 +42,13 @@ const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undef
     if (!space) return
 
     setError(undefined)
-    trackEvent({ ...SPACE_EVENTS.DELETE_SPACE })
 
     try {
       await deleteSpace({ id: space.id })
 
       onClose()
 
+      trackEvent({ ...SPACE_EVENTS.DELETE_SPACE })
       dispatch(
         showNotification({
           message: `Deleted space ${space.name}.`,

--- a/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
@@ -53,7 +53,7 @@ const SpaceSettings = () => {
               variant="danger"
               onClick={() => {
                 setDeleteSpaceOpen(true)
-                trackEvent({ ...SPACE_EVENTS.REMOVE_SPACE_MODAL })
+                trackEvent({ ...SPACE_EVENTS.DELETE_SPACE_MODAL })
               }}
               disabled={!isAdmin}
             >

--- a/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
@@ -9,7 +9,7 @@ import PreviewInvite from '@/features/spaces/components/InviteBanner/PreviewInvi
 import DeleteSpaceDialog from '@/features/spaces/components/SpaceSettings/DeleteSpaceDialog'
 import UpdateSpaceForm from '@/features/spaces/components/SpaceSettings/UpdateSpaceForm'
 import { trackEvent } from '@/services/analytics'
-import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import ExternalLink from '@/components/common/ExternalLink'
 import { AppRoutes } from '@/config/routes'
 
@@ -53,7 +53,7 @@ const SpaceSettings = () => {
               variant="danger"
               onClick={() => {
                 setDeleteSpaceOpen(true)
-                trackEvent({ ...SPACE_EVENTS.DELETE_SPACE_MODAL })
+                trackEvent({ ...SPACE_EVENTS.DELETE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
               }}
               disabled={!isAdmin}
             >

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -144,4 +144,5 @@ export enum SPACE_LABELS {
   member_list = 'member_list',
   invite_list = 'invite_list',
   add_accounts_modal = 'add_accounts_modal',
+  space_settings = 'space_settings',
 }

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -91,12 +91,12 @@ export const SPACE_EVENTS = {
     action: 'Submit delete account',
     category: SPACE_CATEGORY,
   },
-  REMOVE_SPACE_MODAL: {
-    action: 'Open remove space modal',
+  DELETE_SPACE_MODAL: {
+    action: 'Open delete space modal',
     category: SPACE_CATEGORY,
   },
-  REMOVE_SPACE: {
-    action: 'Submit remove space',
+  DELETE_SPACE: {
+    action: 'Submit delete space',
     category: SPACE_CATEGORY,
   },
   VIEW_ALL_ACCOUNTS: {

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -145,4 +145,5 @@ export enum SPACE_LABELS {
   invite_list = 'invite_list',
   add_accounts_modal = 'add_accounts_modal',
   space_settings = 'space_settings',
+  space_context_menu = 'space_context_menu',
 }


### PR DESCRIPTION
## What it solves

QA feedback for: https://github.com/safe-global/safe-wallet-monorepo/issues/5055

## How this PR fixes it
- do not send a tracking event when clicking the `Spaces` tab on the accounts page, if it has already been selected
- do not send an event for expanding a multi chain safe in the space accounts list.
- add missing events in the delete space flow.
- Minor name changes.

## How to test it
- go to the accounts page and click the spaces tab. See that the event is fired correctly. Clicking the tab again immediately should not fire the event a second time.
- go to the accounts list for a space. Expand a multichain safe item. See that no event is fired.
- Open the `delete space` dialog from the context menu in the spaces list. See that an event is fired.
- Click the confirm deletion from the `delete space` dialog. See that an event is fired.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
