### PR TITLE
Refactor(Spaces): Use current spaceId from local storage

### DIFF
--- a/apps/web/src/features/myAccounts/hooks/useGetHref.ts
+++ b/apps/web/src/features/myAccounts/hooks/useGetHref.ts
@@ -23,7 +23,7 @@ export const useGetHref = (router: NextRouter) => {
             : isSingleTxPage
               ? AppRoutes.transactions.history
               : router.pathname,
-        query: { ...router.query, safe: `${chain.shortName}:${address}` },
+        query: { ...(!isSpacePage && router.query), safe: `${chain.shortName}:${address}` },
       }
     },
     [isSingleTxPage, isWelcomePage, isSpacePage, router.pathname, router.query],

--- a/apps/web/src/features/spaces/components/AuthState/index.tsx
+++ b/apps/web/src/features/spaces/components/AuthState/index.tsx
@@ -1,10 +1,10 @@
-import { type ReactNode } from 'react'
+import { type ReactNode, useEffect } from 'react'
 import SignedOutState from '@/features/spaces/components/SignedOutState'
 import { isUnauthorized } from '@/features/spaces/utils'
 import UnauthorizedState from '@/features/spaces/components/UnauthorizedState'
 import LoadingState from '@/features/spaces/components/LoadingState'
-import { useAppSelector } from '@/store'
-import { isAuthenticated } from '@/store/authSlice'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { isAuthenticated, setLastUsedSpace } from '@/store/authSlice'
 import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 import { MemberStatus } from '@/features/spaces/hooks/useSpaceMembers'
@@ -13,6 +13,7 @@ import { FEATURES } from '@/utils/chains'
 import useFeatureFlagRedirect from '@/features/spaces/hooks/useFeatureFlagRedirect'
 
 const AuthState = ({ spaceId, children }: { spaceId: string; children: ReactNode }) => {
+  const dispatch = useAppDispatch()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
   const { currentData, error, isLoading } = useSpacesGetOneV1Query({ id: Number(spaceId) }, { skip: !isUserSignedIn })
@@ -22,6 +23,10 @@ const AuthState = ({ spaceId, children }: { spaceId: string; children: ReactNode
   const isCurrentUserDeclined = currentData?.members.some(
     (member) => member.user.id === currentUser?.id && member.status === MemberStatus.DECLINED,
   )
+
+  useEffect(() => {
+    dispatch(setLastUsedSpace(spaceId))
+  }, [dispatch, spaceId])
 
   if (!isSpacesFeatureEnabled) return null
 

--- a/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
@@ -66,7 +66,7 @@ const AggregatedBalanceByChain = ({ fiatTotalByChain }: { fiatTotalByChain: Fiat
 
   return (
     <Stack>
-      <Typography variant="body2" color="primary.light" mb={0.5} height="24px">
+      <Typography component="div" variant="body2" color="primary.light" mb={0.5} height="24px">
         {fiatTotalByChain.chainId === 'Other' ? 'Other' : <ChainIndicator chainId={fiatTotalByChain.chainId} />}
       </Typography>
 

--- a/apps/web/src/features/spaces/components/Dashboard/styles.module.css
+++ b/apps/web/src/features/spaces/components/Dashboard/styles.module.css
@@ -1,48 +1,48 @@
 .content {
-  min-height: calc(100vh - 100px); /* Header + padding height */
-  border-radius: 6px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+    min-height: calc(100vh - 100px); /* Header + padding height */
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .contentWrapper {
-  position: relative;
-  z-index: 1;
+    position: relative;
+    z-index: 1;
 }
 
 .contentInner {
-  background-color: var(--color-background-paper);
-  max-width: 500px;
-  padding: var(--space-5);
-  border-radius: var(--space-1);
+    background-color: var(--color-background-paper);
+    max-width: 500px;
+    padding: var(--space-5);
+    border-radius: var(--space-1);
 }
 
 .iconBG {
-  width: 40px;
-  height: 40px;
-  background-color: var(--color-background-main);
-  border-radius: 50%;
-  margin-bottom: var(--space-2);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+    width: 40px;
+    height: 40px;
+    background-color: var(--color-background-main);
+    border-radius: 50%;
+    margin-bottom: var(--space-2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .image {
-  max-width: 100%;
-  height: auto;
+    max-width: 100%;
+    height: auto;
 }
 
 .chainIndicator {
-  width: 100%;
-  height: 4px;
-  background-color: var(--color-background-main);
-  border-radius: 5px;
+    width: 100%;
+    height: 4px;
+    background-color: var(--color-background-main);
+    border-radius: 5px;
 }
 
 .chainIndicatorColor {
-  display: block;
-  height: 100%;
-  border-radius: 5px;
+    display: block;
+    height: 100%;
+    border-radius: 5px;
 }

--- a/apps/web/src/features/spaces/components/SignInButton/index.tsx
+++ b/apps/web/src/features/spaces/components/SignInButton/index.tsx
@@ -28,7 +28,7 @@ const SignInButton = () => {
 
       if (result) {
         const oneDayInMs = 24 * 60 * 60 * 1000
-        dispatch(setAuthenticated({ sessionExpiresAt: Date.now() + oneDayInMs }))
+        dispatch(setAuthenticated(Date.now() + oneDayInMs))
       }
     } catch (error) {
       logError(ErrorCodes._640)

--- a/apps/web/src/features/spaces/components/SpaceBreadcrumbs/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceBreadcrumbs/index.tsx
@@ -6,16 +6,18 @@ import { isAuthenticated } from '@/store/authSlice'
 import SpaceIcon from '@/public/images/spaces/space.svg'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
-import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useSpaceSafesGetV1Query, useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import InitialsAvatar from '@/features/spaces/components/InitialsAvatar'
 import { BreadcrumbItem } from '@/components/common/Breadcrumbs/BreadcrumbItem'
-import useSafeInfo from '@/hooks/useSafeInfo'
 import { useParentSafe } from '@/hooks/useParentSafe'
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@/utils/chains'
 import Track from '@/components/common/Track'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
+import useChainId from '@/hooks/useChainId'
+import { useMemo } from 'react'
 
 const SpaceBreadcrumbs = () => {
   const isSpacesFeatureEnabled = useHasFeature(FEATURES.SPACES)
@@ -23,11 +25,21 @@ const SpaceBreadcrumbs = () => {
   const spaceId = useCurrentSpaceId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: space } = useSpacesGetOneV1Query({ id: Number(spaceId) }, { skip: !isUserSignedIn || !spaceId })
-  const { safeAddress } = useSafeInfo()
+  const { currentData: safes } = useSpaceSafesGetV1Query(
+    { spaceId: Number(spaceId) },
+    { skip: !isUserSignedIn || !spaceId },
+  )
+  const safeAddress = useSafeAddressFromUrl()
+  const chainId = useChainId()
   const parentSafe = useParentSafe()
-  const isSpaceRoute = pathname.startsWith(AppRoutes.spaces.index)
+  const isSpaceRoute = pathname.startsWith(AppRoutes.spaces.index) || pathname.startsWith(AppRoutes.welcome.spaces)
 
-  if (!isUserSignedIn || !spaceId || isSpaceRoute || !space || !isSpacesFeatureEnabled) {
+  const isSafePartOfSpace = useMemo(
+    () => safes && Object.entries(safes.safes).some((safe) => safe[0] === chainId && safe[1].includes(safeAddress)),
+    [chainId, safeAddress, safes],
+  )
+
+  if (!isUserSignedIn || !spaceId || isSpaceRoute || !space || !isSpacesFeatureEnabled || !isSafePartOfSpace) {
     return null
   }
 

--- a/apps/web/src/features/spaces/components/SpacesDashboardWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesDashboardWidget/index.tsx
@@ -27,16 +27,13 @@ const SpacesDashboardWidget = () => {
   return (
     <>
       <Stack direction="row" flexWrap="wrap" gap={2} p={3} sx={gradientBg} position="relative">
-        <Track {...SPACE_EVENTS.HIDE_DASHBOARD_WIDGET}>
-          <IconButton
-            aria-label="close"
-            onClick={onHide}
-            size="small"
-            sx={{ position: 'absolute', right: 24, top: 16 }}
-          >
-            <CloseIcon fontSize="medium" />
-          </IconButton>
-        </Track>
+        <Box sx={{ position: 'absolute', right: 24, top: 16 }}>
+          <Track {...SPACE_EVENTS.HIDE_DASHBOARD_WIDGET}>
+            <IconButton aria-label="close" onClick={onHide} size="small">
+              <CloseIcon fontSize="medium" />
+            </IconButton>
+          </Track>
+        </Box>
 
         <Box flex={1} minWidth="60%">
           <Chip label="Beta" sx={{ backgroundColor: '#12FF80', borderRadius: '4px' }} size="small" />

--- a/apps/web/src/features/spaces/hooks/useCurrentSpaceId.ts
+++ b/apps/web/src/features/spaces/hooks/useCurrentSpaceId.ts
@@ -1,7 +1,6 @@
-import { useRouter } from 'next/router'
+import { useAppSelector } from '@/store'
+import { lastUsedSpace } from '@/store/authSlice'
 
 export const useCurrentSpaceId = () => {
-  const router = useRouter()
-  const spaceId = Array.isArray(router.query.spaceId) ? router.query.spaceId[0] : router.query.spaceId
-  return spaceId
+  return useAppSelector(lastUsedSpace)
 }

--- a/apps/web/src/store/authSlice.ts
+++ b/apps/web/src/store/authSlice.ts
@@ -4,30 +4,40 @@ import { cgwClient } from '@safe-global/store/gateway/cgwClient'
 
 type AuthPayload = {
   sessionExpiresAt: number | null
+  lastUsedSpace: string | null
 }
 
 const initialState: AuthPayload = {
   sessionExpiresAt: null,
+  lastUsedSpace: null,
 }
 
 export const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    setAuthenticated: (state, { payload }: PayloadAction<AuthPayload>) => {
-      state.sessionExpiresAt = payload.sessionExpiresAt
+    setAuthenticated: (state, { payload }: PayloadAction<AuthPayload['sessionExpiresAt']>) => {
+      state.sessionExpiresAt = payload
     },
 
     setUnauthenticated: (state) => {
       state.sessionExpiresAt = null
     },
+
+    setLastUsedSpace: (state, { payload }: PayloadAction<AuthPayload['lastUsedSpace']>) => {
+      state.lastUsedSpace = payload
+    },
   },
 })
 
-export const { setAuthenticated, setUnauthenticated } = authSlice.actions
+export const { setAuthenticated, setUnauthenticated, setLastUsedSpace } = authSlice.actions
 
 export const isAuthenticated = (state: RootState): boolean => {
   return !!state.auth.sessionExpiresAt && state.auth.sessionExpiresAt > Date.now()
+}
+
+export const lastUsedSpace = (state: RootState) => {
+  return state.auth.lastUsedSpace
 }
 
 export const authListener = (listenerMiddleware: typeof listenerMiddlewareInstance) => {


### PR DESCRIPTION
## What it solves

Instead of pushing the `spaceId` query parameter whenever the user "leaves" a space and use that as a source of truth we store it in local storage and update it whenever the `spaceId` changes.

## How this PR fixes it

- Removes the `spaceId` query parameter outside of spaces
- Stores it as part of the `authSlice`
- Checks that the currently opened safe is part of the space

## How to test it

1. Open a space
2. Navigate to one of the safes
3. Observe no spaceId in the url
4. Open a safe that is not part of the space
5. Observe the breadcrumbs are not showing

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
