### PR TITLE
feat(mobile): set a user-agent

### DIFF
--- a/apps/mobile/shim.js
+++ b/apps/mobile/shim.js
@@ -5,6 +5,7 @@ global.fetch = (url, options = {}) => {
   options.headers = {
     ...options.headers,
     'User-Agent': `SafeMobile/${Platform.OS === 'ios' ? 'iOS' : 'Android'}/${Application.nativeApplicationVersion}/${Application.nativeBuildVersion}`,
+    Origin: 'https://app.safe.global',
   }
   return originalFetch(url, options)
 }


### PR DESCRIPTION
## What it solves
iOS and Android are sending different user-agent headers with every fetch request. By specifying our own user-agent we can better know which request actually came through the mobile app.
