### PR TITLE
feat(mobile): rehydrate chainConfig slice

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -35,9 +35,13 @@ configureReanimatedLogger({
   strict: false,
 })
 
-// Initialize store-side effects
-store.dispatch(apiSliceWithChainsConfig.endpoints.getChainsConfig.initiate())
-
+persistor.subscribe(() => {
+  const { bootstrapped } = persistor.getState()
+  if (bootstrapped) {
+    // The chain config is persisted in the store, but might be outdated.
+    store.dispatch(apiSliceWithChainsConfig.endpoints.getChainsConfig.initiate(undefined, { forceRefetch: true }))
+  }
+})
 const HooksInitializer = () => {
   useInitWeb3()
   useInitSafeCoreSDK()

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -4,7 +4,6 @@ import '@/src/platform/intl-polyfills'
 import { Stack } from 'expo-router'
 import 'react-native-reanimated'
 import { SafeThemeProvider } from '@/src/theme/provider/safeTheme'
-import { useEffect } from 'react'
 import { Provider } from 'react-redux'
 import { persistor, store } from '@/src/store'
 import { PersistGate } from 'redux-persist/integration/react'
@@ -42,20 +41,16 @@ const HooksInitializer = () => {
   return null
 }
 
+persistor.subscribe(() => {
+  const { bootstrapped } = persistor.getState()
+  if (bootstrapped) {
+    // The chain config is persisted in the store, but might be outdated.
+    store.dispatch(apiSliceWithChainsConfig.endpoints.getChainsConfig.initiate(undefined, { forceRefetch: true }))
+  }
+})
+
 function RootLayout() {
   useScreenTracking()
-
-  useEffect(() => {
-    const persistorSubscription = persistor.subscribe(() => {
-      const { bootstrapped } = persistor.getState()
-      if (bootstrapped) {
-        // The chain config is persisted in the store, but might be outdated.
-        store.dispatch(apiSliceWithChainsConfig.endpoints.getChainsConfig.initiate(undefined, { forceRefetch: true }))
-      }
-    })
-
-    return () => persistorSubscription()
-  }, [])
 
   return (
     <GestureHandlerRootView>

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -17,15 +17,23 @@ import devToolsEnhancer from 'redux-devtools-expo-dev-plugin'
 import { GATEWAY_URL, isTestingEnv } from '../config/constants'
 import { web3API } from './signersBalance'
 import { setBaseUrl as setSDKBaseURL } from '@safe-global/safe-gateway-typescript-sdk'
+import { createFilter } from '@safe-global/store/utils/persistTransformFilter'
 
 setSDKBaseURL(GATEWAY_URL)
 setBaseUrl(GATEWAY_URL)
+
+const cgwClientFilter = createFilter(
+  cgwClient.reducerPath,
+  ['queries.getChainsConfig(undefined)', 'config'],
+  ['queries.getChainsConfig(undefined)', 'config'],
+)
 
 const persistConfig = {
   key: 'root',
   version: 1,
   storage: reduxStorage,
-  blacklist: [cgwClient.reducerPath, web3API.reducerPath, 'myAccounts'],
+  blacklist: [web3API.reducerPath, 'myAccounts'],
+  transforms: [cgwClientFilter],
 }
 
 export const rootReducer = combineReducers({
@@ -44,7 +52,11 @@ export const rootReducer = combineReducers({
   [cgwClient.reducerPath]: cgwClient.reducer,
 })
 
-const persistedReducer = persistReducer(persistConfig, rootReducer)
+// Define the type for the root reducer
+export type RootReducerState = ReturnType<typeof rootReducer>
+
+// Use the persistReducer with the correct types
+const persistedReducer = persistReducer<RootReducerState>(persistConfig, rootReducer)
 
 export const makeStore = () =>
   configureStore({

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -15,6 +15,7 @@
     "jest": "^29.7.0"
   },
   "dependencies": {
+    "redux-persist": "^6.0.0",
     "ts-node": "^10.9.2"
   }
 }

--- a/packages/store/src/gateway/cgwClient.ts
+++ b/packages/store/src/gateway/cgwClient.ts
@@ -1,5 +1,8 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
+import { REHYDRATE } from 'redux-persist'
+import type { UnknownAction } from '@reduxjs/toolkit'
+import type { Api, CombinedState } from '@reduxjs/toolkit/query'
 
 const CREDENTIAL_ROUTES = [
   /^\/v1\/users/,
@@ -56,4 +59,17 @@ export const dynamicBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBas
 export const cgwClient = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: () => ({}),
+  extractRehydrationInfo: (action: UnknownAction, { reducerPath }): CombinedState<{}, never, 'api'> | undefined => {
+    if (action.type === REHYDRATE && action.payload) {
+      // Use type assertion to tell TypeScript the expected structure
+      const payload = action.payload as {
+        [key: string]: { api?: unknown }
+      }
+
+      if (payload[reducerPath] && 'api' in payload[reducerPath]) {
+        return payload[reducerPath].api as CombinedState<{}, never, 'api'>
+      }
+    }
+    return undefined
+  },
 })

--- a/packages/store/src/utils/persistTransformFilter.test.ts
+++ b/packages/store/src/utils/persistTransformFilter.test.ts
@@ -1,0 +1,224 @@
+import createFilter, {
+  createWhitelistFilter,
+  createBlacklistFilter,
+  persistFilter,
+  Path,
+} from './persistTransformFilter'
+
+// Interface for the transform results to fix typings
+interface TransformResult {
+  in: (state: Record<string, unknown>, key: string, config?: unknown) => Record<string, unknown>
+  out: (state: Record<string, unknown>, key: string, config?: unknown) => Record<string, unknown>
+}
+
+describe('redux-persist-transform-filter', () => {
+  describe('persistFilter', () => {
+    it('should be a function', () => {
+      expect(typeof persistFilter).toBe('function')
+    })
+
+    it('should return a subset, given one key', () => {
+      expect(persistFilter({ a: 'a', b: 'b', c: 'c' }, 'a')).toEqual({ a: 'a' })
+    })
+
+    it('should return a subset, given an array of keys', () => {
+      expect(persistFilter({ a: 'a', b: 'b', c: 'c' }, ['a'])).toEqual({ a: 'a' })
+      expect(persistFilter({ a: 'a', b: 'b', c: 'c' }, ['a', 'b'])).toEqual({ a: 'a', b: 'b' })
+    })
+
+    it('should return a subset, given one key path', () => {
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, 'a.b')).toEqual({ a: { b: 'b' } })
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, 'a.c')).toEqual({ a: { c: 'c' } })
+    })
+
+    it('should return a subset, given an array of key paths', () => {
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, ['a.b'])).toEqual({ a: { b: 'b' } })
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, [['a', 'b']])).toEqual({ a: { b: 'b' } })
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, ['a.b', 'a.c'])).toEqual({ a: { b: 'b', c: 'c' } })
+      expect(
+        persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, [
+          ['a', 'b'],
+          ['a', 'c'],
+        ]),
+      ).toEqual({ a: { b: 'b', c: 'c' } })
+    })
+
+    it('should return a subset, given an object that contains a path and a filterFunction', () => {
+      const store = { a: { id1: { x: true, b: 'b' }, id2: { x: true, b: 'bb' }, id3: { x: false, b: 'bbb' } }, d: 'd' }
+      expect(
+        persistFilter(store, [{ path: 'a', filterFunction: (item: unknown) => (item as { x: boolean }).x }]),
+      ).toEqual({
+        a: { id1: { x: true, b: 'b' }, id2: { x: true, b: 'bb' } },
+      })
+      expect(
+        persistFilter(store, [{ path: 'a', filterFunction: (item: unknown) => (item as { b: string }).b === 'bb' }]),
+      ).toEqual({
+        a: { id2: { x: true, b: 'bb' } },
+      })
+    })
+  })
+
+  describe('persistFilter (blacklist)', () => {
+    it('should return a subset, given one key', () => {
+      expect(persistFilter({ a: 'a', b: 'b', c: 'c' }, 'a', 'blacklist')).toEqual({ b: 'b', c: 'c' })
+    })
+
+    it('should return a subset, given an array of keys', () => {
+      expect(persistFilter({ a: 'a', b: 'b', c: 'c' }, ['a'], 'blacklist')).toEqual({ b: 'b', c: 'c' })
+      expect(persistFilter({ a: 'a', b: 'b', c: 'c' }, ['a', 'b'], 'blacklist')).toEqual({ c: 'c' })
+    })
+
+    it('should return a subset, given one key path', () => {
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, 'a.b', 'blacklist')).toEqual({ a: { c: 'c' }, d: 'd' })
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, 'a.c', 'blacklist')).toEqual({ a: { b: 'b' }, d: 'd' })
+    })
+
+    it('should return a subset, given an array of key paths', () => {
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, ['a.b'], 'blacklist')).toEqual({ a: { c: 'c' }, d: 'd' })
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, [['a', 'b']], 'blacklist')).toEqual({
+        a: { c: 'c' },
+        d: 'd',
+      })
+      expect(persistFilter({ a: { b: 'b', c: 'c' }, d: 'd' }, ['a.b', 'a.c'], 'blacklist')).toEqual({ a: {}, d: 'd' })
+      expect(
+        persistFilter(
+          { a: { b: 'b', c: 'c' }, d: 'd' },
+          [
+            ['a', 'b'],
+            ['a', 'c'],
+          ],
+          'blacklist',
+        ),
+      ).toEqual({ a: {}, d: 'd' })
+    })
+
+    it('should return a subset, given an object that contains a path and a filterFunction', () => {
+      const store = { a: { id1: { x: true, b: 'b' }, id2: { x: true, b: 'bb' }, id3: { x: false, b: 'bbb' } }, d: 'd' }
+      expect(
+        persistFilter(
+          JSON.parse(JSON.stringify(store)),
+          [{ path: 'a', filterFunction: (item: unknown) => (item as { x: boolean }).x }],
+          'blacklist',
+        ),
+      ).toEqual({ a: { id3: { x: false, b: 'bbb' } }, d: 'd' })
+      expect(
+        persistFilter(
+          JSON.parse(JSON.stringify(store)),
+          [{ path: 'a', filterFunction: (item: unknown) => (item as { b: string }).b === 'bb' }],
+          'blacklist',
+        ),
+      ).toEqual({ a: { id1: { x: true, b: 'b' }, id3: { x: false, b: 'bbb' } }, d: 'd' })
+    })
+
+    it('should return a subset, given an object that contains a path and a filterFunction to reduce array', () => {
+      const store = { a: [1, 2, 3], b: 'b' }
+      const result = persistFilter(
+        JSON.parse(JSON.stringify(store)) as Record<string, unknown>,
+        [{ path: 'a', filterFunction: (_item: unknown) => true }],
+        'blacklist',
+      )
+
+      expect(result).toEqual({ a: [], b: 'b' })
+
+      expect(Object.keys(result.a || {}).length).toBe(0)
+    })
+  })
+
+  describe('createFilter', () => {
+    it('should be a function', () => {
+      expect(typeof createFilter).toBe('function')
+    })
+
+    it('should return an object with in and out functions', () => {
+      const myFilter = createFilter('reducerName', 'a.b' as Path, 'a.c' as Path, 'whitelist')
+      expect(typeof myFilter).toBe('object')
+      expect(myFilter).toHaveProperty('in')
+      expect(myFilter).toHaveProperty('out')
+      expect(typeof myFilter.in).toBe('function')
+      expect(typeof myFilter.out).toBe('function')
+    })
+
+    it('should save a subset', () => {
+      const myFilter = createFilter('reducerName', ['a.b', 'd'] as Path[], undefined, 'whitelist') as TransformResult
+
+      const result = myFilter.in({ a: { b: 'b', c: 'c' }, d: 'd' }, 'reducerName', {})
+
+      expect(result).toEqual({ a: { b: 'b' }, d: 'd' })
+    })
+
+    it('should load a subset', () => {
+      const myFilter = createFilter('reducerName', undefined, ['a.b', 'd'] as Path[], 'whitelist') as TransformResult
+
+      const result = myFilter.out({ a: { b: 'b', c: 'c' }, d: 'd' }, 'reducerName', {})
+
+      expect(result).toEqual({ a: { b: 'b' }, d: 'd' })
+    })
+  })
+
+  describe('createWhitelistFilter', () => {
+    it('should be a function', () => {
+      expect(typeof createWhitelistFilter).toBe('function')
+    })
+
+    it('should return an object with in and out functions', () => {
+      const myFilter = createWhitelistFilter('reducerName', 'a.b' as Path, 'a.c' as Path)
+
+      expect(typeof myFilter).toBe('object')
+      expect(myFilter).toHaveProperty('in')
+      expect(myFilter).toHaveProperty('out')
+      expect(typeof myFilter.in).toBe('function')
+      expect(typeof myFilter.out).toBe('function')
+    })
+
+    it('should save a subset', () => {
+      const myFilter = createWhitelistFilter('reducerName', ['a.b', 'd'] as Path[]) as TransformResult
+
+      const result = myFilter.in({ a: { b: 'b', c: 'c' }, d: 'd' }, 'reducerName', {})
+
+      expect(result).toEqual({ a: { b: 'b' }, d: 'd' })
+    })
+
+    it('should load a subset', () => {
+      const myFilter = createWhitelistFilter('reducerName', undefined, ['a.b', 'd'] as Path[]) as TransformResult
+
+      const result = myFilter.out({ a: { b: 'b', c: 'c' }, d: 'd' }, 'reducerName', {})
+
+      expect(result).toEqual({ a: { b: 'b' }, d: 'd' })
+    })
+  })
+
+  describe('createBlacklistFilter', () => {
+    it('should export functions', () => {
+      expect(typeof createBlacklistFilter).toBe('function')
+    })
+
+    it('should return an object with in and out functions', () => {
+      const myFilter = createBlacklistFilter('reducerName', 'a.b' as Path, 'a.c' as Path)
+      expect(typeof myFilter).toBe('object')
+      expect(myFilter).toHaveProperty('in')
+      expect(myFilter).toHaveProperty('out')
+      expect(typeof myFilter.in).toBe('function')
+      expect(typeof myFilter.out).toBe('function')
+    })
+
+    it('should save a subset', () => {
+      const state = { a: { b: 'b', c: 'c' }, d: 'd' }
+      const myFilter = createBlacklistFilter('reducerName', ['a.b', 'd'] as Path[]) as TransformResult
+
+      const result = myFilter.in(state, 'reducerName', {})
+
+      expect(result).toEqual({ a: { c: 'c' } })
+      expect(state).toEqual({ a: { b: 'b', c: 'c' }, d: 'd' })
+    })
+
+    it('should load a subset', () => {
+      const state = { a: { b: 'b', c: 'c' }, d: 'd' }
+      const myFilter = createBlacklistFilter('reducerName', undefined, ['a.b', 'd'] as Path[]) as TransformResult
+
+      const result = myFilter.out(state, 'reducerName', {})
+
+      expect(result).toEqual({ a: { c: 'c' } })
+      expect(state).toEqual({ a: { b: 'b', c: 'c' }, d: 'd' })
+    })
+  })
+})

--- a/packages/store/src/utils/persistTransformFilter.ts
+++ b/packages/store/src/utils/persistTransformFilter.ts
@@ -1,0 +1,154 @@
+// this is copy-paste from https://github.com/edy/redux-persist-transform-filter/tree/master
+// I've changed to typescript and modified the tests to work with jest
+
+import { createTransform, Transform } from 'redux-persist'
+import { set, get, unset, isEmpty, cloneDeep } from 'lodash'
+
+type TransformType = 'whitelist' | 'blacklist'
+type State = Record<string, unknown>
+
+export type Path = string | string[] | { path: string; filterFunction: (value: unknown) => boolean }
+
+export interface FilterObj {
+  path: string
+  filterFunction: (value: unknown) => boolean
+}
+
+/**
+ * Filter object based on provided paths
+ */
+export const persistFilter = (
+  state: State,
+  paths: Path[] | Path,
+  transformType: TransformType = 'whitelist',
+): State => {
+  // Convert single path to array for consistent handling
+  const pathsArray: Path[] = Array.isArray(paths) ? paths : [paths]
+
+  // For whitelist, start with empty object and add whitelisted properties
+  if (transformType === 'whitelist') {
+    const subset: State = {}
+
+    pathsArray.forEach((path) => {
+      if (typeof path === 'object' && 'path' in path) {
+        // Handle filter function paths
+        const { path: pathStr, filterFunction } = path
+        const value = get(state, pathStr)
+
+        if (typeof value === 'object' && value !== null) {
+          if (Array.isArray(value)) {
+            // Handle arrays
+            const filtered = value.filter(filterFunction)
+            if (filtered.length > 0) {
+              set(subset, pathStr, filtered)
+            }
+          } else {
+            // Handle objects
+            const filtered: Record<string, unknown> = {}
+
+            Object.entries(value as Record<string, unknown>).forEach(([key, val]) => {
+              if (filterFunction(val)) {
+                filtered[key] = val
+              }
+            })
+
+            if (!isEmpty(filtered)) {
+              set(subset, pathStr, filtered)
+            }
+          }
+        }
+      } else {
+        // Handle string or array paths
+        const pathStr = Array.isArray(path) ? path.join('.') : path
+        const value = get(state, pathStr)
+
+        if (typeof value !== 'undefined') {
+          set(subset, pathStr, value)
+        }
+      }
+    })
+
+    return subset
+  } else {
+    // For blacklist, start with deep copy of state and remove blacklisted properties
+    const subset = cloneDeep(state)
+
+    pathsArray.forEach((path) => {
+      if (typeof path === 'object' && 'path' in path) {
+        // Handle filter function paths
+        const { path: pathStr, filterFunction } = path
+        const value = get(state, pathStr)
+
+        if (typeof value === 'object' && value !== null) {
+          if (Array.isArray(value)) {
+            // For arrays, just empty the array if using filter functions
+            set(subset, pathStr, [])
+          } else {
+            // For objects, remove keys where filter function is true
+            const currentValue = get(subset, pathStr)
+
+            if (typeof currentValue === 'object' && currentValue !== null && !Array.isArray(currentValue)) {
+              Object.entries(currentValue as Record<string, unknown>).forEach(([key, val]) => {
+                if (filterFunction(val)) {
+                  unset(subset, `${pathStr}.${key}`)
+                }
+              })
+            }
+          }
+        }
+      } else {
+        // Handle string or array paths
+        const pathStr = Array.isArray(path) ? path.join('.') : path
+        unset(subset, pathStr)
+      }
+    })
+
+    return subset
+  }
+}
+
+/**
+ * Create a filter for redux-persist
+ */
+export function createFilter(
+  reducerName: string,
+  inboundPaths?: Path[] | Path,
+  outboundPaths?: Path[] | Path,
+  transformType: TransformType = 'whitelist',
+): Transform<State, State> {
+  return createTransform(
+    // inbound
+    (inboundState: State): State => {
+      return inboundPaths ? persistFilter(inboundState, inboundPaths, transformType) : inboundState
+    },
+    // outbound
+    (outboundState: State): State => {
+      return outboundPaths ? persistFilter(outboundState, outboundPaths, transformType) : outboundState
+    },
+    { whitelist: [reducerName] },
+  )
+}
+
+/**
+ * Create a whitelist filter for redux-persist
+ */
+export function createWhitelistFilter(
+  reducerName: string,
+  inboundPaths?: Path[] | Path,
+  outboundPaths?: Path[] | Path,
+): Transform<State, State> {
+  return createFilter(reducerName, inboundPaths, outboundPaths, 'whitelist')
+}
+
+/**
+ * Create a blacklist filter for redux-persist
+ */
+export function createBlacklistFilter(
+  reducerName: string,
+  inboundPaths?: Path[] | Path,
+  outboundPaths?: Path[] | Path,
+): Transform<State, State> {
+  return createFilter(reducerName, inboundPaths, outboundPaths, 'blacklist')
+}
+
+export default createFilter

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -2,5 +2,8 @@
   "extends": "../../config/tsconfig/confs/base.json",
   "include": [
     "**/*.ts"
-  ]
+  ],
+  "compilerOptions": {
+    "baseUrl": "."
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8316,6 +8316,7 @@ __metadata:
   dependencies:
     "@types/jest": "npm:^29.5.14"
     jest: "npm:^29.7.0"
+    redux-persist: "npm:^6.0.0"
     ts-node: "npm:^10.9.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## What it solves
Currenlty we had to wait for the app to fetch the chainConfig. It doesn’t change that often, so it makes sense that we persist it and use it directly when the app starts. Then we dispatch a new fetch and can update it if something has changed.

## How to test
Launch the app, hit cmd + shift in the terminal and open redux dev tools. Add a safe, Reload the app and inspect the rehydrate action. You should see it having the query and config objects
![grafik](https://github.com/user-attachments/assets/a00a5a5c-e0b4-4b01-ac5c-fdfdaf7816ab)
