### PR TITLE
Fix(Spaces): only include active members in space member count

### DIFF
--- a/apps/web/src/features/spaces/components/InviteBanner/index.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/index.tsx
@@ -13,6 +13,7 @@ import Track from '@/components/common/Track'
 import AcceptButton from './AcceptButton'
 import DeclineButton from './DeclineButton'
 import { trackEvent } from '@/services/analytics'
+import { MemberStatus } from '@/features/spaces/hooks/useSpaceMembers'
 
 type SpaceListInvite = {
   space: GetSpaceResponse
@@ -22,7 +23,7 @@ const SpaceListInvite = ({ space }: SpaceListInvite) => {
   const { id, name, members } = space
   const { currentData: currentUser } = useUsersGetWithWalletsV1Query()
   const numberOfAccounts = useSpaceSafeCount(id)
-  const numberOfMembers = members.length
+  const numberOfMembers = members.filter((member) => member.status === MemberStatus.ACTIVE).length
 
   const invitedBy = space.members.find((member) => member.user.id === currentUser?.id)?.invitedBy
 

--- a/apps/web/src/features/spaces/components/SpaceCard/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCard/index.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames'
 import { useSpaceSafeCount } from '@/features/spaces/hooks/useSpaceSafeCount'
 import InitialsAvatar from '@/features/spaces/components/InitialsAvatar'
 import SpaceContextMenu from '@/features/spaces/components/SpaceCard/SpaceContextMenu'
-import { useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
+import { MemberStatus, useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
 import { maybePlural } from '@safe-global/utils/utils/formatters'
 
 export const SpaceSummary = ({
@@ -53,7 +53,7 @@ const SpaceCard = ({
   isLink?: boolean
 }) => {
   const { id, name, members } = space
-  const numberOfMembers = members.length
+  const numberOfMembers = members.filter((member) => member.status === MemberStatus.ACTIVE).length
   const numberOfAccounts = useSpaceSafeCount(id)
   const isAdmin = useIsAdmin(id)
 


### PR DESCRIPTION
## What it solves
The member count in the space summary is showing the wrong number. It is including the invited members in the count.

## How this PR fixes it
- only count active members for the space summary.

## How to test it
- Go to a space with pending invites.
- View the space summary:
    - in the space switcher in the sidebar
    - on the spaces list page
    - on the invitation on top of the space list for an invited member
- see that the correct number of members is shown.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
