### PR TITLE
Fix(PK Module): Use `signMessageSync` for personal_sign with PK module

### DIFF
--- a/apps/web/src/hooks/wallets/consts.ts
+++ b/apps/web/src/hooks/wallets/consts.ts
@@ -7,7 +7,7 @@ export const enum WALLET_KEYS {
   LEDGER_V2 = 'LEDGER_V2',
   TREZOR = 'TREZOR',
   KEYSTONE = 'KEYSTONE',
-  PK = 'PK',
+  PK = 'PRIVATE KEY',
 }
 
 // TODO: Check if undefined is needed as a return type, possibly couple this with WALLET_MODULES

--- a/apps/web/src/services/private-key-module/index.ts
+++ b/apps/web/src/services/private-key-module/index.ts
@@ -100,7 +100,7 @@ const PrivateKeyModule = (chainId: ChainInfo['chainId'], rpcUri: ChainInfo['rpcU
               },
 
               personal_sign: async ({ params }) => {
-                return wallet.signMessageSync(params[0])
+                return wallet.signMessage(params[0])
               },
 
               eth_signTypedData: async ({ params }) => {

--- a/apps/web/src/services/private-key-module/index.ts
+++ b/apps/web/src/services/private-key-module/index.ts
@@ -100,8 +100,7 @@ const PrivateKeyModule = (chainId: ChainInfo['chainId'], rpcUri: ChainInfo['rpcU
               },
 
               personal_sign: async ({ params }) => {
-                const signedMessage = wallet.signingKey.sign(params[0])
-                return signedMessage.serialized
+                return wallet.signMessageSync(params[0])
               },
 
               eth_signTypedData: async ({ params }) => {

--- a/apps/web/src/services/siwe/useSiwe.tsx
+++ b/apps/web/src/services/siwe/useSiwe.tsx
@@ -4,14 +4,17 @@ import { useCallback } from 'react'
 import { getSignableMessage } from './utils'
 import { logError } from '../exceptions'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
+import useWallet from '@/hooks/wallets/useWallet'
+import { isPKWallet } from '@/utils/wallets'
 
 export const useSiwe = () => {
+  const wallet = useWallet()
   const provider = useWeb3()
   const [fetchNonce] = useLazyAuthGetNonceV1Query()
   const [verifyAuthMutation] = useAuthVerifyV1Mutation()
 
   const signIn = useCallback(async () => {
-    if (!provider) return
+    if (!provider || !wallet) return
 
     try {
       const { data } = await fetchNonce()
@@ -20,13 +23,19 @@ export const useSiwe = () => {
       const [network, signer] = await Promise.all([provider.getNetwork(), provider.getSigner()])
       const signableMessage = getSignableMessage(signer.address, network.chainId, data.nonce)
 
-      const signature = await signer.signMessage(signableMessage)
+      let signature
+      // Using the signer.signMessage hexlifies the message which doesn't work with the personal_sign of the PK module
+      if (isPKWallet(wallet)) {
+        signature = await provider.send('personal_sign', [signableMessage, signer.address.toLowerCase()])
+      } else {
+        signature = await signer.signMessage(signableMessage)
+      }
 
       return verifyAuthMutation({ siweDto: { message: signableMessage, signature } })
     } catch (error) {
       logError(ErrorCodes._640)
     }
-  }, [fetchNonce, provider, verifyAuthMutation])
+  }, [fetchNonce, provider, verifyAuthMutation, wallet])
 
   return {
     signIn,

--- a/apps/web/src/utils/wallets.ts
+++ b/apps/web/src/utils/wallets.ts
@@ -40,6 +40,10 @@ export const isHardwareWallet = (wallet: ConnectedWallet): boolean => {
   )
 }
 
+export const isPKWallet = (wallet: ConnectedWallet): boolean => {
+  return wallet.label.toUpperCase() === WALLET_KEYS.PK
+}
+
 export const isSmartContract = async (address: string, provider?: JsonRpcProvider): Promise<boolean> => {
   const web3 = provider ?? getWeb3ReadOnly()
 


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/162

This now uses the same method as on mobile for the PK module that we use for testing.

## How this PR fixes it

- In case the connected wallet is the PK module we pass the signable message directly via `personal_sign` instead of using `signer.signMessage`

## How to test it

1. Open spaces
2. Connect a PK module wallet
3. Sign in
4. Observe it working
5. Connect with any other wallet
6. Sign in
7. Observe it still working

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
