### PR TITLE
refactor: move blockaid utilities & types to @safe-global/utils

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/__snapshots__/AlreadySigned.test.tsx.snap
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/__snapshots__/AlreadySigned.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`AlreadySigned matches snapshot 1`] = `
       style={
         {
           "color": "#A1A3A7",
-          "fontSize": 16,
-          "fontWeight": 400,
+          "fontFamily": "DM Sans",
+          "fontSize": 14,
           "textAlign": "center",
         }
       }
@@ -74,8 +74,8 @@ exports[`AlreadySigned matches snapshot 1`] = `
           style={
             {
               "color": "#121312",
-              "fontSize": 16,
-              "fontWeight": 700,
+              "fontFamily": "DMSans-Bold",
+              "fontSize": 14,
               "textAlign": "center",
             }
           }

--- a/apps/web/src/components/tx/ReviewTransaction/__tests__/ReviewTransactionContent.test.tsx
+++ b/apps/web/src/components/tx/ReviewTransaction/__tests__/ReviewTransactionContent.test.tsx
@@ -7,7 +7,7 @@ import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sd
 import { ReviewTransactionContent } from '../ReviewTransactionContent'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
-import { defaultSecurityContextValues } from '../../security/shared/TxSecurityContext'
+import { defaultSecurityContextValues } from '@safe-global/utils/components/tx/security/shared/utils'
 
 const txDetails = {
   safeAddress: '0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67',

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/ExecuteForm.test.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/ExecuteForm.test.tsx
@@ -1,4 +1,4 @@
-import { defaultSecurityContextValues } from '@/components/tx/security/shared/TxSecurityContext'
+import { defaultSecurityContextValues } from '@safe-global/utils/components/tx/security/shared/utils'
 import { type AsyncResult } from '@/hooks/useAsync'
 import { createMockSafeTransaction } from '@/tests/transactions'
 import { OperationType } from '@safe-global/safe-core-sdk-types'

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/SignForm.test.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/SignForm.test.tsx
@@ -1,4 +1,4 @@
-import { defaultSecurityContextValues } from '@/components/tx/security/shared/TxSecurityContext'
+import { defaultSecurityContextValues } from '@safe-global/utils/components/tx/security/shared/utils'
 import { type ReactElement } from 'react'
 import * as hooks from '@/components/tx/SignOrExecuteForm/hooks'
 import * as useValidateTxData from '@/hooks/useValidateTxData'

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/SignFormV2.test.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/SignFormV2.test.tsx
@@ -1,4 +1,4 @@
-import { defaultSecurityContextValues } from '@/components/tx/security/shared/TxSecurityContext'
+import { defaultSecurityContextValues } from '@safe-global/utils/components/tx/security/shared/utils'
 import { type ReactElement } from 'react'
 import * as hooks from '@/components/tx/SignOrExecuteForm/hooks'
 import * as useValidateTxData from '@/hooks/useValidateTxData'

--- a/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
+++ b/apps/web/src/components/tx/security/blockaid/ContractChangeWarning.tsx
@@ -8,15 +8,7 @@ import { SecuritySeverity } from '@safe-global/utils/services/security/modules/t
 import { mapSecuritySeverity } from '../utils'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { Warning } from '.'
-
-const CONTRACT_CHANGE_TITLES_MAPPING: Record<
-  ProxyUpgradeManagement['type'] | OwnershipChangeManagement['type'] | ModulesChangeManagement['type'],
-  string
-> = {
-  PROXY_UPGRADE: 'This transaction will change the mastercopy of the Safe',
-  OWNERSHIP_CHANGE: 'This transaction will change the ownership of the Safe',
-  MODULES_CHANGE: 'This transaction contains a Safe modules change',
-}
+import { CONTRACT_CHANGE_TITLES_MAPPING } from '@safe-global/utils/components/tx/security/blockaid/utils'
 
 const ProxyUpgradeSummary = ({ beforeAddress, afterAddress }: { beforeAddress: string; afterAddress: string }) => {
   return (

--- a/apps/web/src/components/tx/security/blockaid/__tests__/useBlockaid.test.ts
+++ b/apps/web/src/components/tx/security/blockaid/__tests__/useBlockaid.test.ts
@@ -12,9 +12,9 @@ import {
 import { faker } from '@faker-js/faker/locale/af_ZA'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { safeInfoBuilder } from '@/tests/builders/safe'
-import { CLASSIFICATION_MAPPING, REASON_MAPPING } from '..'
 import { renderHook, waitFor } from '@/tests/test-utils'
 import { type SignerWallet } from '@/components/common/WalletProvider'
+import { CLASSIFICATION_MAPPING, REASON_MAPPING } from '@safe-global/utils/components/tx/security/blockaid/utils'
 
 const setupFetchStub = (data: any) => () => {
   return Promise.resolve({

--- a/apps/web/src/components/tx/security/blockaid/index.tsx
+++ b/apps/web/src/components/tx/security/blockaid/index.tsx
@@ -16,33 +16,7 @@ import { type SecurityWarningProps, mapSecuritySeverity } from '../utils'
 import { BlockaidHint } from './BlockaidHint'
 import { ContractChangeWarning } from './ContractChangeWarning'
 import { FEATURES } from '@safe-global/utils/utils/chains'
-
-export const REASON_MAPPING: Record<string, string> = {
-  raw_ether_transfer: 'transfers native currency',
-  signature_farming: 'is a raw signed transaction',
-  transfer_farming: 'transfers tokens',
-  approval_farming: 'approves erc20 tokens',
-  set_approval_for_all: 'approves all tokens of the account',
-  permit_farming: 'authorizes access or permissions',
-  seaport_farming: 'authorizes transfer of assets via Opeansea marketplace',
-  blur_farming: 'authorizes transfer of assets via Blur marketplace',
-  delegatecall_execution: 'involves a delegate call',
-}
-
-export const CLASSIFICATION_MAPPING: Record<string, string> = {
-  known_malicious: 'to a known malicious address',
-  unverified_contract: 'to an unverified contract',
-  new_address: 'to a new address',
-  untrusted_address: 'to an untrusted address',
-  address_poisoning: 'to a poisoned address',
-  losing_mint: 'resulting in a mint for a new token with a significantly higher price than the known price',
-  losing_assets: 'resulting in a loss of assets without any compensation',
-  losing_trade: 'resulting in a losing trade',
-  drainer_contract: 'to a known drainer contract',
-  user_mistake: 'resulting in a loss of assets due to an innocent mistake',
-  gas_farming_attack: 'resulting in a waste of the account address’ gas to generate tokens for a scammer',
-  other: 'resulting in a malicious outcome',
-}
+import { CLASSIFICATION_MAPPING, REASON_MAPPING } from '@safe-global/utils/components/tx/security/blockaid/utils'
 
 export const Warning = ({
   title,

--- a/apps/web/src/components/tx/security/shared/TxSecurityContext.tsx
+++ b/apps/web/src/components/tx/security/shared/TxSecurityContext.tsx
@@ -1,56 +1,9 @@
 import { SecuritySeverity } from '@safe-global/utils/services/security/modules/types'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
-import {
-  createContext,
-  type Dispatch,
-  type SetStateAction,
-  useContext,
-  useMemo,
-  useState,
-  type ReactElement,
-} from 'react'
-import type { BlockaidModuleResponse } from '@safe-global/utils/services/security/modules/BlockaidModule'
+import { createContext, type ReactElement, useContext, useMemo, useState } from 'react'
 import { useBlockaid } from '../blockaid/useBlockaid'
-
-export const defaultSecurityContextValues = {
-  blockaidResponse: {
-    warnings: [],
-    description: undefined,
-    classification: undefined,
-    reason: undefined,
-    balanceChange: undefined,
-    severity: SecuritySeverity.NONE,
-    contractManagement: undefined,
-    isLoading: false,
-    error: undefined,
-  },
-  needsRiskConfirmation: false,
-  isRiskConfirmed: false,
-  setIsRiskConfirmed: () => {},
-  isRiskIgnored: false,
-  setIsRiskIgnored: () => {},
-}
-
-export type TxSecurityContextProps = {
-  blockaidResponse:
-    | {
-        description: BlockaidModuleResponse['description']
-        classification: BlockaidModuleResponse['classification']
-        reason: BlockaidModuleResponse['reason']
-        warnings: NonNullable<BlockaidModuleResponse['issues']>
-        balanceChange: BlockaidModuleResponse['balanceChange'] | undefined
-        severity: SecuritySeverity | undefined
-        contractManagement: BlockaidModuleResponse['contractManagement'] | undefined
-        isLoading: boolean
-        error: Error | undefined
-      }
-    | undefined
-  needsRiskConfirmation: boolean
-  isRiskConfirmed: boolean
-  setIsRiskConfirmed: Dispatch<SetStateAction<boolean>>
-  isRiskIgnored: boolean
-  setIsRiskIgnored: Dispatch<SetStateAction<boolean>>
-}
+import { defaultSecurityContextValues } from '@safe-global/utils/components/tx/security/shared/utils'
+import { type TxSecurityContextProps } from '@safe-global/utils/components/tx/security/shared/types'
 
 export const TxSecurityContext = createContext<TxSecurityContextProps>(defaultSecurityContextValues)
 

--- a/packages/utils/src/components/tx/security/blockaid/utils.ts
+++ b/packages/utils/src/components/tx/security/blockaid/utils.ts
@@ -1,0 +1,39 @@
+import type {
+  ModulesChangeManagement,
+  OwnershipChangeManagement,
+  ProxyUpgradeManagement,
+} from '@safe-global/utils/services/security/modules/BlockaidModule/types'
+
+export const REASON_MAPPING: Record<string, string> = {
+  raw_ether_transfer: 'transfers native currency',
+  signature_farming: 'is a raw signed transaction',
+  transfer_farming: 'transfers tokens',
+  approval_farming: 'approves erc20 tokens',
+  set_approval_for_all: 'approves all tokens of the account',
+  permit_farming: 'authorizes access or permissions',
+  seaport_farming: 'authorizes transfer of assets via Opeansea marketplace',
+  blur_farming: 'authorizes transfer of assets via Blur marketplace',
+  delegatecall_execution: 'involves a delegate call',
+}
+export const CLASSIFICATION_MAPPING: Record<string, string> = {
+  known_malicious: 'to a known malicious address',
+  unverified_contract: 'to an unverified contract',
+  new_address: 'to a new address',
+  untrusted_address: 'to an untrusted address',
+  address_poisoning: 'to a poisoned address',
+  losing_mint: 'resulting in a mint for a new token with a significantly higher price than the known price',
+  losing_assets: 'resulting in a loss of assets without any compensation',
+  losing_trade: 'resulting in a losing trade',
+  drainer_contract: 'to a known drainer contract',
+  user_mistake: 'resulting in a loss of assets due to an innocent mistake',
+  gas_farming_attack: 'resulting in a waste of the account address’ gas to generate tokens for a scammer',
+  other: 'resulting in a malicious outcome',
+}
+export const CONTRACT_CHANGE_TITLES_MAPPING: Record<
+  ProxyUpgradeManagement['type'] | OwnershipChangeManagement['type'] | ModulesChangeManagement['type'],
+  string
+> = {
+  PROXY_UPGRADE: 'This transaction will change the mastercopy of the Safe',
+  OWNERSHIP_CHANGE: 'This transaction will change the ownership of the Safe',
+  MODULES_CHANGE: 'This transaction contains a Safe modules change',
+}

--- a/packages/utils/src/components/tx/security/shared/types.ts
+++ b/packages/utils/src/components/tx/security/shared/types.ts
@@ -1,0 +1,24 @@
+import type { BlockaidModuleResponse } from '@safe-global/utils/services/security/modules/BlockaidModule'
+import { SecuritySeverity } from '@safe-global/utils/services/security/modules/types'
+import type { Dispatch, SetStateAction } from 'react'
+
+export type TxSecurityContextProps = {
+  blockaidResponse:
+    | {
+        description: BlockaidModuleResponse['description']
+        classification: BlockaidModuleResponse['classification']
+        reason: BlockaidModuleResponse['reason']
+        warnings: NonNullable<BlockaidModuleResponse['issues']>
+        balanceChange: BlockaidModuleResponse['balanceChange'] | undefined
+        severity: SecuritySeverity | undefined
+        contractManagement: BlockaidModuleResponse['contractManagement'] | undefined
+        isLoading: boolean
+        error: Error | undefined
+      }
+    | undefined
+  needsRiskConfirmation: boolean
+  isRiskConfirmed: boolean
+  setIsRiskConfirmed: Dispatch<SetStateAction<boolean>>
+  isRiskIgnored: boolean
+  setIsRiskIgnored: Dispatch<SetStateAction<boolean>>
+}

--- a/packages/utils/src/components/tx/security/shared/utils.ts
+++ b/packages/utils/src/components/tx/security/shared/utils.ts
@@ -1,0 +1,20 @@
+import { SecuritySeverity } from '@safe-global/utils/services/security/modules/types'
+
+export const defaultSecurityContextValues = {
+  blockaidResponse: {
+    warnings: [],
+    description: undefined,
+    classification: undefined,
+    reason: undefined,
+    balanceChange: undefined,
+    severity: SecuritySeverity.NONE,
+    contractManagement: undefined,
+    isLoading: false,
+    error: undefined,
+  },
+  needsRiskConfirmation: false,
+  isRiskConfirmed: false,
+  setIsRiskConfirmed: () => {},
+  isRiskIgnored: false,
+  setIsRiskIgnored: () => {},
+}

--- a/packages/utils/src/config/constants.ts
+++ b/packages/utils/src/config/constants.ts
@@ -1,9 +1,14 @@
 export const LATEST_SAFE_VERSION =
-  process.env.NEXT_PUBLIC_SAFE_VERSION || process.env.EXPO_PUBLIC_SAFE_VERSION || '1.4.1' // Risk mitigation (Blockaid)
-export const BLOCKAID_API = 'https://client.blockaid.io'
-export const BLOCKAID_CLIENT_ID = process.env.NEXT_PUBLIC_BLOCKAID_CLIENT_ID // Safe Apps
+  process.env.NEXT_PUBLIC_SAFE_VERSION || process.env.EXPO_PUBLIC_SAFE_VERSION || '1.4.1'
+
+// Risk mitigation (Blockaid)
+export const BLOCKAID_API =
+  process.env.NEXT_PUBLIC_BLOCKAID_API || process.env.EXPO_PUBLIC_BLOCKAID_API || 'https://client.blockaid.io'
+export const BLOCKAID_CLIENT_ID =
+  process.env.NEXT_PUBLIC_BLOCKAID_CLIENT_ID || process.env.EXPO_PUBLIC_BLOCKAID_CLIENT_ID || ''
 // Access keys
 export const INFURA_TOKEN = process.env.NEXT_PUBLIC_INFURA_TOKEN || process.env.EXPO_PUBLIC_INFURA_TOKEN || ''
+// Safe Apps
 export const SAFE_APPS_INFURA_TOKEN =
   process.env.NEXT_PUBLIC_SAFE_APPS_INFURA_TOKEN || process.env.EXPO_PUBLIC_SAFE_APPS_INFURA_TOKEN || INFURA_TOKEN
 


### PR DESCRIPTION
## What it solves
Move blockaid utilities & types to @safe-global/utils. This allows us to share this functionality between web & mobile.


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
