### PR TITLE
Fix typo in "expanded" test descriptions and format addressBookContacts export

### DIFF
--- a/apps/web/cypress/e2e/regression/add_owner.cy.js
+++ b/apps/web/cypress/e2e/regression/add_owner.cy.js
@@ -41,15 +41,15 @@ describe('Add Owners tests', () => {
   it('Verify that the "Name" field is auto-filled with the relevant name from Address Book', () => {
     cy.visit(constants.addressBookUrl + staticSafes.SEP_STATIC_SAFE_4)
     addressBook.clickOnCreateEntryBtn()
-    addressBook.typeInName(constants.addresBookContacts.user1.name)
-    addressBook.typeInAddress(constants.addresBookContacts.user1.address)
+    addressBook.typeInName(constants.addressBookContacts.user1.name)
+    addressBook.typeInAddress(constants.addressBookContacts.user1.address)
     addressBook.clickOnSaveEntryBtn()
-    addressBook.verifyNewEntryAdded(constants.addresBookContacts.user1.name, constants.addresBookContacts.user1.address)
+    addressBook.verifyNewEntryAdded(constants.addressBookContacts.user1.name, constants.addressBookContacts.user1.address)
     cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
     wallet.connectSigner(signer)
     owner.openAddOwnerWindow()
-    owner.typeOwnerAddress(constants.addresBookContacts.user1.address)
-    owner.verifyNewOwnerName(constants.addresBookContacts.user1.name)
+    owner.typeOwnerAddress(constants.addressBookContacts.user1.address)
+    owner.verifyNewOwnerName(constants.addressBookContacts.user1.name)
   })
 
   it('Verify that Name field not mandatory', () => {

--- a/apps/web/cypress/e2e/regression/replace_owner.cy.js
+++ b/apps/web/cypress/e2e/regression/replace_owner.cy.js
@@ -43,8 +43,8 @@ describe('Replace Owners tests', () => {
     wallet.connectSigner(signer)
     owner.waitForConnectionStatus()
     owner.openReplaceOwnerWindow(0)
-    owner.typeOwnerAddress(constants.addresBookContacts.user1.address)
-    owner.verifyNewOwnerName(constants.addresBookContacts.user1.name)
+    owner.typeOwnerAddress(constants.addressBookContacts.user1.address)
+    owner.verifyNewOwnerName(constants.addressBookContacts.user1.name)
   })
 
   it('Verify that Name field not mandatory. Verify confirmation for owner replacement is displayed', () => {

--- a/apps/web/cypress/e2e/smoke/add_owner.cy.js
+++ b/apps/web/cypress/e2e/smoke/add_owner.cy.js
@@ -27,13 +27,13 @@ describe('[SMOKE] Add Owners tests', () => {
     owner.typeOwnerAddress(main.generateRandomString(10))
     owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidFormat)
 
-    owner.typeOwnerAddress(constants.addresBookContacts.user1.address.toUpperCase())
+    owner.typeOwnerAddress(constants.addressBookContacts.user1.address.toUpperCase())
     owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
 
     owner.typeOwnerAddress(staticSafes.SEP_STATIC_SAFE_4)
     owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.ownSafe)
 
-    owner.typeOwnerAddress(constants.addresBookContacts.user1.address.replace('F', 'f'))
+    owner.typeOwnerAddress(constants.addressBookContacts.user1.address.replace('F', 'f'))
     owner.verifyErrorMsgInvalidAddress(constants.addressBookErrrMsg.invalidChecksum)
 
     owner.typeOwnerAddress(constants.DEFAULT_OWNER_ADDRESS)

--- a/apps/web/cypress/e2e/smoke/messages_offchain.cy.js
+++ b/apps/web/cypress/e2e/smoke/messages_offchain.cy.js
@@ -52,13 +52,13 @@ describe('[SMOKE] Offchain Messages tests', () => {
   })
 
   // mock
-  it('[SMOKE] Verify exapanded details for EIP 191 off-chain message', () => {
+  it('[SMOKE] Verify expanded details for EIP 191 off-chain message', () => {
     createTx.clickOnTransactionItemByIndex(2)
     cy.contains(typeMessagesOffchain.message2).should('be.visible')
   })
 
   // mock
-  it('[SMOKE] Verify exapanded details for EIP 712 off-chain message', () => {
+  it('[SMOKE] Verify expanded details for EIP 712 off-chain message', () => {
     const jsonString = createTx.messageNestedStr
     const values = [
       typeMessagesOffchain.name,

--- a/apps/web/cypress/support/constants.js
+++ b/apps/web/cypress/support/constants.js
@@ -243,7 +243,7 @@ export const nonceTooltipMsg = {
   mustBeNumber: 'Nonce must be a number',
 }
 
-export const addresBookContacts = {
+export const addressBookContacts = {
   user1: {
     address: '0x01A9F68e339da12565cfBc47fe7D6EdEcB11C46f',
     name: 'David',


### PR DESCRIPTION


**Description:**
This PR includes the following changes:

1. Fixed typo in test descriptions where "exapanded" was incorrectly spelled
   - Updated in messages_offchain.cy.js for both EIP 191 and EIP 712 test cases

2. Minor formatting fix in constants.js
   - Cleaned up spacing around addressBookContacts export declaration

These are minor cleanup changes that improve code readability and fix spelling errors in test descriptions.


