### PR TITLE
fix(mobile): no size defined for $md & $sm warning

### DIFF
--- a/apps/mobile/src/theme/tokens.ts
+++ b/apps/mobile/src/theme/tokens.ts
@@ -31,6 +31,8 @@ export const fontSizes = {
   3: 13,
   4: 14,
   true: 14,
+  $sm: 14,
+  $md: 14,
   5: 16,
   6: 18,
   7: 20,


### PR DESCRIPTION
## What it solves
Console was poluted by a huge No font size found $md error
![grafik](https://github.com/user-attachments/assets/b780f743-3806-4846-8368-d8b827076f6d)
That made looking at the logs very hard. 

That also fixes a problem where the wrong font was used for buttons.

Resolves
partially resolves https://github.com/orgs/safe-global/projects/1/views/16?pane=issue&itemId=105267036&issue=safe-global%7Cwallet-private-tasks%7C142
## How this PR fixes it

## How to test it
Launch the app, enable the JS debugger -> observe no warnings when you open a screen that has buttons.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
