### PR TITLE
fix(mobile): subscribe to notifications in one click

### DIFF
--- a/apps/mobile/src/hooks/useNotificationManager.test.ts
+++ b/apps/mobile/src/hooks/useNotificationManager.test.ts
@@ -32,6 +32,7 @@ jest.mock('@/src/services/notifications/NotificationService', () => ({
   isDeviceNotificationEnabled: jest.fn(),
   getAllPermissions: jest.fn(),
   requestPushNotificationsPermission: jest.fn(),
+  handlePermissionFlow: jest.fn(),
 }))
 
 jest.mock('@/src/hooks/useRegisterForNotifications', () => ({
@@ -87,6 +88,7 @@ describe('useNotificationManager', () => {
 
   it('handles device notification permission check when enabling notifications', async () => {
     jest.mocked(NotificationsService.isDeviceNotificationEnabled).mockResolvedValueOnce(false)
+    jest.mocked(NotificationsService.handlePermissionFlow).mockResolvedValueOnce({ granted: false })
 
     const { result } = renderHook(() => useNotificationManager())
 
@@ -95,7 +97,7 @@ describe('useNotificationManager', () => {
       expect(success).toBe(false)
     })
 
-    expect(NotificationsService.getAllPermissions).toHaveBeenCalled()
+    expect(NotificationsService.handlePermissionFlow).toHaveBeenCalledWith(true)
   })
 
   it('handles errors when enabling notifications', async () => {


### PR DESCRIPTION
## What it solves

This PR implements fix on the UX of enabling Notifications. A bug leading users to click twice was also fixed.

Resolves https://github.com/safe-global/wallet-private-tasks/issues/145

**Notifications use cases.**
 - [x] - Enable Notifications for the first time through Opt-In.
 - [x] - Enable Notifications for the first time through Notifications Settings.
 - [x] - Rejecting Native Permission Prompt and then Enabling Notifications (leading user to Settings)
 - [x] - Disabling Notifications Settings on device while App notifications are enabled.

## How this PR fixes it
Implement handlers/references to handle different states.

## How to test it
Run each use case mentioned above.

## Screenshots

https://github.com/user-attachments/assets/c102a3b6-b9a7-4b4f-8362-55350d8fdbe6

https://github.com/user-attachments/assets/12954308-d949-467a-97a6-8ab574b032d6

https://github.com/user-attachments/assets/67213057-54c3-4696-b1ee-332627672695


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
