### PR TITLE
Fix(Spaces): Filter address book entries by active chains

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
@@ -1,7 +1,7 @@
 import ChainIndicator from '@/components/common/ChainIndicator'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import css from '@/features/spaces/components/AddAccounts/styles.module.css'
-import { Box, Checkbox, List, ListItem } from '@mui/material'
+import { Box, Checkbox, List, ListItem, Tooltip } from '@mui/material'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
@@ -57,29 +57,34 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
               }
 
               return (
-                <ListItem className={css.safeItem} disablePadding>
-                  <ListItemButton onClick={handleItemClick} disabled={alreadyAdded || isSameAddressSelected}>
-                    <ListItemIcon onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        checked={isSelected || alreadyAdded}
-                        onChange={(event) => field.onChange(event.target.checked ? contactItem.name : undefined)}
+                <Tooltip
+                  title={isSameAddressSelected ? 'There is already an item with this address selected' : undefined}
+                  arrow
+                >
+                  <ListItem className={css.safeItem} disablePadding>
+                    <ListItemButton onClick={handleItemClick} disabled={alreadyAdded || isSameAddressSelected}>
+                      <ListItemIcon onClick={(e) => e.stopPropagation()}>
+                        <Checkbox
+                          checked={isSelected || alreadyAdded}
+                          onChange={(event) => field.onChange(event.target.checked ? contactItem.name : undefined)}
+                        />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={
+                          <Box className={css.safeRow}>
+                            <EthHashInfo
+                              address={contactItem.address}
+                              chainId={contactItem.chainId}
+                              name={contactItem.name}
+                              copyAddress={false}
+                            />
+                            <ChainIndicator chainId={contactItem.chainId} responsive onlyLogo />
+                          </Box>
+                        }
                       />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={
-                        <Box className={css.safeRow}>
-                          <EthHashInfo
-                            address={contactItem.address}
-                            chainId={contactItem.chainId}
-                            name={contactItem.name}
-                            copyAddress={false}
-                          />
-                          <ChainIndicator chainId={contactItem.chainId} responsive onlyLogo />
-                        </Box>
-                      }
-                    />
-                  </ListItemButton>
-                </ListItem>
+                    </ListItemButton>
+                  </ListItem>
+                </Tooltip>
               )
             }}
           />

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog.tsx
@@ -22,6 +22,7 @@ import SearchIcon from '@/public/images/common/search.svg'
 import { debounce } from 'lodash'
 import { useContactSearch } from '@/features/spaces/components/SpaceAddressBook/useContactSearch'
 import { createContactItems, flattenAddressBook } from '@/features/spaces/components/SpaceAddressBook/utils'
+import useChains from '@/hooks/useChains'
 
 export type ImportContactsFormValues = {
   contacts: Record<string, string | undefined> // e.g. "1:0x123": "Alice"
@@ -30,13 +31,20 @@ export type ImportContactsFormValues = {
 const ImportAddressBookDialog = ({ handleClose }: { handleClose: () => void }) => {
   const [error, setError] = useState<string>()
   const [searchQuery, setSearchQuery] = useState('')
+  const { configs } = useChains()
 
   const allAddressBooks = useAllAddressBooks()
-  const allContactItems = useMemo(() => flattenAddressBook(allAddressBooks), [allAddressBooks])
+  const allContactItems = useMemo(
+    () =>
+      flattenAddressBook(allAddressBooks).filter((contactItem) =>
+        configs.some((chain) => chain.chainId === contactItem.chainId),
+      ),
+    [allAddressBooks, configs],
+  )
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSearch = useCallback(debounce(setSearchQuery, 300), [])
-  const filteredEntries = useContactSearch(allAddressBooks, searchQuery)
+  const filteredEntries = useContactSearch(allContactItems, searchQuery)
 
   const formMethods = useForm<ImportContactsFormValues>({
     mode: 'onChange',

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog.tsx
@@ -21,11 +21,7 @@ import css from '@/features/spaces/components/AddAccounts/styles.module.css'
 import SearchIcon from '@/public/images/common/search.svg'
 import { debounce } from 'lodash'
 import { useContactSearch } from '@/features/spaces/components/SpaceAddressBook/useContactSearch'
-import {
-  createContactItems,
-  flattenAddressBook,
-  getContactId,
-} from '@/features/spaces/components/SpaceAddressBook/utils'
+import { createContactItems, flattenAddressBook } from '@/features/spaces/components/SpaceAddressBook/utils'
 
 export type ImportContactsFormValues = {
   contacts: Record<string, string | undefined> // e.g. "1:0x123": "Alice"
@@ -49,17 +45,10 @@ const ImportAddressBookDialog = ({ handleClose }: { handleClose: () => void }) =
     },
   })
 
-  const { handleSubmit, formState, setValue, watch } = formMethods
+  const { handleSubmit, formState, watch } = formMethods
 
   const selectedContacts = watch('contacts')
   const selectedContactsLength = Object.values(selectedContacts).filter(Boolean)
-
-  const selectAll = () => {
-    allContactItems.forEach((item) => {
-      const itemId = getContactId(item)
-      setValue(`contacts.${itemId}`, item.name)
-    })
-  }
 
   const onSubmit = handleSubmit(async (data) => {
     setError(undefined)
@@ -121,10 +110,6 @@ const ImportAddressBookDialog = ({ handleClose }: { handleClose: () => void }) =
                 ) : (
                   <ContactsList contactItems={allContactItems} />
                 )}
-
-                <Box m={2}>
-                  <Button onClick={selectAll}>Select all</Button>
-                </Box>
 
                 {error && (
                   <Alert severity="error" sx={{ mt: 2 }}>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/useContactSearch.ts
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/useContactSearch.ts
@@ -1,34 +1,28 @@
 import { useMemo } from 'react'
 import Fuse from 'fuse.js'
-import type { AddressBookState } from '@/store/addressBookSlice'
 import type { ContactItem } from '@/features/spaces/components/SpaceAddressBook/Import/ContactsList'
-import { flattenAddressBook } from '@/features/spaces/components/SpaceAddressBook/utils'
 
 /**
  * Custom hook to filter the address book by a search query.
  *
- * @param addressBookState - The entire address book state.
+ * @param contactItems - The contact items
  * @param searchQuery - The string to filter by (address or name).
  * @returns A list of objects matching the search query.
  */
-export function useContactSearch(addressBookState: AddressBookState, searchQuery: string): ContactItem[] {
-  const flattenedAddresses = useMemo<ContactItem[]>(() => {
-    return flattenAddressBook(addressBookState)
-  }, [addressBookState])
-
+export function useContactSearch(contactItems: ContactItem[], searchQuery: string): ContactItem[] {
   const fuse = useMemo(() => {
-    return new Fuse<ContactItem>(flattenedAddresses, {
+    return new Fuse<ContactItem>(contactItems, {
       keys: ['address', 'name'],
       includeScore: true,
       threshold: 0.3,
     })
-  }, [flattenedAddresses])
+  }, [contactItems])
 
   const results = useMemo(() => {
-    if (!searchQuery) return flattenedAddresses
+    if (!searchQuery) return contactItems
 
     return fuse.search(searchQuery).map((result) => result.item)
-  }, [searchQuery, flattenedAddresses, fuse])
+  }, [searchQuery, contactItems, fuse])
 
   return results
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/114#issuecomment-2808143091

## How this PR fixes it

- Removes the `Select all` button because the behaviour is not clear when encountering the same address multiple times
- Filters out address book entries on chains that are not active (e.g. old chains that have now been deactivated)

## How to test it

1. Open a space
2. Go to the address book
3. Press import
4. Observe only entries on active chains are displayed
5. Observe no Select all button

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
