### PR TITLE
Fix(Spaces): Use EthHashInfo for SafeList items to support copy

### DIFF
--- a/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -97,7 +97,7 @@ const SrcEthHashInfo = ({
 
       <Box overflow="hidden" className={onlyName ? css.inline : undefined} gap={0.5}>
         {name && (
-          <Box title={name} display="flex" alignItems="center" gap={0.5}>
+          <Box title={name} className="ethHashInfo-name" display="flex" alignItems="center" gap={0.5}>
             <Box overflow="hidden" textOverflow="ellipsis">
               {name}
             </Box>

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
                             class="MuiBox-root css-1lchl8k"
                           >
                             <div
-                              class="MuiBox-root css-171onha"
+                              class="ethHashInfo-name MuiBox-root css-171onha"
                               title="GnosisSafeProxy"
                             >
                               <div

--- a/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`SettingsChange should display the SettingsChange component with newOwne
         class="MuiBox-root css-1lchl8k"
       >
         <div
-          class="MuiBox-root css-171onha"
+          class="ethHashInfo-name MuiBox-root css-171onha"
           title="Bob"
         >
           <div
@@ -115,7 +115,7 @@ exports[`SettingsChange should display the SettingsChange component with newOwne
         class="MuiBox-root css-1lchl8k"
       >
         <div
-          class="MuiBox-root css-171onha"
+          class="ethHashInfo-name MuiBox-root css-171onha"
           title="Alice"
         >
           <div
@@ -206,7 +206,7 @@ exports[`SettingsChange should display the SettingsChange component with owner d
         class="MuiBox-root css-1lchl8k"
       >
         <div
-          class="MuiBox-root css-171onha"
+          class="ethHashInfo-name MuiBox-root css-171onha"
           title="Nevinha"
         >
           <div

--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -18,6 +18,7 @@ import {
   Tooltip,
   SvgIcon,
   IconButton,
+  useMediaQuery,
 } from '@mui/material'
 import SafeIcon from '@/components/common/SafeIcon'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS, PIN_SAFE_LABELS, trackEvent } from '@/services/analytics'
@@ -49,6 +50,7 @@ import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import { getComparator } from '@/features/myAccounts/utils/utils'
 import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
 import EthHashInfo from '@/components/common/EthHashInfo'
+import { useTheme } from '@mui/material/styles'
 
 export const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
   return (
@@ -223,6 +225,9 @@ type MultiAccountItemProps = {
 }
 
 const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = false }: MultiAccountItemProps) => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+
   const {
     address,
     name,
@@ -282,6 +287,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = fal
                 showPrefix={false}
                 showAvatar={false}
                 copyPrefix={false}
+                copyAddress={!isMobile}
               />
             </Typography>
             <MultichainIndicator safes={sortedSafes} />

--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -48,6 +48,7 @@ import { defaultSafeInfo } from '@safe-global/store/slices/SafeInfo/utils'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import { getComparator } from '@/features/myAccounts/utils/utils'
 import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
+import EthHashInfo from '@/components/common/EthHashInfo'
 
 export const MultichainIndicator = ({ safes }: { safes: SafeItem[] }) => {
   return (
@@ -272,22 +273,16 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = fal
             <Box sx={{ pr: 2.5 }} data-testid="group-safe-icon">
               <SafeIcon address={address} owners={sharedSetup?.owners.length} threshold={sharedSetup?.threshold} />
             </Box>
+
             <Typography variant="body2" component="div" className={css.safeAddress}>
-              {multiSafeAccountItem.name && (
-                <Typography variant="subtitle2" component="p" sx={{ fontWeight: 'bold' }} className={css.safeName}>
-                  {multiSafeAccountItem.name}
-                </Typography>
-              )}
-              <Typography
-                data-testid="group-address"
-                component="span"
-                sx={{
-                  color: 'var(--color-primary-light)',
-                  fontSize: 'inherit',
-                }}
-              >
-                {shortenAddress(address)}
-              </Typography>
+              <EthHashInfo
+                address={address}
+                name={multiSafeAccountItem.name}
+                shortAddress
+                showPrefix={false}
+                showAvatar={false}
+                copyPrefix={false}
+              />
             </Typography>
             <MultichainIndicator safes={sortedSafes} />
             <Typography

--- a/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
@@ -36,6 +36,7 @@ import { defaultSafeInfo } from '@safe-global/store/slices/SafeInfo/utils'
 import FiatValue from '@/components/common/FiatValue'
 import { AccountInfoChips } from '../AccountInfoChips'
 import SendTransactionButton from '@/features/spaces/components/SafeAccounts/SendTransactionButton'
+import EthHashInfo from '@/components/common/EthHashInfo'
 
 type AccountItemProps = {
   safeItem: SafeItem
@@ -185,18 +186,7 @@ const SingleAccountItem = ({
             {chain?.chainName}
           </Typography>
         ) : (
-          <>
-            {chain?.shortName}:
-            <Typography
-              component="span"
-              sx={{
-                color: 'var(--color-primary-light)',
-                fontSize: 'inherit',
-              }}
-            >
-              {shortenAddress(address)}
-            </Typography>
-          </>
+          <EthHashInfo address={address} shortAddress chainId={chain?.chainId} showAvatar={false} />
         )}
         {!isMobile && (
           <AccountInfoChips

--- a/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
@@ -163,18 +163,6 @@ const SingleAccountItem = ({
       </Box>
 
       <Typography variant="body2" component="div" className={css.safeAddress}>
-        {name && (
-          <Typography
-            variant="subtitle2"
-            component="p"
-            className={css.safeName}
-            sx={{
-              fontWeight: 'bold',
-            }}
-          >
-            {name}
-          </Typography>
-        )}
         {isMultiChainItem ? (
           <Typography
             component="span"
@@ -186,7 +174,14 @@ const SingleAccountItem = ({
             {chain?.chainName}
           </Typography>
         ) : (
-          <EthHashInfo address={address} shortAddress chainId={chain?.chainId} showAvatar={false} />
+          <EthHashInfo
+            address={address}
+            name={name}
+            shortAddress
+            chainId={chain?.chainId}
+            showAvatar={false}
+            copyAddress={!isMobile}
+          />
         )}
         {!isMobile && (
           <AccountInfoChips

--- a/apps/web/src/features/myAccounts/components/AccountItems/styles.module.css
+++ b/apps/web/src/features/myAccounts/components/AccountItems/styles.module.css
@@ -75,6 +75,10 @@
   text-overflow: ellipsis;
 }
 
+.safeAddress :global .ethHashInfo-name {
+  font-weight: bold;
+}
+
 .listHeader {
   display: flex;
 }

--- a/apps/web/src/features/spaces/components/SpaceCreationModal/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCreationModal/index.tsx
@@ -47,9 +47,10 @@ function SpaceCreationModal({ onClose }: { onClose: () => void }): ReactElement 
       if (response.error) {
         throw response.error
       }
-    } catch (e) {
-      // TODO: Show more specific error message
-      setError('Failed creating the space. Please try again.')
+    } catch (error) {
+      // @ts-ignore
+      const errorMessage = error?.data?.message || 'Failed creating the space. Please try again.'
+      setError(errorMessage)
     } finally {
       setIsSubmitting(false)
     }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/169
Resolves https://github.com/safe-global/wallet-private-tasks/issues/170

## How this PR fixes it

- Uses `EthHashInfo` within `SingleAccountItem` and `MultiAccountItem`
- Adds a more useful error message when reaching the space creation limit

## How to test it

1. Open a space
2. Add safes to that space
3. Hover over the address in the list
4. Observe a "Copy to clipboard" tooltip
5. Click the address
6. Observe the address is copied and the user is not navigated to that safe
7. Click anywhere else
8. The user is navigated to that safe
9. Accounts page and safe sidebar will also have this change
10. Add a safe address (multi-chain and single chain) to your address book
11. Observe the name shows up only once in the list

## Screenshots
<img width="843" alt="Screenshot 2025-04-10 at 15 34 12" src="https://github.com/user-attachments/assets/b4d5e86b-d0ff-4966-9f68-91f236e9f48a" />
<img width="634" alt="Screenshot 2025-04-10 at 15 34 27" src="https://github.com/user-attachments/assets/8c728b35-def3-4d01-9363-8d8269330ec8" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
