### PR TITLE
Fix(Spaces): Check address book when adding a member

### DIFF
--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -24,7 +24,7 @@ const NameInput = ({
         maxLength: 50,
         required,
         validate: (value) => {
-          if (value?.trim() === '') return 'Required'
+          if (value?.trim() === '' && required) return 'Required'
           return true
         },
       }}

--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -12,7 +12,7 @@ const NameInput = ({
   name: string
   required?: boolean
 }) => {
-  const { register, formState, control } = useFormContext() || {}
+  const { formState, control } = useFormContext() || {}
   // the name can be a path: e.g. "owner.3.name"
   const fieldError = get(formState.errors, name) as FieldError | undefined
 
@@ -20,8 +20,16 @@ const NameInput = ({
     <Controller
       name={name}
       control={control}
+      rules={{
+        maxLength: 50,
+        required,
+        validate: (value) => {
+          if (value?.trim() === '') return 'Required'
+          return true
+        },
+      }}
       // eslint-disable-next-line
-      render={({ field: { ref, ...field } }) => (
+      render={({ field: { ref, onBlur, onChange, ...field } }) => (
         <TextField
           {...field}
           {...props}
@@ -29,13 +37,14 @@ const NameInput = ({
           label={<>{fieldError?.type === 'maxLength' ? 'Maximum 50 symbols' : fieldError?.message || props.label}</>}
           error={Boolean(fieldError)}
           fullWidth
+          onChange={(e) => onChange(e)}
+          onBlur={(e) => {
+            onBlur()
+            onChange(e.target.value.trim())
+          }}
           required={required}
           className={inputCss.input}
           onKeyDown={(e) => e.stopPropagation()}
-          {...register(name, {
-            maxLength: 50,
-            required,
-          })}
         />
       )}
     />

--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -1,7 +1,7 @@
 import type { TextFieldProps } from '@mui/material'
 import { TextField } from '@mui/material'
 import get from 'lodash/get'
-import { type FieldError, useFormContext } from 'react-hook-form'
+import { Controller, type FieldError, useFormContext } from 'react-hook-form'
 import inputCss from '@/styles/inputs.module.css'
 
 const NameInput = ({
@@ -12,25 +12,33 @@ const NameInput = ({
   name: string
   required?: boolean
 }) => {
-  const { register, formState } = useFormContext() || {}
+  const { register, formState, control } = useFormContext() || {}
   // the name can be a path: e.g. "owner.3.name"
   const fieldError = get(formState.errors, name) as FieldError | undefined
 
   return (
-    <TextField
+    <Controller
       {...props}
-      variant="outlined"
-      label={<>{fieldError?.type === 'maxLength' ? 'Maximum 50 symbols' : fieldError?.message || props.label}</>}
-      error={Boolean(fieldError)}
-      fullWidth
-      required={required}
-      className={inputCss.input}
-      onKeyDown={(e) => e.stopPropagation()}
-      {...register(name, {
-        maxLength: 50,
-        required,
-        setValueAs: (value) => value.trim(),
-      })}
+      name={name}
+      control={control}
+      // eslint-disable-next-line
+      render={({ field: { ref, ...field } }) => (
+        <TextField
+          {...field}
+          variant="outlined"
+          label={<>{fieldError?.type === 'maxLength' ? 'Maximum 50 symbols' : fieldError?.message || props.label}</>}
+          error={Boolean(fieldError)}
+          fullWidth
+          required={required}
+          className={inputCss.input}
+          onKeyDown={(e) => e.stopPropagation()}
+          {...register(name, {
+            maxLength: 50,
+            required,
+            setValueAs: (value) => value.trim(),
+          })}
+        />
+      )}
     />
   )
 }

--- a/apps/web/src/components/common/NameInput/index.tsx
+++ b/apps/web/src/components/common/NameInput/index.tsx
@@ -18,13 +18,13 @@ const NameInput = ({
 
   return (
     <Controller
-      {...props}
       name={name}
       control={control}
       // eslint-disable-next-line
       render={({ field: { ref, ...field } }) => (
         <TextField
           {...field}
+          {...props}
           variant="outlined"
           label={<>{fieldError?.type === 'maxLength' ? 'Maximum 50 symbols' : fieldError?.message || props.label}</>}
           error={Boolean(fieldError)}
@@ -35,7 +35,6 @@ const NameInput = ({
           {...register(name, {
             maxLength: 50,
             required,
-            setValueAs: (value) => value.trim(),
           })}
         />
       )}

--- a/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useState } from 'react'
+import { type ReactElement, useEffect, useState } from 'react'
 import {
   Alert,
   Box,
@@ -14,7 +14,6 @@ import { FormProvider, useForm } from 'react-hook-form'
 import ModalDialog from '@/components/common/ModalDialog'
 import memberIcon from '@/public/images/spaces/member.svg'
 import adminIcon from '@/public/images/spaces/admin.svg'
-import AddressInput from '@/components/common/AddressInput'
 import CheckIcon from '@mui/icons-material/Check'
 import css from './styles.module.css'
 import { useMembersInviteUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
@@ -27,6 +26,8 @@ import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import MemberInfoForm from '@/features/spaces/components/AddMemberModal/MemberInfoForm'
+import AddressBookInput from '@/components/common/AddressBookInput'
+import useAddressBook from '@/hooks/useAddressBook'
 
 type MemberField = {
   name: string
@@ -76,6 +77,7 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
   const [error, setError] = useState<string>()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [inviteMembers] = useMembersInviteUserV1Mutation()
+  const addressBook = useAddressBook()
 
   const methods = useForm<MemberField>({
     mode: 'onChange',
@@ -86,7 +88,16 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
     },
   })
 
-  const { handleSubmit, formState } = methods
+  const { handleSubmit, formState, watch, setValue } = methods
+
+  const addressValue = watch('address')
+
+  useEffect(() => {
+    const addressBookName = addressBook[addressValue]
+    if (addressBookName) {
+      setValue('name', addressBookName)
+    }
+  }, [addressBook, addressValue, setValue])
 
   const onSubmit = handleSubmit(async (data) => {
     setError(undefined)
@@ -144,7 +155,7 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
             <Stack spacing={3}>
               <MemberInfoForm />
 
-              <AddressInput name="address" label="Address" required showPrefix={false} />
+              <AddressBookInput name="address" label="Address" required showPrefix={false} />
             </Stack>
 
             {error && (


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/115

## How this PR fixes it

- Changes the `NameInput` to be wrapped by a `Controller` to fix the shrink issue when setting a value
- Checks the address book whenever the address changed and sets the name value if there is a hit
- Uses the `AddressBookInput` for the address when adding a member

## How to test it

1. Open a space
2. Add a member
3. Observe suggestions from the address book
4. Select one
5. Observe the name is filled automatically

## Screenshots
<img width="777" alt="Screenshot 2025-04-04 at 14 09 21" src="https://github.com/user-attachments/assets/a04a52c1-c244-4072-8a07-8967b09e2a37" />
<img width="663" alt="Screenshot 2025-04-04 at 14 09 32" src="https://github.com/user-attachments/assets/2cb4cdc2-3fdb-44a7-b5dc-6fa3ff123436" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
