### PR TITLE
fix(web): truncate long name tokens

### DIFF
--- a/apps/web/src/components/common/TokenAmount/index.tsx
+++ b/apps/web/src/components/common/TokenAmount/index.tsx
@@ -2,11 +2,12 @@ import { type ReactElement } from 'react'
 import { Tooltip } from '@mui/material'
 import { TransferDirection } from '@safe-global/safe-gateway-typescript-sdk'
 import css from './styles.module.css'
-import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
+import { formatVisualAmount, ellipsis } from '@safe-global/utils/utils/formatters'
 import TokenIcon from '../TokenIcon'
 import classNames from 'classnames'
 
 const PRECISION = 20
+const MAX_TOKEN_SYMBOL_LENGTH = 15
 
 const TokenAmount = ({
   value,
@@ -28,6 +29,10 @@ const TokenAmount = ({
   const sign = direction === TransferDirection.OUTGOING ? '-' : ''
   const amount =
     decimals !== undefined ? formatVisualAmount(value, decimals, preciseAmount ? PRECISION : undefined) : value
+  
+  // Truncate token symbol if it's too long
+  const displayTokenSymbol = tokenSymbol ? ellipsis(tokenSymbol, MAX_TOKEN_SYMBOL_LENGTH) : undefined
+  
   const fullAmount =
     decimals !== undefined ? sign + formatVisualAmount(value, decimals, PRECISION) + ' ' + tokenSymbol : value
 
@@ -35,9 +40,9 @@ const TokenAmount = ({
     <Tooltip title={fullAmount}>
       <span className={classNames(css.container, { [css.verticalAlign]: logoUri })}>
         {logoUri && <TokenIcon logoUri={logoUri} tokenSymbol={tokenSymbol} fallbackSrc={fallbackSrc} />}
-        <b>
+        <b className={css.tokenText}>
           {sign}
-          {amount} {tokenSymbol}
+          {amount} {displayTokenSymbol}
         </b>
       </span>
     </Tooltip>

--- a/apps/web/src/components/common/TokenAmount/index.tsx
+++ b/apps/web/src/components/common/TokenAmount/index.tsx
@@ -2,12 +2,11 @@ import { type ReactElement } from 'react'
 import { Tooltip } from '@mui/material'
 import { TransferDirection } from '@safe-global/safe-gateway-typescript-sdk'
 import css from './styles.module.css'
-import { formatVisualAmount, ellipsis } from '@safe-global/utils/utils/formatters'
+import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
 import TokenIcon from '../TokenIcon'
 import classNames from 'classnames'
 
 const PRECISION = 20
-const MAX_TOKEN_SYMBOL_LENGTH = 15
 
 const TokenAmount = ({
   value,
@@ -30,9 +29,6 @@ const TokenAmount = ({
   const amount =
     decimals !== undefined ? formatVisualAmount(value, decimals, preciseAmount ? PRECISION : undefined) : value
   
-  // Truncate token symbol if it's too long
-  const displayTokenSymbol = tokenSymbol ? ellipsis(tokenSymbol, MAX_TOKEN_SYMBOL_LENGTH) : undefined
-  
   const fullAmount =
     decimals !== undefined ? sign + formatVisualAmount(value, decimals, PRECISION) + ' ' + tokenSymbol : value
 
@@ -42,7 +38,7 @@ const TokenAmount = ({
         {logoUri && <TokenIcon logoUri={logoUri} tokenSymbol={tokenSymbol} fallbackSrc={fallbackSrc} />}
         <b className={css.tokenText}>
           {sign}
-          {amount} {displayTokenSymbol}
+          {amount} {tokenSymbol}
         </b>
       </span>
     </Tooltip>

--- a/apps/web/src/components/common/TokenAmount/styles.module.css
+++ b/apps/web/src/components/common/TokenAmount/styles.module.css
@@ -3,8 +3,15 @@
   align-items: center;
   gap: var(--space-1);
   color: var(--color-text-primary);
+  max-width: 100%;
 }
 
 .verticalAlign {
   vertical-align: middle;
+}
+
+.tokenText {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
## What it solves
This PR fixes a bug where long token names overlap with the date display in the Queue and History views.

Resolves #3438

## How this PR fixes it
- Introduces MAX_TOKEN_SYMBOL_LENGTH to the TokenAmount component.
- Truncates token names on all pages where TokenAmount is used, preventing layout overflow.

## How to test it
- Find (or create) any Safe transactions in {Wallet} (eg. gno:0x03F4156023e340779Feda280185C251B6aF00343)
- Use the browser console to add a long token name (e.g., REALTOKEN-S-13041-HAYES-ST-DETROIT-MI).
- Verify that the long token name is truncated and does not overlap with the date.

## Screenshots
<img width="1281" alt="Screenshot 2025-04-07 at 16 24 38" src="https://github.com/user-attachments/assets/d92374f0-11ae-4ea9-8c97-392e5cc1273c" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (not applicable) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
