### PR TITLE
fix(mobile): display info about swap and twap

### DIFF
--- a/apps/mobile/src/components/transactions-list/Card/TxOrderCard/SellOrder.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxOrderCard/SellOrder.tsx
@@ -56,7 +56,7 @@ export function SellOrder({ order, bordered, executionInfo, inQueue, onPress }: 
       rightNode={
         <View alignItems="flex-end">
           <Text color="$primary">
-            +{formatValue(order.buyAmount, order.buyToken.decimals)} {order.buyToken.symbol}
+            ~{formatValue(order.buyAmount, order.buyToken.decimals)} {order.buyToken.symbol}
           </Text>
           <Text fontSize="$3">
             −{formatValue(order.sellAmount, order.sellToken.decimals)} {order.sellToken.symbol}

--- a/apps/mobile/src/components/transactions-list/Card/TxOrderCard/TwapOrder.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxOrderCard/TwapOrder.tsx
@@ -52,7 +52,7 @@ export const TwapOrder = ({ order, bordered, executionInfo, inQueue, onPress }: 
       rightNode={
         <View alignItems="flex-end">
           <Text color="$primary">
-            +{formatValue(order.buyAmount, order.buyToken.decimals)} {order.buyToken.symbol}
+            ~{formatValue(order.buyAmount, order.buyToken.decimals)} {order.buyToken.symbol}
           </Text>
           <Text fontSize="$3">
             −{formatValue(order.sellAmount, order.sellToken.decimals)} {order.sellToken.symbol}

--- a/apps/mobile/src/components/transactions-list/Card/TxOrderCard/__snapshots__/TxOrderCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxOrderCard/__snapshots__/TxOrderCard.test.tsx.snap
@@ -276,7 +276,7 @@ exports[`TxSwapCard should render the default markup 1`] = `
         }
         suppressHighlighting={true}
       >
-        +
+        ~
         0.05
          
         ETH


### PR DESCRIPTION
## What it solves
It solve the way how we're display the information about the swap / twap tokens.

Resolves https://github.com/safe-global/wallet-private-tasks/issues/135

## How this PR fixes it
After discussing to the PO, we decided to add a "~" which makes more sense then just removing the information of the amount exchanged by the token.

## How to test it
Follow the instructions on this issue:  https://github.com/safe-global/wallet-private-tasks/issues/135

## Screenshots
<img width="319" alt="Screenshot 2025-04-22 at 16 26 17" src="https://github.com/user-attachments/assets/e8f4fa07-e93d-4c01-beba-d15d02e8e3bb" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
