### PR TITLE
Fix(mobile): show contract name in enable module action

### DIFF
--- a/apps/mobile/src/features/ActionDetails/utils.tsx
+++ b/apps/mobile/src/features/ActionDetails/utils.tsx
@@ -33,6 +33,25 @@ const TxOptions = ({ value }: { value: string }) => {
   )
 }
 
+const getContractItemLayout = ({
+  logoUri,
+  value,
+  name,
+}: {
+  logoUri?: string | null
+  value: string
+  name?: string | null
+}) => ({
+  label: 'Contract',
+  render: () => (
+    <View flexDirection="row" alignItems="center" gap="$2">
+      {logoUri ? <Logo logoUri={logoUri} size="$6" /> : <Identicon address={value as Address} size={24} />}
+      <Text fontSize="$4">{ellipsis(name || value, 16)}</Text>
+      <TxOptions value={value} />
+    </View>
+  ),
+})
+
 export const formatActionDetails = ({ txData, action }: formatActionDetailsReturn): ListTableItem[] => {
   if (!txData) {
     return []
@@ -69,20 +88,9 @@ export const formatActionDetails = ({ txData, action }: formatActionDetailsRetur
   const contractCall = getContractCall(action, txData.addressInfoIndex as AddressInfoIndex)
 
   if (contractCall) {
-    columns.push({
-      label: 'Contract',
-      render: () => (
-        <View flexDirection="row" alignItems="center" gap="$2">
-          {contractCall.logoUri ? (
-            <Logo logoUri={contractCall.logoUri} size="$6" />
-          ) : (
-            <Identicon address={contractCall.value as Address} size={24} />
-          )}
-          <Text fontSize="$4">{ellipsis(contractCall.name || contractCall.value, 16)}</Text>
-          <TxOptions value={contractCall.value} />
-        </View>
-      ),
-    })
+    columns.push(getContractItemLayout(contractCall))
+  } else if (action.to) {
+    columns.push(getContractItemLayout({ value: action.to }))
   }
 
   if (action.dataDecoded) {


### PR DESCRIPTION
## What it solves

Resolves https://github.com/orgs/safe-global/projects/1/views/10?pane=issue&itemId=103102381&issue=safe-global%7Cwallet-private-tasks%7C25

## How this PR fixes it
It adds the `to` information of the action, in case the contractCall info is not present.

## How to test it
follow the steps described in the issue: https://github.com/orgs/safe-global/projects/1/views/10?pane=issue&itemId=103102381&issue=safe-global%7Cwallet-private-tasks%7C25 and the contract address with icon should appears in the enable module action.

## Screenshots
<img width="251" alt="Screenshot 2025-04-29 at 13 11 12" src="https://github.com/user-attachments/assets/66547b2a-9be1-4d7c-bbd1-5b2b0e002ef5" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
