### PR TITLE
feat(Signing UX): show combo button also on receipt step

### DIFF
--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, type ReactNode } from 'react'
+import React, { useCallback, useMemo, type ReactNode } from 'react'
 import useTxStepper from './useTxStepper'
 import SafeTxProvider from './SafeTxProvider'
 import { TxInfoProvider } from './TxInfoProvider'
@@ -56,6 +56,28 @@ export const TxFlow = <T extends unknown>({
     [step, childrenArray.length],
   )
 
+  const handleFlowSubmit = useCallback<SubmitCallback>(
+    (props) => {
+      onSubmit?.({ ...props, data })
+    },
+    [onSubmit, data],
+  )
+
+  const submit = (
+    <>
+      <Counterfactual />
+      <ExecuteThroughRole />
+
+      <ComboSubmit>
+        <Sign />
+        <Execute />
+        <Batching />
+      </ComboSubmit>
+
+      <Propose />
+    </>
+  )
+
   return (
     <SafeTxProvider>
       <TxInfoProvider>
@@ -77,24 +99,15 @@ export const TxFlow = <T extends unknown>({
               <TxFlowContent>
                 {...childrenArray}
 
-                <ReviewTransactionComponent onSubmit={(props = {}) => onSubmit?.({ ...props, data })}>
+                <ReviewTransactionComponent onSubmit={handleFlowSubmit}>
                   <TxChecks />
                   <TxNote />
                   <SignerSelect />
 
-                  <Counterfactual />
-                  <ExecuteThroughRole />
-
-                  <ComboSubmit>
-                    <Sign />
-                    <Execute />
-                    <Batching />
-                  </ComboSubmit>
-
-                  <Propose />
+                  {submit}
                 </ReviewTransactionComponent>
 
-                <ConfirmTxReceipt />
+                <ConfirmTxReceipt onSubmit={handleFlowSubmit}>{submit}</ConfirmTxReceipt>
               </TxFlowContent>
             </TxFlowProvider>
           </SlotProvider>

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -17,6 +17,7 @@ import commonCss from '@/components/tx-flow/common/styles.module.css'
 
 const Batching = ({
   onSubmit,
+  onSubmitSuccess,
   options = [],
   onChange,
   disabled = false,
@@ -33,6 +34,8 @@ const Batching = ({
     e.preventDefault()
 
     if (!safeTx) return
+
+    onSubmit?.()
 
     trackEvent(BATCH_EVENTS.BATCH_APPEND)
 
@@ -51,7 +54,7 @@ const Batching = ({
       return
     }
 
-    onSubmit({ isExecuted: false })
+    onSubmitSuccess?.({ isExecuted: false })
 
     setIsSubmittable(true)
 

--- a/apps/web/src/components/tx-flow/actions/Counterfactual.tsx
+++ b/apps/web/src/components/tx-flow/actions/Counterfactual.tsx
@@ -5,16 +5,16 @@ import CounterfactualForm from '@/features/counterfactual/CounterfactualForm'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { type SlotComponentProps, SlotName, withSlot } from '../slots'
 
-const Counterfactual = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
+const Counterfactual = ({ onSubmitSuccess }: SlotComponentProps<SlotName.Submit>) => {
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const { isCreation, trackTxEvent, isSubmittable } = useContext(TxFlowContext)
 
   const handleSubmit = useCallback(
     async (txId: string, isExecuted = false) => {
-      onSubmit({ txId, isExecuted })
+      onSubmitSuccess?.({ txId, isExecuted })
       trackTxEvent(txId, isExecuted)
     },
-    [onSubmit, trackTxEvent],
+    [onSubmitSuccess, trackTxEvent],
   )
 
   return (

--- a/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/ExecuteForm.tsx
@@ -36,6 +36,7 @@ export const ExecuteForm = ({
   safeTx,
   txId,
   onSubmit,
+  onSubmitSuccess,
   options = [],
   onChange,
   disableSubmit = false,
@@ -69,8 +70,7 @@ export const ExecuteForm = ({
   const { executeTx } = txActions
   const { setTxFlow } = useContext(TxModalContext)
   const { needsRiskConfirmation, isRiskConfirmed, setIsRiskIgnored } = txSecurity
-  const { isSubmittable, setIsSubmittable, onNext, onPrev, setSubmitError, setIsRejectedByUser } =
-    useContext(TxFlowContext)
+  const { isSubmittable, setIsSubmittable, setSubmitError, setIsRejectedByUser } = useContext(TxFlowContext)
 
   // We default to relay, but the option is only shown if we canRelay
   const [executionMethod, setExecutionMethod] = useState(ExecutionMethod.RELAY)
@@ -108,7 +108,7 @@ export const ExecuteForm = ({
 
     const txOptions = getTxOptions(advancedParams, currentChain)
 
-    onNext()
+    onSubmit?.()
 
     let executedTxId: string
     try {
@@ -122,14 +122,13 @@ export const ExecuteForm = ({
         setSubmitError(err)
       }
 
-      onPrev()
       setIsSubmittable(true)
       setIsSubmittableLocal(true)
       return
     }
 
     // On success
-    onSubmit?.({ txId: executedTxId, isExecuted: true })
+    onSubmitSuccess?.({ txId: executedTxId, isExecuted: true })
     setTxFlow(<SuccessScreenFlow txId={executedTxId} />, undefined, false)
   }
 

--- a/apps/web/src/components/tx-flow/actions/Execute/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Execute/index.tsx
@@ -12,7 +12,13 @@ import type { SubmitCallback } from '../../TxFlow'
 
 const CheckboxGuardedExecuteForm = withCheckboxGuard(ExecuteForm, SIGN_CHECKBOX_LABEL, SIGN_CHECKBOX_TOOLTIP)
 
-const Execute = ({ onSubmit, disabled = false, onChange, ...props }: SlotComponentProps<SlotName.ComboSubmit>) => {
+const Execute = ({
+  onSubmit,
+  onSubmitSuccess,
+  disabled = false,
+  onChange,
+  ...props
+}: SlotComponentProps<SlotName.ComboSubmit>) => {
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const { txId, isCreation, onlyExecute, isSubmittable, trackTxEvent, setShouldExecute } = useContext(TxFlowContext)
   const hasSigned = useAlreadySigned(safeTx)
@@ -25,10 +31,10 @@ const Execute = ({ onSubmit, disabled = false, onChange, ...props }: SlotCompone
 
   const handleSubmit = useCallback<SubmitCallback>(
     async ({ txId, isExecuted = false } = {}) => {
-      onSubmit({ txId, isExecuted })
+      onSubmitSuccess?.({ txId, isExecuted })
       trackTxEvent(txId!, isExecuted)
     },
-    [onSubmit, trackTxEvent],
+    [onSubmitSuccess, trackTxEvent],
   )
 
   const onChangeSubmitOption = useCallback(
@@ -51,7 +57,8 @@ const Execute = ({ onSubmit, disabled = false, onChange, ...props }: SlotCompone
     <ExecuteFormComponent
       safeTx={safeTx}
       txId={txId}
-      onSubmit={handleSubmit}
+      onSubmit={onSubmit}
+      onSubmitSuccess={handleSubmit}
       onCheckboxChange={handleCheckboxChange}
       isChecked={checked}
       disableSubmit={!isSubmittable || disabled}

--- a/apps/web/src/components/tx-flow/actions/ExecuteThroughRole/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/ExecuteThroughRole/index.tsx
@@ -5,16 +5,16 @@ import ExecuteThroughRoleForm from './ExecuteThroughRoleForm'
 import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounterfactualSafe'
 import { type SlotComponentProps, SlotName, withSlot } from '../../slots'
 
-const ExecuteThroughRole = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
+const ExecuteThroughRole = ({ onSubmitSuccess }: SlotComponentProps<SlotName.Submit>) => {
   const { safeTx } = useContext(SafeTxContext)
   const { trackTxEvent, role, isSubmittable } = useContext(TxFlowContext)
 
   const handleSubmit = useCallback(
     async (txId: string, isExecuted = false) => {
-      onSubmit({ txId, isExecuted })
+      onSubmitSuccess?.({ txId, isExecuted })
       trackTxEvent(txId, isExecuted, true)
     },
-    [onSubmit, trackTxEvent],
+    [onSubmitSuccess, trackTxEvent],
   )
 
   return <ExecuteThroughRoleForm safeTx={safeTx} disableSubmit={!isSubmittable} role={role!} onSubmit={handleSubmit} />

--- a/apps/web/src/components/tx-flow/actions/Propose/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Propose/index.tsx
@@ -4,16 +4,16 @@ import { TxFlowContext } from '../../TxFlowProvider'
 import ProposerForm from './ProposerForm'
 import { type SlotComponentProps, SlotName, withSlot } from '../../slots'
 
-const Propose = ({ onSubmit }: SlotComponentProps<SlotName.Submit>) => {
+const Propose = ({ onSubmitSuccess }: SlotComponentProps<SlotName.Submit>) => {
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const { trackTxEvent, isSubmittable } = useContext(TxFlowContext)
 
   const handleSubmit = useCallback(
     async (txId: string, isExecuted = false) => {
-      onSubmit({ txId, isExecuted })
+      onSubmitSuccess?.({ txId, isExecuted })
       trackTxEvent(txId, isExecuted, false, true)
     },
-    [onSubmit, trackTxEvent],
+    [onSubmitSuccess, trackTxEvent],
   )
 
   return <ProposerForm safeTx={safeTx} origin={txOrigin} disableSubmit={!isSubmittable} onSubmit={handleSubmit} />

--- a/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/SignForm.tsx
@@ -24,6 +24,7 @@ export const SignForm = ({
   safeTx,
   txId,
   onSubmit,
+  onSubmitSuccess,
   onChange,
   options = [],
   disableSubmit = false,
@@ -49,8 +50,7 @@ export const SignForm = ({
   // Hooks
   const { signTx } = txActions
   const { setTxFlow } = useContext(TxModalContext)
-  const { isSubmittable, setIsSubmittable, onNext, onPrev, setSubmitError, setIsRejectedByUser } =
-    useContext(TxFlowContext)
+  const { isSubmittable, setIsSubmittable, setSubmitError, setIsRejectedByUser } = useContext(TxFlowContext)
   const { needsRiskConfirmation, isRiskConfirmed, setIsRiskIgnored } = txSecurity
   const hasSigned = useAlreadySigned(safeTx)
   const signer = useSigner()
@@ -76,7 +76,7 @@ export const SignForm = ({
     setSubmitError(undefined)
     setIsRejectedByUser(false)
 
-    onNext()
+    onSubmit?.()
 
     let resultTxId: string
     try {
@@ -89,14 +89,13 @@ export const SignForm = ({
         trackError(Errors._804, err)
         setSubmitError(err)
       }
-      onPrev()
       setIsSubmittable(true)
       setIsSubmittableLocal(true)
       return
     }
 
     // On successful sign
-    onSubmit?.({ txId: resultTxId })
+    onSubmitSuccess?.({ txId: resultTxId })
 
     if (signer?.isSafe) {
       setTxFlow(<NestedTxSuccessScreenFlow txId={resultTxId} />, undefined, false)

--- a/apps/web/src/components/tx-flow/actions/Sign/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/index.tsx
@@ -14,7 +14,12 @@ export const SIGN_CHECKBOX_TOOLTIP = 'Review details and check the box to enable
 
 const CheckboxGuardedSignForm = withCheckboxGuard(SignForm, SIGN_CHECKBOX_LABEL, SIGN_CHECKBOX_TOOLTIP)
 
-export const Sign = ({ onSubmit, disabled = false, ...props }: SlotComponentProps<SlotName.ComboSubmit>) => {
+export const Sign = ({
+  onSubmit,
+  onSubmitSuccess,
+  disabled = false,
+  ...props
+}: SlotComponentProps<SlotName.ComboSubmit>) => {
   const [checked, setChecked] = useState(false)
   const { safeTx, txOrigin } = useContext(SafeTxContext)
   const { txId, trackTxEvent, isSubmittable } = useContext(TxFlowContext)
@@ -24,12 +29,12 @@ export const Sign = ({ onSubmit, disabled = false, ...props }: SlotComponentProp
     trackEvent({ ...MODALS_EVENTS.CONFIRM_SIGN_CHECKBOX, label: checked })
   }, [])
 
-  const handleSubmit = useCallback<SubmitCallback>(
+  const handleSubmitSuccess = useCallback<SubmitCallback>(
     async ({ txId, isExecuted = false } = {}) => {
-      onSubmit({ txId, isExecuted })
+      onSubmitSuccess?.({ txId, isExecuted })
       trackTxEvent(txId!, isExecuted)
     },
-    [onSubmit, trackTxEvent],
+    [onSubmitSuccess, trackTxEvent],
   )
 
   return (
@@ -37,7 +42,8 @@ export const Sign = ({ onSubmit, disabled = false, ...props }: SlotComponentProp
       disableSubmit={!isSubmittable || disabled}
       origin={txOrigin}
       safeTx={safeTx}
-      onSubmit={handleSubmit}
+      onSubmit={onSubmit}
+      onSubmitSuccess={handleSubmitSuccess}
       isChecked={checked}
       onCheckboxChange={handleCheckboxChange}
       txId={txId}

--- a/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
+++ b/apps/web/src/components/tx-flow/slots/SlotProvider.tsx
@@ -18,10 +18,12 @@ export enum SlotName {
 
 type SlotComponentPropsMap = {
   [SlotName.Submit]: PropsWithChildren<{
-    onSubmit: SubmitCallback
+    onSubmit?: () => void
+    onSubmitSuccess?: SubmitCallback
   }>
   [SlotName.ComboSubmit]: PropsWithChildren<{
-    onSubmit: SubmitCallback
+    onSubmit?: () => void
+    onSubmitSuccess?: SubmitCallback
     options: { label: string; id: string }[]
     onChange: (option: string) => void
     disabled?: boolean

--- a/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
@@ -11,6 +11,8 @@ import useWallet from '@/hooks/wallets/useWallet'
 import { isHardwareWallet, isLedgerLive } from '@/utils/wallets'
 import { TxFlowStep } from '@/components/tx-flow/TxFlowStep'
 import { TxDetails } from '../ConfirmTxDetails/TxDetails'
+import { Slot, SlotName } from '@/components/tx-flow/slots'
+import { Sign } from '@/components/tx-flow/actions/Sign'
 
 const InfoSteps = [
   {
@@ -64,7 +66,7 @@ const HardwareWalletStep = [
   InfoSteps[2],
 ]
 
-export const ConfirmTxReceipt = ({ children }: PropsWithChildren) => {
+export const ConfirmTxReceipt = ({ children, onSubmit }: PropsWithChildren<{ onSubmit: () => void }>) => {
   const { safeTx } = useContext(SafeTxContext)
   const [txPreview] = useTxPreview(safeTx?.data)
   const wallet = useWallet()
@@ -100,6 +102,15 @@ export const ConfirmTxReceipt = ({ children }: PropsWithChildren) => {
         {children}
 
         <Divider className={commonCss.nestedDivider} sx={{ pt: 3 }} />
+
+        <Slot name={SlotName.Submit} onSubmitSuccess={onSubmit}>
+          <Sign
+            onSubmitSuccess={onSubmit}
+            options={[{ id: 'sign', label: 'Sign' }]}
+            onChange={() => {}}
+            slotId="sign"
+          />
+        </Slot>
       </TxCard>
     </TxFlowStep>
   )

--- a/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
+++ b/apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx
@@ -42,7 +42,7 @@ export const ReviewTransactionContent = ({
   txPreview?: TransactionPreview
   txId?: string
 }): ReactElement => {
-  const { willExecute, isCreation, showMethodCall, isProposing, isRejection } = useContext(TxFlowContext)
+  const { willExecute, isCreation, showMethodCall, isProposing, isRejection, onNext } = useContext(TxFlowContext)
 
   const [readableApprovals] = useApprovalInfos({ safeTransaction: safeTx })
   const isApproval = readableApprovals && readableApprovals.length > 0
@@ -101,8 +101,14 @@ export const ReviewTransactionContent = ({
 
         <Blockaid />
 
-        <Slot name={SlotName.Submit} onSubmit={onSubmit}>
-          <Sign onSubmit={onSubmit} options={[{ id: 'sign', label: 'Sign' }]} onChange={() => {}} slotId="sign" />
+        <Slot name={SlotName.Submit} onSubmit={onNext} onSubmitSuccess={onSubmit}>
+          <Sign
+            onSubmit={onNext}
+            onSubmitSuccess={onSubmit}
+            options={[{ id: 'sign', label: 'Sign' }]}
+            onChange={() => {}}
+            slotId="sign"
+          />
         </Slot>
       </TxCard>
     </>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/ReviewTransactionContent.test.tsx
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/ReviewTransactionContent.test.tsx
@@ -204,11 +204,13 @@ describe('ReviewTransactionContent', () => {
         expect(button).not.toBeInTheDocument()
       })
 
-      it('Shows the Add to batch button if there registered for the "action" slot', () => {
+      it('Shows the Add to batch button if there registered for the "feature" slot', () => {
         jest
           .spyOn(slotProvider, 'useSlot')
           .mockImplementation((slotName) =>
-            slotName === slotProvider.SlotName.Action ? [() => <button>Add to batch</button>] : [],
+            slotName === slotProvider.SlotName.Feature
+              ? [{ Component: () => <button>Add to batch</button>, id: 'batching', label: 'Add to batch' }]
+              : [],
           )
 
         const { getByText } = renderReviewTransactionContent()

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteForm.tsx
@@ -160,7 +160,8 @@ export const SignOrExecuteForm = ({
           options={[{ label: 'Execute', id: 'execute' }]}
           slotId="execute"
           onChange={() => {}}
-          onSubmit={({ txId, isExecuted } = {}) => onFormSubmit(txId!, isExecuted)}
+          onSubmit={() => {}}
+          onSubmitSuccess={({ txId, isExecuted } = {}) => onFormSubmit(txId!, isExecuted)}
         />
       )
     }

--- a/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteFormV2.tsx
+++ b/apps/web/src/components/tx/SignOrExecuteForm/SignOrExecuteFormV2.tsx
@@ -130,7 +130,8 @@ export const SignOrExecuteFormV2 = ({
         options={[{ label: 'Execute', id: 'execute' }]}
         slotId="execute"
         onChange={() => {}}
-        onSubmit={({ txId, isExecuted } = {}) => onFormSubmit(txId!, isExecuted)}
+        onSubmit={() => {}}
+        onSubmitSuccess={({ txId, isExecuted } = {}) => onFormSubmit(txId!, isExecuted)}
       />
     )
   }


### PR DESCRIPTION
Show the combo button also on the receipt step and don't navigate to the previous step on sign/execute error.