### PR TITLE
feat(Signing UX): move Note to the sidebar

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxFlowContent/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxFlowContent/index.tsx
@@ -11,6 +11,7 @@ import ChainIndicator from '@/components/common/ChainIndicator'
 import SecurityWarnings from '@/components/tx/security/SecurityWarnings'
 import TxStatusWidget from '@/components/tx-flow/common/TxStatusWidget'
 import { TxLayoutHeader } from '../TxLayout'
+import { SlotName, useSlot } from '../../slots'
 
 /**
  * TxFlowContent is a component that renders the main content of the transaction flow.
@@ -36,6 +37,8 @@ export const TxFlowContent = ({ children }: { children?: ReactNode[] | ReactNode
     progress,
     onPrev,
   } = useContext(TxFlowContext)
+
+  const sidebarFeatures = useSlot(SlotName.Sidebar)
 
   const childrenArray = Array.isArray(children) ? children : [children]
 
@@ -127,6 +130,10 @@ export const TxFlowContent = ({ children }: { children?: ReactNode[] | ReactNode
                   isMessage={isMessage}
                 />
               )}
+
+              {sidebarFeatures.map((SidebarFeature, i) => (
+                <SidebarFeature key={`sidebar-feature-${i}`} />
+              ))}
 
               <Box className={css.sticky}>
                 <SecurityWarnings />

--- a/apps/web/src/components/tx-flow/features/TxNote.tsx
+++ b/apps/web/src/components/tx-flow/features/TxNote.tsx
@@ -27,7 +27,7 @@ const useShouldRegisterSlot = () => {
 
 const TxNoteSlot = withSlot({
   Component: TxNote,
-  slotName: SlotName.Feature,
+  slotName: SlotName.Sidebar,
   id: 'txNote',
   useSlotCondition: useShouldRegisterSlot,
 })

--- a/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
+++ b/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
@@ -22,11 +22,11 @@ type SlotComponentPropsMap = {
   [SlotName.Action]: {
     onSubmit?: (args?: any) => void
   }
-  [SlotName.Feature]: {}
-  [SlotName.Sidebar]: {}
 }
 
-export type SlotComponentProps<T extends SlotName> = SlotComponentPropsMap[T]
+export type SlotComponentProps<T extends SlotName> = T extends keyof SlotComponentPropsMap
+  ? SlotComponentPropsMap[T]
+  : {}
 
 type SlotContextType = {
   registerSlot: <T extends SlotName>(

--- a/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
+++ b/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
@@ -12,6 +12,7 @@ export enum SlotName {
   Submit = 'submit',
   Action = 'action',
   Feature = 'feature',
+  Sidebar = 'sidebar',
 }
 
 type SlotComponentPropsMap = {
@@ -22,6 +23,7 @@ type SlotComponentPropsMap = {
     onSubmit?: (args?: any) => void
   }
   [SlotName.Feature]: {}
+  [SlotName.Sidebar]: {}
 }
 
 export type SlotComponentProps<T extends SlotName> = SlotComponentPropsMap[T]

--- a/apps/web/src/features/tx-notes/TxNoteInput.tsx
+++ b/apps/web/src/features/tx-notes/TxNoteInput.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from 'react'
-import { InputAdornment, Stack, TextField, Typography, Alert } from '@mui/material'
+import { InputAdornment, Stack, TextField, Typography, SvgIcon, Box } from '@mui/material'
 import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
 import { useForm } from 'react-hook-form'
+import InfoOutlinedIcon from '@/public/images/notifications/info.svg'
 
 const MAX_NOTE_LENGTH = 60
 
@@ -38,19 +39,12 @@ export const TxNoteInput = ({ onChange }: { onChange: (note: string) => void }) 
   return (
     <>
       <Stack direction="row" alignItems="flex-end" gap={1}>
-        <Typography variant="h5">Optional note</Typography>
-        <Typography variant="body2" color="text.secondary">
-          Experimental
-        </Typography>
+        <Typography variant="h5">Add transaction note</Typography>
       </Stack>
-
-      <Alert data-testid="tx-note-alert" severity="info">
-        The notes are <b>publicly visible</b>, do not share any private or sensitive details.
-      </Alert>
 
       <TextField
         data-testid="tx-note-textfield"
-        label="Note"
+        label="Note (optional)"
         fullWidth
         slotProps={{
           htmlInput: { maxLength: MAX_NOTE_LENGTH },
@@ -69,6 +63,16 @@ export const TxNoteInput = ({ onChange }: { onChange: (note: string) => void }) 
         onBlur={onBlur}
         onFocus={onFocus}
       />
+
+      <Stack data-testid="tx-note-alert" direction="row" gap={1} color="text.secondary">
+        <SvgIcon component={InfoOutlinedIcon} sx={{ width: '20px', height: '20px', rotate: '180deg' }} inheritViewBox />
+        <Box>
+          <Typography variant="body2" fontWeight="700">
+            Notes are publicly visible.
+          </Typography>
+          <Typography variant="body2">Do not share any private or sensitive details.</Typography>
+        </Box>
+      </Stack>
     </>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves #5625 

Moves the Note feature to the sidebar.

## How this PR fixes it

* Add a new `Sidebar` slot and update TxNote component to register for that slot.
* Update the TxNote UI to match the design.

## Screenshots

<img width="736" alt="Screenshot 2025-04-07 at 17 32 31" src="https://github.com/user-attachments/assets/32c7a588-1d39-4e93-b69e-e575b6113b56" /> <img width="686" alt="Screenshot 2025-04-07 at 17 32 47" src="https://github.com/user-attachments/assets/091eaf0f-ee6b-40d5-b723-584168892bfd" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
