### PR TITLE
feat(mobile): add missing staking tx cards in history

### DIFF
--- a/apps/mobile/src/components/TokenAmount/TokenAmount.tsx
+++ b/apps/mobile/src/components/TokenAmount/TokenAmount.tsx
@@ -15,6 +15,7 @@ interface TokenAmountProps {
   preciseAmount?: boolean
   textProps?: TextProps
   displayPositiveSign?: boolean
+  testID?: string
 }
 
 export const TokenAmount = ({
@@ -25,6 +26,7 @@ export const TokenAmount = ({
   preciseAmount,
   textProps,
   displayPositiveSign,
+  testID,
 }: TokenAmountProps): ReactElement => {
   const getSign = (): string => {
     if (direction === TransferDirection.OUTGOING) {
@@ -44,7 +46,7 @@ export const TokenAmount = ({
   }
 
   return (
-    <Text fontWeight={700} {...textProps}>
+    <Text fontWeight={700} {...textProps} testID={testID}>
       {getSign()}
       {formatAmount()} {tokenSymbol}
     </Text>

--- a/apps/mobile/src/components/TxInfo/TxInfo.tsx
+++ b/apps/mobile/src/components/TxInfo/TxInfo.tsx
@@ -11,6 +11,7 @@ import {
   isMultiSendTxInfo,
   isOrderTxInfo,
   isSettingsChangeTxInfo,
+  isStakingTxExitInfo,
   isStakingTxWithdrawInfo,
   isTransferTxInfo,
 } from '@/src/utils/transaction-guards'
@@ -22,6 +23,7 @@ import { TxOrderCard } from '@/src/components/transactions-list/Card/TxOrderCard
 import { TxCreationCard } from '@/src/components/transactions-list/Card/TxCreationCard'
 import { TxCardPress } from './types'
 import { StakingTxWithdrawCard } from '@/src/components/transactions-list/Card/StakingTxWithdrawCard'
+import { StakingTxExitCard } from '../transactions-list/Card/StakingTxExitCard'
 interface TxInfoProps {
   tx: Transaction
   bordered?: boolean
@@ -140,6 +142,10 @@ function TxInfoComponent({ tx, bordered, inQueue, onPress }: TxInfoProps) {
         txInfo={txInfo}
       />
     )
+  }
+
+  if (isStakingTxExitInfo(txInfo)) {
+    return <StakingTxExitCard info={txInfo} />
   }
 
   if (isStakingTxWithdrawInfo(txInfo)) {

--- a/apps/mobile/src/components/TxInfo/TxInfo.tsx
+++ b/apps/mobile/src/components/TxInfo/TxInfo.tsx
@@ -11,6 +11,7 @@ import {
   isMultiSendTxInfo,
   isOrderTxInfo,
   isSettingsChangeTxInfo,
+  isStakingTxWithdrawInfo,
   isTransferTxInfo,
 } from '@/src/utils/transaction-guards'
 import { TxBatchCard } from '@/src/components/transactions-list/Card/TxBatchCard'
@@ -20,7 +21,7 @@ import { TxContractInteractionCard } from '@/src/components/transactions-list/Ca
 import { TxOrderCard } from '@/src/components/transactions-list/Card/TxOrderCard'
 import { TxCreationCard } from '@/src/components/transactions-list/Card/TxCreationCard'
 import { TxCardPress } from './types'
-
+import { StakingTxWithdrawCard } from '@/src/components/transactions-list/Card/StakingTxWithdrawCard'
 interface TxInfoProps {
   tx: Transaction
   bordered?: boolean
@@ -139,6 +140,10 @@ function TxInfoComponent({ tx, bordered, inQueue, onPress }: TxInfoProps) {
         txInfo={txInfo}
       />
     )
+  }
+
+  if (isStakingTxWithdrawInfo(txInfo)) {
+    return <StakingTxWithdrawCard info={txInfo} />
   }
 
   return <></>

--- a/apps/mobile/src/components/TxInfo/TxInfo.tsx
+++ b/apps/mobile/src/components/TxInfo/TxInfo.tsx
@@ -11,6 +11,7 @@ import {
   isMultiSendTxInfo,
   isOrderTxInfo,
   isSettingsChangeTxInfo,
+  isStakingTxDepositInfo,
   isStakingTxExitInfo,
   isStakingTxWithdrawInfo,
   isTransferTxInfo,
@@ -23,6 +24,7 @@ import { TxOrderCard } from '@/src/components/transactions-list/Card/TxOrderCard
 import { TxCreationCard } from '@/src/components/transactions-list/Card/TxCreationCard'
 import { TxCardPress } from './types'
 import { StakingTxWithdrawCard } from '@/src/components/transactions-list/Card/StakingTxWithdrawCard'
+import { StakingTxDepositCard } from '../transactions-list/Card/StakingTxDepositCard'
 import { StakingTxExitCard } from '../transactions-list/Card/StakingTxExitCard'
 interface TxInfoProps {
   tx: Transaction
@@ -142,6 +144,10 @@ function TxInfoComponent({ tx, bordered, inQueue, onPress }: TxInfoProps) {
         txInfo={txInfo}
       />
     )
+  }
+
+  if (isStakingTxDepositInfo(txInfo)) {
+    return <StakingTxDepositCard info={txInfo} />
   }
 
   if (isStakingTxExitInfo(txInfo)) {

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.stories.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { StakingTxDepositCard } from '@/src/components/transactions-list/Card/StakingTxDepositCard'
+import { NativeStakingDepositTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { TransactionInfoType } from '@safe-global/store/gateway/types'
+
+// Mock data for NativeStakingDepositTransactionInfo
+const mockStakingTxDepositInfo: NativeStakingDepositTransactionInfo = {
+  type: 'NativeStakingDeposit' as TransactionInfoType.NATIVE_STAKING_DEPOSIT,
+  humanDescription: 'Deposit tokens for staking',
+  status: 'ACTIVE',
+  estimatedEntryTime: Date.now() + 86400000, // 1 day from now
+  estimatedExitTime: Date.now() + 30 * 86400000, // 30 days from now
+  estimatedWithdrawalTime: Date.now() + 32 * 86400000, // 32 days from now
+  fee: 5, // 5% fee
+  monthlyNrr: 4.2, // 4.2% monthly return
+  annualNrr: 50.4, // 50.4% annual return
+  value: '1000000000000000000', // 1 ETH in wei
+  numValidators: 1,
+  expectedAnnualReward: '50400000000000000', // 0.0504 ETH
+  expectedMonthlyReward: '4200000000000000', // 0.0042 ETH
+  expectedFiatAnnualReward: 151.2, // $151.2 assuming 1 ETH = $300
+  expectedFiatMonthlyReward: 12.6, // $12.6
+  tokenInfo: {
+    address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // Common ETH placeholder address
+    decimals: 18,
+    logoUri: 'https://safe-transaction-assets.safe.global/chains/1/chain_logo.png',
+    name: 'Ethereum',
+    symbol: 'ETH',
+    trusted: true,
+  },
+  validators: ['0xvalidator1', '0xvalidator2'],
+}
+
+const meta: Meta<typeof StakingTxDepositCard> = {
+  title: 'TransactionsList/StakingTxDepositCard',
+  component: StakingTxDepositCard,
+  argTypes: {},
+  args: {
+    info: mockStakingTxDepositInfo,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof StakingTxDepositCard>
+
+export const Default: Story = {}
+
+export const CustomAmount: Story = {
+  args: {
+    info: {
+      ...mockStakingTxDepositInfo,
+      value: '5000000000000000000', // 5 ETH in wei
+    },
+  },
+}
+
+export const DifferentToken: Story = {
+  args: {
+    info: {
+      ...mockStakingTxDepositInfo,
+      tokenInfo: {
+        address: '0x1111111111',
+        decimals: 18,
+        logoUri:
+          'https://safe-transaction-assets.safe.global/tokens/logos/0x5aFE3855358E112B5647B952709E6165e1c1eEEe.png',
+        name: 'SafeToken',
+        symbol: 'SAFE',
+        trusted: true,
+      },
+    },
+  },
+}

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.test.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { render } from '@/src/tests/test-utils'
+import { StakingTxDepositCard } from './StakingTxDepositCard'
+import { NativeStakingDepositTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+describe('StakingTxDepositCard', () => {
+  const mockInfo = {
+    value: '1000000000000000000',
+    tokenInfo: {
+      symbol: 'ETH',
+      decimals: 18,
+      logoUri: 'https://example.com/eth-logo.png',
+      name: 'Ethereum',
+      address: '0x0000000000000000000000000000000000000000',
+      trusted: true,
+    },
+    type: 'NativeStakingDeposit',
+    humanDescription: 'Deposit tokens for staking',
+    status: 'ACTIVE',
+    estimatedEntryTime: Date.now() + 86400000,
+    estimatedExitTime: Date.now() + 30 * 86400000,
+    estimatedWithdrawalTime: Date.now() + 32 * 86400000,
+    fee: 5,
+    monthlyNrr: 4.2,
+    annualNrr: 50.4,
+    numValidators: 1,
+    expectedAnnualReward: '50400000000000000',
+    expectedMonthlyReward: '4200000000000000',
+    expectedFiatAnnualReward: 151.2,
+    expectedFiatMonthlyReward: 12.6,
+    validators: ['0xvalidator1'],
+  } as NativeStakingDepositTransactionInfo
+
+  it('renders correctly', () => {
+    const { toJSON } = render(<StakingTxDepositCard info={mockInfo} />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+
+  it('renders correctly with given info', () => {
+    const screen = render(<StakingTxDepositCard info={mockInfo} />)
+
+    // Check that important props are passed correctly
+    expect(screen.getByText('Deposit')).toBeTruthy()
+    expect(screen.getByText('1 ETH')).toBeTruthy()
+    expect(screen.getByTestId('logo-image')).toBeTruthy()
+  })
+})

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.tsx
@@ -1,0 +1,18 @@
+import type { NativeStakingDepositTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { TokenAmount } from '@/src/components/TokenAmount'
+import { SafeListItem } from '@/src/components/SafeListItem'
+import { Logo } from '@/src/components/Logo'
+
+export const StakingTxDepositCard = ({ info }: { info: NativeStakingDepositTransactionInfo }) => {
+  return (
+    <SafeListItem
+      label={`Deposit`}
+      icon="transaction-stake"
+      type={'Stake'}
+      rightNode={
+        <TokenAmount value={info.value} tokenSymbol={info.tokenInfo.symbol} decimals={info.tokenInfo.decimals} />
+      }
+      leftNode={<Logo logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+    />
+  )
+}

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
@@ -1,0 +1,241 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StakingTxDepositCard renders correctly 1`] = `
+<View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#FFFFFF",
+        "borderBottomLeftRadius": 7,
+        "borderBottomRightRadius": 7,
+        "borderTopLeftRadius": 7,
+        "borderTopRightRadius": 7,
+        "flexDirection": "row",
+        "flexWrap": "wrap",
+        "gap": 12,
+        "justifyContent": "space-between",
+        "paddingBottom": 16,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 16,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 12,
+          "maxWidth": "55%",
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "width": 40,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "position": "absolute",
+              "right": -10,
+              "top": -10,
+              "zIndex": 1,
+            }
+          }
+        />
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "borderBottomLeftRadius": 100000,
+              "borderBottomRightRadius": 100000,
+              "borderTopLeftRadius": 100000,
+              "borderTopRightRadius": 100000,
+              "flexDirection": "column",
+              "height": 40,
+              "justifyContent": "center",
+              "maxHeight": 40,
+              "maxWidth": 40,
+              "minHeight": 40,
+              "minWidth": 40,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 0,
+              "position": "relative",
+              "width": 40,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "bottom": 0,
+                "flexDirection": "column",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 1,
+              }
+            }
+          >
+            <Image
+              accessibilityLabel="ETH"
+              fullscreen={true}
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                {
+                  "uri": "https://example.com/eth-logo.png",
+                }
+              }
+              style={
+                {
+                  "backgroundColor": "#121312",
+                  "height": 40,
+                  "width": 40,
+                }
+              }
+              testID="logo-image"
+            />
+          </View>
+          <View
+            style={
+              {
+                "backgroundColor": "#EEEFF0",
+                "bottom": 0,
+                "flexDirection": "column",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "#EEEFF0",
+                  "borderBottomLeftRadius": 100,
+                  "borderBottomRightRadius": 100,
+                  "borderTopLeftRadius": 100,
+                  "borderTopRightRadius": 100,
+                  "paddingBottom": 8,
+                  "paddingLeft": 8,
+                  "paddingRight": 8,
+                  "paddingTop": 8,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#A1A3A7",
+                      "fontSize": 24,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "SafeIcons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+                testID="logo-fallback-icon"
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "gap": 4,
+              "marginBottom": 4,
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#A1A3A7",
+                  "fontSize": 10,
+                },
+                undefined,
+                {
+                  "fontFamily": "SafeIcons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+            testID="safe-list-transaction-stake-icon"
+          >
+            
+          </Text>
+          <Text
+            style={
+              {
+                "color": "#A1A3A7",
+                "fontFamily": "DM Sans",
+                "fontSize": 13,
+                "marginBottom": 2,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Stake
+          </Text>
+        </View>
+        <Text
+          style={
+            {
+              "color": "#121312",
+              "fontFamily": "DMSans-SemiBold",
+              "fontSize": 14,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Deposit
+        </Text>
+      </View>
+    </View>
+    <Text
+      style={
+        {
+          "color": "#121312",
+          "fontFamily": "DMSans-Bold",
+        }
+      }
+      suppressHighlighting={true}
+    >
+      1
+       
+      ETH
+    </Text>
+  </View>
+</View>
+`;

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/index.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/index.tsx
@@ -1,0 +1,1 @@
+export { StakingTxDepositCard } from './StakingTxDepositCard'

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.stories.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { StakingTxExitCard } from '@/src/components/transactions-list/Card/StakingTxExitCard'
+import { NativeStakingValidatorsExitTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { TransactionInfoType } from '@safe-global/store/gateway/types'
+
+// Mock data for NativeStakingValidatorsExitTransactionInfo
+const mockStakingTxExitInfo: NativeStakingValidatorsExitTransactionInfo = {
+  type: 'NativeStakingValidatorsExit' as TransactionInfoType.NATIVE_STAKING_VALIDATORS_EXIT,
+  humanDescription: 'Exit staking validators',
+  numValidators: 2,
+  status: 'EXITING',
+  estimatedExitTime: 1703980800, // Unix timestamp for 2023-12-31
+  estimatedWithdrawalTime: 1704585600, // Unix timestamp for 2024-01-07
+  value: '32000000000000000000', // 32 ETH in wei
+  validators: ['0xvalidator1', '0xvalidator2'],
+  tokenInfo: {
+    address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // Common ETH placeholder address
+    decimals: 18,
+    logoUri: 'https://safe-transaction-assets.safe.global/chains/1/chain_logo.png',
+    name: 'Ethereum',
+    symbol: 'ETH',
+    trusted: true,
+  },
+}
+
+const meta: Meta<typeof StakingTxExitCard> = {
+  title: 'TransactionsList/StakingTxExitCard',
+  component: StakingTxExitCard,
+  argTypes: {},
+  args: {
+    info: mockStakingTxExitInfo,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof StakingTxExitCard>
+
+export const Default: Story = {}
+
+export const SingleValidator: Story = {
+  args: {
+    info: {
+      ...mockStakingTxExitInfo,
+      numValidators: 1,
+      validators: ['0xvalidator1'],
+    },
+  },
+}
+
+export const MultipleValidators: Story = {
+  args: {
+    info: {
+      ...mockStakingTxExitInfo,
+      numValidators: 5,
+      validators: ['0xvalidator1', '0xvalidator2', '0xvalidator3', '0xvalidator4', '0xvalidator5'],
+      value: '160000000000000000000', // 160 ETH in wei (5 validators * 32 ETH)
+    },
+  },
+}
+
+export const DifferentToken: Story = {
+  args: {
+    info: {
+      ...mockStakingTxExitInfo,
+      tokenInfo: {
+        address: '0x1111111111',
+        decimals: 18,
+        logoUri:
+          'https://safe-transaction-assets.safe.global/tokens/logos/0x5aFE3855358E112B5647B952709E6165e1c1eEEe.png',
+        name: 'SafeToken',
+        symbol: 'SAFE',
+        trusted: true,
+      },
+    },
+  },
+}

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.test.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { render } from '@/src/tests/test-utils'
+import { StakingTxExitCard } from './StakingTxExitCard'
+import { NativeStakingValidatorsExitTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+describe('StakingTxExitCard', () => {
+  const mockInfo = {
+    numValidators: 2,
+    tokenInfo: {
+      symbol: 'ETH',
+      decimals: 18,
+      logoUri: 'https://example.com/eth-logo.png',
+      name: 'Ethereum',
+      address: '0x0000000000000000000000000000000000000000',
+    },
+  } as NativeStakingValidatorsExitTransactionInfo
+
+  it('renders correctly', () => {
+    const { toJSON } = render(<StakingTxExitCard info={mockInfo} />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+
+  it('renders correctly with given info', () => {
+    const screen = render(<StakingTxExitCard info={mockInfo} />)
+
+    // Check that important props are passed correctly
+    expect(screen.getByText('Withdraw')).toBeTruthy()
+    expect(screen.getByText('2 Validators')).toBeTruthy()
+    expect(screen.getByTestId('logo-image')).toBeTruthy()
+  })
+
+  it('renders singular form for one validator', () => {
+    const singleValidatorInfo = {
+      ...mockInfo,
+      numValidators: 1,
+    } as NativeStakingValidatorsExitTransactionInfo
+
+    const screen = render(<StakingTxExitCard info={singleValidatorInfo} />)
+    expect(screen.getByText('1 Validator')).toBeTruthy()
+  })
+})

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.tsx
@@ -1,0 +1,21 @@
+import type { NativeStakingValidatorsExitTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { SafeListItem } from '@/src/components/SafeListItem'
+import { Logo } from '@/src/components/Logo'
+import { maybePlural } from '@safe-global/utils/utils/formatters'
+import { Text } from 'tamagui'
+
+export const StakingTxExitCard = ({ info }: { info: NativeStakingValidatorsExitTransactionInfo }) => {
+  return (
+    <SafeListItem
+      label={`Withdraw`}
+      icon="transaction-stake"
+      type={'Stake'}
+      rightNode={
+        <Text color="$color" fontWeight={600} textAlign="right">
+          {info.numValidators} Validator{maybePlural(info.numValidators)}
+        </Text>
+      }
+      leftNode={<Logo logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+    />
+  )
+}

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
@@ -1,0 +1,242 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StakingTxExitCard renders correctly 1`] = `
+<View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#FFFFFF",
+        "borderBottomLeftRadius": 7,
+        "borderBottomRightRadius": 7,
+        "borderTopLeftRadius": 7,
+        "borderTopRightRadius": 7,
+        "flexDirection": "row",
+        "flexWrap": "wrap",
+        "gap": 12,
+        "justifyContent": "space-between",
+        "paddingBottom": 16,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 16,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 12,
+          "maxWidth": "55%",
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "width": 40,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "position": "absolute",
+              "right": -10,
+              "top": -10,
+              "zIndex": 1,
+            }
+          }
+        />
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "borderBottomLeftRadius": 100000,
+              "borderBottomRightRadius": 100000,
+              "borderTopLeftRadius": 100000,
+              "borderTopRightRadius": 100000,
+              "flexDirection": "column",
+              "height": 40,
+              "justifyContent": "center",
+              "maxHeight": 40,
+              "maxWidth": 40,
+              "minHeight": 40,
+              "minWidth": 40,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 0,
+              "position": "relative",
+              "width": 40,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "bottom": 0,
+                "flexDirection": "column",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 1,
+              }
+            }
+          >
+            <Image
+              accessibilityLabel="ETH"
+              fullscreen={true}
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                {
+                  "uri": "https://example.com/eth-logo.png",
+                }
+              }
+              style={
+                {
+                  "backgroundColor": "#121312",
+                  "height": 40,
+                  "width": 40,
+                }
+              }
+              testID="logo-image"
+            />
+          </View>
+          <View
+            style={
+              {
+                "backgroundColor": "#EEEFF0",
+                "bottom": 0,
+                "flexDirection": "column",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "#EEEFF0",
+                  "borderBottomLeftRadius": 100,
+                  "borderBottomRightRadius": 100,
+                  "borderTopLeftRadius": 100,
+                  "borderTopRightRadius": 100,
+                  "paddingBottom": 8,
+                  "paddingLeft": 8,
+                  "paddingRight": 8,
+                  "paddingTop": 8,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#A1A3A7",
+                      "fontSize": 24,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "SafeIcons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+                testID="logo-fallback-icon"
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "gap": 4,
+              "marginBottom": 4,
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#A1A3A7",
+                  "fontSize": 10,
+                },
+                undefined,
+                {
+                  "fontFamily": "SafeIcons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+            testID="safe-list-transaction-stake-icon"
+          >
+            
+          </Text>
+          <Text
+            style={
+              {
+                "color": "#A1A3A7",
+                "fontFamily": "DM Sans",
+                "fontSize": 13,
+                "marginBottom": 2,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Stake
+          </Text>
+        </View>
+        <Text
+          style={
+            {
+              "color": "#121312",
+              "fontFamily": "DMSans-SemiBold",
+              "fontSize": 14,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Withdraw
+        </Text>
+      </View>
+    </View>
+    <Text
+      style={
+        {
+          "color": "#121312",
+          "fontFamily": "DMSans-SemiBold",
+          "textAlign": "right",
+        }
+      }
+      suppressHighlighting={true}
+    >
+      2
+       Validator
+      s
+    </Text>
+  </View>
+</View>
+`;

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/index.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/index.tsx
@@ -1,0 +1,1 @@
+export { StakingTxExitCard } from './StakingTxExitCard'

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.stories.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { StakingTxWithdrawCard } from '@/src/components/transactions-list/Card/StakingTxWithdrawCard'
+import { NativeStakingWithdrawTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { TransactionInfoType } from '@safe-global/store/gateway/types'
+
+// Mock data for NativeStakingWithdrawTransactionInfo
+const mockStakingTxWithdrawInfo: NativeStakingWithdrawTransactionInfo = {
+  type: 'NativeStakingWithdraw' as TransactionInfoType.NATIVE_STAKING_WITHDRAW,
+  humanDescription: 'Withdraw staked tokens',
+  value: '1000000000000000000', // 1 ETH in wei
+  tokenInfo: {
+    address: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', // Common ETH placeholder address
+    decimals: 18,
+    logoUri: 'https://safe-transaction-assets.safe.global/chains/1/chain_logo.png',
+    name: 'Ethereum',
+    symbol: 'ETH',
+    trusted: true,
+  },
+  validators: ['0xvalidator1', '0xvalidator2'],
+}
+
+const meta: Meta<typeof StakingTxWithdrawCard> = {
+  title: 'TransactionsList/StakingTxWithdrawCard',
+  component: StakingTxWithdrawCard,
+  argTypes: {},
+  args: {
+    info: mockStakingTxWithdrawInfo,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof StakingTxWithdrawCard>
+
+export const Default: Story = {}
+
+export const CustomAmount: Story = {
+  args: {
+    info: {
+      ...mockStakingTxWithdrawInfo,
+      value: '5000000000000000000', // 5 ETH in wei
+    },
+  },
+}
+
+export const DifferentToken: Story = {
+  args: {
+    info: {
+      ...mockStakingTxWithdrawInfo,
+      tokenInfo: {
+        address: '0x1111111111',
+        decimals: 18,
+        logoUri:
+          'https://safe-transaction-assets.safe.global/tokens/logos/0x5aFE3855358E112B5647B952709E6165e1c1eEEe.png',
+        name: 'SafeToken',
+        symbol: 'SAFE',
+        trusted: true,
+      },
+    },
+  },
+}

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.test.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render } from '@/src/tests/test-utils'
+import { StakingTxWithdrawCard } from './StakingTxWithdrawCard'
+import { NativeStakingWithdrawTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+describe('StakingTxWithdrawCard', () => {
+  const mockInfo = {
+    value: '1000000000000000000',
+    tokenInfo: {
+      symbol: 'ETH',
+      decimals: 18,
+      logoUri: 'https://example.com/eth-logo.png',
+      name: 'Ethereum',
+      address: '0x0000000000000000000000000000000000000000',
+    },
+  } as NativeStakingWithdrawTransactionInfo
+
+  it('renders correctly', () => {
+    const { toJSON } = render(<StakingTxWithdrawCard info={mockInfo} />)
+    expect(toJSON()).toMatchSnapshot()
+  })
+
+  it('renders correctly with given info', () => {
+    const screen = render(<StakingTxWithdrawCard info={mockInfo} />)
+
+    // Check that important props are passed correctly
+    expect(screen.getByText('Claim')).toBeTruthy()
+    expect(screen.getByTestId('token-amount')).toHaveTextContent('1 ETH')
+    expect(screen.getByTestId('logo-image')).toBeTruthy()
+  })
+})

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.tsx
@@ -1,0 +1,23 @@
+import { SafeListItem } from '@/src/components/SafeListItem'
+import { TokenAmount } from '@/src/components/TokenAmount'
+import { NativeStakingWithdrawTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { Logo } from '@/src/components/Logo'
+
+export const StakingTxWithdrawCard = ({ info }: { info: NativeStakingWithdrawTransactionInfo }) => {
+  return (
+    <SafeListItem
+      label={`Claim`}
+      icon="transaction-stake"
+      type={'Stake'}
+      rightNode={
+        <TokenAmount
+          testID="token-amount"
+          value={info.value}
+          tokenSymbol={info.tokenInfo.symbol}
+          decimals={info.tokenInfo.decimals}
+        />
+      }
+      leftNode={<Logo logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+    />
+  )
+}

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
@@ -1,0 +1,242 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StakingTxWithdrawCard renders correctly 1`] = `
+<View>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "backgroundColor": "#FFFFFF",
+        "borderBottomLeftRadius": 7,
+        "borderBottomRightRadius": 7,
+        "borderTopLeftRadius": 7,
+        "borderTopRightRadius": 7,
+        "flexDirection": "row",
+        "flexWrap": "wrap",
+        "gap": 12,
+        "justifyContent": "space-between",
+        "paddingBottom": 16,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 16,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "gap": 12,
+          "maxWidth": "55%",
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "width": 40,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "position": "absolute",
+              "right": -10,
+              "top": -10,
+              "zIndex": 1,
+            }
+          }
+        />
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "borderBottomLeftRadius": 100000,
+              "borderBottomRightRadius": 100000,
+              "borderTopLeftRadius": 100000,
+              "borderTopRightRadius": 100000,
+              "flexDirection": "column",
+              "height": 40,
+              "justifyContent": "center",
+              "maxHeight": 40,
+              "maxWidth": 40,
+              "minHeight": 40,
+              "minWidth": 40,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 0,
+              "position": "relative",
+              "width": 40,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "bottom": 0,
+                "flexDirection": "column",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 1,
+              }
+            }
+          >
+            <Image
+              accessibilityLabel="ETH"
+              fullscreen={true}
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                {
+                  "uri": "https://example.com/eth-logo.png",
+                }
+              }
+              style={
+                {
+                  "backgroundColor": "#121312",
+                  "height": 40,
+                  "width": 40,
+                }
+              }
+              testID="logo-image"
+            />
+          </View>
+          <View
+            style={
+              {
+                "backgroundColor": "#EEEFF0",
+                "bottom": 0,
+                "flexDirection": "column",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "#EEEFF0",
+                  "borderBottomLeftRadius": 100,
+                  "borderBottomRightRadius": 100,
+                  "borderTopLeftRadius": 100,
+                  "borderTopRightRadius": 100,
+                  "paddingBottom": 8,
+                  "paddingLeft": 8,
+                  "paddingRight": 8,
+                  "paddingTop": 8,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#A1A3A7",
+                      "fontSize": 24,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "SafeIcons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+                testID="logo-fallback-icon"
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View>
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "gap": 4,
+              "marginBottom": 4,
+            }
+          }
+        >
+          <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#A1A3A7",
+                  "fontSize": 10,
+                },
+                undefined,
+                {
+                  "fontFamily": "SafeIcons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+            testID="safe-list-transaction-stake-icon"
+          >
+            
+          </Text>
+          <Text
+            style={
+              {
+                "color": "#A1A3A7",
+                "fontFamily": "DM Sans",
+                "fontSize": 13,
+                "marginBottom": 2,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Stake
+          </Text>
+        </View>
+        <Text
+          style={
+            {
+              "color": "#121312",
+              "fontFamily": "DMSans-SemiBold",
+              "fontSize": 14,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Claim
+        </Text>
+      </View>
+    </View>
+    <Text
+      style={
+        {
+          "color": "#121312",
+          "fontFamily": "DMSans-Bold",
+        }
+      }
+      suppressHighlighting={true}
+      testID="token-amount"
+    >
+      1
+       
+      ETH
+    </Text>
+  </View>
+</View>
+`;

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/index.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/index.tsx
@@ -1,0 +1,1 @@
+export { StakingTxWithdrawCard } from './StakingTxWithdrawCard'

--- a/apps/mobile/src/utils/transaction-guards.ts
+++ b/apps/mobile/src/utils/transaction-guards.ts
@@ -30,6 +30,7 @@ import type {
   CreationTransactionInfo,
   CustomTransactionInfo,
   MultisigExecutionDetails,
+  NativeStakingDepositTransactionInfo,
   NativeStakingValidatorsExitTransactionInfo,
   NativeStakingWithdrawTransactionInfo,
 } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
@@ -130,6 +131,10 @@ export const isOrderTxInfo = (value: Transaction['txInfo']): value is SwapOrderT
 
 export const isCancellationTxInfo = (value: Transaction['txInfo']): value is Cancellation => {
   return isCustomTxInfo(value) && value.isCancellation
+}
+
+export const isStakingTxDepositInfo = (value: Transaction['txInfo']): value is NativeStakingDepositTransactionInfo => {
+  return value.type === TransactionInfoType.NATIVE_STAKING_DEPOSIT
 }
 
 export const isStakingTxExitInfo = (

--- a/apps/mobile/src/utils/transaction-guards.ts
+++ b/apps/mobile/src/utils/transaction-guards.ts
@@ -30,6 +30,7 @@ import type {
   CreationTransactionInfo,
   CustomTransactionInfo,
   MultisigExecutionDetails,
+  NativeStakingValidatorsExitTransactionInfo,
   NativeStakingWithdrawTransactionInfo,
 } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
@@ -129,6 +130,12 @@ export const isOrderTxInfo = (value: Transaction['txInfo']): value is SwapOrderT
 
 export const isCancellationTxInfo = (value: Transaction['txInfo']): value is Cancellation => {
   return isCustomTxInfo(value) && value.isCancellation
+}
+
+export const isStakingTxExitInfo = (
+  value: Transaction['txInfo'],
+): value is NativeStakingValidatorsExitTransactionInfo => {
+  return value.type === TransactionInfoType.NATIVE_STAKING_VALIDATORS_EXIT
 }
 
 export const isStakingTxWithdrawInfo = (

--- a/apps/mobile/src/utils/transaction-guards.ts
+++ b/apps/mobile/src/utils/transaction-guards.ts
@@ -30,6 +30,7 @@ import type {
   CreationTransactionInfo,
   CustomTransactionInfo,
   MultisigExecutionDetails,
+  NativeStakingWithdrawTransactionInfo,
 } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
 import { HistoryTransactionItems, PendingTransactionItems } from '@safe-global/store/gateway/types'
@@ -128,6 +129,12 @@ export const isOrderTxInfo = (value: Transaction['txInfo']): value is SwapOrderT
 
 export const isCancellationTxInfo = (value: Transaction['txInfo']): value is Cancellation => {
   return isCustomTxInfo(value) && value.isCancellation
+}
+
+export const isStakingTxWithdrawInfo = (
+  value: Transaction['txInfo'],
+): value is NativeStakingWithdrawTransactionInfo => {
+  return value.type === TransactionInfoType.NATIVE_STAKING_WITHDRAW
 }
 
 export const isTransactionListItem = (

--- a/packages/store/src/gateway/types.ts
+++ b/packages/store/src/gateway/types.ts
@@ -66,6 +66,7 @@ export enum TransactionInfoType {
   SWAP_ORDER = 'SwapOrder',
   TWAP_ORDER = 'TwapOrder',
   SWAP_TRANSFER = 'SwapTransfer',
+  NATIVE_STAKING_DEPOSIT = 'NativeStakingDeposit',
   NATIVE_STAKING_VALIDATORS_EXIT = 'NativeStakingValidatorsExit',
   NATIVE_STAKING_WITHDRAW = 'NativeStakingWithdraw',
 }

--- a/packages/store/src/gateway/types.ts
+++ b/packages/store/src/gateway/types.ts
@@ -66,6 +66,7 @@ export enum TransactionInfoType {
   SWAP_ORDER = 'SwapOrder',
   TWAP_ORDER = 'TwapOrder',
   SWAP_TRANSFER = 'SwapTransfer',
+  NATIVE_STAKING_WITHDRAW = 'NativeStakingWithdraw',
 }
 
 export enum ConflictType {

--- a/packages/store/src/gateway/types.ts
+++ b/packages/store/src/gateway/types.ts
@@ -66,6 +66,7 @@ export enum TransactionInfoType {
   SWAP_ORDER = 'SwapOrder',
   TWAP_ORDER = 'TwapOrder',
   SWAP_TRANSFER = 'SwapTransfer',
+  NATIVE_STAKING_VALIDATORS_EXIT = 'NativeStakingValidatorsExit',
   NATIVE_STAKING_WITHDRAW = 'NativeStakingWithdraw',
 }
 


### PR DESCRIPTION
## What it solves
Staking txs were missing decoding in the history and as such were not shown at all

Resolves https://github.com/safe-global/wallet-private-tasks/issues/225

## How this PR fixes it
Ads decoding for
- staking deposit
- staking withdraw
- staking claim

## How to test it
Import eth:0xAD1Cf279D18f34a13c3Bf9b79F4D427D5CD9505B and check the history tab. You should see the staking tx in the history now.

## Screenshots
<img src="https://github.com/user-attachments/assets/6e8e7778-dceb-4901-85c2-42f443f62962" width="150" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
