### PR TITLE
fix(mobile): Revert gesture-handler usage while add style inline with Figma

### DIFF
--- a/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
+++ b/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { View } from 'react-native'
+import { View, Pressable } from 'react-native'
 import { Theme, XStack, getTokenValue } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { Pressable } from 'react-native-gesture-handler'
 import { IdenticonWithBadge } from '@/src/features/Settings/components/IdenticonWithBadge'
 
 import { shortenAddress } from '@/src/utils/formatters'
@@ -79,7 +78,7 @@ export const Navbar = () => {
               <SafeFontIcon name="qr-code-1" size={16} />
             </Pressable>
           </Link>
-          <Pressable onPress={handleNotificationAccess} hitSlop={{ top: 20, bottom: 20, right: 20 }}>
+          <Pressable onPressIn={handleNotificationAccess} hitSlop={{ top: 20, bottom: 20, right: 20 }}>
             <SafeFontIcon name="bell" size={20} />
           </Pressable>
         </View>

--- a/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
@@ -1,6 +1,5 @@
-import { getTokenValue, Theme, useTheme } from 'tamagui'
-import { Pressable } from 'react-native-gesture-handler'
-import { Linking, Platform, Alert, View } from 'react-native'
+import { getTokenValue, Theme, useTheme, View } from 'tamagui'
+import { Linking, Platform, Pressable, Alert } from 'react-native'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import React from 'react'
 import { getExplorerLink } from '@safe-global/utils/utils/gateway'
@@ -48,25 +47,25 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
           right: -10,
         }}
       >
-        <Pressable
-          testID={'settings-screen-header-app-settings-button'}
-          hitSlop={{ top: 20, bottom: 20, left: 20 }}
-          style={{
-            zIndex: 2,
-            backgroundColor: '$backgroundSkeleton',
-            borderRadius: 16,
-            marginRight: 4,
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: 32,
-            height: 32,
-          }}
-          onPress={() => {
-            router.push('/app-settings')
-          }}
+        <View
+          backgroundColor={'$backgroundSkeleton'}
+          alignItems={'center'}
+          justifyContent={'center'}
+          borderRadius={16}
+          height={32}
+          width={32}
+          marginRight={4}
         >
-          <SafeFontIcon name={'settings'} size={20} />
-        </Pressable>
+          <Pressable
+            testID={'settings-screen-header-app-settings-button'}
+            hitSlop={{ top: 40, bottom: 40, left: 40 }}
+            onPressIn={() => {
+              router.push('/app-settings')
+            }}
+          >
+            <SafeFontIcon name={'settings'} size={20} color={'$color'} />
+          </Pressable>
+        </View>
 
         <FloatingMenu
           onPressAction={({ nativeEvent }) => {
@@ -163,20 +162,20 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
           ]}
         >
           <Pressable
-            hitSlop={{ top: 20, bottom: 20, right: 20 }}
-            style={{
-              zIndex: 2,
-              backgroundColor: '$backgroundSkeleton',
-              borderRadius: 16,
-              marginLeft: 4,
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 32,
-              height: 32,
-            }}
+            hitSlop={{ top: 40, bottom: 40, right: 40 }}
             testID={'settings-screen-header-more-settings-button'}
           >
-            <SafeFontIcon name={'options-horizontal'} size={20} />
+            <View
+              backgroundColor={'$backgroundSkeleton'}
+              alignItems={'center'}
+              justifyContent={'center'}
+              borderRadius={16}
+              marginLeft={4}
+              height={32}
+              width={32}
+            >
+              <SafeFontIcon name={'options-horizontal'} size={20} color={'$color'} />
+            </View>
           </Pressable>
         </FloatingMenu>
       </View>


### PR DESCRIPTION
## What it solves
The bug was caused by introducing react-native-gesture-handler as suggested [here](https://github.com/expo/expo/issues/34683) and [here](https://github.com/react-navigation/react-navigation/issues/7052), as a side effect.

Resolves #
https://github.com/safe-global/wallet-private-tasks/issues/142

## How this PR fixes it
We reverted the usage of such library while replacing the onPress handler by onPressIn. 

## How to test it

## Screenshots
![dark](https://github.com/user-attachments/assets/7a91b071-098d-4697-bec4-41db66013170)
![light](https://github.com/user-attachments/assets/e2c8c9a0-940b-4e4b-9328-d355e934db62)

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
