### PR TITLE
fix: redirect user to the import signer flow if he cames from import safe flow

### DIFF
--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -12,6 +12,7 @@ import { useAppSelector } from '@/src/store/hooks'
 import { selectContactByAddress } from '@/src/store/addressBookSlice'
 import { useCopyAndDispatchToast } from '@/src/hooks/useCopyAndDispatchToast'
 import { router, useLocalSearchParams } from 'expo-router'
+import logger from '@/src/utils/logger'
 
 interface SignersListItemProps {
   item: AddressInfo
@@ -42,6 +43,25 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
     })
   }
 
+  const redirectToImport = () => {
+    router.push({
+      pathname: '/import-signers',
+      params: {
+        safeAddress: local.safeAddress,
+        chainId: local.chainId,
+        import_safe: local.import_safe,
+      },
+    })
+  }
+
+  const handleItemPress = () => {
+    if (local.import_safe && !isMySigner) {
+      return redirectToImport()
+    }
+
+    return redirectToDetails()
+  }
+
   const onPressMenuAction = ({ nativeEvent }: NativeActionEvent) => {
     if (nativeEvent.event === 'rename') {
       return redirectToDetails(true)
@@ -52,20 +72,15 @@ function SignersListItem({ item, index, signersGroup }: SignersListItemProps) {
     }
 
     if (nativeEvent.event === 'import' && !isMySigner) {
-      return router.push({
-        pathname: '/import-signers',
-        params: {
-          safeAddress: local.safeAddress,
-          chainId: local.chainId,
-          import_safe: local.import_safe,
-        },
-      })
+      return redirectToImport()
     }
+
+    logger.error('No action found for nativeEvent', nativeEvent)
   }
 
   return (
     <View position="relative">
-      <TouchableOpacity onPress={() => redirectToDetails()} testID={`signer-${item.value}`}>
+      <TouchableOpacity onPress={handleItemPress} testID={`signer-${item.value}`}>
         <View
           backgroundColor={colorScheme === 'dark' ? '$backgroundPaper' : '$background'}
           borderTopRightRadius={index === 0 ? '$4' : undefined}


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/130

## How this PR fixes it
Now we check in the item click, if the user is coming from the import safe flow or not. If the `import_safe` parameter is passed and the signer that we clicked is not a imported signer, we redirect him to the import signer flow.

## How to test it
Check https://github.com/safe-global/wallet-private-tasks/issues/130

## Video

https://github.com/user-attachments/assets/e3875d99-3068-410d-8e39-64881f945d5f



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
