### PR TITLE
chore(mobile): add account badge on selector

### DIFF
--- a/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
+++ b/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { Theme, XStack, getTokenValue } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Pressable } from 'react-native-gesture-handler'
-import { Identicon } from '@/src/components/Identicon'
+import { IdenticonWithBadge } from '@/src/features/Settings/components/IdenticonWithBadge'
+
 import { shortenAddress } from '@/src/utils/formatters'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useAppSelector } from '@/src/store/hooks'
@@ -11,6 +12,8 @@ import { DropdownLabel } from '@/src/components/Dropdown/DropdownLabel'
 import { selectAppNotificationStatus } from '@/src/store/notificationsSlice'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { selectContactByAddress } from '@/src/store/addressBookSlice'
+import { selectSafeInfo } from '@/src/store/safesSlice'
+import { RootState } from '@/src/store'
 
 const dropdownLabelProps = {
   fontSize: '$5',
@@ -32,6 +35,8 @@ export const Navbar = () => {
     }
   }
 
+  const activeSafeInfo = useAppSelector((state: RootState) => selectSafeInfo(state, activeSafe.address))
+
   return (
     <Theme name="navbar">
       <XStack
@@ -45,7 +50,16 @@ export const Navbar = () => {
         <DropdownLabel
           label={contact ? contact.name : shortenAddress(activeSafe.address)}
           labelProps={dropdownLabelProps}
-          leftNode={<Identicon address={activeSafe.address} size={30} />}
+          leftNode={
+            <IdenticonWithBadge
+              testID="threshold-info-badge"
+              size={40}
+              fontSize={10}
+              address={activeSafe.address}
+              badgeContent={`${activeSafeInfo?.SafeInfo.threshold}/${activeSafeInfo?.SafeInfo.owners.length}`}
+            />
+          }
+          // leftNode={<Identicon address={activeSafe.address} size={30} />}
           onPress={() => {
             router.push('/accounts-sheet')
           }}

--- a/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
+++ b/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
@@ -53,6 +53,7 @@ export const Navbar = () => {
           leftNode={
             <IdenticonWithBadge
               testID="threshold-info-badge"
+              variant="sm"
               size={40}
               fontSize={10}
               address={activeSafe.address}

--- a/apps/mobile/src/features/Settings/components/IdenticonWithBadge/IdenticonWithBadge.tsx
+++ b/apps/mobile/src/features/Settings/components/IdenticonWithBadge/IdenticonWithBadge.tsx
@@ -12,6 +12,7 @@ type IdenticonWithBadgeProps = {
   size?: number
   testID?: string
   fontSize?: number
+  variant?: 'sm' | 'md'
 }
 
 export const IdenticonWithBadge = ({
@@ -20,11 +21,12 @@ export const IdenticonWithBadge = ({
   badgeContent,
   fontSize = 12,
   size = 56,
+  variant = 'md',
 }: IdenticonWithBadgeProps) => {
   return (
     <View style={styles.container} testID={testID}>
       <Identicon address={address} size={size} />
-      <View style={styles.badge}>
+      <View style={[variant === 'sm' ? styles.badgeSm : styles.badge]}>
         <Skeleton colorMode={'dark'} radius="round" height={28} width={28}>
           {badgeContent && (
             <Badge
@@ -51,5 +53,10 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: -5,
     right: -10,
+  },
+  badgeSm: {
+    position: 'absolute',
+    top: -5,
+    right: -5,
   },
 })


### PR DESCRIPTION
## What it solves

Resolves #
From Notion
[x] - Asset screen: badge threshold missing New Mobile App

## How this PR fixes it
Added badge with signers count on account selector

## How to test it
Open the app and on the Home, check if the account selector shows a badge.

## Screenshots
<img width="520" alt="Screenshot 2025-04-08 at 01 13 37" src="https://github.com/user-attachments/assets/692f0e10-a2a9-4ba7-b45e-64f3c9c461bf" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
