### PR TITLE
Fix(Spaces): Adjust Spaces UI elements

### DIFF
--- a/apps/web/src/features/spaces/components/AddAccounts/SafesList.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/SafesList.tsx
@@ -68,7 +68,17 @@ const SafesList = ({ safes }: { safes: AllSafeItems }) => {
 
   return (
     <List
-      sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1, maxHeight: 400, minHeight: 400, overflow: 'auto' }}
+      sx={{
+        px: 2,
+        pb: 2,
+        pt: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1,
+        maxHeight: 400,
+        minHeight: 400,
+        overflow: 'auto',
+      }}
     >
       {safes.map((safe, index) => {
         if (isMultiChainSafeItem(safe)) {
@@ -94,7 +104,7 @@ const SafesList = ({ safes }: { safes: AllSafeItems }) => {
           }
 
           return (
-            <Accordion key={index} disableGutters sx={{ flexShrink: '0' }}>
+            <Accordion key={index} className={css.accordion} disableGutters sx={{ flexShrink: '0' }}>
               <AccordionSummary
                 expandIcon={<ExpandMoreIcon />}
                 sx={{

--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -183,7 +183,7 @@ const AddAccounts = () => {
         hideChainIndicator
         PaperProps={{ sx: { backgroundColor: 'border.background' } }}
       >
-        <DialogContent sx={{ display: 'flex', alignItems: 'center' }}>
+        <DialogContent sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
           <Container fixed maxWidth="sm" disableGutters>
             <Typography component="div" variant="h1" mb={1}>
               Add Safe Accounts
@@ -195,7 +195,7 @@ const AddAccounts = () => {
             <Card>
               <FormProvider {...formMethods}>
                 <form onSubmit={onSubmit}>
-                  <Box mt={2} mx={2}>
+                  <Box m={2}>
                     <TextField
                       id="search-by-name"
                       placeholder="Search"

--- a/apps/web/src/features/spaces/components/AddAccounts/styles.module.css
+++ b/apps/web/src/features/spaces/components/AddAccounts/styles.module.css
@@ -21,3 +21,11 @@
   border: 1px solid var(--color-border-light);
   height: 66px;
 }
+
+.accordion {
+  border: 1px solid var(--color-border-light) !important;
+}
+
+.accordion:hover > h3 > button {
+  background-color: rgba(0, 0, 0, 0.04);
+}

--- a/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
@@ -3,6 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { MenuItem, Select, Stack } from '@mui/material'
 import { RoleMenuItem } from '@/features/spaces/components/AddMemberModal/index'
 import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
+import css from './styles.module.css'
 
 const MemberInfoForm = ({ isEdit = false }: { isEdit?: boolean }) => {
   const { control } = useFormContext()
@@ -24,10 +25,10 @@ const MemberInfoForm = ({ isEdit = false }: { isEdit?: boolean }) => {
             sx={{ minWidth: '150px', py: 0.5 }}
             renderValue={(role) => <RoleMenuItem role={role as MemberRole} />}
           >
-            <MenuItem value={MemberRole.ADMIN}>
+            <MenuItem value={MemberRole.ADMIN} className={css.menuItem}>
               <RoleMenuItem role={MemberRole.ADMIN} hasDescription selected={value === MemberRole.ADMIN} />
             </MenuItem>
-            <MenuItem value={MemberRole.MEMBER}>
+            <MenuItem value={MemberRole.MEMBER} className={css.menuItem}>
               <RoleMenuItem role={MemberRole.MEMBER} hasDescription selected={value === MemberRole.MEMBER} />
             </MenuItem>
           </Select>

--- a/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
@@ -168,7 +168,7 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
               data-testid="add-member-modal-button"
               type="submit"
               variant="contained"
-              disabled={!formState.isValid}
+              disabled={!formState.isValid || isSubmitting}
               disableElevation
             >
               {isSubmitting ? <CircularProgress size={20} /> : 'Add member'}

--- a/apps/web/src/features/spaces/components/AddMemberModal/styles.module.css
+++ b/apps/web/src/features/spaces/components/AddMemberModal/styles.module.css
@@ -6,3 +6,11 @@
     '.         description checkIcon';
   column-gap: var(--space-1);
 }
+
+.menuItem:hover {
+  background-color: var(--color-background-main) !important;
+}
+
+.menuItem:global(.Mui-selected) {
+  background-color: var(--color-background-main);
+}

--- a/apps/web/src/features/spaces/components/MembersList/MemberName.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/MemberName.tsx
@@ -14,7 +14,7 @@ const MemberName = ({ member }: { member: Member }) => {
         {member.name}{' '}
         {isCurrentUser && (
           <Typography variant="body2" component="span" color="text.secondary" ml={1}>
-            you
+            You
           </Typography>
         )}
       </Typography>

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
@@ -34,7 +34,7 @@ export const navItems: DynamicNavItem[] = [
     icon: <SvgIcon component={TransactionIcon} inheritViewBox />,
     href: '', // TODO: Replace with empty page
     disabled: true,
-    tag: <Chip label="Soon" sx={{ backgroundColor: 'background.main', color: 'primary.main' }} />,
+    tag: <Chip label="Soon" sx={{ backgroundColor: 'background.main', color: 'primary.light' }} />,
   },
   {
     label: 'Members',
@@ -46,7 +46,7 @@ export const navItems: DynamicNavItem[] = [
     icon: <SvgIcon component={ABIcon} inheritViewBox />,
     href: '', // TODO: Replace with empty page
     disabled: true,
-    tag: <Chip label="Soon" sx={{ backgroundColor: 'background.main', color: 'primary.main' }} />,
+    tag: <Chip label="Soon" sx={{ backgroundColor: 'background.main', color: 'primary.light' }} />,
   },
   {
     label: 'Settings',

--- a/apps/web/src/features/spaces/components/SpaceSidebarSelector/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarSelector/index.tsx
@@ -76,6 +76,7 @@ const SpaceSidebarSelector = () => {
               variant="body2"
               fontWeight="bold"
               noWrap
+              color="text.primary"
               sx={{ maxWidth: '140px', textOverflow: 'ellipsis', overflow: 'hidden' }}
             >
               {selectedSpace.name}


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/MVP-Feedback-1c88180fe57380c498d4ec2e105f3037?pvs=4#1c88180fe573804494baf9b5f9edf56a

## How this PR fixes it

- Fixes the multichain item hover color when adding safe accounts
- Fixes the add safe accounts dialog layout when on smaller screens
- Adjusts the sidebar selector color in dark mode
- Adjusts the sidebar Soon color in dark mode
- Adjusts the hover color of member roles on hover
- Capitalizes the "you" in the member list

## How to test it

1. Open a space and compare elements with the feedback document screenshots

## Screenshots

<img width="276" alt="Screenshot 2025-04-16 at 14 02 04" src="https://github.com/user-attachments/assets/bdb38041-521f-469b-8109-40ec10332bb9" />
<img width="504" alt="Screenshot 2025-04-16 at 14 02 51" src="https://github.com/user-attachments/assets/bf1f0a7b-cb96-4cd6-9f14-114cc6a5e9a3" />
<img width="691" alt="Screenshot 2025-04-16 at 14 03 45" src="https://github.com/user-attachments/assets/3767c5d5-64f6-4796-934b-d0c20c957d1d" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
