### PR TITLE
chore: fixed broken links

### DIFF
--- a/apps/web/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
+++ b/apps/web/src/components/tx-flow/flows/NewSpendingLimit/CreateSpendingLimit.tsx
@@ -16,7 +16,7 @@ import { SpendingLimitFields } from '.'
 import { validateAmount, validateDecimalLength } from '@safe-global/utils/utils/validation'
 
 export const _validateSpendingLimit = (val: string, decimals?: number | null) => {
-  // Allowance amount is uint96 https://github.com/safe-global/safe-modules/blob/master/allowances/contracts/AlowanceModule.sol#L52
+  // Allowance amount is uint96 https://github.com/safe-global/safe-modules/blob/main/modules/allowances/contracts/AllowanceModule.sol#L52
   try {
     const amount = parseUnits(val, decimals ?? 'Gwei')
     AbiCoder.defaultAbiCoder().encode(['int96'], [amount])

--- a/packages/utils/src/components/tx/security/tenderly/utils.ts
+++ b/packages/utils/src/components/tx/security/tenderly/utils.ts
@@ -119,7 +119,7 @@ const getNonceOverwrite = (params: SimulationTxParams): number | undefined => {
   to do a proper simulation that takes transaction guards into account.
   The threshold is stored in storage slot 4 and uses full 32 bytes slot.
   Safe storage layout can be found here:
-  https://github.com/gnosis/safe-contracts/blob/main/contracts/libraries/GnosisSafeStorage.sol */
+  https://github.com/gnosis/safe-contracts/blob/main/contracts/libraries/SafeStorage.sol */
 export const THRESHOLD_STORAGE_POSITION = toBeHex('0x4', 32)
 export const THRESHOLD_OVERWRITE = toBeHex('0x1', 32)
 export const NONCE_STORAGE_POSITION = toBeHex('0x5', 32)


### PR DESCRIPTION
## What it solves

Hi! I fixed two broken links referencing Safe contract implementations.

## Screenshots
rename `GnosisSafeStorage.sol` - `SafeStorage.sol`
![image](https://github.com/user-attachments/assets/35916802-803a-43f9-983b-0ddfb3ae51b1)
ref: https://github.com/safe-global/safe-smart-account/commits/main/contracts/libraries/SafeStorage.sol
## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
