### PR TITLE
Fix(Orgs): Update aggregated balances design

### DIFF
--- a/apps/web/src/features/spaces/components/Dashboard/styles.module.css
+++ b/apps/web/src/features/spaces/components/Dashboard/styles.module.css
@@ -42,7 +42,6 @@
 }
 
 .chainIndicatorColor {
-  width: 100%;
   display: block;
   height: 100%;
   border-radius: 5px;


### PR DESCRIPTION
## What it solves

Follow-up on #5464 

## How this PR fixes it

- Adjusts the design of the aggregated balances to include chain logos
- Displays the chain indicator as a percentage of the total

## How to test it

1. Compare with [Figma](https://www.figma.com/design/PeChIDi5UKPjf58IOChtET/Spaces-(prev.-Organisations)?node-id=4641-48061&m=dev)

## Screenshots

<img width="926" alt="Screenshot 2025-03-31 at 16 18 19" src="https://github.com/user-attachments/assets/7ea9c43a-d103-473c-88d8-e0522d5da150" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
