### PR TITLE
feat(mobile): import menu conditionally and UI fix

### DIFF
--- a/apps/mobile/src/features/ImportPrivateKey/components/ImportSuccess/ImportSuccess.tsx
+++ b/apps/mobile/src/features/ImportPrivateKey/components/ImportSuccess/ImportSuccess.tsx
@@ -45,7 +45,7 @@ export function ImportSuccess() {
         <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
           <View flex={1} flexGrow={1} alignItems="center" justifyContent="center" paddingHorizontal="$3">
             <Badge
-              circleProps={{ backgroundColor: '#1B2A22' }}
+              circleProps={{ backgroundColor: '$success' }}
               themeName="badge_success"
               circleSize={64}
               content={<SafeFontIcon size={32} color="$primary" name="check-filled" />}

--- a/apps/mobile/src/features/ImportReadOnly/components/AddSignersFormView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/AddSignersFormView.tsx
@@ -25,7 +25,7 @@ export const AddSignersFormView = ({
       <SignersList
         navbarTitle={'Import your signers to unlock account'}
         isFetching={isFetching}
-        hasLocalSingers={!!signersGroupedBySection.imported?.data.length}
+        hasLocalSigners={!!signersGroupedBySection.imported?.data.length}
         signersGroup={signersSections}
       />
       <View paddingHorizontal={'$4'} paddingTop={'$2'} paddingBottom={bottom || 60}>

--- a/apps/mobile/src/features/Settings/Settings.tsx
+++ b/apps/mobile/src/features/Settings/Settings.tsx
@@ -62,14 +62,15 @@ export const Settings = ({ address, data, onImplementationTap, displayDevMenu, c
                 <YStack
                   alignItems="center"
                   backgroundColor={'$background'}
-                  padding={'$4'}
+                  paddingTop={'$3'}
+                  paddingBottom={'$2'}
                   borderRadius={'$6'}
                   width={80}
                   marginRight={'$2'}
                 >
                   <View width={30}>
                     <Skeleton colorMode={colorScheme === 'dark' ? 'dark' : 'light'}>
-                      <Text fontWeight="700" textAlign="center" fontSize={'$4'}>
+                      <Text fontWeight="bold" textAlign="center" fontSize={'$4'}>
                         {owners.length}
                       </Text>
                     </Skeleton>
@@ -82,7 +83,7 @@ export const Settings = ({ address, data, onImplementationTap, displayDevMenu, c
                 <YStack
                   alignItems="center"
                   backgroundColor={'$background'}
-                  paddingTop={'$4'}
+                  paddingTop={'$3'}
                   paddingBottom={'$2'}
                   borderRadius={'$6'}
                   width={80}

--- a/apps/mobile/src/features/Signers/Signers.container.tsx
+++ b/apps/mobile/src/features/Signers/Signers.container.tsx
@@ -28,7 +28,7 @@ export const SignersContainer = () => {
       <View flex={1}>
         <SignersList
           isFetching={isFetching}
-          hasLocalSingers={!!group.imported?.data.length}
+          hasLocalSigners={!!group.imported?.data.length}
           signersGroup={signersSections}
         />
       </View>

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersList.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersList.tsx
@@ -21,11 +21,11 @@ const keyExtractor = (item: AddressInfo, index: number) => item.value + index
 interface SignersListProps {
   signersGroup: SignerSection[]
   isFetching: boolean
-  hasLocalSingers: boolean
+  hasLocalSigners: boolean
   navbarTitle?: string
 }
 
-export function SignersList({ signersGroup, isFetching, hasLocalSingers, navbarTitle }: SignersListProps) {
+export function SignersList({ signersGroup, isFetching, hasLocalSigners, navbarTitle }: SignersListProps) {
   const title = navbarTitle || 'Signers'
   const { handleScroll } = useScrollableHeader({
     children: <NavBarTitle>{title}</NavBarTitle>,
@@ -39,8 +39,8 @@ export function SignersList({ signersGroup, isFetching, hasLocalSingers, navbarT
   )
 
   const ListHeaderComponent = useCallback(
-    () => <SignersListHeader sectionTitle={title} withAlert={!hasLocalSingers} />,
-    [hasLocalSingers],
+    () => <SignersListHeader sectionTitle={title} withAlert={!hasLocalSigners} />,
+    [hasLocalSigners],
   )
 
   return (

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersList.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersList.tsx
@@ -12,6 +12,7 @@ import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transacti
 import SignersListItem from './SignersListItem'
 
 export type SignerSection = {
+  id: string
   title: string
   data: SafeState['owners']
 }

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { MenuView, NativeActionEvent } from '@react-native-menu/menu'
+import { MenuView, NativeActionEvent, MenuAction } from '@react-native-menu/menu'
 import { useSignersActions } from './hooks/useSignersActions'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { SignersCard } from '@/src/components/transactions-list/Card/SignersCard'
@@ -24,7 +24,15 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
   const colorScheme = useColorScheme()
   const contact = useAppSelector(selectContactByAddress(item.value))
   const local = useLocalSearchParams<{ safeAddress: string; chainId: string; import_safe: string }>()
-  const actions = useSignersActions()
+
+  // Check if the current item belongs to the 'My signers' section
+  const isMySigner = signersGroup.some(
+    (section) => section.title === 'My signers' && section.data.some((signer) => signer.value === item.value),
+  )
+
+  const fullActions = useSignersActions(isMySigner) // This was necessary to prevent typescript from complaining about the actions array
+  // Filter out any false values to ensure the array type matches MenuAction[]
+  const actions = fullActions.filter(Boolean) as MenuAction[]
   const isLastItem = signersGroup.some((section) => section.data.length === index + 1)
   const dispatch = useAppDispatch()
   const copy = useCopyAndDispatchToast()
@@ -45,7 +53,7 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
       copy(item.value as string)
     }
 
-    if (nativeEvent.event === 'import') {
+    if (nativeEvent.event === 'import' && !isMySigner) {
       router.push({
         pathname: '/import-signers',
         params: {

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -25,9 +25,9 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
   const contact = useAppSelector(selectContactByAddress(item.value))
   const local = useLocalSearchParams<{ safeAddress: string; chainId: string; import_safe: string }>()
 
-  // Check if the current item belongs to the 'My signers' section
+  // Check if the current item belongs to the 'Imported signers' section
   const isMySigner = signersGroup.some(
-    (section) => section.title === 'My signers' && section.data.some((signer) => signer.value === item.value),
+    (section) => section.id === 'imported_signers' && section.data.some((signer) => signer.value === item.value),
   )
 
   const fullActions = useSignersActions(isMySigner) // This was necessary to prevent typescript from complaining about the actions array

--- a/apps/mobile/src/features/Signers/components/SignersList/hooks/useSignersActions.ts
+++ b/apps/mobile/src/features/Signers/components/SignersList/hooks/useSignersActions.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { Platform } from 'react-native'
 import { useTheme } from 'tamagui'
 
-export const useSignersActions = () => {
+export const useSignersActions = (disableImport: boolean) => {
   const theme = useTheme()
   const color = theme.color?.get()
   const actions = useMemo(
@@ -25,7 +25,7 @@ export const useSignersActions = () => {
         }),
         imageColor: Platform.select({ ios: color, android: '#000' }),
       },
-      {
+      !disableImport && {
         id: 'import',
         title: 'Import signer',
         image: Platform.select({
@@ -35,7 +35,7 @@ export const useSignersActions = () => {
         imageColor: Platform.select({ ios: color, android: '#000' }),
       },
     ],
-    [color],
+    [color, disableImport],
   )
 
   return actions

--- a/apps/mobile/src/features/Signers/constants.ts
+++ b/apps/mobile/src/features/Signers/constants.ts
@@ -2,10 +2,12 @@ import { SignerSection } from './components/SignersList/SignersList'
 
 export const groupedSigners: Record<string, SignerSection> = {
   imported: {
+    id: 'imported_signers',
     title: 'My signers',
     data: [],
   },
   notImported: {
+    id: 'not_imported_signers',
     title: 'Not imported signers',
     data: [],
   },


### PR DESCRIPTION
## What it solves
This PR implements a condition to avoid show import on item menu if the item was imported already.

Resolves #
https://github.com/safe-global/wallet-private-tasks/issues/99

## How this PR fixes it
Adds state and conditionals to prevent showing unnecessary menu action to the user.

## How to test it
Import and account and click on the 3dots.

## Screenshots
<img width="520" alt="Screenshot 2025-04-08 at 01 24 33" src="https://github.com/user-attachments/assets/6ee44954-076f-4742-a2d5-ba718e808271" />
<img width="520" alt="Screenshot 2025-04-08 at 01 24 24" src="https://github.com/user-attachments/assets/a258d860-58f8-4030-936e-709843afd5bf" />
<img width="520" alt="Screenshot 2025-04-08 at 01 23 58" src="https://github.com/user-attachments/assets/aef333c9-a823-4898-bb0e-c1c10bcb20ef" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
