### PR TITLE
fix(mobile): wrong status theme in light mode

### DIFF
--- a/apps/mobile/src/components/Badge/theme.ts
+++ b/apps/mobile/src/components/Badge/theme.ts
@@ -26,7 +26,7 @@ export const badgeTheme = {
     color: tokens.color.primaryMainLight,
   },
   light_badge_warning: {
-    color: tokens.color.warning1MainLight,
+    color: tokens.color.warning1ContrastTextLight,
     background: tokens.color.warningBackgroundLight,
   },
   dark_badge_warning: {


### PR DESCRIPTION
## What it solves
In light mode the status text of a swap was not visible.

Resolves https://github.com/safe-global/wallet-private-tasks/issues/137

## How this PR fixes it
Switches the text color to the value from the figma design.

## How to test it
Create a swap and view it in light mode

## Screenshots
before:
<img src="https://github.com/user-attachments/assets/075e5cdf-b755-4302-9157-4bd422f7c677" width="150" />

after:
<img src="https://github.com/user-attachments/assets/214d3138-185d-4b96-b704-805ba1480570" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
