### PR TITLE
Feat(Spaces): add confirmation dialog for deleting an address entry

### DIFF
--- a/apps/web/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
+++ b/apps/web/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
@@ -11,7 +11,7 @@ import { getDeviatingSetups, getSafeSetups } from '@/features/multichain/utils/u
 import { Box, Typography } from '@mui/material'
 import ChainIndicator from '@/components/common/ChainIndicator'
 
-const ChainIndicatorList = ({ chainIds }: { chainIds: string[] }) => {
+export const ChainIndicatorList = ({ chainIds }: { chainIds: string[] }) => {
   const { configs } = useChains()
 
   return (
@@ -20,7 +20,7 @@ const ChainIndicatorList = ({ chainIds }: { chainIds: string[] }) => {
         const chain = configs.find((chain) => chain.chainId === chainId)
         return (
           <Box key={chainId} display="inline-flex" flexWrap="wrap" position="relative" top={5}>
-            <ChainIndicator key={chainId} chainId={chainId} showUnknown={false} onlyLogo={true} />
+            <ChainIndicator responsive key={chainId} chainId={chainId} showUnknown={false} onlyLogo={true} />
             <Typography position="relative" mx={0.5} top={2}>
               {chain && chain.chainName}
               {index === chainIds.length - 1 ? '.' : ','}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddressBookContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddressBookContextMenu.tsx
@@ -11,6 +11,8 @@ import EditIcon from '@/public/images/common/edit.svg'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { trackEvent } from '@/services/analytics'
 import { useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
+import RemoveAddressBookEntryDialog from './RemoveAddressBookEntryDialog'
+import type { SpaceAddressBookEntry } from '../../types'
 
 enum ModalType {
   RENAME = 'rename',
@@ -19,7 +21,7 @@ enum ModalType {
 
 const defaultOpen = { [ModalType.RENAME]: false, [ModalType.REMOVE]: false }
 
-const AddressBookContextMenu = () => {
+const AddressBookContextMenu = ({ entry }: { entry: SpaceAddressBookEntry }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>()
   const [open, setOpen] = useState<typeof defaultOpen>(defaultOpen)
   const isAdmin = useIsAdmin()
@@ -39,6 +41,10 @@ const AddressBookContextMenu = () => {
     if (type === ModalType.REMOVE) trackEvent({ ...SPACE_EVENTS.DELETE_ACCOUNT_MODAL })
     setAnchorEl(undefined)
     setOpen((prev) => ({ ...prev, [type]: true }))
+  }
+
+  const handleCloseModal = () => {
+    setOpen(defaultOpen)
   }
 
   return (
@@ -63,6 +69,15 @@ const AddressBookContextMenu = () => {
           </MenuItem>
         )}
       </ContextMenu>
+
+      {open[ModalType.REMOVE] && (
+        <RemoveAddressBookEntryDialog
+          name={entry.name}
+          address={entry.address}
+          networks={entry.networks}
+          onClose={handleCloseModal}
+        />
+      )}
     </>
   )
 }

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/RemoveAddressBookEntryDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/RemoveAddressBookEntryDialog.tsx
@@ -1,0 +1,59 @@
+import DialogContent from '@mui/material/DialogContent'
+import DialogActions from '@mui/material/DialogActions'
+import Button from '@mui/material/Button'
+import Typography from '@mui/material/Typography'
+import DialogTitle from '@mui/material/DialogTitle'
+import ModalDialog from '@/components/common/ModalDialog'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { ChainIndicatorList } from '@/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning'
+
+type RemoveAddressBookEntryDialogProps = {
+  name: string
+  address: string
+  networks: {
+    chainId: string
+    name: string
+    id: string
+  }[]
+  onClose: () => void
+}
+
+const RemoveAddressBookEntryDialog = ({ name, address, networks, onClose }: RemoveAddressBookEntryDialogProps) => {
+  const handleConfirm = async () => {
+    try {
+      // TODO: Implement the API call to remove the address book entry
+      //   await Promise.all(entryIds.map((id) => removeAddressBookEntry(id)))
+      console.log('remove address book entries', name, address, networks)
+      trackEvent({ ...SPACE_EVENTS.REMOVE_ADDRESS_SUBMIT })
+      onClose()
+    } catch (error) {
+      console.error('Failed to remove address book entry', error)
+    }
+  }
+
+  return (
+    <ModalDialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Remove address book entry</DialogTitle>
+
+      <DialogContent sx={{ p: '24px !important' }}>
+        <Typography>
+          Are you sure you want to remove <strong>{name}</strong> from the address book? This change will apply to the
+          following networks:
+        </Typography>
+        <ChainIndicatorList chainIds={networks.map(({ chainId }) => chainId)} />
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose} color="inherit">
+          Cancel
+        </Button>
+        <Button data-testid="delete-btn" onClick={handleConfirm} variant="danger" disableElevation>
+          Remove
+        </Button>
+      </DialogActions>
+    </ModalDialog>
+  )
+}
+
+export default RemoveAddressBookEntryDialog

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -4,10 +4,10 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import Identicon from '@/components/common/Identicon'
 import { Box, Stack, Tooltip } from '@mui/material'
-import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import NetworkLogosList from '@/features/multichain/components/NetworkLogosList'
 import AddressBookContextMenu from './AddressBookContextMenu'
 import ChainIndicator from '@/components/common/ChainIndicator'
+import type { SpaceAddressBookEntry } from '../../types'
 
 const headCells = [
   { id: 'contact', label: 'Contact' },
@@ -16,7 +16,7 @@ const headCells = [
 ]
 
 type SpaceAddressBookTableProps = {
-  entries: { address: string; name: string; networks: ChainInfo[] }[]
+  entries: SpaceAddressBookEntry[]
 }
 
 function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
@@ -71,7 +71,7 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
             <Button data-testid="send-btn" variant="contained" color="primary" size="small" onClick={() => {}}>
               Send
             </Button>
-            <AddressBookContextMenu />
+            <AddressBookContextMenu entry={{ address, name, networks }} />
           </div>
         ),
       },

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -7,7 +7,7 @@ import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import AddContact from './AddContact'
 import EmptyAddressBook from '@/features/spaces/components/SpaceAddressBook/EmptyAddressBook'
 import SpaceAddressBookTable from './SpaceAddressBookTable'
-import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import type { SpaceAddressBookEntry } from '../../types'
 
 const SpaceAddressBook = () => {
   const isAdmin = useIsAdmin()
@@ -19,35 +19,26 @@ const SpaceAddressBook = () => {
   }
 
   // TODO: Get data from CGW
-  const entries = [
+  const entries: SpaceAddressBookEntry[] = [
     {
       address: '0xF94c38db9992cfE106C6502bfB6efa58519f7570',
       name: 'John Doe',
       networks: [
         {
           chainId: '11155111',
-          chainName: 'Sepolia',
-          l2: false,
-          nativeCurrency: {
-            symbol: 'ETH',
-          },
-        } as ChainInfo,
+          name: 'John Doe',
+          id: '123',
+        },
         {
           chainId: '137',
-          chainName: 'Polygon',
-          l2: false,
-          nativeCurrency: {
-            symbol: 'ETH',
-          },
-        } as ChainInfo,
+          name: 'John Doe',
+          id: '123',
+        },
         {
           chainId: '17000',
-          chainName: 'Holesky',
-          l2: false,
-          nativeCurrency: {
-            symbol: 'ETH',
-          },
-        } as ChainInfo,
+          name: 'John Doe',
+          id: '123',
+        },
       ],
     },
     {
@@ -56,12 +47,9 @@ const SpaceAddressBook = () => {
       networks: [
         {
           chainId: '1',
-          chainName: 'Ethereum',
-          l2: false,
-          nativeCurrency: {
-            symbol: 'ETH',
-          },
-        } as ChainInfo,
+          name: 'Jane Smith',
+          id: '123',
+        },
       ],
     },
   ]

--- a/apps/web/src/features/spaces/types.ts
+++ b/apps/web/src/features/spaces/types.ts
@@ -1,0 +1,17 @@
+// Todo: replace with type from rtk query
+export type CGWAddressbookEntry = {
+  id: string
+  name: string
+  address: string
+  chainId?: string
+}
+
+export type SpaceAddressBookEntry = {
+  address: string
+  name: string
+  networks: {
+    chainId: string
+    name: string
+    id: string
+  }[]
+}

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -145,6 +145,14 @@ export const SPACE_EVENTS = {
     action: 'Submit add address',
     category: SPACE_CATEGORY,
   },
+  REMOVE_ADDRESS: {
+    action: 'Open remove address dialog',
+    category: SPACE_CATEGORY,
+  },
+  REMOVE_ADDRESS_SUBMIT: {
+    action: 'Submit remove address',
+    category: SPACE_CATEGORY,
+  },
 }
 
 export enum SPACE_LABELS {


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/113#issue-2969298203

## How this PR fixes it
- Adds a confirm dialog showing the entry to be deleted and the chains the affected.
Note: designs are not ready for this so this is just a preliminary design

## How to test it
- Open a space and go to the address book.
- Click the context menu and click the delete icon.
- A confirmation dialog should open showing the entry to be deleted.
- On submit we should log to the console each of the payloads which will be sent in the delete requests (one per chain).

## Screenshots
![image](https://github.com/user-attachments/assets/6f5df9f8-707f-4109-9703-71a559602c6e)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
