### PR TITLE
feat(mobile): track visited screens for crashlytics

### DIFF
--- a/apps/mobile/firebase.json
+++ b/apps/mobile/firebase.json
@@ -1,6 +1,8 @@
 {
   "react-native": {
     "analytics_auto_collection_enabled": false,
+    "google_analytics_automatic_screen_reporting_enabled": false,
+    "analytics_default_allow_ad_personalization_signals": false,
     "crashlytics_auto_collection_enabled": false,
     "crashlytics_javascript_exception_handler_chaining_enabled": false,
     "messaging_auto_init_enabled": true,

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -24,6 +24,7 @@ import { useInitWeb3 } from '@/src/hooks/useInitWeb3'
 import { useInitSafeCoreSDK } from '@/src/hooks/coreSDK/useInitSafeCoreSDK'
 import NotificationsService from '@/src/services/notifications/NotificationService'
 import { StatusBar } from 'expo-status-bar'
+import { useScreenTracking } from '@/src/hooks/useScreenTracking'
 
 Logger.setLevel(__DEV__ ? LogLevel.TRACE : LogLevel.ERROR)
 // Initialize all notification handlers
@@ -44,6 +45,8 @@ const HooksInitializer = () => {
 }
 
 function RootLayout() {
+  useScreenTracking()
+
   return (
     <GestureHandlerRootView>
       <Provider store={store}>

--- a/apps/mobile/src/app/developer.tsx
+++ b/apps/mobile/src/app/developer.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { View } from 'tamagui'
 import { DeveloperContainer } from '@/src/features/Developer'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 function DeveloperScreen() {
+  const { bottom } = useSafeAreaInsets()
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, paddingBottom: bottom }}>
       <DeveloperContainer />
     </View>
   )

--- a/apps/mobile/src/features/Developer/components/Developer.tsx
+++ b/apps/mobile/src/features/Developer/components/Developer.tsx
@@ -1,6 +1,8 @@
 import { View, Text, ScrollView, H2 } from 'tamagui'
 import { CopyButton } from '@/src/components/CopyButton'
 import { type Info } from '@/src/features/Developer/types'
+import crashlytics from '@react-native-firebase/crashlytics'
+import { SafeButton } from '@/src/components/SafeButton'
 
 type DeveloperProps = {
   info: Info
@@ -32,7 +34,7 @@ const Info = ({ info }: InfoProps) => {
 export const Developer = ({ info }: DeveloperProps) => {
   return (
     <View flex={1}>
-      <ScrollView marginHorizontal={'$4'}>
+      <ScrollView paddingHorizontal={'$4'}>
         <View>
           <H2>App info</H2>
           <Info info={info.application} />
@@ -40,6 +42,10 @@ export const Developer = ({ info }: DeveloperProps) => {
         <View marginTop={'$2'}>
           <H2>Device Info</H2>
           <Info info={info.device} />
+        </View>
+        <View marginTop={'$4'}>
+          <Text>The button below will crash the app on purpose. This is for testing purposes only.</Text>
+          <SafeButton onPress={() => crashlytics().crash()}>Crash App</SafeButton>
         </View>
       </ScrollView>
     </View>

--- a/apps/mobile/src/features/GetStarted/GetStarted.tsx
+++ b/apps/mobile/src/features/GetStarted/GetStarted.tsx
@@ -6,6 +6,7 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { BlurView } from 'expo-blur'
 import crashlytics from '@react-native-firebase/crashlytics'
+import analytics from '@react-native-firebase/analytics'
 
 export const GetStarted = () => {
   const router = useRouter()
@@ -13,6 +14,7 @@ export const GetStarted = () => {
 
   const enableCrashlytics = async () => {
     await crashlytics().setCrashlyticsCollectionEnabled(true)
+    await analytics().setAnalyticsCollectionEnabled(true)
   }
 
   const onPressAddAccount = useCallback(async () => {

--- a/apps/mobile/src/hooks/useScreenTracking.ts
+++ b/apps/mobile/src/hooks/useScreenTracking.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+import { usePathname, useGlobalSearchParams } from 'expo-router'
+import analytics from '@react-native-firebase/analytics'
+
+export const useScreenTracking = () => {
+  const pathname = usePathname()
+  const params = useGlobalSearchParams()
+
+  useEffect(() => {
+    const logScreenView = async () => {
+      await analytics().logScreenView({
+        screen_name: pathname,
+        screen_class: pathname,
+      })
+    }
+    logScreenView()
+  }, [pathname, params])
+}


### PR DESCRIPTION
## What it solves
Currently when we get a crash report uploaded to crashlytics we don't have any breadcrumbs and don't know which screens the user visited. 

## How this PR fixes it
We enabled analytics collection and are uploading the screen the user is to analytics. This gets combined with the crash data and we get a nice breadcrumb like this:
![grafik](https://github.com/user-attachments/assets/7aa3151e-bf34-4eac-9f01-a10102f9ef3c)


## How to test it
On the settings page, click 3 times on the safe version, navigate into the hidden Developer menu and hit the "crash app" button. This will generate a dummy crash report and send it to crashylitics once you start the app again. 

**Note**: analytics collection is only enabled during the onboarding when the user clicks on "get started" and creates a safe. This means that we won't be getting this data for users that have already imported a safe. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
