### PR TITLE
Fix(Tx flow): don't show hex data as a fallback in multisend

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -76,7 +76,7 @@ const Summary = ({ safeTxData, txData, txInfo, txDetails, showMultisend = true }
       )}
 
       {showDetails && (
-        <Box mt={submittedAt ? 2 : 3}>
+        <Box mt={2}>
           <ColorCodedTxAccordion txInfo={txInfo} txData={txData}>
             <Box my={1}>
               <DecodedData txData={txData} toInfo={toInfo} />

--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/Multisend/index.tsx
@@ -1,4 +1,3 @@
-import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { Operation } from '@safe-global/safe-gateway-typescript-sdk'
 import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
 import { useState, useEffect } from 'react'
@@ -58,19 +57,8 @@ export const Multisend = ({ txData, compact = false }: MultisendProps): ReactEle
     }
   }, [multiSendTransactions, isOpenMapUndefined])
 
-  if (!txData) return null
+  if (!multiSendTransactions) return null
 
-  // ? when can a multiSend call take no parameters?
-  if (!txData.dataDecoded?.parameters) {
-    if (txData.hexData) {
-      return <HexEncodedData title="Data (hex encoded)" hexData={txData.hexData} />
-    }
-    return null
-  }
-
-  if (!multiSendTransactions) {
-    return null
-  }
   return (
     <>
       <MultisendActionsHeader setOpen={setOpenMap} amount={multiSendTransactions.length} compact={compact} />

--- a/apps/web/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
+++ b/apps/web/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
@@ -33,7 +33,7 @@ const ReviewNftBatch = ({ onSubmit, children }: ReviewTransactionProps): ReactEl
     <ReviewTransaction onSubmit={onSubmit}>
       <SendToBlock address={data?.recipient || ''} />
 
-      <FieldsGrid title={`NFT${maybePlural(tokens)}:`}>
+      <FieldsGrid title={`NFT${maybePlural(tokens)}`}>
         <NftItems tokens={tokens} />
       </FieldsGrid>
 

--- a/apps/web/src/components/tx-flow/flows/NftTransfer/SendNftBatch.tsx
+++ b/apps/web/src/components/tx-flow/flows/NftTransfer/SendNftBatch.tsx
@@ -58,11 +58,9 @@ const NftItem = ({ image, name, description }: { image: string; name: string; de
 
 export const NftItems = ({ tokens }: { tokens: SafeCollectibleResponse[] }) => {
   return (
-    <Box
+    <Stack
       data-testid="nft-item-list"
       sx={{
-        display: 'flex',
-        flexDirection: 'column',
         gap: 2,
         overflow: 'auto',
         maxHeight: '20vh',
@@ -77,7 +75,7 @@ export const NftItems = ({ tokens }: { tokens: SafeCollectibleResponse[] }) => {
           description={`Token ID: ${token.id}${token.name ? ` - ${token.name}` : ''}`}
         />
       ))}
-    </Box>
+    </Stack>
   )
 }
 

--- a/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
         </div>
       </div>
       <div
-        class="MuiBox-root css-178yklu"
+        class="MuiBox-root css-1yuhvjn"
       >
         <div
           class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-wrhbuy-MuiPaper-root-MuiAccordion-root"
@@ -333,7 +333,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                         style="--Paper-shadow: none;"
                       >
                         <div
-                          class="MuiStack-root css-1sazv7p-MuiStack-root"
+                          class="MuiStack-root css-eh7dui-MuiStack-root"
                         >
                           <div
                             class="MuiStack-root css-1n46f6x-MuiStack-root"
@@ -372,28 +372,11 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                             </div>
                           </div>
                           <div
-                            class="MuiBox-root css-a35v6e"
+                            class="MuiBox-root css-e0rnc0"
                           >
                             <div
                               class="MuiStack-root css-jfdv4h-MuiStack-root"
                             >
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Primary type
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  SafeTx
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
                               <div
                                 class="MuiStack-root css-665wph-MuiStack-root"
                               >

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
         </div>
       </div>
       <div
-        class="MuiBox-root css-178yklu"
+        class="MuiBox-root css-1yuhvjn"
       >
         <div
           class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-wrhbuy-MuiPaper-root-MuiAccordion-root"
@@ -333,7 +333,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                         style="--Paper-shadow: none;"
                       >
                         <div
-                          class="MuiStack-root css-1sazv7p-MuiStack-root"
+                          class="MuiStack-root css-eh7dui-MuiStack-root"
                         >
                           <div
                             class="MuiStack-root css-1n46f6x-MuiStack-root"
@@ -372,28 +372,11 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                             </div>
                           </div>
                           <div
-                            class="MuiBox-root css-a35v6e"
+                            class="MuiBox-root css-e0rnc0"
                           >
                             <div
                               class="MuiStack-root css-jfdv4h-MuiStack-root"
                             >
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Primary type
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  SafeTx
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
                               <div
                                 class="MuiStack-root css-665wph-MuiStack-root"
                               >

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
         </div>
       </div>
       <div
-        class="MuiBox-root css-178yklu"
+        class="MuiBox-root css-1yuhvjn"
       >
         <div
           class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-wrhbuy-MuiPaper-root-MuiAccordion-root"
@@ -333,7 +333,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                         style="--Paper-shadow: none;"
                       >
                         <div
-                          class="MuiStack-root css-1sazv7p-MuiStack-root"
+                          class="MuiStack-root css-eh7dui-MuiStack-root"
                         >
                           <div
                             class="MuiStack-root css-1n46f6x-MuiStack-root"
@@ -372,28 +372,11 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                             </div>
                           </div>
                           <div
-                            class="MuiBox-root css-a35v6e"
+                            class="MuiBox-root css-e0rnc0"
                           >
                             <div
                               class="MuiStack-root css-jfdv4h-MuiStack-root"
                             >
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Primary type
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  SafeTx
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
                               <div
                                 class="MuiStack-root css-665wph-MuiStack-root"
                               >

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
         </div>
       </div>
       <div
-        class="MuiBox-root css-178yklu"
+        class="MuiBox-root css-1yuhvjn"
       >
         <div
           class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-wrhbuy-MuiPaper-root-MuiAccordion-root"
@@ -333,7 +333,7 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                         style="--Paper-shadow: none;"
                       >
                         <div
-                          class="MuiStack-root css-1sazv7p-MuiStack-root"
+                          class="MuiStack-root css-eh7dui-MuiStack-root"
                         >
                           <div
                             class="MuiStack-root css-1n46f6x-MuiStack-root"
@@ -372,28 +372,11 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                             </div>
                           </div>
                           <div
-                            class="MuiBox-root css-a35v6e"
+                            class="MuiBox-root css-e0rnc0"
                           >
                             <div
                               class="MuiStack-root css-jfdv4h-MuiStack-root"
                             >
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Primary type
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  SafeTx
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
                               <div
                                 class="MuiStack-root css-665wph-MuiStack-root"
                               >


### PR DESCRIPTION
## What it solves

Resolves https://www.notion.so/safe-global/Repeated-data-field-in-the-Send-NFT-tx-1f38180fe5738034871cef3bc475a073

## How this PR fixes it

I've removed the raw data fallback in the Multisend component because we display the same data in the advanced details.