### PR TITLE
Fix(Spaces): Only update auth slice if user was signed in

### DIFF
--- a/apps/web/src/components/common/WalletInfo/index.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.tsx
@@ -12,7 +12,7 @@ import madProps from '@/utils/mad-props'
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 import useChainId from '@/hooks/useChainId'
 import { useAuthLogoutV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
-import { setUnauthenticated } from '@/store/authSlice'
+import { setUnauthenticated, isAuthenticated } from '@/store/authSlice'
 
 type WalletInfoProps = {
   wallet: ConnectedWallet
@@ -25,6 +25,7 @@ type WalletInfoProps = {
 
 export const WalletInfo = ({ wallet, balance, currentChainId, onboard, addressBook, handleClose }: WalletInfoProps) => {
   const [authLogout] = useAuthLogoutV1Mutation()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
   const dispatch = useAppDispatch()
   const chainInfo = useAppSelector((state) => selectChainById(state, wallet.chainId))
   const prefix = chainInfo?.shortName
@@ -42,7 +43,9 @@ export const WalletInfo = ({ wallet, balance, currentChainId, onboard, addressBo
     })
     try {
       await authLogout()
-      dispatch(setUnauthenticated())
+      if (isUserSignedIn) {
+        dispatch(setUnauthenticated())
+      }
     } catch (error) {
       // TODO: handle error
     }

--- a/apps/web/src/hooks/wallets/useOnboard.ts
+++ b/apps/web/src/hooks/wallets/useOnboard.ts
@@ -12,7 +12,7 @@ import { type EnvState, selectRpc } from '@/store/settingsSlice'
 import { formatAmount } from '@safe-global/utils/utils/formatNumber'
 import { localItem } from '@/services/local-storage/local'
 import { isWalletConnect, isWalletUnlocked } from '@/utils/wallets'
-import { setUnauthenticated } from '@/store/authSlice'
+import { isAuthenticated, setUnauthenticated } from '@/store/authSlice'
 
 export type ConnectedWallet = {
   label: string
@@ -158,6 +158,7 @@ export const useInitOnboard = () => {
   const chain = useCurrentChain()
   const onboard = useStore()
   const customRpc = useAppSelector(selectRpc)
+  const isUserSignedIn = useAppSelector(isAuthenticated)
   const dispatch = useAppDispatch()
 
   useEffect(() => {
@@ -198,14 +199,17 @@ export const useInitOnboard = () => {
       } else if (lastConnectedWallet) {
         lastConnectedWallet = ''
         saveLastWallet(lastConnectedWallet)
-        dispatch(setUnauthenticated())
+
+        if (isUserSignedIn) {
+          dispatch(setUnauthenticated())
+        }
       }
     })
 
     return () => {
       walletSubscription.unsubscribe()
     }
-  }, [onboard, dispatch])
+  }, [onboard, dispatch, isUserSignedIn])
 }
 
 export default useStore


### PR DESCRIPTION
## What it solves

There were a lot of requests and flickering happening whenever the user disconnected their wallet (even if not signed in). This is because we are resetting the logged in state whenever that happens which rerenders every component where we access the authenticated state.

This PR changes this to only update the state if the user is logged in.

Note: The app still flickers in case the user is signed in and disconnects. This will be optimized in a future PR.

## How this PR fixes it

- Check for `isAuthenticated` before calling `setUnauthenticated`

## How to test it

1. Open a Safe
2. Connect your wallet
3. Disconnect your wallet
4. Observe no flicker

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
