### PR TITLE
fix(mobile): unable to subscribe to push notifications on android

### DIFF
--- a/apps/mobile/src/hooks/useGTW.ts
+++ b/apps/mobile/src/hooks/useGTW.ts
@@ -16,6 +16,7 @@ import Logger from '@/src/utils/logger'
 import { HDNodeWallet, Wallet } from 'ethers'
 import { NOTIFICATION_ACCOUNT_TYPE } from '../store/constants'
 import { OWNER_NOTIFICATIONS, REGULAR_NOTIFICATIONS } from '../utils/notifications'
+import { convertToUuid } from '@/src/utils/uuid'
 
 export function useGTW() {
   // Queries
@@ -49,7 +50,8 @@ export function useGTW() {
 
       try {
         const signature = await signMessage({ signer, message })
-        const deviceUuid = await DeviceInfo.getUniqueId()
+        const deviceId = await DeviceInfo.getUniqueId()
+        const deviceUuid = convertToUuid(deviceId)
 
         await authVerifyV1({
           siweDto: {
@@ -115,7 +117,8 @@ export function useGTW() {
         }
 
         const signature = await signMessage({ signer, message })
-        const deviceUuid = await DeviceInfo.getUniqueId()
+        const deviceId = await DeviceInfo.getUniqueId()
+        const deviceUuid = convertToUuid(deviceId)
 
         authVerifyV1({
           siweDto: {

--- a/apps/mobile/src/utils/uuid.test.ts
+++ b/apps/mobile/src/utils/uuid.test.ts
@@ -1,0 +1,60 @@
+import { convertToUuid, isValidUuid } from './uuid'
+
+// Mock react-native-quick-crypto
+jest.mock('react-native-quick-crypto', () => ({
+  createHash: jest.fn().mockReturnValue({
+    update: jest.fn().mockReturnThis(),
+    digest: jest.fn().mockReturnValue('abcdef1234567890abcdef1234567890'),
+  }),
+}))
+
+describe('UUID Utilities', () => {
+  describe('convertToUuid', () => {
+    it('should return the same string if it already contains hyphens', () => {
+      const uuid = '123e4567-e89b-12d3-a456-426614174000'
+      expect(convertToUuid(uuid)).toBe(uuid)
+    })
+
+    it('should convert a device ID to a valid UUID v4 format', () => {
+      const deviceId = '1234567890abcdef'
+      const uuid = convertToUuid(deviceId)
+
+      // Check the format using regex
+      expect(uuid).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+
+      // Verify parts of the UUID
+      const parts = uuid.split('-')
+      expect(parts.length).toBe(5)
+      expect(parts[0].length).toBe(8)
+      expect(parts[1].length).toBe(4)
+      expect(parts[2].length).toBe(4)
+      expect(parts[2][0]).toBe('4') // Version 4
+      expect(['8', '9', 'a', 'b'].includes(parts[3][0].toLowerCase())).toBeTruthy() // Variant
+      expect(parts[3].length).toBe(4)
+      expect(parts[4].length).toBe(12)
+    })
+
+    it('should generate the same UUID for the same device ID', () => {
+      const deviceId = '1234567890abcdef'
+      const uuid1 = convertToUuid(deviceId)
+      const uuid2 = convertToUuid(deviceId)
+
+      expect(uuid1).toBe(uuid2)
+    })
+  })
+
+  describe('isValidUuid', () => {
+    it('should return true for valid UUIDs', () => {
+      expect(isValidUuid('123e4567-e89b-42d3-a456-426614174000')).toBe(true)
+      expect(isValidUuid('a8098c1a-f86e-4538-8B2F-ABB9770C8BDE')).toBe(true) // Case insensitive
+    })
+
+    it('should return false for invalid UUIDs', () => {
+      expect(isValidUuid('not-a-uuid')).toBe(false)
+      expect(isValidUuid('123e4567-e89b-12d3-a456-426614174000')).toBe(false) // Wrong version (not 4)
+      expect(isValidUuid('123e4567-e89b-42d3-e456-426614174000')).toBe(false) // Wrong variant (not 8-b)
+      expect(isValidUuid('123e4567-e89b42d3-a456-426614174000')).toBe(false) // Wrong format
+      expect(isValidUuid('')).toBe(false)
+    })
+  })
+})

--- a/apps/mobile/src/utils/uuid.ts
+++ b/apps/mobile/src/utils/uuid.ts
@@ -1,0 +1,44 @@
+import crypto from 'react-native-quick-crypto'
+
+/**
+ * Converts a device ID to a proper RFC4122-compliant UUID v4
+ * @param deviceId The device ID to convert
+ * @returns A valid UUID v4 string in format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ */
+export const convertToUuid = (deviceId: string): string => {
+  // If already in UUID format, return as is
+  if (deviceId.includes('-')) {
+    return deviceId
+  }
+
+  // Generate deterministic "random" bytes based on the device ID
+  const randomBytes = crypto.createHash('md5').update(deviceId).digest('hex')
+
+  // Format as UUID v4
+  return (
+    randomBytes.substring(0, 8) +
+    '-' +
+    randomBytes.substring(8, 12) +
+    '-' +
+    // Set version bits (bits 12-15 of time_hi_and_version) to 0100 (version 4)
+    '4' +
+    randomBytes.substring(13, 16) +
+    '-' +
+    // Set variant bits (bits 6-7 of clock_seq_hi_and_reserved) to 10
+    // (8, 9, a, or b) followed by the rest
+    ((parseInt(randomBytes.charAt(16), 16) & 0x3) | 0x8).toString(16) +
+    randomBytes.substring(17, 20) +
+    '-' +
+    randomBytes.substring(20, 32)
+  )
+}
+
+/**
+ * Validates if a string is a valid UUID
+ * @param uuid String to validate
+ * @returns True if the string is a valid UUID
+ */
+export const isValidUuid = (uuid: string): boolean => {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  return uuidRegex.test(uuid)
+}


### PR DESCRIPTION
## What it solves
When calling the register/notifications endpoint on android we were recieving a 422. It turned out that this is due to the format of the uuid that we send. The react-native-device-crypto getUniqueId method return uuid v4 on iOS, but only a 64-bix hex on android. Now, I’m converting the android id to a unique uuid. This way we are now able to subscribe on the gateway.

Resolves #
https://github.com/safe-global/wallet-private-tasks/issues/143

## How this PR fixes it
Converts the 64-bit hex string to a 128-bit UUID.

## How to test it
Try to subscribe to push notifications on android. You should not see a 422 error. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
