### PR TITLE
Fix(Spaces): Revert setUnauthenticated change

### DIFF
--- a/apps/web/src/components/common/WalletInfo/index.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.tsx
@@ -12,7 +12,7 @@ import madProps from '@/utils/mad-props'
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 import useChainId from '@/hooks/useChainId'
 import { useAuthLogoutV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
-import { setUnauthenticated, isAuthenticated } from '@/store/authSlice'
+import { setUnauthenticated } from '@/store/authSlice'
 
 type WalletInfoProps = {
   wallet: ConnectedWallet
@@ -25,7 +25,6 @@ type WalletInfoProps = {
 
 export const WalletInfo = ({ wallet, balance, currentChainId, onboard, addressBook, handleClose }: WalletInfoProps) => {
   const [authLogout] = useAuthLogoutV1Mutation()
-  const isUserSignedIn = useAppSelector(isAuthenticated)
   const dispatch = useAppDispatch()
   const chainInfo = useAppSelector((state) => selectChainById(state, wallet.chainId))
   const prefix = chainInfo?.shortName
@@ -43,9 +42,7 @@ export const WalletInfo = ({ wallet, balance, currentChainId, onboard, addressBo
     })
     try {
       await authLogout()
-      if (isUserSignedIn) {
-        dispatch(setUnauthenticated())
-      }
+      dispatch(setUnauthenticated())
     } catch (error) {
       // TODO: handle error
     }

--- a/apps/web/src/hooks/wallets/useOnboard.ts
+++ b/apps/web/src/hooks/wallets/useOnboard.ts
@@ -12,7 +12,7 @@ import { type EnvState, selectRpc } from '@/store/settingsSlice'
 import { formatAmount } from '@safe-global/utils/utils/formatNumber'
 import { localItem } from '@/services/local-storage/local'
 import { isWalletConnect, isWalletUnlocked } from '@/utils/wallets'
-import { isAuthenticated, setUnauthenticated } from '@/store/authSlice'
+import { setUnauthenticated } from '@/store/authSlice'
 
 export type ConnectedWallet = {
   label: string
@@ -158,7 +158,6 @@ export const useInitOnboard = () => {
   const chain = useCurrentChain()
   const onboard = useStore()
   const customRpc = useAppSelector(selectRpc)
-  const isUserSignedIn = useAppSelector(isAuthenticated)
   const dispatch = useAppDispatch()
 
   useEffect(() => {
@@ -199,17 +198,14 @@ export const useInitOnboard = () => {
       } else if (lastConnectedWallet) {
         lastConnectedWallet = ''
         saveLastWallet(lastConnectedWallet)
-
-        if (isUserSignedIn) {
-          dispatch(setUnauthenticated())
-        }
+        dispatch(setUnauthenticated())
       }
     })
 
     return () => {
       walletSubscription.unsubscribe()
     }
-  }, [onboard, dispatch, isUserSignedIn])
+  }, [onboard, dispatch])
 }
 
 export default useStore


### PR DESCRIPTION
## What it solves

Reverts https://github.com/safe-global/safe-wallet-monorepo/pull/5575

## How this PR fixes it

After implementing the RTK slice fix in #5576 we can safely revert the previous fix that limited the scope only

## How to test it

1. Open a safe while signed in
2. Disconnect your wallet
3. Observe no excessive network requests or flicker

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
