### PR TITLE
fix(web): fix horizontal scrolling on WC modal

### DIFF
--- a/apps/web/src/features/walletconnect/components/WcProposalForm/CompatibilityWarning.tsx
+++ b/apps/web/src/features/walletconnect/components/WcProposalForm/CompatibilityWarning.tsx
@@ -30,7 +30,7 @@ export const CompatibilityWarning = ({
             Supported networks
           </Typography>
 
-          <Stack direction="row">
+          <Stack direction="row" flexWrap="wrap" justifyContent="center" className={css.chainContainer}>
             {chainIds.map((chainId) => (
               <ChainIndicator inline chainId={chainId} key={chainId} className={css.chain} />
             ))}

--- a/apps/web/src/features/walletconnect/components/WcProposalForm/CompatibilityWarning.tsx
+++ b/apps/web/src/features/walletconnect/components/WcProposalForm/CompatibilityWarning.tsx
@@ -30,7 +30,7 @@ export const CompatibilityWarning = ({
             Supported networks
           </Typography>
 
-          <Stack direction="row" flexWrap="wrap" justifyContent="center" className={css.chainContainer}>
+          <Stack direction="row" className={css.chainContainer}>
             {chainIds.map((chainId) => (
               <ChainIndicator inline chainId={chainId} key={chainId} className={css.chain} />
             ))}

--- a/apps/web/src/features/walletconnect/components/WcProposalForm/styles.module.css
+++ b/apps/web/src/features/walletconnect/components/WcProposalForm/styles.module.css
@@ -10,7 +10,24 @@
 }
 
 .chain {
-  margin: 2px;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chainContainer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin: 0 auto;
+  gap: 10px;
+  padding: 0;
 }
 
 .origin {
@@ -23,6 +40,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+  width: 100%;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .alert {

--- a/apps/web/src/features/walletconnect/components/WcProposalForm/styles.module.css
+++ b/apps/web/src/features/walletconnect/components/WcProposalForm/styles.module.css
@@ -22,7 +22,7 @@
 .chainContainer {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: left-align;
   align-items: center;
   width: 100%;
   margin: 0 auto;

--- a/apps/web/src/features/walletconnect/components/WcProposalForm/styles.module.css
+++ b/apps/web/src/features/walletconnect/components/WcProposalForm/styles.module.css
@@ -22,7 +22,7 @@
 .chainContainer {
   display: flex;
   flex-wrap: wrap;
-  justify-content: left-align;
+  justify-content: flex-start;
   align-items: center;
   width: 100%;
   margin: 0 auto;


### PR DESCRIPTION
## What it solves
This PR fixes the horizontal scrolling issue in the Compatibility Warning modal when using WalletConnect.

Resolves #4927

## How this PR fixes it
- Adds `.chainContainer` element 
- Updates styles for `.chain` and `.origin` elements to ensure proper wrapping and spacing.

## How to test it
- Attempt to connect to OpenSea using WalletConnect on Sepolia.
- Open the console and copy an element that contains a chain (e.g. from the modal).
- Paste and duplicate it in the console to simulate a long list of chains.

## Screenshots
![Screenshot 2025-04-14 at 16 42 04](https://github.com/user-attachments/assets/3454eab7-6eff-4687-a6fe-7804cbb8586a)

## Checklist

- [ ] I've tested the branch on mobile (not applicable) 📱
- [ ] I've documented how it affects the analytics (not applicable) 📊
- [ ] I've written a unit/e2e test for it (not applicable) 🧑‍💻
