### PR TITLE
fix(mobile): user terms and privacy hard to click

### DIFF
--- a/apps/mobile/src/features/GetStarted/GetStarted.tsx
+++ b/apps/mobile/src/features/GetStarted/GetStarted.tsx
@@ -1,12 +1,17 @@
 import React, { useCallback } from 'react'
 import { Link, useRouter } from 'expo-router'
-import { View, Text, YStack } from 'tamagui'
+import { View, Text, YStack, styled } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { BlurView } from 'expo-blur'
 import { getCrashlytics } from '@react-native-firebase/crashlytics'
 import { getAnalytics } from '@react-native-firebase/analytics'
+
+const StyledText = styled(Text, {
+  fontSize: '$3',
+  color: '$colorSecondary',
+})
 
 export const GetStarted = () => {
   const router = useRouter()
@@ -60,21 +65,24 @@ export const GetStarted = () => {
         >
           Add account
         </SafeButton>
-        <Text paddingHorizontal={'$10'} marginTop={'$2'} textAlign={'center'} fontSize={'$3'} color={'$colorSecondary'}>
-          By continuing, you agree to our{' '}
-          <Link href={'https://app.safe.global/terms'} target={'_blank'}>
-            <Text textDecorationLine={'underline'} color={'$colorSecondary'}>
-              User Terms
-            </Text>
-          </Link>{' '}
-          and{' '}
-          <Link href={'https://app.safe.global/privacy'} target={'_blank'} asChild>
-            <Text textDecorationLine={'underline'} color={'$colorSecondary'}>
-              Privacy Policy
-            </Text>
+        <View
+          paddingHorizontal={'$10'}
+          marginTop={'$2'}
+          flexDirection="row"
+          alignItems="center"
+          flexWrap="wrap"
+          justifyContent="center"
+        >
+          <StyledText>By continuing, you agree to our </StyledText>
+          <Link href={'https://app.safe.global/terms'} target={'_blank'} asChild>
+            <StyledText textDecorationLine={'underline'}>User Terms</StyledText>
           </Link>
-          .
-        </Text>
+          <StyledText> and </StyledText>
+          <Link href={'https://app.safe.global/privacy'} target={'_blank'} asChild>
+            <StyledText textDecorationLine={'underline'}>Privacy Policy</StyledText>
+          </Link>
+          <StyledText>.</StyledText>
+        </View>
       </YStack>
     </YStack>
   )


### PR DESCRIPTION
## What it solves
The double nesting of Text seems to cause the problem as the tappable area ends up being too small. 

Resolves https://github.com/safe-global/safe-wallet-monorepo/issues/4952

## How this PR fixes it
We no longer nest text within text and this seems to make the tappable area bigger.

## How to test it
On the getting started screen tap on "user terms" and "privacy policy" - the buttons should be easy to tap and shouldn't require you hitting the text directly in the middle.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
