### PR TITLE
Feat(Spaces): Implement address book upsertion

### DIFF
--- a/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -16,6 +16,7 @@ export type EthHashInfoProps = {
   address: string
   chainId?: string
   name?: string | null
+  spaceName?: string | null
   showAvatar?: boolean
   onlyName?: boolean
   showCopyButton?: boolean

--- a/apps/web/src/components/common/EthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/index.tsx
@@ -18,7 +18,7 @@ const EthHashInfo = ({
   const addressBooks = useAllAddressBooks()
   const link = chain && props.hasExplorer ? getBlockExplorerLink(chain, props.address) : undefined
   const addressBookName = chain ? addressBooks?.[chain.chainId]?.[props.address] : undefined
-  const name = showName ? addressBookName || props.name : undefined
+  const name = showName ? props.spaceName || addressBookName || props.name : undefined
 
   return (
     <SrcEthHashInfo

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddressBookContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddressBookContextMenu.tsx
@@ -15,6 +15,7 @@ import { useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
 import EditContactDialog from './EditContactDialog'
 import DeleteContactDialog from './DeleteContactDialog'
 import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import Track from '@/components/common/Track'
 
 enum ModalType {
   EDIT = 'edit',
@@ -55,20 +56,24 @@ const AddressBookContextMenu = ({ entry }: { entry: SpaceAddressBookItemDto }) =
         <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />
       </IconButton>
       <ContextMenu anchorEl={anchorEl} open={!!anchorEl} onClose={handleCloseContextMenu}>
-        <MenuItem onClick={(e) => handleOpenModal(e, ModalType.EDIT)}>
-          <ListItemIcon>
-            <SvgIcon component={EditIcon} inheritViewBox fontSize="small" color="success" />
-          </ListItemIcon>
-          <ListItemText>Edit</ListItemText>
-        </MenuItem>
+        <Track {...SPACE_EVENTS.EDIT_ADDRESS}>
+          <MenuItem onClick={(e) => handleOpenModal(e, ModalType.EDIT)}>
+            <ListItemIcon>
+              <SvgIcon component={EditIcon} inheritViewBox fontSize="small" color="success" />
+            </ListItemIcon>
+            <ListItemText>Edit</ListItemText>
+          </MenuItem>
+        </Track>
 
         {isAdmin && (
-          <MenuItem onClick={(e) => handleOpenModal(e, ModalType.REMOVE)}>
-            <ListItemIcon>
-              <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" color="error" />
-            </ListItemIcon>
-            <ListItemText>Remove</ListItemText>
-          </MenuItem>
+          <Track {...SPACE_EVENTS.REMOVE_ADDRESS}>
+            <MenuItem onClick={(e) => handleOpenModal(e, ModalType.REMOVE)}>
+              <ListItemIcon>
+                <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" color="error" />
+              </ListItemIcon>
+              <ListItemText>Remove</ListItemText>
+            </MenuItem>
+          </Track>
         )}
       </ContextMenu>
 

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
@@ -11,7 +11,7 @@ import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import useChains from '@/hooks/useChains'
 import type { ContactField } from './AddContact'
 import {
-  SpaceAddressBookItemDto,
+  type SpaceAddressBookItemDto,
   useAddressBooksUpsertAddressBookItemsV1Mutation,
 } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { showNotification } from '@/store/notificationsSlice'

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
@@ -8,6 +8,10 @@ import ListItemText from '@mui/material/ListItemText'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import type { ImportContactsFormValues } from '@/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog'
 import { getSelectedAddresses, getContactId } from '@/features/spaces/components/SpaceAddressBook/utils'
+import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
+import { useAddressBooksGetAddressBookItemsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 
 export type ContactItem = {
   chainId: string
@@ -19,8 +23,14 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
   const { control } = useFormContext<ImportContactsFormValues>()
   const selectedContacts = useWatch({ control, name: 'contacts' })
   const selectedAddresses = getSelectedAddresses(selectedContacts)
+  const spaceId = useCurrentSpaceId()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { currentData } = useAddressBooksGetAddressBookItemsV1Query(
+    { spaceId: Number(spaceId) },
+    { skip: !isUserSignedIn },
+  )
 
-  const spaceContacts: ContactItem[] = [] // TODO: Fetch via RTK Query
+  const spaceContacts = currentData?.data || []
 
   return (
     <List
@@ -38,10 +48,7 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
     >
       {contactItems.map((contactItem) => {
         const contactItemId = getContactId(contactItem)
-        const alreadyAdded = spaceContacts.some(
-          (spaceContact) =>
-            spaceContact.address === contactItem.address && spaceContact.chainId === contactItem.chainId,
-        )
+        const alreadyAdded = spaceContacts.some((spaceContact) => spaceContact.address === contactItem.address)
 
         return (
           <Controller
@@ -58,7 +65,9 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
 
               return (
                 <Tooltip
-                  title={isSameAddressSelected ? 'There is already an item with this address selected' : undefined}
+                  title={
+                    isSameAddressSelected || alreadyAdded ? 'You already added a contact with this address.' : undefined
+                  }
                   arrow
                 >
                   <ListItem className={css.safeItem} disablePadding>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
@@ -12,6 +12,7 @@ import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import { useAddressBooksGetAddressBookItemsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
 
 export type ContactItem = {
   chainId: string
@@ -48,7 +49,9 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
     >
       {contactItems.map((contactItem) => {
         const contactItemId = getContactId(contactItem)
-        const alreadyAdded = spaceContacts.some((spaceContact) => spaceContact.address === contactItem.address)
+        const alreadyAdded = spaceContacts.some((spaceContact) =>
+          sameAddress(spaceContact.address, contactItem.address),
+        )
 
         return (
           <Controller

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -29,7 +29,7 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
             <Identicon address={entry.address} size={32} />
             <Stack direction="column" spacing={0.5}>
               <EthHashInfo
-                name={entry.name}
+                spaceName={entry.name}
                 showAvatar={false}
                 address={entry.address}
                 shortAddress={false}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/utils.test.ts
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/utils.test.ts
@@ -92,7 +92,7 @@ describe('space address book utils', () => {
       }
 
       const result = createContactItems(data)
-      expect(result).toEqual([{ chainId: '1', address: '0x123', name: 'Alice' }])
+      expect(result).toEqual([{ chainIds: ['1'], address: '0x123', name: 'Alice' }])
     })
 
     it('filters out entries without a name and only keeps valid items', () => {
@@ -108,8 +108,8 @@ describe('space address book utils', () => {
       expect(result).toHaveLength(2)
       expect(result).toEqual(
         expect.arrayContaining([
-          { chainId: '1', address: '0x123', name: 'Alice' },
-          { chainId: '5', address: '0xABC', name: 'Charlie' },
+          { chainIds: ['1'], address: '0x123', name: 'Alice' },
+          { chainIds: ['5'], address: '0xABC', name: 'Charlie' },
         ]),
       )
     })
@@ -127,9 +127,9 @@ describe('space address book utils', () => {
       expect(result).toHaveLength(3)
       expect(result).toEqual(
         expect.arrayContaining([
-          { chainId: '1', address: '0x123', name: 'Alice' },
-          { chainId: '1', address: '0x456', name: 'Bob' },
-          { chainId: '5', address: '0xABC', name: 'Charlie' },
+          { chainIds: ['1'], address: '0x123', name: 'Alice' },
+          { chainIds: ['1'], address: '0x456', name: 'Bob' },
+          { chainIds: ['5'], address: '0xABC', name: 'Charlie' },
         ]),
       )
     })

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/utils.ts
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/utils.ts
@@ -1,6 +1,7 @@
 import type { AddressBookState } from '@/store/addressBookSlice'
 import type { ContactItem } from '@/features/spaces/components/SpaceAddressBook/Import/ContactsList'
 import type { ImportContactsFormValues } from '@/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog'
+import type { AddressBookItem } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 
 export const flattenAddressBook = (allAddressBooks: AddressBookState): ContactItem[] => {
   return Object.entries(allAddressBooks).flatMap(([chainId, addressBook]) => {
@@ -19,12 +20,12 @@ export const createContactItems = (data: ImportContactsFormValues) => {
       if (!name) return
 
       return {
-        chainId,
+        chainIds: [chainId],
         address,
         name,
       }
     })
-    .filter(Boolean) as ContactItem[]
+    .filter(Boolean) as AddressBookItem[]
 }
 
 export const getSelectedAddresses = (contacts: ImportContactsFormValues['contacts']) => {

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -157,6 +157,14 @@ export const SPACE_EVENTS = {
     action: 'Import address book',
     category: SPACE_CATEGORY,
   },
+  EDIT_ADDRESS: {
+    action: 'Open edit address',
+    category: SPACE_CATEGORY,
+  },
+  EDIT_ADDRESS_SUBMIT: {
+    action: 'Submit edit address',
+    category: SPACE_CATEGORY,
+  },
 }
 
 export enum SPACE_LABELS {


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/192

## How this PR fixes it

- Adds the upsertion call to the Import, Add contacts and Edit contact dialog
- Shows a success message if it succeeds
- Adds tracking for edit and remove to the buttons
- Disables items during the import if they are already added

## How to test it

1. Open a space
2. Go to address book
3. Press the import button and select one or more items
4. Submit the form
5. Observe a success message and the items show up in the list
6. Do the same with Add contact
7. Do the same with Edit contact
8. Make sure there are GA events when opening and submitting each action (import, add, edit)

## Screenshots
<img width="632" alt="Screenshot 2025-04-28 at 14 38 31" src="https://github.com/user-attachments/assets/78696d8a-03ca-4d84-9dcc-349257c5e43e" />
<img width="547" alt="Screenshot 2025-04-28 at 14 38 46" src="https://github.com/user-attachments/assets/d5a1b750-304d-4197-a322-3ce0b310a5d1" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
