### PR TITLE
Limit parallel threads in s3_upload.sh

### DIFF
--- a/apps/web/scripts/github/s3_upload.sh
+++ b/apps/web/scripts/github/s3_upload.sh
@@ -9,31 +9,18 @@ fi
 cd out
 
 # Upload the build to S3
-aws s3 sync . $BUCKET --delete
+aws s3 sync . "$BUCKET" --delete
 
-function parallel_limit {
-    local max="$1"
-    while (( $(jobs -rp | wc -l) >= max )); do
-        sleep 0.1
-    done
-}
-
-export BUCKET  
+export BUCKET
 
 MAX_JOBS=10
 
-# Upload all HTML files again but w/o an extention so that URLs like /welcome open the right page
-find . -name '*.html' -print0 | while IFS= read -r -d '' file; do
-    filepath="${file#./}"
-    noext="${filepath%.html}"
-
-    # Throttle jobs when max limit is hit
-    parallel_limit "$MAX_JOBS"
-
-    # Upload files to S3 using parallel threads
-    aws s3 cp "$filepath" "$BUCKET/$noext" --content-type 'text/html' &
-done
-
-wait
+# Upload all HTML files again but w/o an extension so that URLs like /welcome open the right page
+find . -name '*.html' -print0 | \
+xargs -0 -n 1 -P "$MAX_JOBS" -I {} bash -c '
+  filepath="{}"
+  noext="${filepath%.html}"
+  aws s3 cp "$filepath" "$BUCKET/$noext" --content-type "text/html"
+'
 
 cd -

--- a/apps/web/scripts/github/s3_upload.sh
+++ b/apps/web/scripts/github/s3_upload.sh
@@ -11,9 +11,27 @@ cd out
 # Upload the build to S3
 aws s3 sync . $BUCKET --delete
 
+function parallel_limit {
+    local max="$1"
+    while (( $(jobs -rp | wc -l) >= max )); do
+        sleep 0.1
+    done
+}
+
+export BUCKET  
+
+MAX_JOBS=10
+
 # Upload all HTML files again but w/o an extention so that URLs like /welcome open the right page
-for file in $(find . -name '*.html' | sed 's|^\./||'); do
-    aws s3 cp ${file%} $BUCKET/${file%.*} --content-type 'text/html' &
+find . -name '*.html' -print0 | while IFS= read -r -d '' file; do
+    filepath="${file#./}"
+    noext="${filepath%.html}"
+
+    # Throttle jobs when max limit is hit
+    parallel_limit "$MAX_JOBS"
+
+    # Upload files to S3 using parallel threads
+    aws s3 cp "$filepath" "$BUCKET/$noext" --content-type 'text/html' &
 done
 
 wait


### PR DESCRIPTION
## What it solves

This fix prevents the build outages we faced on docs.safe.global after the build output became large enough (~500 pages). Predictably, fixing this file (that both the codebases have in common) solved this issue. Limiting threads was [already rightfully mentioned in previous discussions](https://github.com/safe-global/safe-wallet-monorepo/pull/4842), but not implemented in the end as we could not get it to work properly at the time.

## How this PR fixes it

Replace the `for` loop by a `while` and add a throttling function when the max limit is hit.

## How to test it

Check that the GitHub action used for deployment still succeeds, even with large build outputs. Already tested on the [docs repo](https://github.com/safe-global/safe-docs/pull/728). 

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A) ❌
- [ ] I've documented how it affects the analytics (if at all) 📊 (N/A) ❌
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (N/A) ❌
