### PR TITLE
Fix(mobile): improve tab buttons accessibility

### DIFF
--- a/apps/mobile/src/components/SafeTab/SafeTabBar.tsx
+++ b/apps/mobile/src/components/SafeTab/SafeTabBar.tsx
@@ -43,7 +43,7 @@ export const SafeTabBar = ({
     >
       {tabNames.map((name) => (
         <TouchableOpacity style={isActiveTab(name) && activeButtonStyle} onPress={handleTabPressed(name)} key={name}>
-          <Text color={isActiveTab(name) ? '$color' : '$colorSecondary'} fontSize="$4" fontWeight={600}>
+          <Text color={isActiveTab(name) ? '$color' : '$colorSecondary'} fontSize="$6" fontWeight={700}>
             {name}
           </Text>
         </TouchableOpacity>

--- a/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
+++ b/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
@@ -27,9 +27,7 @@ export function AssetsHeader({ amount, isLoading, onPendingTransactionsPress, ha
 
       <BalanceContainer />
 
-      <View marginBottom="$4">
-        <ReadOnlyContainer />
-      </View>
+      <ReadOnlyContainer />
     </StyledAssetsHeader>
   )
 }

--- a/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.container.tsx
+++ b/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.container.tsx
@@ -4,14 +4,14 @@ import { selectSafeInfo } from '@/src/store/safesSlice'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { selectSigners } from '@/src/store/signersSlice'
 import { getSafeSigners } from '@/src/utils/signer'
-import { ReadOnly } from './ReadOnly'
+import { ReadOnly, ReadOnlyProps } from './ReadOnly'
 
-export const ReadOnlyContainer = () => {
+export const ReadOnlyContainer = ({ marginBottom, marginTop }: Omit<ReadOnlyProps, 'signers'>) => {
   const activeSafe = useDefinedActiveSafe()
   const safeInfo = useSelector((state: RootState) => selectSafeInfo(state, activeSafe?.address))
   const signers = useSelector(selectSigners)
 
   const safeSigners = safeInfo?.SafeInfo ? getSafeSigners(safeInfo.SafeInfo, signers) : []
 
-  return <ReadOnly signers={safeSigners} />
+  return <ReadOnly signers={safeSigners} marginBottom={marginBottom} marginTop={marginTop} />
 }

--- a/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.tsx
+++ b/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.tsx
@@ -1,14 +1,28 @@
 import { Container } from '@/src/components/Container'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { DimensionValue } from 'react-native'
 import { View, Text } from 'tamagui'
 
-export const ReadOnly = ({ signers }: { signers: string[] }) => {
+export interface ReadOnlyProps {
+  signers: string[]
+  marginBottom?: DimensionValue | string
+  marginTop?: DimensionValue | string
+}
+
+export const ReadOnly = ({ signers, marginBottom = '$7', marginTop = '$2' }: ReadOnlyProps) => {
   if (signers.length === 0) {
     return (
-      <Container padding="$2" justifyContent="center" alignItems="center" backgroundColor="$backgroundSecondary">
+      <Container
+        marginBottom={marginBottom}
+        marginTop={marginTop}
+        padding="$3"
+        justifyContent="center"
+        alignItems="center"
+        backgroundColor="$backgroundSecondary"
+      >
         <View flexDirection="row" alignItems="center" gap="$2">
           <SafeFontIcon name="eye-n" size={20} color="$colorLight" />
-          <Text color="$colorLight" fontWeight={600}>
+          <Text color="$colorLight" fontSize="$5" fontWeight={600}>
             This is a read-only account
           </Text>
         </View>

--- a/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.tsx
+++ b/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.tsx
@@ -9,7 +9,7 @@ export interface ReadOnlyProps {
   marginTop?: DimensionValue | string
 }
 
-export const ReadOnly = ({ signers, marginBottom = '$7', marginTop = '$2' }: ReadOnlyProps) => {
+export const ReadOnly = ({ signers, marginBottom = '$8', marginTop = '$2' }: ReadOnlyProps) => {
   if (signers.length === 0) {
     return (
       <Container


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-monorepo/issues/5717

## How this PR fixes it
It increases the measures for tab buttons and margins for the readonly alert. 

## Screenshots

| **Before** | **After** |
|------------|-----------|
| <img width="400" alt="Screenshot 2025-04-23 at 13 06 59" src="https://github.com/user-attachments/assets/d8f3eebb-f6f1-4e54-9dab-2a96c1a3bb23" /> |  <img width="502" alt="Screenshot 2025-04-23 at 15 26 21" src="https://github.com/user-attachments/assets/26483b14-2a15-451d-8cbf-438eeca22db3" /> |

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
