### PR TITLE
feat: show details of blockaid error

### DIFF
--- a/apps/web/src/components/tx/security/blockaid/__tests__/useBlockaid.test.ts
+++ b/apps/web/src/components/tx/security/blockaid/__tests__/useBlockaid.test.ts
@@ -115,13 +115,13 @@ describe.each([TEST_CASES.MESSAGE, TEST_CASES.TRANSACTION])('useBlockaid for %s'
     jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
 
     const mockFetch = jest.spyOn(global, 'fetch')
-    mockFetch.mockImplementation(() => Promise.reject({ message: '403 not authorized' }))
+    mockFetch.mockImplementation(() => Promise.reject(new Error('403 not authorized')))
 
     const { result } = renderHook(() => useBlockaid(mockPayload))
 
     await waitFor(() => {
       expect(result.current[0]).toBeUndefined()
-      expect(result.current[1]).toEqual(new Error('Unavailable'))
+      expect(result.current[1]).toEqual(new Error('403 not authorized'))
       expect(result.current[2]).toBeFalsy()
     })
   })
@@ -161,7 +161,7 @@ describe.each([TEST_CASES.MESSAGE, TEST_CASES.TRANSACTION])('useBlockaid for %s'
 
     await waitFor(() => {
       expect(result.current[0]).toBeDefined()
-      expect(result.current[1]).toEqual(new Error('Simulation failed'))
+      expect(result.current[1]).toEqual(new Error('Simulation failed: GS13'))
       expect(result.current[2]).toBeFalsy()
     })
   })

--- a/apps/web/src/components/tx/security/blockaid/index.tsx
+++ b/apps/web/src/components/tx/security/blockaid/index.tsx
@@ -17,6 +17,7 @@ import { BlockaidHint } from './BlockaidHint'
 import { ContractChangeWarning } from './ContractChangeWarning'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import { CLASSIFICATION_MAPPING, REASON_MAPPING } from '@safe-global/utils/components/tx/security/blockaid/utils'
+import ErrorMessage from '../../ErrorMessage'
 
 export const Warning = ({
   title,
@@ -94,24 +95,14 @@ const ResultDescription = ({
   )
 }
 
-const BlockaidError = () => {
+const BlockaidError = ({ error }: { error: Error }) => {
   return (
-    <Alert severity="warning" className={css.customAlert}>
-      <AlertTitle>
-        <Typography
-          variant="subtitle1"
-          sx={{
-            fontWeight: 700,
-          }}
-        >
-          Proceed with caution
-        </Typography>
-      </AlertTitle>
+    <ErrorMessage level="warning" className={css.customAlert} title="Proceed with caution" error={error}>
       <Typography variant="body2">
         The transaction could not be checked for security alerts. Verify the details and addresses before proceeding.
       </Typography>
       <BlockaidMessage />
-    </Alert>
+    </ErrorMessage>
   )
 }
 
@@ -145,7 +136,7 @@ const BlockaidWarning = () => {
   }
 
   if (error) {
-    return <BlockaidError />
+    return <BlockaidError error={error} />
   }
 
   if (isLoading || !blockaidResponse) {

--- a/apps/web/src/components/tx/security/blockaid/useBlockaid.ts
+++ b/apps/web/src/components/tx/security/blockaid/useBlockaid.ts
@@ -16,8 +16,6 @@ import { FEATURES } from '@safe-global/utils/utils/chains'
 
 const BlockaidModuleInstance = new BlockaidModule()
 
-const DEFAULT_ERROR_MESSAGE = 'Unavailable'
-
 export const useBlockaid = (
   data: SafeTransaction | TypedData | undefined,
   origin?: string,
@@ -53,10 +51,6 @@ export const useBlockaid = (
     }
   }, [loading, blockaidPayload])
 
-  const errorMsg = useMemo(
-    () => (blockaidErrors ? new Error(DEFAULT_ERROR_MESSAGE) : blockaidPayload?.payload?.error),
-
-    [blockaidErrors, blockaidPayload],
-  )
+  const errorMsg = useMemo(() => blockaidErrors ?? blockaidPayload?.payload?.error, [blockaidErrors, blockaidPayload])
   return [blockaidPayload, errorMsg, loading]
 }

--- a/packages/utils/src/services/security/modules/BlockaidModule/index.ts
+++ b/packages/utils/src/services/security/modules/BlockaidModule/index.ts
@@ -139,7 +139,7 @@ export class BlockaidModule implements SecurityModule<BlockaidModuleRequest, Blo
       balanceChange = simulation.assets_diffs[safeAddress]
       contractManagement = simulation.contract_management?.[safeAddress] || []
     } else if (simulation?.status === 'Error') {
-      error = new Error('Simulation failed')
+      error = new Error(simulation.error)
     }
 
     // Sometimes the validation is missing


### PR DESCRIPTION
## What it solves

Resolves #4815 

## How this PR fixes it
- Instead of returning a default error it returns the actual error of the blockaid request
- In case of simulation errors it returns the simulation error

## How to test it
- Create a transaction that is going to fail e.g. removing an owner that doesnt exist or sending funds you don't hold
- Observe the Security warning has a Details block now
- Expand it


## Screenshots

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
