### PR TITLE
fix(mobile): change error text

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignError.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignError.tsx
@@ -35,7 +35,7 @@ export default function SignError({ onRetryPress, description }: { onRetryPress:
 
               <View margin="$4" width="100%" alignItems="center" gap="$4">
                 <LargeHeaderTitle textAlign="center" size="$8" lineHeight={32} maxWidth={200} fontWeight={600}>
-                  Couldn’t execute the transaction
+                  Couldn't sign the transaction
                 </LargeHeaderTitle>
 
                 <Text textAlign="center" fontSize="$4" width="80%">


### PR DESCRIPTION
## What it solves
We currently don't support execution, only signing so the text is misleading

Resolves https://github.com/safe-global/wallet-private-tasks/issues/217

## How this PR fixes it
Changes the text

## How to test it
Somehow trigger a signing error(disconnecting from network before hitting the sign button)

## Screenshots
<img src="https://github.com/user-attachments/assets/cd1f8673-f933-4cfe-b9dd-25ec6f42a3cc" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
