### PR TITLE
fix(mobile): Implement custom splash screen solution for Android

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -74,6 +74,17 @@ export default {
             image: './assets/images/splash.png',
             backgroundColor: '#000000',
           },
+          android: {
+            image: './assets/images/icon.png',
+            imageWidth: 124,
+            imageHeight: 124,
+            imageResizeMode: 'contain',
+            backgroundColor: '#000000',
+          },
+          ios: {
+            image: './assets/images/splash.png',
+            imageResizeMode: 'contain',
+          },
         },
       ],
       [


### PR DESCRIPTION
## What it solves
Expo splash screens has some inconsistencies as [this](https://github.com/expo/expo/issues/32515) on Android platform when using a full image as splash scree,

Resolves #
https://github.com/safe-global/wallet-private-tasks/issues/165

## How this PR fixes it
Implement a custom splash screen to be used on Android devices

## How to test it

## Screenshots
![Screenshot_20250415_202017](https://github.com/user-attachments/assets/ad123d79-28fc-4c9b-ac7c-8bd2c0447f90)

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
