### PR TITLE
fix(web): align signers and proposers sections

### DIFF
--- a/apps/web/src/components/settings/ProposersList/index.tsx
+++ b/apps/web/src/components/settings/ProposersList/index.tsx
@@ -85,10 +85,6 @@ const ProposersList = () => {
     <Paper sx={{ mt: 2 }}>
       <Box data-testid="proposer-section" display="flex" flexDirection="column" gap={2}>
         <Grid container spacing={3}>
-          <Grid item lg={4} xs={12}>
-            <Typography variant="h4" fontWeight={700}></Typography>
-          </Grid>
-
           <Grid item xs>
             <Typography fontWeight="bold" mb={2}>
               Proposers <Chip label="New" sx={{ backgroundColor: 'secondary.light', color: 'static.main' }} />

--- a/apps/web/src/components/settings/owner/OwnerList/index.tsx
+++ b/apps/web/src/components/settings/owner/OwnerList/index.tsx
@@ -98,17 +98,6 @@ export const OwnerList = () => {
       }}
     >
       <Grid container spacing={3}>
-        <Grid item lg={4} xs={12}>
-          <Typography
-            variant="h4"
-            sx={{
-              fontWeight: 700,
-            }}
-          >
-            Members
-          </Typography>
-        </Grid>
-
         <Grid data-testid="signer-list" item xs>
           <Typography
             fontWeight="bold"

--- a/apps/web/src/pages/settings/setup.tsx
+++ b/apps/web/src/pages/settings/setup.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import { Grid, Paper, Skeleton, SvgIcon, Tooltip, Typography } from '@mui/material'
+import { Grid, Paper, Skeleton, SvgIcon, Tooltip, Typography, Box } from '@mui/material'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import { ContractVersion } from '@/components/settings/ContractVersion'
 import { OwnerList } from '@/components/settings/owner/OwnerList'
@@ -61,9 +61,20 @@ const Setup: NextPage = () => {
         </Paper>
 
         <Paper sx={{ p: 4, mb: 2 }}>
-          <OwnerList />
+          <Grid container spacing={3}>
+            <Grid item lg={4} xs={12}>
+              <Typography variant="h4" fontWeight={700}>
+                Members
+              </Typography>
+            </Grid>
 
-          <ProposersList />
+            <Grid item xs>
+              <Box display="flex" flexDirection="column" gap={2}>
+                <OwnerList />
+                <ProposersList />
+              </Box>
+            </Grid>
+          </Grid>
 
           <RequiredConfirmation threshold={threshold} owners={ownerLength} />
         </Paper>


### PR DESCRIPTION
## What it solves
This PR fixes misalignment between Signers and Proposers sections on the Settings page with smaller viewports.

Resolves #4554

## How this PR fixes it
- Introduces a shared `Grid` container for the entire Members section in `setup.tsx`
- Removes left `Grid` wrappers for signers and proposers.
- Add both OwnerList and ProposersList components inside a single `Box` to unify their structure and responsiveness.

## How to test it
- Go to the settings page
- Make the viewport smaller
- Observe the signers section and the proposers section aligned all time

## Screenshots
https://github.com/user-attachments/assets/20823900-a27a-45b3-b638-2c8814f47ff6

## Checklist

- [ ] I've tested the branch on mobile (not applicable) 📱
- [ ] I've documented how it affects the analytics (not applicable) 📊
- [ ] I've written a unit/e2e test for it  (not applicable) 🧑‍💻
