### PR TITLE
fix(web): add white safe logo and spaces on ExecutionMethodSelector

### DIFF
--- a/apps/web/src/components/tx/SponsoredBy/styles.module.css
+++ b/apps/web/src/components/tx/SponsoredBy/styles.module.css
@@ -17,4 +17,15 @@
 .logo {
   width: 16px;
   height: 16px;
+  margin-left: 4px;
+}
+
+[data-theme='dark'] .logo {
+  filter: brightness(0) invert(1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .logo {
+    filter: brightness(0) invert(1);
+  }
 }

--- a/apps/web/src/components/tx/SponsoredBy/styles.module.css
+++ b/apps/web/src/components/tx/SponsoredBy/styles.module.css
@@ -17,7 +17,7 @@
 .logo {
   width: 16px;
   height: 16px;
-  margin-left: 4px;
+  margin-left: 2px;
 }
 
 [data-theme='dark'] .logo {


### PR DESCRIPTION
## What it solves
This PR addresses visibility and spacing issues with the logo in the `ExecutionMethodSelector` component.

Resolves #5439

## How this PR fixes it
- Adds `margin-left` to the logo for proper spacing between the logo and text.
- Implements dark mode support to display the `logo` in white when dark mode is enabled.

## How to test it
- Create a transaction and go to the sponsorship modal
- Check the `spacing` (4px between logo and text) and color of logo

## Screenshots
<img width="725" alt="Screenshot 2025-04-07 at 17 41 24" src="https://github.com/user-attachments/assets/14730970-ee27-4725-a300-aa0c16a15e3d" />
## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (not applicable) 📊
- [ ] I've written a unit/e2e test for it (not applicable) 🧑‍💻
