### PR TITLE
Fix(Spaces): Adjust query param inclusion in sidebar navigation

### DIFF
--- a/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
@@ -89,6 +89,11 @@ const Navigation = (): ReactElement => {
         const isSelected = currentSubdirectory === getSubdirectory(item.href)
         const isDisabled = item.disabled || !enabledNavItems.includes(item)
         let ItemTag = item.tag ? item.tag : null
+        const spaceId = router.query.spaceId
+        const query = {
+          safe: router.query.safe,
+          ...(spaceId && { spaceId }),
+        }
 
         if (item.href === AppRoutes.transactions.history) {
           ItemTag = queueSize ? <SidebarListItemCounter count={queueSize} /> : null
@@ -115,7 +120,7 @@ const Navigation = (): ReactElement => {
                   href={
                     item.href && {
                       pathname: getRoute(item.href),
-                      query: { ...router.query, safe: router.query.safe },
+                      query,
                     }
                   }
                   disabled={isDisabled}

--- a/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
@@ -115,7 +115,7 @@ const Navigation = (): ReactElement => {
                   href={
                     item.href && {
                       pathname: getRoute(item.href),
-                      query: { safe: router.query.safe, spaceId: router.query.spaceId },
+                      query: { ...router.query, safe: router.query.safe },
                     }
                   }
                   disabled={isDisabled}


### PR DESCRIPTION
## What it solves

Include all query params when navigating via the sidebar instead of always adding a `spaceId` param even if its empty

## How to test it

1. Open a safe
2. Navigate through the sidebar
3. Observe no spaceId param added to the url

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
