### PR TITLE
feat(web): add optional custom paramaters for safe apps

### DIFF
--- a/apps/web/src/components/safe-apps/AppFrame/SafeAppIframe.tsx
+++ b/apps/web/src/components/safe-apps/AppFrame/SafeAppIframe.tsx
@@ -1,4 +1,5 @@
 import type { MutableRefObject, ReactElement } from 'react'
+import type { SafeAppDataWithPermissions } from '@/components/safe-apps/types'
 import css from './styles.module.css'
 
 type SafeAppIFrameProps = {
@@ -7,19 +8,30 @@ type SafeAppIFrameProps = {
   title?: string
   iframeRef?: MutableRefObject<HTMLIFrameElement | null>
   onLoad?: () => void
+  safeApp?: SafeAppDataWithPermissions
 }
 
 // see sandbox mdn docs for more details https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
 const IFRAME_SANDBOX_ALLOWED_FEATURES =
   'allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-forms allow-downloads allow-orientation-lock'
 
-const SafeAppIframe = ({ appUrl, allowedFeaturesList, iframeRef, onLoad, title }: SafeAppIFrameProps): ReactElement => {
+const SafeAppIframe = ({
+  appUrl,
+  allowedFeaturesList,
+  iframeRef,
+  onLoad,
+  title,
+  safeApp,
+}: SafeAppIFrameProps): ReactElement => {
+  // Use the original URL with parameters if available, otherwise fallback to the provided URL
+  const safeAppUrl = safeApp?.originalUrl || appUrl
+
   return (
     <iframe
       className={css.iframe}
       id={`iframe-${appUrl}`}
       ref={iframeRef}
-      src={appUrl}
+      src={safeAppUrl}
       title={title}
       onLoad={onLoad}
       sandbox={IFRAME_SANDBOX_ALLOWED_FEATURES}

--- a/apps/web/src/components/safe-apps/types.ts
+++ b/apps/web/src/components/safe-apps/types.ts
@@ -50,4 +50,7 @@ export const isBrowserFeature = (featureKey: string): featureKey is AllowedFeatu
 
 export type AllowedFeatureSelection = { feature: AllowedFeatures; checked: boolean }
 
-export type SafeAppDataWithPermissions = SafeAppData & { safeAppsPermissions: AllowedFeatures[] }
+export type SafeAppDataWithPermissions = SafeAppData & {
+  safeAppsPermissions: AllowedFeatures[]
+  originalUrl?: string
+}

--- a/apps/web/src/services/safe-apps/manifest.ts
+++ b/apps/web/src/services/safe-apps/manifest.ts
@@ -1,5 +1,5 @@
 import type { AllowedFeatures, SafeAppDataWithPermissions } from '@/components/safe-apps/types'
-import { isRelativeUrl, trimTrailingSlash } from '@/utils/url'
+import { isRelativeUrl, trimTrailingSlash, stripURLParams } from '@/utils/url'
 import { SafeAppAccessPolicyTypes } from '@safe-global/safe-gateway-typescript-sdk'
 
 type AppManifestIcon = {
@@ -56,7 +56,9 @@ const getAppLogoUrl = (appUrl: string, { icons = [], iconPath = '' }: AppManifes
 }
 
 const fetchAppManifest = async (appUrl: string, timeout = 5000): Promise<unknown> => {
-  const normalizedUrl = trimTrailingSlash(appUrl)
+  // Strip URL parameters for fetching the manifest
+  const baseUrl = stripURLParams(appUrl)
+  const normalizedUrl = trimTrailingSlash(baseUrl)
   const manifestUrl = `${normalizedUrl}/manifest.json`
 
   // A lot of apps are hosted on IPFS and IPFS never times out, so we add our own timeout
@@ -89,7 +91,10 @@ const fetchSafeAppFromManifest = async (
   appUrl: string,
   currentChainId: string,
 ): Promise<SafeAppDataWithPermissions> => {
-  const normalizedAppUrl = trimTrailingSlash(appUrl)
+  // Strip URL parameters for the normalized app URL but keep the original URL for the iframe
+  const baseUrl = stripURLParams(appUrl)
+  const normalizedAppUrl = trimTrailingSlash(baseUrl)
+  // Use the base URL to fetch the manifest
   const appManifest = await fetchAppManifest(appUrl)
 
   if (!isAppManifestValid(appManifest)) {
@@ -98,10 +103,14 @@ const fetchSafeAppFromManifest = async (
 
   const iconUrl = getAppLogoUrl(normalizedAppUrl, appManifest)
 
+  // Preserve the original URL with parameters
+  const originalUrl = appUrl
+
   return {
     // Must satisfy https://docs.djangoproject.com/en/5.0/ref/models/fields/#positiveintegerfield
     id: Math.round(Math.random() * 1e9 + 1e6),
-    url: normalizedAppUrl,
+    url: normalizedAppUrl, // Store the base URL without parameters for matching
+    originalUrl, // Store the original URL with parameters
     name: appManifest.name,
     description: appManifest.description,
     accessControl: { type: SafeAppAccessPolicyTypes.NoRestrictions },

--- a/apps/web/src/utils/url.ts
+++ b/apps/web/src/utils/url.ts
@@ -43,3 +43,14 @@ export const getOriginPath = (url: string): string => {
     return url
   }
 }
+
+// Function to strip URL parameters, returning only the base URL
+export const stripURLParams = (url: string): string => {
+  try {
+    const urlObj = new URL(url)
+    return `${urlObj.origin}${urlObj.pathname}`
+  } catch (e) {
+    console.error('Error parsing URL', url, e)
+    return url
+  }
+}


### PR DESCRIPTION
## What it solves
Safe Apps cannot properly handle URL parameters (like UTM tracking) because they interfere with manifest loading. This PR implements a solution that allows Safe Apps to maintain URL parameters while ensuring correct manifest loading.

Resolves #187


## How this PR fixes it
- Added `stripURLParams` to strip URL parameters, returning only the base URL
- Added `originalUrl` to `SafeAppDataWithPermissions` type to track URLs with parameters
- Modified manifest fetching to use clean URLs while preserving original parameters
- Updated iframe component to use the full URL with parameters

## How to test it
- Start local development server
- Add a Custom Safe App
- Use URL https://app.venus.io/#/?utm_source=SafeWallet
- App can be added
- Apps loads correctly

## Screenshots
<img width="1512" alt="Screenshot 2025-04-28 at 15 36 38" src="https://github.com/user-attachments/assets/5682e175-ff26-4171-ad1f-b51424c48abe" />

## Checklist

- [] I've tested the branch on mobile (not applicable) 📱
- [] I've documented how it affects the analytics (not applicable) 📊
- [] I've written a unit/e2e test for it (if applicable) 🧑‍💻
