### PR TITLE
feat(mobile): add pull down to refresh history

### DIFF
--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
@@ -12,9 +12,11 @@ interface TxHistoryList {
   transactions?: HistoryTransactionItems[]
   onEndReached: (info: { distanceFromEnd: number }) => void
   isLoading?: boolean
+  refreshing?: boolean
+  onRefresh?: () => void
 }
 
-export function TxHistoryList({ transactions, onEndReached, isLoading }: TxHistoryList) {
+export function TxHistoryList({ transactions, onEndReached, isLoading, refreshing, onRefresh }: TxHistoryList) {
   const groupedList: GroupedTxsWithTitle<TransactionItem>[] = useMemo(() => {
     return groupTxsByDate(transactions || [])
   }, [transactions])
@@ -28,6 +30,8 @@ export function TxHistoryList({ transactions, onEndReached, isLoading }: TxHisto
       keyExtractor={(item, index) => (Array.isArray(item) ? getTxHash(item[0]) + index : getTxHash(item) + index)}
       renderItem={renderItem}
       onEndReached={onEndReached}
+      refreshing={refreshing}
+      onRefresh={onRefresh}
       contentContainerStyle={{
         paddingHorizontal: 16,
         paddingTop: 8,


### PR DESCRIPTION
## What it 
Ads pull down to refresh on the history page

Resolves
https://github.com/safe-global/wallet-private-tasks/issues/128

## How this PR fixes it

## How to test it
Open safe, navigate to the history, pull down - you would see a spinner and the tx will load from the server. (you could try sending a tx to the safe and then pulling down to see the newest tx at the top.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
