### PR TITLE
fix: add check for Lens to use ZKsync flows

### DIFF
--- a/apps/web/src/components/new-safe/create/logic/utils.ts
+++ b/apps/web/src/components/new-safe/create/logic/utils.ts
@@ -36,7 +36,8 @@ export const getAvailableSaltNonce = async (
       throw new Error('Could not initiate RPC')
     }
     let safeAddress: string
-    if (chain.chainId === chains['zksync']) {
+    // FIXME a new check to indicate ZKsync chain will be added to the config service and available under ChainInfo
+    if (chain.chainId === chains['zksync'] || chain.chainId === chains['lens']) {
       // ZK-sync is using a different create2 method which is supported by the SDK
       safeAddress = await computeNewSafeAddress(
         rpcUrl,

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -181,14 +181,14 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
     () =>
       chain
         ? createNewUndeployedSafeWithoutSalt(
-            data.safeVersion,
-            {
-              owners: data.owners.map((owner) => owner.address),
-              threshold: data.threshold,
-              paymentReceiver: data.paymentReceiver,
-            },
-            chain,
-          )
+          data.safeVersion,
+          {
+            owners: data.owners.map((owner) => owner.address),
+            threshold: data.threshold,
+            paymentReceiver: data.paymentReceiver,
+          },
+          chain,
+        )
         : undefined,
     [chain, data.owners, data.safeVersion, data.threshold, data.paymentReceiver],
   )
@@ -196,9 +196,9 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
   const safePropsForGasEstimation = useMemo(() => {
     return newSafeProps
       ? {
-          ...newSafeProps,
-          saltNonce: Date.now().toString(),
-        }
+        ...newSafeProps,
+        saltNonce: Date.now().toString(),
+      }
       : undefined
   }, [newSafeProps])
 
@@ -241,7 +241,8 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
       let safeAddress: string
 
-      if (chain.chainId === chains['zksync']) {
+      // FIXME a new check to indicate ZKsync chain will be added to the config service and available under ChainInfo
+      if (chain.chainId === chains['zksync'] || chain.chainId === chains['lens']) {
         safeAddress = await computeNewSafeAddress(
           customRpcUrl || getRpcServiceUrl(chain.rpcUri),
           {
@@ -308,10 +309,10 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
       const options: DeploySafeProps['options'] = isEIP1559
         ? {
-            maxFeePerGas: maxFeePerGas?.toString(),
-            maxPriorityFeePerGas: maxPriorityFeePerGas?.toString(),
-            gasLimit: gasLimit?.toString(),
-          }
+          maxFeePerGas: maxFeePerGas?.toString(),
+          maxPriorityFeePerGas: maxPriorityFeePerGas?.toString(),
+          gasLimit: gasLimit?.toString(),
+        }
         : { gasPrice: maxFeePerGas?.toString(), gasLimit: gasLimit?.toString() }
 
       const onSubmitCallback = async (taskId?: string, txHash?: string) => {

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -181,14 +181,14 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
     () =>
       chain
         ? createNewUndeployedSafeWithoutSalt(
-          data.safeVersion,
-          {
-            owners: data.owners.map((owner) => owner.address),
-            threshold: data.threshold,
-            paymentReceiver: data.paymentReceiver,
-          },
-          chain,
-        )
+            data.safeVersion,
+            {
+              owners: data.owners.map((owner) => owner.address),
+              threshold: data.threshold,
+              paymentReceiver: data.paymentReceiver,
+            },
+            chain,
+          )
         : undefined,
     [chain, data.owners, data.safeVersion, data.threshold, data.paymentReceiver],
   )
@@ -196,9 +196,9 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
   const safePropsForGasEstimation = useMemo(() => {
     return newSafeProps
       ? {
-        ...newSafeProps,
-        saltNonce: Date.now().toString(),
-      }
+          ...newSafeProps,
+          saltNonce: Date.now().toString(),
+        }
       : undefined
   }, [newSafeProps])
 
@@ -309,10 +309,10 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
       const options: DeploySafeProps['options'] = isEIP1559
         ? {
-          maxFeePerGas: maxFeePerGas?.toString(),
-          maxPriorityFeePerGas: maxPriorityFeePerGas?.toString(),
-          gasLimit: gasLimit?.toString(),
-        }
+            maxFeePerGas: maxFeePerGas?.toString(),
+            maxPriorityFeePerGas: maxPriorityFeePerGas?.toString(),
+            gasLimit: gasLimit?.toString(),
+          }
         : { gasPrice: maxFeePerGas?.toString(), gasLimit: gasLimit?.toString() }
 
       const onSubmitCallback = async (taskId?: string, txHash?: string) => {

--- a/apps/web/src/hooks/useGasLimit.ts
+++ b/apps/web/src/hooks/useGasLimit.ts
@@ -162,7 +162,10 @@ const useGasLimit = (
 
     // if we are dealing with zksync and the walletAddress is a Safe, we have to do some magic
     // FIXME a new check to indicate ZKsync chain will be added to the config service and available under ChainInfo
-    if ((safe.chainId === chains.zksync || safe.chainId === chains.lens) && (await web3ReadOnly.getCode(walletAddress)) !== '0x') {
+    if (
+      (safe.chainId === chains.zksync || safe.chainId === chains.lens) &&
+      (await web3ReadOnly.getCode(walletAddress)) !== '0x'
+    ) {
       return getGasLimitForZkSync(safe, web3ReadOnly, safeSDK, safeTx)
     }
 

--- a/apps/web/src/hooks/useGasLimit.ts
+++ b/apps/web/src/hooks/useGasLimit.ts
@@ -161,7 +161,8 @@ const useGasLimit = (
     )
 
     // if we are dealing with zksync and the walletAddress is a Safe, we have to do some magic
-    if (safe.chainId === chains.zksync && (await web3ReadOnly.getCode(walletAddress)) !== '0x') {
+    // FIXME a new check to indicate ZKsync chain will be added to the config service and available under ChainInfo
+    if ((safe.chainId === chains.zksync || safe.chainId === chains.lens) && (await web3ReadOnly.getCode(walletAddress)) !== '0x') {
       return getGasLimitForZkSync(safe, web3ReadOnly, safeSDK, safeTx)
     }
 

--- a/apps/web/src/services/tx/tx-sender/dispatch.ts
+++ b/apps/web/src/services/tx/tx-sender/dispatch.ts
@@ -144,7 +144,10 @@ export const dispatchOnChainSigning = async (
   const safeTxHash = await sdk.getTransactionHash(safeTx)
   const eventParams = { txId, nonce: safeTx.data.nonce }
 
-  const options = (chainId === chains.zksync || chainId === chains.lens) ? { gasLimit: ZK_SYNC_ON_CHAIN_SIGNATURE_GAS_LIMIT } : undefined
+  const options =
+    chainId === chains.zksync || chainId === chains.lens
+      ? { gasLimit: ZK_SYNC_ON_CHAIN_SIGNATURE_GAS_LIMIT }
+      : undefined
   let txHashOrParentSafeTxHash: string
   try {
     // TODO: This is a workaround until there is a fix for unchecked transactions in the protocol-kit

--- a/apps/web/src/services/tx/tx-sender/dispatch.ts
+++ b/apps/web/src/services/tx/tx-sender/dispatch.ts
@@ -144,7 +144,7 @@ export const dispatchOnChainSigning = async (
   const safeTxHash = await sdk.getTransactionHash(safeTx)
   const eventParams = { txId, nonce: safeTx.data.nonce }
 
-  const options = chainId === chains.zksync ? { gasLimit: ZK_SYNC_ON_CHAIN_SIGNATURE_GAS_LIMIT } : undefined
+  const options = (chainId === chains.zksync || chainId === chains.lens) ? { gasLimit: ZK_SYNC_ON_CHAIN_SIGNATURE_GAS_LIMIT } : undefined
   let txHashOrParentSafeTxHash: string
   try {
     // TODO: This is a workaround until there is a fix for unchecked transactions in the protocol-kit


### PR DESCRIPTION
## What it solves

Resolves #address calculation for Lens, which uses ZKsync

## How this PR fixes it
Adds Lens chains to the checks where we use ZKsync flows.

This is just a temporary solution to unlock QA, not an ideal solution as the chances of adding new ZKsync chains are higher over time. Already requested that a config parameter is added to the config service so we can check from ChainInfo if the chain uses ZKsync allowing dinamically to configure them in the future.

