### PR TITLE
fix(web): HexEncodedData component

### DIFF
--- a/apps/web/src/components/transactions/HexEncodedData/HexEncodedData.test.tsx
+++ b/apps/web/src/components/transactions/HexEncodedData/HexEncodedData.test.tsx
@@ -1,7 +1,10 @@
-import { render } from '@/tests/test-utils'
+import { fireEvent, render, screen } from '@/tests/test-utils'
 import { HexEncodedData } from '.'
 
 const hexData = '0xed2ad31ed00088fc64d00c49774b2fe3fb7fd7db1c2a714700892607b9f77dc1'
+
+const longHexData =
+  '0xb460af94123400000000000000000000000000000000000000000000000000000000000186a00000000000000000000000009a1148b5d6a2d34ca46111379d0fd1352a0ade4a0000000000000000000000009a1148b5d6a2d34ca46111379d0fd1352a0ade4a'
 
 describe('HexEncodedData', () => {
   it('should render the default component markup', () => {
@@ -27,10 +30,39 @@ describe('HexEncodedData', () => {
   })
 
   it('should not cut the text in case the limit option is higher than the provided hexData', () => {
-    const result = render(<HexEncodedData hexData={hexData} limit={1000} title="Data (hex-encoded)" />)
+    render(<HexEncodedData hexData={hexData} limit={1000} title="Data (hex-encoded)" />)
 
-    expect(result.container.querySelector("button[data-testid='show-more']")).not.toBeInTheDocument()
+    expect(screen.queryByTestId('show-more')).not.toBeInTheDocument()
+  })
 
-    expect(result.container).toMatchSnapshot()
+  it('should show the full data when expanded', () => {
+    render(<HexEncodedData hexData={longHexData} limit={20} title="Data (hex-encoded)" />)
+
+    // Initially should show shortened data
+    const initialData = screen.getByTestId('tx-hexData')
+    expect(initialData).toHaveTextContent(`${longHexData.slice(0, 20)}… Show more`)
+
+    // Click show more
+    const showMoreButton = screen.getByTestId('show-more')
+    fireEvent.click(showMoreButton)
+
+    // Should now show full data
+    expect(initialData).toHaveTextContent(longHexData)
+
+    // Check that we have tree blocks of dimmed zeroes
+    const zeroesBlocks = initialData.querySelectorAll('span.zeroes')
+    expect(zeroesBlocks).toHaveLength(3)
+    expect(zeroesBlocks[0].textContent).toHaveLength(59)
+    expect(zeroesBlocks[1].textContent).toHaveLength(25)
+    expect(zeroesBlocks[2].textContent).toHaveLength(24)
+    // Show less button should be visible
+    expect(showMoreButton).toHaveTextContent('Show less')
+
+    // Click show less
+    fireEvent.click(showMoreButton)
+
+    // Should be back to shortened data
+    expect(initialData).toHaveTextContent(`${longHexData.slice(0, 20)}… Show more`)
+    expect(showMoreButton).toHaveTextContent('Show more')
   })
 })

--- a/apps/web/src/components/transactions/HexEncodedData/index.tsx
+++ b/apps/web/src/components/transactions/HexEncodedData/index.tsx
@@ -38,16 +38,17 @@ export const HexEncodedData = ({ hexData, title, highlightFirstBytes = true, lim
 
   const dimmedZeroes: ReactElement[] = []
   let index = 0
-  restBytes.replace(/(.*?)(0{18,})(.*?)/g, (_, p1, p2, p3) => {
+  const remainder = restBytes.replace(/(.*?)(0{18,})/g, (_, p1, p2) => {
     dimmedZeroes.push(
       <Fragment key={index++}>{p1}</Fragment>,
       <span className={css.zeroes} key={index++}>
         {p2}
       </span>,
-      <Fragment key={index++}>{p3}</Fragment>,
     )
     return ''
   })
+
+  dimmedZeroes.push(<Fragment key={index++}>{remainder}</Fragment>)
 
   const fullData = dimmedZeroes.length ? dimmedZeroes : restBytes
 


### PR DESCRIPTION
## What it solves
https://www.notion.so/safe-global/Expanded-value-not-shown-in-full-length-Signing-UX-v2-1f38180fe5738003a135e4be534bd4a3

The regex used in `HexEncodedData` to dim zeroes, was not greedy in its third group causing it to always being empty.

## How this PR fixes it
- Removes the 3rd group from regex and instead appends the remainder after splitting blocks of zeroes in `HexEncodedData` to the result.

## How to test it
Test transaction: 
`[URL-to-deployment]/transactions/tx?safe=sep:0x9a1148b5D6a2D34CA46111379d0FD1352a0ade4a&id=multisig_0x9a1148b5D6a2D34CA46111379d0FD1352a0ade4a_0xafb1fa8ce1cb66f51c8c54afd519f59efb904ac307bfb2464cbd5ee4025478e8`

## Screenshots

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
