### PR TITLE
Feat(Spaces): add select all option to the network multi selector

### DIFF
--- a/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.tsx
+++ b/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.tsx
@@ -16,7 +16,7 @@ type NetworkMultiSelectorInputProps = {
   showSelectAll?: boolean
 }
 
-const SELECT_ALL_OPTION = { chainId: 'select-all', chainName: 'Select All' }
+const SELECT_ALL_OPTION = { chainId: 'select-all', chainName: 'Select All' } as ChainInfo
 
 const NetworkMultiSelectorInput = ({
   value,
@@ -35,8 +35,8 @@ const NetworkMultiSelectorInput = ({
   const handleChange = useCallback(
     (newNetworks: ChainInfo[]) => {
       const filteredData = showSelectAll
-        ? (newNetworks.filter((item) => item.chainId !== SELECT_ALL_OPTION.chainId) as ChainInfo[])
-        : (newNetworks as ChainInfo[])
+        ? newNetworks.filter((item) => item.chainId !== SELECT_ALL_OPTION.chainId)
+        : newNetworks
 
       setValue(name, filteredData, { shouldValidate: true })
       if (onNetworkChange) {
@@ -130,7 +130,7 @@ const NetworkMultiSelectorInput = ({
       renderOption={renderOption}
       getOptionLabel={(option) => option.chainName}
       getOptionDisabled={(option) =>
-        showSelectAll && option.chainId === SELECT_ALL_OPTION.chainId ? false : getOptionDisabled(option as ChainInfo)
+        showSelectAll && option.chainId === SELECT_ALL_OPTION.chainId ? false : getOptionDisabled(option)
       }
       renderInput={(params) => <TextField {...params} error={error} helperText={helperText} />}
       filterOptions={(options, { inputValue }) => {
@@ -142,7 +142,7 @@ const NetworkMultiSelectorInput = ({
         )
       }}
       isOptionEqualToValue={(option, value) => option.chainId === value.chainId}
-      onChange={(_, data) => handleChange(data as ChainInfo[])}
+      onChange={(_, data) => handleChange(data)}
     />
   )
 }

--- a/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.tsx
+++ b/apps/web/src/components/common/NetworkSelector/NetworkMultiSelectorInput.tsx
@@ -60,10 +60,6 @@ const NetworkMultiSelectorInput = ({
     }
   }, [isAllSelected, handleChange, configs])
 
-  const handleDeleteAll = useCallback(() => {
-    handleChange([])
-  }, [handleChange])
-
   const options = showSelectAll ? [SELECT_ALL_OPTION, ...configs] : configs
 
   return (

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
@@ -9,6 +9,7 @@ import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import NetworkMultiSelectorInput from '@/components/common/NetworkSelector/NetworkMultiSelectorInput'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import useChains from '@/hooks/useChains'
 
 export type ContactField = {
   name: string
@@ -16,16 +17,17 @@ export type ContactField = {
   networks: ChainInfo[]
 }
 
-const defaultValues = {
-  name: '',
-  address: '',
-  networks: [],
-}
-
 const AddContact = () => {
   const [open, setOpen] = useState(false)
   const [error, setError] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const { configs: allNetworks } = useChains()
+
+  const defaultValues = {
+    name: '',
+    address: '',
+    networks: allNetworks,
+  }
 
   const methods = useForm<ContactField>({
     mode: 'onChange',
@@ -88,7 +90,6 @@ const AddContact = () => {
                   <Controller
                     name="networks"
                     control={control}
-                    defaultValue={[]}
                     render={({ field }) => (
                       <NetworkMultiSelectorInput
                         name="networks"

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
@@ -92,6 +92,7 @@ const AddContact = () => {
                     render={({ field }) => (
                       <NetworkMultiSelectorInput
                         name="networks"
+                        showSelectAll
                         value={field.value || []}
                         error={!!errors.networks}
                         helperText={errors.networks ? 'Select at least one network' : ''}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
@@ -111,6 +111,7 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
                   render={({ field }) => (
                     <NetworkMultiSelectorInput
                       name="networks"
+                      showSelectAll
                       value={field.value || []}
                       error={!!errors.networks}
                       helperText={errors.networks ? 'Select at least one network' : ''}


### PR DESCRIPTION
## What it solves

https://github.com/safe-global/wallet-private-tasks/issues/184

## How this PR fixes it
- Adds a select all option to the network selector options
- Selects all networks by default when adding a contact.

## How to test it
- open the add contact dialog in a space
- see that all contacts are selected by default. You should still be able to select a subset of networks as before if desired.

## Screenshots
![image](https://github.com/user-attachments/assets/2e4a5f90-4704-4ae8-b75d-44fa6bef29bf)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
