### PR TITLE
Fix(mobile): redirect user to the rename screen when pressing in the rename option

### DIFF
--- a/apps/mobile/src/app/signers/_layout.tsx
+++ b/apps/mobile/src/app/signers/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from 'expo-router'
 import { getDefaultScreenOptions } from '@/src/navigation/hooks/utils'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { SignerHeader } from '@/src/features/Signer/components/SignerHeader'
 
 export default function SignersLayout() {
   return (
@@ -12,7 +13,11 @@ export default function SignersLayout() {
       <Stack.Screen name="index" options={{ headerShown: true, title: 'Signers' }} />
       <Stack.Screen
         name="[address]"
-        options={{ headerShown: true, title: 'Signer', headerRight: () => <SafeFontIcon name={'edit'} size={20} /> }}
+        options={{
+          headerShown: true,
+          headerTitle: SignerHeader,
+          headerRight: () => <SafeFontIcon name={'edit'} size={20} />,
+        }}
       />
     </Stack>
   )

--- a/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
@@ -8,12 +8,11 @@ import { useCopyAndDispatchToast } from '@/src/hooks/useCopyAndDispatchToast'
 import { useToastController } from '@tamagui/toast'
 import { selectChainById } from '@/src/store/chains'
 import { RootState } from '@/src/store'
-import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
+import { useAppSelector } from '@/src/store/hooks'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useEditAccountItem } from '@/src/features/AccountsSheet/AccountItem/hooks/useEditAccountItem'
 import { type Address } from '@/src/types/address'
-import { useRouter } from 'expo-router'
-import { selectContactByAddress, upsertContact } from '@/src/store/addressBookSlice'
+import { router } from 'expo-router'
 import { FloatingMenu } from '../FloatingMenu'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 type Props = {
@@ -24,13 +23,10 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
   const insets = useSafeAreaInsets()
   const activeSafe = useDefinedActiveSafe()
   const { deleteSafe } = useEditAccountItem()
-  const dispatch = useAppDispatch()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const copyAndDispatchToast = useCopyAndDispatchToast()
-  const contact = useAppSelector(selectContactByAddress(activeSafe.address))
   const theme = useTheme()
   const color = theme.color?.get()
-  const router = useRouter()
   const colorError = 'red'
 
   if (!safeAddress) {
@@ -71,10 +67,9 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
         <FloatingMenu
           onPressAction={({ nativeEvent }) => {
             if (nativeEvent.event === 'rename') {
-              Alert.prompt('Rename safe', 'Enter a new name for the safe', (newName) => {
-                if (newName) {
-                  dispatch(upsertContact({ ...contact, value: safeAddress, name: newName }))
-                }
+              router.push({
+                pathname: '/signers/[address]',
+                params: { address: safeAddress, editMode: 'true', title: 'Rename safe' },
               })
             }
 

--- a/apps/mobile/src/features/Signer/Signer.container.tsx
+++ b/apps/mobile/src/features/Signer/Signer.container.tsx
@@ -19,8 +19,10 @@ export const SignerContainer = () => {
   const { address } = useLocalSearchParams<{ address: string }>()
   const dispatch = useAppDispatch()
   const activeChain = useAppSelector(selectActiveChain)
+  const local = useLocalSearchParams<{ editMode: string }>()
   const contact = useAppSelector(selectContactByAddress(address))
-  const [editMode, setEditMode] = useState(false)
+  const [editMode, setEditMode] = useState(Boolean(local.editMode))
+
   usePreventLeaveScreen(editMode)
 
   const onPressExplorer = useCallback(() => {

--- a/apps/mobile/src/features/Signer/components/SignerHeader.tsx
+++ b/apps/mobile/src/features/Signer/components/SignerHeader.tsx
@@ -1,0 +1,7 @@
+import { useLocalSearchParams } from 'expo-router'
+import { Text } from 'tamagui'
+
+export const SignerHeader = () => {
+  const { title = 'Signer' } = useLocalSearchParams<{ title: string }>()
+  return <Text>{title}</Text>
+}


### PR DESCRIPTION
## How this PR fixes it
It redirects the user to the rename screen when any "rename" option is pressed

## How to test it

- Go to settings screen
- Click in the 3 dots in the top
- Click in the rename option

**Expected scenario**
- User should be redirected to the rename screen.

## Demo video

https://github.com/user-attachments/assets/f896842e-0d29-4e96-a4c6-57f4a933e34f



## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
