### PR TITLE
fix(mobile): activate QR camera on user interaction

### DIFF
--- a/apps/mobile/src/components/Camera/QrCamera.tsx
+++ b/apps/mobile/src/components/Camera/QrCamera.tsx
@@ -1,6 +1,6 @@
 import { Camera, useCodeScanner, useCameraDevice, Code, CameraPermissionStatus } from 'react-native-vision-camera'
-import { View, Theme, H3 } from 'tamagui'
-import { Dimensions, Linking, Pressable, StyleSheet, useWindowDimensions } from 'react-native'
+import { View, Theme, H3, getTokenValue } from 'tamagui'
+import { Dimensions, Linking, Pressable, StyleSheet, useColorScheme, useWindowDimensions } from 'react-native'
 import React, { useCallback, useEffect } from 'react'
 import { useRouter } from 'expo-router'
 
@@ -66,6 +66,14 @@ function CameraLens({
   onActivateCamera: () => void
   isCameraActive: boolean
 }) {
+  const colorScheme = useColorScheme()
+
+  let color = getTokenValue('$color.textPrimaryDark')
+
+  if (colorScheme === 'light') {
+    color = getTokenValue('$color.textPrimaryLight')
+  }
+
   const handleGrantOrActivatePress = () => {
     if (!hasPermission) {
       requestPermission()
@@ -92,7 +100,7 @@ function CameraLens({
       {/* Show button/icon only if permission denied, not granted, or granted but inactive */}
       {(denied || !hasPermission || (hasPermission && !isCameraActive)) && (
         <View style={styles.deniedCameraContainer}>
-          <SafeFontIcon name={'camera'} size={40} color={denied ? '$error' : '$white50'} />
+          <SafeFontIcon name={'camera'} size={40} color={denied ? '$error' : color} />
           <SafeButton rounded secondary onPress={buttonAction} marginTop={20}>
             {buttonText}
           </SafeButton>

--- a/apps/mobile/src/components/Camera/QrCamera.tsx
+++ b/apps/mobile/src/components/Camera/QrCamera.tsx
@@ -1,7 +1,7 @@
 import { Camera, useCodeScanner, useCameraDevice, Code, CameraPermissionStatus } from 'react-native-vision-camera'
 import { View, Theme, H3 } from 'tamagui'
 import { Dimensions, Linking, Pressable, StyleSheet, useWindowDimensions } from 'react-native'
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { useRouter } from 'expo-router'
 
 const { width } = Dimensions.get('window')
@@ -16,6 +16,9 @@ type QrCameraProps = {
   onScan: (code: Code[]) => void
   isCameraActive: boolean
   permission: CameraPermissionStatus
+  requestPermission: () => void
+  hasPermission: boolean
+  onActivateCamera: () => void
 }
 
 function CameraHeader({ heading }: { heading: React.ReactNode }) {
@@ -48,28 +51,67 @@ function CameraFooter(props: { footer: React.ReactNode }) {
   )
 }
 
-function CameraLens({ denied, onPress }: { denied: boolean; onPress: () => Promise<void> }) {
+function CameraLens({
+  denied,
+  onPressSettings,
+  requestPermission,
+  hasPermission,
+  onActivateCamera,
+  isCameraActive,
+}: {
+  denied: boolean
+  onPressSettings: () => Promise<void>
+  requestPermission: () => void
+  hasPermission: boolean
+  onActivateCamera: () => void
+  isCameraActive: boolean
+}) {
+  const handleGrantOrActivatePress = () => {
+    if (!hasPermission) {
+      requestPermission()
+    } else if (hasPermission && !isCameraActive) {
+      onActivateCamera()
+    }
+  }
+
+  const buttonText = denied ? 'Open Settings' : 'Enable camera'
+  const buttonAction = denied ? onPressSettings : handleGrantOrActivatePress
+
   return (
-    <View style={[styles.transparentBox, denied && { backgroundColor: 'rgba(0, 0, 0, 0.8)' }]}>
+    <Pressable
+      style={[styles.transparentBox, denied && { backgroundColor: 'rgba(0, 0, 0, 0.8)' }]}
+      onPress={hasPermission && !isCameraActive ? handleGrantOrActivatePress : undefined}
+      disabled={denied || !hasPermission}
+    >
       {/* Green corners */}
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.topLeft]} />
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.topRight]} />
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.bottomLeft]} />
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.bottomRight]} />
 
-      {denied && (
+      {/* Show button/icon only if permission denied, not granted, or granted but inactive */}
+      {(denied || !hasPermission || (hasPermission && !isCameraActive)) && (
         <View style={styles.deniedCameraContainer}>
-          <SafeFontIcon name={'camera'} size={40} color={'$error'} />
-          <SafeButton rounded secondary onPress={onPress} marginTop={20}>
-            Enable camera
+          <SafeFontIcon name={'camera'} size={40} color={denied ? '$error' : '$white50'} />
+          <SafeButton rounded secondary onPress={buttonAction} marginTop={20}>
+            {buttonText}
           </SafeButton>
         </View>
       )}
-    </View>
+    </Pressable>
   )
 }
 
-export const QrCamera = ({ heading = 'Scan a QR Code', footer, onScan, isCameraActive, permission }: QrCameraProps) => {
+export const QrCamera = ({
+  heading = 'Scan a QR Code',
+  footer,
+  onScan,
+  isCameraActive,
+  permission,
+  requestPermission,
+  hasPermission,
+  onActivateCamera,
+}: QrCameraProps) => {
   const device = useCameraDevice('back')
   const { height } = useWindowDimensions()
   const codeScanner = useCodeScanner({
@@ -83,13 +125,20 @@ export const QrCamera = ({ heading = 'Scan a QR Code', footer, onScan, isCameraA
     await Linking.openSettings()
   }, [])
 
+  // Effect to automatically activate camera once permission is granted
+  useEffect(() => {
+    if (permission === 'granted' && hasPermission && !isCameraActive) {
+      onActivateCamera()
+    }
+  }, [permission, hasPermission, isCameraActive, onActivateCamera])
+
   const denied = permission === 'denied'
 
   return (
     <Theme name={'dark'}>
       <View style={styles.container}>
-        {/* Camera View */}
-        {device && (
+        {/* Only render Camera when active and device is available */}
+        {isCameraActive && device && (
           <Camera style={StyleSheet.absoluteFill} device={device} isActive={isCameraActive} codeScanner={codeScanner} />
         )}
 
@@ -112,7 +161,14 @@ export const QrCamera = ({ heading = 'Scan a QR Code', footer, onScan, isCameraA
                 tint={'systemUltraThinMaterialDark'}
               />
 
-              <CameraLens denied={denied} onPress={openSettings} />
+              <CameraLens
+                denied={denied}
+                onPressSettings={openSettings}
+                requestPermission={requestPermission}
+                hasPermission={hasPermission}
+                onActivateCamera={onActivateCamera}
+                isCameraActive={isCameraActive}
+              />
               <BlurView
                 style={[styles.sideBlur, denied && styles.deniedCameraBlur]}
                 intensity={30}

--- a/apps/mobile/src/features/ImportReadOnly/ScanQrAccount.container.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/ScanQrAccount.container.tsx
@@ -1,6 +1,6 @@
 import { Camera, Code, useCameraPermission } from 'react-native-vision-camera'
-import React, { useCallback, useEffect, useState } from 'react'
-import { useFocusEffect, useRouter } from 'expo-router'
+import React, { useCallback, useState } from 'react'
+import { useRouter } from 'expo-router'
 
 import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
 import { isValidAddress } from '@safe-global/utils/utils/validation'
@@ -11,30 +11,11 @@ const toastForValueShown: Record<string, boolean> = {}
 
 export const ScanQrAccountContainer = () => {
   const router = useRouter()
-  const [isCameraActive, setIsCameraActive] = useState(true)
+  const [isCameraActive, setIsCameraActive] = useState(false)
   const toast = useToastController()
 
   const permission = Camera.getCameraPermissionStatus()
   const { hasPermission, requestPermission } = useCameraPermission()
-
-  useEffect(() => {
-    if (hasPermission === false && permission === 'not-determined') {
-      requestPermission()
-    }
-  }, [permission, hasPermission, requestPermission])
-
-  useFocusEffect(
-    // Callback should be wrapped in `React.useCallback` to avoid running the effect too often.
-    useCallback(() => {
-      // Invoked whenever the route is focused.
-      setIsCameraActive(true)
-
-      // Return function is invoked whenever the route gets out of focus.
-      return () => {
-        setIsCameraActive(false)
-      }
-    }, []),
-  )
 
   const onScan = useCallback(
     (codes: Code[]) => {
@@ -65,11 +46,18 @@ export const ScanQrAccountContainer = () => {
     router.push(`/(import-accounts)/form`)
   }, [router])
 
+  const handleActivateCamera = useCallback(() => {
+    setIsCameraActive(true)
+  }, [])
+
   return (
     <QrCameraView
       permission={permission}
+      hasPermission={hasPermission}
+      requestPermission={requestPermission}
       isCameraActive={isCameraActive}
       onScan={onScan}
+      onActivateCamera={handleActivateCamera}
       onEnterManuallyPress={onEnterManuallyPress}
     />
   )

--- a/apps/mobile/src/features/ImportReadOnly/components/ScanQrAccountView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/ScanQrAccountView.tsx
@@ -11,14 +11,28 @@ type QrCameraViewProps = {
   isCameraActive: boolean
   onScan: (codes: Code[]) => void
   onEnterManuallyPress: () => void
+  requestPermission: () => void
+  hasPermission: boolean
+  onActivateCamera: () => void
 }
 
-export const QrCameraView = ({ permission, isCameraActive, onScan, onEnterManuallyPress }: QrCameraViewProps) => (
+export const QrCameraView = ({
+  permission,
+  isCameraActive,
+  onScan,
+  onEnterManuallyPress,
+  requestPermission,
+  hasPermission,
+  onActivateCamera,
+}: QrCameraViewProps) => (
   <>
     <QrCamera
       permission={permission}
+      hasPermission={hasPermission}
+      requestPermission={requestPermission}
       isCameraActive={isCameraActive}
       onScan={onScan}
+      onActivateCamera={onActivateCamera}
       heading={permission === 'denied' ? 'Camera access disabled' : 'Scan a QR code'}
       footer={
         <>
@@ -30,7 +44,7 @@ export const QrCameraView = ({ permission, isCameraActive, onScan, onEnterManual
           <View alignItems="center" marginTop="$5">
             <SafeButton
               secondary
-              icon={<SafeFontIcon name="copy" />}
+              icon={<SafeFontIcon name="copy" size={18} />}
               onPress={onEnterManuallyPress}
               testID={'enter-manually'}
             >


### PR DESCRIPTION
## What it solves

This PR implements fix the QRCode Scan flow while importing a Safe

Resolves #
From Notion
[x] - Update text in QR code scanner: You can find it in the web app’s sidebar on top.
[x] - Avoid camera to be prompt before user's interaction.

## How this PR fixes it
 Add a button on CRScanner so the user trigger a camera permission request, instead of automatically on render.

## How to test it
Install a fresh version and try import a Safe.

## Screenshots

<img width="520" alt="Screenshot 2025-04-08 at 01 00 26" src="https://github.com/user-attachments/assets/9863a802-5334-48d4-8e79-714e934d97a1" />
<img width="520" alt="Screenshot 2025-04-08 at 01 00 14" src="https://github.com/user-attachments/assets/c0720a97-9aad-465a-a949-de501f47b81b" />
<img width="520" alt="Screenshot 2025-04-08 at 01 00 08" src="https://github.com/user-attachments/assets/12668ac2-d9b4-4b52-86b4-4d134d50553d" />

## Checklist
- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
