### PR TITLE
Fix(Signing UX): improvements for hex data

### DIFF
--- a/apps/web/src/components/transactions/HexEncodedData/index.tsx
+++ b/apps/web/src/components/transactions/HexEncodedData/index.tsx
@@ -32,9 +32,7 @@ export const HexEncodedData = ({ hexData, title, highlightFirstBytes = true, lim
 
   const content = (
     <Box data-testid="tx-hexData" className={css.encodedData}>
-      <CopyButton text={hexData} />
-
-      <>
+      <CopyButton text={hexData}>
         {firstBytes}
         {showTxData || !showExpandBtn ? restBytes : shortenText(restBytes, limit - FIRST_BYTES)}{' '}
         {showExpandBtn && (
@@ -48,7 +46,7 @@ export const HexEncodedData = ({ hexData, title, highlightFirstBytes = true, lim
             Show {showTxData ? 'less' : 'more'}
           </Link>
         )}
-      </>
+      </CopyButton>
     </Box>
   )
 

--- a/apps/web/src/components/transactions/HexEncodedData/styles.module.css
+++ b/apps/web/src/components/transactions/HexEncodedData/styles.module.css
@@ -2,10 +2,5 @@
   line-break: anywhere;
   word-break: break-all;
   line-height: 1.1;
-}
-
-.encodedData button {
-  padding-top: 0;
-  padding-bottom: 0;
-  padding-left: 0;
+  font-family: monospace;
 }

--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react'
+import { memo, type ReactElement } from 'react'
 import { generateDataRowValue, TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
 import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
 import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
@@ -10,6 +10,7 @@ import DecodedData from '../TxData/DecodedData'
 import ColorCodedTxAccordion from '@/components/tx/ColorCodedTxAccordion'
 import { Box, Divider, Typography } from '@mui/material'
 import DecoderLinks from './DecoderLinks'
+import isEqual from 'lodash/isEqual'
 
 interface Props {
   safeTxData?: SafeTransactionData
@@ -83,4 +84,4 @@ const Summary = ({ safeTxData, txData, txInfo, txDetails, showMethodCall }: Prop
   )
 }
 
-export default Summary
+export default memo(Summary, isEqual)


### PR DESCRIPTION
## What it solves

* Make the hex data monospaced 
* Remove the copy icon and just make the whole text click-to-copiable
* Memoize the Summary component to avoid re-renders on Safe polling

<img width="514" alt="Screenshot 2025-04-08 at 16 13 55" src="https://github.com/user-attachments/assets/afca9af2-7fe5-42a4-aed6-de424a24a3cf" />