### PR TITLE
Fix(Spaces): flag read only safe in the space accounts list

### DIFF
--- a/apps/web/src/features/myAccounts/hooks/useAllSafesGrouped.ts
+++ b/apps/web/src/features/myAccounts/hooks/useAllSafesGrouped.ts
@@ -7,6 +7,7 @@ import useWallet from '@/hooks/wallets/useWallet'
 import useAllOwnedSafes from '@/features/myAccounts/hooks/useAllOwnedSafes'
 import { useAppSelector } from '@/store'
 import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
+import type { AllOwnedSafes } from '@safe-global/safe-gateway-typescript-sdk'
 
 export type MultiChainSafeItem = {
   address: string
@@ -31,19 +32,24 @@ export const _buildMultiChainSafeItem = (address: string, safes: SafeItems): Mul
   return { address, safes, isPinned, lastVisited, name }
 }
 
-export function _buildSafeItems(safes: Record<string, string[]>, allSafeNames: AddressBookState): SafeItem[] {
+export function _buildSafeItems(
+  safes: Record<string, string[]>,
+  allSafeNames: AddressBookState,
+  allOwned?: AllOwnedSafes,
+): SafeItem[] {
   const result: SafeItem[] = []
 
   for (const chainId in safes) {
     const addresses = safes[chainId]
 
     addresses.forEach((address) => {
+      const isReadOnly = !!allOwned && !(allOwned[chainId] || []).includes(address)
       const name = allSafeNames[chainId]?.[address]
 
       result.push({
         chainId,
         address,
-        isReadOnly: false,
+        isReadOnly,
         isPinned: false,
         lastVisited: 0,
         name,

--- a/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
@@ -8,6 +8,8 @@ import { getComparator } from '@/features/myAccounts/utils/utils'
 import { useMemo } from 'react'
 import { selectAllAddressBooks } from '@/store/addressBookSlice'
 import { isAuthenticated } from '@/store/authSlice'
+import useAllOwnedSafes from '@/features/myAccounts/hooks/useAllOwnedSafes'
+import useWallet from '@/hooks/wallets/useWallet'
 
 export const useSpaceSafes = () => {
   const spaceId = useCurrentSpaceId()
@@ -15,7 +17,9 @@ export const useSpaceSafes = () => {
   const { currentData, isLoading } = useSpaceSafesGetV1Query({ spaceId: Number(spaceId) }, { skip: !isUserSignedIn })
 
   const allSafeNames = useAppSelector(selectAllAddressBooks)
-  const safeItems = currentData ? _buildSafeItems(currentData.safes, allSafeNames) : []
+  const { address: walletAddress = '' } = useWallet() || {}
+  const [allOwned = {}] = useAllOwnedSafes(walletAddress)
+  const safeItems = currentData ? _buildSafeItems(currentData.safes, allSafeNames, allOwned) : []
   const safes = useAllSafesGrouped(safeItems)
   const { orderBy } = useAppSelector(selectOrderByPreference)
   const sortComparator = getComparator(orderBy)


### PR DESCRIPTION
## What it solves
Read only safes are missing the read only chip in the space accounts list

## How this PR fixes it
- checks if the space safes are owned by the currently connected wallet and sets the isReadOnly flag accordingly.

## How to test it
- go to the space accounts page and add a read only safe account to the space
- see that it has the read only flag in the list

## Screenshots
![image](https://github.com/user-attachments/assets/820ed20c-e722-4e39-9768-5b3db3b6504c)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
