### PR TITLE
feat(Signing UX): combo submit button

### DIFF
--- a/apps/web/src/components/common/SplitMenuButton/index.tsx
+++ b/apps/web/src/components/common/SplitMenuButton/index.tsx
@@ -67,13 +67,19 @@ export default function SplitMenuButton({
   }
 
   const { label, id } = useMemo(() => options[selectedIndex], [options, selectedIndex])
+  const maxCharLen = Math.max(...options.map(({ id, label }) => (label || id).length)) + 2
 
   return (
     <>
       <ButtonGroup variant="contained" ref={anchorRef} aria-label="Button group with a nested menu" fullWidth>
         <Tooltip title={tooltip} placement="top">
           <Box flex={1}>
-            <Button onClick={handleClick} type="submit" disabled={disabled}>
+            <Button
+              onClick={handleClick}
+              type="submit"
+              disabled={disabled}
+              sx={{ minWidth: `${maxCharLen}ch !important` }}
+            >
               {loading ? <CircularProgress size={20} /> : label || id}
             </Button>
           </Box>

--- a/apps/web/src/components/common/SplitMenuButton/index.tsx
+++ b/apps/web/src/components/common/SplitMenuButton/index.tsx
@@ -50,9 +50,12 @@ export default function SplitMenuButton({
 
   const handleMenuItemClick = (e: React.MouseEvent<HTMLLIElement, MouseEvent>, index: number) => {
     e.preventDefault()
-    setSelectedIndex(index)
-    setOpen(false)
-    onChange?.(options[index])
+
+    if (index !== selectedIndex) {
+      setSelectedIndex(index)
+      setOpen(false)
+      onChange?.(options[index])
+    }
   }
 
   const handleToggle = () => {

--- a/apps/web/src/components/common/SplitMenuButton/index.tsx
+++ b/apps/web/src/components/common/SplitMenuButton/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type SyntheticEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type SyntheticEvent } from 'react'
 import Button from '@mui/material/Button'
 import ButtonGroup from '@mui/material/ButtonGroup'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
@@ -6,22 +6,27 @@ import MenuItem from '@mui/material/MenuItem'
 import MenuList from '@mui/material/MenuList'
 import { Box, CircularProgress, Popover, Tooltip } from '@mui/material'
 
+type Option = {
+  id: string
+  label?: string
+}
+
 export default function SplitMenuButton({
   options,
   disabled = false,
   tooltip,
   onClick,
   onChange,
-  selectedOption,
+  selected,
   disabledIndex,
   loading = false,
 }: {
-  options: string[]
+  options: Option[]
   disabled?: boolean
   tooltip?: string
-  onClick?: (option: string, e: SyntheticEvent) => void
-  onChange?: (option: string) => void
-  selectedOption?: string
+  onClick?: (option: Option, e: SyntheticEvent) => void
+  onChange?: (option: Option) => void
+  selected?: Option['id']
   disabledIndex?: number
   loading?: boolean
 }) {
@@ -30,13 +35,13 @@ export default function SplitMenuButton({
   const [selectedIndex, setSelectedIndex] = useState(0)
 
   useEffect(() => {
-    if (selectedOption) {
-      const index = options.indexOf(selectedOption)
+    if (selected) {
+      const index = options.findIndex((option) => option.id === selected)
       if (index !== -1) {
         setSelectedIndex(index)
       }
     }
-  }, [selectedOption, options])
+  }, [selected, options])
 
   const handleClick = (e: SyntheticEvent) => {
     onClick?.(options[selectedIndex], e)
@@ -61,13 +66,15 @@ export default function SplitMenuButton({
     setOpen(false)
   }
 
+  const { label, id } = useMemo(() => options[selectedIndex], [options, selectedIndex])
+
   return (
     <>
       <ButtonGroup variant="contained" ref={anchorRef} aria-label="Button group with a nested menu" fullWidth>
         <Tooltip title={tooltip} placement="top">
           <Box flex={1}>
             <Button onClick={handleClick} type="submit" disabled={disabled}>
-              {loading ? <CircularProgress size={20} /> : options[selectedIndex]}
+              {loading ? <CircularProgress size={20} /> : label || id}
             </Button>
           </Box>
         </Tooltip>
@@ -79,6 +86,7 @@ export default function SplitMenuButton({
             aria-label="select action"
             aria-haspopup="menu"
             onClick={handleToggle}
+            disabled={loading}
             sx={{ minWidth: '0 !important', maxWidth: 48, px: 1.5 }}
           >
             <ArrowDropDownIcon />
@@ -102,12 +110,12 @@ export default function SplitMenuButton({
         <MenuList autoFocusItem>
           {options.map((option, index) => (
             <MenuItem
-              key={option}
+              key={option.id}
               selected={index === selectedIndex}
               disabled={disabledIndex === index}
               onClick={(event) => handleMenuItemClick(event, index)}
             >
-              {option}
+              {option.label || option.id}
             </MenuItem>
           ))}
         </MenuList>

--- a/apps/web/src/components/common/SplitMenuButton/index.tsx
+++ b/apps/web/src/components/common/SplitMenuButton/index.tsx
@@ -4,7 +4,8 @@ import ButtonGroup from '@mui/material/ButtonGroup'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import MenuItem from '@mui/material/MenuItem'
 import MenuList from '@mui/material/MenuList'
-import { Box, CircularProgress, Popover, Tooltip } from '@mui/material'
+import { Box, CircularProgress, ListItemText, Popover, Tooltip } from '@mui/material'
+import CheckIcon from '@mui/icons-material/Check'
 
 type Option = {
   id: string
@@ -120,8 +121,10 @@ export default function SplitMenuButton({
               selected={index === selectedIndex}
               disabled={disabledIndex === index}
               onClick={(event) => handleMenuItemClick(event, index)}
+              sx={{ gap: 2 }}
             >
-              {option.label || option.id}
+              <ListItemText>{option.label || option.id}</ListItemText>
+              {index === selectedIndex ? <CheckIcon /> : <Box sx={{ width: 24 }} />}
             </MenuItem>
           ))}
         </MenuList>

--- a/apps/web/src/components/common/SplitMenuButton/index.tsx
+++ b/apps/web/src/components/common/SplitMenuButton/index.tsx
@@ -67,7 +67,7 @@ export default function SplitMenuButton({
     setOpen(false)
   }
 
-  const { label, id } = useMemo(() => options[selectedIndex], [options, selectedIndex])
+  const { label, id } = useMemo(() => options[selectedIndex] || {}, [options, selectedIndex])
   const maxCharLen = Math.max(...options.map(({ id, label }) => (label || id).length)) + 2
 
   return (

--- a/apps/web/src/components/common/SplitMenuButton/index.tsx
+++ b/apps/web/src/components/common/SplitMenuButton/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type SyntheticEvent } from 'react'
+import { useEffect, useRef, useState, type SyntheticEvent } from 'react'
 import Button from '@mui/material/Button'
 import ButtonGroup from '@mui/material/ButtonGroup'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
@@ -8,18 +8,24 @@ import Paper from '@mui/material/Paper'
 import Popper from '@mui/material/Popper'
 import MenuItem from '@mui/material/MenuItem'
 import MenuList from '@mui/material/MenuList'
-import { CircularProgress } from '@mui/material'
+import { CircularProgress, Tooltip } from '@mui/material'
 
 export default function SplitMenuButton({
   options,
   disabled = false,
+  tooltip,
   onClick,
+  onChange,
+  selectedOption,
   disabledIndex,
   loading = false,
 }: {
   options: string[]
   disabled?: boolean
-  onClick: (option: string, e: SyntheticEvent) => void
+  tooltip?: string
+  onClick?: (option: string, e: SyntheticEvent) => void
+  onChange?: (option: string) => void
+  selectedOption?: string
   disabledIndex?: number
   loading?: boolean
 }) {
@@ -27,13 +33,23 @@ export default function SplitMenuButton({
   const anchorRef = useRef<HTMLDivElement>(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
 
+  useEffect(() => {
+    if (selectedOption) {
+      const index = options.indexOf(selectedOption)
+      if (index !== -1) {
+        setSelectedIndex(index)
+      }
+    }
+  }, [selectedOption, options])
+
   const handleClick = (e: SyntheticEvent) => {
-    onClick(options[selectedIndex], e)
+    onClick?.(options[selectedIndex], e)
   }
 
   const handleMenuItemClick = (event: React.MouseEvent<HTMLLIElement, MouseEvent>, index: number) => {
     setSelectedIndex(index)
     setOpen(false)
+    onChange?.(options[index])
   }
 
   const handleToggle = () => {
@@ -53,15 +69,24 @@ export default function SplitMenuButton({
   return (
     <>
       <ButtonGroup variant="contained" ref={anchorRef} aria-label="Button group with a nested menu">
-        <Button onClick={handleClick} type="submit" disabled={disabled} sx={{ minWidth: `${maxCharLen}ch !important` }}>
-          {loading ? <CircularProgress size={20} /> : options[selectedIndex]}
-        </Button>
+        <Tooltip title={tooltip} placement="top">
+          <span>
+            <Button
+              onClick={handleClick}
+              type="submit"
+              disabled={disabled}
+              sx={{ minWidth: `${maxCharLen}ch !important` }}
+            >
+              {loading ? <CircularProgress size={20} /> : options[selectedIndex]}
+            </Button>
+          </span>
+        </Tooltip>
 
         {options.length > 1 && (
           <Button
             size="small"
             aria-expanded={open ? 'true' : undefined}
-            aria-label="select merge strategy"
+            aria-label="select action"
             aria-haspopup="menu"
             onClick={handleToggle}
             sx={{ minWidth: '0 !important', px: 1.5 }}

--- a/apps/web/src/components/common/SplitMenuButton/index.tsx
+++ b/apps/web/src/components/common/SplitMenuButton/index.tsx
@@ -79,6 +79,7 @@ export default function SplitMenuButton({
         <Tooltip title={tooltip} placement="top">
           <Box flex={1}>
             <Button
+              data-testid={`combo-submit-${id}`}
               onClick={handleClick}
               type="submit"
               disabled={disabled}

--- a/apps/web/src/components/common/SplitMenuButton/index.tsx
+++ b/apps/web/src/components/common/SplitMenuButton/index.tsx
@@ -2,13 +2,9 @@ import { useEffect, useRef, useState, type SyntheticEvent } from 'react'
 import Button from '@mui/material/Button'
 import ButtonGroup from '@mui/material/ButtonGroup'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
-import ClickAwayListener from '@mui/material/ClickAwayListener'
-import Grow from '@mui/material/Grow'
-import Paper from '@mui/material/Paper'
-import Popper from '@mui/material/Popper'
 import MenuItem from '@mui/material/MenuItem'
 import MenuList from '@mui/material/MenuList'
-import { CircularProgress, Tooltip } from '@mui/material'
+import { Box, CircularProgress, Popover, Tooltip } from '@mui/material'
 
 export default function SplitMenuButton({
   options,
@@ -46,7 +42,8 @@ export default function SplitMenuButton({
     onClick?.(options[selectedIndex], e)
   }
 
-  const handleMenuItemClick = (event: React.MouseEvent<HTMLLIElement, MouseEvent>, index: number) => {
+  const handleMenuItemClick = (e: React.MouseEvent<HTMLLIElement, MouseEvent>, index: number) => {
+    e.preventDefault()
     setSelectedIndex(index)
     setOpen(false)
     onChange?.(options[index])
@@ -64,22 +61,15 @@ export default function SplitMenuButton({
     setOpen(false)
   }
 
-  const maxCharLen = Math.max(...options.map((option) => option.length)) + 2
-
   return (
     <>
-      <ButtonGroup variant="contained" ref={anchorRef} aria-label="Button group with a nested menu">
+      <ButtonGroup variant="contained" ref={anchorRef} aria-label="Button group with a nested menu" fullWidth>
         <Tooltip title={tooltip} placement="top">
-          <span>
-            <Button
-              onClick={handleClick}
-              type="submit"
-              disabled={disabled}
-              sx={{ minWidth: `${maxCharLen}ch !important` }}
-            >
+          <Box flex={1}>
+            <Button onClick={handleClick} type="submit" disabled={disabled}>
               {loading ? <CircularProgress size={20} /> : options[selectedIndex]}
             </Button>
-          </span>
+          </Box>
         </Tooltip>
 
         {options.length > 1 && (
@@ -89,47 +79,39 @@ export default function SplitMenuButton({
             aria-label="select action"
             aria-haspopup="menu"
             onClick={handleToggle}
-            sx={{ minWidth: '0 !important', px: 1.5 }}
+            sx={{ minWidth: '0 !important', maxWidth: 48, px: 1.5 }}
           >
             <ArrowDropDownIcon />
           </Button>
         )}
       </ButtonGroup>
 
-      <Popper
-        sx={{ zIndex: 100 }}
+      <Popover
         open={open}
         anchorEl={anchorRef.current}
-        role={undefined}
-        transition
-        placement="bottom-end"
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{ horizontal: 'right', vertical: -2 }}
+        slotProps={{
+          root: { slotProps: { backdrop: { sx: { backgroundColor: 'transparent' } } } },
+        }}
       >
-        {({ TransitionProps }) => (
-          <Grow
-            {...TransitionProps}
-            style={{
-              transformOrigin: 'center right',
-            }}
-          >
-            <Paper elevation={1}>
-              <ClickAwayListener onClickAway={handleClose}>
-                <MenuList autoFocusItem>
-                  {options.map((option, index) => (
-                    <MenuItem
-                      key={option}
-                      selected={index === selectedIndex}
-                      disabled={disabledIndex === index}
-                      onClick={(event) => handleMenuItemClick(event, index)}
-                    >
-                      {option}
-                    </MenuItem>
-                  ))}
-                </MenuList>
-              </ClickAwayListener>
-            </Paper>
-          </Grow>
-        )}
-      </Popper>
+        <MenuList autoFocusItem>
+          {options.map((option, index) => (
+            <MenuItem
+              key={option}
+              selected={index === selectedIndex}
+              disabled={disabledIndex === index}
+              onClick={(event) => handleMenuItemClick(event, index)}
+            >
+              {option}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Popover>
     </>
   )
 }

--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -77,7 +77,7 @@ export const TxFlow = <T extends unknown>({
               <TxFlowContent>
                 {...childrenArray}
 
-                <ReviewTransactionComponent onSubmit={() => nextStep(data)}>
+                <ReviewTransactionComponent onSubmit={(props = {}) => onSubmit?.({ ...props, data })}>
                   <TxChecks />
                   <TxNote />
                   <SignerSelect />
@@ -94,7 +94,7 @@ export const TxFlow = <T extends unknown>({
                   <Propose />
                 </ReviewTransactionComponent>
 
-                <ConfirmTxReceipt onSubmit={(props = {}) => onSubmit?.({ ...props, data })} />
+                <ConfirmTxReceipt />
               </TxFlowContent>
             </TxFlowProvider>
           </SlotProvider>

--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -84,12 +84,14 @@ export const TxFlow = <T extends unknown>({
                   <ExecuteCheckbox />
 
                   <Counterfactual />
-                  <Execute />
                   <ExecuteThroughRole />
+
                   <ComboSubmit>
                     <Sign />
+                    <Execute />
                     <Batching />
                   </ComboSubmit>
+
                   <Propose />
                 </ReviewTransactionComponent>
 

--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -7,7 +7,7 @@ import TxFlowProvider, { type TxFlowContextType } from './TxFlowProvider'
 import { TxFlowContent } from './common/TxFlowContent'
 import ReviewTransaction from '../tx/ReviewTransactionV2'
 import { ConfirmTxReceipt } from '../tx/ConfirmTxReceipt'
-import { ExecuteCheckbox, TxChecks, TxNote, SignerSelect } from './features'
+import { TxChecks, TxNote, SignerSelect } from './features'
 import { Batching, ComboSubmit, Counterfactual, Execute, ExecuteThroughRole, Propose, Sign } from './actions'
 import { SlotProvider } from './slots'
 
@@ -81,7 +81,6 @@ export const TxFlow = <T extends unknown>({
                   <TxChecks />
                   <TxNote />
                   <SignerSelect />
-                  <ExecuteCheckbox />
 
                   <Counterfactual />
                   <ExecuteThroughRole />

--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -8,7 +8,7 @@ import { TxFlowContent } from './common/TxFlowContent'
 import ReviewTransaction from '../tx/ReviewTransactionV2'
 import { ConfirmTxReceipt } from '../tx/ConfirmTxReceipt'
 import { ExecuteCheckbox, TxChecks, TxNote, SignerSelect } from './features'
-import { Batching, Counterfactual, Execute, ExecuteThroughRole, Propose, Sign } from './actions'
+import { Batching, ComboSubmit, Counterfactual, Execute, ExecuteThroughRole, Propose, Sign } from './actions'
 import { SlotProvider } from './slots'
 
 type SubmitCallbackProps = { txId?: string; isExecuted?: boolean }
@@ -78,20 +78,22 @@ export const TxFlow = <T extends unknown>({
                 {...childrenArray}
 
                 <ReviewTransactionComponent onSubmit={() => nextStep(data)}>
-                  <Batching />
                   <TxChecks />
                   <TxNote />
                   <SignerSelect />
                   <ExecuteCheckbox />
-                </ReviewTransactionComponent>
 
-                <ConfirmTxReceipt onSubmit={(props = {}) => onSubmit?.({ ...props, data })}>
                   <Counterfactual />
                   <Execute />
                   <ExecuteThroughRole />
-                  <Sign />
+                  <ComboSubmit>
+                    <Sign />
+                    <Batching />
+                  </ComboSubmit>
                   <Propose />
-                </ConfirmTxReceipt>
+                </ReviewTransactionComponent>
+
+                <ConfirmTxReceipt onSubmit={(props = {}) => onSubmit?.({ ...props, data })} />
               </TxFlowContent>
             </TxFlowProvider>
           </SlotProvider>

--- a/apps/web/src/components/tx-flow/TxFlowProvider.tsx
+++ b/apps/web/src/components/tx-flow/TxFlowProvider.tsx
@@ -68,7 +68,7 @@ export type TxFlowContextType<T extends unknown = any> = {
   role?: Role
 }
 
-const initialContext: TxFlowContextType = {
+export const initialContext: TxFlowContextType = {
   step: 0,
   progress: 0,
   data: undefined,

--- a/apps/web/src/components/tx-flow/TxFlowProvider.tsx
+++ b/apps/web/src/components/tx-flow/TxFlowProvider.tsx
@@ -51,8 +51,14 @@ export type TxFlowContextType<T extends unknown = any> = {
   canExecute: boolean
   shouldExecute: boolean
   setShouldExecute: Dispatch<SetStateAction<boolean>>
+
   isSubmittable: boolean
   setIsSubmittable: Dispatch<SetStateAction<boolean>>
+  submitError?: Error
+  setSubmitError: Dispatch<SetStateAction<Error | undefined>>
+  isRejectedByUser: boolean
+  setIsRejectedByUser: Dispatch<SetStateAction<boolean>>
+
   willExecuteThroughRole: boolean
   canExecuteThroughRole: boolean
   txDetails?: TransactionDetails
@@ -82,8 +88,14 @@ const initialContext: TxFlowContextType = {
   canExecute: false,
   shouldExecute: false,
   setShouldExecute: () => {},
+
   isSubmittable: true,
   setIsSubmittable: () => {},
+  submitError: undefined,
+  setSubmitError: () => {},
+  isRejectedByUser: false,
+  setIsRejectedByUser: () => {},
+
   willExecuteThroughRole: false,
   canExecuteThroughRole: false,
   isBatch: false,
@@ -130,7 +142,9 @@ const TxFlowProvider = <T extends unknown>({
   const isCorrectNonce = useValidateNonce(safeTx)
   const { transactionExecution } = useAppSelector(selectSettings)
   const [shouldExecute, setShouldExecute] = useState<boolean>(transactionExecution)
-  const [isSubmittable, setIsSubmittable] = useState<boolean>(true)
+  const [isSubmittable, setIsSubmittable] = useState<boolean>(initialContext.isSubmittable)
+  const [submitError, setSubmitError] = useState<Error | undefined>(initialContext.submitError)
+  const [isRejectedByUser, setIsRejectedByUser] = useState<boolean>(initialContext.isRejectedByUser)
   const [txLayoutProps, setTxLayoutProps] = useState<TxFlowContextType['txLayoutProps']>(defaultTxLayoutProps)
   const [trigger] = useLazyGetTransactionDetailsQuery()
   const isCounterfactualSafe = useIsCounterfactualSafe()
@@ -200,8 +214,14 @@ const TxFlowProvider = <T extends unknown>({
     willExecute,
     shouldExecute,
     setShouldExecute,
+
     isSubmittable,
     setIsSubmittable,
+    submitError,
+    setSubmitError,
+    isRejectedByUser,
+    setIsRejectedByUser,
+
     willExecuteThroughRole,
     canExecuteThroughRole,
     role: allowingRole || mostLikelyRole,

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -15,7 +15,7 @@ import { TxCardActions } from '../../common/TxCard'
 import { Box, Divider } from '@mui/material'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 
-const Batching = ({ onSubmit, options = [], onChange }: SlotComponentProps<SlotName.ComboSubmit>) => {
+const Batching = ({ onSubmit, options = [], onChange, disabled = false }: SlotComponentProps<SlotName.ComboSubmit>) => {
   const { setTxFlow } = useContext(TxModalContext)
   const { addToBatch } = useTxActions()
   const { safeTx } = useContext(SafeTxContext)
@@ -62,7 +62,7 @@ const Batching = ({ onSubmit, options = [], onChange }: SlotComponentProps<SlotN
           selected="batching"
           onChange={({ id }) => onChange(id)}
           options={options}
-          disabled={!isSubmittable || !isBatchable}
+          disabled={!isSubmittable || !isBatchable || disabled}
           loading={!isSubmittable}
           tooltip={!isBatchable ? `Cannot batch this type of transaction` : undefined}
         />

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -11,6 +11,9 @@ import { asError } from '@safe-global/utils/services/exceptions/utils'
 import { Errors, logError } from '@/services/exceptions'
 import SplitMenuButton from '@/components/common/SplitMenuButton'
 import { BATCH_EVENTS, trackEvent } from '@/services/analytics'
+import { TxCardActions } from '../../common/TxCard'
+import { Box, Divider } from '@mui/material'
+import commonCss from '@/components/tx-flow/common/styles.module.css'
 
 const Batching = ({ onSubmit, options = [], onChange }: SlotComponentProps<SlotName.ComboSubmit>) => {
   const { setTxFlow } = useContext(TxModalContext)
@@ -50,15 +53,21 @@ const Batching = ({ onSubmit, options = [], onChange }: SlotComponentProps<SlotN
   }
 
   return (
-    <SplitMenuButton
-      onClick={handleSubmit}
-      selectedOption="batching"
-      onChange={onChange}
-      options={options}
-      disabled={!isSubmittable || !isBatchable}
-      loading={!isSubmittable}
-      tooltip={!isBatchable ? `Cannot batch this type of transaction` : undefined}
-    />
+    <Box>
+      <Divider className={commonCss.nestedDivider} />
+
+      <TxCardActions>
+        <SplitMenuButton
+          onClick={handleSubmit}
+          selectedOption="batching"
+          onChange={onChange}
+          options={options}
+          disabled={!isSubmittable || !isBatchable}
+          loading={!isSubmittable}
+          tooltip={!isBatchable ? `Cannot batch this type of transaction` : undefined}
+        />
+      </TxCardActions>
+    </Box>
   )
 }
 

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -73,18 +73,10 @@ const Batching = ({ onSubmit, options = [], onChange }: SlotComponentProps<SlotN
 
 const useShouldRegisterSlot = () => {
   const isCounterfactualSafe = useIsCounterfactualSafe()
-  const { willExecute, isBatch, isProposing, willExecuteThroughRole, isCreation } = useContext(TxFlowContext)
+  const { isBatch, isProposing, willExecuteThroughRole, isCreation } = useContext(TxFlowContext)
   const isOwner = useIsSafeOwner()
 
-  return (
-    isOwner &&
-    isCreation &&
-    !isBatch &&
-    !isCounterfactualSafe &&
-    !willExecute &&
-    !willExecuteThroughRole &&
-    !isProposing
-  )
+  return isOwner && isCreation && !isBatch && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
 }
 
 const BatchingSlot = withSlot({

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -23,7 +23,7 @@ const Batching = ({ onSubmit, options = [], onChange }: SlotComponentProps<SlotN
 
   const isBatchable = !!safeTx && !isDelegateCall(safeTx)
 
-  const handleSubmit = async (_option: string, e: SyntheticEvent) => {
+  const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault()
 
     if (!safeTx) return
@@ -58,9 +58,9 @@ const Batching = ({ onSubmit, options = [], onChange }: SlotComponentProps<SlotN
 
       <TxCardActions>
         <SplitMenuButton
-          onClick={handleSubmit}
-          selectedOption="batching"
-          onChange={onChange}
+          onClick={(_, e) => handleSubmit(e)}
+          selected="batching"
+          onChange={({ id }) => onChange(id)}
           options={options}
           disabled={!isSubmittable || !isBatchable}
           loading={!isSubmittable}
@@ -89,6 +89,7 @@ const useShouldRegisterSlot = () => {
 
 const BatchingSlot = withSlot({
   Component: Batching,
+  label: 'Add to batch',
   slotName: SlotName.ComboSubmit,
   id: 'batching',
   useSlotCondition: useShouldRegisterSlot,

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -15,7 +15,13 @@ import { TxCardActions } from '../../common/TxCard'
 import { Box, Divider } from '@mui/material'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 
-const Batching = ({ onSubmit, options = [], onChange, disabled = false }: SlotComponentProps<SlotName.ComboSubmit>) => {
+const Batching = ({
+  onSubmit,
+  options = [],
+  onChange,
+  disabled = false,
+  slotId,
+}: SlotComponentProps<SlotName.ComboSubmit>) => {
   const { setTxFlow } = useContext(TxModalContext)
   const { addToBatch } = useTxActions()
   const { safeTx } = useContext(SafeTxContext)
@@ -59,7 +65,7 @@ const Batching = ({ onSubmit, options = [], onChange, disabled = false }: SlotCo
       <TxCardActions>
         <SplitMenuButton
           onClick={(_, e) => handleSubmit(e)}
-          selected="batching"
+          selected={slotId}
           onChange={({ id }) => onChange(id)}
           options={options}
           disabled={!isSubmittable || !isBatchable || disabled}

--- a/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
+++ b/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { type SlotComponentProps, SlotName, useSlot, useSlotIds, withSlot } from '../slots'
 import { Box } from '@mui/material'
 import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
@@ -7,9 +7,11 @@ import { TxFlowContext } from '../TxFlowProvider'
 
 const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
   const { submitError, isRejectedByUser } = useContext(TxFlowContext)
-  const slotIds = useSlotIds(SlotName.ComboSubmit)
+  const slotItems = useSlot(SlotName.ComboSubmit)
   const [submitAction, setSubmitAction] = useState<string>('sign')
-  const [SubmitComponent] = useSlot(SlotName.ComboSubmit, submitAction)
+  const [{ Component: SubmitComponent } = {}] = useSlot(SlotName.ComboSubmit, submitAction)
+
+  const options = useMemo(() => slotItems.map(({ label, id }) => ({ label, id })), [slotItems])
 
   return (
     <>
@@ -24,7 +26,8 @@ const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
           <WalletRejectionError />
         </Box>
       )}
-      <SubmitComponent onSubmit={onSubmit} options={slotIds} onChange={setSubmitAction} />
+
+      {!!SubmitComponent && <SubmitComponent onSubmit={onSubmit} options={options} onChange={setSubmitAction} />}
     </>
   )
 }

--- a/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
+++ b/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { Slot, type SlotComponentProps, SlotName, useSlot, useSlotIds, withSlot } from '../slots'
 import { Box } from '@mui/material'
 import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
@@ -6,9 +6,13 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import { TxFlowContext } from '../TxFlowProvider'
 
 const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
-  const { submitError, isRejectedByUser } = useContext(TxFlowContext)
+  const { submitError, isRejectedByUser, setShouldExecute } = useContext(TxFlowContext)
   const slotItems = useSlot(SlotName.ComboSubmit)
   const [submitAction, setSubmitAction] = useState<string>('sign')
+
+  useEffect(() => {
+    setShouldExecute(submitAction === 'execute')
+  }, [submitAction, setShouldExecute])
 
   const options = useMemo(() => slotItems.map(({ label, id }) => ({ label, id })), [slotItems])
 
@@ -39,9 +43,7 @@ const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
 
 const useShouldRegisterSlot = () => {
   const slotIds = useSlotIds(SlotName.ComboSubmit)
-
-  // Workaround to not render combo button if the slotIds only include 'batching'
-  return slotIds.length > 0 && slotIds.includes('sign')
+  return slotIds.length > 0
 }
 
 const ComboSubmitSlot = withSlot({

--- a/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
+++ b/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
@@ -9,7 +9,7 @@ import useLocalStorage from '@/services/local-storage/useLocalStorage'
 
 const COMBO_SUBMIT_ACTION = 'comboSubmitAction'
 
-const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
+export const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
   const { txId, submitError, isRejectedByUser } = useContext(TxFlowContext)
   const slotItems = useSlot(SlotName.ComboSubmit)
   const slotIds = useSlotIds(SlotName.ComboSubmit)

--- a/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
+++ b/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
@@ -9,7 +9,6 @@ import { useValidateTxData } from '@/hooks/useValidateTxData'
 const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
   const { txId, submitError, isRejectedByUser } = useContext(TxFlowContext)
   const slotItems = useSlot(SlotName.ComboSubmit)
-  const [submitAction, setSubmitAction] = useState<string>('sign')
 
   const [validationResult, , validationLoading] = useValidateTxData(txId)
   const validationError = useMemo(
@@ -18,8 +17,13 @@ const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
   )
 
   const options = useMemo(() => slotItems.map(({ label, id }) => ({ label, id })), [slotItems])
+  const [submitAction, setSubmitAction] = useState<string | undefined>(options?.[0]?.id)
 
   const disabled = validationError !== undefined || validationLoading
+
+  if (options.length === 0) {
+    return false
+  }
 
   return (
     <>

--- a/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
+++ b/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
@@ -1,0 +1,46 @@
+import { useContext, useState } from 'react'
+import { type SlotComponentProps, SlotName, useSlot, useSlotIds, withSlot } from '../slots'
+import { Box } from '@mui/material'
+import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
+import ErrorMessage from '@/components/tx/ErrorMessage'
+import { TxFlowContext } from '../TxFlowProvider'
+
+const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
+  const { submitError, isRejectedByUser } = useContext(TxFlowContext)
+  const slotIds = useSlotIds(SlotName.ComboSubmit)
+  const [submitAction, setSubmitAction] = useState<string>('sign')
+  const [SubmitComponent] = useSlot(SlotName.ComboSubmit, submitAction)
+
+  return (
+    <>
+      {submitError && (
+        <Box mt={1}>
+          <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
+        </Box>
+      )}
+
+      {isRejectedByUser && (
+        <Box mt={1}>
+          <WalletRejectionError />
+        </Box>
+      )}
+      <SubmitComponent onSubmit={onSubmit} options={slotIds} onChange={setSubmitAction} />
+    </>
+  )
+}
+
+const useShouldRegisterSlot = () => {
+  const slotIds = useSlotIds(SlotName.ComboSubmit)
+
+  // Workaround to not render combo button if the slotIds only include 'batching'
+  return slotIds.length > 0 && slotIds.includes('sign')
+}
+
+const ComboSubmitSlot = withSlot({
+  Component: ComboSubmit,
+  slotName: SlotName.Submit,
+  id: 'combo-submit',
+  useSlotCondition: useShouldRegisterSlot,
+})
+
+export default ComboSubmitSlot

--- a/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
+++ b/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo, useState } from 'react'
-import { type SlotComponentProps, SlotName, useSlot, useSlotIds, withSlot } from '../slots'
+import { Slot, type SlotComponentProps, SlotName, useSlot, useSlotIds, withSlot } from '../slots'
 import { Box } from '@mui/material'
 import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 import ErrorMessage from '@/components/tx/ErrorMessage'
@@ -9,7 +9,6 @@ const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
   const { submitError, isRejectedByUser } = useContext(TxFlowContext)
   const slotItems = useSlot(SlotName.ComboSubmit)
   const [submitAction, setSubmitAction] = useState<string>('sign')
-  const [{ Component: SubmitComponent } = {}] = useSlot(SlotName.ComboSubmit, submitAction)
 
   const options = useMemo(() => slotItems.map(({ label, id }) => ({ label, id })), [slotItems])
 
@@ -27,7 +26,13 @@ const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
         </Box>
       )}
 
-      {!!SubmitComponent && <SubmitComponent onSubmit={onSubmit} options={options} onChange={setSubmitAction} />}
+      <Slot
+        name={SlotName.ComboSubmit}
+        id={submitAction}
+        onSubmit={onSubmit}
+        options={options}
+        onChange={setSubmitAction}
+      />
     </>
   )
 }

--- a/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
+++ b/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { Slot, type SlotComponentProps, SlotName, useSlot, useSlotIds, withSlot } from '../slots'
 import { Box } from '@mui/material'
 import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
@@ -7,7 +7,7 @@ import { TxFlowContext } from '../TxFlowProvider'
 import { useValidateTxData } from '@/hooks/useValidateTxData'
 
 const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
-  const { txId, submitError, isRejectedByUser, setShouldExecute } = useContext(TxFlowContext)
+  const { txId, submitError, isRejectedByUser } = useContext(TxFlowContext)
   const slotItems = useSlot(SlotName.ComboSubmit)
   const [submitAction, setSubmitAction] = useState<string>('sign')
 
@@ -16,10 +16,6 @@ const ComboSubmit = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
     () => (validationResult !== undefined ? new Error(validationResult) : undefined),
     [validationResult],
   )
-
-  useEffect(() => {
-    setShouldExecute(submitAction === 'execute')
-  }, [submitAction, setShouldExecute])
 
   const options = useMemo(() => slotItems.map(({ label, id }) => ({ label, id })), [slotItems])
 

--- a/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
@@ -44,6 +44,7 @@ export const ExecuteForm = ({
   isCreation,
   isOwner,
   isExecutionLoop,
+  slotId,
   txActions,
   tooltip,
   txSecurity,
@@ -200,7 +201,7 @@ export const ExecuteForm = ({
               <Tooltip title={tooltip} placement="top">
                 <Box sx={{ minWidth: '112px', width: ['100%', '100%', '100%', 'auto'] }}>
                   <SplitMenuButton
-                    selected="execute"
+                    selected={slotId}
                     onChange={({ id }) => onChange?.(id)}
                     options={options}
                     disabled={!isOk || submitDisabled}

--- a/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
@@ -31,7 +31,6 @@ import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
 import SplitMenuButton from '@/components/common/SplitMenuButton'
 import { SlotComponentProps, SlotName } from '../../slots'
 import { TxFlowContext } from '../../TxFlowProvider'
-import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 
 export const ExecuteForm = ({
   safeTx,
@@ -64,11 +63,6 @@ export const ExecuteForm = ({
   // Form state
   const [isSubmittableLocal, setIsSubmittableLocal] = useState<boolean>(true) // TODO: remove this local state and use only the one from TxFlowContext when tx-flow refactor is done
 
-  const [validationResult, , validationLoading] = useValidateTxData(txId)
-  const validationError = useMemo(
-    () => (validationResult !== undefined ? new Error(validationResult) : undefined),
-    [validationResult],
-  )
   // Hooks
   const currentChain = useCurrentChain()
   const { executeTx } = txActions
@@ -151,9 +145,7 @@ export const ExecuteForm = ({
     disableSubmit ||
     isExecutionLoop ||
     cannotPropose ||
-    (needsRiskConfirmation && !isRiskConfirmed) ||
-    validationError !== undefined ||
-    validationLoading
+    (needsRiskConfirmation && !isRiskConfirmed)
 
   return (
     <>
@@ -197,22 +189,6 @@ export const ExecuteForm = ({
               {` To save gas costs, ${isCreation ? 'avoid creating' : 'reject'} this transaction.`}
             </ErrorMessage>
           )
-        )}
-
-        {submitError && (
-          <Box mt={1}>
-            <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
-          </Box>
-        )}
-
-        {isRejectedByUser && (
-          <Box mt={1}>
-            <WalletRejectionError />
-          </Box>
-        )}
-
-        {validationError !== undefined && (
-          <ErrorMessage error={validationError}>Error validating transaction data</ErrorMessage>
         )}
 
         <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />

--- a/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
@@ -29,7 +29,7 @@ import { TxSecurityContext } from '@/components/tx/security/shared/TxSecurityCon
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
 import SplitMenuButton from '@/components/common/SplitMenuButton'
-import { SlotComponentProps, SlotName } from '../../slots'
+import type { SlotComponentProps, SlotName } from '../../slots'
 import { TxFlowContext } from '../../TxFlowProvider'
 
 export const ExecuteForm = ({

--- a/apps/web/src/components/tx-flow/actions/Execute/__tests__/ExecuteForm.test.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/__tests__/ExecuteForm.test.tsx
@@ -44,11 +44,11 @@ describe('ExecuteForm', () => {
     },
     txSecurity: defaultSecurityContextValues,
     options: [
-      { id: 'item1', label: 'Item 1' },
-      { id: 'item2', label: 'Item 2' },
+      { id: 'execute', label: 'Execute' },
+      { id: 'sign', label: 'Sign' },
     ],
     onChange: jest.fn(),
-    slotId: 'item1',
+    slotId: 'execute',
   }
 
   beforeEach(() => {
@@ -148,35 +148,6 @@ describe('ExecuteForm', () => {
     expect(
       getByText('This transaction will most likely fail. To save gas costs, reject this transaction.'),
     ).toBeInTheDocument()
-  })
-
-  it('shows a submit error', async () => {
-    const mockExecuteTx = jest.fn(() => {
-      throw new Error('Error submitting the tx')
-    })
-
-    const { getByText } = render(
-      <ExecuteForm
-        {...defaultProps}
-        safeTx={safeTransaction}
-        onSubmit={jest.fn()}
-        txActions={{
-          proposeTx: jest.fn(),
-          signTx: jest.fn(),
-          addToBatch: jest.fn(),
-          executeTx: mockExecuteTx,
-          signProposerTx: jest.fn(),
-        }}
-      />,
-    )
-
-    const button = getByText('Execute')
-
-    fireEvent.click(button)
-
-    await waitFor(() => {
-      expect(getByText('Error submitting the transaction. Please try again.')).toBeInTheDocument()
-    })
   })
 
   it('execute the tx when the submit button is clicked', async () => {

--- a/apps/web/src/components/tx-flow/actions/Execute/__tests__/ExecuteForm.test.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/__tests__/ExecuteForm.test.tsx
@@ -43,6 +43,12 @@ describe('ExecuteForm', () => {
       signProposerTx: jest.fn(),
     },
     txSecurity: defaultSecurityContextValues,
+    options: [
+      { id: 'item1', label: 'Item 1' },
+      { id: 'item2', label: 'Item 2' },
+    ],
+    onChange: jest.fn(),
+    slotId: 'item1',
   }
 
   beforeEach(() => {

--- a/apps/web/src/components/tx-flow/actions/Execute/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/index.tsx
@@ -12,7 +12,7 @@ import { SubmitCallback } from '../../TxFlow'
 
 const CheckboxGuardedExecuteForm = withCheckboxGuard(ExecuteForm, SIGN_CHECKBOX_LABEL, SIGN_CHECKBOX_TOOLTIP)
 
-const Execute = ({ onSubmit, options = [], onChange }: SlotComponentProps<SlotName.ComboSubmit>) => {
+const Execute = ({ onSubmit, options = [], onChange, disabled = false }: SlotComponentProps<SlotName.ComboSubmit>) => {
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const { txId, isCreation, onlyExecute, isSubmittable, trackTxEvent } = useContext(TxFlowContext)
   const hasSigned = useAlreadySigned(safeTx)
@@ -42,7 +42,7 @@ const Execute = ({ onSubmit, options = [], onChange }: SlotComponentProps<SlotNa
       options={options}
       onCheckboxChange={handleCheckboxChange}
       isChecked={checked}
-      disableSubmit={!isSubmittable}
+      disableSubmit={!isSubmittable || disabled}
       origin={txOrigin}
       onlyExecute={onlyExecute}
       isCreation={isCreation}

--- a/apps/web/src/components/tx-flow/actions/Execute/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/index.tsx
@@ -8,7 +8,7 @@ import { withCheckboxGuard } from '../../withCheckboxGuard'
 import { SIGN_CHECKBOX_LABEL, SIGN_CHECKBOX_TOOLTIP } from '../Sign'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { type SlotComponentProps, SlotName, withSlot } from '../../slots'
-import { SubmitCallback } from '../../TxFlow'
+import type { SubmitCallback } from '../../TxFlow'
 
 const CheckboxGuardedExecuteForm = withCheckboxGuard(ExecuteForm, SIGN_CHECKBOX_LABEL, SIGN_CHECKBOX_TOOLTIP)
 
@@ -20,6 +20,7 @@ const Execute = ({ onSubmit, disabled = false, onChange, ...props }: SlotCompone
 
   useEffect(() => {
     setShouldExecute(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleSubmit = useCallback<SubmitCallback>(

--- a/apps/web/src/components/tx-flow/actions/Execute/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/index.tsx
@@ -12,7 +12,7 @@ import { SubmitCallback } from '../../TxFlow'
 
 const CheckboxGuardedExecuteForm = withCheckboxGuard(ExecuteForm, SIGN_CHECKBOX_LABEL, SIGN_CHECKBOX_TOOLTIP)
 
-const Execute = ({ onSubmit, options = [], onChange, disabled = false }: SlotComponentProps<SlotName.ComboSubmit>) => {
+const Execute = ({ onSubmit, disabled = false, ...props }: SlotComponentProps<SlotName.ComboSubmit>) => {
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const { txId, isCreation, onlyExecute, isSubmittable, trackTxEvent } = useContext(TxFlowContext)
   const hasSigned = useAlreadySigned(safeTx)
@@ -38,14 +38,13 @@ const Execute = ({ onSubmit, options = [], onChange, disabled = false }: SlotCom
       safeTx={safeTx}
       txId={txId}
       onSubmit={handleSubmit}
-      onChange={onChange}
-      options={options}
       onCheckboxChange={handleCheckboxChange}
       isChecked={checked}
       disableSubmit={!isSubmittable || disabled}
       origin={txOrigin}
       onlyExecute={onlyExecute}
       isCreation={isCreation}
+      {...props}
     />
   )
 }
@@ -60,8 +59,8 @@ const useShouldRegisterSlot = () => {
 const ExecuteSlot = withSlot({
   Component: Execute,
   slotName: SlotName.ComboSubmit,
-  id: 'execute',
   label: 'Execute',
+  id: 'execute',
   useSlotCondition: useShouldRegisterSlot,
 })
 

--- a/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
@@ -29,6 +29,7 @@ export const SignForm = ({
   disableSubmit = false,
   origin,
   isOwner,
+  slotId,
   txActions,
   txSecurity,
   tooltip,
@@ -129,7 +130,7 @@ export const SignForm = ({
               {(isOk) => (
                 <SplitMenuButton
                   data-testid="sign-btn"
-                  selected="sign"
+                  selected={slotId}
                   onChange={({ id }) => handleOptionChange(id)}
                   options={options}
                   disabled={!isOk || submitDisabled}

--- a/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
@@ -1,5 +1,5 @@
 import madProps from '@/utils/mad-props'
-import { type ReactElement, type SyntheticEvent, useContext, useMemo, useState } from 'react'
+import { type ReactElement, type SyntheticEvent, useContext, useState } from 'react'
 import { Box, Divider, Stack } from '@mui/material'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { trackError, Errors } from '@/services/exceptions'
@@ -15,7 +15,6 @@ import { asError } from '@safe-global/utils/services/exceptions/utils'
 import { isWalletRejection } from '@/utils/wallets'
 import { useSigner } from '@/hooks/wallets/useWallet'
 import { NestedTxSuccessScreenFlow } from '@/components/tx-flow/flows'
-import { useValidateTxData } from '@/hooks/useValidateTxData'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { TxCardActions } from '@/components/tx-flow/common/TxCard'
 import SplitMenuButton from '@/components/common/SplitMenuButton'
@@ -46,12 +45,6 @@ export const SignForm = ({
   // Form state
   const [isSubmittableLocal, setIsSubmittableLocal] = useState<boolean>(true) // TODO: remove this local state and use only the one from TxFlowContext when tx-flow refactor is done
 
-  const [validationResult, , validationLoading] = useValidateTxData(txId)
-  const validationError = useMemo(
-    () => (validationResult !== undefined ? new Error(validationResult) : undefined),
-    [validationResult],
-  )
-
   // Hooks
   const { signTx } = txActions
   const { setTxFlow } = useContext(TxModalContext)
@@ -74,7 +67,7 @@ export const SignForm = ({
       return
     }
 
-    if (!safeTx || validationError) return
+    if (!safeTx) return
 
     setIsSubmittable(false)
     setIsSubmittableLocal(false)
@@ -118,19 +111,13 @@ export const SignForm = ({
     !isSubmittableLocal ||
     disableSubmit ||
     cannotPropose ||
-    (needsRiskConfirmation && !isRiskConfirmed) ||
-    validationError !== undefined ||
-    validationLoading
+    (needsRiskConfirmation && !isRiskConfirmed)
 
   return (
     <Stack gap={3}>
       {hasSigned && <ErrorMessage level="warning">You have already signed this transaction.</ErrorMessage>}
 
       {cannotPropose && <NonOwnerError />}
-
-      {validationError !== undefined && (
-        <ErrorMessage error={validationError}>Error validating transaction data</ErrorMessage>
-      )}
 
       <Box>
         <Divider className={commonCss.nestedDivider} />

--- a/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
@@ -1,6 +1,6 @@
 import madProps from '@/utils/mad-props'
 import { type ReactElement, type SyntheticEvent, useContext, useMemo, useState } from 'react'
-import { Divider } from '@mui/material'
+import { Box, Divider, Stack } from '@mui/material'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { trackError, Errors } from '@/services/exceptions'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
@@ -123,7 +123,7 @@ export const SignForm = ({
     validationLoading
 
   return (
-    <form onSubmit={handleSubmit}>
+    <Stack gap={3}>
       {hasSigned && <ErrorMessage level="warning">You have already signed this transaction.</ErrorMessage>}
 
       {cannotPropose && <NonOwnerError />}
@@ -132,25 +132,29 @@ export const SignForm = ({
         <ErrorMessage error={validationError}>Error validating transaction data</ErrorMessage>
       )}
 
-      <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />
+      <Box>
+        <Divider className={commonCss.nestedDivider} />
 
-      <TxCardActions>
         {/* Submit button */}
-        <CheckWallet checkNetwork={!submitDisabled}>
-          {(isOk) => (
-            <SplitMenuButton
-              data-testid="sign-btn"
-              selectedOption="sign"
-              onChange={handleOptionChange}
-              options={options}
-              disabled={!isOk || submitDisabled}
-              loading={!isSubmittable || !isSubmittableLocal}
-              tooltip={isOk ? tooltip : undefined}
-            />
-          )}
-        </CheckWallet>
-      </TxCardActions>
-    </form>
+        <TxCardActions>
+          <form onSubmit={handleSubmit}>
+            <CheckWallet checkNetwork={!submitDisabled}>
+              {(isOk) => (
+                <SplitMenuButton
+                  data-testid="sign-btn"
+                  selectedOption="sign"
+                  onChange={handleOptionChange}
+                  options={options}
+                  disabled={!isOk || submitDisabled}
+                  loading={!isSubmittable || !isSubmittableLocal}
+                  tooltip={isOk ? tooltip : undefined}
+                />
+              )}
+            </CheckWallet>
+          </form>
+        </TxCardActions>
+      </Box>
+    </Stack>
   )
 }
 

--- a/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
@@ -129,7 +129,6 @@ export const SignForm = ({
             <CheckWallet checkNetwork={!submitDisabled}>
               {(isOk) => (
                 <SplitMenuButton
-                  data-testid="sign-btn"
                   selected={slotId}
                   onChange={({ id }) => handleOptionChange(id)}
                   options={options}

--- a/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
@@ -142,8 +142,8 @@ export const SignForm = ({
               {(isOk) => (
                 <SplitMenuButton
                   data-testid="sign-btn"
-                  selectedOption="sign"
-                  onChange={handleOptionChange}
+                  selected="sign"
+                  onChange={({ id }) => handleOptionChange(id)}
                   options={options}
                   disabled={!isOk || submitDisabled}
                   loading={!isSubmittable || !isSubmittableLocal}

--- a/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
@@ -1,18 +1,16 @@
 import madProps from '@/utils/mad-props'
 import { type ReactElement, type SyntheticEvent, useContext, useMemo, useState } from 'react'
-import { CircularProgress, Box, Button, Divider, Tooltip } from '@mui/material'
+import { Divider } from '@mui/material'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import { trackError, Errors } from '@/services/exceptions'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import CheckWallet from '@/components/common/CheckWallet'
 import { useAlreadySigned, useTxActions } from '@/components/tx/SignOrExecuteForm/hooks'
-import type { SignOrExecuteProps } from '@/components/tx/SignOrExecuteForm/SignOrExecuteFormV2'
 import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import { TxModalContext } from '@/components/tx-flow'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { TxSecurityContext } from '@/components/tx/security/shared/TxSecurityContext'
 import NonOwnerError from '@/components/tx/SignOrExecuteForm/NonOwnerError'
-import WalletRejectionError from '@/components/tx/SignOrExecuteForm/WalletRejectionError'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 import { isWalletRejection } from '@/utils/wallets'
 import { useSigner } from '@/hooks/wallets/useWallet'
@@ -20,18 +18,25 @@ import { NestedTxSuccessScreenFlow } from '@/components/tx-flow/flows'
 import { useValidateTxData } from '@/hooks/useValidateTxData'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { TxCardActions } from '@/components/tx-flow/common/TxCard'
+import SplitMenuButton from '@/components/common/SplitMenuButton'
+import { type SlotComponentProps, SlotName } from '../../slots'
 
 export const SignForm = ({
   safeTx,
   txId,
   onSubmit,
+  onChange,
+  options = [],
   disableSubmit = false,
   origin,
   isOwner,
   txActions,
   txSecurity,
   tooltip,
-}: SignOrExecuteProps & {
+}: SlotComponentProps<SlotName.ComboSubmit> & {
+  txId?: string
+  disableSubmit?: boolean
+  origin?: string
   isOwner: ReturnType<typeof useIsSafeOwner>
   txActions: ReturnType<typeof useTxActions>
   txSecurity: ReturnType<typeof useTxSecurityContext>
@@ -40,8 +45,6 @@ export const SignForm = ({
 }): ReactElement => {
   // Form state
   const [isSubmittableLocal, setIsSubmittableLocal] = useState<boolean>(true) // TODO: remove this local state and use only the one from TxFlowContext when tx-flow refactor is done
-  const [submitError, setSubmitError] = useState<Error | undefined>()
-  const [isRejectedByUser, setIsRejectedByUser] = useState<Boolean>(false)
 
   const [validationResult, , validationLoading] = useValidateTxData(txId)
   const validationError = useMemo(
@@ -52,10 +55,15 @@ export const SignForm = ({
   // Hooks
   const { signTx } = txActions
   const { setTxFlow } = useContext(TxModalContext)
-  const { isSubmittable, setIsSubmittable } = useContext(TxFlowContext)
+  const { isSubmittable, setIsSubmittable, onNext, onPrev, setSubmitError, setIsRejectedByUser } =
+    useContext(TxFlowContext)
   const { needsRiskConfirmation, isRiskConfirmed, setIsRiskIgnored } = txSecurity
   const hasSigned = useAlreadySigned(safeTx)
   const signer = useSigner()
+
+  const handleOptionChange = (option: string) => {
+    onChange?.(option)
+  }
 
   // On modal submit
   const handleSubmit = async (e: SyntheticEvent) => {
@@ -74,6 +82,8 @@ export const SignForm = ({
     setSubmitError(undefined)
     setIsRejectedByUser(false)
 
+    onNext()
+
     let resultTxId: string
     try {
       resultTxId = await signTx(safeTx, txId, origin)
@@ -85,13 +95,14 @@ export const SignForm = ({
         trackError(Errors._804, err)
         setSubmitError(err)
       }
+      onPrev()
       setIsSubmittable(true)
       setIsSubmittableLocal(true)
       return
     }
 
     // On successful sign
-    onSubmit?.(resultTxId)
+    onSubmit?.({ txId: resultTxId })
 
     if (signer?.isSafe) {
       setTxFlow(<NestedTxSuccessScreenFlow txId={resultTxId} />, undefined, false)
@@ -115,19 +126,7 @@ export const SignForm = ({
     <form onSubmit={handleSubmit}>
       {hasSigned && <ErrorMessage level="warning">You have already signed this transaction.</ErrorMessage>}
 
-      {cannotPropose ? (
-        <NonOwnerError />
-      ) : (
-        submitError && (
-          <ErrorMessage error={submitError}>Error submitting the transaction. Please try again.</ErrorMessage>
-        )
-      )}
-
-      {isRejectedByUser && (
-        <Box mt={1}>
-          <WalletRejectionError />
-        </Box>
-      )}
+      {cannotPropose && <NonOwnerError />}
 
       {validationError !== undefined && (
         <ErrorMessage error={validationError}>Error validating transaction data</ErrorMessage>
@@ -139,19 +138,15 @@ export const SignForm = ({
         {/* Submit button */}
         <CheckWallet checkNetwork={!submitDisabled}>
           {(isOk) => (
-            <Tooltip title={isOk ? tooltip : undefined} placement="top">
-              <span>
-                <Button
-                  data-testid="sign-btn"
-                  variant="contained"
-                  type="submit"
-                  disabled={!isOk || submitDisabled}
-                  sx={{ minWidth: '82px', order: '1', width: ['100%', '100%', '100%', 'auto'] }}
-                >
-                  {!isSubmittable || !isSubmittableLocal ? <CircularProgress size={20} /> : 'Sign'}
-                </Button>
-              </span>
-            </Tooltip>
+            <SplitMenuButton
+              data-testid="sign-btn"
+              selectedOption="sign"
+              onChange={handleOptionChange}
+              options={options}
+              disabled={!isOk || submitDisabled}
+              loading={!isSubmittable || !isSubmittableLocal}
+              tooltip={isOk ? tooltip : undefined}
+            />
           )}
         </CheckWallet>
       </TxCardActions>

--- a/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
@@ -18,7 +18,7 @@ import { NestedTxSuccessScreenFlow } from '@/components/tx-flow/flows'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { TxCardActions } from '@/components/tx-flow/common/TxCard'
 import SplitMenuButton from '@/components/common/SplitMenuButton'
-import { type SlotComponentProps, SlotName } from '../../slots'
+import type { SlotComponentProps, SlotName } from '../../slots'
 
 export const SignForm = ({
   safeTx,

--- a/apps/web/src/components/tx-flow/actions/Sign/__tests__/SignForm.test.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/__tests__/SignForm.test.tsx
@@ -35,6 +35,12 @@ describe('SignForm', () => {
       signProposerTx: jest.fn(),
     },
     txSecurity: defaultSecurityContextValues,
+    options: [
+      { id: 'item1', label: 'Item 1' },
+      { id: 'item2', label: 'Item 2' },
+    ],
+    onChange: jest.fn(),
+    slotId: 'item1',
   }
 
   beforeEach(() => {

--- a/apps/web/src/components/tx-flow/actions/Sign/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/index.tsx
@@ -6,7 +6,7 @@ import SignForm from './SignForm'
 import { withCheckboxGuard } from '../../withCheckboxGuard'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { type SlotComponentProps, SlotName, withSlot } from '../../slots'
-import { SubmitCallback } from '../../TxFlow'
+import type { SubmitCallback } from '../../TxFlow'
 import { useAlreadySigned } from '@/components/tx/SignOrExecuteForm/hooks'
 
 export const SIGN_CHECKBOX_LABEL = "I understand what I'm signing and that this is an irreversible action."

--- a/apps/web/src/components/tx-flow/actions/Sign/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/index.tsx
@@ -7,6 +7,7 @@ import { withCheckboxGuard } from '../../withCheckboxGuard'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { type SlotComponentProps, SlotName, withSlot } from '../../slots'
 import { SubmitCallback } from '../../TxFlow'
+import { useAlreadySigned } from '@/components/tx/SignOrExecuteForm/hooks'
 
 export const SIGN_CHECKBOX_LABEL = "I understand what I'm signing and that this is an irreversible action."
 export const SIGN_CHECKBOX_TOOLTIP = 'Review details and check the box to enable signing'
@@ -50,8 +51,9 @@ const useShouldRegisterSlot = () => {
   const { isProposing, willExecuteThroughRole } = useContext(TxFlowContext)
   const { safeTx } = useContext(SafeTxContext)
   const isCounterfactualSafe = useIsCounterfactualSafe()
+  const hasSigned = useAlreadySigned(safeTx)
 
-  return !!safeTx && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
+  return !!safeTx && !hasSigned && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
 }
 
 const SignSlot = withSlot({

--- a/apps/web/src/components/tx-flow/actions/Sign/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/index.tsx
@@ -56,6 +56,7 @@ const useShouldRegisterSlot = () => {
 
 const SignSlot = withSlot({
   Component: Sign,
+  label: 'Sign',
   slotName: SlotName.ComboSubmit,
   id: 'sign',
   useSlotCondition: useShouldRegisterSlot,

--- a/apps/web/src/components/tx-flow/actions/Sign/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/index.tsx
@@ -14,7 +14,7 @@ export const SIGN_CHECKBOX_TOOLTIP = 'Review details and check the box to enable
 
 const CheckboxGuardedSignForm = withCheckboxGuard(SignForm, SIGN_CHECKBOX_LABEL, SIGN_CHECKBOX_TOOLTIP)
 
-export const Sign = ({ onSubmit, options, onChange, disabled = false }: SlotComponentProps<SlotName.ComboSubmit>) => {
+export const Sign = ({ onSubmit, disabled = false, ...props }: SlotComponentProps<SlotName.ComboSubmit>) => {
   const [checked, setChecked] = useState(false)
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const { txId, trackTxEvent, isSubmittable } = useContext(TxFlowContext)
@@ -38,11 +38,10 @@ export const Sign = ({ onSubmit, options, onChange, disabled = false }: SlotComp
       origin={txOrigin}
       safeTx={safeTx}
       onSubmit={handleSubmit}
-      options={options}
-      onChange={onChange}
       isChecked={checked}
       onCheckboxChange={handleCheckboxChange}
       txId={txId}
+      {...props}
     />
   )
 }

--- a/apps/web/src/components/tx-flow/actions/Sign/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/index.tsx
@@ -13,7 +13,7 @@ export const SIGN_CHECKBOX_TOOLTIP = 'Review details and check the box to enable
 
 const CheckboxGuardedSignForm = withCheckboxGuard(SignForm, SIGN_CHECKBOX_LABEL, SIGN_CHECKBOX_TOOLTIP)
 
-export const Sign = ({ onSubmit, options, onChange }: SlotComponentProps<SlotName.ComboSubmit>) => {
+export const Sign = ({ onSubmit, options, onChange, disabled = false }: SlotComponentProps<SlotName.ComboSubmit>) => {
   const [checked, setChecked] = useState(false)
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const { txId, trackTxEvent, isSubmittable } = useContext(TxFlowContext)
@@ -33,7 +33,7 @@ export const Sign = ({ onSubmit, options, onChange }: SlotComponentProps<SlotNam
 
   return (
     <CheckboxGuardedSignForm
-      disableSubmit={!isSubmittable}
+      disableSubmit={!isSubmittable || disabled}
       origin={txOrigin}
       safeTx={safeTx}
       onSubmit={handleSubmit}

--- a/apps/web/src/components/tx-flow/actions/Sign/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/index.tsx
@@ -6,13 +6,14 @@ import SignForm from './SignForm'
 import { withCheckboxGuard } from '../../withCheckboxGuard'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { type SlotComponentProps, SlotName, withSlot } from '../../slots'
+import { SubmitCallback } from '../../TxFlow'
 
 export const SIGN_CHECKBOX_LABEL = "I understand what I'm signing and that this is an irreversible action."
 export const SIGN_CHECKBOX_TOOLTIP = 'Review details and check the box to enable signing'
 
 const CheckboxGuardedSignForm = withCheckboxGuard(SignForm, SIGN_CHECKBOX_LABEL, SIGN_CHECKBOX_TOOLTIP)
 
-export const Sign = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
+export const Sign = ({ onSubmit, options, onChange }: SlotComponentProps<SlotName.ComboSubmit>) => {
   const [checked, setChecked] = useState(false)
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const { txId, trackTxEvent, isSubmittable } = useContext(TxFlowContext)
@@ -22,10 +23,10 @@ export const Sign = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
     trackEvent({ ...MODALS_EVENTS.CONFIRM_SIGN_CHECKBOX, label: checked })
   }, [])
 
-  const handleSubmit = useCallback(
-    async (txId: string, isExecuted = false) => {
+  const handleSubmit = useCallback<SubmitCallback>(
+    async ({ txId, isExecuted = false } = {}) => {
       onSubmit({ txId, isExecuted })
-      trackTxEvent(txId, isExecuted)
+      trackTxEvent(txId!, isExecuted)
     },
     [onSubmit, trackTxEvent],
   )
@@ -36,6 +37,8 @@ export const Sign = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
       origin={txOrigin}
       safeTx={safeTx}
       onSubmit={handleSubmit}
+      options={options}
+      onChange={onChange}
       isChecked={checked}
       onCheckboxChange={handleCheckboxChange}
       txId={txId}
@@ -44,16 +47,16 @@ export const Sign = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
 }
 
 const useShouldRegisterSlot = () => {
-  const { isProposing, willExecute, willExecuteThroughRole } = useContext(TxFlowContext)
+  const { isProposing, willExecuteThroughRole } = useContext(TxFlowContext)
   const { safeTx } = useContext(SafeTxContext)
   const isCounterfactualSafe = useIsCounterfactualSafe()
 
-  return !!safeTx && !isCounterfactualSafe && !willExecute && !willExecuteThroughRole && !isProposing
+  return !!safeTx && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
 }
 
 const SignSlot = withSlot({
   Component: Sign,
-  slotName: SlotName.Submit,
+  slotName: SlotName.ComboSubmit,
   id: 'sign',
   useSlotCondition: useShouldRegisterSlot,
 })

--- a/apps/web/src/components/tx-flow/actions/index.ts
+++ b/apps/web/src/components/tx-flow/actions/index.ts
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic'
 
 export const Batching = dynamic(() => import('./Batching'))
+export const ComboSubmit = dynamic(() => import('./ComboSubmit'))
 export const Counterfactual = dynamic(() => import('./Counterfactual'))
 export const Execute = dynamic(() => import('./Execute'))
 export const ExecuteThroughRole = dynamic(() => import('./ExecuteThroughRole'))

--- a/apps/web/src/components/tx-flow/common/TxFlowContent/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxFlowContent/index.tsx
@@ -11,7 +11,7 @@ import ChainIndicator from '@/components/common/ChainIndicator'
 import SecurityWarnings from '@/components/tx/security/SecurityWarnings'
 import TxStatusWidget from '@/components/tx-flow/common/TxStatusWidget'
 import { TxLayoutHeader } from '../TxLayout'
-import { SlotName, useSlot } from '../../slots'
+import { Slot, SlotName } from '../../slots'
 
 /**
  * TxFlowContent is a component that renders the main content of the transaction flow.
@@ -37,8 +37,6 @@ export const TxFlowContent = ({ children }: { children?: ReactNode[] | ReactNode
     progress,
     onPrev,
   } = useContext(TxFlowContext)
-
-  const sidebarFeatures = useSlot(SlotName.Sidebar)
 
   const childrenArray = Array.isArray(children) ? children : [children]
 
@@ -131,9 +129,7 @@ export const TxFlowContent = ({ children }: { children?: ReactNode[] | ReactNode
                 />
               )}
 
-              {sidebarFeatures.map(({ Component }, i) => (
-                <Component key={`sidebar-feature-${i}`} />
-              ))}
+              <Slot name={SlotName.Sidebar} />
 
               <Box className={css.sticky}>
                 <SecurityWarnings />

--- a/apps/web/src/components/tx-flow/common/TxFlowContent/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxFlowContent/index.tsx
@@ -131,8 +131,8 @@ export const TxFlowContent = ({ children }: { children?: ReactNode[] | ReactNode
                 />
               )}
 
-              {sidebarFeatures.map((SidebarFeature, i) => (
-                <SidebarFeature key={`sidebar-feature-${i}`} />
+              {sidebarFeatures.map(({ Component }, i) => (
+                <Component key={`sidebar-feature-${i}`} />
               ))}
 
               <Box className={css.sticky}>

--- a/apps/web/src/components/tx-flow/slots/Slot.tsx
+++ b/apps/web/src/components/tx-flow/slots/Slot.tsx
@@ -1,0 +1,31 @@
+import type { PropsWithChildren, ReactElement } from 'react'
+import { SlotComponentProps, type SlotName, useSlot } from '@/components/tx-flow/slots'
+
+export type SlotProps<T extends SlotName> = PropsWithChildren<
+  {
+    name: T
+    id?: string
+  } & SlotComponentProps<T>
+>
+
+/**
+ * Slot component for rendering components in specific slots.
+ * It takes a slot name and an optional id to identify the slot.
+ * If there are registered components for the slot, it renders them.
+ * Otherwise, it renders the children passed to it as fallback.
+ */
+export const Slot = <T extends SlotName>({ name, id, children, ...props }: SlotProps<T>): ReactElement => {
+  const slotItems = useSlot(name, id)
+
+  if (slotItems.length === 0) {
+    return <>{children}</>
+  }
+
+  return (
+    <>
+      {slotItems.map(({ Component, id }, i) => (
+        <Component {...(props as unknown as SlotComponentProps<T>)} key={`slot-${name}-${i}-${id}`} />
+      ))}
+    </>
+  )
+}

--- a/apps/web/src/components/tx-flow/slots/Slot.tsx
+++ b/apps/web/src/components/tx-flow/slots/Slot.tsx
@@ -1,11 +1,11 @@
 import type { PropsWithChildren, ReactElement } from 'react'
-import { SlotComponentProps, type SlotName, useSlot } from '@/components/tx-flow/slots'
+import { type SlotComponentProps, type SlotName, useSlot } from '@/components/tx-flow/slots'
 
 export type SlotProps<T extends SlotName> = PropsWithChildren<
   {
     name: T
     id?: string
-  } & SlotComponentProps<T>
+  } & Omit<SlotComponentProps<T>, 'slotId'>
 >
 
 /**
@@ -14,17 +14,19 @@ export type SlotProps<T extends SlotName> = PropsWithChildren<
  * If there are registered components for the slot, it renders them.
  * Otherwise, it renders the children passed to it as fallback.
  */
-export const Slot = <T extends SlotName>({ name, id, children, ...props }: SlotProps<T>): ReactElement => {
+export const Slot = <T extends SlotName>({ name, id, children, ...rest }: SlotProps<T>): ReactElement => {
   const slotItems = useSlot(name, id)
 
   if (slotItems.length === 0) {
     return <>{children}</>
   }
 
+  const props = { ...rest, slotId: id } as unknown as SlotComponentProps<T>
+
   return (
     <>
       {slotItems.map(({ Component, id }, i) => (
-        <Component {...(props as unknown as SlotComponentProps<T>)} key={`slot-${name}-${i}-${id}`} />
+        <Component {...props} key={`slot-${name}-${i}-${id}`} />
       ))}
     </>
   )

--- a/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
+++ b/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
@@ -24,6 +24,7 @@ type SlotComponentPropsMap = {
     onSubmit: SubmitCallback
     options: { label: string; id: string }[]
     onChange: (option: string) => void
+    disabled?: boolean
   }>
 }
 

--- a/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
+++ b/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
@@ -28,9 +28,13 @@ type SlotComponentPropsMap = {
   }>
 }
 
+type BaseSlotComponentProps = {
+  slotId: string
+}
+
 export type SlotComponentProps<T extends SlotName> = T extends keyof SlotComponentPropsMap
-  ? SlotComponentPropsMap[T]
-  : {}
+  ? SlotComponentPropsMap[T] & BaseSlotComponentProps
+  : BaseSlotComponentProps
 
 type SlotContextType = {
   registerSlot: <T extends SlotName>(args: {

--- a/apps/web/src/components/tx-flow/slots/hooks/index.ts
+++ b/apps/web/src/components/tx-flow/slots/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useRegisterSlot'
 export * from './useSlotContext'
 export * from './useSlot'
+export * from './useSlotIds'

--- a/apps/web/src/components/tx-flow/slots/hooks/useRegisterSlot.ts
+++ b/apps/web/src/components/tx-flow/slots/hooks/useRegisterSlot.ts
@@ -1,11 +1,12 @@
-import { type ComponentType, useEffect } from 'react'
-import type { SlotComponentProps, SlotName } from '../SlotProvider'
+import { useEffect } from 'react'
+import type { SlotItem, SlotName } from '../SlotProvider'
 import { useSlotContext } from './useSlotContext'
 
 export type UseRegisterSlotProps<T extends SlotName> = {
   slotName: T
   id: string
-  Component: ComponentType<SlotComponentProps<T>>
+  Component: SlotItem<T>['Component']
+  label?: SlotItem<T>['label']
   condition?: boolean
 }
 
@@ -17,13 +18,14 @@ export const useRegisterSlot = <T extends SlotName>({
   slotName,
   id,
   Component,
+  label,
   condition = true,
 }: UseRegisterSlotProps<T>) => {
   const { registerSlot, unregisterSlot } = useSlotContext()
 
   useEffect(() => {
     if (condition) {
-      registerSlot(slotName, id, Component)
+      registerSlot({ slotName, id, Component, label })
     } else {
       unregisterSlot(slotName, id)
     }
@@ -31,5 +33,5 @@ export const useRegisterSlot = <T extends SlotName>({
     return () => {
       unregisterSlot(slotName, id)
     }
-  }, [condition, registerSlot, unregisterSlot, slotName, Component, id])
+  }, [condition, registerSlot, unregisterSlot, slotName, Component, label, id])
 }

--- a/apps/web/src/components/tx-flow/slots/hooks/useSlot.ts
+++ b/apps/web/src/components/tx-flow/slots/hooks/useSlot.ts
@@ -1,8 +1,8 @@
-import { type ComponentType, useMemo } from 'react'
-import type { SlotComponentProps, SlotName } from '../SlotProvider'
+import { useMemo } from 'react'
+import type { SlotName, SlotItem } from '../SlotProvider'
 import { useSlotContext } from './useSlotContext'
 
-export const useSlot = <T extends SlotName>(slotName: T, id?: string): ComponentType<SlotComponentProps<T>>[] => {
+export const useSlot = <T extends SlotName>(slotName: T, id?: string): SlotItem<T>[] => {
   const { getSlot } = useSlotContext()
   const slot = useMemo(() => getSlot(slotName, id), [getSlot, slotName, id])
   return slot

--- a/apps/web/src/components/tx-flow/slots/hooks/useSlot.ts
+++ b/apps/web/src/components/tx-flow/slots/hooks/useSlot.ts
@@ -2,8 +2,8 @@ import { type ComponentType, useMemo } from 'react'
 import type { SlotComponentProps, SlotName } from '../SlotProvider'
 import { useSlotContext } from './useSlotContext'
 
-export const useSlot = <T extends SlotName>(slotName: T): ComponentType<SlotComponentProps<T>>[] => {
+export const useSlot = <T extends SlotName>(slotName: T, id?: string): ComponentType<SlotComponentProps<T>>[] => {
   const { getSlot } = useSlotContext()
-  const slot = useMemo(() => getSlot(slotName), [getSlot, slotName])
+  const slot = useMemo(() => getSlot(slotName, id), [getSlot, slotName, id])
   return slot
 }

--- a/apps/web/src/components/tx-flow/slots/hooks/useSlotIds.ts
+++ b/apps/web/src/components/tx-flow/slots/hooks/useSlotIds.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react'
+import type { SlotName } from '../SlotProvider'
+import { useSlotContext } from './useSlotContext'
+
+export const useSlotIds = <T extends SlotName>(slotName: T): string[] => {
+  const { getSlotIds } = useSlotContext()
+  const slotIds = useMemo(() => getSlotIds(slotName), [getSlotIds, slotName])
+  return slotIds
+}

--- a/apps/web/src/components/tx-flow/slots/index.ts
+++ b/apps/web/src/components/tx-flow/slots/index.ts
@@ -1,3 +1,4 @@
+export * from './Slot'
 export * from './SlotProvider'
 export * from './hooks'
 export * from './withSlot'

--- a/apps/web/src/components/tx-flow/slots/withSlot.tsx
+++ b/apps/web/src/components/tx-flow/slots/withSlot.tsx
@@ -1,3 +1,4 @@
+import type { PropsWithChildren } from 'react'
 import type { SlotName } from './SlotProvider'
 import { useRegisterSlot, type UseRegisterSlotProps } from './hooks'
 
@@ -13,9 +14,9 @@ export const withSlot = <T extends SlotName>({
 }: Omit<UseRegisterSlotProps<T>, 'condition'> & {
   useSlotCondition: () => boolean
 }) => {
-  return () => {
+  return ({ children }: PropsWithChildren) => {
     const shouldRegisterSlot = useSlotCondition()
     useRegisterSlot({ slotName, id, Component, condition: shouldRegisterSlot })
-    return false
+    return children
   }
 }

--- a/apps/web/src/components/tx-flow/slots/withSlot.tsx
+++ b/apps/web/src/components/tx-flow/slots/withSlot.tsx
@@ -8,6 +8,7 @@ import { useRegisterSlot, type UseRegisterSlotProps } from './hooks'
  */
 export const withSlot = <T extends SlotName>({
   Component,
+  label,
   slotName,
   id,
   useSlotCondition = () => true,
@@ -16,7 +17,7 @@ export const withSlot = <T extends SlotName>({
 }) => {
   return ({ children }: PropsWithChildren) => {
     const shouldRegisterSlot = useSlotCondition()
-    useRegisterSlot({ slotName, id, Component, condition: shouldRegisterSlot })
+    useRegisterSlot({ slotName, id, Component, label, condition: shouldRegisterSlot })
     return children
   }
 }

--- a/apps/web/src/components/tx-flow/withCheckboxGuard.tsx
+++ b/apps/web/src/components/tx-flow/withCheckboxGuard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, type ComponentType } from 'react'
-import { Checkbox, FormControlLabel } from '@mui/material'
+import { Checkbox, FormControlLabel, Stack } from '@mui/material'
 
 /**
  * Higher-order component that wraps a given component with a checkbox guard.
@@ -33,15 +33,15 @@ export const withCheckboxGuard = <P extends { disableSubmit?: boolean; tooltip?:
     const checkboxTooltip = useMemo(() => (tooltip || !isChecked ? tooltipText : undefined), [tooltip, isChecked])
 
     return (
-      <>
+      <Stack gap={2} width="100%">
         <FormControlLabel
-          sx={{ mt: 2, mb: -1.3 }}
+          sx={{ mt: 2 }}
           control={<Checkbox checked={isChecked} onChange={handleCheckboxChange} />}
           label={label}
         />
 
         <WrappedComponent {...(props as P)} disableSubmit={!isChecked || disableSubmit} tooltip={checkboxTooltip} />
-      </>
+      </Stack>
     )
   }
 }

--- a/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
@@ -10,7 +10,6 @@ import { MODALS_EVENTS } from '@/services/analytics'
 import useWallet from '@/hooks/wallets/useWallet'
 import { isHardwareWallet, isLedgerLive } from '@/utils/wallets'
 import { TxFlowStep } from '@/components/tx-flow/TxFlowStep'
-import type { SubmitCallback } from '@/components/tx-flow/TxFlow'
 import { TxDetails } from '../ConfirmTxDetails/TxDetails'
 
 const InfoSteps = [
@@ -65,11 +64,7 @@ const HardwareWalletStep = [
   InfoSteps[2],
 ]
 
-export type ConfirmTxReceiptProps = PropsWithChildren<{
-  onSubmit: SubmitCallback
-}>
-
-export const ConfirmTxReceipt = ({ children, onSubmit }: ConfirmTxReceiptProps) => {
+export const ConfirmTxReceipt = ({ children }: PropsWithChildren) => {
   const { safeTx } = useContext(SafeTxContext)
   const [txPreview] = useTxPreview(safeTx?.data)
   const wallet = useWallet()

--- a/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
@@ -10,9 +10,7 @@ import { MODALS_EVENTS } from '@/services/analytics'
 import useWallet from '@/hooks/wallets/useWallet'
 import { isHardwareWallet, isLedgerLive } from '@/utils/wallets'
 import { TxFlowStep } from '@/components/tx-flow/TxFlowStep'
-import { SlotName, useSlot } from '@/components/tx-flow/slots'
 import type { SubmitCallback } from '@/components/tx-flow/TxFlow'
-import { Sign } from '@/components/tx-flow/actions/Sign'
 import { TxDetails } from '../ConfirmTxDetails/TxDetails'
 
 const InfoSteps = [
@@ -77,7 +75,6 @@ export const ConfirmTxReceipt = ({ children, onSubmit }: ConfirmTxReceiptProps) 
   const wallet = useWallet()
   const showHashes = wallet ? isHardwareWallet(wallet) || isLedgerLive(wallet) : false
   const steps = showHashes ? HardwareWalletStep : InfoSteps
-  const [SubmitComponent] = useSlot(SlotName.Submit)
 
   if (!safeTx) {
     return false
@@ -108,8 +105,6 @@ export const ConfirmTxReceipt = ({ children, onSubmit }: ConfirmTxReceiptProps) 
         {children}
 
         <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />
-
-        {SubmitComponent ? <SubmitComponent onSubmit={onSubmit} /> : <Sign onSubmit={onSubmit} />}
       </TxCard>
     </TxFlowStep>
   )

--- a/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
@@ -43,7 +43,7 @@ export const ReviewTransactionContent = ({
 }): ReactElement => {
   const { willExecute, isCreation, showMethodCall, isProposing, isRejection } = useContext(TxFlowContext)
 
-  const [SubmitComponent] = useSlot(SlotName.Submit)
+  const [{ Component: SubmitComponent } = {}] = useSlot(SlotName.Submit)
 
   const [readableApprovals] = useApprovalInfos({ safeTransaction: safeTx })
   const isApproval = readableApprovals && readableApprovals.length > 0
@@ -76,8 +76,8 @@ export const ReviewTransactionContent = ({
         {!isCounterfactualSafe && !isRejection && <BlockaidBalanceChanges />}
       </TxCard>
 
-      {features.map((Feature, i) => (
-        <Feature key={`feature-${i}`} />
+      {features.map(({ Component }, i) => (
+        <Component key={`feature-${i}`} />
       ))}
 
       <TxCard>
@@ -98,8 +98,8 @@ export const ReviewTransactionContent = ({
           </ErrorMessage>
         )}
 
-        {footerFeatures.map((FooterFeature, i) => (
-          <FooterFeature key={`footer-feature-${i}`} />
+        {footerFeatures.map(({ Component }, i) => (
+          <Component key={`footer-feature-${i}`} />
         ))}
 
         <NetworkWarning />
@@ -111,7 +111,7 @@ export const ReviewTransactionContent = ({
         {SubmitComponent ? (
           <SubmitComponent onSubmit={onSubmit} />
         ) : (
-          <Sign onSubmit={onSubmit} options={['sign']} onChange={() => {}} />
+          <Sign onSubmit={onSubmit} options={[{ id: 'sign', label: 'Sign' }]} onChange={() => {}} />
         )}
       </TxCard>
     </>

--- a/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
@@ -16,7 +16,7 @@ import ConfirmationView from '../confirmation-views'
 import UnknownContractError from '../SignOrExecuteForm/UnknownContractError'
 import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
-import { SlotName, useSlot } from '@/components/tx-flow/slots'
+import { Slot, SlotName } from '@/components/tx-flow/slots'
 import { Sign } from '@/components/tx-flow/actions/Sign'
 
 export type ReviewTransactionContentProps = PropsWithChildren<{
@@ -43,13 +43,9 @@ export const ReviewTransactionContent = ({
 }): ReactElement => {
   const { willExecute, isCreation, showMethodCall, isProposing, isRejection } = useContext(TxFlowContext)
 
-  const [{ Component: SubmitComponent } = {}] = useSlot(SlotName.Submit)
-
   const [readableApprovals] = useApprovalInfos({ safeTransaction: safeTx })
   const isApproval = readableApprovals && readableApprovals.length > 0
   const isCounterfactualSafe = useIsCounterfactualSafe()
-  const features = useSlot(SlotName.Feature)
-  const footerFeatures = useSlot(SlotName.Footer)
 
   return (
     <>
@@ -76,9 +72,7 @@ export const ReviewTransactionContent = ({
         {!isCounterfactualSafe && !isRejection && <BlockaidBalanceChanges />}
       </TxCard>
 
-      {features.map(({ Component }, i) => (
-        <Component key={`feature-${i}`} />
-      ))}
+      <Slot name={SlotName.Feature} />
 
       <TxCard>
         <ConfirmationTitle
@@ -98,9 +92,7 @@ export const ReviewTransactionContent = ({
           </ErrorMessage>
         )}
 
-        {footerFeatures.map(({ Component }, i) => (
-          <Component key={`footer-feature-${i}`} />
-        ))}
+        <Slot name={SlotName.Footer} />
 
         <NetworkWarning />
 
@@ -108,11 +100,9 @@ export const ReviewTransactionContent = ({
 
         <Blockaid />
 
-        {SubmitComponent ? (
-          <SubmitComponent onSubmit={onSubmit} />
-        ) : (
+        <Slot name={SlotName.Submit} onSubmit={onSubmit}>
           <Sign onSubmit={onSubmit} options={[{ id: 'sign', label: 'Sign' }]} onChange={() => {}} />
-        )}
+        </Slot>
       </TxCard>
     </>
   )

--- a/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
@@ -3,7 +3,7 @@ import { useContext } from 'react'
 import madProps from '@/utils/mad-props'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import ErrorMessage from '../ErrorMessage'
-import TxCard, { TxCardActions } from '@/components/tx-flow/common/TxCard'
+import TxCard from '@/components/tx-flow/common/TxCard'
 import ConfirmationTitle, { ConfirmationTitleTypes } from '@/components/tx/SignOrExecuteForm/ConfirmationTitle'
 import { ErrorBoundary } from '@sentry/react'
 import ApprovalEditor from '../ApprovalEditor'
@@ -108,14 +108,11 @@ export const ReviewTransactionContent = ({
 
         <Blockaid />
 
-        <TxCardActions>
-          {/* Submit button */}
-          {SubmitComponent ? (
-            <SubmitComponent onSubmit={onSubmit} />
-          ) : (
-            <Sign onSubmit={onSubmit} options={['sign']} onChange={() => {}} />
-          )}
-        </TxCardActions>
+        {SubmitComponent ? (
+          <SubmitComponent onSubmit={onSubmit} />
+        ) : (
+          <Sign onSubmit={onSubmit} options={['sign']} onChange={() => {}} />
+        )}
       </TxCard>
     </>
   )

--- a/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
@@ -18,9 +18,10 @@ import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { Slot, SlotName } from '@/components/tx-flow/slots'
 import { Sign } from '@/components/tx-flow/actions/Sign'
+import type { SubmitCallback } from '@/components/tx-flow/TxFlow'
 
 export type ReviewTransactionContentProps = PropsWithChildren<{
-  onSubmit: () => void
+  onSubmit: SubmitCallback
   isBatch?: boolean
 }>
 

--- a/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
@@ -101,7 +101,7 @@ export const ReviewTransactionContent = ({
         <Blockaid />
 
         <Slot name={SlotName.Submit} onSubmit={onSubmit}>
-          <Sign onSubmit={onSubmit} options={[{ id: 'sign', label: 'Sign' }]} onChange={() => {}} />
+          <Sign onSubmit={onSubmit} options={[{ id: 'sign', label: 'Sign' }]} onChange={() => {}} slotId={'sign'} />
         </Slot>
       </TxCard>
     </>

--- a/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
@@ -101,7 +101,7 @@ export const ReviewTransactionContent = ({
         <Blockaid />
 
         <Slot name={SlotName.Submit} onSubmit={onSubmit}>
-          <Sign onSubmit={onSubmit} options={[{ id: 'sign', label: 'Sign' }]} onChange={() => {}} slotId={'sign'} />
+          <Sign onSubmit={onSubmit} options={[{ id: 'sign', label: 'Sign' }]} onChange={() => {}} slotId="sign" />
         </Slot>
       </TxCard>
     </>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -789,26 +789,104 @@ exports[`ReviewTransaction should display an error screen 1`] = `
         </div>
       </div>
       <div
-        class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
+        class="MuiStack-root css-eir3lh-MuiStack-root"
       >
-        <div
-          class="MuiStack-root css-irtfmw-MuiStack-root"
+        <label
+          class="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd css-q4bnt8-MuiFormControlLabel-root"
         >
           <span
-            aria-label="Please connect your wallet"
-            class=""
-            data-mui-internal-clone-element="true"
+            class="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium css-a4ywlg-MuiButtonBase-root-MuiCheckbox-root"
           >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1hp2ejb-MuiButtonBase-root-MuiButton-root"
-              data-testid="continue-sign-btn"
-              disabled=""
-              tabindex="-1"
-              type="submit"
+            <input
+              class="PrivateSwitchBase-input css-j8yymo"
+              data-indeterminate="false"
+              type="checkbox"
+            />
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1dhtbeh-MuiSvgIcon-root"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              Continue
-            </button>
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
           </span>
+          <span
+            class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label css-v6lhhw-MuiTypography-root"
+          >
+            I understand what I'm signing and that this is an irreversible action.
+          </span>
+        </label>
+        <div
+          class="MuiStack-root css-msk5bl-MuiStack-root"
+        >
+          <div
+            class="container error errorMessage"
+            data-testid="error-message"
+          >
+            <div
+              class="message"
+            >
+              <mock-icon
+                aria-hidden=""
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1vcpomi-MuiSvgIcon-root"
+                focusable="false"
+              />
+              <div>
+                <span
+                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                >
+                  You are currently not a signer of this Safe Account and won't be able to submit this transaction.
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-0"
+          >
+            <hr
+              class="MuiDivider-root MuiDivider-fullWidth nestedDivider css-1facvfi-MuiDivider-root"
+            />
+            <div
+              class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
+            >
+              <div
+                class="MuiStack-root css-irtfmw-MuiStack-root"
+              >
+                <form>
+                  <span
+                    aria-label="Please connect your wallet"
+                    class=""
+                    data-mui-internal-clone-element="true"
+                  >
+                    <div
+                      aria-label="Button group with a nested menu"
+                      class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-horizontal MuiButtonGroup-fullWidth MuiButtonGroup-colorPrimary css-izkk6m-MuiButtonGroup-root"
+                      role="group"
+                    >
+                      <div
+                        class="MuiBox-root css-1rr4qq7"
+                        data-mui-internal-clone-element="true"
+                      >
+                        <button
+                          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary css-jfe8rk-MuiButtonBase-root-MuiButton-root"
+                          data-testid="combo-submit-sign"
+                          disabled=""
+                          tabindex="-1"
+                          type="submit"
+                        >
+                          Sign
+                        </button>
+                      </div>
+                    </div>
+                  </span>
+                </form>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
@@ -154,7 +154,14 @@ export const SignOrExecuteForm = ({
     }
 
     if (!isCounterfactualSafe && willExecute && !isProposing) {
-      return <ExecuteForm {...commonProps} />
+      return (
+        <ExecuteForm
+          {...commonProps}
+          options={[{ label: 'Execute', id: 'execute' }]}
+          onChange={() => {}}
+          onSubmit={({ txId, isExecuted } = {}) => onFormSubmit(txId!, isExecuted)}
+        />
+      )
     }
 
     if (!isCounterfactualSafe && willExecuteThroughRole) {

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
@@ -158,6 +158,7 @@ export const SignOrExecuteForm = ({
         <ExecuteForm
           {...commonProps}
           options={[{ label: 'Execute', id: 'execute' }]}
+          slotId="execute"
           onChange={() => {}}
           onSubmit={({ txId, isExecuted } = {}) => onFormSubmit(txId!, isExecuted)}
         />

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteFormV2.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteFormV2.tsx
@@ -124,7 +124,14 @@ export const SignOrExecuteFormV2 = ({
   }
 
   if (!isCounterfactualSafe && willExecute && !isProposing) {
-    return <ExecuteForm {...commonProps} />
+    return (
+      <ExecuteForm
+        {...commonProps}
+        options={[{ label: 'Execute', id: 'execute' }]}
+        onChange={() => {}}
+        onSubmit={({ txId, isExecuted } = {}) => onFormSubmit(txId!, isExecuted)}
+      />
+    )
   }
 
   if (!isCounterfactualSafe && willExecuteThroughRole) {

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteFormV2.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteFormV2.tsx
@@ -6,7 +6,6 @@ import { type ReactElement, type ReactNode, useContext, useCallback } from 'reac
 import madProps from '@/utils/mad-props'
 import { useImmediatelyExecutable, useValidateNonce } from './hooks'
 import ExecuteForm from '@/components/tx-flow/actions/Execute/ExecuteForm'
-import SignForm from '@/components/tx-flow/actions/Sign/SignForm'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
@@ -22,6 +21,7 @@ import { useLazyGetTransactionDetailsQuery } from '@/store/api/gateway'
 import type { TransactionDetails, TransactionPreview } from '@safe-global/safe-gateway-typescript-sdk'
 import { useSigner } from '@/hooks/wallets/useWallet'
 import { trackTxEvents } from './tracking'
+import SignForm from './SignForm'
 
 export type SubmitCallback = (txId: string, isExecuted?: boolean) => void
 

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteFormV2.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteFormV2.tsx
@@ -128,6 +128,7 @@ export const SignOrExecuteFormV2 = ({
       <ExecuteForm
         {...commonProps}
         options={[{ label: 'Execute', id: 'execute' }]}
+        slotId="execute"
         onChange={() => {}}
         onSubmit={({ txId, isExecuted } = {}) => onFormSubmit(txId!, isExecuted)}
       />


### PR DESCRIPTION
## What it solves

Resolves #5556

Introduces a combo button for signing, executing, or batching transactions, enhanced with memory to remember the user's last choice.

## How this PR fixes it

### `SplitMenuButton`

- Added new props:  
  - `tooltip`: Displays contextual information on hover.  
  - `onChange`: Handles selection changes.  
  - `selected`: Controls the active option.  
- Updated `options` prop to support objects with `id` and `label` keys, enabling more descriptive and flexible menu options.
- Replaced `Popper` with `Popover` to improve accessibility and user experience.

### `TxFlow`

- Render the new `SplitMenuButton` in Sign, Execute, and Batching components.
- **New `ComboSubmit` slot**: Introduced a dedicated slot to handle multi-action submission logic in one cohesive component.  
  See [[1]](diffhunk://#diff-7726c8aaa4686f635e5e29a4ab8e4428f4ea36628368b6c31c04a0e440c7b38dL10-R11), [[2]](diffhunk://#diff-7726c8aaa4686f635e5e29a4ab8e4428f4ea36628368b6c31c04a0e440c7b38dL81-R97)
- Moved `submitError` and `isRejectedByUser` into `TxFlowContext`, making them accessible to all TxFlow components.  
    References: [[1]](diffhunk://#diff-f5c0b23f4b744c45966e8120e01603e6a62e30a28806687154aef59a6dcfbd79R54-R61), [[2]](diffhunk://#diff-f5c0b23f4b744c45966e8120e01603e6a62e30a28806687154aef59a6dcfbd79R91-R98), [[3]](diffhunk://#diff-f5c0b23f4b744c45966e8120e01603e6a62e30a28806687154aef59a6dcfbd79L133-R147), [[4]](diffhunk://#diff-f5c0b23f4b744c45966e8120e01603e6a62e30a28806687154aef59a6dcfbd79R217-R224)
- **Error handling centralization**: Moved error messages previously shown in Sign/Execute components to the new `ComboSubmit`, ensuring consistent UX.

## Screenshots
<img width="736" alt="Screenshot 2025-04-10 at 14 58 02" src="https://github.com/user-attachments/assets/18eb3c97-3a83-46d8-9bd7-aa8bc8cc9028" />
<img width="507" alt="Screenshot 2025-04-10 at 14 56 37" src="https://github.com/user-attachments/assets/885b24f7-fa8b-4c44-ac2f-5ac7d6a3420d" />

https://github.com/user-attachments/assets/b2aff253-dcfb-4e97-b6e4-e910f857bf5e


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
