### PR TITLE
Feat(Spaces): add address book route

### DIFF
--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -53,6 +53,7 @@ export const AppRoutes = {
     safeAccounts: '/spaces/safe-accounts',
     members: '/spaces/members',
     index: '/spaces',
+    addressBook: '/spaces/address-book',
   },
   transactions: {
     tx: '/transactions/tx',

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -51,7 +51,7 @@ const SpaceAddressBook = () => {
         {isAdmin && (
           <Track {...SPACE_EVENTS.ADD_ADDRESS}>
             <Button variant="contained" startIcon={<PlusIcon />} onClick={() => {}}>
-              Add entry
+              Add contact
             </Button>
           </Track>
         )}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -1,0 +1,63 @@
+import { Button, InputAdornment, Stack, SvgIcon, TextField, Typography } from '@mui/material'
+import SearchIcon from '@/public/images/common/search.svg'
+import { useIsInvited, useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
+import PreviewInvite from '../InviteBanner/PreviewInvite'
+import Track from '@/components/common/Track'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import PlusIcon from '@/public/images/common/plus.svg'
+
+const SpaceAddressBook = () => {
+  const isAdmin = useIsAdmin()
+  const isInvited = useIsInvited()
+
+  const handleSearch = (value: string) => {
+    // TODO: implement search
+    console.log(value)
+  }
+
+  return (
+    <>
+      {isInvited && <PreviewInvite />}
+      <Typography variant="h1" mb={3}>
+        Address book
+      </Typography>
+
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="flex-start"
+        mb={3}
+        flexWrap="wrap"
+        gap={2}
+        flexDirection={{ xs: 'column-reverse', md: 'row' }}
+      >
+        <TextField
+          placeholder="Search"
+          variant="filled"
+          hiddenLabel
+          onChange={(e) => {
+            handleSearch(e.target.value)
+          }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" />
+              </InputAdornment>
+            ),
+            disableUnderline: true,
+          }}
+          size="small"
+        />
+        {isAdmin && (
+          <Track {...SPACE_EVENTS.ADD_ADDRESS}>
+            <Button variant="contained" startIcon={<PlusIcon />} onClick={() => {}}>
+              Add entry
+            </Button>
+          </Track>
+        )}
+      </Stack>
+    </>
+  )
+}
+
+export default SpaceAddressBook

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
@@ -45,7 +45,6 @@ export const navItems: DynamicNavItem[] = [
     label: 'Address book',
     icon: <SvgIcon component={ABIcon} inheritViewBox />,
     href: AppRoutes.spaces.addressBook,
-    disabled: false,
   },
   {
     label: 'Settings',

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
@@ -44,9 +44,8 @@ export const navItems: DynamicNavItem[] = [
   {
     label: 'Address book',
     icon: <SvgIcon component={ABIcon} inheritViewBox />,
-    href: '', // TODO: Replace with empty page
-    disabled: true,
-    tag: <Chip label="Soon" sx={{ backgroundColor: 'background.main', color: 'primary.main' }} />,
+    href: AppRoutes.spaces.addressBook,
+    disabled: false,
   },
   {
     label: 'Settings',

--- a/apps/web/src/hooks/useIsSpaceRoute.ts
+++ b/apps/web/src/hooks/useIsSpaceRoute.ts
@@ -7,6 +7,7 @@ const SPACES_ROUTES = [
   AppRoutes.spaces.settings,
   AppRoutes.spaces.members,
   AppRoutes.spaces.safeAccounts,
+  AppRoutes.spaces.addressBook,
 ]
 
 export const useIsSpaceRoute = (): boolean => {

--- a/apps/web/src/pages/spaces/address-book.tsx
+++ b/apps/web/src/pages/spaces/address-book.tsx
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import { BRAND_NAME } from '@/config/constants'
+import AuthState from '@/features/spaces/components/AuthState'
+import SpaceAddressBook from '@/features/spaces/components/SpaceAddressBook'
+
+export default function SpaceSettingsPage() {
+  const router = useRouter()
+  const { spaceId } = router.query
+
+  if (!router.isReady || !spaceId || typeof spaceId !== 'string') return null
+
+  return (
+    <>
+      <Head>
+        <title>{`${BRAND_NAME} – Space address book`}</title>
+      </Head>
+
+      <main>
+        <AuthState spaceId={spaceId}>
+          <SpaceAddressBook />
+        </AuthState>
+      </main>
+    </>
+  )
+}

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -137,6 +137,10 @@ export const SPACE_EVENTS = {
     action: 'Hide spaces dashboard widget',
     category: SPACE_CATEGORY,
   },
+  ADD_ADDRESS: {
+    action: 'Add address',
+    category: SPACE_CATEGORY,
+  },
 }
 
 export enum SPACE_LABELS {


### PR DESCRIPTION
## What it solves

Resolves: https://github.com/safe-global/wallet-private-tasks/issues/109#issue-2969278932

## How this PR fixes it
- Adds the address book route
- Updates `routes.ts`
- Adds the route to the list of spaces routes.
- renders an empty page with dummy button and search input.

## How to test it
- Open a space
- Click the address book link in the sidebar. The link should be enabled, and redirect to `/spaces/address-book`
- It should show an empty address book page with just the title, search bar, and add button.

## Screenshots
![image](https://github.com/user-attachments/assets/53a76615-7884-40a7-b8a5-9a09800469aa)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
