### PR TITLE
Fix(mobile): remove padding bottom on tx history

### DIFF
--- a/apps/mobile/src/app/(tabs)/transactions/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/transactions/_layout.tsx
@@ -16,7 +16,7 @@ const getHeaderTitle = (route: Partial<Route<string>>) => {
 
 export default function TransactionsLayout() {
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView style={{ flex: 1 }} edges={['top']}>
       <Stack
         screenOptions={{
           headerLargeTitle: false,


### PR DESCRIPTION
## What it solves
After the fix on the title being displayed under the phone status bar, we introduced an issue of having the view with an unnecessary padding bottom.

## How this PR fixes it
It adds an `edge=['top']` prop, so the place affected will be only in the top of the view

## How to test it
- Go to tx history list and check if the list is being cut at the bottom

## Screenshots
| Before | After |
|----------|----------|
| <img width="458" alt="Screenshot 2025-04-25 at 12 39 23" src="https://github.com/user-attachments/assets/5373c68e-7c5d-48cd-b1a0-10928dea44e7" /> | <img width="502" alt="Screenshot 2025-04-25 at 12 42 16" src="https://github.com/user-attachments/assets/e38b773c-3f34-4a49-a555-1a338cc9c04c" /> |

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
