### PR TITLE
refactor(mobile): migrate to v22

### DIFF
--- a/apps/mobile/src/features/Developer/components/Developer.tsx
+++ b/apps/mobile/src/features/Developer/components/Developer.tsx
@@ -1,7 +1,7 @@
 import { View, Text, ScrollView, H2 } from 'tamagui'
 import { CopyButton } from '@/src/components/CopyButton'
 import { type Info } from '@/src/features/Developer/types'
-import crashlytics from '@react-native-firebase/crashlytics'
+import { getCrashlytics } from '@react-native-firebase/crashlytics'
 import { SafeButton } from '@/src/components/SafeButton'
 
 type DeveloperProps = {
@@ -45,7 +45,7 @@ export const Developer = ({ info }: DeveloperProps) => {
         </View>
         <View marginTop={'$4'}>
           <Text>The button below will crash the app on purpose. This is for testing purposes only.</Text>
-          <SafeButton onPress={() => crashlytics().crash()}>Crash App</SafeButton>
+          <SafeButton onPress={() => getCrashlytics().crash()}>Crash App</SafeButton>
         </View>
       </ScrollView>
     </View>

--- a/apps/mobile/src/features/GetStarted/GetStarted.tsx
+++ b/apps/mobile/src/features/GetStarted/GetStarted.tsx
@@ -5,16 +5,16 @@ import { SafeButton } from '@/src/components/SafeButton'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { BlurView } from 'expo-blur'
-import crashlytics from '@react-native-firebase/crashlytics'
-import analytics from '@react-native-firebase/analytics'
+import { getCrashlytics } from '@react-native-firebase/crashlytics'
+import { getAnalytics } from '@react-native-firebase/analytics'
 
 export const GetStarted = () => {
   const router = useRouter()
   const insets = useSafeAreaInsets()
 
   const enableCrashlytics = async () => {
-    await crashlytics().setCrashlyticsCollectionEnabled(true)
-    await analytics().setAnalyticsCollectionEnabled(true)
+    await getCrashlytics().setCrashlyticsCollectionEnabled(true)
+    await getAnalytics().setAnalyticsCollectionEnabled(true)
   }
 
   const onPressAddAccount = useCallback(async () => {

--- a/apps/mobile/src/hooks/useScreenTracking.ts
+++ b/apps/mobile/src/hooks/useScreenTracking.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { usePathname, useGlobalSearchParams } from 'expo-router'
-import analytics from '@react-native-firebase/analytics'
+import { getAnalytics } from '@react-native-firebase/analytics'
 
 export const useScreenTracking = () => {
   const pathname = usePathname()
@@ -8,7 +8,7 @@ export const useScreenTracking = () => {
 
   useEffect(() => {
     const logScreenView = async () => {
-      await analytics().logScreenView({
+      await getAnalytics().logScreenView({
         screen_name: pathname,
         screen_class: pathname,
       })

--- a/apps/mobile/src/services/notifications/FCMService.ts
+++ b/apps/mobile/src/services/notifications/FCMService.ts
@@ -1,4 +1,4 @@
-import messaging, { FirebaseMessagingTypes } from '@react-native-firebase/messaging'
+import { FirebaseMessagingTypes, getMessaging } from '@react-native-firebase/messaging'
 import Logger from '@/src/utils/logger'
 import NotificationsService from './NotificationService'
 import { ChannelId, withTimeout } from '@/src/utils/notifications'
@@ -20,8 +20,8 @@ class FCMService {
   async saveFCMToken(): Promise<void> {
     try {
       // Register the app with FCM forcefully to get the token since it has not been reliably saved otherwise
-      await messaging().registerDeviceForRemoteMessages()
-      const fcmToken = await withTimeout(messaging().getToken(), 10000)
+      await getMessaging().registerDeviceForRemoteMessages()
+      const fcmToken = await withTimeout(getMessaging().getToken(), 10000)
       Logger.info('FCMService :: fcmToken', fcmToken)
       if (fcmToken) {
         store.dispatch(savePushToken(fcmToken))
@@ -32,7 +32,7 @@ class FCMService {
   }
 
   listenForMessagesForeground = (): UnsubscribeFunc => {
-    return messaging().onMessage(async (remoteMessage: FirebaseMessagingTypes.RemoteMessage) => {
+    return getMessaging().onMessage(async (remoteMessage: FirebaseMessagingTypes.RemoteMessage) => {
       NotificationsService.displayNotification({
         channelId: ChannelId.DEFAULT_NOTIFICATION_CHANNEL_ID,
         title: remoteMessage.notification?.title || '',
@@ -44,7 +44,7 @@ class FCMService {
   }
 
   listenForMessagesBackground = (): void => {
-    messaging().setBackgroundMessageHandler(async (remoteMessage: FirebaseMessagingTypes.RemoteMessage) => {
+    getMessaging().setBackgroundMessageHandler(async (remoteMessage: FirebaseMessagingTypes.RemoteMessage) => {
       NotificationsService.displayNotification({
         channelId: ChannelId.DEFAULT_NOTIFICATION_CHANNEL_ID,
         title: remoteMessage.notification?.title || '',
@@ -56,7 +56,7 @@ class FCMService {
   }
 
   async registerAppWithFCM(): Promise<void> {
-    await messaging()
+    await getMessaging()
       .registerDeviceForRemoteMessages()
       .then((status: unknown) => {
         Logger.info('registerDeviceForRemoteMessages status', status)

--- a/apps/mobile/src/services/notifications/NotificationService.ts
+++ b/apps/mobile/src/services/notifications/NotificationService.ts
@@ -13,7 +13,7 @@ import { store } from '@/src/store'
 import { updatePromptAttempts, updateLastTimePromptAttempted } from '@/src/store/notificationsSlice'
 import { toggleAppNotifications, toggleDeviceNotifications } from '@/src/store/notificationsSlice'
 import { HandleNotificationCallback, LAUNCH_ACTIVITY, PressActionId } from '@/src/store/constants'
-import messaging from '@react-native-firebase/messaging'
+import { getMessaging } from '@react-native-firebase/messaging'
 import * as TaskManager from 'expo-task-manager'
 
 import { ChannelId, notificationChannels, withTimeout } from '@/src/utils/notifications'
@@ -349,7 +349,7 @@ class NotificationsService {
    * Registers the Firebase messaging background handler
    */
   private registerFirebaseBackgroundHandler(): void {
-    messaging().setBackgroundMessageHandler(async (remoteMessage) => {
+    getMessaging().setBackgroundMessageHandler(async (remoteMessage) => {
       Logger.info('Message handled in the background!', remoteMessage)
 
       // Display the notification using Notifee


### PR DESCRIPTION
## What it solves
https://rnfirebase.io/migrating-to-v22

We were already using version 22, but the code we were using the old syntax. Because of this our developer console was poluted by a mile long messages that we use the API incorrectly.

## How this PR fixes it
Changes to the Modular Web API syntax.

## How to test it
You should no longer see any react-native-firebase message logged in the developer console

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
