### PR TITLE
Feat(Spaces): expand search input width when in focus

### DIFF
--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -170,6 +170,7 @@ const AddAccounts = () => {
             variant="contained"
             onClick={() => setOpen(true)}
             disabled={!isAdmin}
+            sx={{ whiteSpace: 'nowrap' }}
           >
             Add accounts
           </Button>

--- a/apps/web/src/features/spaces/components/Members/index.tsx
+++ b/apps/web/src/features/spaces/components/Members/index.tsx
@@ -1,17 +1,16 @@
 import PlusIcon from '@/public/images/common/plus.svg'
-import { Button, InputAdornment, Stack, SvgIcon, TextField, Typography } from '@mui/material'
+import { Button, Stack, Typography } from '@mui/material'
 import AddMemberModal from 'src/features/spaces/components/AddMemberModal'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import MembersList from '@/features/spaces/components/MembersList'
-import SearchIcon from '@/public/images/common/search.svg'
 import { useMembersSearch } from '@/features/spaces/hooks/useMembersSearch'
 import { useIsInvited, useSpaceMembersByStatus, useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import { SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
-import { debounce } from 'lodash'
 import { trackEvent } from '@/services/analytics'
+import SearchInput from '../SearchInput'
 
 const SpaceMembers = () => {
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
@@ -22,9 +21,6 @@ const SpaceMembers = () => {
 
   const filteredMembers = useMembersSearch(activeMembers, searchQuery)
   const filteredInvites = useMembersSearch(invitedMembers, searchQuery)
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleSearch = useCallback(debounce(setSearchQuery, 300), [])
 
   useEffect(() => {
     if (searchQuery) {
@@ -43,27 +39,11 @@ const SpaceMembers = () => {
         justifyContent="space-between"
         alignItems="flex-start"
         mb={3}
-        flexWrap="wrap"
+        flexWrap="nowrap"
         gap={2}
-        flexDirection={{ xs: 'column-reverse', md: 'row' }}
+        flexDirection={{ xs: 'column-reverse', sm: 'row' }}
       >
-        <TextField
-          placeholder="Search"
-          variant="filled"
-          hiddenLabel
-          onChange={(e) => {
-            handleSearch(e.target.value)
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" />
-              </InputAdornment>
-            ),
-            disableUnderline: true,
-          }}
-          size="small"
-        />
+        <SearchInput onSearch={setSearchQuery} />
         {isAdmin && (
           <Track {...SPACE_EVENTS.ADD_MEMBER_MODAL} label={SPACE_LABELS.members_page}>
             <Button
@@ -71,6 +51,7 @@ const SpaceMembers = () => {
               variant="contained"
               startIcon={<PlusIcon />}
               onClick={() => setOpenAddMembersModal(true)}
+              sx={{ whiteSpace: 'nowrap' }}
             >
               Add member
             </Button>

--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -43,7 +43,7 @@ const SpaceSafeAccounts = () => {
         flexWrap="nowrap"
         flexDirection={{ xs: 'column-reverse', md: 'row' }}
       >
-        <SearchInput onSearch={setSearchQuery} placeholder="Search accounts" />
+        <SearchInput onSearch={setSearchQuery} />
 
         {isAdmin && (
           <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>

--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -1,9 +1,7 @@
 import AddAccounts from '@/features/spaces/components/AddAccounts'
 import EmptySafeAccounts from '@/features/spaces/components/SafeAccounts/EmptySafeAccounts'
-import SearchIcon from '@/public/images/common/search.svg'
-import { Stack, SvgIcon, TextField, Typography } from '@mui/material'
-import InputAdornment from '@mui/material/InputAdornment'
-import { useCallback, useEffect, useState } from 'react'
+import { Stack, Typography } from '@mui/material'
+import { useEffect, useState } from 'react'
 import SafesList from '@/features/myAccounts/components/SafesList'
 import { useSpaceSafes } from '@/features/spaces/hooks/useSpaceSafes'
 import { useSafesSearch } from '@/features/myAccounts/hooks/useSafesSearch'
@@ -13,7 +11,7 @@ import { SPACE_LABELS } from '@/services/analytics/events/spaces'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 import { trackEvent } from '@/services/analytics'
-import debounce from 'lodash/debounce'
+import SearchInput from '../SearchInput'
 
 const SpaceSafeAccounts = () => {
   const [searchQuery, setSearchQuery] = useState('')
@@ -23,9 +21,6 @@ const SpaceSafeAccounts = () => {
   const isInvited = useIsInvited()
 
   const safes = searchQuery ? filteredSafes : allSafes
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleSearch = useCallback(debounce(setSearchQuery, 300), [])
 
   useEffect(() => {
     if (searchQuery) {
@@ -45,26 +40,10 @@ const SpaceSafeAccounts = () => {
         alignItems="flex-start"
         gap={2}
         mb={3}
-        flexWrap="wrap"
+        flexWrap="nowrap"
         flexDirection={{ xs: 'column-reverse', md: 'row' }}
       >
-        <TextField
-          placeholder="Search"
-          variant="filled"
-          hiddenLabel
-          onChange={(e) => {
-            handleSearch(e.target.value)
-          }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" />
-              </InputAdornment>
-            ),
-            disableUnderline: true,
-          }}
-          size="small"
-        />
+        <SearchInput onSearch={setSearchQuery} placeholder="Search accounts" />
 
         {isAdmin && (
           <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>

--- a/apps/web/src/features/spaces/components/SearchInput/index.test.tsx
+++ b/apps/web/src/features/spaces/components/SearchInput/index.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import SearchInput from './index'
+
+describe('SearchInput', () => {
+  const mockOnSearch = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the component', () => {
+    render(<SearchInput onSearch={mockOnSearch} />)
+
+    const input = screen.getByPlaceholderText('Search')
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveAttribute('type', 'text')
+    const searchIcon = screen.getByTestId('search-icon')
+    expect(searchIcon).toBeInTheDocument()
+  })
+
+  it('calls onSearch with input value', async () => {
+    render(<SearchInput onSearch={mockOnSearch} />)
+
+    const input = screen.getByPlaceholderText('Search')
+    fireEvent.change(input, { target: { value: 'test search' } })
+
+    await waitFor(() => {
+      expect(mockOnSearch).toHaveBeenCalledWith('test search')
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SearchInput/index.tsx
+++ b/apps/web/src/features/spaces/components/SearchInput/index.tsx
@@ -1,0 +1,44 @@
+import { InputAdornment, SvgIcon, TextField } from '@mui/material'
+import SearchIcon from '@/public/images/common/search.svg'
+import { useCallback } from 'react'
+import { debounce } from 'lodash'
+
+interface SearchInputProps {
+  placeholder?: string
+  onSearch: (value: string) => void
+  debounceTime?: number
+}
+
+const SearchInput = ({ placeholder = 'Search', onSearch, debounceTime = 300 }: SearchInputProps) => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleSearch = useCallback(debounce(onSearch, debounceTime), [onSearch, debounceTime])
+
+  return (
+    <TextField
+      placeholder={placeholder}
+      variant="filled"
+      hiddenLabel
+      onChange={(e) => {
+        handleSearch(e.target.value)
+      }}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" />
+          </InputAdornment>
+        ),
+        disableUnderline: true,
+      }}
+      size="small"
+      sx={{
+        transition: 'width 0.15s ease-in-out',
+        width: { xs: '100%', sm: '250px' },
+        '&:focus-within': {
+          width: { xs: '100%', sm: '470px' },
+        },
+      }}
+    />
+  )
+}
+
+export default SearchInput

--- a/apps/web/src/features/spaces/components/SearchInput/index.tsx
+++ b/apps/web/src/features/spaces/components/SearchInput/index.tsx
@@ -9,13 +9,14 @@ interface SearchInputProps {
   debounceTime?: number
 }
 
-const SearchInput = ({ placeholder = 'Search', onSearch, debounceTime = 300 }: SearchInputProps) => {
+const SearchInput = ({ onSearch, debounceTime = 300 }: SearchInputProps) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSearch = useCallback(debounce(onSearch, debounceTime), [onSearch, debounceTime])
 
   return (
     <TextField
-      placeholder={placeholder}
+      aria-label="Search"
+      placeholder="Search"
       variant="filled"
       hiddenLabel
       onChange={(e) => {
@@ -24,7 +25,7 @@ const SearchInput = ({ placeholder = 'Search', onSearch, debounceTime = 300 }: S
       InputProps={{
         startAdornment: (
           <InputAdornment position="start">
-            <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" />
+            <SvgIcon component={SearchIcon} inheritViewBox color="border" fontSize="small" data-testid="search-icon" />
           </InputAdornment>
         ),
         disableUnderline: true,


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/127#issue-2971379246

## How this PR fixes it
- increases the size of the search input when you click into it.
- Makes the search input width 100% for smaller screens.
- Adds tests

## How to test it
- Go to the members or accounts page of a space.
- Click the search input. 
- See that the width increases.

## Screenshots
![image](https://github.com/user-attachments/assets/85cf5f33-80a0-4b45-a529-fae70f7c9591)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
