### PR TITLE
Fix(Spaces): Only sign in user if they submit the sign in request

### DIFF
--- a/apps/web/src/features/spaces/components/SignInButton/index.tsx
+++ b/apps/web/src/features/spaces/components/SignInButton/index.tsx
@@ -26,8 +26,10 @@ const SignInButton = () => {
         throw result.error
       }
 
-      const oneDayInMs = 24 * 60 * 60 * 1000
-      dispatch(setAuthenticated({ sessionExpiresAt: Date.now() + oneDayInMs }))
+      if (result) {
+        const oneDayInMs = 24 * 60 * 60 * 1000
+        dispatch(setAuthenticated({ sessionExpiresAt: Date.now() + oneDayInMs }))
+      }
     } catch (error) {
       logError(ErrorCodes._640)
 


### PR DESCRIPTION
## What it solves

Only sets the sign in state if the sign in request succeeded

## How to test it

1. Open `/welcome/spaces`
2. Connect your wallet and press the sign in button
3. Cancel the sign in message in your wallet
4. Observe the sign in button is still visible

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
