### PR TITLE
Fix(Spaces): revert accidental changes to space safe context menu

### DIFF
--- a/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
@@ -60,7 +60,7 @@ const SpaceSafeContextMenu = ({ safeItem }: { safeItem: SafeItem | MultiChainSaf
   return (
     <>
       <IconButton edge="end" size="small" onClick={handleOpenContextMenu}>
-        <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />
+        <MoreVertIcon sx={{ color: 'border.main' }} />
       </IconButton>
       <ContextMenu anchorEl={anchorEl} open={!!anchorEl} onClose={handleCloseContextMenu}>
         <MenuItem onClick={(e) => handleOpenModal(e, ModalType.RENAME)}>

--- a/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SpaceSafeContextMenu.tsx
@@ -1,5 +1,6 @@
 import type { SafeItem } from '@/features/myAccounts/hooks/useAllSafes'
 import type { MultiChainSafeItem } from '@/features/myAccounts/hooks/useAllSafesGrouped'
+import RemoveSafeDialog from '@/features/spaces/components/SafeAccounts/RemoveSafeDialog'
 import { type MouseEvent, useState } from 'react'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import { SvgIcon } from '@mui/material'
@@ -10,16 +11,28 @@ import MenuItem from '@mui/material/MenuItem'
 import ContextMenu from '@/components/common/ContextMenu'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import EditIcon from '@/public/images/common/edit.svg'
+import EntryDialog from '@/components/address-book/EntryDialog'
 import { useAppSelector } from '@/store'
 import { selectAllAddressBooks } from '@/store/addressBookSlice'
 import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { trackEvent } from '@/services/analytics'
 import { useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
+
+enum ModalType {
+  RENAME = 'rename',
+  REMOVE = 'remove',
+}
+
+const defaultOpen = { [ModalType.RENAME]: false, [ModalType.REMOVE]: false }
 
 const SpaceSafeContextMenu = ({ safeItem }: { safeItem: SafeItem | MultiChainSafeItem }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | undefined>()
+  const [open, setOpen] = useState<typeof defaultOpen>(defaultOpen)
   const isAdmin = useIsAdmin()
 
   const allAddressBooks = useAppSelector(selectAllAddressBooks)
+  const chainIds = isMultiChainSafeItem(safeItem) ? safeItem.safes.map((safe) => safe.chainId) : [safeItem.chainId]
   const name = isMultiChainSafeItem(safeItem) ? safeItem.name : allAddressBooks[safeItem.chainId]?.[safeItem.address]
   const hasName = !!name
 
@@ -33,13 +46,24 @@ const SpaceSafeContextMenu = ({ safeItem }: { safeItem: SafeItem | MultiChainSaf
     setAnchorEl(undefined)
   }
 
+  const handleOpenModal = (e: MouseEvent, type: keyof typeof open) => {
+    e.stopPropagation()
+    if (type === ModalType.REMOVE) trackEvent({ ...SPACE_EVENTS.DELETE_ACCOUNT_MODAL })
+    setAnchorEl(undefined)
+    setOpen((prev) => ({ ...prev, [type]: true }))
+  }
+
+  const handleCloseModal = () => {
+    setOpen(defaultOpen)
+  }
+
   return (
     <>
       <IconButton edge="end" size="small" onClick={handleOpenContextMenu}>
         <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />
       </IconButton>
       <ContextMenu anchorEl={anchorEl} open={!!anchorEl} onClose={handleCloseContextMenu}>
-        <MenuItem onClick={() => {}}>
+        <MenuItem onClick={(e) => handleOpenModal(e, ModalType.RENAME)}>
           <ListItemIcon>
             <SvgIcon component={EditIcon} inheritViewBox fontSize="small" color="success" />
           </ListItemIcon>
@@ -47,7 +71,7 @@ const SpaceSafeContextMenu = ({ safeItem }: { safeItem: SafeItem | MultiChainSaf
         </MenuItem>
 
         {isAdmin && (
-          <MenuItem onClick={() => {}}>
+          <MenuItem onClick={(e) => handleOpenModal(e, ModalType.REMOVE)}>
             <ListItemIcon>
               <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" color="error" />
             </ListItemIcon>
@@ -55,6 +79,18 @@ const SpaceSafeContextMenu = ({ safeItem }: { safeItem: SafeItem | MultiChainSaf
           </MenuItem>
         )}
       </ContextMenu>
+
+      {open[ModalType.RENAME] && (
+        <EntryDialog
+          handleClose={handleCloseModal}
+          defaultValues={{ name: name || '', address: safeItem.address }}
+          chainIds={chainIds}
+          currentChainId={isMultiChainSafeItem(safeItem) ? undefined : chainIds[0]}
+          disableAddressInput
+        />
+      )}
+
+      {open[ModalType.REMOVE] && <RemoveSafeDialog safeItem={safeItem} handleClose={handleCloseModal} />}
     </>
   )
 }

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
@@ -8,24 +8,20 @@ import type { MultiChainSafeItem } from '@/features/myAccounts/hooks/useAllSafes
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 
-// Mock dependencies
 jest.mock('@/store')
 jest.mock('@/features/spaces/hooks/useSpaceMembers')
 jest.mock('@/services/analytics')
 jest.mock('@/features/multichain/utils/utils')
 
-// Mock the RemoveSafeDialog component
 jest.mock('../RemoveSafeDialog', () => {
   return jest.fn(() => <div data-testid="remove-safe-dialog">Remove Safe Dialog</div>)
 })
 
-// Mock the EntryDialog component
 jest.mock('@/components/address-book/EntryDialog', () => {
   return jest.fn(() => <div data-testid="entry-dialog">Entry Dialog</div>)
 })
 
 describe('SpaceSafeContextMenu', () => {
-  // Create mock objects that match the required interfaces
   const mockSafeItem: SafeItem = {
     address: '0x123',
     chainId: '5',
@@ -54,8 +50,6 @@ describe('SpaceSafeContextMenu', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-
-    // Default mocks
     ;(useAppSelector as jest.Mock).mockReturnValue(mockAddressBooks)
     ;(useIsAdmin as jest.Mock).mockReturnValue(false)
     ;(isMultiChainSafeItem as unknown as jest.Mock).mockImplementation(

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeContextMenu.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import SpaceSafeContextMenu from '../SpaceSafeContextMenu'
+import { useAppSelector } from '@/store'
+import { useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
+import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
+import type { SafeItem } from '@/features/myAccounts/hooks/useAllSafes'
+import type { MultiChainSafeItem } from '@/features/myAccounts/hooks/useAllSafesGrouped'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+
+// Mock dependencies
+jest.mock('@/store')
+jest.mock('@/features/spaces/hooks/useSpaceMembers')
+jest.mock('@/services/analytics')
+jest.mock('@/features/multichain/utils/utils')
+
+// Mock the RemoveSafeDialog component
+jest.mock('../RemoveSafeDialog', () => {
+  return jest.fn(() => <div data-testid="remove-safe-dialog">Remove Safe Dialog</div>)
+})
+
+// Mock the EntryDialog component
+jest.mock('@/components/address-book/EntryDialog', () => {
+  return jest.fn(() => <div data-testid="entry-dialog">Entry Dialog</div>)
+})
+
+describe('SpaceSafeContextMenu', () => {
+  // Create mock objects that match the required interfaces
+  const mockSafeItem: SafeItem = {
+    address: '0x123',
+    chainId: '5',
+    isReadOnly: false,
+    isPinned: false,
+    lastVisited: 0,
+    name: 'Test Safe',
+  }
+
+  const mockMultiChainSafeItem: MultiChainSafeItem = {
+    address: '0x123',
+    name: 'Multi Chain Safe',
+    safes: [
+      { address: '0x123', chainId: '5', isReadOnly: false, isPinned: false, lastVisited: 0, name: 'Test Safe 1' },
+      { address: '0x123', chainId: '1', isReadOnly: false, isPinned: false, lastVisited: 0, name: 'Test Safe 2' },
+    ],
+    isPinned: false,
+    lastVisited: 0,
+  }
+
+  const mockAddressBooks = {
+    '5': {
+      '0x123': 'Test Safe Name',
+    },
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    // Default mocks
+    ;(useAppSelector as jest.Mock).mockReturnValue(mockAddressBooks)
+    ;(useIsAdmin as jest.Mock).mockReturnValue(false)
+    ;(isMultiChainSafeItem as unknown as jest.Mock).mockImplementation(
+      (item) => 'safes' in item && Array.isArray(item.safes),
+    )
+  })
+
+  it('renders with a SafeItem', () => {
+    render(<SpaceSafeContextMenu safeItem={mockSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    expect(menuButton).toBeInTheDocument()
+  })
+
+  it('renders with a MultiChainSafeItem', () => {
+    render(<SpaceSafeContextMenu safeItem={mockMultiChainSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    expect(menuButton).toBeInTheDocument()
+  })
+
+  it('opens context menu when clicking the button', async () => {
+    render(<SpaceSafeContextMenu safeItem={mockSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    fireEvent.click(menuButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Rename')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Give name" when safe has no name', async () => {
+    ;(useAppSelector as jest.Mock).mockReturnValue({})
+
+    render(<SpaceSafeContextMenu safeItem={mockSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    fireEvent.click(menuButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Give name')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Rename" when safe has a name in address book', async () => {
+    render(<SpaceSafeContextMenu safeItem={mockSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    fireEvent.click(menuButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Rename')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Rename" when MultiChainSafeItem has a name', async () => {
+    render(<SpaceSafeContextMenu safeItem={mockMultiChainSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    fireEvent.click(menuButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Rename')).toBeInTheDocument()
+    })
+  })
+
+  it('shows Remove option for admin users', async () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(true)
+
+    render(<SpaceSafeContextMenu safeItem={mockSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    fireEvent.click(menuButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Remove')).toBeInTheDocument()
+    })
+  })
+
+  it('does not show Remove option for non-admin users', async () => {
+    render(<SpaceSafeContextMenu safeItem={mockSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    fireEvent.click(menuButton)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Remove')).not.toBeInTheDocument()
+    })
+  })
+
+  it('opens EntryDialog when clicking Rename option', async () => {
+    render(<SpaceSafeContextMenu safeItem={mockSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    fireEvent.click(menuButton)
+
+    await waitFor(() => {
+      const renameOption = screen.getByText('Rename')
+      fireEvent.click(renameOption)
+    })
+
+    // Verify the EntryDialog is rendered
+    expect(screen.getByTestId('entry-dialog')).toBeInTheDocument()
+  })
+
+  it('opens RemoveSafeDialog when clicking Remove option', async () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(true)
+
+    render(<SpaceSafeContextMenu safeItem={mockSafeItem} />)
+
+    const menuButton = screen.getByRole('button')
+    fireEvent.click(menuButton)
+
+    await waitFor(() => {
+      const removeOption = screen.getByText('Remove')
+      fireEvent.click(removeOption)
+    })
+
+    // Verify the RemoveSafeDialog is rendered
+    expect(screen.getByTestId('remove-safe-dialog')).toBeInTheDocument()
+    expect(trackEvent).toHaveBeenCalledWith(SPACE_EVENTS.DELETE_ACCOUNT_MODAL)
+  })
+})


### PR DESCRIPTION
## What it solves
Due to some accidental changes that were supposed to be applied to the address book context menu, the safe context menu no longer works.

## How this PR fixes it
- Revert the changes
- Add tests for the SpaceSafeContextMenu component

## How to test it
- go to the safes list of a space
- Click on the context menu.
- Check that clicking the delete and edit options will open the conformation dialogs as expected


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
