### PR TITLE
fix(web): nft image overlap on text in tx flow

### DIFF
--- a/apps/web/src/components/tx-flow/flows/NftTransfer/SendNftBatch.tsx
+++ b/apps/web/src/components/tx-flow/flows/NftTransfer/SendNftBatch.tsx
@@ -20,7 +20,7 @@ type SendNftBatchProps = {
 }
 
 const NftItem = ({ image, name, description }: { image: string; name: string; description?: string }) => (
-  <Stack direction="row" spacing={1} flexWrap="nowrap" alignItems="flex-start">
+  <Stack direction="row" spacing={2} flexWrap="nowrap" alignItems="flex-start">
     <Box flex={0}>
       <ImageFallback
         src={image}


### PR DESCRIPTION
## What it solves
This PR addresses the spacing issue between the NFT image and the text in the transaction flow.

Resolves ##3114

## How this PR fixes it
Increased spacing value from `1` to `2` to ensure sufficient padding between the image and the text content.

## How to test it
1. Open the transaction flow where the NFT image appears.
2. Inject the following test image using the console:
`<img style="display: block; margin: 0 auto;" height="64" width="64" alt="Test Image" src="https://picsum.photos/1920/1080">`
Inside the element: `<div class="MuiBox-root mui-style-72fd9l"></div>`

## Screenshots
<img width="750" alt="Screenshot 2025-04-11 at 13 57 07" src="https://github.com/user-attachments/assets/babc4711-4c24-43ad-84c3-3a9dd2416374" />

## Checklist

- [ ] I've tested the branch on mobile (not applicable) 📱
- [ ] I've documented how it affects the analytics (not applicable) 📊
- [ ] I've written a unit/e2e test for it ((not applicable)) 🧑‍💻
