### PR TITLE
fix(mobile): can’t edit signer

### DIFF
--- a/apps/mobile/src/features/Signer/Signer.container.tsx
+++ b/apps/mobile/src/features/Signer/Signer.container.tsx
@@ -1,5 +1,6 @@
 import { SignerView } from '@/src/features/Signer/components/SignerView'
-import { useLocalSearchParams, useNavigation } from 'expo-router'
+import { useLocalSearchParams } from 'expo-router'
+import { useNavigation } from '@react-navigation/native'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
 import { selectContactByAddress, upsertContact } from '@/src/store/addressBookSlice'
 import React, { useCallback, useEffect, useState } from 'react'


### PR DESCRIPTION
## What it solves
We are hitting this bug: https://github.com/expo/expo/issues/36475. If the screen in question is neested in a navigator the useNavigation hook from expo-router doesn’t end up on the current screen and calling setOptions doesn’t update the options on the correct screen.

Resolves #
Can't set a signer name

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
