### PR TITLE
fix: Only invalidate space related redux state

### DIFF
--- a/apps/web/src/store/authSlice.ts
+++ b/apps/web/src/store/authSlice.ts
@@ -44,7 +44,8 @@ export const authListener = (listenerMiddleware: typeof listenerMiddlewareInstan
   listenerMiddleware.startListening({
     actionCreator: authSlice.actions.setUnauthenticated,
     effect: (_action, { dispatch }) => {
-      dispatch(cgwClient.util.resetApiState())
+      // @ts-ignore TS2322: Type string is not assignable to type FullTagDescription<never>
+      dispatch(cgwClient.util.invalidateTags(['spaces']))
     },
   })
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-monorepo/pull/5575#issuecomment-2772245429

## How this PR fixes it

- Instead of calling `resetApiState` on the api slice we only invalidate the `spaces` tags when a user disconnects. This effectively removes all previous spaces data from Redux

## How to test it

1. Open a space
2. Sign in with your wallet
3. Go to a safe
4. Sign out with your wallet
5. Observe no flickering or excessive requests


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
