### PR TITLE
Fix(mobile): Adjust multiSend confirmation view to be according to figma

### DIFF
--- a/apps/mobile/src/components/Badge/Badge.tsx
+++ b/apps/mobile/src/components/Badge/Badge.tsx
@@ -40,7 +40,13 @@ export const Badge = ({
   if (circular) {
     return (
       <Theme name={themeName}>
-        <Circle testID={testID} size={circleSize} backgroundColor={'$background'} {...circleProps}>
+        <Circle
+          testID={testID}
+          size={circleSize}
+          backgroundColor={'$background'}
+          borderColor={'$borderColor'}
+          {...circleProps}
+        >
           {contentToRender}
         </Circle>
       </Theme>

--- a/apps/mobile/src/components/Badge/theme.ts
+++ b/apps/mobile/src/components/Badge/theme.ts
@@ -56,6 +56,7 @@ export const badgeTheme = {
   light_badge_background: {
     color: tokens.color.textPrimaryLight,
     background: tokens.color.logoBackgroundLight,
+    borderColor: tokens.color.logoBackgroundLight,
   },
   light_badge_error: {
     color: tokens.color.errorMainLight,

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/utils.tsx
@@ -9,6 +9,8 @@ import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { Identicon } from '@/src/components/Identicon'
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
 import { CopyButton } from '@/src/components/CopyButton'
+import { TouchableOpacity } from 'react-native'
+import useOpenExplorer from '@/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer'
 
 export const getSignerName = (txInfo: NormalizedSettingsChangeTransaction) => {
   if (!txInfo.settingsInfo) {
@@ -30,6 +32,7 @@ export const formatAddSignerItems = (
   executionInfo: MultisigExecutionDetails,
 ) => {
   const newSignerAddress = getSignerName(txInfo)
+  const viewOnExplorer = useOpenExplorer(txInfo.settingsInfo?.owner?.value)
 
   return [
     {
@@ -40,7 +43,9 @@ export const formatAddSignerItems = (
           <Text fontSize="$4">{newSignerAddress}</Text>
           <CopyButton value={txInfo.settingsInfo?.owner?.value} color={'$textSecondaryLight'} />
 
-          <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+          <TouchableOpacity onPress={viewOnExplorer}>
+            <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+          </TouchableOpacity>
         </View>
       ),
     },

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
@@ -43,9 +43,7 @@ export function Contract({ txInfo, executionInfo, txId }: ContractProps) {
         submittedAt={executionInfo.submittedAt}
       />
 
-      <ListTable items={items}>
-        <ParametersButton txId={txId} />
-      </ListTable>
+      <ListTable items={items}>{!txInfo.actionCount && <ParametersButton txId={txId} />}</ListTable>
 
       {txInfo.actionCount && (
         <SafeListItem

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
@@ -8,11 +8,14 @@ import { CustomTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { CopyButton } from '@/src/components/CopyButton'
+import { TouchableOpacity } from 'react-native'
 
+import useOpenExplorer from '@/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer'
 const mintBadgeProps: CircleProps = { borderRadius: '$2', paddingHorizontal: '$2', paddingVertical: '$1' }
 
 export const formatContractItems = (txInfo: CustomTransactionInfo, chain: Chain) => {
   const contractName = txInfo.to.name ? ellipsis(txInfo.to.name, 18) : shortenAddress(txInfo.to.value)
+  const viewOnExplorer = useOpenExplorer(txInfo.to.value)
 
   return [
     {
@@ -29,14 +32,18 @@ export const formatContractItems = (txInfo: CustomTransactionInfo, chain: Chain)
     },
     {
       label: 'Contract',
-      render: () => (
-        <View flexDirection="row" alignItems="center" gap="$2">
-          <Logo logoUri={txInfo.to.logoUri} size="$6" />
-          <Text fontSize="$4">{contractName}</Text>
-          <CopyButton value={txInfo.to.value} color={'$textSecondaryLight'} />
-          <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
-        </View>
-      ),
+      render: () => {
+        return (
+          <View flexDirection="row" alignItems="center" gap="$2">
+            <Logo logoUri={txInfo.to.logoUri} size="$6" />
+            <Text fontSize="$4">{contractName}</Text>
+            <CopyButton value={txInfo.to.value} color={'$textSecondaryLight'} />
+            <TouchableOpacity onPress={viewOnExplorer}>
+              <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+            </TouchableOpacity>
+          </View>
+        )
+      },
     },
     {
       label: 'Network',

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/utils.tsx
@@ -54,6 +54,7 @@ export const formatGenericViewItems = ({
           )}
           <Text fontSize="$4">{genericViewName}</Text>
           <CopyButton value={txData.to.value} color={'$textSecondaryLight'} />
+
           <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
         </View>
       ),

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/utils.tsx
@@ -8,9 +8,12 @@ import { getSignerName } from '../AddSigner/utils'
 
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
 import { CopyButton } from '@/src/components/CopyButton'
+import { TouchableOpacity } from 'react-native'
+import useOpenExplorer from '@/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer'
 
 export const formatRemoveSignerItems = (txInfo: NormalizedSettingsChangeTransaction, chain: Chain) => {
   const newRemovedSigners = getSignerName(txInfo)
+  const viewOnExplorer = useOpenExplorer(txInfo.settingsInfo?.owner?.value)
 
   return [
     {
@@ -20,7 +23,9 @@ export const formatRemoveSignerItems = (txInfo: NormalizedSettingsChangeTransact
           <Identicon address={txInfo.settingsInfo?.owner?.value} size={24} />
           <Text fontSize="$4">{newRemovedSigners}</Text>
           <CopyButton value={txInfo.settingsInfo?.owner?.value} color={'$textSecondaryLight'} />
-          <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+          <TouchableOpacity onPress={viewOnExplorer}>
+            <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+          </TouchableOpacity>
         </View>
       ),
     },

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SendNFT/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SendNFT/utils.tsx
@@ -8,7 +8,12 @@ import { Address } from '@/src/types/address'
 import { Identicon } from '@/src/components/Identicon'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import { TouchableOpacity } from 'react-native'
+import useOpenExplorer from '@/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer'
+
 export const formatSendNFTItems = (txInfo: TransferTransactionInfo, chain: Chain) => {
+  const viewOnExplorer = useOpenExplorer(txInfo.recipient.value)
+
   return [
     {
       label: 'New signer',
@@ -19,7 +24,9 @@ export const formatSendNFTItems = (txInfo: TransferTransactionInfo, chain: Chain
             {txInfo.recipient.name ? ellipsis(txInfo.recipient.name, 18) : shortenAddress(txInfo.recipient.value)}
           </Text>
           <SafeFontIcon name="copy" size={14} color="textSecondaryLight" />
-          <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+          <TouchableOpacity onPress={viewOnExplorer}>
+            <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+          </TouchableOpacity>
         </View>
       ),
     },

--- a/apps/mobile/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer.ts
+++ b/apps/mobile/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer.ts
@@ -1,0 +1,20 @@
+import { useAppSelector } from '@/src/store/hooks'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { RootState } from '@/src/store'
+import { selectChainById } from '@/src/store/chains'
+import { getExplorerLink } from '@safe-global/utils/utils/gateway'
+import { Linking } from 'react-native'
+
+function useOpenExplorer(address: string) {
+  const activeSafe = useDefinedActiveSafe()
+  const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
+
+  const viewOnExplorer = () => {
+    const link = getExplorerLink(address, activeChain.blockExplorerUriTemplate)
+    Linking.openURL(link.href)
+  }
+
+  return viewOnExplorer
+}
+
+export default useOpenExplorer


### PR DESCRIPTION
## What it solves

Resolves https://github.com/orgs/safe-global/projects/1/views/10?pane=issue&itemId=103133072&issue=safe-global%7Cwallet-private-tasks%7C33

## How this PR fixes it
- Hides the parameters button in the header of multisend contract
- Adjust the border of the Logo component in light mode
- Adds explorer link functionality for all the confirmation views that are missing this implementation.

## How to test it
Follow the steps described here: https://github.com/orgs/safe-global/projects/1/views/10?pane=issue&itemId=103133072&issue=safe-global%7Cwallet-private-tasks%7C33

## Screenshots
<img width="251" alt="Screenshot 2025-04-29 at 11 56 28" src="https://github.com/user-attachments/assets/2ba28fd7-1323-4b11-b5c2-a11fce6b2618" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
