### PR TITLE
Fix(mobile): import safe refactor

### DIFF
--- a/apps/mobile/src/app/(import-accounts)/form.tsx
+++ b/apps/mobile/src/app/(import-accounts)/form.tsx
@@ -1,11 +1,27 @@
 import React from 'react'
 import { ImportAccountFormContainer } from '@/src/features/ImportReadOnly'
 import { View } from 'tamagui'
+import { useForm, FormProvider } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { formSchema } from '@/src/features/ImportReadOnly/schema'
+import { useLocalSearchParams } from 'expo-router'
 
 function ImportAccountFormScreen() {
+  const params = useLocalSearchParams<{ safeAddress: string }>()
+  const methods = useForm({
+    resolver: zodResolver(formSchema),
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+      safeAddress: params.safeAddress || '',
+    },
+  })
+
   return (
     <View style={{ flex: 1 }}>
-      <ImportAccountFormContainer />
+      <FormProvider {...methods}>
+        <ImportAccountFormContainer />
+      </FormProvider>
     </View>
   )
 }

--- a/apps/mobile/src/app/(import-accounts)/form.tsx
+++ b/apps/mobile/src/app/(import-accounts)/form.tsx
@@ -1,27 +1,11 @@
 import React from 'react'
 import { ImportAccountFormContainer } from '@/src/features/ImportReadOnly'
 import { View } from 'tamagui'
-import { useForm, FormProvider } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { formSchema } from '@/src/features/ImportReadOnly/schema'
-import { useLocalSearchParams } from 'expo-router'
 
 function ImportAccountFormScreen() {
-  const params = useLocalSearchParams<{ safeAddress: string }>()
-  const methods = useForm({
-    resolver: zodResolver(formSchema),
-    mode: 'onChange',
-    defaultValues: {
-      name: '',
-      safeAddress: params.safeAddress || '',
-    },
-  })
-
   return (
     <View style={{ flex: 1 }}>
-      <FormProvider {...methods}>
-        <ImportAccountFormContainer />
-      </FormProvider>
+      <ImportAccountFormContainer />
     </View>
   )
 }

--- a/apps/mobile/src/components/SafeAccountInput/hooks/useImportSafe.ts
+++ b/apps/mobile/src/components/SafeAccountInput/hooks/useImportSafe.ts
@@ -1,0 +1,92 @@
+import { useEffect, useCallback } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { makeSafeId } from '@/src/utils/formatters'
+import { isValidAddress } from '@safe-global/utils/utils/validation'
+import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectAllChainsIds } from '@/src/store/chains'
+import { useLazySafesGetOverviewForManyQuery } from '@safe-global/store/gateway/safes'
+import { FormValues } from '@/src/features/ImportReadOnly/types'
+import debounce from 'lodash/debounce'
+
+const params = {
+  currency: 'usd',
+  trusted: true,
+  excludeSpam: true,
+}
+
+const NO_SAFE_DEPLOYMENT_ERROR = 'No Safe deployment found for this address'
+
+export const useImportSafe = () => {
+  const chainIds = useAppSelector(selectAllChainsIds)
+  const {
+    watch,
+    getFieldState,
+    setValue,
+    setError,
+    clearErrors,
+    getValues,
+    trigger: triggerInput,
+    formState: { isValid },
+  } = useFormContext<FormValues>()
+  const [trigger, result] = useLazySafesGetOverviewForManyQuery()
+
+  const inputAddress = watch('safeAddress')
+
+  const onSafeAddressChange = useCallback(
+    debounce(() => {
+      const { address } = parsePrefixedAddress(inputAddress)
+      const isValid = isValidAddress(address)
+
+      if (isValid) {
+        trigger({
+          safes: chainIds.map((chainId: string) => makeSafeId(chainId, address)),
+          ...params,
+        })
+      } else {
+        setValue('importedSafeResult', undefined)
+      }
+    }, 200),
+    [chainIds, trigger, inputAddress, setValue],
+  )
+
+  useEffect(() => {
+    onSafeAddressChange()
+    return () => {
+      onSafeAddressChange.cancel()
+    }
+  }, [onSafeAddressChange])
+
+  useEffect(() => {
+    const onResultChange = () => {
+      setValue('importedSafeResult', {
+        data: result?.data,
+        isFetching: result?.isFetching,
+        error: result?.error,
+      })
+
+      const addressState = getFieldState('safeAddress')
+
+      if (!addressState.isDirty) {
+        return
+      }
+
+      if (result?.data?.length === 0 && !result?.isLoading) {
+        setError('safeAddress', { message: NO_SAFE_DEPLOYMENT_ERROR })
+      } else if (addressState.invalid) {
+        triggerInput('name')
+        clearErrors('safeAddress')
+      }
+    }
+
+    onResultChange()
+  }, [result, setValue, setError, clearErrors, triggerInput])
+
+  useEffect(() => {
+    const importedSafeResult = getValues('importedSafeResult')
+
+    if (importedSafeResult?.data?.length === 0 && !importedSafeResult?.isFetching) {
+      setError('safeAddress', { message: NO_SAFE_DEPLOYMENT_ERROR })
+    }
+  }, [isValid, getValues])
+}

--- a/apps/mobile/src/components/SafeAccountInput/index.tsx
+++ b/apps/mobile/src/components/SafeAccountInput/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { SafeInput } from '../SafeInput'
+import { useFormContext } from 'react-hook-form'
+import { Controller } from 'react-hook-form'
+import { FormValues } from '@/src/features/ImportReadOnly/types'
+import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
+import { Identicon } from '../Identicon'
+import { View } from 'tamagui'
+import { SafeFontIcon } from '../SafeFontIcon'
+import { useImportSafe } from './hooks/useImportSafe'
+function SafeAccountInput() {
+  const {
+    control,
+    formState: { errors, dirtyFields },
+    watch,
+  } = useFormContext<FormValues>()
+
+  useImportSafe()
+
+  const result = watch('importedSafeResult')
+
+  return (
+    <Controller
+      control={control}
+      name="safeAddress"
+      render={({ field: { onChange, value } }) => {
+        const addressWithoutPrefix = parsePrefixedAddress(value).address
+        return (
+          <SafeInput
+            value={value}
+            onChangeText={onChange}
+            multiline={true}
+            placeholder="Paste address..."
+            error={errors.safeAddress?.message}
+            success={dirtyFields.safeAddress && !errors.safeAddress}
+            left={addressWithoutPrefix ? <Identicon address={addressWithoutPrefix as `0x${string}`} size={32} /> : null}
+            right={
+              result?.data?.length && !errors.safeAddress && !result?.isFetching ? (
+                <SafeFontIcon name={'check-filled'} size={20} color={'$success'} testID={'success-icon'} />
+              ) : (
+                <View width={20} />
+              )
+            }
+          />
+        )
+      }}
+    />
+  )
+}
+
+export default SafeAccountInput

--- a/apps/mobile/src/features/ImportReadOnly/ImportAccountForm.container.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/ImportAccountForm.container.tsx
@@ -1,30 +1,43 @@
-import { useRouter } from 'expo-router'
+import { useLocalSearchParams, useRouter } from 'expo-router'
 import React, { useCallback } from 'react'
 import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
 import { ImportAccountFormView } from '@/src/features/ImportReadOnly/components/ImportAccountFormView'
-import { useFormContext } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { formSchema } from './schema'
+import { FormValues } from './types'
 
 export const ImportAccountFormContainer = () => {
   const router = useRouter()
-  const { getFieldState, getValues } = useFormContext()
+  const params = useLocalSearchParams<{ safeAddress: string }>()
+  const methods = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+      safeAddress: params.safeAddress || '',
+    },
+  })
 
-  const addressState = getFieldState('safeAddress')
+  const addressState = methods.getFieldState('safeAddress')
 
   const handleContinue = useCallback(() => {
-    const inputAddress = getValues('safeAddress')
-    const chainId = getValues('chainId')
-    const safeName = getValues('name')
+    const inputAddress = methods.getValues('safeAddress')
+    const chainId = methods.getValues('importedSafeResult.data.0.chainId')
+    const safeName = methods.getValues('name')
     const { address } = parsePrefixedAddress(inputAddress)
 
     router.push(
       `/(import-accounts)/signers?safeAddress=${address}&chainId=${chainId}&import_safe=true&safeName=${safeName}`,
     )
-  }, [router, getValues])
+  }, [router, methods.getValues])
 
   return (
-    <ImportAccountFormView
-      isEnteredAddressValid={addressState.isTouched && !addressState.invalid}
-      onContinue={handleContinue}
-    />
+    <FormProvider {...methods}>
+      <ImportAccountFormView
+        isEnteredAddressValid={addressState.isTouched && !addressState.invalid}
+        onContinue={handleContinue}
+      />
+    </FormProvider>
   )
 }

--- a/apps/mobile/src/features/ImportReadOnly/ImportAccountForm.container.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/ImportAccountForm.container.tsx
@@ -1,94 +1,30 @@
-import { useLocalSearchParams, useRouter } from 'expo-router'
-import React, { useCallback, useEffect } from 'react'
-import { makeSafeId } from '@/src/utils/formatters'
-import { useAppSelector } from '@/src/store/hooks'
-import { selectAllChainsIds } from '@/src/store/chains'
-import { useLazySafesGetOverviewForManyQuery } from '@safe-global/store/gateway/safes'
-import { isValidAddress } from '@safe-global/utils/utils/validation'
+import { useRouter } from 'expo-router'
+import React, { useCallback } from 'react'
 import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
 import { ImportAccountFormView } from '@/src/features/ImportReadOnly/components/ImportAccountFormView'
-import { useForm } from 'react-hook-form'
-import { FormValues } from '@/src/features/ImportReadOnly/types'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { formSchema } from '@/src/features/ImportReadOnly/schema'
+import { useFormContext } from 'react-hook-form'
 
 export const ImportAccountFormContainer = () => {
-  const params = useLocalSearchParams<{ safeAddress: string }>()
-  const chainIds = useAppSelector(selectAllChainsIds)
   const router = useRouter()
-
-  const {
-    control,
-    getValues,
-    getFieldState,
-    setError,
-    watch,
-    clearErrors,
-    formState: { errors, dirtyFields, isValid },
-  } = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
-    mode: 'onChange',
-    defaultValues: {
-      name: '',
-      safeAddress: params.safeAddress || '',
-    },
-  })
+  const { getFieldState, getValues } = useFormContext()
 
   const addressState = getFieldState('safeAddress')
 
-  const [trigger, result] = useLazySafesGetOverviewForManyQuery()
-
-  const safeExists = (result.data && result.data.length > 0) || false
-  const inputAddress = watch('safeAddress')
-
-  useEffect(() => {
-    if (!addressState.invalid) {
-      const { address } = parsePrefixedAddress(inputAddress)
-      const isValid = isValidAddress(address)
-
-      if (isValid) {
-        trigger({
-          safes: chainIds.map((chainId: string) => makeSafeId(chainId, address)),
-          currency: 'usd',
-          trusted: true,
-          excludeSpam: true,
-        })
-      }
-    }
-  }, [chainIds, trigger, inputAddress, addressState.isDirty, addressState.invalid])
-
-  useEffect(() => {
-    if (!addressState.isDirty) {
-      return
-    }
-
-    if (!result?.data?.length) {
-      setError('safeAddress', { message: 'Safe not found' })
-    } else {
-      clearErrors('safeAddress')
-    }
-  }, [result.data, setError, getValues, addressState.isDirty, clearErrors, addressState.invalid])
-
-  const canContinue = isValid && safeExists
-
   const handleContinue = useCallback(() => {
     const inputAddress = getValues('safeAddress')
+    const chainId = getValues('chainId')
+    const safeName = getValues('name')
     const { address } = parsePrefixedAddress(inputAddress)
+
     router.push(
-      `/(import-accounts)/signers?safeAddress=${address}&chainId=${result.data?.[0].chainId}&import_safe=true&safeName=${getValues('name')}`,
+      `/(import-accounts)/signers?safeAddress=${address}&chainId=${chainId}&import_safe=true&safeName=${safeName}`,
     )
-  }, [result.data, router])
+  }, [router, getValues])
 
   return (
     <ImportAccountFormView
-      canContinue={canContinue}
-      result={result}
       isEnteredAddressValid={addressState.isTouched && !addressState.invalid}
       onContinue={handleContinue}
-      control={control}
-      errors={errors}
-      dirtyFields={dirtyFields}
-      isFormValid={isValid}
     />
   )
 }

--- a/apps/mobile/src/features/ImportReadOnly/components/ImportAccountFormView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/ImportAccountFormView.tsx
@@ -2,42 +2,29 @@ import React from 'react'
 import { KeyboardAvoidingView } from 'react-native'
 import { LargeHeaderTitle } from '@/src/components/Title/LargeHeaderTitle'
 import { SafeInput } from '@/src/components/SafeInput/SafeInput'
-import { Identicon } from '@/src/components/Identicon'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { SafeButton } from '@/src/components/SafeButton'
 import { VerificationStatus } from '@/src/features/ImportReadOnly/components/VerificationStatus'
 import { View, Text, ScrollView, YStack, getTokenValue } from 'tamagui'
-import { useLazySafesGetOverviewForManyQuery } from '@safe-global/store/gateway/safes'
 import { useScrollableHeader } from '@/src/navigation/useScrollableHeader'
 import { NavBarTitle } from '@/src/components/Title'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { type Control, Controller, type FieldErrors, FieldNamesMarkedBoolean } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 import type { FormValues } from '@/src/features/ImportReadOnly/types'
-import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
-
-type LazyQueryResult = ReturnType<typeof useLazySafesGetOverviewForManyQuery>[1]
+import SafeAccountInput from '@/src/components/SafeAccountInput'
 
 type ImportAccountFormViewProps = {
-  canContinue: boolean
-  result: LazyQueryResult
   isEnteredAddressValid: boolean
   onContinue: () => void
-  control: Control<FormValues>
-  errors: FieldErrors<FormValues>
-  dirtyFields: FieldNamesMarkedBoolean<FormValues>
-  isFormValid: boolean
 }
 
-export const ImportAccountFormView: React.FC<ImportAccountFormViewProps> = ({
-  canContinue,
-  result,
-  isEnteredAddressValid,
-  onContinue,
-  control,
-  errors,
-  dirtyFields,
-}) => {
+export const ImportAccountFormView: React.FC<ImportAccountFormViewProps> = ({ isEnteredAddressValid, onContinue }) => {
+  const {
+    control,
+    formState: { errors, isValid, dirtyFields },
+    watch,
+  } = useFormContext<FormValues>()
   const { top, bottom } = useSafeAreaInsets()
+  const result = watch('importedSafeResult')
 
   const { handleScroll } = useScrollableHeader({
     children: <NavBarTitle paddingRight={5}>Import Safe account</NavBarTitle>,
@@ -75,48 +62,25 @@ export const ImportAccountFormView: React.FC<ImportAccountFormViewProps> = ({
           </View>
 
           <View marginTop={'$4'}>
-            <Controller
-              control={control}
-              name="safeAddress"
-              render={({ field: { onChange, value } }) => {
-                const addressWithoutPrefix = parsePrefixedAddress(value).address
-                return (
-                  <SafeInput
-                    value={value}
-                    onChangeText={onChange}
-                    multiline={true}
-                    placeholder="Paste address..."
-                    error={errors.safeAddress?.message}
-                    success={dirtyFields.safeAddress && !errors.safeAddress}
-                    left={
-                      addressWithoutPrefix ? (
-                        <Identicon address={addressWithoutPrefix as `0x${string}`} size={32} />
-                      ) : null
-                    }
-                    right={
-                      result?.data?.length && !errors.safeAddress ? (
-                        <SafeFontIcon name={'check-filled'} size={20} color={'$success'} testID={'success-icon'} />
-                      ) : (
-                        <View width={20} />
-                      )
-                    }
-                  />
-                )
-              }}
-            />
+            <SafeAccountInput />
           </View>
 
           {!errors.safeAddress && (
             <VerificationStatus
-              isLoading={result.isLoading}
-              data={result.data}
+              isLoading={result?.isFetching}
+              data={result?.data}
               isEnteredAddressValid={isEnteredAddressValid}
             />
           )}
         </ScrollView>
 
         <View paddingHorizontal={'$4'} paddingTop={'$2'} paddingBottom={bottom || getTokenValue('$4')}>
-          <SafeButton primary onPress={onContinue} disabled={!canContinue} testID={'continue-button'}>
+          <SafeButton
+            primary
+            onPress={onContinue}
+            disabled={!isValid || result?.isFetching || !result?.data?.length}
+            testID={'continue-button'}
+          >
             Continue
           </SafeButton>
         </View>

--- a/apps/mobile/src/features/ImportReadOnly/types.ts
+++ b/apps/mobile/src/features/ImportReadOnly/types.ts
@@ -1,4 +1,13 @@
 import { z } from 'zod'
 import { formSchema } from '@/src/features/ImportReadOnly/schema'
+import { useLazySafesGetOverviewForManyQuery } from '@safe-global/store/gateway/safes'
 
-export type FormValues = z.infer<typeof formSchema>
+type LazyQueryResult = ReturnType<typeof useLazySafesGetOverviewForManyQuery>[1]
+
+export type FormValues = z.infer<typeof formSchema> & {
+  importedSafeResult?: {
+    data: LazyQueryResult['data']
+    isFetching: LazyQueryResult['isFetching']
+    error: LazyQueryResult['error']
+  }
+}


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/218 and https://github.com/safe-global/wallet-private-tasks/issues/86

## How this PR fixes it
It changes the way of how we're using react-hook-form on this screen to be according to its docs. Previously we were having conflicts with react-hook-form internal state due to validating/request the address outside the zod schema and the Controller component.

## How to test it
- Get an cleaned app
- Try to import a valid safe: button should be green and the chains should appear
- Try to import a EOA address: button should be disabled and the error message should appears
- Try to import a valid safe again: button should be green and the chains should appear again.

## Screenshots
<img width="502" alt="Screenshot 2025-05-07 at 10 19 40" src="https://github.com/user-attachments/assets/6ed6fd3b-001f-456c-a99d-9c9be37f8738" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
