### PR TITLE
Fix(Spaces): Add Done status to spaces dashboard if address book imported

### DIFF
--- a/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
@@ -20,7 +20,7 @@ const AddAccountsCard = () => {
             Add your Safe Accounts
           </Typography>
 
-          <Typography variant="body1" color="text.secondary" mb={2}>
+          <Typography variant="body1" color="primary.light" mb={2}>
             Start by adding Safe Accounts to your space. Any accounts that are linked to your connected wallet can be
             added to the space.
           </Typography>

--- a/apps/web/src/features/spaces/components/Dashboard/ImportAddressBookCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/ImportAddressBookCard.tsx
@@ -5,13 +5,13 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import { useState } from 'react'
 import ImportAddressBookDialog from '@/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog'
-import useGetAddressBook from '@/features/spaces/hooks/useGetAddressBook'
+import useGetSpaceAddressBook from '@/features/spaces/hooks/useGetSpaceAddressBook'
 import CheckIcon from '@/public/images/common/check.svg'
 import classnames from 'classnames'
 
 const AddressBookCard = () => {
   const [open, setOpen] = useState(false)
-  const addressBookItems = useGetAddressBook()
+  const addressBookItems = useGetSpaceAddressBook()
 
   const handleImport = () => {
     trackEvent({ ...SPACE_EVENTS.IMPORT_ADDRESS_BOOK, label: SPACE_LABELS.space_dashboard_card })

--- a/apps/web/src/features/spaces/components/Dashboard/ImportAddressBookCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/ImportAddressBookCard.tsx
@@ -1,42 +1,74 @@
-import { Typography, Paper, Box, Button, SvgIcon } from '@mui/material'
+import { Typography, Paper, Box, Button, SvgIcon, Chip, Stack } from '@mui/material'
 import css from '@/features/spaces/components/Dashboard/styles.module.css'
 import AddressBookIcon from '@/public/images/sidebar/address-book.svg'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
+import { useState } from 'react'
+import ImportAddressBookDialog from '@/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog'
+import useGetAddressBook from '@/features/spaces/hooks/useGetAddressBook'
+import CheckIcon from '@/public/images/common/check.svg'
+import classnames from 'classnames'
 
 const AddressBookCard = () => {
+  const [open, setOpen] = useState(false)
+  const addressBookItems = useGetAddressBook()
+
   const handleImport = () => {
     trackEvent({ ...SPACE_EVENTS.IMPORT_ADDRESS_BOOK, label: SPACE_LABELS.space_dashboard_card })
-    // TODO: Implement import functionality
+    setOpen(true)
   }
 
   return (
-    <Paper sx={{ p: 3, borderRadius: '12px', height: '100%' }}>
-      <Box position="relative" width={1}>
-        <Box className={css.iconBG}>
-          <SvgIcon component={AddressBookIcon} inheritViewBox />
-        </Box>
+    <>
+      <Paper sx={{ p: 3, borderRadius: '12px', height: '100%' }}>
+        <Box position="relative" width={1}>
+          <Box className={classnames(css.iconBG, css.iconBGBlue)}>
+            <SvgIcon component={AddressBookIcon} inheritViewBox color="info" />
+          </Box>
 
-        <Button
-          onClick={handleImport}
-          variant="outlined"
-          size="compact"
-          sx={{ position: 'absolute', top: 0, right: 0 }}
-          aria-label="Import address book"
-        >
-          Import
-        </Button>
-      </Box>
-      <Box>
-        <Typography variant="body1" color="text.primary" fontWeight={700} mb={1}>
-          Import address book
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          Simplify managing your funds collaboratively by importing your local address book. It will be available to all
-          members of the space.
-        </Typography>
-      </Box>
-    </Paper>
+          {addressBookItems.length > 0 ? (
+            <Chip
+              label={
+                <Stack direction="row" gap={0.5}>
+                  <SvgIcon component={CheckIcon} inheritViewBox fontSize="small" />
+                  <Typography variant="caption" fontWeight="bold">
+                    Done
+                  </Typography>
+                </Stack>
+              }
+              sx={{
+                borderRadius: '6px',
+                backgroundColor: 'success.background',
+                color: 'success.main',
+                position: 'absolute',
+                top: 0,
+                right: 0,
+              }}
+            />
+          ) : (
+            <Button
+              onClick={handleImport}
+              variant="outlined"
+              size="compact"
+              sx={{ position: 'absolute', top: 0, right: 0 }}
+              aria-label="Import address book"
+            >
+              Import address book
+            </Button>
+          )}
+        </Box>
+        <Box>
+          <Typography variant="body1" color="text.primary" fontWeight={700} mb={1}>
+            Import address book
+          </Typography>
+          <Typography variant="body2" color="primary.light">
+            Simplify managing your funds collaboratively by importing your local address book. It will be available to
+            all members of the space.
+          </Typography>
+        </Box>
+      </Paper>
+      {open && <ImportAddressBookDialog handleClose={() => setOpen(false)} />}
+    </>
   )
 }
 

--- a/apps/web/src/features/spaces/components/Dashboard/MembersCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/MembersCard.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames'
 import css from '@/features/spaces/components/Dashboard/styles.module.css'
 import MemberIcon from '@/public/images/spaces/member.svg'
 import { Typography, Paper, Box, Button, SvgIcon, Tooltip } from '@mui/material'
@@ -21,8 +22,8 @@ const MembersCard = () => {
     <>
       <Paper sx={{ p: 3, borderRadius: '12px' }}>
         <Box position="relative" width={1}>
-          <Box className={css.iconBG}>
-            <SvgIcon component={MemberIcon} inheritViewBox />
+          <Box className={classnames(css.iconBG, css.iconBGBlue)}>
+            <SvgIcon component={MemberIcon} inheritViewBox color="info" />
           </Box>
           <Tooltip title={isButtonDisabled ? 'You need to be an Admin to add members' : ''} placement="top">
             <Box component="span" sx={{ position: 'absolute', top: 0, right: 0 }}>
@@ -45,7 +46,7 @@ const MembersCard = () => {
           <Typography variant="body1" color="text.primary" fontWeight={700} mb={1}>
             Add members
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" color="primary.light">
             Invite team members to help manage your Safe Accounts. You can add both Safe Account signers and external
             collaborators.
           </Typography>

--- a/apps/web/src/features/spaces/components/Dashboard/SpacesCTACard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/SpacesCTACard.tsx
@@ -40,7 +40,7 @@ const SpacesCTACard = () => {
           <Typography variant="body1" color="text.primary" fontWeight={700} mb={1}>
             Explore spaces
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" color="primary.light">
             Seamlessly use your Safe Accounts from one place and collaborate with your team members.
           </Typography>
         </Box>

--- a/apps/web/src/features/spaces/components/Dashboard/styles.module.css
+++ b/apps/web/src/features/spaces/components/Dashboard/styles.module.css
@@ -29,6 +29,10 @@
   justify-content: center;
 }
 
+.iconBGBlue {
+  background-color: var(--color-info-background);
+}
+
 .image {
   max-width: 100%;
   height: auto;

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
@@ -9,7 +9,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import type { ImportContactsFormValues } from '@/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog'
 import { getSelectedAddresses, getContactId } from '@/features/spaces/components/SpaceAddressBook/utils'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
-import useGetAddressBook from '@/features/spaces/hooks/useGetAddressBook'
+import useGetSpaceAddressBook from '@/features/spaces/hooks/useGetSpaceAddressBook'
 
 export type ContactItem = {
   chainId: string
@@ -21,7 +21,7 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
   const { control } = useFormContext<ImportContactsFormValues>()
   const selectedContacts = useWatch({ control, name: 'contacts' })
   const selectedAddresses = getSelectedAddresses(selectedContacts)
-  const spaceContacts = useGetAddressBook()
+  const spaceContacts = useGetSpaceAddressBook()
 
   return (
     <List

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
@@ -8,11 +8,8 @@ import ListItemText from '@mui/material/ListItemText'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import type { ImportContactsFormValues } from '@/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog'
 import { getSelectedAddresses, getContactId } from '@/features/spaces/components/SpaceAddressBook/utils'
-import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
-import { useAppSelector } from '@/store'
-import { isAuthenticated } from '@/store/authSlice'
-import { useAddressBooksGetAddressBookItemsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+import useGetAddressBook from '@/features/spaces/hooks/useGetAddressBook'
 
 export type ContactItem = {
   chainId: string
@@ -24,14 +21,7 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
   const { control } = useFormContext<ImportContactsFormValues>()
   const selectedContacts = useWatch({ control, name: 'contacts' })
   const selectedAddresses = getSelectedAddresses(selectedContacts)
-  const spaceId = useCurrentSpaceId()
-  const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { currentData } = useAddressBooksGetAddressBookItemsV1Query(
-    { spaceId: Number(spaceId) },
-    { skip: !isUserSignedIn },
-  )
-
-  const spaceContacts = currentData?.data || []
+  const spaceContacts = useGetAddressBook()
 
   return (
     <List

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ImportAddressBookDialog.tsx
@@ -28,6 +28,8 @@ import { useAddressBooksUpsertAddressBookItemsV1Mutation } from '@safe-global/st
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
 import { showNotification } from '@/store/notificationsSlice'
 import { useAppDispatch } from '@/store'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 
 export type ImportContactsFormValues = {
   contacts: Record<string, string | undefined> // e.g. "1:0x123": "Alice"
@@ -91,6 +93,8 @@ const ImportAddressBookDialog = ({ handleClose }: { handleClose: () => void }) =
           groupKey: 'import-contacts-success',
         }),
       )
+
+      trackEvent(SPACE_EVENTS.IMPORT_ADDRESS_BOOK_SUBMIT)
 
       handleClose()
     } catch (e) {

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -10,23 +10,14 @@ import ImportAddressBook from '@/features/spaces/components/SpaceAddressBook/Imp
 import SearchInput from '@/features/spaces/components/SearchInput'
 import useAddressBookSearch from '@/features/spaces/hooks/useAddressBookSearch'
 import { useState } from 'react'
-import { useAddressBooksGetAddressBookItemsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
-import { useAppSelector } from '@/store'
-import { isAuthenticated } from '@/store/authSlice'
+import useGetAddressBook from '@/features/spaces/hooks/useGetAddressBook'
 
 const SpaceAddressBook = () => {
   const [searchQuery, setSearchQuery] = useState('')
   const isAdmin = useIsAdmin()
   const isInvited = useIsInvited()
-  const spaceId = useCurrentSpaceId()
-  const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { currentData: addressBook } = useAddressBooksGetAddressBookItemsV1Query(
-    { spaceId: Number(spaceId) },
-    { skip: !isUserSignedIn },
-  )
+  const addressBookItems = useGetAddressBook()
 
-  const addressBookItems = addressBook?.data || []
   const filteredAddressBook = useAddressBookSearch(addressBookItems, searchQuery)
 
   return (

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -10,13 +10,13 @@ import ImportAddressBook from '@/features/spaces/components/SpaceAddressBook/Imp
 import SearchInput from '@/features/spaces/components/SearchInput'
 import useAddressBookSearch from '@/features/spaces/hooks/useAddressBookSearch'
 import { useState } from 'react'
-import useGetAddressBook from '@/features/spaces/hooks/useGetAddressBook'
+import useGetSpaceAddressBook from '@/features/spaces/hooks/useGetSpaceAddressBook'
 
 const SpaceAddressBook = () => {
   const [searchQuery, setSearchQuery] = useState('')
   const isAdmin = useIsAdmin()
   const isInvited = useIsInvited()
-  const addressBookItems = useGetAddressBook()
+  const addressBookItems = useGetSpaceAddressBook()
 
   const filteredAddressBook = useAddressBookSearch(addressBookItems, searchQuery)
 

--- a/apps/web/src/features/spaces/hooks/useGetAddressBook.ts
+++ b/apps/web/src/features/spaces/hooks/useGetAddressBook.ts
@@ -1,0 +1,17 @@
+import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
+import { useAddressBooksGetAddressBookItemsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+const useGetAddressBook = () => {
+  const spaceId = useCurrentSpaceId()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { currentData: addressBook } = useAddressBooksGetAddressBookItemsV1Query(
+    { spaceId: Number(spaceId) },
+    { skip: !isUserSignedIn },
+  )
+
+  return addressBook?.data || []
+}
+
+export default useGetAddressBook

--- a/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
+++ b/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
@@ -3,7 +3,7 @@ import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import { useAddressBooksGetAddressBookItemsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 
-const useGetAddressBook = () => {
+const useGetSpaceAddressBook = () => {
   const spaceId = useCurrentSpaceId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: addressBook } = useAddressBooksGetAddressBookItemsV1Query(
@@ -14,4 +14,4 @@ const useGetAddressBook = () => {
   return addressBook?.data || []
 }
 
-export default useGetAddressBook
+export default useGetSpaceAddressBook

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -157,6 +157,10 @@ export const SPACE_EVENTS = {
     action: 'Import address book',
     category: SPACE_CATEGORY,
   },
+  IMPORT_ADDRESS_BOOK_SUBMIT: {
+    action: 'Submit import address book',
+    category: SPACE_CATEGORY,
+  },
   EDIT_ADDRESS: {
     action: 'Open edit address',
     category: SPACE_CATEGORY,


### PR DESCRIPTION
## What it solves

Part of https://github.com/safe-global/wallet-private-tasks/issues/114

## How this PR fixes it

- Adds the `ImportAddressBookDialog` to the dashboard when pressing the import button
- Adds an event when submitting the import
- Shows a Done state when there are entries in the space address book
- Extracts logic to get space address book into a custom hook `useGetAddressBook`

## How to test it

1. Create a new space
2. Observe an address book card on the dashboard
3. Press the import button
4. Observe the import dialog opens
5. Import contacts from your local address book
6. Observe a done state instead of the import button

## Screenshots
<img width="739" alt="Screenshot 2025-05-06 at 12 15 13" src="https://github.com/user-attachments/assets/5715921d-7397-4c29-8a4a-e273071e4b4c" />
<img width="742" alt="Screenshot 2025-05-06 at 12 15 52" src="https://github.com/user-attachments/assets/f4b4fc21-db33-499e-9caa-7abd4306ac0d" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
