### PR TITLE
fix(mobile): crash when there are no active signers

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
+++ b/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
@@ -57,7 +57,7 @@ function ConfirmTxContainer() {
         <TransactionInfo txId={txId} detailedExecutionInfo={detailedExecutionInfo} />
       </ScrollView>
 
-      <View paddingTop="$1" backgroundColor="$background">
+      <View paddingTop="$1">
         <ConfirmTxForm
           hasSigned={Boolean(hasSigned)}
           hasEnoughConfirmations={hasEnoughConfirmations}

--- a/apps/mobile/src/features/ConfirmTx/components/CanNotSign/CanNotSign.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/CanNotSign/CanNotSign.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render } from '@/src/tests/test-utils'
+import { CanNotSign } from './CanNotSign'
+import { SelectSigner } from '@/src/components/SelectSigner'
+
+// Mock the SelectSigner component
+jest.mock('@/src/components/SelectSigner', () => ({
+  SelectSigner: jest.fn(() => null),
+}))
+
+describe('CanNotSign', () => {
+  const defaultProps = {
+    address: '0x123' as const,
+    txId: 'tx123',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the correct message', () => {
+    const { getByText } = render(<CanNotSign {...defaultProps} />)
+    expect(getByText('Only signers of this safe can sign this transaction')).toBeTruthy()
+  })
+
+  it('renders SelectSigner when address is provided', () => {
+    render(<CanNotSign {...defaultProps} />)
+
+    expect(SelectSigner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0x123',
+        txId: 'tx123',
+      }),
+      undefined,
+    )
+  })
+
+  it('does not render SelectSigner when address is undefined', () => {
+    render(<CanNotSign {...defaultProps} address={undefined} />)
+
+    expect(SelectSigner).not.toHaveBeenCalled()
+  })
+
+  it('matches snapshot with address', () => {
+    const { toJSON } = render(<CanNotSign {...defaultProps} />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+
+  it('matches snapshot without address', () => {
+    const { toJSON } = render(<CanNotSign {...defaultProps} address={undefined} />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+})

--- a/apps/mobile/src/features/ConfirmTx/components/CanNotSign/CanNotSign.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/CanNotSign/CanNotSign.tsx
@@ -4,14 +4,14 @@ import { SelectSigner } from '@/src/components/SelectSigner'
 import { Address } from '@/src/types/address'
 
 interface CanNotSignProps {
-  address: Address
+  address: Address | undefined
   txId: string
 }
 
 export function CanNotSign({ address, txId }: CanNotSignProps) {
   return (
-    <YStack gap="$4" alignItems="center" justifyContent="center">
-      <SelectSigner address={address} txId={txId} />
+    <YStack gap="$4" padding="$2" alignItems="center" justifyContent="center" testID="can-not-sign-container">
+      {address && <SelectSigner address={address} txId={txId} />}
       <Text fontSize="$4" fontWeight={400} width="70%" textAlign="center" color="$textSecondaryLight">
         Only signers of this safe can sign this transaction
       </Text>

--- a/apps/mobile/src/features/ConfirmTx/components/CanNotSign/__snapshots__/CanNotSign.test.tsx.snap
+++ b/apps/mobile/src/features/ConfirmTx/components/CanNotSign/__snapshots__/CanNotSign.test.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CanNotSign matches snapshot with address 1`] = `
+<View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flexDirection": "column",
+        "gap": 16,
+        "justifyContent": "center",
+        "paddingBottom": 8,
+        "paddingLeft": 8,
+        "paddingRight": 8,
+        "paddingTop": 8,
+      }
+    }
+    testID="can-not-sign-container"
+  >
+    <Text
+      style={
+        {
+          "color": "#A1A3A7",
+          "fontFamily": "DM Sans",
+          "fontSize": 14,
+          "textAlign": "center",
+          "width": "70%",
+        }
+      }
+      suppressHighlighting={true}
+    >
+      Only signers of this safe can sign this transaction
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`CanNotSign matches snapshot without address 1`] = `
+<View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flexDirection": "column",
+        "gap": 16,
+        "justifyContent": "center",
+        "paddingBottom": 8,
+        "paddingLeft": 8,
+        "paddingRight": 8,
+        "paddingTop": 8,
+      }
+    }
+    testID="can-not-sign-container"
+  >
+    <Text
+      style={
+        {
+          "color": "#A1A3A7",
+          "fontFamily": "DM Sans",
+          "fontSize": 14,
+          "textAlign": "center",
+          "width": "70%",
+        }
+      }
+      suppressHighlighting={true}
+    >
+      Only signers of this safe can sign this transaction
+    </Text>
+  </View>
+</View>
+`;

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmTxForm/ConfirmTxForm.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmTxForm/ConfirmTxForm.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { View, Text } from 'react-native'
+import { ConfirmTxForm } from './ConfirmTxForm'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { AlreadySigned } from '../confirmation-views/AlreadySigned'
+import { CanNotSign } from '../CanNotSign'
+import { ExecuteForm } from '../ExecuteForm'
+import { SignForm } from '../SignForm'
+
+// Mock the hooks and components
+jest.mock('@/src/store/hooks/activeSafe')
+jest.mock('../confirmation-views/AlreadySigned')
+jest.mock('../CanNotSign')
+jest.mock('../ExecuteForm')
+jest.mock('../SignForm')
+
+describe('ConfirmTxForm', () => {
+  const mockActiveSafe = {
+    address: '0x123',
+    chainId: '1',
+  }
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.clearAllMocks()
+
+    // Mock the useDefinedActiveSafe hook
+    ;(useDefinedActiveSafe as jest.Mock).mockReturnValue(mockActiveSafe)
+
+    // Mock the components to return React Native components
+    ;(AlreadySigned as jest.Mock).mockReturnValue(
+      <View>
+        <Text>AlreadySigned</Text>
+      </View>,
+    )
+    ;(CanNotSign as jest.Mock).mockReturnValue(
+      <View>
+        <Text>CanNotSign</Text>
+      </View>,
+    )
+    ;(ExecuteForm as jest.Mock).mockReturnValue(
+      <View>
+        <Text>ExecuteForm</Text>
+      </View>,
+    )
+    ;(SignForm as jest.Mock).mockReturnValue(
+      <View>
+        <Text>SignForm</Text>
+      </View>,
+    )
+  })
+
+  const defaultProps = {
+    hasEnoughConfirmations: false,
+    activeSigner: { value: '0x456' },
+    isExpired: false,
+    txId: 'tx123',
+    hasSigned: false,
+    canSign: true,
+  }
+
+  it('renders AlreadySigned when hasSigned is true', () => {
+    const props = { ...defaultProps, hasSigned: true }
+    const { getByText } = render(<ConfirmTxForm {...props} />)
+
+    expect(getByText('AlreadySigned')).toBeTruthy()
+    expect(AlreadySigned).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txId: 'tx123',
+        safeAddress: '0x123',
+        chainId: '1',
+      }),
+      undefined,
+    )
+  })
+
+  it('renders CanNotSign when canSign is false', () => {
+    const props = { ...defaultProps, canSign: false }
+    const { getByText } = render(<ConfirmTxForm {...props} />)
+
+    expect(getByText('CanNotSign')).toBeTruthy()
+    expect(CanNotSign).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: '0x456',
+        txId: 'tx123',
+      }),
+      undefined,
+    )
+  })
+
+  it('renders ExecuteForm when hasEnoughConfirmations is true', () => {
+    const props = { ...defaultProps, hasEnoughConfirmations: true }
+    const { getByText } = render(<ConfirmTxForm {...props} />)
+
+    expect(getByText('ExecuteForm')).toBeTruthy()
+    expect(ExecuteForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safeAddress: '0x123',
+        chainId: '1',
+      }),
+      undefined,
+    )
+  })
+
+  it('renders SignForm when activeSigner exists and not expired', () => {
+    const props = { ...defaultProps }
+    const { getByText } = render(<ConfirmTxForm {...props} />)
+
+    expect(getByText('SignForm')).toBeTruthy()
+    expect(SignForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txId: 'tx123',
+        address: '0x456',
+      }),
+      undefined,
+    )
+  })
+
+  it('renders null when no conditions are met', () => {
+    const props = {
+      ...defaultProps,
+      activeSigner: undefined,
+      isExpired: true,
+    }
+    const { toJSON } = render(<ConfirmTxForm {...props} />)
+
+    expect(toJSON()).toBeNull()
+  })
+
+  it('handles undefined activeSigner in CanNotSign', () => {
+    const props = {
+      ...defaultProps,
+      canSign: false,
+      activeSigner: undefined,
+    }
+    const { getByText } = render(<ConfirmTxForm {...props} />)
+
+    expect(getByText('CanNotSign')).toBeTruthy()
+    expect(CanNotSign).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: undefined,
+        txId: 'tx123',
+      }),
+      undefined,
+    )
+  })
+})

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmTxForm/ConfirmTxForm.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmTxForm/ConfirmTxForm.tsx
@@ -29,7 +29,7 @@ export function ConfirmTxForm({
   }
 
   if (!canSign) {
-    return <CanNotSign address={activeSigner?.value as Address} txId={txId} />
+    return <CanNotSign address={activeSigner?.value as Address | undefined} txId={txId} />
   }
 
   if (hasEnoughConfirmations) {


### PR DESCRIPTION
## What it solves
The recent fix for the "ready to execute view" caused a crash when there is no active signer https://github.com/safe-global/safe-wallet-monorepo/pull/5828

## How this PR fixes it
We now accept the fact that the user might not have a signer imported and don't render the signer selector component that was causing the crash. 

## How to test it
1. Import a safe with pending txs
2. Make sure that you have no signers imported for it
3. Navigate to a pending tx
4. Observe no crash

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
