### PR TITLE
Fix(web): don't copy chain prefix when copying addresses

### DIFF
--- a/apps/web/src/store/settingsSlice.ts
+++ b/apps/web/src/store/settingsSlice.ts
@@ -47,8 +47,8 @@ export const initialState: SettingsState = {
   hideSuspiciousTransactions: true,
 
   shortName: {
-    copy: true,
-    qr: true,
+    copy: false,
+    qr: false,
   },
   theme: {},
   env: {

--- a/apps/web/src/store/settingsSlice.ts
+++ b/apps/web/src/store/settingsSlice.ts
@@ -46,6 +46,10 @@ export const initialState: SettingsState = {
 
   hideSuspiciousTransactions: true,
 
+  // The `shortName` object contains settings related to short name interactions.
+  // The `copy` setting determines if the short name can be copied, while the `qr` setting
+  // determines if a QR code for the short name is displayed. Both are disabled by default
+  // for consistency and to avoid unintended behavior.
   shortName: {
     copy: false,
     qr: false,


### PR DESCRIPTION
## What it solves

Copying the chain prefix is confusing to many users as most wallets and dapps still don't support this format.

This PR disables copying prefixes when copying addresses by default. It's still possible to enable it in user preferences.