### PR TITLE
fix(web): update spending limits table to match recovery table style

### DIFF
--- a/apps/web/src/components/settings/SpendingLimits/index.tsx
+++ b/apps/web/src/components/settings/SpendingLimits/index.tsx
@@ -26,7 +26,6 @@ const SpendingLimits = () => {
         spacing={3}
         sx={{
           justifyContent: 'space-between',
-          mb: 2,
         }}
       >
         <Grid item lg={4} xs={12}>
@@ -54,7 +53,7 @@ const SpendingLimits = () => {
                     <Button
                       data-testid="new-spending-limit"
                       onClick={() => setTxFlow(<NewSpendingLimitFlow />)}
-                      sx={{ mt: 2 }}
+                      sx={{ mt: 2, mb: 2 }}
                       variant="contained"
                       disabled={!isOk}
                       size="small"
@@ -66,13 +65,15 @@ const SpendingLimits = () => {
               </CheckWallet>
 
               {!spendingLimits.length && !spendingLimitsLoading && <NoSpendingLimits />}
+              {spendingLimits.length > 0 && (
+                <SpendingLimitsTable isLoading={spendingLimitsLoading} spendingLimits={spendingLimits} />
+              )}
             </Box>
           ) : (
             <Typography>The spending limit feature is not yet available on this chain.</Typography>
           )}
         </Grid>
       </Grid>
-      <SpendingLimitsTable isLoading={spendingLimitsLoading} spendingLimits={spendingLimits} />
     </Paper>
   )
 }


### PR DESCRIPTION
## What it solves
This PR updates the Spending Limits table styling to match the Recovery table style.

Resolves #2923

## How this PR fixes it
- Removed the `mb: 2` from the Grid container styling 
- Added `mb: 2` to the "New spending limit" button for proper spacing
- Moved the `<SpendingLimitsTable> `component inside the `<Grid item xs>` and inside the same `<Box>` as the text

## How to test it
- Add spending limits
- Check the table view
- The table view should like the Figma [design](https://www.figma.com/design/pO43pjVwR34Uy1ihMsY3OM/Recovery-Hub?node-id=1-2&p=f&t=cHxWEvfBRneKnAqT-0) 

## Screenshots
![Screenshot 2025-04-08 at 15 53 55](https://github.com/user-attachments/assets/7c0fe938-6552-40fa-b25a-3f2720e3c982)

## Checklist

- [ ] I've tested the branch on mobile (not applicable) 📱
- [ ] I've documented how it affects the analytics (not applicable) 📊
- [ ] I've written a unit/e2e test for it (not applicable) 🧑‍💻
