### PR TITLE
fix(mobile): change the sign feedback message

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmTxForm/ConfirmTxForm.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmTxForm/ConfirmTxForm.tsx
@@ -25,7 +25,14 @@ export function ConfirmTxForm({
   const activeSafe = useDefinedActiveSafe()
 
   if (hasSigned) {
-    return <AlreadySigned txId={txId} safeAddress={activeSafe.address} chainId={activeSafe.chainId} />
+    return (
+      <AlreadySigned
+        hasEnoughConfirmations={hasEnoughConfirmations}
+        txId={txId}
+        safeAddress={activeSafe.address}
+        chainId={activeSafe.chainId}
+      />
+    )
   }
 
   if (!canSign) {

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/AlreadySigned.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/AlreadySigned.test.tsx
@@ -46,7 +46,7 @@ describe('AlreadySigned', () => {
   }
 
   it('renders correctly with all required elements', async () => {
-    const { getByText } = await renderWithStore(<AlreadySigned {...mockProps} />)
+    const { getByText } = await renderWithStore(<AlreadySigned hasEnoughConfirmations={true} {...mockProps} />)
 
     expect(getByText('This transaction can be executed in the web app only.')).toBeTruthy()
     expect(getByText('Go to Web app')).toBeTruthy()
@@ -54,7 +54,7 @@ describe('AlreadySigned', () => {
   })
 
   it('opens web app URL when "Go to Web app" is pressed', async () => {
-    const { getByText } = await renderWithStore(<AlreadySigned {...mockProps} />)
+    const { getByText } = await renderWithStore(<AlreadySigned hasEnoughConfirmations={true} {...mockProps} />)
 
     const expectedUrl = SAFE_WEB_TRANSACTIONS_URL.replace(
       ':safeAddressWithChainPrefix',
@@ -65,8 +65,14 @@ describe('AlreadySigned', () => {
     expect(mockOpenURL).toHaveBeenCalledWith(expectedUrl)
   })
 
+  it('renders correctly with all required elements', async () => {
+    const { getByText } = await renderWithStore(<AlreadySigned hasEnoughConfirmations={false} {...mockProps} />)
+
+    expect(getByText('Can be executed once the threshold is reached')).toBeTruthy()
+  })
+
   it('matches snapshot', async () => {
-    const { toJSON } = await renderWithStore(<AlreadySigned {...mockProps} />)
+    const { toJSON } = await renderWithStore(<AlreadySigned hasEnoughConfirmations={true} {...mockProps} />)
     expect(toJSON()).toMatchSnapshot()
   })
 })

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/AlreadySigned.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/AlreadySigned/AlreadySigned.tsx
@@ -11,9 +11,10 @@ type Props = {
   txId: string
   safeAddress: string
   chainId: string
+  hasEnoughConfirmations: boolean
 }
 
-export function AlreadySigned({ txId, safeAddress, chainId }: Props) {
+export function AlreadySigned({ txId, safeAddress, chainId, hasEnoughConfirmations }: Props) {
   const chain = useAppSelector((state) => selectChainById(state, chainId))
   const onPressGoToWebApp = useCallback(() => {
     const url = SAFE_WEB_TRANSACTIONS_URL.replace(
@@ -27,22 +28,29 @@ export function AlreadySigned({ txId, safeAddress, chainId }: Props) {
   return (
     <YStack justifyContent="center" gap="$4" alignItems="center" paddingHorizontal={'$4'}>
       <Text fontSize="$4" fontWeight={400} textAlign="center" color="$textSecondaryLight">
-        This transaction can be executed in the web app only.
+        {hasEnoughConfirmations
+          ? 'This transaction can be executed in the web app only.'
+          : 'Can be executed once the threshold is reached'}
       </Text>
-      <TouchableOpacity onPress={onPressGoToWebApp}>
-        <View flexDirection="row" alignItems="center" gap="$2">
-          <Text fontSize="$4" fontWeight={700} textAlign="center" color="$color">
-            Go to Web app
-          </Text>
-          <SafeFontIcon name="external-link" size={16} color="$color" />
-        </View>
-      </TouchableOpacity>
 
-      <View height={50} width="100%">
-        <SafeButton height="100%" rounded fullscreen fontWeight={600} disabled testID="confirm-button">
-          Confirm
-        </SafeButton>
-      </View>
+      {hasEnoughConfirmations && (
+        <>
+          <TouchableOpacity onPress={onPressGoToWebApp}>
+            <View flexDirection="row" alignItems="center" gap="$2">
+              <Text fontSize="$4" fontWeight={700} textAlign="center" color="$color">
+                Go to Web app
+              </Text>
+              <SafeFontIcon name="external-link" size={16} color="$color" />
+            </View>
+          </TouchableOpacity>
+
+          <View height={50} width="100%">
+            <SafeButton height="100%" rounded fullscreen fontWeight={600} disabled testID="confirm-button">
+              Confirm
+            </SafeButton>
+          </View>
+        </>
+      )}
     </YStack>
   )
 }


### PR DESCRIPTION
## What it solves 

Resolves https://github.com/safe-global/wallet-private-tasks/issues/15

## How this PR fixes it
Now we show "Can be executed once the threshold is reached" when there isn't enough confirmations but all the imported signers in the app has already signed

## How to test it
follow the steps described by @liliya-soroka on this issue: https://github.com/safe-global/wallet-private-tasks/issues/15

## Screenshots
<img width="502" alt="Screenshot 2025-05-09 at 08 25 44" src="https://github.com/user-attachments/assets/76f8d4ba-a981-4cd4-988c-29f7f848b6cf" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
