### PR TITLE
fix: remove localState from useTheme hook

### DIFF
--- a/apps/mobile/src/theme/hooks/useTheme.tsx
+++ b/apps/mobile/src/theme/hooks/useTheme.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import { AppState, ColorSchemeName, useColorScheme } from 'react-native'
+import { useCallback, useEffect } from 'react'
+import { AppState, useColorScheme } from 'react-native'
 import { updateSettings } from '@/src/store/settingsSlice'
 import { selectSettings } from '@/src/store/settingsSlice'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
@@ -8,7 +8,6 @@ import { ThemePreference } from '@/src/types/theme'
 export const useTheme = () => {
   const dispatch = useAppDispatch()
   const colorScheme = useColorScheme()
-  const [currentTheme, setTheme] = useState<ColorSchemeName>(colorScheme)
 
   const themePreference = useAppSelector(
     (state) => selectSettings(state, 'themePreference') ?? 'auto',
@@ -27,7 +26,7 @@ export const useTheme = () => {
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextAppState) => {
       if (nextAppState === 'active') {
-        setTheme(themePreference === 'auto' ? colorScheme : themePreference)
+        dispatch(updateSettings({ themePreference }))
       }
     })
 
@@ -36,5 +35,9 @@ export const useTheme = () => {
     }
   }, [colorScheme, themePreference])
 
-  return { themePreference, setThemePreference, currentTheme }
+  return {
+    themePreference,
+    setThemePreference,
+    currentTheme: themePreference === 'auto' ? colorScheme : themePreference,
+  }
 }


### PR DESCRIPTION
## What it solves

Resolves #XYZ (please replace with actual issue number)

## How this PR fixes it

This PR fixes a theme management issue in the mobile app by removing local state from the `useTheme` hook. Instead of maintaining a separate local state for the current theme, the hook now directly calculates and returns the current theme based on the theme preference and system color scheme.

Key changes:

- Removed `useState` hook and `currentTheme` local state from `useTheme`
- Modified the return value to calculate the theme dynamically
- Simplified the AppState change handler to only refresh the theme preference
- Removed unnecessary imports for `useState` and `ColorSchemeName`

This change eliminates potential state synchronization issues between the app's stored preferences and the displayed theme.

## How to test it

1. Open the app and navigate to the theme settings
2. Toggle between different theme options (Light, Dark, Auto)
3. Put the app in the background and then back to foreground
4. Verify that the theme correctly applies and persists after app state changes
5. If using "System" preference, verify that the app respects the device theme changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
