### PR TITLE
fix(mobile): add better detection for strongbox support

### DIFF
--- a/.yarn/patches/react-native-device-crypto-npm-0.1.7-dbd2698fc4.patch
+++ b/.yarn/patches/react-native-device-crypto-npm-0.1.7-dbd2698fc4.patch
@@ -1,0 +1,90 @@
+diff --git a/android/src/main/java/com/reactnativedevicecrypto/Helpers.java b/android/src/main/java/com/reactnativedevicecrypto/Helpers.java
+index 03fd79e8a389f33a2841ecf0e177ffc9ea01b78c..681f07efab020e078ee75d697434a1d3ce414f32 100644
+--- a/android/src/main/java/com/reactnativedevicecrypto/Helpers.java
++++ b/android/src/main/java/com/reactnativedevicecrypto/Helpers.java
+@@ -39,6 +39,7 @@ public class Helpers {
+     private static final int AES_IV_SIZE = 128;
+     public static final String PEM_HEADER = "-----BEGIN PUBLIC KEY-----\n";
+     public static final String PEM_FOOTER = "-----END PUBLIC KEY-----";
++    private static Boolean sIsStrongBoxSupported = null; // Cache for StrongBox support
+ 
+     public interface KeyType {
+         @Retention(SOURCE)
+@@ -81,6 +82,64 @@ public class Helpers {
+         }
+     }
+ 
++    public static boolean isStrongBoxSupported() {
++        // Return cached result if available
++        if (sIsStrongBoxSupported != null) {
++            return sIsStrongBoxSupported;
++        }
++
++        // Try to create a key with StrongBox requirement and see if it succeeds
++        String testAlias = "test_strongbox_support";
++        try {
++            // First, clean up any existing test key
++            try {
++                KeyStore keyStore = getKeyStore();
++                if (keyStore.containsAlias(testAlias)) {
++                    keyStore.deleteEntry(testAlias);
++                }
++            } catch (Exception e) {
++                // Ignore errors during cleanup
++            }
++
++            // Attempt to create a key with StrongBox backing
++            KeyGenParameterSpec testSpec = new KeyGenParameterSpec.Builder(testAlias, KeyProperties.PURPOSE_ENCRYPT)
++                    .setIsStrongBoxBacked(true)
++                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
++                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
++                    .setKeySize(256)
++                    .build();
++            KeyGenerator testKeyGen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEY_STORE);
++            testKeyGen.init(testSpec);
++            testKeyGen.generateKey();
++
++            // If we reach here, StrongBox is supported
++            // Clean up the test key
++            KeyStore keyStore = getKeyStore();
++            keyStore.deleteEntry(testAlias);
++
++            // Cache the result
++            sIsStrongBoxSupported = true;
++            Log.i(RN_MODULE, "StrongBox is supported on this device");
++            return true;
++        } catch (Exception e) {
++            Log.i(RN_MODULE, "StrongBox not supported on this device: " + e.getMessage());
++
++            // Clean up any test key that might have been created
++            try {
++                KeyStore keyStore = getKeyStore();
++                if (keyStore.containsAlias(testAlias)) {
++                    keyStore.deleteEntry(testAlias);
++                }
++            } catch (Exception cleanupEx) {
++                // Ignore errors during cleanup
++            }
++
++            // Cache the result
++            sIsStrongBoxSupported = false;
++            return false;
++        }
++    }
++
+     public static boolean isKeyExists(@NonNull String alias, @KeyType.Types int keyType) throws Exception {
+         KeyStore keyStore = Helpers.getKeyStore();
+         if (!keyStore.containsAlias(alias)) {
+@@ -143,8 +202,10 @@ public class Helpers {
+             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+               builder.setInvalidatedByBiometricEnrollment(invalidateOnNewBiometry);
+             }
+-            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
+-              builder.setIsStrongBoxBacked(true);
++            // Only try to enable StrongBox if API level is high enough and the device
++            // actually supports it
++            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isStrongBoxSupported()) {
++                builder.setIsStrongBoxBacked(true);
+             }
+             break;
+         }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -99,7 +99,7 @@
     "react-hook-form": "^7.54.2",
     "react-native": "0.76.9",
     "react-native-collapsible-tab-view": "^8.0.0",
-    "react-native-device-crypto": "^0.1.7",
+    "react-native-device-crypto": "patch:react-native-device-crypto@npm%3A0.1.7#~/.yarn/patches/react-native-device-crypto-npm-0.1.7-dbd2698fc4.patch",
     "react-native-device-info": "^14.0.1",
     "react-native-draggable-flatlist": "^4.0.1",
     "react-native-gesture-handler": "~2.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8238,7 +8238,7 @@ __metadata:
     react-hook-form: "npm:^7.54.2"
     react-native: "npm:0.76.9"
     react-native-collapsible-tab-view: "npm:^8.0.0"
-    react-native-device-crypto: "npm:^0.1.7"
+    react-native-device-crypto: "patch:react-native-device-crypto@npm%3A0.1.7#~/.yarn/patches/react-native-device-crypto-npm-0.1.7-dbd2698fc4.patch"
     react-native-device-info: "npm:^14.0.1"
     react-native-draggable-flatlist: "npm:^4.0.1"
     react-native-gesture-handler: "npm:~2.20.2"
@@ -27965,13 +27965,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-device-crypto@npm:^0.1.7":
+"react-native-device-crypto@npm:0.1.7":
   version: 0.1.7
   resolution: "react-native-device-crypto@npm:0.1.7"
   peerDependencies:
     react: "*"
     react-native: "*"
   checksum: 10/0c4f9e8b8a10659511d74e4ec33cc3353a1cbe15038e5f4bae4012d679f2733e00fac4568a3c332ce11f984c2324f9a51373858ccf6ec24a2e6755273b5e595f
+  languageName: node
+  linkType: hard
+
+"react-native-device-crypto@patch:react-native-device-crypto@npm%3A0.1.7#~/.yarn/patches/react-native-device-crypto-npm-0.1.7-dbd2698fc4.patch":
+  version: 0.1.7
+  resolution: "react-native-device-crypto@patch:react-native-device-crypto@npm%3A0.1.7#~/.yarn/patches/react-native-device-crypto-npm-0.1.7-dbd2698fc4.patch::version=0.1.7&hash=a313f2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/78d90c718b8e7436bba7971cc5e6d431592701e40c2f0b83e8b3cc8b4dd384866eb56487ceb2b738a4286f9ad750f7642fd2562bba0c1338c53bf0a4bf67ffad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves
Despite strongbox support in SDK v28 there are a lot of devices that don’t have the hardware component to support strongbox encryption. Relying solely on the sdk version is not good enough. We try to store a key with strongbox if that fail we know that this is not supported and don’t turn it on.

Resolves #

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
