### PR TITLE
fix(web): use recommended nonce when editing the nonce is allowed

### DIFF
--- a/apps/web/src/components/tx-flow/SafeTxProvider.tsx
+++ b/apps/web/src/components/tx-flow/SafeTxProvider.tsx
@@ -60,7 +60,7 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const [isMassPayout, setIsMassPayout] = useState<boolean>()
 
   // Signed txs cannot be updated
-  const isSigned = safeTx && safeTx.signatures.size > 0
+  const isSigned = Boolean(safeTx && safeTx.signatures.size > 0)
 
   // Recommended nonce and safeTxGas
   const recommendedNonce = useRecommendedNonce()
@@ -69,14 +69,14 @@ const SafeTxProvider = ({ children }: { children: ReactNode }): ReactElement => 
   const canEdit = !isSigned && !isReadOnly
 
   // Priority to external nonce, then to the recommended one
-  const finalNonce = canEdit ? safeTx?.data.nonce : (nonce ?? recommendedNonce ?? safeTx?.data.nonce)
+  const finalNonce = canEdit ? (nonce ?? recommendedNonce ?? safeTx?.data.nonce) : safeTx?.data.nonce
   const finalSafeTxGas = canEdit
-    ? safeTx?.data.safeTxGas
-    : (safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas)
+    ? (safeTxGas ?? recommendedSafeTxGas ?? safeTx?.data.safeTxGas)
+    : safeTx?.data.safeTxGas
 
   // Update the tx when the nonce or safeTxGas change
   useEffect(() => {
-    if (canEdit || !safeTx?.data) return
+    if (!canEdit || !safeTx?.data) return
     if (safeTx.data.nonce === finalNonce && safeTx.data.safeTxGas === finalSafeTxGas) return
 
     setSafeTxError(undefined)


### PR DESCRIPTION
## What it solves
The recommended nonce is not used when creating a new transaction

## How this PR fixes it
Fixes the condition such that the `SafeTxProvider` uses the `recommendedNonce` when the form can be edited.

## How to test it
- Create a new transaction in a Safe that has queued transactions
- Observe that the nonce is chosen correctly to be at the end of the queue


## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
