### PR TITLE
Tests: Enable decoding tests

### DIFF
--- a/apps/web/cypress/e2e/regression/staking_history.cy.js
+++ b/apps/web/cypress/e2e/regression/staking_history.cy.js
@@ -7,8 +7,7 @@ const safe = 'eth:0xAD1Cf279D18f34a13c3Bf9b79F4D427D5CD9505B'
 const historyData = staking_data.type.history
 
 describe('Staking history tests', { defaultCommandTimeout: 30000 }, () => {
-  // Unskip when decoding is fixed on staging
-  it.skip('Verify Claim tx shows amount received', () => {
+  it('Verify Claim tx shows amount received', () => {
     cy.visit(constants.transactionUrl + safe + staking.stakingTxs.claim)
     staking.checkTxHeaderData([historyData.ETH_3205184, historyData.claim])
     create_tx.verifyExpandedDetails([historyData.ETH_3205184, historyData.received])
@@ -16,8 +15,7 @@ describe('Staking history tests', { defaultCommandTimeout: 30000 }, () => {
     create_tx.verifyAdvancedDetails([historyData.call_batchWithdrawCLFee, historyData.StakingContract])
   })
 
-  // Unskip when decoding is fixed on staging
-  it.skip('Verify Withdraw request shows amount of validators and Validator status', () => {
+  it('Verify Withdraw request shows amount of validators and Validator status', () => {
     cy.visit(constants.transactionUrl + safe + staking.stakingTxs.withdrawal)
     staking.checkTxHeaderData([historyData.withdrawal, historyData.validator_1])
     staking.verifyValidatorCount(1)
@@ -26,8 +24,7 @@ describe('Staking history tests', { defaultCommandTimeout: 30000 }, () => {
     create_tx.verifyAdvancedDetails([historyData.call_requestValidatorsExit, historyData.StakingContract])
   })
 
-  // Unskip when decoding is fixed on staging
-  it.skip('Verify Stake tx show the amount staked and proper fields', () => {
+  it('Verify Stake tx show the amount staked and proper fields', () => {
     cy.visit(constants.transactionUrl + safe + staking.stakingTxs.stake)
     staking.checkTxHeaderData([historyData.ETH32_2, historyData.stake])
     staking.checkDataFields(staking.dataFields.deposit, historyData.ETH_32)


### PR DESCRIPTION
## How this PR fixes it

- Since decoding is back on staging, the tests are re-enabled again to perform required checks. 

## How to test it

- Run Cypress tests and observe outcome.
