### PR TITLE
Fix(Spaces): Add hover effect for space tab navigation

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
@@ -15,7 +15,7 @@ const AccountsNavigation = () => {
   }
 
   const trackSpacesClick = () => {
-    if (isActiveNavigation(AppRoutes.welcome.spaces)) {
+    if (!isActiveNavigation(AppRoutes.welcome.spaces)) {
       trackEvent({ ...SPACE_EVENTS.OPEN_SPACE_LIST_PAGE, label: SPACE_LABELS.accounts_page })
     }
   }

--- a/apps/web/src/features/myAccounts/styles.module.css
+++ b/apps/web/src/features/myAccounts/styles.module.css
@@ -64,6 +64,10 @@
   color: var(--color-text-secondary);
 }
 
+.link:hover {
+  color: var(--color-text-primary);
+}
+
 .active {
   pointer-events: none;
   color: var(--color-text-primary);


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/141

## How this PR fixes it

- Adjusts the condition for emitting the analytics event
- Adds a hover effect to the spaces and accounts tab

## How to test it

1. Go to `/welcome/accounts`
2. Hover the Spaces tab
3. Observe a visual feedback
4. Click the Spaces button
5. Observe an event is emitted in the console

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
