### PR TITLE
feat(web): pass current chain to bridge widget

### DIFF
--- a/apps/web/src/features/bridge/components/BridgeWidget/index.test.tsx
+++ b/apps/web/src/features/bridge/components/BridgeWidget/index.test.tsx
@@ -1,20 +1,17 @@
-import { faker } from '@faker-js/faker'
-
 import { _getAppData } from '@/features/bridge/components/BridgeWidget'
 import { chainBuilder } from '@/tests/builders/chains'
-
-import { FEATURES } from '@safe-global/utils/utils/chains'
 
 describe('BridgeWidget', () => {
   describe('getAppData', () => {
     it('should return the correct SafeAppDataWithPermissions', () => {
-      const result = _getAppData(false)
+      const chain = chainBuilder().build()
+      const result = _getAppData(false, chain)
 
       expect(result).toStrictEqual({
         accessControl: {
           type: 'NO_RESTRICTIONS',
         },
-        chainIds: [],
+        chainIds: [chain.chainId],
         description: '',
         developerWebsite: '',
         features: [],
@@ -24,18 +21,19 @@ describe('BridgeWidget', () => {
         safeAppsPermissions: [],
         socialProfiles: [],
         tags: [],
-        url: 'https://iframe.jumper.exchange/?theme=light',
+        url: `https://iframe.jumper.exchange/?fromChain=${chain.chainId}&theme=light`,
       })
     })
 
     it('should return the correct SafeAppDataWithPermissions with dark mode', () => {
-      const result = _getAppData(true)
+      const chain = chainBuilder().build()
+      const result = _getAppData(true, chain)
 
       expect(result).toStrictEqual({
         accessControl: {
           type: 'NO_RESTRICTIONS',
         },
-        chainIds: [],
+        chainIds: [chain.chainId],
         description: '',
         developerWebsite: '',
         features: [],
@@ -45,38 +43,7 @@ describe('BridgeWidget', () => {
         safeAppsPermissions: [],
         socialProfiles: [],
         tags: [],
-        url: 'https://iframe.jumper.exchange/?theme=dark',
-      })
-    })
-
-    it('should return the correct SafeAppDataWithPermissions with chains', () => {
-      const chains = Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => {
-        return (
-          chainBuilder()
-            // @ts-expect-error
-            .with({ features: i % 2 ? [FEATURES.BRIDGE] : [] })
-            .build()
-        )
-      })
-
-      const result = _getAppData(false, chains)
-
-      expect(result).toStrictEqual({
-        accessControl: {
-          type: 'NO_RESTRICTIONS',
-        },
-        // @ts-expect-error
-        chainIds: chains.filter((chain) => chain.features.includes(FEATURES.BRIDGE)).map((chain) => chain.chainId),
-        description: '',
-        developerWebsite: '',
-        features: [],
-        iconUrl: '/images/common/bridge.svg',
-        id: expect.any(Number),
-        name: 'Bridge',
-        safeAppsPermissions: [],
-        socialProfiles: [],
-        tags: [],
-        url: 'https://iframe.jumper.exchange/?theme=light',
+        url: `https://iframe.jumper.exchange/?fromChain=${chain.chainId}&theme=dark`,
       })
     })
   })

--- a/apps/web/src/features/bridge/components/BridgeWidget/index.tsx
+++ b/apps/web/src/features/bridge/components/BridgeWidget/index.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react'
 
 import AppFrame from '@/components/safe-apps/AppFrame'
 import { getEmptySafeApp } from '@/components/safe-apps/utils'
-import useChains from '@/hooks/useChains'
+import { useCurrentChain } from '@/hooks/useChains'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import type { SafeAppDataWithPermissions } from '@/components/safe-apps/types'
 import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
@@ -11,13 +11,20 @@ import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
 
 export const BRIDGE_WIDGET_URL = 'https://iframe.jumper.exchange'
 
-export function BridgeWidget(): ReactElement {
+export function BridgeWidget(): ReactElement | null {
   const isDarkMode = useDarkMode()
-  const { configs } = useChains()
+  const chain = useCurrentChain()
 
-  const appData = useMemo((): SafeAppDataWithPermissions => {
-    return _getAppData(isDarkMode, configs)
-  }, [configs, isDarkMode])
+  const appData = useMemo((): SafeAppDataWithPermissions | null => {
+    if (!chain || !hasFeature(chain, FEATURES.BRIDGE)) {
+      return null
+    }
+    return _getAppData(isDarkMode, chain)
+  }, [chain, isDarkMode])
+
+  if (!appData) {
+    return null
+  }
 
   return (
     <AppFrame
@@ -29,25 +36,13 @@ export function BridgeWidget(): ReactElement {
   )
 }
 
-export function _getAppData(isDarkMode: boolean, chains?: Array<ChainInfo>): SafeAppDataWithPermissions {
+export function _getAppData(isDarkMode: boolean, chain: ChainInfo): SafeAppDataWithPermissions {
   const theme = isDarkMode ? 'dark' : 'light'
   return {
     ...getEmptySafeApp(),
     name: 'Bridge',
     iconUrl: '/images/common/bridge.svg',
-    chainIds: getChainIds(chains),
-    url: `${BRIDGE_WIDGET_URL}/?theme=${theme}`,
+    chainIds: [chain.chainId],
+    url: `${BRIDGE_WIDGET_URL}/?fromChain=${chain.chainId}&theme=${theme}`,
   }
-}
-
-function getChainIds(chains?: Array<ChainInfo>): Array<string> {
-  if (!chains) {
-    return []
-  }
-  return chains.reduce<Array<string>>((acc, cur) => {
-    if (hasFeature(cur, FEATURES.BRIDGE)) {
-      acc.push(cur.chainId)
-    }
-    return acc
-  }, [])
 }


### PR DESCRIPTION
## What it solves

The bridge widget being able to determine the current chain.

## How this PR fixes it

In order to restrict config. within the bridge widget, it needs to know the current chain. This add a new `fromChain` query param. to the widget URL with the current chain ID.

## How to test it

Observe no option to select other chains.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
