### PR TITLE
Feat(Spaces): Plug space address book into existing UI

### DIFF
--- a/apps/web/src/components/address-book/AddressBookHeader/index.tsx
+++ b/apps/web/src/components/address-book/AddressBookHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Button, SvgIcon, Grid } from '@mui/material'
+import { Button, SvgIcon, Grid, Box, Typography } from '@mui/material'
 import type { ReactElement, ElementType } from 'react'
 import InputAdornment from '@mui/material/InputAdornment'
 import SearchIcon from '@/public/images/common/search.svg'
@@ -14,6 +14,13 @@ import ImportIcon from '@/public/images/common/import.svg'
 import ExportIcon from '@/public/images/common/export.svg'
 import AddCircleIcon from '@/public/images/common/add-outlined.svg'
 import mapProps from '@/utils/mad-props'
+import Link from 'next/link'
+import { AppRoutes } from '@/config/routes'
+import MUILink from '@mui/material/Link'
+import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
+import { isAuthenticated } from '@/store/authSlice'
+import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
 
 const HeaderButton = ({
   icon,
@@ -32,6 +39,27 @@ const HeaderButton = ({
     <Button onClick={onClick} disabled={disabled} variant="text" color="primary" size="small" startIcon={svg}>
       {children}
     </Button>
+  )
+}
+
+const SpaceAddressBookCTA = () => {
+  const spaceId = useCurrentSpaceId()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const isAdmin = useIsAdmin()
+  const { currentData: space } = useSpacesGetOneV1Query({ id: Number(spaceId) }, { skip: !isUserSignedIn || !spaceId })
+
+  if (!spaceId || !isUserSignedIn || !space || !isAdmin) return null
+
+  return (
+    <Box width={1}>
+      <Typography pl={1} mb={2} maxWidth="500px">
+        This data is stored in your local storage. Do you want to manage your <b>{space.name}</b> space address book
+        instead?{' '}
+        <Link href={{ pathname: AppRoutes.spaces.addressBook, query: { spaceId } }} passHref>
+          <MUILink>Click here</MUILink>
+        </Link>
+      </Typography>
+    </Box>
   )
 }
 
@@ -62,6 +90,8 @@ function AddressBookHeader({
             pb: 1,
           }}
         >
+          <SpaceAddressBookCTA />
+
           <Grid item xs={12} md={5} xl={4.5}>
             <TextField
               placeholder="Search"

--- a/apps/web/src/components/common/AddressBookInput/index.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.tsx
@@ -27,10 +27,14 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
   const { setValue, control } = useFormContext()
   const addressValue = useWatch({ name, control })
 
-  const allAddressBookEntries = mergedAddressBook.map((entry) => ({
-    label: entry.address,
-    name: entry.name,
-  }))
+  const allAddressBookEntries = useMemo(
+    () =>
+      mergedAddressBook.map((entry) => ({
+        label: entry.address,
+        name: entry.name,
+      })),
+    [mergedAddressBook],
+  )
 
   const hasVisibleOptions = useMemo(
     () => !!allAddressBookEntries.filter((entry) => entry.label.includes(addressValue)).length,

--- a/apps/web/src/components/common/AddressBookInput/index.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.tsx
@@ -2,7 +2,6 @@ import { type ReactElement, useState, useMemo } from 'react'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { SvgIcon, Typography } from '@mui/material'
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete'
-import useAddressBook from '@/hooks/useAddressBook'
 import AddressInput, { type AddressInputProps } from '../AddressInput'
 import EthHashInfo from '../EthHashInfo'
 import InfoIcon from '@/public/images/notifications/info.svg'
@@ -11,6 +10,7 @@ import css from './styles.module.css'
 import inputCss from '@/styles/inputs.module.css'
 import { isValidAddress } from '@safe-global/utils/utils/validation'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { useAllMergedAddressBooks } from '@/hooks/useAllAddressBooks'
 
 const abFilterOptions = createFilterOptions({
   stringify: (option: { label: string; name: string }) => option.name + ' ' + option.label,
@@ -20,25 +20,26 @@ const abFilterOptions = createFilterOptions({
  *  Temporary component until revamped safe components are done
  */
 const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canAdd?: boolean }): ReactElement => {
-  const addressBook = useAddressBook()
-  const { setValue, control } = useFormContext()
-  const addressValue = useWatch({ name, control })
   const [open, setOpen] = useState(false)
   const [openAddressBook, setOpenAddressBook] = useState<boolean>(false)
+  const mergedAddressBook = useAllMergedAddressBooks()
 
-  const addressBookEntries = Object.entries(addressBook).map(([address, name]) => ({
-    label: address,
-    name,
+  const { setValue, control } = useFormContext()
+  const addressValue = useWatch({ name, control })
+
+  const allAddressBookEntries = mergedAddressBook.map((entry) => ({
+    label: entry.address,
+    name: entry.name,
   }))
 
   const hasVisibleOptions = useMemo(
-    () => !!addressBookEntries.filter((entry) => entry.label.includes(addressValue)).length,
-    [addressBookEntries, addressValue],
+    () => !!allAddressBookEntries.filter((entry) => entry.label.includes(addressValue)).length,
+    [allAddressBookEntries, addressValue],
   )
 
   const isInAddressBook = useMemo(
-    () => addressBookEntries.some((entry) => sameAddress(entry.label, addressValue)),
-    [addressBookEntries, addressValue],
+    () => allAddressBookEntries.some((entry) => sameAddress(entry.label, addressValue)),
+    [allAddressBookEntries, addressValue],
   )
 
   const customFilterOptions = (options: any, state: any) => {
@@ -71,7 +72,7 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
             disabled={props.disabled}
             readOnly={props.InputProps?.readOnly}
             freeSolo
-            options={addressBookEntries}
+            options={allAddressBookEntries}
             onChange={(_, value) => (typeof value === 'string' ? field.onChange(value) : field.onChange(value.label))}
             onInputChange={(_, value) => setValue(name, value)}
             filterOptions={customFilterOptions}

--- a/apps/web/src/components/common/AddressInputReadOnly/index.tsx
+++ b/apps/web/src/components/common/AddressInputReadOnly/index.tsx
@@ -5,12 +5,10 @@ import css from './styles.module.css'
 
 const AddressInputReadOnly = ({
   address,
-  name,
   showPrefix,
   chainId,
 }: {
   address: string
-  name?: string
   showPrefix?: boolean
   chainId?: string
 }): ReactElement => {
@@ -24,7 +22,6 @@ const AddressInputReadOnly = ({
             copyAddress={false}
             chainId={chainId}
             showPrefix={showPrefix}
-            spaceName={name}
           />
         </Typography>
       </InputAdornment>

--- a/apps/web/src/components/common/Breadcrumbs/BreadcrumbItem.tsx
+++ b/apps/web/src/components/common/Breadcrumbs/BreadcrumbItem.tsx
@@ -1,16 +1,18 @@
 import Link from 'next/link'
 import type { UrlObject } from 'url'
 import { Tooltip, Typography, useMediaQuery, useTheme } from '@mui/material'
-import useAddressBook from '@/hooks/useAddressBook'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import css from './styles.module.css'
 import Identicon from '@/components/common/Identicon'
+import { useAddressBookItem } from '@/hooks/useAllAddressBooks'
+import useChainId from '@/hooks/useChainId'
 
 export const BreadcrumbItem = ({ title, address, href }: { title: string; address: string; href?: UrlObject }) => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
-  const addressBook = useAddressBook()
-  const name = addressBook[address] ?? (isMobile ? shortenAddress(address) : address)
+  const chainId = useChainId()
+  const addressBookItem = useAddressBookItem(address, chainId)
+  const name = addressBookItem ? addressBookItem.name : isMobile ? shortenAddress(address) : address
 
   return (
     <Tooltip title={title}>

--- a/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -1,9 +1,10 @@
 import classnames from 'classnames'
-import type { ReactNode, ReactElement, SyntheticEvent } from 'react'
+import type { ReactElement, ReactNode, SyntheticEvent } from 'react'
 import { isAddress } from 'ethers'
 import { useTheme } from '@mui/material/styles'
 import { Box, SvgIcon, Tooltip } from '@mui/material'
 import AddressBookIcon from '@/public/images/sidebar/address-book.svg'
+import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import Identicon from '../../Identicon'
 import CopyAddressButton from '../../CopyAddressButton'
@@ -11,12 +12,12 @@ import ExplorerButton, { type ExplorerButtonProps } from '../../ExplorerButton'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import ImageFallback from '../../ImageFallback'
 import css from './styles.module.css'
+import { ContactSource } from '@/hooks/useAllAddressBooks'
 
 export type EthHashInfoProps = {
   address: string
   chainId?: string
   name?: string | null
-  spaceName?: string | null
   showAvatar?: boolean
   onlyName?: boolean
   showCopyButton?: boolean
@@ -32,6 +33,7 @@ export type EthHashInfoProps = {
   trusted?: boolean
   ExplorerButtonProps?: ExplorerButtonProps
   isAddressBookName?: boolean
+  addressBookNameSource?: ContactSource
   highlight4bytes?: boolean
 }
 
@@ -55,6 +57,7 @@ const SrcEthHashInfo = ({
   children,
   trusted = true,
   isAddressBookName = false,
+  addressBookNameSource,
   highlight4bytes = false,
 }: EthHashInfoProps): ReactElement => {
   const shouldPrefix = isAddress(address)
@@ -104,9 +107,14 @@ const SrcEthHashInfo = ({
             </Box>
 
             {isAddressBookName && (
-              <Tooltip title="From your address book" placement="top">
+              <Tooltip title={`From your ${addressBookNameSource} address book`} placement="top">
                 <span style={{ lineHeight: 0 }}>
-                  <SvgIcon component={AddressBookIcon} inheritViewBox color="border" fontSize="small" />
+                  <SvgIcon
+                    component={addressBookNameSource === ContactSource.local ? AddressBookIcon : CloudOutlinedIcon}
+                    inheritViewBox
+                    color="border"
+                    fontSize="small"
+                  />
                 </span>
               </Tooltip>
             )}

--- a/apps/web/src/components/common/EthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/index.tsx
@@ -1,6 +1,6 @@
 import { useChain } from '@/hooks/useChains'
 import { type ReactElement } from 'react'
-import useAllAddressBooks from '@/hooks/useAllAddressBooks'
+import { useAddressBookItem } from '@/hooks/useAllAddressBooks'
 import useChainId from '@/hooks/useChainId'
 import { useAppSelector } from '@/store'
 import { selectSettings } from '@/store/settingsSlice'
@@ -15,10 +15,9 @@ const EthHashInfo = ({
   const settings = useAppSelector(selectSettings)
   const currentChainId = useChainId()
   const chain = useChain(props.chainId || currentChainId)
-  const addressBooks = useAllAddressBooks()
+  const addressBookItem = useAddressBookItem(props.address, chain?.chainId)
   const link = chain && props.hasExplorer ? getBlockExplorerLink(chain, props.address) : undefined
-  const addressBookName = chain ? addressBooks?.[chain.chainId]?.[props.address] : undefined
-  const name = showName ? props.spaceName || addressBookName || props.name : undefined
+  const name = showName ? addressBookItem?.name || props.name : undefined
 
   return (
     <SrcEthHashInfo
@@ -26,7 +25,8 @@ const EthHashInfo = ({
       copyPrefix={settings.shortName.copy}
       {...props}
       name={name}
-      isAddressBookName={!!addressBookName && !props.spaceName}
+      isAddressBookName={!!addressBookItem}
+      addressBookNameSource={addressBookItem?.source}
       customAvatar={props.customAvatar}
       ExplorerButtonProps={{ title: link?.title || '', href: link?.href || '' }}
       avatarSize={avatarSize}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
@@ -122,7 +122,7 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
             <Typography mb={2}>Edit contact details. Anyone in the space can see it.</Typography>
             <Stack spacing={3}>
               <Box pt={1}>
-                <AddressInputReadOnly address={entry.address} name={entry.name} />
+                <AddressInputReadOnly address={entry.address} />
               </Box>
 
               <NameInput name="name" label="Name" required />

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -27,14 +27,7 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
           <Stack direction="row" spacing={1} alignItems="center">
             <Identicon address={entry.address} size={32} />
             <Stack direction="column" spacing={0.5}>
-              <EthHashInfo
-                spaceName={entry.name}
-                showAvatar={false}
-                address={entry.address}
-                shortAddress={false}
-                hasExplorer
-                showCopyButton
-              />
+              <EthHashInfo showAvatar={false} address={entry.address} shortAddress={false} hasExplorer showCopyButton />
             </Stack>
           </Stack>
         ),

--- a/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
+++ b/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
@@ -1,0 +1,142 @@
+import { renderHook } from '@testing-library/react'
+import {
+  useAllMergedAddressBooks,
+  useAddressBookItem,
+  ContactSource,
+  type ExtendedContact,
+} from '@/hooks/useAllAddressBooks'
+import * as spacesQueries from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import * as currentSpaceIdHook from '@/features/spaces/hooks/useCurrentSpaceId'
+
+let signedIn = false
+let currentSpaceId = '123'
+let chainId = '1'
+let localAddressBook: Record<string, string> = {}
+let remoteContacts: ExtendedContact[] = []
+
+jest.mock('@/store', () => ({
+  useAppSelector: (selector: (state: unknown) => unknown) => selector({}),
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: () => signedIn,
+}))
+
+jest.mock('@/store/addressBookSlice', () => ({
+  selectAllAddressBooks: jest.fn(() => localAddressBook),
+}))
+
+jest.mock('@/hooks/useAddressBook', () => () => localAddressBook)
+
+jest.mock('@/hooks/useChainId', () => () => chainId)
+
+describe('useAllAddressBooks', () => {
+  describe('useAllMergedAddressBooks', () => {
+    beforeEach(() => {
+      jest.spyOn(spacesQueries, 'useAddressBooksGetAddressBookItemsV1Query').mockImplementation(() => ({
+        currentData: {
+          data: remoteContacts,
+        },
+        refetch: jest.fn(),
+      }))
+
+      jest.spyOn(currentSpaceIdHook, 'useCurrentSpaceId').mockReturnValue(currentSpaceId)
+    })
+
+    afterEach(() => {
+      remoteContacts = []
+      localAddressBook = {}
+      signedIn = false
+      jest.clearAllMocks()
+    })
+
+    it('returns ONLY local contacts when the user is NOT signed in', () => {
+      signedIn = false
+      localAddressBook = {
+        '0xA': 'Alice',
+        '0xB': 'Bob',
+      }
+
+      const { result } = renderHook(() => useAllMergedAddressBooks())
+
+      expect(result.current).toHaveLength(2)
+      expect(result.current.map((c) => c.address)).toEqual(['0xA', '0xB'])
+      result.current.forEach((c) => expect(c.source).toBe(ContactSource.local))
+    })
+
+    it('merges space & local contacts, filtering duplicates by address', () => {
+      signedIn = true
+      localAddressBook = {
+        '0xA': 'Alice (local)',
+        '0xB': 'Bob',
+      }
+
+      remoteContacts = [
+        {
+          name: 'Alice (space)',
+          address: '0xA',
+          chainIds: ['1'],
+          createdBy: '',
+          lastUpdatedBy: '',
+          source: ContactSource.space,
+        },
+        {
+          name: 'Carl',
+          address: '0xC',
+          chainIds: ['1'],
+          createdBy: '',
+          lastUpdatedBy: '',
+          source: ContactSource.space,
+        },
+      ]
+
+      const { result } = renderHook(() => useAllMergedAddressBooks())
+
+      expect(result.current).toHaveLength(3)
+      expect(result.current.map((c) => c.address)).toEqual(['0xA', '0xC', '0xB'])
+
+      const addressToSource = Object.fromEntries(result.current.map((c) => [c.address, c.source]))
+
+      expect(addressToSource).toEqual({
+        '0xA': ContactSource.space,
+        '0xC': ContactSource.space,
+        '0xB': ContactSource.local,
+      })
+    })
+  })
+
+  describe('useAddressBookItem', () => {
+    afterEach(() => {
+      remoteContacts = []
+      localAddressBook = {}
+      signedIn = false
+    })
+
+    it('returns the matching contact by address + chainId', () => {
+      signedIn = true
+
+      remoteContacts = [
+        {
+          name: 'Alice',
+          address: '0xA',
+          chainIds: ['1', '5'],
+          createdBy: '',
+          lastUpdatedBy: '',
+          source: ContactSource.space,
+        },
+      ]
+
+      const { result } = renderHook(() => useAddressBookItem('0xA', '1'))
+
+      expect(result.current).toEqual(remoteContacts[0])
+    })
+
+    it('returns undefined when no chainId is provided', () => {
+      localAddressBook = { '0xB': 'Bob' }
+
+      const { result } = renderHook(() => useAddressBookItem('0xB', undefined))
+
+      expect(result.current).toBeUndefined()
+    })
+  })
+})

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -1,5 +1,88 @@
 import { useAppSelector } from '@/store'
-import { selectAllAddressBooks } from '@/store/addressBookSlice'
+import { type AddressBook, selectAllAddressBooks } from '@/store/addressBookSlice'
+import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
+import { isAuthenticated } from '@/store/authSlice'
+import {
+  type SpaceAddressBookItemDto,
+  useAddressBooksGetAddressBookItemsV1Query,
+} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import useAddressBook from '@/hooks/useAddressBook'
+import useChainId from '@/hooks/useChainId'
+import { useMemo } from 'react'
+
+export enum ContactSource {
+  space = 'space',
+  local = 'local',
+}
+export type ExtendedContact = SpaceAddressBookItemDto & { source: ContactSource }
+
+const mapAddressBook = (addressBook: AddressBook, chainId: string): ExtendedContact[] => {
+  return Object.entries(addressBook).map(([address, name]) => ({
+    name,
+    address,
+    chainIds: [chainId],
+    createdBy: '',
+    lastUpdatedBy: '',
+    source: ContactSource.local,
+  }))
+}
+
+/**
+ * Returns the local address book for a specific network
+ * in the same structure as the Space address book
+ */
+const useLocalAddressBook = () => {
+  const chainId = useChainId()
+  const addressBook = useAddressBook()
+
+  return mapAddressBook(addressBook, chainId)
+}
+
+export const useAllMergedAddressBooks = (): ExtendedContact[] => {
+  const spaceId = useCurrentSpaceId()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { currentData: addressBook } = useAddressBooksGetAddressBookItemsV1Query(
+    { spaceId: Number(spaceId) },
+    { skip: !isUserSignedIn },
+  )
+
+  const spaceContacts = useMemo<ExtendedContact[]>(() => {
+    if (!addressBook) return []
+
+    return addressBook.data.map<ExtendedContact>((entry) => ({
+      ...entry,
+      source: ContactSource.space,
+    }))
+  }, [addressBook])
+
+  const localContacts = useLocalAddressBook()
+
+  // Only include local contacts if they don't already exist in the space address book
+  return useMemo<ExtendedContact[]>(() => {
+    return [
+      ...spaceContacts,
+      ...localContacts.filter(
+        (localContact) =>
+          !spaceContacts.some((spaceContact) => sameAddress(spaceContact.address, localContact.address)),
+      ),
+    ]
+  }, [spaceContacts, localContacts])
+}
+
+/**
+ * Return a name for the given address and chainId either
+ * from the local address book or from a space address book
+ * @param address
+ * @param chainId
+ */
+export const useAddressBookItem = (address: string, chainId: string | undefined) => {
+  const allAddressBooks = useAllMergedAddressBooks()
+
+  return chainId
+    ? allAddressBooks.find((entry) => sameAddress(entry.address, address) && entry.chainIds.includes(chainId))
+    : undefined
+}
 
 const useAllAddressBooks = () => {
   return useAppSelector(selectAllAddressBooks)


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/195

## How this PR fixes it

- Creates a new hook `useAllMergedAddressBooks` that merges the space address book with the local address book (for the current network)
- Creates a new hook `useAddressBookItem` that returns a specific item from the above hook
- Uses the newly created hooks inside `AddressBookInput` and `EthHashInfo` among other places where names need to be shown
- If the user is not signed in or no space has been visited or the current safe doesn't belong to a space fall back to the local address book

## How to test it

1. Open a space with an address book and safe accounts attached to it
2. Sign in and navigate to one of the safes
3. Observe the names shown either come from the local address book or space address book
4. Observe a different icon next to the name depending on its source
5. Create a new transaction
6. Click into the recipient field
7. Observe entries from both sources
8. Disconnect your wallet
9. Observe a fallback to the local address book
10. Navigate to the address book within a safe
11. Observe everything is still the same
12. Observe a CTA that leads to the space address book in case you are an admin

## Screenshots

<img width="706" alt="Screenshot 2025-05-13 at 12 24 04" src="https://github.com/user-attachments/assets/0518c482-e5e7-4905-9966-79909d3c9051" />
<img width="396" alt="Screenshot 2025-05-13 at 12 24 11" src="https://github.com/user-attachments/assets/d8b4487d-5282-44d5-9598-57f6af96b961" />
<img width="828" alt="Screenshot 2025-05-15 at 10 44 58" src="https://github.com/user-attachments/assets/b7dbac35-e0d6-4b48-ab0a-bd7941e5409b" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
