### PR TITLE
fix(Signing UX): hide sign option if transaction is fully signed

### DIFF
--- a/apps/web/src/components/tx-flow/actions/Sign/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Sign/index.tsx
@@ -6,6 +6,7 @@ import useIsCounterfactualSafe from '@/features/counterfactual/hooks/useIsCounte
 import { type SlotComponentProps, SlotName, withSlot } from '../../slots'
 import type { SubmitCallback } from '../../TxFlow'
 import { useAlreadySigned } from '@/components/tx/SignOrExecuteForm/hooks'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 export const Sign = ({
   onSubmit,
@@ -42,8 +43,11 @@ const useShouldRegisterSlot = () => {
   const { safeTx } = useContext(SafeTxContext)
   const isCounterfactualSafe = useIsCounterfactualSafe()
   const hasSigned = useAlreadySigned(safeTx)
+  const { safe } = useSafeInfo()
 
-  return !!safeTx && !hasSigned && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
+  const isFullySigned = safeTx ? safeTx.signatures.size >= safe.threshold : false
+
+  return !!safeTx && !hasSigned && !isFullySigned && !isCounterfactualSafe && !willExecuteThroughRole && !isProposing
 }
 
 const SignSlot = withSlot({


### PR DESCRIPTION
## What it solves

Hides the Sign option when a transaction is already fully signed.

This also fixes #5847 where the combo button dropdown menu was overlapped by the tooltip when no signer was connected. 

## How to test it

1. Create a transaction and fully sign it without executing
2. Go to the receipt step with the execute button
3. Switch the connected EOA to a wallet that is not an owner of the Safe
4. Observe that only the "Execute" button is visible, instead of the combo button

## Screenshots

## Before

<img width="801" alt="Screenshot 2025-05-09 at 15 07 18" src="https://github.com/user-attachments/assets/2b69c01a-d10d-4d71-8399-39a7b3e844e0" />

## Now

<img width="767" alt="Screenshot 2025-05-09 at 15 36 20" src="https://github.com/user-attachments/assets/380180ca-b891-4de9-a533-2c29f77f03f1" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
