### PR TITLE
fix(mobile): camera permission on android was wrong

### DIFF
--- a/apps/mobile/src/components/Camera/QrCamera.tsx
+++ b/apps/mobile/src/components/Camera/QrCamera.tsx
@@ -61,7 +61,7 @@ function CameraLens({
 }: {
   denied: boolean
   onPressSettings: () => Promise<void>
-  requestPermission: () => void
+  requestPermission: () => Promise<void>
   hasPermission: boolean
   onActivateCamera: () => void
   isCameraActive: boolean
@@ -74,16 +74,20 @@ function CameraLens({
     color = getTokenValue('$color.textPrimaryLight')
   }
 
-  const handleGrantOrActivatePress = () => {
+  const handleGrantOrActivatePress = useCallback(async () => {
     if (!hasPermission) {
-      requestPermission()
+      const permission = await Camera.requestCameraPermission()
+
+      if (permission === 'denied') {
+        await onPressSettings()
+      }
     } else if (hasPermission && !isCameraActive) {
       onActivateCamera()
     }
-  }
+  }, [hasPermission, isCameraActive, onActivateCamera, onPressSettings])
 
-  const buttonText = denied ? 'Open Settings' : 'Enable camera'
-  const buttonAction = denied ? onPressSettings : handleGrantOrActivatePress
+  const buttonText = 'Enable camera'
+  const buttonAction = handleGrantOrActivatePress
 
   return (
     <Pressable


### PR DESCRIPTION
## What it solves
On android we were directly sending the user to the OS settings for the app instead of bringing the camera permission prompt inside the app.

Now we bring the prompt. If the user denies we send him in the settings.

Resolves #
https://github.com/safe-global/wallet-private-tasks/issues/166

## How this PR fixes it
On android we by default get a denied permission, but that doesn't prevent us from asking. 

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
