### PR TITLE
fix(mobile): content on android was behing Statusbar

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -18,7 +18,6 @@ import { configureReanimatedLogger, ReanimatedLogLevel } from 'react-native-rean
 import { OnboardingHeader } from '@/src/features/Onboarding/components/OnboardingHeader'
 import { getDefaultScreenOptions } from '@/src/navigation/hooks/utils'
 import { NavigationGuardHOC } from '@/src/navigation/NavigationGuardHOC'
-import { StatusBar } from 'expo-status-bar'
 import { TestCtrls } from '@/src/tests/e2e-maestro/components/TestCtrls'
 import Logger, { LogLevel } from '@/src/utils/logger'
 import { useInitWeb3 } from '@/src/hooks/useInitWeb3'
@@ -160,7 +159,6 @@ function RootLayout() {
                         />
                         <Stack.Screen name="+not-found" />
                       </Stack>
-                      <StatusBar />
                     </NavigationGuardHOC>
                   </SafeToastProvider>
                 </SafeThemeProvider>

--- a/apps/mobile/src/theme/provider/safeTheme.tsx
+++ b/apps/mobile/src/theme/provider/safeTheme.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { StatusBar } from 'react-native'
 import { ThemeProvider } from '@react-navigation/native'
 import { TamaguiProvider } from '@tamagui/core'
 
@@ -30,8 +29,6 @@ export const SafeThemeProvider = ({ children }: SafeThemeProviderProps) => {
 
   return (
     <FontProvider>
-      <StatusBar animated={true} barStyle="light-content" backgroundColor="transparent" translucent={true} />
-
       <TamaguiProvider config={config} defaultTheme={currentTheme ?? 'light'}>
         {themeProvider}
       </TamaguiProvider>


### PR DESCRIPTION
## What it solves
There are differences between the way android and ios handle content behind the statusbar. On android the Header from react-navigation ends up being behind the Statusbar which is unexpected. For now we are opting out of translucent statusbar and will tacle this at a later stage. It turns out to be a complicated issue with multiple bug reports, libraries to choose from (e.g. https://www.npmjs.com/package/react-native-edge-to-edge). Currently I'm not sure where the problem comes from. iOS seems to behave correctly where android does crazy stuff. 

Resolves #
before:
<img width="150" src="https://github.com/user-attachments/assets/7e7d2586-36cc-47f3-bdff-dc7fe9b7bdb3" />

after:
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/c26b73a2-662c-47cc-92b5-6067f3882b6e" />

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
