### PR TITLE
fix(mobile): display info on biometrics screen

### DIFF
--- a/apps/mobile/src/app/biometrics-opt-in.tsx
+++ b/apps/mobile/src/app/biometrics-opt-in.tsx
@@ -5,8 +5,10 @@ import { router, useLocalSearchParams } from 'expo-router'
 import { useToastController } from '@tamagui/toast'
 import { useBiometrics } from '@/src/hooks/useBiometrics'
 import Logger from '@/src/utils/logger'
-
+import { View } from 'tamagui'
+import { useModalStyle } from '@/src/navigation/hooks/useModalStyle'
 function BiometricsOptIn() {
+  const modalStyle = useModalStyle()
   const { toggleBiometrics, getBiometricsButtonLabel, isBiometricsEnabled, isLoading } = useBiometrics()
 
   const local = useLocalSearchParams<{
@@ -76,24 +78,29 @@ function BiometricsOptIn() {
 
   const image = colorScheme === 'dark' ? darkImage : lightImage
 
+  const infoMessage = 'Biometrics is required to import a signer.'
+
   return (
-    <OptIn
-      testID="biometrics-opt-in-screen"
-      title="Simplify access, enhance security"
-      description="Enable biometrics to unlock the app quickly and confirm transactions securely using Face ID."
-      image={image}
-      isVisible
-      isLoading={isLoading}
-      colorScheme={colorScheme}
-      ctaButton={{
-        onPress: handleAccept,
-        label: getBiometricsButtonLabel(),
-      }}
-      secondaryButton={{
-        onPress: handleReject,
-        label: 'Maybe later',
-      }}
-    />
+    <View style={{ ...modalStyle }}>
+      <OptIn
+        testID="biometrics-opt-in-screen"
+        title="Simplify access, enhance security"
+        description="Enable biometrics to unlock the app quickly and confirm transactions securely using Face ID."
+        image={image}
+        isVisible
+        isLoading={isLoading}
+        colorScheme={colorScheme}
+        infoMessage={infoMessage}
+        ctaButton={{
+          onPress: handleAccept,
+          label: getBiometricsButtonLabel(),
+        }}
+        secondaryButton={{
+          onPress: handleReject,
+          label: 'Maybe later',
+        }}
+      />
+    </View>
   )
 }
 

--- a/apps/mobile/src/components/OptIn/OptIn.tsx
+++ b/apps/mobile/src/components/OptIn/OptIn.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { ColorSchemeName, ImageSourcePropType, SafeAreaView, StyleSheet } from 'react-native'
-import { Image, Text, getTokenValue } from 'tamagui'
+import { ColorSchemeName, ImageSourcePropType, StyleSheet } from 'react-native'
+import { H2, Image, Text, getTokenValue, View } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
 import { WINDOW_HEIGHT } from '@/src/store/constants'
-import { FloatingContainer } from '../FloatingContainer'
 import { Loader } from '../Loader'
+import { SafeFontIcon } from '../SafeFontIcon'
+import { Container } from '../Container'
 
 interface OptInProps {
   title: string
@@ -24,6 +24,7 @@ interface OptInProps {
   isVisible?: boolean
   isLoading?: boolean
   colorScheme: ColorSchemeName
+  infoMessage?: string
 }
 
 export const OptIn: React.FC<OptInProps> = React.memo(
@@ -38,31 +39,48 @@ export const OptIn: React.FC<OptInProps> = React.memo(
     isVisible,
     isLoading,
     colorScheme,
+    infoMessage,
   }: OptInProps) => {
-    const insets = useSafeAreaInsets()
-
     if (!isVisible) {
       return
     }
 
     return (
-      <SafeAreaView testID={testID} style={[styles.wrapper, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
-        {kicker && (
-          <Text textAlign="center" fontWeight={700} fontSize="$4" lineHeight="$6">
-            {kicker}
-          </Text>
-        )}
-        <Text textAlign="center" fontWeight={600} fontSize="$8" lineHeight="$8">
-          {title}
-        </Text>
-        {description && (
-          <Text textAlign="center" fontWeight={400} fontSize="$4" paddingHorizontal={'$4'}>
-            {description}
-          </Text>
-        )}
-        {image && <Image style={styles.image} source={image} />}
+      <View testID={testID} style={[styles.wrapper]} paddingTop={'$10'}>
+        <View flex={1} justifyContent="space-between" alignItems="center">
+          <View gap={'$4'}>
+            {kicker && (
+              <Text textAlign="center" fontWeight={700} fontSize="$4" lineHeight="$6">
+                {kicker}
+              </Text>
+            )}
+            <H2 textAlign="center" fontWeight={600}>
+              {title}
+            </H2>
+            {description && (
+              <Text textAlign="center" fontWeight={400} fontSize="$4" paddingHorizontal={'$4'}>
+                {description}
+              </Text>
+            )}
+            {infoMessage && (
+              <Container
+                flexDirection="row"
+                gap={'$2'}
+                paddingVertical={'$2'}
+                justifyContent="center"
+                alignItems="center"
+              >
+                <SafeFontIcon testID="info-icon" name="info" size={20} />
+                <Text fontSize="$3" color="$textMuted">
+                  {infoMessage}
+                </Text>
+              </Container>
+            )}
+          </View>
+          {image && <Image style={styles.image} source={image} />}
+        </View>
 
-        <FloatingContainer sticky testID="notifications-opt-in-cta-buttons" style={{ paddingHorizontal: 16 }}>
+        <View testID="notifications-opt-in-cta-buttons" flexDirection="column">
           <SafeButton onPress={ctaButton.onPress} marginBottom={'$3'} testID={'opt-in-primary-button'}>
             {!isLoading ? (
               ctaButton.label
@@ -82,8 +100,8 @@ export const OptIn: React.FC<OptInProps> = React.memo(
               {secondaryButton.label}
             </SafeButton>
           )}
-        </FloatingContainer>
-      </SafeAreaView>
+        </View>
+      </View>
     )
   },
 )
@@ -91,10 +109,9 @@ export const OptIn: React.FC<OptInProps> = React.memo(
 const styles = StyleSheet.create({
   wrapper: {
     flex: 1,
-    marginTop: 24,
-    gap: '$8',
-    alignItems: 'center',
-    justifyContent: 'flex-start',
+    gap: getTokenValue('$4', 'space'),
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
   },
   image: {
     width: '100%',

--- a/apps/mobile/src/navigation/hooks/useModalStyle.ts
+++ b/apps/mobile/src/navigation/hooks/useModalStyle.ts
@@ -27,6 +27,6 @@ export const useModalStyle = () => {
 
   return {
     ...modalStyle,
-    paddingBottom: bottom * 2 + getTokenValue('$4'),
+    paddingBottom: bottom + getTokenValue('$4'),
   }
 }

--- a/apps/mobile/src/theme/tokens.ts
+++ b/apps/mobile/src/theme/tokens.ts
@@ -31,6 +31,8 @@ export const fontSizes = {
   3: 13,
   4: 14,
   true: 14,
+  $sm: 14,
+  $md: 14,
   5: 16,
   6: 18,
   7: 20,


### PR DESCRIPTION
## What it solves
Display an info box on the biometrics screen explaining why we need it (Biometrics is required to import a signer). 

Resolves
https://github.com/safe-global/wallet-private-tasks/issues/96

## How this PR fixes it
Ads the missing banner component
Also properly aligns the design.

## How to test it

## Screenshots

before:
![grafik](https://github.com/user-attachments/assets/0a93a461-7e43-4a98-a941-a64ed71361b0)

after:
![grafik](https://github.com/user-attachments/assets/441d9af2-e7d0-4398-b028-821aa52013c0)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
