### PR TITLE
Fix(Mobile): Center no contacts illustration

### DIFF
--- a/apps/mobile/src/features/AddressBook/AddressBookView.tsx
+++ b/apps/mobile/src/features/AddressBook/AddressBookView.tsx
@@ -6,11 +6,14 @@ import { View } from 'tamagui'
 import SafeSearchBar from '@/src/components/SafeSearchBar/SafeSearchBar'
 import { AddressBookList } from './components/List/AddressBookList'
 import { LargeHeaderTitle } from '@/src/components/Title'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
 type Props = {
   contacts: AddressInfo[]
 }
 
 export const AddressBookView = ({ contacts }: Props) => {
+  const insets = useSafeAreaInsets()
   const [filteredContacts, setFilteredContacts] = useState<AddressInfo[]>(contacts)
 
   const handleSearch = useCallback(
@@ -32,7 +35,12 @@ export const AddressBookView = ({ contacts }: Props) => {
     [contacts],
   )
   return (
-    <View paddingHorizontal="$4" marginTop="$2" style={{ flex: 1 }} testID={'address-book-screen'}>
+    <View
+      paddingHorizontal="$4"
+      marginTop="$2"
+      style={{ flex: 1, marginBottom: insets.bottom }}
+      testID={'address-book-screen'}
+    >
       <LargeHeaderTitle>Address book</LargeHeaderTitle>
       <SafeSearchBar placeholder="Name, address" onSearch={handleSearch} throttleTime={300} />
       {contacts.length === 0 && <NoContacts />}

--- a/apps/mobile/src/features/AddressBook/components/List/AddressBookList.tsx
+++ b/apps/mobile/src/features/AddressBook/components/List/AddressBookList.tsx
@@ -73,5 +73,9 @@ export const AddressBookList: React.FC<AddressBookListProps> = ({ contacts, onSe
 
   const keyExtractor = useCallback((item: AddressInfo) => item.value, [])
 
+  if (contacts.length === 0) {
+    return null
+  }
+
   return <FlashList data={contacts} renderItem={renderContact} estimatedItemSize={200} keyExtractor={keyExtractor} />
 }

--- a/apps/mobile/src/features/AddressBook/components/List/NoContacts.tsx
+++ b/apps/mobile/src/features/AddressBook/components/List/NoContacts.tsx
@@ -10,7 +10,7 @@ export const NoContacts = () => {
   const EmptyAddress = colorScheme === 'dark' ? <EmptyAddressBookDark /> : <EmptyAddressBookLight />
 
   return (
-    <View testID="empty-token" alignItems="center" gap="$4">
+    <View testID="empty-token" alignItems="center" flex={1} justifyContent="center" gap="$4">
       {EmptyAddress}
       <H3 fontWeight={600}>No contacts yet</H3>
       <Text textAlign="center" color="$colorSecondary" width="70%" fontSize="$4">


### PR DESCRIPTION
## How this PR fixes it

Centers the No contacts illustartion on the address book view

## How to test it

1. Open the app
2. Navigate to the address book with an empty address book
3. Observe the illustartion is vertically centered

## Screenshots
<img width="424" alt="Screenshot 2025-04-11 at 16 12 09" src="https://github.com/user-attachments/assets/b715500b-6cce-4a89-b66e-544a3299f4fb" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
