### PR TITLE
web(chore): update safe-deployments to v1.37.22

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,7 +59,7 @@
     "@safe-global/protocol-kit": "^4.1.7",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "@safe-global/safe-client-gateway-sdk": "v1.60.1",
-    "@safe-global/safe-deployments": "^1.37.31",
+    "@safe-global/safe-deployments": "^1.37.32",
     "@safe-global/safe-gateway-typescript-sdk": "3.23.1",
     "@safe-global/safe-modules-deployments": "^2.2.8",
     "@safe-global/store": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8257,6 +8257,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@safe-global/safe-deployments@npm:^1.37.32":
+  version: 1.37.32
+  resolution: "@safe-global/safe-deployments@npm:1.37.32"
+  dependencies:
+    semver: "npm:^7.6.2"
+  checksum: 10/95dcf1b4a8e44783979c621bb4aa0f1718be2fca0d35868065dc4baf76e891a8f26c037b4302f5ba537e07b959125c4f66a302ee1ff8170b0310c28f4e5edab5
+  languageName: node
+  linkType: hard
+
 "@safe-global/safe-gateway-typescript-sdk@npm:3.23.1":
   version: 3.23.1
   resolution: "@safe-global/safe-gateway-typescript-sdk@npm:3.23.1"
@@ -8395,7 +8404,7 @@ __metadata:
     "@safe-global/safe-apps-sdk": "npm:^9.1.0"
     "@safe-global/safe-client-gateway-sdk": "npm:v1.60.1"
     "@safe-global/safe-core-sdk-types": "npm:^5.0.1"
-    "@safe-global/safe-deployments": "npm:^1.37.31"
+    "@safe-global/safe-deployments": "npm:^1.37.32"
     "@safe-global/safe-gateway-typescript-sdk": "npm:3.23.1"
     "@safe-global/safe-modules-deployments": "npm:^2.2.8"
     "@safe-global/store": "workspace:^"


### PR DESCRIPTION
## What it solves
The latest deployment has support for hoodi which we need on staging.
