### PR TITLE
fix(mobile): Add UI touches and fix flow after QA round

### DIFF
--- a/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
+++ b/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '../Container'
-import { Text, Theme, ThemeName, View } from 'tamagui'
+import { Text, Theme, ThemeName, View, Stack } from 'tamagui'
 import { IconProps, SafeFontIcon } from '../SafeFontIcon/SafeFontIcon'
 import { ellipsis } from '@/src/utils/formatters'
 import { isMultisigExecutionInfo } from '@/src/utils/transaction-guards'
@@ -46,7 +46,6 @@ export function SafeListItem({
       spaced={spaced}
       bordered={bordered}
       gap={12}
-      onPress={onPress}
       transparent={transparent}
       themeName={themeName}
       alignItems={'center'}
@@ -54,7 +53,15 @@ export function SafeListItem({
       flexDirection="row"
       justifyContent="space-between"
     >
-      <View flexDirection="row" maxWidth={rightNode ? '55%' : '100%'} alignItems="center" gap={12}>
+      <Stack
+        flexDirection="row"
+        alignItems="center"
+        gap={12}
+        onPress={onPress}
+        flexShrink={1}
+        flexGrow={1}
+        pressStyle={{ opacity: 0.7 }}
+      >
         {leftNode}
 
         <View>
@@ -76,7 +83,7 @@ export function SafeListItem({
           )}
         </View>
         {tag && <Tag>{tag}</Tag>}
-      </View>
+      </Stack>
 
       {inQueue && executionInfo && isMultisigExecutionInfo(executionInfo) ? (
         <View alignItems="center" flexDirection="row">

--- a/apps/mobile/src/components/SafeListItem/__snapshots__/SafeListItem.test.tsx.snap
+++ b/apps/mobile/src/components/SafeListItem/__snapshots__/SafeListItem.test.tsx.snap
@@ -23,12 +23,23 @@ exports[`SafeListItem should render a list item with a custom label template 1`]
     }
   >
     <View
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         {
           "alignItems": "center",
           "flexDirection": "row",
+          "flexGrow": 1,
+          "flexShrink": 1,
           "gap": 12,
-          "maxWidth": "100%",
+          "opacity": 1,
         }
       }
     >

--- a/apps/mobile/src/components/transactions-list/Card/SignersCard/SignersCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/SignersCard/SignersCard.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import { TouchableOpacity } from 'react-native'
 import { Text, View, type TextProps } from 'tamagui'
 import { Identicon } from '@/src/components/Identicon'
 import { SafeListItem } from '@/src/components/SafeListItem'
@@ -12,6 +13,7 @@ type SignersCardProps = {
   transparent?: boolean
   onPress?: () => void
   getSignerTag?: (address: Address) => string | undefined
+  onLeftNodePress?: () => void
 }
 
 const descriptionStyle: Partial<TextProps> = {
@@ -25,7 +27,15 @@ const titleStyle: Partial<TextProps> = {
   fontWeight: 600,
 }
 
-export function SignersCard({ onPress, name, transparent = true, address, rightNode, getSignerTag }: SignersCardProps) {
+export function SignersCard({
+  onPress,
+  name,
+  transparent = true,
+  address,
+  rightNode,
+  getSignerTag,
+  onLeftNodePress,
+}: SignersCardProps) {
   const textProps = useMemo(() => {
     return name ? descriptionStyle : titleStyle
   }, [name])
@@ -35,7 +45,7 @@ export function SignersCard({ onPress, name, transparent = true, address, rightN
       onPress={onPress}
       transparent={transparent}
       label={
-        <View>
+        <TouchableOpacity onPress={onLeftNodePress} testID={`signer-${address}`}>
           {name && (
             <View flexDirection="row" alignItems="center" gap="$2">
               {typeof name === 'string' ? (
@@ -67,14 +77,14 @@ export function SignersCard({ onPress, name, transparent = true, address, rightN
           )}
 
           <EthAddress address={address} textProps={textProps} />
-        </View>
+        </TouchableOpacity>
       }
+      rightNode={rightNode}
       leftNode={
         <View width="$10">
           <Identicon address={address} size={40} />
         </View>
       }
-      rightNode={rightNode}
     />
   )
 }

--- a/apps/mobile/src/components/transactions-list/Card/SignersCard/SignersCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/SignersCard/SignersCard.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react'
-import { TouchableOpacity } from 'react-native'
 import { Text, View, type TextProps } from 'tamagui'
 import { Identicon } from '@/src/components/Identicon'
 import { SafeListItem } from '@/src/components/SafeListItem'
@@ -11,9 +10,8 @@ type SignersCardProps = {
   address: `0x${string}`
   rightNode?: React.ReactNode
   transparent?: boolean
-  onPress?: () => void
   getSignerTag?: (address: Address) => string | undefined
-  onLeftNodePress?: () => void
+  onPress?: () => void
 }
 
 const descriptionStyle: Partial<TextProps> = {
@@ -27,15 +25,7 @@ const titleStyle: Partial<TextProps> = {
   fontWeight: 600,
 }
 
-export function SignersCard({
-  onPress,
-  name,
-  transparent = true,
-  address,
-  rightNode,
-  getSignerTag,
-  onLeftNodePress,
-}: SignersCardProps) {
+export function SignersCard({ onPress, name, transparent = true, address, rightNode, getSignerTag }: SignersCardProps) {
   const textProps = useMemo(() => {
     return name ? descriptionStyle : titleStyle
   }, [name])
@@ -45,7 +35,7 @@ export function SignersCard({
       onPress={onPress}
       transparent={transparent}
       label={
-        <TouchableOpacity onPress={onLeftNodePress} testID={`signer-${address}`}>
+        <View testID={`signer-${address}`}>
           {name && (
             <View flexDirection="row" alignItems="center" gap="$2">
               {typeof name === 'string' ? (
@@ -77,7 +67,7 @@ export function SignersCard({
           )}
 
           <EthAddress address={address} textProps={textProps} />
-        </TouchableOpacity>
+        </View>
       }
       rightNode={rightNode}
       leftNode={

--- a/apps/mobile/src/components/transactions-list/Card/TxBatchCard/__snapshots__/TxBatchCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxBatchCard/__snapshots__/TxBatchCard.test.tsx.snap
@@ -3,15 +3,6 @@
 exports[`TxBatchCard should render the default markup 1`] = `
 <View>
   <View
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -32,12 +23,23 @@ exports[`TxBatchCard should render the default markup 1`] = `
     }
   >
     <View
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         {
           "alignItems": "center",
           "flexDirection": "row",
+          "flexGrow": 1,
+          "flexShrink": 1,
           "gap": 12,
-          "maxWidth": "100%",
+          "opacity": 1,
         }
       }
     >

--- a/apps/mobile/src/components/transactions-list/Card/TxOrderCard/__snapshots__/TxOrderCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxOrderCard/__snapshots__/TxOrderCard.test.tsx.snap
@@ -3,15 +3,6 @@
 exports[`TxSwapCard should render the default markup 1`] = `
 <View>
   <View
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -32,12 +23,23 @@ exports[`TxSwapCard should render the default markup 1`] = `
     }
   >
     <View
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         {
           "alignItems": "center",
           "flexDirection": "row",
+          "flexGrow": 1,
+          "flexShrink": 1,
           "gap": 12,
-          "maxWidth": "55%",
+          "opacity": 1,
         }
       }
     >

--- a/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/__snapshots__/TxSettingCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/__snapshots__/TxSettingCard.test.tsx.snap
@@ -3,15 +3,6 @@
 exports[`TxSettingCard should render the default markup 1`] = `
 <View>
   <View
-    onBlur={[Function]}
-    onClick={[Function]}
-    onFocus={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -32,12 +23,23 @@ exports[`TxSettingCard should render the default markup 1`] = `
     }
   >
     <View
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         {
           "alignItems": "center",
           "flexDirection": "row",
+          "flexGrow": 1,
+          "flexShrink": 1,
           "gap": 12,
-          "maxWidth": "100%",
+          "opacity": 1,
         }
       }
     >

--- a/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
+++ b/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { Theme, XStack, getTokenValue } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Pressable } from 'react-native-gesture-handler'
-import { Identicon } from '@/src/components/Identicon'
+import { IdenticonWithBadge } from '@/src/features/Settings/components/IdenticonWithBadge'
+
 import { shortenAddress } from '@/src/utils/formatters'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useAppSelector } from '@/src/store/hooks'
@@ -11,6 +12,8 @@ import { DropdownLabel } from '@/src/components/Dropdown/DropdownLabel'
 import { selectAppNotificationStatus } from '@/src/store/notificationsSlice'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { selectContactByAddress } from '@/src/store/addressBookSlice'
+import { selectSafeInfo } from '@/src/store/safesSlice'
+import { RootState } from '@/src/store'
 
 const dropdownLabelProps = {
   fontSize: '$5',
@@ -32,6 +35,8 @@ export const Navbar = () => {
     }
   }
 
+  const activeSafeInfo = useAppSelector((state: RootState) => selectSafeInfo(state, activeSafe.address))
+
   return (
     <Theme name="navbar">
       <XStack
@@ -45,7 +50,16 @@ export const Navbar = () => {
         <DropdownLabel
           label={contact ? contact.name : shortenAddress(activeSafe.address)}
           labelProps={dropdownLabelProps}
-          leftNode={<Identicon address={activeSafe.address} size={30} />}
+          leftNode={
+            <IdenticonWithBadge
+              testID="threshold-info-badge"
+              size={40}
+              fontSize={10}
+              address={activeSafe.address}
+              badgeContent={`${activeSafeInfo?.SafeInfo.threshold}/${activeSafeInfo?.SafeInfo.owners.length}`}
+            />
+          }
+          // leftNode={<Identicon address={activeSafe.address} size={30} />}
           onPress={() => {
             router.push('/accounts-sheet')
           }}

--- a/apps/mobile/src/features/ImportPrivateKey/components/ImportSuccess/ImportSuccess.tsx
+++ b/apps/mobile/src/features/ImportPrivateKey/components/ImportSuccess/ImportSuccess.tsx
@@ -45,7 +45,7 @@ export function ImportSuccess() {
         <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
           <View flex={1} flexGrow={1} alignItems="center" justifyContent="center" paddingHorizontal="$3">
             <Badge
-              circleProps={{ backgroundColor: '#1B2A22' }}
+              circleProps={{ backgroundColor: '$success' }}
               themeName="badge_success"
               circleSize={64}
               content={<SafeFontIcon size={32} color="$primary" name="check-filled" />}

--- a/apps/mobile/src/features/ImportReadOnly/ScanQrAccount.container.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/ScanQrAccount.container.tsx
@@ -1,6 +1,6 @@
 import { Camera, Code, useCameraPermission } from 'react-native-vision-camera'
 import React, { useCallback, useState } from 'react'
-import { useFocusEffect, useRouter } from 'expo-router'
+import { useRouter } from 'expo-router'
 
 import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
 import { isValidAddress } from '@safe-global/utils/utils/validation'
@@ -11,24 +11,11 @@ const toastForValueShown: Record<string, boolean> = {}
 
 export const ScanQrAccountContainer = () => {
   const router = useRouter()
-  const [isCameraActive, setIsCameraActive] = useState(true)
+  const [isCameraActive, setIsCameraActive] = useState(false)
   const toast = useToastController()
 
   const permission = Camera.getCameraPermissionStatus()
   const { hasPermission, requestPermission } = useCameraPermission()
-
-  useFocusEffect(
-    // Callback should be wrapped in `React.useCallback` to avoid running the effect too often.
-    useCallback(() => {
-      // Invoked whenever the route is focused.
-      setIsCameraActive(true)
-
-      // Return function is invoked whenever the route gets out of focus.
-      return () => {
-        setIsCameraActive(false)
-      }
-    }, []),
-  )
 
   const onScan = useCallback(
     (codes: Code[]) => {
@@ -59,6 +46,10 @@ export const ScanQrAccountContainer = () => {
     router.push(`/(import-accounts)/form`)
   }, [router])
 
+  const handleActivateCamera = useCallback(() => {
+    setIsCameraActive(true)
+  }, [])
+
   return (
     <QrCameraView
       permission={permission}
@@ -66,6 +57,7 @@ export const ScanQrAccountContainer = () => {
       requestPermission={requestPermission}
       isCameraActive={isCameraActive}
       onScan={onScan}
+      onActivateCamera={handleActivateCamera}
       onEnterManuallyPress={onEnterManuallyPress}
     />
   )

--- a/apps/mobile/src/features/ImportReadOnly/ScanQrAccount.container.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/ScanQrAccount.container.tsx
@@ -1,5 +1,5 @@
 import { Camera, Code, useCameraPermission } from 'react-native-vision-camera'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useFocusEffect, useRouter } from 'expo-router'
 
 import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
@@ -16,12 +16,6 @@ export const ScanQrAccountContainer = () => {
 
   const permission = Camera.getCameraPermissionStatus()
   const { hasPermission, requestPermission } = useCameraPermission()
-
-  useEffect(() => {
-    if (hasPermission === false && permission === 'not-determined') {
-      requestPermission()
-    }
-  }, [permission, hasPermission, requestPermission])
 
   useFocusEffect(
     // Callback should be wrapped in `React.useCallback` to avoid running the effect too often.
@@ -68,6 +62,8 @@ export const ScanQrAccountContainer = () => {
   return (
     <QrCameraView
       permission={permission}
+      hasPermission={hasPermission}
+      requestPermission={requestPermission}
       isCameraActive={isCameraActive}
       onScan={onScan}
       onEnterManuallyPress={onEnterManuallyPress}

--- a/apps/mobile/src/features/ImportReadOnly/components/AddSignersFormView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/AddSignersFormView.tsx
@@ -25,7 +25,7 @@ export const AddSignersFormView = ({
       <SignersList
         navbarTitle={'Import your signers to unlock account'}
         isFetching={isFetching}
-        hasLocalSingers={!!signersGroupedBySection.imported?.data.length}
+        hasLocalSigners={!!signersGroupedBySection.imported?.data.length}
         signersGroup={signersSections}
       />
       <View paddingHorizontal={'$4'} paddingTop={'$2'} paddingBottom={bottom || 60}>

--- a/apps/mobile/src/features/ImportReadOnly/components/ScanQrAccountView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/ScanQrAccountView.tsx
@@ -13,6 +13,7 @@ type QrCameraViewProps = {
   onEnterManuallyPress: () => void
   requestPermission: () => void
   hasPermission: boolean
+  onActivateCamera: () => void
 }
 
 export const QrCameraView = ({
@@ -22,6 +23,7 @@ export const QrCameraView = ({
   onEnterManuallyPress,
   requestPermission,
   hasPermission,
+  onActivateCamera,
 }: QrCameraViewProps) => (
   <>
     <QrCamera
@@ -30,6 +32,7 @@ export const QrCameraView = ({
       requestPermission={requestPermission}
       isCameraActive={isCameraActive}
       onScan={onScan}
+      onActivateCamera={onActivateCamera}
       heading={permission === 'denied' ? 'Camera access disabled' : 'Scan a QR code'}
       footer={
         <>
@@ -41,7 +44,7 @@ export const QrCameraView = ({
           <View alignItems="center" marginTop="$5">
             <SafeButton
               secondary
-              icon={<SafeFontIcon name="copy" />}
+              icon={<SafeFontIcon name="copy" size={18} />}
               onPress={onEnterManuallyPress}
               testID={'enter-manually'}
             >

--- a/apps/mobile/src/features/ImportReadOnly/components/ScanQrAccountView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/ScanQrAccountView.tsx
@@ -11,12 +11,23 @@ type QrCameraViewProps = {
   isCameraActive: boolean
   onScan: (codes: Code[]) => void
   onEnterManuallyPress: () => void
+  requestPermission: () => void
+  hasPermission: boolean
 }
 
-export const QrCameraView = ({ permission, isCameraActive, onScan, onEnterManuallyPress }: QrCameraViewProps) => (
+export const QrCameraView = ({
+  permission,
+  isCameraActive,
+  onScan,
+  onEnterManuallyPress,
+  requestPermission,
+  hasPermission,
+}: QrCameraViewProps) => (
   <>
     <QrCamera
       permission={permission}
+      hasPermission={hasPermission}
+      requestPermission={requestPermission}
       isCameraActive={isCameraActive}
       onScan={onScan}
       heading={permission === 'denied' ? 'Camera access disabled' : 'Scan a QR code'}

--- a/apps/mobile/src/features/Settings/Settings.tsx
+++ b/apps/mobile/src/features/Settings/Settings.tsx
@@ -62,14 +62,15 @@ export const Settings = ({ address, data, onImplementationTap, displayDevMenu, c
                 <YStack
                   alignItems="center"
                   backgroundColor={'$background'}
-                  padding={'$4'}
+                  paddingTop={'$3'}
+                  paddingBottom={'$2'}
                   borderRadius={'$6'}
                   width={80}
                   marginRight={'$2'}
                 >
                   <View width={30}>
                     <Skeleton colorMode={colorScheme === 'dark' ? 'dark' : 'light'}>
-                      <Text fontWeight="700" textAlign="center" fontSize={'$4'}>
+                      <Text fontWeight="bold" textAlign="center" fontSize={'$4'}>
                         {owners.length}
                       </Text>
                     </Skeleton>
@@ -82,7 +83,7 @@ export const Settings = ({ address, data, onImplementationTap, displayDevMenu, c
                 <YStack
                   alignItems="center"
                   backgroundColor={'$background'}
-                  paddingTop={'$4'}
+                  paddingTop={'$3'}
                   paddingBottom={'$2'}
                   borderRadius={'$6'}
                   width={80}

--- a/apps/mobile/src/features/Signers/Signers.container.tsx
+++ b/apps/mobile/src/features/Signers/Signers.container.tsx
@@ -28,7 +28,7 @@ export const SignersContainer = () => {
       <View flex={1}>
         <SignersList
           isFetching={isFetching}
-          hasLocalSingers={!!group.imported?.data.length}
+          hasLocalSigners={!!group.imported?.data.length}
           signersGroup={signersSections}
         />
       </View>

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersList.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersList.tsx
@@ -21,11 +21,11 @@ const keyExtractor = (item: AddressInfo, index: number) => item.value + index
 interface SignersListProps {
   signersGroup: SignerSection[]
   isFetching: boolean
-  hasLocalSingers: boolean
+  hasLocalSigners: boolean
   navbarTitle?: string
 }
 
-export function SignersList({ signersGroup, isFetching, hasLocalSingers, navbarTitle }: SignersListProps) {
+export function SignersList({ signersGroup, isFetching, hasLocalSigners, navbarTitle }: SignersListProps) {
   const title = navbarTitle || 'Signers'
   const { handleScroll } = useScrollableHeader({
     children: <NavBarTitle>{title}</NavBarTitle>,
@@ -39,8 +39,8 @@ export function SignersList({ signersGroup, isFetching, hasLocalSingers, navbarT
   )
 
   const ListHeaderComponent = useCallback(
-    () => <SignersListHeader sectionTitle={title} withAlert={!hasLocalSingers} />,
-    [hasLocalSingers],
+    () => <SignersListHeader sectionTitle={title} withAlert={!hasLocalSigners} />,
+    [hasLocalSigners],
   )
 
   return (

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -6,7 +6,6 @@ import { SignersCard } from '@/src/components/transactions-list/Card/SignersCard
 import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { SignerSection } from './SignersList'
 import { View } from 'tamagui'
-import { TouchableOpacity } from 'react-native-gesture-handler'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { Alert, useColorScheme } from 'react-native'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
@@ -58,25 +57,24 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
   }
 
   return (
-    <TouchableOpacity onPress={onPress} testID={`signer-${item.value}`}>
-      <View
-        backgroundColor={colorScheme === 'dark' ? '$backgroundPaper' : '$background'}
-        borderTopRightRadius={index === 0 ? '$4' : undefined}
-        borderTopLeftRadius={index === 0 ? '$4' : undefined}
-        borderBottomRightRadius={isLastItem ? '$4' : undefined}
-        borderBottomLeftRadius={isLastItem ? '$4' : undefined}
-      >
-        <SignersCard
-          name={contact ? (contact.name as string) : (item.name as string)}
-          address={item.value as `0x${string}`}
-          rightNode={
-            <MenuView onPressAction={onPressMenuAction} actions={actions}>
-              <SafeFontIcon name="options-horizontal" />
-            </MenuView>
-          }
-        />
-      </View>
-    </TouchableOpacity>
+    <View
+      backgroundColor={colorScheme === 'dark' ? '$backgroundPaper' : '$background'}
+      borderTopRightRadius={index === 0 ? '$4' : undefined}
+      borderTopLeftRadius={index === 0 ? '$4' : undefined}
+      borderBottomRightRadius={isLastItem ? '$4' : undefined}
+      borderBottomLeftRadius={isLastItem ? '$4' : undefined}
+    >
+      <SignersCard
+        onLeftNodePress={onPress}
+        name={contact ? (contact.name as string) : (item.name as string)}
+        address={item.value as `0x${string}`}
+        rightNode={
+          <MenuView onPressAction={onPressMenuAction} actions={actions}>
+            <SafeFontIcon name="options-horizontal" />
+          </MenuView>
+        }
+      />
+    </View>
   )
 }
 

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { MenuView, NativeActionEvent } from '@react-native-menu/menu'
+import { MenuView, NativeActionEvent, MenuAction } from '@react-native-menu/menu'
 import { useSignersActions } from './hooks/useSignersActions'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { SignersCard } from '@/src/components/transactions-list/Card/SignersCard'
@@ -23,7 +23,15 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
   const colorScheme = useColorScheme()
   const contact = useAppSelector(selectContactByAddress(item.value))
   const local = useLocalSearchParams<{ safeAddress: string; chainId: string; import_safe: string }>()
-  const actions = useSignersActions()
+
+  // Check if the current item belongs to the 'My signers' section
+  const isMySigner = signersGroup.some(
+    (section) => section.title === 'My signers' && section.data.some((signer) => signer.value === item.value),
+  )
+
+  const fullActions = useSignersActions(isMySigner) // This was necessary to prevent typescript from complaining about the actions array
+  // Filter out any false values to ensure the array type matches MenuAction[]
+  const actions = fullActions.filter(Boolean) as MenuAction[]
   const isLastItem = signersGroup.some((section) => section.data.length === index + 1)
   const dispatch = useAppDispatch()
   const copy = useCopyAndDispatchToast()

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -73,7 +73,7 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
       borderBottomLeftRadius={isLastItem ? '$4' : undefined}
     >
       <SignersCard
-        onLeftNodePress={onPress}
+        onPress={onPress}
         name={contact ? (contact.name as string) : (item.name as string)}
         address={item.value as `0x${string}`}
         rightNode={

--- a/apps/mobile/src/features/Signers/components/SignersList/hooks/useSignersActions.ts
+++ b/apps/mobile/src/features/Signers/components/SignersList/hooks/useSignersActions.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { Platform } from 'react-native'
 import { useTheme } from 'tamagui'
 
-export const useSignersActions = () => {
+export const useSignersActions = (disableImport: boolean) => {
   const theme = useTheme()
   const color = theme.color?.get()
   const actions = useMemo(
@@ -25,7 +25,7 @@ export const useSignersActions = () => {
         }),
         imageColor: Platform.select({ ios: color, android: '#000' }),
       },
-      {
+      !disableImport && {
         id: 'import',
         title: 'Import signer',
         image: Platform.select({
@@ -35,7 +35,7 @@ export const useSignersActions = () => {
         imageColor: Platform.select({ ios: color, android: '#000' }),
       },
     ],
-    [color],
+    [color, disableImport],
   )
 
   return actions


### PR DESCRIPTION
## What it solves

This PR implements fix on UI findings from QA round listed below, as well as QRCode Scan flow.

Resolves #

https://github.com/safe-global/wallet-private-tasks/issues/94
https://github.com/safe-global/wallet-private-tasks/issues/99

From Notion
[x] - Asset screen: badge threshold missing New Mobile App(Jonathan)
[x] - Update text in QR code scanner: You can find it in the web app’s sidebar on top.
[x] - Avoid camera to be prompt before user's interaction.

## How to test it

1 - Open the app, check if QRCode now offers a enable button
2 - After importing a PK, check the Success badge color
3 - On Home, check the account selector badge
4 - On Android, try to open 3dots menu on signers listing

## Screenshots
<img width="502" alt="Screenshot 2025-04-04 at 12 46 14" src="https://github.com/user-attachments/assets/67b391ba-d3bd-4599-aa91-59da7200466e" />
<img width="502" alt="Screenshot 2025-04-04 at 12 42 29" src="https://github.com/user-attachments/assets/930f01ed-7b68-4b43-88f0-16185a4e53e8" />
<img width="502" alt="Screenshot 2025-04-04 at 12 42 21" src="https://github.com/user-attachments/assets/624c9c1c-53b7-4a22-839a-54e518133ebf" />

https://github.com/user-attachments/assets/189d8cdf-dd7f-4720-8755-486c2499500c


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
