### PR TITLE
Fix(mobile): put the current theme in a local state to avoid side effects of useColorScheme hook

### DIFF
--- a/apps/mobile/src/theme/hooks/useTheme.tsx
+++ b/apps/mobile/src/theme/hooks/useTheme.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo } from 'react'
-import { useColorScheme } from 'react-native'
+import { useCallback, useEffect, useState } from 'react'
+import { AppState, ColorSchemeName, useColorScheme } from 'react-native'
 import { updateSettings } from '@/src/store/settingsSlice'
 import { selectSettings } from '@/src/store/settingsSlice'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
@@ -8,6 +8,8 @@ import { ThemePreference } from '@/src/types/theme'
 export const useTheme = () => {
   const dispatch = useAppDispatch()
   const colorScheme = useColorScheme()
+  const [currentTheme, setTheme] = useState<ColorSchemeName>(colorScheme)
+
   const themePreference = useAppSelector(
     (state) => selectSettings(state, 'themePreference') ?? 'auto',
   ) as ThemePreference
@@ -19,9 +21,20 @@ export const useTheme = () => {
     [dispatch],
   )
 
-  const currentTheme = useMemo(() => {
-    return themePreference === 'auto' ? colorScheme : themePreference
-  }, [themePreference, colorScheme])
+  // Prevent theme from changing when the app is in the background
+  // Issue: https://github.com/facebook/react-native/issues/35972
+  // They closed but issue still exists. Check the link for more details.
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      if (nextAppState === 'active') {
+        setTheme(themePreference === 'auto' ? colorScheme : themePreference)
+      }
+    })
+
+    return () => {
+      subscription.remove()
+    }
+  }, [colorScheme, themePreference])
 
   return { themePreference, setThemePreference, currentTheme }
 }


### PR DESCRIPTION
#### Resolves https://github.com/safe-global/wallet-private-tasks/issues/23

useColorSchema hook changes the current theme when app enters in background because the OS takes what is called a 'snapshot' on iOS, to facilitate the preview when you browse your open applications; a snapshot is required for both light & dark mode in case you change modes while on the open application screen, so the OS will report a brief moment in time both light & dark mode where the app should respond to these modes, or risk a flawed snapshot

## How this PR fixes it
It adds an event listener in the app using AppState instance and every time the nextAppState is `active` (when the app is resumed), it sets the theme to use the right theme. 

## How to test it
Follow the steps described in the issue: https://github.com/safe-global/wallet-private-tasks/issues/23

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
