### PR TITLE
fix(web): estimate gas for recovery attempt execution

### DIFF
--- a/apps/web/src/components/tx-flow/flows/RecoveryAttempt/RecoveryAttemptReview.tsx
+++ b/apps/web/src/components/tx-flow/flows/RecoveryAttempt/RecoveryAttemptReview.tsx
@@ -16,6 +16,9 @@ import { useAsyncCallback } from '@/hooks/useAsync'
 import FieldsGrid from '@/components/tx/FieldsGrid'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { SafeTxContext } from '../../SafeTxProvider'
+import useGasPrice from '@/hooks/useGasPrice'
+import { useCurrentChain } from '@/hooks/useChains'
+import { hasFeature, FEATURES } from '@/utils/chains'
 
 type RecoveryAttemptReviewProps = {
   item: RecoveryQueueItem
@@ -27,12 +30,22 @@ const RecoveryAttemptReview = ({ item }: RecoveryAttemptReviewProps) => {
   const { safe } = useSafeInfo()
   const { setTxFlow } = useContext(TxModalContext)
   const { setNonceNeeded } = useContext(SafeTxContext)
+  const [gasPrice] = useGasPrice()
+  const chain = useCurrentChain()
 
   const onFormSubmit = useCallback(
     async (e: SyntheticEvent) => {
       e.preventDefault()
 
-      if (!wallet) return
+      if (!wallet || !gasPrice) return
+
+      const isEIP1559 = chain && hasFeature(chain, FEATURES.EIP1559)
+      const overrides = isEIP1559
+        ? {
+            maxFeePerGas: gasPrice?.maxFeePerGas?.toString(),
+            maxPriorityFeePerGas: gasPrice?.maxPriorityFeePerGas?.toString(),
+          }
+        : { gasPrice: gasPrice?.maxFeePerGas?.toString() }
 
       try {
         await asyncCallback({
@@ -41,13 +54,14 @@ const RecoveryAttemptReview = ({ item }: RecoveryAttemptReviewProps) => {
           args: item.args,
           delayModifierAddress: item.address,
           signerAddress: wallet.address,
+          overrides,
         })
         setTxFlow(undefined)
       } catch (err) {
         trackError(Errors._812, err)
       }
     },
-    [asyncCallback, setTxFlow, wallet, safe, item.address, item.args],
+    [wallet, gasPrice, chain, asyncCallback, safe.chainId, item.args, item.address, setTxFlow],
   )
 
   useEffect(() => {

--- a/apps/web/src/features/recovery/services/recovery-sender.ts
+++ b/apps/web/src/features/recovery/services/recovery-sender.ts
@@ -145,12 +145,14 @@ export async function dispatchRecoveryExecution({
   args,
   delayModifierAddress,
   signerAddress,
+  overrides,
 }: {
   provider: Eip1193Provider
   chainId: string
   args: TransactionAddedEvent.Log['args']
   delayModifierAddress: string
   signerAddress: string
+  overrides: Overrides
 }) {
   const { delayModifier, isUnchecked } = await getDelayModifierContract({
     provider,
@@ -162,7 +164,7 @@ export async function dispatchRecoveryExecution({
   const txType = RecoveryTxType.EXECUTION
 
   try {
-    const tx = await delayModifier.executeNextTx(args.to, args.value, args.data, args.operation)
+    const tx = await delayModifier.executeNextTx(args.to, args.value, args.data, args.operation, overrides)
 
     if (isUnchecked) {
       recoveryDispatch(RecoveryEvent.PROCESSING_BY_SMART_CONTRACT_WALLET, {


### PR DESCRIPTION
## What it solves

Resolves inability to execute a recovery attempt with a Ledger device.

## How this PR fixes it

Similar to issues [creating recovery attempts](https://github.com/safe-global/safe-wallet-monorepo/pull/5738#issuecomment-2823012481), which was resolved by passing a gas estimation (882b672fe3b79a0d153186f8722ce57985b03813), this propagates the same changes to execution flow. Without an estimation, no gas is passed is present in the raw transaction.

If we see this issue again, we should consider adding gas estimation to the Ledger module (although it wasn't there previously).

## How to test it

It should be possible to successfully create and execute a recovery attempt with a (directly connected) Ledger device.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
