### PR TITLE
fix(Signing UX): restore contract name in method call

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -1,6 +1,6 @@
 import { memo, type ReactElement } from 'react'
 import { generateDataRowValue, TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
-import { isMultiSendTxInfo, isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
+import { isCustomTxInfo, isMultiSendTxInfo, isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
 import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeTransactionData } from '@safe-global/safe-core-sdk-types'
 import { dateString } from '@safe-global/utils/utils/formatters'
@@ -24,7 +24,8 @@ interface Props {
 
 const Summary = ({ safeTxData, txData, txInfo, txDetails, showMultisend = true }: Props): ReactElement => {
   const { txHash, executedAt } = txDetails ?? {}
-  const toInfo = txData?.addressInfoIndex?.[txData?.to.value] || txData?.to
+  const customTxInfo = txInfo && isCustomTxInfo(txInfo) ? txInfo : undefined
+  const toInfo = customTxInfo?.to || txData?.addressInfoIndex?.[txData?.to.value] || txData?.to
   const showDetails = Boolean(txInfo && txData)
 
   let baseGas, gasPrice, gasToken, safeTxGas, refundReceiver, submittedAt, nonce

--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -91,7 +91,14 @@ const Summary = ({ safeTxData, txData, txInfo, txDetails, showMultisend = true }
 
               <DecoderLinks />
 
-              <Receipt safeTxData={safeTxData} txData={txData} txDetails={txDetails} withSignatures grid />
+              <Receipt
+                safeTxData={safeTxData}
+                txData={txData}
+                txDetails={txDetails}
+                txInfo={txInfo}
+                withSignatures
+                grid
+              />
             </Box>
           </ColorCodedTxAccordion>
         </Box>

--- a/apps/web/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
@@ -11,11 +11,15 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { MigrateToL2Information } from '@/components/tx/confirmation-views/MigrateToL2Information'
 import { Box } from '@mui/material'
-import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
+import { isCustomTxInfo, isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
 import useTxPreview from '@/components/tx/confirmation-views/useTxPreview'
 import Summary from '../../Summary'
 
-export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetails }) => {
+export const MigrationToL2TxData = ({
+  txDetails: { txData, txInfo, txHash, detailedExecutionInfo },
+}: {
+  txDetails: TransactionDetails
+}) => {
   const readOnlyProvider = useWeb3ReadOnly()
   const chain = useCurrentChain()
   const { safe } = useSafeInfo()
@@ -23,10 +27,10 @@ export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetai
   // Reconstruct real tx
   const [realSafeTx, realSafeTxError, realSafeTxLoading] = useAsync(async () => {
     // Fetch tx receipt from backend
-    if (!txDetails.txHash || !chain || !sdk) {
+    if (!txHash || !chain || !sdk) {
       return undefined
     }
-    const txResult = await readOnlyProvider?.getTransaction(txDetails.txHash)
+    const txResult = await readOnlyProvider?.getTransaction(txHash)
     const txData = txResult?.data
 
     // Search for a Safe Tx to MultiSend contract
@@ -59,26 +63,24 @@ export const MigrationToL2TxData = ({ txDetails }: { txDetails: TransactionDetai
           gasToken: execTxArgs[7].toString(),
           refundReceiver: execTxArgs[8],
         },
-        isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)
-          ? txDetails.detailedExecutionInfo.nonce
-          : undefined,
+        isMultisigDetailedExecutionInfo(detailedExecutionInfo) ? detailedExecutionInfo.nonce : undefined,
       )
     }
-  }, [txDetails.txHash, txDetails.detailedExecutionInfo, chain, sdk, readOnlyProvider, safe.version])
+  }, [txHash, detailedExecutionInfo, chain, sdk, readOnlyProvider, safe.version])
 
   const decodedDataUnavailable = !realSafeTx && !realSafeTxLoading
   const [txPreview, txPreviewError] = useTxPreview(realSafeTx?.data)
 
   return (
     <Box>
-      <MigrateToL2Information variant="history" txData={txDetails.txData} />
+      <MigrateToL2Information variant="history" txData={txData} />
 
       {realSafeTxError ? (
         <ErrorMessage>{realSafeTxError.message}</ErrorMessage>
       ) : txPreviewError ? (
         <ErrorMessage>{txPreviewError.message}</ErrorMessage>
       ) : decodedDataUnavailable ? (
-        <DecodedData txData={txDetails.txData} />
+        <DecodedData txData={txData} toInfo={txInfo && isCustomTxInfo(txInfo) ? txInfo.to : txData?.to} />
       ) : (
         txPreview && <Summary {...txPreview} safeTxData={realSafeTx?.data} />
       )}

--- a/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
@@ -109,7 +109,7 @@ const TxData = ({
     return <SafeUpdate txData={txData} />
   }
 
-  return <DecodedData txData={txData} toInfo={txData?.to} />
+  return <DecodedData txData={txData} toInfo={isCustomTxInfo(txInfo) ? txInfo.to : txData?.to} />
 }
 
 export default TxData

--- a/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
@@ -1,11 +1,21 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { useAddressName } from '@/components/common/NamedAddressInfo'
+import { isCustomTxInfo } from '@/utils/transaction-guards'
 import { Chip } from '@mui/material'
-import type { TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
+import type { TransactionData, TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 
-const NameChip = ({ txData, withBackground }: { txData?: TransactionData; withBackground?: boolean }) => {
+const NameChip = ({
+  txData,
+  withBackground,
+  txInfo,
+}: {
+  txData?: TransactionData
+  txInfo?: TransactionDetails['txInfo']
+  withBackground?: boolean
+}) => {
   const toAddress = txData?.to.value
-  const toInfo = txData?.addressInfoIndex?.[txData?.to.value] || txData?.to
+  const customTxInfo = txInfo && isCustomTxInfo(txInfo) ? txInfo : undefined
+  const toInfo = customTxInfo?.to || txData?.addressInfoIndex?.[txData?.to.value] || txData?.to
   const toName = toInfo?.name || (toInfo && 'displayName' in toInfo ? String(toInfo.displayName || '') : undefined)
   const toLogo = toInfo?.logoUri
   const contractInfo = useAddressName(toAddress, toName)

--- a/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
@@ -19,6 +19,7 @@ type TxDetailsProps = {
   safeTxData: SafeTransaction['data']
   txData?: TransactionData
   txDetails?: TransactionDetails
+  txInfo?: TransactionDetails['txInfo']
   grid?: boolean
   withSignatures?: boolean
 }
@@ -27,7 +28,7 @@ const ContentWrapper = ({ children }: { children: ReactElement | ReactElement[] 
   <Box sx={{ maxHeight: '550px', flex: 1, overflowY: 'auto', px: 2, pt: 1, mt: '0 !important' }}>{children}</Box>
 )
 
-export const Receipt = ({ safeTxData, txData, txDetails, grid, withSignatures = false }: TxDetailsProps) => {
+export const Receipt = ({ safeTxData, txData, txDetails, txInfo, grid, withSignatures = false }: TxDetailsProps) => {
   const safeTxHash = useSafeTxHash({ safeTxData })
   const domainHash = useDomainHash()
   const messageHash = useMessageHash({ safeTxData })
@@ -50,7 +51,7 @@ export const Receipt = ({ safeTxData, txData, txDetails, grid, withSignatures = 
               <Stack spacing={1} divider={<Divider />}>
                 <TxDetailsRow label="To" grid={grid}>
                   <ToWrapper>
-                    <NameChip txData={txData} withBackground={grid} />
+                    <NameChip txData={txData} txInfo={txInfo} withBackground={grid} />
 
                     <Typography
                       variant="body2"

--- a/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/index.tsx
@@ -92,7 +92,7 @@ export const ConfirmTxDetails = (props: SignOrExecuteProps) => {
           </Stack>
         </Grid>
         <Grid size={{ xs: 12, sm: 6 }}>
-          <Receipt safeTxData={safeTx.data} txData={txPreview?.txData} />
+          <Receipt safeTxData={safeTx.data} txData={txPreview?.txData} txInfo={txPreview?.txInfo} />
         </Grid>
       </Grid>
 

--- a/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
+++ b/apps/web/src/components/tx/ConfirmTxReceipt/index.tsx
@@ -94,7 +94,7 @@ export const ConfirmTxReceipt = ({ children, onSubmit }: PropsWithChildren<{ onS
             </Stack>
           </Grid>
           <Grid size={{ xs: 12, sm: 6 }}>
-            <Receipt safeTxData={safeTx?.data} txData={txPreview?.txData} />
+            <Receipt safeTxData={safeTx?.data} txData={txPreview?.txData} txInfo={txPreview?.txInfo} />
           </Grid>
         </Grid>
 


### PR DESCRIPTION
## What it solves

Resolves: https://www.notion.so/safe-global/Contract-name-not-shown-anymore-Signing-UX-v2-1f38180fe573803c80d2cb8d089062b1?pvs=4

Update the transaction details to show the contract name again if available, which got lost in the Signing UX refactoring.

## How to test it

1. Create a staking withdrawal function using Kiln
2. In the confirm transaction view observe the contract name being shown
  * in the method call details
  * in the transaction details 
4. When having executed the transaction open it in the queue
5. Observe the contract name being present also in the transaction details here

## Screenshots
<img width="771" alt="Screenshot 2025-05-16 at 09 30 37" src="https://github.com/user-attachments/assets/503633c8-cb4a-4ff5-aff4-033d270e18a2" />
<img width="771" alt="Screenshot 2025-05-16 at 09 31 10" src="https://github.com/user-attachments/assets/bd5819bb-36b4-441d-98c9-f3193b6e8ec5" />
