### PR TITLE
Fix(Spaces): Don't track meta events in spaces

### DIFF
--- a/apps/web/src/services/analytics/useMetaEvents.ts
+++ b/apps/web/src/services/analytics/useMetaEvents.ts
@@ -7,43 +7,46 @@ import useChainId from '@/hooks/useChainId'
 import useBalances from '@/hooks/useBalances'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useHiddenTokens from '@/hooks/useHiddenTokens'
+import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
 
 // Track meta events on app load
 const useMetaEvents = () => {
   const chainId = useChainId()
   const { safeAddress } = useSafeInfo()
+  const isSpaceRoute = useIsSpaceRoute()
 
   // Queue size
   const queue = useAppSelector(selectQueuedTransactions)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const safeQueue = useMemo(() => queue, [safeAddress, queue !== undefined])
   useEffect(() => {
-    if (!safeQueue) return
+    if (!safeQueue || isSpaceRoute) return
 
     gtmTrack({
       ...TX_LIST_EVENTS.QUEUED_TXS,
       label: safeQueue.length.toString(),
     })
-  }, [safeQueue])
+  }, [safeQueue, isSpaceRoute])
 
   // Tokens
   const { balances } = useBalances()
   const totalTokens = balances?.items.length ?? 0
   useEffect(() => {
-    if (!safeAddress || totalTokens <= 0) return
+    if (!safeAddress || totalTokens <= 0 || isSpaceRoute) return
 
     gtmTrack({ ...ASSETS_EVENTS.DIFFERING_TOKENS, label: totalTokens })
-  }, [totalTokens, safeAddress, chainId])
+  }, [totalTokens, safeAddress, chainId, isSpaceRoute])
 
   // Manually hidden tokens
   const hiddenTokens = useHiddenTokens()
   const totalHiddenFromBalance =
     balances?.items.filter((item) => hiddenTokens.includes(item.tokenInfo.address)).length ?? 0
+
   useEffect(() => {
-    if (!safeAddress || totalTokens <= 0) return
+    if (!safeAddress || totalTokens <= 0 || isSpaceRoute) return
 
     gtmTrack({ ...ASSETS_EVENTS.HIDDEN_TOKENS, label: totalHiddenFromBalance })
-  }, [safeAddress, totalHiddenFromBalance, totalTokens])
+  }, [safeAddress, totalHiddenFromBalance, totalTokens, isSpaceRoute])
 }
 
 export default useMetaEvents


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/160

## How this PR fixes it

- Checks `isSpaceRoute` before emitting meta events

## How to test it

1. Open a space with some safes added
2. Press the send token button next to a safe item
3. Observe only one GA event in the console
4. Close the send tokens flow
5. Observe no GA events in the console

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
