### PR TITLE
Fix(Spaces): Add a CTA to empty spaces card on the spaces list page

### DIFF
--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -84,7 +84,7 @@ const NoSpacesState = () => {
           </Link>
         </Box>
         <Track {...SPACE_EVENTS.CREATE_SPACE_MODAL} label={SPACE_LABELS.space_list_page}>
-          <AddSpaceButton disabled={false} size="medium" />
+          <AddSpaceButton disabled={false} />
         </Track>
       </Card>
       {isInfoOpen && (

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -28,7 +28,7 @@ const AddSpaceButton = ({ disabled }: { disabled: boolean }) => {
         variant="contained"
         size="small"
         onClick={() => setOpenCreationModal(true)}
-        sx={{ height: '36px', px: 2 }}
+        sx={{ height: '36px' }}
         disabled={disabled}
       >
         <Box mt="1px">Create space</Box>
@@ -47,7 +47,7 @@ const SignedOutState = () => {
       <Card sx={{ p: 5, textAlign: 'center' }}>
         <SpacesIcon />
 
-        <Box mb={2}>
+        <Box mb={3}>
           <Typography color="text.secondary" mb={1}>
             To view your space or create one,{' '}
             {!!wallet ? 'sign in with your connected wallet.' : 'connect your wallet.'}
@@ -74,13 +74,18 @@ const NoSpacesState = () => {
       <Card sx={{ p: 5, textAlign: 'center', width: 1 }}>
         <SpacesIcon />
 
-        <Typography color="text.secondary" mb={1}>
-          No spaces found.
-          <br />
-        </Typography>
-        <Link onClick={() => setIsInfoOpen(true)} href="#">
-          What are spaces?
-        </Link>
+        <Box mb={3}>
+          <Typography color="text.secondary" mb={1}>
+            No spaces found.
+            <br />
+          </Typography>
+          <Link onClick={() => setIsInfoOpen(true)} href="#">
+            What are spaces?
+          </Link>
+        </Box>
+        <Track {...SPACE_EVENTS.CREATE_SPACE_MODAL} label={SPACE_LABELS.space_list_page}>
+          <AddSpaceButton disabled={false} size="medium" />
+        </Track>
       </Card>
       {isInfoOpen && (
         <SpaceInfoModal onCreateSpace={() => setOpenCreationModal(true)} onClose={() => setIsInfoOpen(false)} />
@@ -104,9 +109,11 @@ const SpacesList = () => {
         <Box className={css.spacesHeader}>
           <AccountsNavigation />
 
-          <Track {...SPACE_EVENTS.CREATE_SPACE_MODAL} label={SPACE_LABELS.space_list_page}>
-            <AddSpaceButton disabled={!isUserSignedIn} />
-          </Track>
+          {isUserSignedIn && activeSpaces.length > 0 && (
+            <Track {...SPACE_EVENTS.CREATE_SPACE_MODAL} label={SPACE_LABELS.space_list_page}>
+              <AddSpaceButton disabled={false} />
+            </Track>
+          )}
         </Box>
 
         {isUserSignedIn &&

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -18,7 +18,7 @@ import Track from '@/components/common/Track'
 import SpaceInfoModal from '../SpaceInfoModal'
 import { filterSpacesByStatus } from '@/features/spaces/utils'
 
-const AddSpaceButton = ({ disabled }: { disabled: boolean }) => {
+const AddSpaceButton = () => {
   const [openCreationModal, setOpenCreationModal] = useState<boolean>(false)
 
   return (
@@ -29,7 +29,6 @@ const AddSpaceButton = ({ disabled }: { disabled: boolean }) => {
         size="small"
         onClick={() => setOpenCreationModal(true)}
         sx={{ height: '36px' }}
-        disabled={disabled}
       >
         <Box mt="1px">Create space</Box>
       </Button>
@@ -84,7 +83,7 @@ const NoSpacesState = () => {
           </Link>
         </Box>
         <Track {...SPACE_EVENTS.CREATE_SPACE_MODAL} label={SPACE_LABELS.space_list_page}>
-          <AddSpaceButton disabled={false} />
+          <AddSpaceButton />
         </Track>
       </Card>
       {isInfoOpen && (
@@ -111,7 +110,7 @@ const SpacesList = () => {
 
           {isUserSignedIn && activeSpaces.length > 0 && (
             <Track {...SPACE_EVENTS.CREATE_SPACE_MODAL} label={SPACE_LABELS.space_list_page}>
-              <AddSpaceButton disabled={false} />
+              <AddSpaceButton />
             </Track>
           )}
         </Box>


### PR DESCRIPTION
## What it solves
The CTA for the logged out and disconnected states is in the center of the screen, but for the empty state, the CTA jumps to the top right.

## How this PR fixes it
- When there are no spaces in the list, do not show the CTA at the top right, add it to the empty spaces card instead.
- Also adds some padding above the CTA for this screen and the logged out and disconnected states

## How to test it
- Go to the spaces page and sign in with a EOA that is not part of any spaces yet.
- See that the CTA to create a space is in the middle of the screen

## Screenshots
![image](https://github.com/user-attachments/assets/66f94c46-2539-4b50-88ee-6b36a1c52cfe)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
