### PR TITLE
fix(mobile): fix different sizing issues

### DIFF
--- a/apps/mobile/src/components/SafeButton/SafeButton.tsx
+++ b/apps/mobile/src/components/SafeButton/SafeButton.tsx
@@ -78,12 +78,14 @@ export const SafeButton = styled(Button, {
         paddingVertical: 14,
         paddingHorizontal: 20,
         margin: 0,
-        lineHeight: 20,
         fontWeight: 600,
         letterSpacing: -0.1,
         fontSize: 14,
         scaleIcon: 0.9,
         scaleSpace: 0.3,
+        textProps: {
+          marginBottom: -2.5,
+        },
       }),
       $sm: () => ({
         height: 36,
@@ -91,8 +93,10 @@ export const SafeButton = styled(Button, {
         paddingHorizontal: '$3',
         fontWeight: 600,
         scaleIcon: 0.8,
-        lineHeight: 20,
         scaleSpace: 0.2,
+        textProps: {
+          marginBottom: -2.5,
+        },
       }),
     },
   } as const,

--- a/apps/mobile/src/components/SafeInput/styled.ts
+++ b/apps/mobile/src/components/SafeInput/styled.ts
@@ -28,5 +28,6 @@ export const StyledInput = styled(Input, {
 
   style: {
     padding: 0,
+    lineHeight: 20.5,
   },
 })

--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.test.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.test.tsx
@@ -5,7 +5,7 @@ describe('MyAccountsFooter', () => {
   it('should render the defualt template', () => {
     const container = render(<MyAccountsFooter />)
 
-    expect(container.getByText('Add Existing Account')).toBeDefined()
-    expect(container.getByText('Join New Account')).toBeDefined()
+    expect(container.getByText('Add existing account')).toBeDefined()
+    expect(container.getByText('Join new account')).toBeDefined()
   })
 })

--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
@@ -37,7 +37,7 @@ export function MyAccountsFooter() {
           </View>
 
           <Text fontSize="$4" fontWeight={600}>
-            Add Existing Account
+            Add existing account
           </Text>
         </MyAccountsButton>
       </Link>
@@ -49,7 +49,7 @@ export function MyAccountsFooter() {
           </View>
 
           <Text fontSize="$4" fontWeight={600}>
-            Join New Account
+            Join new account
           </Text>
         </MyAccountsButton>
       </TouchableOpacity>

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/__snapshots__/AlreadySigned.test.tsx.snap
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/__snapshots__/AlreadySigned.test.tsx.snap
@@ -120,7 +120,6 @@ exports[`AlreadySigned matches snapshot 1`] = `
             "borderColor": "$background",
           }
         }
-        lineHeight={20}
         pointerEvents="none"
         role="button"
         style={
@@ -175,6 +174,7 @@ exports[`AlreadySigned matches snapshot 1`] = `
               "fontSize": 14,
               "letterSpacing": -0.1,
               "lineHeight": 15.400000000000002,
+              "marginBottom": -2.5,
               "userSelect": "none",
             }
           }

--- a/apps/mobile/src/features/GetStarted/GetStarted.tsx
+++ b/apps/mobile/src/features/GetStarted/GetStarted.tsx
@@ -61,7 +61,7 @@ export const GetStarted = () => {
           onPress={onPressJoinAccount}
           testID={'join-account-button'}
         >
-          Join Account
+          Join account
         </SafeButton>
         <SafeButton
           outlined

--- a/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
@@ -124,7 +124,7 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
             },
             {
               id: 'explorer',
-              title: 'View on Explorer',
+              title: 'View on explorer',
               image: Platform.select({
                 ios: 'link',
                 android: 'baseline_explore_24',

--- a/apps/mobile/src/features/Share/components/ShareView.tsx
+++ b/apps/mobile/src/features/Share/components/ShareView.tsx
@@ -85,20 +85,10 @@ export const ShareView = ({ activeSafe, availableChains }: ShareViewProps) => {
             </View>
           </Container>
           <XStack gap={'$3'} marginTop={'$6'}>
-            <SafeButton
-              size={'$sm'}
-              onPress={onPressShare}
-              icon={<SafeFontIcon name={'export'} size={16} style={{ marginTop: -4 }} />}
-              secondary
-            >
+            <SafeButton size={'$sm'} onPress={onPressShare} icon={<SafeFontIcon name={'export'} size={16} />} secondary>
               Share
             </SafeButton>
-            <SafeButton
-              size={'$sm'}
-              onPress={onPressCopy}
-              icon={<SafeFontIcon name={'copy'} size={16} style={{ marginTop: -4 }} />}
-              secondary
-            >
+            <SafeButton size={'$sm'} onPress={onPressCopy} icon={<SafeFontIcon name={'copy'} size={16} />} secondary>
               Copy
             </SafeButton>
           </XStack>


### PR DESCRIPTION
## What it solves
- center aligns button text and icon
- center aligns the text in input fields.
- fixes the places where we were using title case in buttons

Resolves
Makes annoyed users with laser eyes happy. 

## How this PR fixes it

## How to test it
If you open the app and you don't puke at the buttons and input text, then they are properly aligned 😄 

## Screenshots
before
<img src="https://github.com/user-attachments/assets/7cd895da-2212-4b0d-8c68-4f289755ebcb" width="150" />

after
<img src="https://github.com/user-attachments/assets/9dc225a6-2182-4dff-acf0-74b17bf80624" width="150" />

before
<img src="https://github.com/user-attachments/assets/9c580c7e-c00e-4442-a944-63a53f778809" width="150" />

after
<img src="https://github.com/user-attachments/assets/a5115888-e227-43e2-87f8-e59fbe9a239d" width="150" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
