### PR TITLE
Fix(mobile): Allow user to see the signer list item options

### DIFF
--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -74,8 +74,26 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
         </View>
       </TouchableOpacity>
 
-      <View position="absolute" right={16} top={23}>
-        <MenuView onPressAction={onPressMenuAction} actions={actions}>
+      <View
+        position="absolute"
+        right={0}
+        top={0}
+        height={'100%'}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <MenuView
+          onPressAction={onPressMenuAction}
+          actions={actions}
+          style={{
+            height: '100%',
+            justifyContent: 'center',
+            alignItems: 'center',
+            paddingRight: 16,
+            paddingLeft: 16,
+          }}
+        >
           <SafeFontIcon name="options-horizontal" />
         </MenuView>
       </View>

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -59,9 +59,8 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
 
   return (
     <View position="relative">
-      <TouchableOpacity testID={`signer-${item.value}`}>
+      <TouchableOpacity onPress={onPress} testID={`signer-${item.value}`}>
         <View
-          onPress={onPress}
           backgroundColor={colorScheme === 'dark' ? '$backgroundPaper' : '$background'}
           borderTopRightRadius={index === 0 ? '$4' : undefined}
           borderTopLeftRadius={index === 0 ? '$4' : undefined}

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -58,25 +58,29 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
   }
 
   return (
-    <TouchableOpacity onPress={onPress} testID={`signer-${item.value}`}>
-      <View
-        backgroundColor={colorScheme === 'dark' ? '$backgroundPaper' : '$background'}
-        borderTopRightRadius={index === 0 ? '$4' : undefined}
-        borderTopLeftRadius={index === 0 ? '$4' : undefined}
-        borderBottomRightRadius={isLastItem ? '$4' : undefined}
-        borderBottomLeftRadius={isLastItem ? '$4' : undefined}
-      >
-        <SignersCard
-          name={contact ? (contact.name as string) : (item.name as string)}
-          address={item.value as `0x${string}`}
-          rightNode={
-            <MenuView onPressAction={onPressMenuAction} actions={actions}>
-              <SafeFontIcon name="options-horizontal" />
-            </MenuView>
-          }
-        />
+    <View position="relative">
+      <TouchableOpacity testID={`signer-${item.value}`}>
+        <View
+          onPress={onPress}
+          backgroundColor={colorScheme === 'dark' ? '$backgroundPaper' : '$background'}
+          borderTopRightRadius={index === 0 ? '$4' : undefined}
+          borderTopLeftRadius={index === 0 ? '$4' : undefined}
+          borderBottomRightRadius={isLastItem ? '$4' : undefined}
+          borderBottomLeftRadius={isLastItem ? '$4' : undefined}
+        >
+          <SignersCard
+            name={contact ? (contact.name as string) : (item.name as string)}
+            address={item.value as `0x${string}`}
+          />
+        </View>
+      </TouchableOpacity>
+
+      <View position="absolute" right={16} top={23}>
+        <MenuView onPressAction={onPressMenuAction} actions={actions}>
+          <SafeFontIcon name="options-horizontal" />
+        </MenuView>
       </View>
-    </TouchableOpacity>
+    </View>
   )
 }
 


### PR DESCRIPTION
## What it solves
The signers list items are not displaying the menu dropdown when clicking in the 3 dots

## How to test it
- Go to the signers list
- Click in any list item 3 dots icon

**Expected scenario**
- The menu dropdown should open

## Screenshots
https://github.com/user-attachments/assets/bfbd827d-f481-4d55-bf4b-2ef3c823c2c3


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
