### PR TITLE
fix: contract icon size

### DIFF
--- a/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
@@ -22,6 +22,7 @@ export function TxContractInteractionCard({
 }: TxContractInteractionCardProps) {
   const logoUri = txInfo.to.logoUri
   const label = txInfo.to.name || 'Contract interaction'
+
   return (
     <SafeListItem
       label={label}
@@ -36,8 +37,16 @@ export function TxContractInteractionCard({
             {logoUri && <Avatar.Image backgroundColor="$color" accessibilityLabel={label} src={logoUri} />}
 
             <Avatar.Fallback backgroundColor="$background">
-              <View backgroundColor="$background" padding="$2" borderRadius={100}>
-                <SafeFontIcon name="code-blocks" color="$color" />
+              <View
+                backgroundColor="$background"
+                padding="$2"
+                flexDirection="row"
+                alignItems="center"
+                justifyContent="center"
+                borderRadius={100}
+                flex={1}
+              >
+                <SafeFontIcon name="code-blocks" color="$color" size={16} />
               </View>
             </Avatar.Fallback>
           </Theme>


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/105

## How this PR fixes it
It adds a flex: 1 property in the parent container of the icon to make it to have the full height of the its container, align it with flex properties and also changes the font-size of the icon in order to make it smaller.

## How to test it
Go to any safe tx history and look for a contract interaction transaction.

## Screenshots
<img width="502" alt="Screenshot 2025-05-05 at 09 51 57" src="https://github.com/user-attachments/assets/af15f035-d3a9-4ccc-a072-90e83561f546" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
