### PR TITLE
Feat(web): don't notify about 1.4.1 upgrades

### DIFF
--- a/apps/web/src/components/settings/ContractVersion/index.tsx
+++ b/apps/web/src/components/settings/ContractVersion/index.tsx
@@ -30,7 +30,7 @@ export const ContractVersion = () => {
   const showUpdateDialog = safeMasterCopy?.deployer === MasterCopyDeployer.GNOSIS && needsUpdate
   const isLatestVersion = safe.version && !showUpdateDialog
 
-  const latestSafeVersion = getLatestSafeVersion(currentChain, true)
+  const latestSafeVersion = getLatestSafeVersion(currentChain)
 
   return (
     <>

--- a/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
@@ -22,6 +22,7 @@ import { GeoblockingContext } from '@/components/common/GeoblockingProvider'
 import { STAKE_EVENTS, STAKE_LABELS } from '@/services/analytics/events/stake'
 import { Tooltip } from '@mui/material'
 import { BRIDGE_EVENTS, BRIDGE_LABELS } from '@/services/analytics/events/bridge'
+import { isNonCriticalUpdate } from '@safe-global/utils/utils/chains'
 
 const getSubdirectory = (pathname: string): string => {
   return pathname.split('/')[1]
@@ -64,7 +65,9 @@ const Navigation = (): ReactElement => {
   const getBadge = (item: NavItem) => {
     // Indicate whether the current Safe needs an upgrade
     if (item.href === AppRoutes.settings.setup) {
-      return safe.implementationVersionState === ImplementationVersionState.OUTDATED
+      return (
+        safe.implementationVersionState === ImplementationVersionState.OUTDATED && !isNonCriticalUpdate(safe.version)
+      )
     }
   }
 

--- a/apps/web/src/hooks/useSafeNotifications.ts
+++ b/apps/web/src/hooks/useSafeNotifications.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect } from 'react'
-import semverSatisfies from 'semver/functions/satisfies'
 import { showNotification, closeNotification } from '@/store/notificationsSlice'
 import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
 import useSafeInfo from './useSafeInfo'
@@ -12,6 +11,7 @@ import useIsSafeOwner from './useIsSafeOwner'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { isValidSafeVersion } from '@safe-global/utils/services/contracts/utils'
+import { isNonCriticalUpdate } from '@safe-global/utils/utils/chains'
 
 const CLI_LINK = {
   href: 'https://github.com/5afe/safe-cli',
@@ -26,14 +26,9 @@ type DismissedUpdateNotifications = {
 
 const DISMISS_NOTIFICATION_KEY = 'dismissUpdateSafe'
 const OUTDATED_VERSION_KEY = 'safe-outdated-version'
-const MIN_SAFE_VERSION = '1.3.0'
 
 const isUpdateSafeNotification = (groupKey: string) => {
   return groupKey === OUTDATED_VERSION_KEY
-}
-
-const isNonCriticalUpdate = (version?: string | null) => {
-  return version && semverSatisfies(version, `>= ${MIN_SAFE_VERSION}`)
 }
 
 /**

--- a/apps/web/src/hooks/useSafeNotifications.ts
+++ b/apps/web/src/hooks/useSafeNotifications.ts
@@ -90,7 +90,8 @@ const useSafeNotifications = (): void => {
       }
     }
 
-    // Is Safe version is outdated?
+    // Is Safe version outdated?
+    // Non-critical Safe upgrades (versions >= '1.3.0') intentionally skip notifications
     if (implementationVersionState !== ImplementationVersionState.OUTDATED || isNonCriticalUpdate(version)) return
 
     const isUnsupported = !isValidSafeVersion(version)

--- a/apps/web/src/hooks/useSafeNotifications.ts
+++ b/apps/web/src/hooks/useSafeNotifications.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from 'react'
+import semverSatisfies from 'semver/functions/satisfies'
 import { showNotification, closeNotification } from '@/store/notificationsSlice'
 import { ImplementationVersionState } from '@safe-global/safe-gateway-typescript-sdk'
 import useSafeInfo from './useSafeInfo'
@@ -25,9 +26,14 @@ type DismissedUpdateNotifications = {
 
 const DISMISS_NOTIFICATION_KEY = 'dismissUpdateSafe'
 const OUTDATED_VERSION_KEY = 'safe-outdated-version'
+const MIN_SAFE_VERSION = '1.3.0'
 
 const isUpdateSafeNotification = (groupKey: string) => {
   return groupKey === OUTDATED_VERSION_KEY
+}
+
+const isNonCriticalUpdate = (version?: string | null) => {
+  return version && semverSatisfies(version, `>= ${MIN_SAFE_VERSION}`)
 }
 
 /**
@@ -67,7 +73,6 @@ const useSafeNotifications = (): void => {
   /**
    * Show a notification when the Safe version is out of date
    */
-
   useEffect(() => {
     if (safeAddress !== urlSafeAddress) return
     if (!isOwner) return
@@ -85,7 +90,8 @@ const useSafeNotifications = (): void => {
       }
     }
 
-    if (implementationVersionState !== ImplementationVersionState.OUTDATED) return
+    // Is Safe version is outdated?
+    if (implementationVersionState !== ImplementationVersionState.OUTDATED || isNonCriticalUpdate(version)) return
 
     const isUnsupported = !isValidSafeVersion(version)
 

--- a/apps/web/src/services/tx/safeUpdateParams.ts
+++ b/apps/web/src/services/tx/safeUpdateParams.ts
@@ -53,7 +53,7 @@ export const createUpdateSafeTxs = async (safe: SafeState, chain: ChainInfo): Pr
   ).getAddress()
   const currentReadOnlySafeContract = await getReadOnlyGnosisSafeContract(chain, safe.version)
 
-  const updatedReadOnlySafeContract = await getReadOnlyGnosisSafeContract(chain, getLatestSafeVersion(chain, true))
+  const updatedReadOnlySafeContract = await getReadOnlyGnosisSafeContract(chain, getLatestSafeVersion(chain))
 
   // @ts-expect-error this was removed in 1.3.0 but we need to support it for older safe versions
   const changeMasterCopyCallData = currentReadOnlySafeContract.encode('changeMasterCopy', [latestMasterCopyAddress])

--- a/apps/web/src/utils/__tests__/chains.test.ts
+++ b/apps/web/src/utils/__tests__/chains.test.ts
@@ -51,15 +51,6 @@ describe('chains', () => {
         ).toEqual('1.3.0')
       })
 
-      it('should always return LATEST_VERSION if true is not passed', () => {
-        expect(
-          getLatestSafeVersion(chainBuilder().with({ chainId: '1', recommendedMasterCopyVersion: '1.4.1' }).build()),
-        ).toEqual('1.4.1')
-        expect(
-          getLatestSafeVersion(chainBuilder().with({ chainId: '137', recommendedMasterCopyVersion: '1.3.0' }).build()),
-        ).toEqual('1.4.1')
-      })
-
       it('should fall back to LATEST_VERSION', () => {
         expect(
           getLatestSafeVersion(

--- a/apps/web/src/utils/__tests__/chains.test.ts
+++ b/apps/web/src/utils/__tests__/chains.test.ts
@@ -44,16 +44,10 @@ describe('chains', () => {
     describe('getLatestSafeVersion', () => {
       it('should return the version from recommendedMasterCopyVersion', () => {
         expect(
-          getLatestSafeVersion(
-            chainBuilder().with({ chainId: '1', recommendedMasterCopyVersion: '1.4.1' }).build(),
-            true,
-          ),
+          getLatestSafeVersion(chainBuilder().with({ chainId: '1', recommendedMasterCopyVersion: '1.4.1' }).build()),
         ).toEqual('1.4.1')
         expect(
-          getLatestSafeVersion(
-            chainBuilder().with({ chainId: '137', recommendedMasterCopyVersion: '1.3.0' }).build(),
-            true,
-          ),
+          getLatestSafeVersion(chainBuilder().with({ chainId: '137', recommendedMasterCopyVersion: '1.3.0' }).build()),
         ).toEqual('1.3.0')
       })
 
@@ -70,7 +64,6 @@ describe('chains', () => {
         expect(
           getLatestSafeVersion(
             chainBuilder().with({ chainId: '11155111', recommendedMasterCopyVersion: null }).build(),
-            true,
           ),
         ).toEqual('1.4.1')
       })

--- a/packages/utils/src/utils/chains.ts
+++ b/packages/utils/src/utils/chains.ts
@@ -59,11 +59,8 @@ export const getBlockExplorerLink = (
 const FALLBACK_SAFE_VERSION = '1.3.0' as const
 export const getLatestSafeVersion = (
   chain: Pick<Chain, 'recommendedMasterCopyVersion' | 'chainId'> | undefined,
-  isUpgrade = false,
 ): SafeVersion => {
-  const latestSafeVersion = isUpgrade
-    ? chain?.recommendedMasterCopyVersion || LATEST_SAFE_VERSION // for upgrades, use the recommended version
-    : LATEST_SAFE_VERSION // for Safe creation, always use the latest version
+  const latestSafeVersion = chain?.recommendedMasterCopyVersion || LATEST_SAFE_VERSION
 
   // Without version filter it will always return the LATEST_SAFE_VERSION constant to avoid automatically updating to the newest version if the deployments change
   const latestDeploymentVersion = (getSafeSingletonDeployment({ network: chain?.chainId, released: true })?.version ??

--- a/packages/utils/src/utils/chains.ts
+++ b/packages/utils/src/utils/chains.ts
@@ -43,6 +43,8 @@ export enum FEATURES {
   SPACES = 'SPACES',
 }
 
+const MIN_SAFE_VERSION = '1.3.0'
+
 export const hasFeature = (chain: Pick<Chain, 'features'>, feature: FEATURES): boolean => {
   return (chain.features as string[]).includes(feature)
 }
@@ -72,4 +74,8 @@ export const getLatestSafeVersion = (
   } else {
     return latestSafeVersion as SafeVersion
   }
+}
+
+export const isNonCriticalUpdate = (version?: string | null) => {
+  return version && semverSatisfies(version, `>= ${MIN_SAFE_VERSION}`)
 }


### PR DESCRIPTION
## What it solves

The Safe version upgrade from 1.3.0 to 1.4.1 isn't critical, so we shouldn't show a notification for it. This will allow us to enable 1.4.1 in the config service.

## How it solves it

* Skip notifications for 1.3.0 Safes
* Use the latest Safe version specified in the config service for both Safe upgrades and new Safe creations (previously it was only used for upgrades).