### PR TITLE
fix(android): dmsans font was not loaded on android

### DIFF
--- a/apps/mobile/src/theme/provider/font.tsx
+++ b/apps/mobile/src/theme/provider/font.tsx
@@ -3,6 +3,10 @@ import { useFonts } from 'expo-font'
 import DmSansSemiBold from '@tamagui/font-dm-sans/fonts/static/DMSans-SemiBold.ttf'
 import DmSansRegular from '@tamagui/font-dm-sans/fonts/static/DMSans-Regular.ttf'
 import DmSansMedium from '@tamagui/font-dm-sans/fonts/static/DMSans-Medium.ttf'
+import DmSansMediumItalic from '@tamagui/font-dm-sans/fonts/static/DMSans-MediumItalic.ttf'
+import DmSansSemiBoldItalic from '@tamagui/font-dm-sans/fonts/static/DMSans-SemiBoldItalic.ttf'
+import DmSansBold from '@tamagui/font-dm-sans/fonts/static/DMSans-Bold.ttf'
+import DmSansBoldItalic from '@tamagui/font-dm-sans/fonts/static/DMSans-BoldItalic.ttf'
 import * as SplashScreen from 'expo-splash-screen'
 
 interface SafeThemeProviderProps {
@@ -19,9 +23,13 @@ SplashScreen.setOptions({
 
 export const FontProvider = ({ children }: SafeThemeProviderProps) => {
   const [loaded] = useFonts({
-    'DmSans-SemiBold': DmSansSemiBold,
-    'DmSans-Regular': DmSansRegular,
-    'DmSans-Medium': DmSansMedium,
+    'DMSans-SemiBold': DmSansSemiBold,
+    'DMSans-Regular': DmSansRegular,
+    'DMSans-Medium': DmSansMedium,
+    'DMSans-MediumItalic': DmSansMediumItalic,
+    'DMSans-SemiBoldItalic': DmSansSemiBoldItalic,
+    'DMSans-Bold': DmSansBold,
+    'DMSans-BoldItalic': DmSansBoldItalic,
   })
 
   useEffect(() => {


### PR DESCRIPTION
## What it solves
Android was not loading the dmsans font. After a lot of time and refactoring of how we load the config I realised that the problem actually stems from the font name. We have a typo in it 🤦 

Resolves #
https://github.com/safe-global/wallet-private-tasks/issues/161

## How this PR fixes it

## How to test it

## Screenshots
before:
<img src="https://github.com/user-attachments/assets/f4486ab0-160e-47d7-a184-661767dac7ba" width="150" />

after:
<img src="https://github.com/user-attachments/assets/2841f28b-17bc-4fd9-946e-e2903863f3c6" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
