### PR TITLE
Refactor(Signing UX): use static import for "features" and "actions"

### DIFF
--- a/apps/web/src/components/tx-flow/actions/index.ts
+++ b/apps/web/src/components/tx-flow/actions/index.ts
@@ -1,9 +1,7 @@
-import dynamic from 'next/dynamic'
-
-export const Batching = dynamic(() => import('./Batching'))
-export const ComboSubmit = dynamic(() => import('./ComboSubmit'))
-export const Counterfactual = dynamic(() => import('./Counterfactual'))
-export const Execute = dynamic(() => import('./Execute'))
-export const ExecuteThroughRole = dynamic(() => import('./ExecuteThroughRole'))
-export const Propose = dynamic(() => import('./Propose'))
-export const Sign = dynamic(() => import('./Sign'))
+export { default as Batching } from './Batching'
+export { default as ComboSubmit } from './ComboSubmit'
+export { default as Counterfactual } from './Counterfactual'
+export { default as Execute } from './Execute'
+export { default as ExecuteThroughRole } from './ExecuteThroughRole'
+export { default as Propose } from './Propose'
+export { default as Sign } from './Sign'

--- a/apps/web/src/components/tx-flow/features/index.ts
+++ b/apps/web/src/components/tx-flow/features/index.ts
@@ -1,6 +1,4 @@
-import dynamic from 'next/dynamic'
-
-export const ExecuteCheckbox = dynamic(() => import('./ExecuteCheckbox'))
-export const TxChecks = dynamic(() => import('./TxChecks'))
-export const TxNote = dynamic(() => import('./TxNote'))
-export const SignerSelect = dynamic(() => import('./SignerSelect'))
+export { default as ExecuteCheckbox } from './ExecuteCheckbox'
+export { default as TxChecks } from './TxChecks'
+export { default as TxNote } from './TxNote'
+export { default as SignerSelect } from './SignerSelect'


### PR DESCRIPTION
No need to lazily import these components as the entire tx flows are already lazily imported.

It does make sense to lazily import individual features but it has to be done conditionally inside the feature hierarchy. E.g. if the user selects "add to batch" – lazy-load the batching feature.