### PR TITLE
Feat(Signing UX): show unverified contracts

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -5,29 +5,30 @@ import EthHashInfo from '../EthHashInfo'
 import type { EthHashInfoProps } from '../EthHashInfo/SrcEthHashInfo'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 
-function useAddressName(address: string, name?: string | null, customAvatar?: string) {
+export function useAddressName(address?: string, name?: string | null, customAvatar?: string) {
   const chainId = useChainId()
   const web3 = useWeb3ReadOnly()
 
   const [contract, error] = useAsync(
-    () => (!name && !customAvatar ? getContract(chainId, address) : undefined),
+    () => (!name && !customAvatar && address ? getContract(chainId, address) : undefined),
     [address, chainId, name, customAvatar],
   )
 
   const [isUnverifiedContract] = useAsync<boolean>(async () => {
-    if (!error) return false // Only check via RPC if getContract returned an error
+    if (!error || !address) return false // Only check via RPC if getContract returned an error
     const code = await web3?.getCode(address)
     return code !== '0x'
   }, [address, web3, error])
 
   return {
     name: name || contract?.displayName || contract?.name || (isUnverifiedContract ? 'Unverified contract' : undefined),
-    avatar: customAvatar || contract?.logoUri,
+    logoUri: customAvatar || contract?.logoUri,
+    isUnverifiedContract,
   }
 }
 
 const NamedAddressInfo = ({ address, name, customAvatar, ...props }: EthHashInfoProps) => {
-  const { name: finalName, avatar: finalAvatar } = useAddressName(address, name, customAvatar)
+  const { name: finalName, logoUri: finalAvatar } = useAddressName(address, name, customAvatar)
 
   return <EthHashInfo address={address} name={finalName} customAvatar={finalAvatar} {...props} />
 }


### PR DESCRIPTION
## What it solves

Resolves #5557

## How this PR fixes it

Uses the existing `useAddressName` hook to show an unverified contract chip.

<img width="647" alt="Screenshot 2025-04-01 at 16 21 54" src="https://github.com/user-attachments/assets/1b9bbac8-24ce-4af7-a614-930f621a1250" />
