### PR TITLE
fix(mobile): remove unnecessary flag to allow build success 

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -24,7 +24,7 @@ export default {
       },
       infoPlist: {
         NSFaceIDUsageDescription: 'Enabling Face ID allows you to create/access secure keys.',
-        UIBackgroundModes: ['remote-notification', 'processing'],
+        UIBackgroundModes: ['remote-notification'],
       },
       supportsTablet: false,
       appleTeamId: 'MXRS32BBL4',


### PR DESCRIPTION
## What it solves

This PR fixes: Error: Validation failed Missing Info.plist value. The Info.plist key 'BGTaskSchedulerPermittedIdentifiers' must contain a list of identifiers used to submit and handle tasks when 'UIBackgroundModes' has a value of 'processing'., which prevents iOS builds to succeed.

We removed a n unnecessary flag, based on [this](https://github.com/expo/expo/issues/32396) and [this](https://github.com/expo/expo/commit/db38d257a2aaacc8562f553e72f07d00bcb5538f)

Resolves #
[173](https://github.com/safe-global/wallet-private-tasks/issues/173)

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
