### PR TITLE
fix(web): explicitly handle Ledger statuses

### DIFF
--- a/apps/web/src/services/onboard/ledger-module.ts
+++ b/apps/web/src/services/onboard/ledger-module.ts
@@ -366,7 +366,7 @@ async function waitForAction<Output, Error extends DmkError, IntermediateValue>(
   let subscription: Subscription | undefined
 
   try {
-    return await new Promise(async (resolve, reject) => {
+    return await new Promise((resolve, reject) => {
       subscription = observable.subscribe({
         next: (actionState) => {
           if (actionState.status === DeviceActionStatus.Completed) {

--- a/apps/web/src/services/onboard/ledger-module.ts
+++ b/apps/web/src/services/onboard/ledger-module.ts
@@ -1,4 +1,5 @@
-import type { DeviceActionState } from '@ledgerhq/device-management-kit'
+import { makeError } from 'ethers'
+import type { DmkError, ExecuteDeviceActionReturnType } from '@ledgerhq/device-management-kit'
 import type {
   GetAddressDAOutput,
   SignPersonalMessageDAOutput,
@@ -8,6 +9,7 @@ import type {
 } from '@ledgerhq/device-signer-kit-ethereum'
 import type { Chain, WalletInit, WalletInterface } from '@web3-onboard/common'
 import type { Account, Asset, BasePath, DerivationPath, ScanAccountsOptions } from '@web3-onboard/hw-common'
+import type { Subscription } from 'rxjs'
 
 const LEDGER_LIVE_PATH: DerivationPath = "44'/60'"
 const LEDGER_LEGACY_PATH: DerivationPath = "44'/60'/0'"
@@ -326,11 +328,9 @@ const enum LedgerErrorCode {
 
 // Promisified Ledger SDK
 async function getLedgerSdk() {
-  const { DeviceActionStatus, DeviceManagementKitBuilder } = await import('@ledgerhq/device-management-kit')
+  const { DeviceManagementKitBuilder } = await import('@ledgerhq/device-management-kit')
   const { webHidTransportFactory, webHidIdentifier } = await import('@ledgerhq/device-transport-kit-web-hid')
   const { SignerEthBuilder } = await import('@ledgerhq/device-signer-kit-ethereum')
-  const { makeError } = await import('ethers')
-  const { default: get } = await import('lodash/get')
   const { lastValueFrom } = await import('rxjs')
 
   // Get connected device and create signer
@@ -339,51 +339,64 @@ async function getLedgerSdk() {
   const sessionId = await dmk.connect({ device })
   const signer = new SignerEthBuilder({ dmk, sessionId }).build()
 
-  function mapOutput<T>(actionState: DeviceActionState<T, unknown, unknown>): T {
-    switch (actionState.status) {
-      case DeviceActionStatus.Completed: {
-        return actionState.output
-      }
-      case DeviceActionStatus.Error: {
-        const errorCode = get(actionState.error, 'originalError.errorCode')
-        const isRejection = errorCode === LedgerErrorCode.REJECTED
-
-        if (!isRejection) {
-          throw actionState.error
-        }
-
-        // Ethers error for user rejection
-        throw makeError('user rejected action', 'ACTION_REJECTED', {
-          action: 'unknown',
-          reason: 'rejected',
-          info: actionState,
-        })
-      }
-      default: {
-        throw new Error(`Device ${actionState.status}`)
-      }
-    }
-  }
-
   return {
     disconnect: async (): Promise<void> => {
       return dmk.disconnect({ sessionId })
     },
     getAddress: async (derivationPath: string): Promise<GetAddressDAOutput> => {
-      const actionState = await lastValueFrom(signer.getAddress(derivationPath, { checkOnDevice: false }).observable)
-      return mapOutput(actionState)
+      return waitForAction(signer.getAddress(derivationPath, { checkOnDevice: false }))
     },
     signMessage: async (derivationPath: string, message: string | Uint8Array): Promise<SignPersonalMessageDAOutput> => {
-      const actionState = await lastValueFrom(signer.signMessage(derivationPath, message).observable)
-      return mapOutput(actionState)
+      return waitForAction(signer.signMessage(derivationPath, message))
     },
     signTransaction: async (derivationPath: string, transaction: Uint8Array): Promise<SignTransactionDAOutput> => {
-      const actionState = await lastValueFrom(signer.signTransaction(derivationPath, transaction).observable)
-      return mapOutput(actionState)
+      return waitForAction(signer.signTransaction(derivationPath, transaction))
     },
     signTypedData: async (derivationPath: string, typedData: TypedData): Promise<SignTypedDataDAOutput> => {
-      const actionState = await lastValueFrom(signer.signTypedData(derivationPath, typedData).observable)
-      return mapOutput(actionState)
+      return waitForAction(signer.signTypedData(derivationPath, typedData))
     },
   }
+}
+
+async function waitForAction<Output, Error extends DmkError, IntermediateValue>({
+  observable,
+}: ExecuteDeviceActionReturnType<Output, Error, IntermediateValue>): Promise<Output> {
+  const { DeviceActionStatus } = await import('@ledgerhq/device-management-kit')
+
+  let subscription: Subscription | undefined
+
+  try {
+    return await new Promise(async (resolve, reject) => {
+      subscription = observable.subscribe({
+        next: (actionState) => {
+          if (actionState.status === DeviceActionStatus.Completed) {
+            resolve(actionState.output)
+          } else if (actionState.status === DeviceActionStatus.Error) {
+            reject(mapEthersError(actionState.error))
+          } else {
+            // Awaiting user action, e.g. device to be unlocked. We could throw
+            // an explicit error message but we keep the signing request alive
+          }
+        },
+      })
+    })
+  } finally {
+    subscription?.unsubscribe()
+  }
+}
+
+function mapEthersError(error: DmkError) {
+  const isRejection = 'errorCode' in error ? error.errorCode === LedgerErrorCode.REJECTED : false
+
+  if (!isRejection) {
+    return makeError(error.message ?? 'unknown', 'UNKNOWN_ERROR', {
+      info: error,
+    })
+  }
+
+  return makeError('user rejected action', 'ACTION_REJECTED', {
+    action: 'unknown',
+    reason: 'rejected',
+    info: error,
+  })
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/186

## How this PR fixes it

Instead of relying on the `lastValueFrom` of an action, we not explicitly subscribe to it and only `resolve`/`reject` if the status of it is complete or erroneous.

Each `signer` action returns an observable, of which there is an "action state" with [multiple states](https://github.com/LedgerHQ/device-sdk-ts/tree/develop/packages/signer/signer-eth#-observable-behavior). These encompass successful execution, errors and "intermediate" states (e.g. a locked device).

We were previously trusting the `lastValueFrom` of each observable but, after a device previously locked, the last "state" is not successful, but rather erroneous - not being able to make RPC requests.

This migrates from using `lastValueFrom` to explicitly waiting for/handling `DeviceActionStatus.Completed` and `DeviceActionStatus.Error` "states" and mapping their responses accordingly - every "intermediate" one is disregarded.

## How to test it

The following actions (and their rejection) should succeed before/after a Ledger device locks/is unlocked:

1. Address retrieval (listing accounts in the wallet connection modal)
2. Signing messages
3. Signing transactions (notification/proposal registration, etc.)
4. Signing typed data (general transactions)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
