### PR TITLE
fix(Signing UX): revert to show combo button only on final receipt step

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -53,18 +53,22 @@ const Summary = ({ safeTxData, txData, txInfo, txDetails }: Props): ReactElement
 
       {submittedAt && (
         <TxDataRow datatestid="tx-created-at" title="Created">
-          <Typography variant="body2">{dateString(submittedAt)}</Typography>
+          <Typography variant="body2" component="div">
+            {dateString(submittedAt)}
+          </Typography>
         </TxDataRow>
       )}
 
       {executedAt && (
         <TxDataRow datatestid="tx-executed-at" title="Executed">
-          <Typography variant="body2">{dateString(executedAt)}</Typography>
+          <Typography variant="body2" component="div">
+            {dateString(executedAt)}
+          </Typography>
         </TxDataRow>
       )}
 
       {showDetails && (
-        <Box mt={3}>
+        <Box mt={submittedAt ? 2 : 3}>
           <ColorCodedTxAccordion txInfo={txInfo} txData={txData}>
             <Box my={1}>
               <DecodedData txData={txData} toInfo={toInfo} />

--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { Stack } from '@mui/material'
+import { Stack, Typography } from '@mui/material'
 import { type AddressEx, TokenType, type TransactionDetails, Operation } from '@safe-global/safe-gateway-typescript-sdk'
 
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
@@ -69,7 +69,9 @@ export const DecodedData = ({ txData, toInfo }: Props): ReactElement | null => {
       {txData.dataDecoded ? (
         <MethodDetails data={txData.dataDecoded} hexData={txData.hexData} addressInfoIndex={txData.addressInfoIndex} />
       ) : txData.hexData ? (
-        <HexEncodedData title="Data" hexData={txData.hexData} />
+        <Typography variant="body2" component="div">
+          <HexEncodedData title="Data" hexData={txData.hexData} />
+        </Typography>
       ) : null}
     </Stack>
   )

--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -61,21 +61,6 @@ export const TxFlow = <T extends unknown>({
     [onSubmit, data],
   )
 
-  const submit = (
-    <>
-      <Counterfactual />
-      <ExecuteThroughRole />
-
-      <ComboSubmit>
-        <Sign />
-        <Execute />
-        <Batching />
-      </ComboSubmit>
-
-      <Propose />
-    </>
-  )
-
   return (
     <SafeTxProvider>
       <TxInfoProvider>
@@ -96,15 +81,24 @@ export const TxFlow = <T extends unknown>({
               <TxFlowContent>
                 {...childrenArray}
 
-                <ReviewTransactionComponent onSubmit={handleFlowSubmit}>
+                <ReviewTransactionComponent onSubmit={() => nextStep()}>
                   <TxChecks />
                   <TxNote />
                   <SignerSelect />
-
-                  {submit}
                 </ReviewTransactionComponent>
 
-                <ConfirmTxReceipt onSubmit={handleFlowSubmit}>{submit}</ConfirmTxReceipt>
+                <ConfirmTxReceipt onSubmit={handleFlowSubmit}>
+                  <Counterfactual />
+                  <ExecuteThroughRole />
+
+                  <ComboSubmit>
+                    <Sign />
+                    <Execute />
+                    <Batching />
+                  </ComboSubmit>
+
+                  <Propose />
+                </ConfirmTxReceipt>
               </TxFlowContent>
             </TxFlowProvider>
           </SlotProvider>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
@@ -751,71 +751,26 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
         </div>
       </div>
       <div
-        class="MuiStack-root css-msk5bl-MuiStack-root"
+        class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
       >
         <div
-          class="container error errorMessage"
-          data-testid="error-message"
+          class="MuiStack-root css-irtfmw-MuiStack-root"
         >
-          <div
-            class="message"
+          <span
+            aria-label="Please connect your wallet"
+            class=""
+            data-mui-internal-clone-element="true"
           >
-            <mock-icon
-              aria-hidden=""
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1vcpomi-MuiSvgIcon-root"
-              focusable="false"
-            />
-            <div>
-              <span
-                class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-              >
-                You are currently not a signer of this Safe Account and won't be able to submit this transaction.
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiBox-root css-0"
-        >
-          <hr
-            class="MuiDivider-root MuiDivider-fullWidth nestedDivider css-1facvfi-MuiDivider-root"
-          />
-          <div
-            class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
-          >
-            <div
-              class="MuiStack-root css-irtfmw-MuiStack-root"
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1hp2ejb-MuiButtonBase-root-MuiButton-root"
+              data-testid="continue-sign-btn"
+              disabled=""
+              tabindex="-1"
+              type="submit"
             >
-              <form>
-                <span
-                  aria-label="Please connect your wallet"
-                  class=""
-                  data-mui-internal-clone-element="true"
-                >
-                  <div
-                    aria-label="Button group with a nested menu"
-                    class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-horizontal MuiButtonGroup-fullWidth MuiButtonGroup-colorPrimary css-izkk6m-MuiButtonGroup-root"
-                    role="group"
-                  >
-                    <div
-                      class="MuiBox-root css-1rr4qq7"
-                      data-mui-internal-clone-element="true"
-                    >
-                      <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary css-jfe8rk-MuiButtonBase-root-MuiButton-root"
-                        data-testid="combo-submit-sign"
-                        disabled=""
-                        tabindex="-1"
-                        type="submit"
-                      >
-                        Sign
-                      </button>
-                    </div>
-                  </div>
-                </span>
-              </form>
-            </div>
-          </div>
+              Continue
+            </button>
+          </span>
         </div>
       </div>
     </div>
@@ -936,71 +891,26 @@ exports[`ReviewTransaction should display an error screen 1`] = `
         </div>
       </div>
       <div
-        class="MuiStack-root css-msk5bl-MuiStack-root"
+        class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
       >
         <div
-          class="container error errorMessage"
-          data-testid="error-message"
+          class="MuiStack-root css-irtfmw-MuiStack-root"
         >
-          <div
-            class="message"
+          <span
+            aria-label="Please connect your wallet"
+            class=""
+            data-mui-internal-clone-element="true"
           >
-            <mock-icon
-              aria-hidden=""
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1vcpomi-MuiSvgIcon-root"
-              focusable="false"
-            />
-            <div>
-              <span
-                class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-              >
-                You are currently not a signer of this Safe Account and won't be able to submit this transaction.
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiBox-root css-0"
-        >
-          <hr
-            class="MuiDivider-root MuiDivider-fullWidth nestedDivider css-1facvfi-MuiDivider-root"
-          />
-          <div
-            class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
-          >
-            <div
-              class="MuiStack-root css-irtfmw-MuiStack-root"
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1hp2ejb-MuiButtonBase-root-MuiButton-root"
+              data-testid="continue-sign-btn"
+              disabled=""
+              tabindex="-1"
+              type="submit"
             >
-              <form>
-                <span
-                  aria-label="Please connect your wallet"
-                  class=""
-                  data-mui-internal-clone-element="true"
-                >
-                  <div
-                    aria-label="Button group with a nested menu"
-                    class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-horizontal MuiButtonGroup-fullWidth MuiButtonGroup-colorPrimary css-izkk6m-MuiButtonGroup-root"
-                    role="group"
-                  >
-                    <div
-                      class="MuiBox-root css-1rr4qq7"
-                      data-mui-internal-clone-element="true"
-                    >
-                      <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary css-jfe8rk-MuiButtonBase-root-MuiButton-root"
-                        data-testid="combo-submit-sign"
-                        disabled=""
-                        tabindex="-1"
-                        type="submit"
-                      >
-                        Sign
-                      </button>
-                    </div>
-                  </div>
-                </span>
-              </form>
-            </div>
-          </div>
+              Continue
+            </button>
+          </span>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -751,71 +751,26 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
         </div>
       </div>
       <div
-        class="MuiStack-root css-msk5bl-MuiStack-root"
+        class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
       >
         <div
-          class="container error errorMessage"
-          data-testid="error-message"
+          class="MuiStack-root css-irtfmw-MuiStack-root"
         >
-          <div
-            class="message"
+          <span
+            aria-label="Please connect your wallet"
+            class=""
+            data-mui-internal-clone-element="true"
           >
-            <mock-icon
-              aria-hidden=""
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1vcpomi-MuiSvgIcon-root"
-              focusable="false"
-            />
-            <div>
-              <span
-                class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-              >
-                You are currently not a signer of this Safe Account and won't be able to submit this transaction.
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiBox-root css-0"
-        >
-          <hr
-            class="MuiDivider-root MuiDivider-fullWidth nestedDivider css-1facvfi-MuiDivider-root"
-          />
-          <div
-            class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
-          >
-            <div
-              class="MuiStack-root css-irtfmw-MuiStack-root"
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1hp2ejb-MuiButtonBase-root-MuiButton-root"
+              data-testid="continue-sign-btn"
+              disabled=""
+              tabindex="-1"
+              type="submit"
             >
-              <form>
-                <span
-                  aria-label="Please connect your wallet"
-                  class=""
-                  data-mui-internal-clone-element="true"
-                >
-                  <div
-                    aria-label="Button group with a nested menu"
-                    class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-horizontal MuiButtonGroup-fullWidth MuiButtonGroup-colorPrimary css-izkk6m-MuiButtonGroup-root"
-                    role="group"
-                  >
-                    <div
-                      class="MuiBox-root css-1rr4qq7"
-                      data-mui-internal-clone-element="true"
-                    >
-                      <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary css-jfe8rk-MuiButtonBase-root-MuiButton-root"
-                        data-testid="combo-submit-sign"
-                        disabled=""
-                        tabindex="-1"
-                        type="submit"
-                      >
-                        Sign
-                      </button>
-                    </div>
-                  </div>
-                </span>
-              </form>
-            </div>
-          </div>
+              Continue
+            </button>
+          </span>
         </div>
       </div>
     </div>
@@ -936,71 +891,26 @@ exports[`ReviewTransaction should display an error screen 1`] = `
         </div>
       </div>
       <div
-        class="MuiStack-root css-msk5bl-MuiStack-root"
+        class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
       >
         <div
-          class="container error errorMessage"
-          data-testid="error-message"
+          class="MuiStack-root css-irtfmw-MuiStack-root"
         >
-          <div
-            class="message"
+          <span
+            aria-label="Please connect your wallet"
+            class=""
+            data-mui-internal-clone-element="true"
           >
-            <mock-icon
-              aria-hidden=""
-              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1vcpomi-MuiSvgIcon-root"
-              focusable="false"
-            />
-            <div>
-              <span
-                class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-              >
-                You are currently not a signer of this Safe Account and won't be able to submit this transaction.
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          class="MuiBox-root css-0"
-        >
-          <hr
-            class="MuiDivider-root MuiDivider-fullWidth nestedDivider css-1facvfi-MuiDivider-root"
-          />
-          <div
-            class="MuiCardActions-root MuiCardActions-spacing css-1q4nm6f-MuiCardActions-root"
-          >
-            <div
-              class="MuiStack-root css-irtfmw-MuiStack-root"
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-1hp2ejb-MuiButtonBase-root-MuiButton-root"
+              data-testid="continue-sign-btn"
+              disabled=""
+              tabindex="-1"
+              type="submit"
             >
-              <form>
-                <span
-                  aria-label="Please connect your wallet"
-                  class=""
-                  data-mui-internal-clone-element="true"
-                >
-                  <div
-                    aria-label="Button group with a nested menu"
-                    class="MuiButtonGroup-root MuiButtonGroup-contained MuiButtonGroup-horizontal MuiButtonGroup-fullWidth MuiButtonGroup-colorPrimary css-izkk6m-MuiButtonGroup-root"
-                    role="group"
-                  >
-                    <div
-                      class="MuiBox-root css-1rr4qq7"
-                      data-mui-internal-clone-element="true"
-                    >
-                      <button
-                        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary css-jfe8rk-MuiButtonBase-root-MuiButton-root"
-                        data-testid="combo-submit-sign"
-                        disabled=""
-                        tabindex="-1"
-                        type="submit"
-                      >
-                        Sign
-                      </button>
-                    </div>
-                  </div>
-                </span>
-              </form>
-            </div>
-          </div>
+              Continue
+            </button>
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What it solves

Show the sign/execute/batch submit button on the Receipt step only and remove it from the transaction review step.
This is to avoid confusion in the signing process (see [this comment](https://github.com/safe-global/safe-wallet-monorepo/issues/5416#issuecomment-2819974099)).

## How to test it

1. Open update threshold transaction flow.
2. Continue to the transaction review step
3. Observe a "Continue" button instead of the combo button

## Screenshots

![Screenshot 2025-04-22 at 15 12 14](https://github.com/user-attachments/assets/c8811312-22ab-4e28-bc30-14e4af4fc4b8)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
