### PR TITLE
Fix(Spaces): Order networks by length in spaces address books

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -11,7 +11,7 @@ import type { SpaceAddressBookEntry } from '../../types'
 
 const headCells = [
   { id: 'contact', label: 'Contact' },
-  { id: 'Box, networks', label: 'Networks' },
+  { id: 'networks', label: 'Networks' },
   { id: 'actions', label: '' },
 ]
 
@@ -41,7 +41,7 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
         ),
       },
       networks: {
-        rawValue: '',
+        rawValue: networks.length,
         content: (
           <>
             <Tooltip


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/168

## How this PR fixes it

- Fixes the crash when trying to order address book entries by network
- Orders entries by the number of networks they have

## How to test it

1. Open a space
2. Go to address book
3. Order by networks
4. Observe the ordering happens by number of networks

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
