### PR TITLE
Fix(mobile): Show correct info in the action details

### DIFF
--- a/apps/mobile/src/features/ActionDetails/utils.tsx
+++ b/apps/mobile/src/features/ActionDetails/utils.tsx
@@ -40,8 +40,6 @@ export const formatActionDetails = ({ txData, action }: formatActionDetailsRetur
 
   let columns: ListTableItem[] = []
 
-  const contractCall = getContractCall(action, txData.addressInfoIndex as AddressInfoIndex)
-
   if (action.dataDecoded?.method) {
     columns.push({
       label: 'Call',
@@ -68,18 +66,20 @@ export const formatActionDetails = ({ txData, action }: formatActionDetailsRetur
     })
   }
 
+  const contractCall = getContractCall(action, txData.addressInfoIndex as AddressInfoIndex)
+
   if (contractCall) {
     columns.push({
       label: 'Contract',
       render: () => (
         <View flexDirection="row" alignItems="center" gap="$2">
-          {txData.to.logoUri ? (
-            <Logo logoUri={txData.to.logoUri} size="$6" />
+          {contractCall.logoUri ? (
+            <Logo logoUri={contractCall.logoUri} size="$6" />
           ) : (
-            <Identicon address={txData.to.value as Address} size={24} />
+            <Identicon address={contractCall.value as Address} size={24} />
           )}
-          <Text fontSize="$4">{ellipsis(txData.to.name || txData.to.value, 16)}</Text>
-          <TxOptions value={txData.to.value} />
+          <Text fontSize="$4">{ellipsis(contractCall.name || contractCall.value, 16)}</Text>
+          <TxOptions value={contractCall.value} />
         </View>
       ),
     })

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/GenericView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/GenericView.tsx
@@ -17,6 +17,7 @@ import { Badge } from '@/src/components/Badge'
 import { ListTable } from '../../ListTable'
 import { TransactionHeader } from '../../TransactionHeader'
 import { ParametersButton } from '../../ParametersButton'
+import { router } from 'expo-router'
 
 interface GenericViewProps {
   txInfo: SettingsChangeTransaction
@@ -32,6 +33,13 @@ export function GenericView({ txInfo, txData, executionInfo, txId }: GenericView
     () => formatGenericViewItems({ txInfo, txData, chain, executionInfo }),
     [txInfo, executionInfo, txData, chain],
   )
+
+  const handleViewActions = () => {
+    router.push({
+      pathname: '/transaction-actions',
+      params: { txId },
+    })
+  }
 
   return (
     <YStack gap="$4">
@@ -51,6 +59,7 @@ export function GenericView({ txInfo, txData, executionInfo, txId }: GenericView
       {'actionCount' in txInfo && (
         <SafeListItem
           label="Actions"
+          onPress={handleViewActions}
           rightNode={
             <View flexDirection="row" alignItems="center" gap="$2">
               <Badge themeName="badge_background_inverted" content={txInfo.actionCount as string} />


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/25

## How this PR fixes it

It takes the information from the `txData` contract call instead the `txInfo`.

## How to test it
Please follow the steps described in this ticket: https://github.com/safe-global/wallet-private-tasks/issues/25

## Screenshots
![Screenshot 2025-04-28 at 11 50 29](https://github.com/user-attachments/assets/beec37d3-039c-4b44-88d0-8cb2140ac965)

ps: the logo is white because we're pointing to staging endpoint, which some urls returns "access denied".

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
