### PR TITLE
fix(web): disable nested safe creation for non-owners

### DIFF
--- a/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
@@ -10,6 +10,7 @@ import { NestedSafesList } from '@/components/sidebar/NestedSafesList'
 import { NestedSafeInfo } from '@/components/sidebar/NestedSafeInfo'
 import Track from '@/components/common/Track'
 import { NESTED_SAFE_EVENTS } from '@/services/analytics/events/nested-safes'
+import CheckWallet from '@/components/common/CheckWallet'
 
 export function NestedSafesPopover({
   anchorEl,
@@ -85,15 +86,20 @@ export function NestedSafesPopover({
         )}
         {!hideCreationButton && (
           <Track {...NESTED_SAFE_EVENTS.ADD}>
-            <Button
-              data-testid="add-nested-safe-button"
-              variant="contained"
-              sx={{ width: '100%', mt: 3 }}
-              onClick={onAdd}
-            >
-              <SvgIcon component={AddIcon} inheritViewBox fontSize="small" />
-              Add Nested Safe
-            </Button>
+            <CheckWallet>
+              {(ok) => (
+                <Button
+                  data-testid="add-nested-safe-button"
+                  variant="contained"
+                  sx={{ width: '100%', mt: 3 }}
+                  onClick={onAdd}
+                  disabled={!ok}
+                >
+                  <SvgIcon component={AddIcon} inheritViewBox fontSize="small" />
+                  Add Nested Safe
+                </Button>
+              )}
+            </CheckWallet>
           </Track>
         )}
       </Stack>


### PR DESCRIPTION
## What it solves
https://www.notion.so/safe-global/Create-nested-safe-button-is-not-disabled-for-non-owners-add-as-a-task-to-monorepo-1f38180fe57380fcbdd3f6c709c0b554

## How this PR fixes it
- Wraps button in `<CheckWallet>` component

## How to test it
- Open the Nested Safes popover without being an owner of that Safe

## Screenshots
![Screenshot 2025-05-15 at 16 00 40](https://github.com/user-attachments/assets/2aab51a8-86cd-4250-bd8a-147d00f87367)


## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
