### PR TITLE
refactor(CancelRecoveryFlow): migrate to new TxFlow logic

### DIFF
--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -3,7 +3,7 @@ import useTxStepper from './useTxStepper'
 import SafeTxProvider from './SafeTxProvider'
 import { TxInfoProvider } from './TxInfoProvider'
 import { TxSecurityProvider } from '../tx/security/shared/TxSecurityContext'
-import TxFlowProvider, { type TxFlowContextType } from './TxFlowProvider'
+import TxFlowProvider, { type TxFlowProviderProps, type TxFlowContextType } from './TxFlowProvider'
 import { TxFlowContent } from './common/TxFlowContent'
 import ReviewTransaction from '../tx/ReviewTransactionV2'
 import { ConfirmTxReceipt } from '../tx/ConfirmTxReceipt'
@@ -18,12 +18,13 @@ export type SubmitCallbackWithData<T> = (args: SubmitCallbackProps & { data?: T 
 type TxFlowProps<T extends unknown> = {
   children?: ReactNode[] | ReactNode
   initialData?: T
-  txId?: string
   onSubmit?: SubmitCallbackWithData<T>
-  onlyExecute?: boolean
-  isExecutable?: boolean
-  isRejection?: boolean
-  isBatch?: boolean
+  txId?: TxFlowProviderProps<T>['txId']
+  onlyExecute?: TxFlowProviderProps<T>['onlyExecute']
+  isExecutable?: TxFlowProviderProps<T>['isExecutable']
+  isRejection?: TxFlowProviderProps<T>['isRejection']
+  isBatch?: TxFlowProviderProps<T>['isBatch']
+  isBatchable?: TxFlowProviderProps<T>['isBatchable']
   ReviewTransactionComponent?: typeof ReviewTransaction
   eventCategory?: string
 } & TxFlowContextType['txLayoutProps']
@@ -43,6 +44,7 @@ export const TxFlow = <T extends unknown>({
   isExecutable,
   isRejection,
   isBatch,
+  isBatchable,
   ReviewTransactionComponent = ReviewTransaction,
   eventCategory,
   ...txLayoutProps
@@ -80,6 +82,7 @@ export const TxFlow = <T extends unknown>({
               isExecutable={isExecutable}
               isRejection={isRejection}
               isBatch={isBatch}
+              isBatchable={isBatchable}
             >
               <TxFlowContent>
                 {...childrenArray}

--- a/apps/web/src/components/tx-flow/TxFlowProvider.tsx
+++ b/apps/web/src/components/tx-flow/TxFlowProvider.tsx
@@ -68,6 +68,7 @@ export type TxFlowContextType<T extends unknown = any> = {
   txDetails?: TransactionDetails
   txDetailsLoading?: boolean
   isBatch: boolean
+  isBatchable: boolean
   role?: Role
 }
 
@@ -106,6 +107,7 @@ export const initialContext: TxFlowContextType = {
   willExecuteThroughRole: false,
   canExecuteThroughRole: false,
   isBatch: false,
+  isBatchable: true,
 }
 
 export const TxFlowContext = createContext<TxFlowContextType>(initialContext)
@@ -123,6 +125,7 @@ export type TxFlowProviderProps<T extends unknown> = {
   isRejection?: TxFlowContextType['isRejection']
   txLayoutProps?: TxFlowContextType['txLayoutProps']
   isBatch?: TxFlowContextType['isBatch']
+  isBatchable?: TxFlowContextType['isBatchable']
 }
 
 const TxFlowProvider = <T extends unknown>({
@@ -138,6 +141,7 @@ const TxFlowProvider = <T extends unknown>({
   txLayoutProps: defaultTxLayoutProps = initialContext.txLayoutProps,
   isRejection = initialContext.isRejection,
   isBatch = initialContext.isBatch,
+  isBatchable = initialContext.isBatchable,
 }: TxFlowProviderProps<T>): ReactElement => {
   const signer = useSigner()
   const isSafeOwner = useIsSafeOwner()
@@ -238,6 +242,7 @@ const TxFlowProvider = <T extends unknown>({
     txDetails,
     txDetailsLoading,
     isBatch,
+    isBatchable,
   }
 
   return <TxFlowContext.Provider value={value}>{children}</TxFlowContext.Provider>

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -26,10 +26,16 @@ const Batching = ({
   const { setTxFlow } = useContext(TxModalContext)
   const { addToBatch } = useTxActions()
   const { safeTx } = useContext(SafeTxContext)
-  const { isSubmitDisabled, setIsSubmitLoading, isSubmitLoading, setSubmitError, setIsRejectedByUser } =
-    useContext(TxFlowContext)
+  const {
+    isBatchable: isBatchableTxFlowContext,
+    isSubmitDisabled,
+    setIsSubmitLoading,
+    isSubmitLoading,
+    setSubmitError,
+    setIsRejectedByUser,
+  } = useContext(TxFlowContext)
 
-  const isBatchable = !!safeTx && !isDelegateCall(safeTx)
+  const isBatchable = isBatchableTxFlowContext && !!safeTx && !isDelegateCall(safeTx)
 
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault()
@@ -83,12 +89,10 @@ const Batching = ({
 
 const useShouldRegisterSlot = () => {
   const isCounterfactualSafe = useIsCounterfactualSafe()
-  const { isBatch, isBatchable, isProposing, willExecuteThroughRole, isCreation } = useContext(TxFlowContext)
+  const { isBatch, isProposing, willExecuteThroughRole, isCreation } = useContext(TxFlowContext)
   const isOwner = useIsSafeOwner()
 
-  return (
-    isBatchable && isOwner && isCreation && !isBatch && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
-  )
+  return isOwner && isCreation && !isBatch && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
 }
 
 const BatchingSlot = withSlot({

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -83,10 +83,12 @@ const Batching = ({
 
 const useShouldRegisterSlot = () => {
   const isCounterfactualSafe = useIsCounterfactualSafe()
-  const { isBatch, isProposing, willExecuteThroughRole, isCreation } = useContext(TxFlowContext)
+  const { isBatch, isBatchable, isProposing, willExecuteThroughRole, isCreation } = useContext(TxFlowContext)
   const isOwner = useIsSafeOwner()
 
-  return isOwner && isCreation && !isBatch && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
+  return (
+    isBatchable && isOwner && isCreation && !isBatch && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
+  )
 }
 
 const BatchingSlot = withSlot({

--- a/apps/web/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryFlowReview.tsx
+++ b/apps/web/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryFlowReview.tsx
@@ -2,7 +2,7 @@ import { trackEvent } from '@/services/analytics'
 import { RECOVERY_EVENTS } from '@/services/analytics/events/recovery'
 import { Typography } from '@mui/material'
 import { useContext } from 'react'
-import type { ReactElement } from 'react'
+import type { PropsWithChildren, ReactElement } from 'react'
 
 import { SafeTxContext } from '../../SafeTxProvider'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
@@ -11,15 +11,16 @@ import { createTx } from '@/services/tx/tx-sender'
 import ErrorMessage from '@/components/tx/ErrorMessage'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
 import useAsync from '@safe-global/utils/hooks/useAsync'
-import ReviewTransaction from '@/components/tx/ReviewTransaction'
+import ReviewTransaction from '@/components/tx/ReviewTransactionV2'
 
 export function CancelRecoveryFlowReview({
   recovery,
   onSubmit,
-}: {
+  children,
+}: PropsWithChildren<{
   recovery: RecoveryQueueItem
   onSubmit: () => void
-}): ReactElement {
+}>): ReactElement {
   const web3ReadOnly = useWeb3ReadOnly()
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
 
@@ -37,7 +38,7 @@ export function CancelRecoveryFlowReview({
   }
 
   return (
-    <ReviewTransaction onSubmit={handleSubmit} isBatchable={false}>
+    <ReviewTransaction onSubmit={handleSubmit}>
       <Typography mb={1}>
         All actions initiated by the Recoverer will be cancelled. The current signers will remain the signers of the
         Safe Account.
@@ -48,6 +49,8 @@ export function CancelRecoveryFlowReview({
         {recovery.isMalicious ? 'malicious transaction' : 'recovery proposal'}. It requires other signer signatures in
         order to be executed.
       </ErrorMessage>
+
+      {children}
     </ReviewTransaction>
   )
 }

--- a/apps/web/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryOverview.tsx
+++ b/apps/web/src/components/tx-flow/flows/CancelRecovery/CancelRecoveryOverview.tsx
@@ -9,9 +9,11 @@ import css from './styles.module.css'
 import ReplaceTxIcon from '@/public/images/transactions/replace-tx.svg'
 import { TxModalContext } from '../..'
 import TxCard from '../../common/TxCard'
+import { TxFlowContext } from '../../TxFlowProvider'
 
-export function CancelRecoveryOverview({ onSubmit }: { onSubmit: () => void }): ReactElement {
+export function CancelRecoveryOverview(): ReactElement {
   const { setTxFlow } = useContext(TxModalContext)
+  const { onNext } = useContext(TxFlowContext)
 
   const onClose = () => {
     setTxFlow(undefined)
@@ -38,7 +40,7 @@ export function CancelRecoveryOverview({ onSubmit }: { onSubmit: () => void }): 
             Go back
           </Button>
 
-          <Button data-testid="cancel-proposal-btn" variant="contained" onClick={onSubmit} className={css.button}>
+          <Button data-testid="cancel-proposal-btn" variant="contained" onClick={onNext} className={css.button}>
             Yes, cancel proposal
           </Button>
         </Box>

--- a/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/CancelRecovery/index.tsx
@@ -1,40 +1,38 @@
 import { useMemo, type ReactElement } from 'react'
-import TxLayout from '../../common/TxLayout'
-import type { TxStep } from '../../common/TxLayout'
 import { CancelRecoveryFlowReview } from './CancelRecoveryFlowReview'
 import { CancelRecoveryOverview } from './CancelRecoveryOverview'
-import useTxStepper from '../../useTxStepper'
 import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-state'
-import { ConfirmTxDetails } from '@/components/tx/ConfirmTxDetails'
 import { TxFlowType } from '@/services/analytics'
+import { TxFlow } from '../../TxFlow'
+import { TxFlowStep } from '../../TxFlowStep'
+import type ReviewTransaction from '@/components/tx/ReviewTransactionV2'
 
 const TITLE = 'Cancel Account recovery'
 
-function CancelRecoveryFlow({ recovery }: { recovery: RecoveryQueueItem }): ReactElement {
-  const { step, nextStep, prevStep } = useTxStepper<undefined>(undefined, TxFlowType.CANCEL_RECOVERY)
+type CancelRecoveryFlowProps = {
+  recovery: RecoveryQueueItem
+}
 
-  const steps = useMemo<TxStep[]>(
-    () => [
-      {
-        txLayoutProps: { title: TITLE, hideNonce: true },
-        content: <CancelRecoveryOverview key={0} onSubmit={() => nextStep(undefined)} />,
+function CancelRecoveryFlow({ recovery }: CancelRecoveryFlowProps): ReactElement {
+  const ReviewTransactionComponent = useMemo<typeof ReviewTransaction>(
+    () =>
+      function ReviewCancelRecovery(props) {
+        return <CancelRecoveryFlowReview recovery={recovery} {...props} />
       },
-      {
-        txLayoutProps: { title: 'Confirm transaction', subtitle: TITLE },
-        content: <CancelRecoveryFlowReview key={1} recovery={recovery} onSubmit={() => nextStep(undefined)} />,
-      },
-      {
-        txLayoutProps: { title: 'Confirm transaction details', subtitle: TITLE, fixedNonce: true },
-        content: <ConfirmTxDetails key={2} onSubmit={() => {}} />,
-      },
-    ],
-    [nextStep, recovery],
+    [recovery],
   )
 
   return (
-    <TxLayout step={step} onBack={prevStep} {...(steps?.[step]?.txLayoutProps || {})}>
-      {steps.map(({ content }) => content)}
-    </TxLayout>
+    <TxFlow
+      subtitle={TITLE}
+      eventCategory={TxFlowType.CANCEL_RECOVERY}
+      isBatchable={false}
+      ReviewTransactionComponent={ReviewTransactionComponent}
+    >
+      <TxFlowStep title={TITLE} subtitle="" hideNonce>
+        <CancelRecoveryOverview />
+      </TxFlowStep>
+    </TxFlow>
   )
 }
 


### PR DESCRIPTION
Migrates the CancelRecoveryFlow to the new logic.

Also adds `isBatchable` flag to TxFlowContext.