### PR TITLE
fix(mobile): display safe app name if provided

### DIFF
--- a/apps/mobile/src/components/TxInfo/TxInfo.tsx
+++ b/apps/mobile/src/components/TxInfo/TxInfo.tsx
@@ -71,10 +71,10 @@ function TxInfoComponent({ tx, bordered, inQueue, onPress }: TxInfoProps) {
       <TxBatchCard
         executionInfo={tx.executionInfo}
         inQueue={inQueue}
-        label={txType.text}
         onPress={onCardPress}
         bordered={bordered}
         txInfo={txInfo}
+        safeAppInfo={tx.safeAppInfo}
       />
     )
   }
@@ -124,6 +124,7 @@ function TxInfoComponent({ tx, bordered, inQueue, onPress }: TxInfoProps) {
         inQueue={inQueue}
         bordered={bordered}
         txInfo={txInfo}
+        safeAppInfo={tx.safeAppInfo}
       />
     )
   }

--- a/apps/mobile/src/components/transactions-list/Card/TxBatchCard/TxBatchCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxBatchCard/TxBatchCard.tsx
@@ -3,7 +3,7 @@ import { Avatar, View } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import type { MultiSend } from '@safe-global/store/gateway/types'
-import type { Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import type { Transaction, SafeAppInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
 interface TxBatchCardProps {
   txInfo: MultiSend
@@ -12,10 +12,19 @@ interface TxBatchCardProps {
   inQueue?: boolean
   executionInfo?: Transaction['executionInfo']
   onPress: () => void
+  safeAppInfo?: SafeAppInfo | null
 }
 
-export function TxBatchCard({ txInfo, bordered, executionInfo, inQueue, label, onPress }: TxBatchCardProps) {
-  const logoUri = txInfo.to.logoUri
+export function TxBatchCard({
+  txInfo,
+  bordered,
+  executionInfo,
+  inQueue,
+  label,
+  safeAppInfo,
+  onPress,
+}: TxBatchCardProps) {
+  const logoUri = safeAppInfo?.logoUri || txInfo.to.logoUri
 
   return (
     <SafeListItem
@@ -24,7 +33,7 @@ export function TxBatchCard({ txInfo, bordered, executionInfo, inQueue, label, o
       onPress={onPress}
       inQueue={inQueue}
       executionInfo={executionInfo}
-      type={'Batch'}
+      type={safeAppInfo?.name || 'Batch'}
       bordered={bordered}
       leftNode={
         <Avatar circular size="$10">

--- a/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
@@ -3,8 +3,8 @@ import { Text, Theme } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import { MultiSend } from '@safe-global/store/gateway/types'
-import { Transaction, CustomTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { SafeAvatar } from '@/src/components/SafeAvatar/SafeAvatar'
+import { Transaction, CustomTransactionInfo, SafeAppInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
 interface TxContractInteractionCardProps {
   bordered?: boolean
@@ -12,6 +12,7 @@ interface TxContractInteractionCardProps {
   inQueue?: boolean
   executionInfo?: Transaction['executionInfo']
   onPress: () => void
+  safeAppInfo?: SafeAppInfo | null
 }
 
 export function TxContractInteractionCard({
@@ -20,15 +21,15 @@ export function TxContractInteractionCard({
   txInfo,
   inQueue,
   onPress,
+  safeAppInfo,
 }: TxContractInteractionCardProps) {
   const logoUri = txInfo.to.logoUri
   const label = txInfo.to.name || 'Contract interaction'
-
   return (
     <SafeListItem
       label={label}
       icon={logoUri ? 'transaction-contract' : undefined}
-      type={txInfo.methodName || ''}
+      type={safeAppInfo?.name || txInfo.methodName || ''}
       bordered={bordered}
       executionInfo={executionInfo}
       inQueue={inQueue}


### PR DESCRIPTION
## What it solves
If the gateway returns a safeAppName for a contract interactioin we display it instead of the method name.

Resolves 
https://github.com/safe-global/wallet-private-tasks/issues/132

## How to test it
1. open sep:0x2a73e61bd15b25B6958b4DA3bfc759ca4db249b9
2. Tx 776 is a batch tx made with the tx builder.

## Screenshots
before:
<img src="https://github.com/user-attachments/assets/43c34968-ba29-4bb5-ba66-3bacb052280e" width="150" />

after:
<img src="https://github.com/user-attachments/assets/3c6b2e03-2e99-4761-bbe1-e3630dedc2da" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
