### PR TITLE
fix(mobile): identicon and address in contact book were wrong

### DIFF
--- a/apps/mobile/src/features/AddressBook/components/List/AddressBookList.tsx
+++ b/apps/mobile/src/features/AddressBook/components/List/AddressBookList.tsx
@@ -47,7 +47,7 @@ const ContactItem: React.FC<AddressBookContactItemProps> = ({ contact, onPress }
               </Text>
             )}
 
-            <EthAddress address={`0x${contact.value}`} textProps={textProps} />
+            <EthAddress address={`${contact.value as Address}`} textProps={textProps} />
           </View>
         }
         leftNode={

--- a/apps/mobile/src/features/AddressBook/components/List/AddressBookList.tsx
+++ b/apps/mobile/src/features/AddressBook/components/List/AddressBookList.tsx
@@ -7,6 +7,7 @@ import { Pressable } from 'react-native'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { Text, View, type TextProps } from 'tamagui'
 import { EthAddress } from '@/src/components/EthAddress'
+import { type Address } from '@/src/types/address'
 
 interface AddressBookListProps {
   contacts: AddressInfo[]
@@ -51,7 +52,7 @@ const ContactItem: React.FC<AddressBookContactItemProps> = ({ contact, onPress }
         }
         leftNode={
           <View width="$10">
-            <Identicon address={`0x${contact.value}`} rounded size={40} />
+            <Identicon address={`${contact.value as Address}`} rounded size={40} />
           </View>
         }
         rightNode={


### PR DESCRIPTION
## What it solves
Wrong indeticons are displayed for the addresses in the addressbook
Addressbook: 0x is displayed twice for the addresses in the addressbook

https://github.com/safe-global/wallet-private-tasks/issues/101
https://github.com/safe-global/wallet-private-tasks/issues/93

## How this PR fixes it
We were not casting to string, but rather prepending 0x to the value

## How to test it
Go to the contacts - the identicon should match the one displayed on settings, no 0x0x in the address.

## Screenshots
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/02abc30b-5069-4476-b40a-ae4d37d7900a" />
<img width="150" src="https://github.com/user-attachments/assets/7357a12b-a920-4852-9e48-eaf02ed8d352" />



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
