### PR TITLE
Fix(Spaces): Allow users to dismiss spaces dashboard widget

### DIFF
--- a/apps/web/src/components/dashboard/index.tsx
+++ b/apps/web/src/components/dashboard/index.tsx
@@ -37,7 +37,7 @@ const Dashboard = (): ReactElement => {
         </Grid>
 
         {isSpacesFeatureEnabled && (
-          <Grid item xs={12}>
+          <Grid item xs={12} className={css.hideIfEmpty}>
             <SpacesDashboardWidget />
           </Grid>
         )}

--- a/apps/web/src/features/spaces/components/SpacesDashboardWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesDashboardWidget/index.tsx
@@ -1,23 +1,47 @@
-import { Box, Button, Stack, Typography } from '@mui/material'
+import { Box, Button, Chip, IconButton, Stack, Typography } from '@mui/material'
 import Track from '@/components/common/Track'
 import SpaceInfoModal from '../SpaceInfoModal'
 import { useState } from 'react'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
+import CloseIcon from '@mui/icons-material/Close'
 
 const gradientBg = {
   background: 'linear-gradient(225deg, rgba(95, 221, 255, 0.15) 12.5%, rgba(18, 255, 128, 0.15) 88.07%)',
 }
 
+const hideWidgetLocalStorageKey = 'hideSpacesDashboardWidget'
+
 const SpacesDashboardWidget = () => {
   const [isInfoOpen, setIsInfoOpen] = useState<boolean>(false)
+  const [widgetHidden = false, setWidgetHidden] = useLocalStorage<boolean>(hideWidgetLocalStorageKey)
+
+  const onHide = () => {
+    setWidgetHidden(true)
+  }
+
+  if (widgetHidden) return null
 
   return (
     <>
-      <Stack direction="row" flexWrap="wrap" gap={2} py={2} px={3} sx={gradientBg}>
+      <Stack direction="row" flexWrap="wrap" gap={2} p={3} sx={gradientBg} position="relative">
+        <Track {...SPACE_EVENTS.HIDE_DASHBOARD_WIDGET}>
+          <IconButton
+            aria-label="close"
+            onClick={onHide}
+            size="small"
+            sx={{ position: 'absolute', right: 24, top: 16 }}
+          >
+            <CloseIcon fontSize="medium" />
+          </IconButton>
+        </Track>
+
         <Box flex={1} minWidth="60%">
-          <Typography variant="h6" fontWeight="700" mb={2}>
+          <Chip label="Beta" sx={{ backgroundColor: '#12FF80', borderRadius: '4px' }} size="small" />
+
+          <Typography variant="h6" fontWeight="700" mb={2} mt={1}>
             Spaces are here!
           </Typography>
 
@@ -29,7 +53,7 @@ const SpacesDashboardWidget = () => {
           </Typography>
         </Box>
 
-        <Stack direction="row" gap={2} alignItems="center">
+        <Stack direction="row" gap={2} alignItems="flex-end">
           <Track {...SPACE_EVENTS.INFO_MODAL} label={SPACE_LABELS.safe_dashboard_banner}>
             <Button variant="outlined" onClick={() => setIsInfoOpen(true)}>
               Learn more
@@ -38,7 +62,9 @@ const SpacesDashboardWidget = () => {
 
           <Track {...SPACE_EVENTS.OPEN_SPACE_LIST_PAGE} label={SPACE_LABELS.safe_dashboard_banner}>
             <Link href={AppRoutes.welcome.spaces} passHref>
-              <Button variant="contained">Try now</Button>
+              <Button variant="contained" sx={{ minHeight: '48px' }}>
+                Try now
+              </Button>
             </Link>
           </Track>
         </Stack>

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -133,6 +133,10 @@ export const SPACE_EVENTS = {
     category: SPACE_CATEGORY,
     event: EventType.META,
   },
+  HIDE_DASHBOARD_WIDGET: {
+    action: 'Hide spaces dashboard widget',
+    category: SPACE_CATEGORY,
+  },
 }
 
 export enum SPACE_LABELS {


### PR DESCRIPTION
## What it solves

- Adds a dismiss button to the spaces widget on the dashboard
- Adds an analytics event

## How to test it

1. Open the dashboard
2. Observe there is a spaces banner
3. Press the X button
4. The banner should disappear and not appear again

## Screenshots
<img width="1273" alt="Screenshot 2025-04-01 at 12 36 01" src="https://github.com/user-attachments/assets/ed2a8cff-0992-4c7d-9c9f-95873ce5fcd7" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
