### PR TITLE
Fix(mobile): transaction history title overlaping system icons

### DIFF
--- a/apps/mobile/src/app/(tabs)/transactions/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/transactions/_layout.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import type { Route } from '@react-navigation/routers'
 import { H2, View } from 'tamagui'
 import { getFocusedRouteNameFromRoute } from '@react-navigation/native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 const getHeaderTitle = (route: Partial<Route<string>>) => {
   const routeName = getFocusedRouteNameFromRoute(route) ?? 'index'
@@ -15,30 +16,32 @@ const getHeaderTitle = (route: Partial<Route<string>>) => {
 
 export default function TransactionsLayout() {
   return (
-    <Stack
-      screenOptions={{
-        headerLargeTitle: false,
-        headerShadowVisible: false,
-      }}
-    >
-      <Stack.Screen
-        name="(tabs)"
-        options={({ route }) => ({
-          headerTitle: (props) => (
-            <View
-              style={{
-                marginTop: 2,
-                flex: 1,
-                width: '100%',
-              }}
-            >
-              <H2 fontWeight={600} {...props}>
-                {getHeaderTitle(route)}
-              </H2>
-            </View>
-          ),
-        })}
-      />
-    </Stack>
+    <SafeAreaView style={{ flex: 1 }}>
+      <Stack
+        screenOptions={{
+          headerLargeTitle: false,
+          headerShadowVisible: false,
+        }}
+      >
+        <Stack.Screen
+          name="(tabs)"
+          options={({ route }) => ({
+            headerTitle: (props) => (
+              <View
+                style={{
+                  marginTop: 2,
+                  flex: 1,
+                  width: '100%',
+                }}
+              >
+                <H2 fontWeight={600} {...props}>
+                  {getHeaderTitle(route)}
+                </H2>
+              </View>
+            ),
+          })}
+        />
+      </Stack>
+    </SafeAreaView>
   )
 }


### PR DESCRIPTION
Resolves https://github.com/safe-global/wallet-private-tasks/issues/175

## How this PR fixes it 
It adds a SafeAreaView into the transaction history list to avoid having the system icons being overlap by the screen title. Looks like all the screen on android are overlapping the system icons when user has not imported the wallet yet though.

## How to test it
- Remove the current app from your phone
- Install it again
- add a wallet
- go to transaction history tab
- The screen title should not be overlapping the system icons anymore.
 
## Screenshots
<img width="445" alt="Screenshot 2025-04-22 at 15 44 49" src="https://github.com/user-attachments/assets/92ac88ca-8e21-4da3-b771-bdf4dc96d124" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
