### PR TITLE
Fix(mobile): Etherscan link for token transactions

### DIFF
--- a/apps/mobile/src/features/ActionDetails/utils.tsx
+++ b/apps/mobile/src/features/ActionDetails/utils.tsx
@@ -28,7 +28,7 @@ const TxOptions = ({ value }: { value: string }) => {
   return (
     <View flexDirection="row" alignItems="center">
       <CopyButton value={value} color={'$textSecondaryLight'} />
-      <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+      <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
     </View>
   )
 }
@@ -79,7 +79,7 @@ export const formatActionDetails = ({ txData, action }: formatActionDetailsRetur
         <View flexDirection="row" alignItems="center" gap="$2">
           <Identicon address={action.to as Address} size={24} />
           <EthAddress copy copyProps={{ color: '$textSecondaryLight' }} address={action.to as Address} />
-          <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+          <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
         </View>
       ),
     })

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/AddSigner.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/AddSigner.tsx
@@ -11,6 +11,7 @@ import { ListTable } from '../../ListTable'
 import { TransactionHeader } from '../../TransactionHeader'
 import { ParametersButton } from '../../ParametersButton'
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
+import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
 
 interface AddSignerProps {
   txInfo: NormalizedSettingsChangeTransaction
@@ -21,9 +22,10 @@ interface AddSignerProps {
 export function AddSigner({ txInfo, executionInfo, txId }: AddSignerProps) {
   const activeSafe = useDefinedActiveSafe()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
+  const viewOnExplorer = useOpenExplorer(txInfo.settingsInfo?.owner?.value)
   const items = useMemo(
-    () => formatAddSignerItems(txInfo, activeChain, executionInfo),
-    [txInfo, activeChain, executionInfo],
+    () => formatAddSignerItems(txInfo, activeChain, executionInfo, viewOnExplorer),
+    [txInfo, activeChain, executionInfo, viewOnExplorer],
   )
   const newSignerAddress = getSignerName(txInfo)
 

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AddSigner/utils.tsx
@@ -10,7 +10,6 @@ import { Identicon } from '@/src/components/Identicon'
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
 import { CopyButton } from '@/src/components/CopyButton'
 import { TouchableOpacity } from 'react-native'
-import useOpenExplorer from '@/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer'
 
 export const getSignerName = (txInfo: NormalizedSettingsChangeTransaction) => {
   if (!txInfo.settingsInfo) {
@@ -30,9 +29,9 @@ export const formatAddSignerItems = (
   txInfo: NormalizedSettingsChangeTransaction,
   chain: Chain,
   executionInfo: MultisigExecutionDetails,
+  viewOnExplorer: () => void,
 ) => {
   const newSignerAddress = getSignerName(txInfo)
-  const viewOnExplorer = useOpenExplorer(txInfo.settingsInfo?.owner?.value)
 
   return [
     {
@@ -44,7 +43,7 @@ export const formatAddSignerItems = (
           <CopyButton value={txInfo.settingsInfo?.owner?.value} color={'$textSecondaryLight'} />
 
           <TouchableOpacity onPress={viewOnExplorer}>
-            <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+            <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
           </TouchableOpacity>
         </View>
       ),

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
@@ -13,6 +13,7 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Badge } from '@/src/components/Badge'
 import { ParametersButton } from '../../ParametersButton'
 import { router } from 'expo-router'
+import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
 
 interface ContractProps {
   txInfo: CustomTransactionInfo
@@ -23,7 +24,9 @@ interface ContractProps {
 export function Contract({ txInfo, executionInfo, txId }: ContractProps) {
   const activeSafe = useDefinedActiveSafe()
   const chain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
-  const items = formatContractItems(txInfo, chain)
+  const viewOnExplorer = useOpenExplorer(txInfo.to.value)
+
+  const items = useMemo(() => formatContractItems(txInfo, chain, viewOnExplorer), [txInfo, chain, viewOnExplorer])
 
   const handleViewActions = () => {
     router.push({

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
@@ -23,7 +23,7 @@ interface ContractProps {
 export function Contract({ txInfo, executionInfo, txId }: ContractProps) {
   const activeSafe = useDefinedActiveSafe()
   const chain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
-  const items = useMemo(() => formatContractItems(txInfo, chain), [txInfo, chain])
+  const items = formatContractItems(txInfo, chain)
 
   const handleViewActions = () => {
     router.push({

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
@@ -38,8 +38,9 @@ export const formatContractItems = (txInfo: CustomTransactionInfo, chain: Chain)
             <Logo logoUri={txInfo.to.logoUri} size="$6" />
             <Text fontSize="$4">{contractName}</Text>
             <CopyButton value={txInfo.to.value} color={'$textSecondaryLight'} />
+
             <TouchableOpacity onPress={viewOnExplorer}>
-              <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+              <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
             </TouchableOpacity>
           </View>
         )

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
@@ -10,12 +10,10 @@ import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { CopyButton } from '@/src/components/CopyButton'
 import { TouchableOpacity } from 'react-native'
 
-import useOpenExplorer from '@/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer'
 const mintBadgeProps: CircleProps = { borderRadius: '$2', paddingHorizontal: '$2', paddingVertical: '$1' }
 
-export const formatContractItems = (txInfo: CustomTransactionInfo, chain: Chain) => {
+export const formatContractItems = (txInfo: CustomTransactionInfo, chain: Chain, viewOnExplorer: () => void) => {
   const contractName = txInfo.to.name ? ellipsis(txInfo.to.name, 18) : shortenAddress(txInfo.to.value)
-  const viewOnExplorer = useOpenExplorer(txInfo.to.value)
 
   return [
     {

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/GenericView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/GenericView.tsx
@@ -18,7 +18,7 @@ import { ListTable } from '../../ListTable'
 import { TransactionHeader } from '../../TransactionHeader'
 import { ParametersButton } from '../../ParametersButton'
 import { router } from 'expo-router'
-
+import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
 interface GenericViewProps {
   txInfo: SettingsChangeTransaction
   executionInfo: MultisigExecutionDetails
@@ -29,9 +29,10 @@ interface GenericViewProps {
 export function GenericView({ txInfo, txData, executionInfo, txId }: GenericViewProps) {
   const activeSafe = useDefinedActiveSafe()
   const chain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
+  const viewOnExplorer = useOpenExplorer(txData.to.value)
   const items = useMemo(
-    () => formatGenericViewItems({ txInfo, txData, chain, executionInfo }),
-    [txInfo, executionInfo, txData, chain],
+    () => formatGenericViewItems({ txInfo, txData, chain, executionInfo, viewOnExplorer }),
+    [txInfo, executionInfo, txData, chain, viewOnExplorer],
   )
 
   const handleViewActions = () => {

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/utils.tsx
@@ -14,6 +14,7 @@ import {
 import { Identicon } from '@/src/components/Identicon'
 import { Address } from '@/src/types/address'
 import { CopyButton } from '@/src/components/CopyButton'
+import { TouchableOpacity } from 'react-native'
 
 const mintBadgeProps: CircleProps = { borderRadius: '$2', paddingHorizontal: '$2', paddingVertical: '$1' }
 
@@ -22,11 +23,13 @@ export const formatGenericViewItems = ({
   txData,
   chain,
   executionInfo,
+  viewOnExplorer,
 }: {
   txInfo: SettingsChangeTransaction
   txData: TransactionData
   chain: Chain
   executionInfo: MultisigExecutionDetails
+  viewOnExplorer: () => void
 }) => {
   const genericViewName = txData.to.name ? ellipsis(txData.to.name, 18) : shortenAddress(txData.to.value)
 
@@ -55,7 +58,9 @@ export const formatGenericViewItems = ({
           <Text fontSize="$4">{genericViewName}</Text>
           <CopyButton value={txData.to.value} color={'$textSecondaryLight'} />
 
-          <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+          <TouchableOpacity onPress={viewOnExplorer}>
+            <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
+          </TouchableOpacity>
         </View>
       ),
     },

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/RemoveSigner.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/RemoveSigner.tsx
@@ -13,6 +13,7 @@ import { ListTable } from '../../ListTable'
 import { getSignerName } from '../AddSigner/utils'
 import { ParametersButton } from '../../ParametersButton'
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
+import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
 
 interface RemoveSignerProps {
   txInfo: NormalizedSettingsChangeTransaction
@@ -23,7 +24,12 @@ interface RemoveSignerProps {
 export function RemoveSigner({ txInfo, executionInfo, txId }: RemoveSignerProps) {
   const activeSafe = useDefinedActiveSafe()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
-  const items = useMemo(() => formatRemoveSignerItems(txInfo, activeChain), [txInfo, activeChain])
+  const viewOnExplorer = useOpenExplorer(txInfo.settingsInfo?.owner?.value)
+
+  const items = useMemo(
+    () => formatRemoveSignerItems(txInfo, activeChain, viewOnExplorer),
+    [txInfo, activeChain, viewOnExplorer],
+  )
   const newRemovedSigners = getSignerName(txInfo)
 
   return (

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/RemoveSigner/utils.tsx
@@ -9,11 +9,13 @@ import { getSignerName } from '../AddSigner/utils'
 import { NormalizedSettingsChangeTransaction } from '../../ConfirmationView/types'
 import { CopyButton } from '@/src/components/CopyButton'
 import { TouchableOpacity } from 'react-native'
-import useOpenExplorer from '@/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer'
 
-export const formatRemoveSignerItems = (txInfo: NormalizedSettingsChangeTransaction, chain: Chain) => {
+export const formatRemoveSignerItems = (
+  txInfo: NormalizedSettingsChangeTransaction,
+  chain: Chain,
+  viewOnExplorer: () => void,
+) => {
   const newRemovedSigners = getSignerName(txInfo)
-  const viewOnExplorer = useOpenExplorer(txInfo.settingsInfo?.owner?.value)
 
   return [
     {
@@ -24,7 +26,7 @@ export const formatRemoveSignerItems = (txInfo: NormalizedSettingsChangeTransact
           <Text fontSize="$4">{newRemovedSigners}</Text>
           <CopyButton value={txInfo.settingsInfo?.owner?.value} color={'$textSecondaryLight'} />
           <TouchableOpacity onPress={viewOnExplorer}>
-            <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+            <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
           </TouchableOpacity>
         </View>
       ),

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SendNFT/SendNFT.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SendNFT/SendNFT.tsx
@@ -10,6 +10,7 @@ import { RootState } from '@/src/store'
 import { useAppSelector } from '@/src/store/hooks'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { selectChainById } from '@/src/store/chains'
+import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
 
 interface SendNFTProps {
   txInfo: TransferTransactionInfo
@@ -19,7 +20,12 @@ interface SendNFTProps {
 export function SendNFT({ txInfo, executionInfo }: SendNFTProps) {
   const activeSafe = useDefinedActiveSafe()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
-  const items = useMemo(() => formatSendNFTItems(txInfo, activeChain), [txInfo, activeChain])
+  const viewOnExplorer = useOpenExplorer(txInfo.recipient.value)
+
+  const items = useMemo(
+    () => formatSendNFTItems(txInfo, activeChain, viewOnExplorer),
+    [txInfo, activeChain, viewOnExplorer],
+  )
   const { value, tokenSymbol } = useTokenDetails(txInfo)
 
   return (

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SendNFT/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SendNFT/utils.tsx
@@ -9,11 +9,8 @@ import { Identicon } from '@/src/components/Identicon'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import { TouchableOpacity } from 'react-native'
-import useOpenExplorer from '@/src/features/ConfirmTx/hooks/useOpenExplorer/useOpenExplorer'
 
-export const formatSendNFTItems = (txInfo: TransferTransactionInfo, chain: Chain) => {
-  const viewOnExplorer = useOpenExplorer(txInfo.recipient.value)
-
+export const formatSendNFTItems = (txInfo: TransferTransactionInfo, chain: Chain, viewOnExplorer: () => void) => {
   return [
     {
       label: 'New signer',
@@ -23,9 +20,9 @@ export const formatSendNFTItems = (txInfo: TransferTransactionInfo, chain: Chain
           <Text fontSize="$4">
             {txInfo.recipient.name ? ellipsis(txInfo.recipient.name, 18) : shortenAddress(txInfo.recipient.value)}
           </Text>
-          <SafeFontIcon name="copy" size={14} color="textSecondaryLight" />
+          <SafeFontIcon name="copy" size={14} color="$textSecondaryLight" />
           <TouchableOpacity onPress={viewOnExplorer}>
-            <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+            <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
           </TouchableOpacity>
         </View>
       ),

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Stake/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Stake/utils.tsx
@@ -41,8 +41,8 @@ export const formatStakingItems = () => {
         <View flexDirection="row" alignItems="center" gap="$2">
           <Logo logoUri={MOCKED_LOGO} size="$6" />
           <Text fontSize="$4">{ellipsis(' Kiln Vault (Aave V3 USDC)', 10)}</Text>
-          <SafeFontIcon name="copy" size={14} color="textSecondaryLight" />
-          <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+          <SafeFontIcon name="copy" size={14} color="$textSecondaryLight" />
+          <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
         </View>
       ),
     },

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/utils.tsx
@@ -73,7 +73,7 @@ export const formatSwapOrderItems = (txInfo: Order, chain: Chain): ListTableItem
               <Text fontSize="$4">{ellipsis(txInfo.uid, 6)}</Text>
               <CopyButton value={txInfo.uid} color={'$textSecondaryLight'} />
               <TouchableOpacity onPress={openCowExplorer}>
-                <SafeFontIcon name="external-link" size={14} color="textSecondaryLight" />
+                <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
               </TouchableOpacity>
             </View>
           ),

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Container } from '@/src/components/Container'
 import { View, YStack, Text, Button, H3 } from 'tamagui'
-import Share from 'react-native-share'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Logo } from '@/src/components/Logo'
 import { EthAddress } from '@/src/components/EthAddress'
@@ -17,9 +16,8 @@ import { selectChainById } from '@/src/store/chains'
 import { RootState } from '@/src/store'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { Address } from '@/src/types/address'
-import Logger from '@/src/utils/logger'
 import { TokenAmount } from '@/src/components/TokenAmount'
-import useOpenExplorer from '../../../hooks/useOpenExplorer/useOpenExplorer'
+import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
 interface TokenTransferProps {
   txInfo: TransferTransactionInfo
   executionInfo: MultisigExecutionDetails

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
@@ -19,6 +19,7 @@ import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { Address } from '@/src/types/address'
 import Logger from '@/src/utils/logger'
 import { TokenAmount } from '@/src/components/TokenAmount'
+import useOpenExplorer from '../../../hooks/useOpenExplorer/useOpenExplorer'
 interface TokenTransferProps {
   txInfo: TransferTransactionInfo
   executionInfo: MultisigExecutionDetails
@@ -32,15 +33,7 @@ export function TokenTransfer({ txInfo, executionInfo, executedAt }: TokenTransf
 
   const recipientAddress = txInfo.recipient.value as Address
 
-  const onPressShare = async () => {
-    Share.open({
-      title: 'Recipient address',
-      message: recipientAddress,
-      type: 'text/plain',
-    }).then((res) => {
-      Logger.info(res.message)
-    })
-  }
+  const viewOnExplorer = useOpenExplorer(recipientAddress)
 
   return (
     <>
@@ -80,9 +73,7 @@ export function TokenTransfer({ txInfo, executionInfo, executedAt }: TokenTransf
                   />
                 </View>
                 <Button
-                  onPress={() => {
-                    onPressShare()
-                  }}
+                  onPress={viewOnExplorer}
                   height={18}
                   style={{ marginLeft: -12 }}
                   pressStyle={{ backgroundColor: 'transparent' }}

--- a/apps/mobile/src/features/ConfirmTx/hooks/useOpenExplorer/index.ts
+++ b/apps/mobile/src/features/ConfirmTx/hooks/useOpenExplorer/index.ts
@@ -1,0 +1,3 @@
+import useOpenExplorer from './useOpenExplorer'
+
+export { useOpenExplorer }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/26

## How this PR fixes it
It uses the useViewExplorer hook in the confirm token transaction view.

## How to test it
please follow the steps described here: https://github.com/safe-global/wallet-private-tasks/issues/26

## Screenshots
<img width="502" alt="Screenshot 2025-05-05 at 10 25 40" src="https://github.com/user-attachments/assets/2221060c-6dcb-4662-8bd6-82d8277127e2" />
<img width="502" alt="Screenshot 2025-05-05 at 10 25 50" src="https://github.com/user-attachments/assets/b372f33a-a30d-4e8c-8e4e-5b0d43d96346" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
