### PR TITLE
Fix(mobile): Remove "Join Account" button from account sheet

### DIFF
--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.test.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.test.tsx
@@ -6,6 +6,5 @@ describe('MyAccountsFooter', () => {
     const container = render(<MyAccountsFooter />)
 
     expect(container.getByText('Add existing account')).toBeDefined()
-    expect(container.getByText('Join new account')).toBeDefined()
   })
 })

--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
@@ -1,10 +1,8 @@
 import { Badge } from '@/src/components/Badge'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import React from 'react'
-import { Alert, TouchableOpacity } from 'react-native'
 import { styled, Text, View } from 'tamagui'
 import { Link } from 'expo-router'
-import { COMING_SOON_MESSAGE, COMING_SOON_TITLE } from '@/src/config/constants'
 const MyAccountsFooterContainer = styled(View, {
   borderTopWidth: 1,
   borderTopColor: '$colorSecondary',
@@ -21,9 +19,6 @@ const MyAccountsButton = styled(View, {
 })
 
 export function MyAccountsFooter() {
-  const onJoinAccountClick = () => {
-    Alert.alert(COMING_SOON_TITLE, COMING_SOON_MESSAGE)
-  }
   return (
     <MyAccountsFooterContainer paddingBottom={'$7'}>
       <Link href={'/(import-accounts)'} asChild>
@@ -41,18 +36,6 @@ export function MyAccountsFooter() {
           </Text>
         </MyAccountsButton>
       </Link>
-
-      <TouchableOpacity onPress={onJoinAccountClick}>
-        <MyAccountsButton testID="join-new-account">
-          <View paddingLeft="$2">
-            <Badge themeName="badge_background" circleSize="$10" content={<SafeFontIcon size={20} name="owners" />} />
-          </View>
-
-          <Text fontSize="$4" fontWeight={600}>
-            Join new account
-          </Text>
-        </MyAccountsButton>
-      </TouchableOpacity>
     </MyAccountsFooterContainer>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/orgs/safe-global/projects/1/views/10?pane=issue&itemId=106238218&issue=safe-global%7Cwallet-private-tasks%7C174

## How this PR fixes it
It removes the join account code from `account-sheet` view.

## How to test it
- Add a wallet in the app
- Go to your account dropdown

**Expected behavior**
Join account button should not appears anymore.

## Screenshots
<img width="251" alt="Screenshot 2025-04-29 at 12 03 38" src="https://github.com/user-attachments/assets/c6ffd67b-a612-4e5d-9bbe-6492f88746ab" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
