### PR TITLE
fix(Recovery): pass data to second step of recovery flow

### DIFF
--- a/apps/web/src/components/tx-flow/TxFlowStep.tsx
+++ b/apps/web/src/components/tx-flow/TxFlowStep.tsx
@@ -13,7 +13,7 @@ export const TxFlowStep = ({ children, ...txLayoutProps }: TxFlowStepProps) => {
   useEffect(() => {
     updateTxLayoutProps(txLayoutProps)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [txLayoutProps.subtitle, txLayoutProps.title])
 
   return <>{children}</>
 }

--- a/apps/web/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowIntro.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowIntro.tsx
@@ -38,7 +38,7 @@ const RecoverySteps = [
 ]
 
 export function UpsertRecoveryFlowIntro(): ReactElement {
-  const { onNext } = useContext(TxFlowContext)
+  const { onNext, data } = useContext(TxFlowContext)
   return (
     <TxCard>
       <Grid
@@ -78,7 +78,7 @@ export function UpsertRecoveryFlowIntro(): ReactElement {
       </Grid>
       <Divider className={commonCss.nestedDivider} />
       <CardActions sx={{ mt: 'var(--space-1) !important' }}>
-        <Button data-testid="next-btn" variant="contained" onClick={onNext}>
+        <Button data-testid="next-btn" variant="contained" onClick={() => onNext(data)}>
           Next
         </Button>
       </CardActions>

--- a/apps/web/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
@@ -114,7 +114,7 @@ export function UpsertRecoveryFlowSettings({ delayModifier }: { delayModifier?: 
   const isEdit = !!delayModifier
 
   const handleSubmit = async () => {
-    const addressType = await getAddressType(data?.recoverer ?? '', chainId)
+    const addressType = await getAddressType(recoverer, chainId)
     const creationEvent = isEdit ? RECOVERY_EVENTS.SUBMIT_RECOVERY_EDIT : RECOVERY_EVENTS.SUBMIT_RECOVERY_CREATE
     const settings = `delay_${delay},expiry_${expiry},type_${addressType}`
 

--- a/apps/web/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
+++ b/apps/web/src/components/tx-flow/flows/UpsertRecovery/UpsertRecoveryFlowSettings.tsx
@@ -121,7 +121,7 @@ export function UpsertRecoveryFlowSettings({ delayModifier }: { delayModifier?: 
     trackEvent({ ...creationEvent })
     trackEvent({ ...RECOVERY_EVENTS.RECOVERY_SETTINGS, label: settings })
 
-    onNext({ expiry, delay, customDelay, selectedDelay, recoverer })
+    onNext({ expiry, delay, customDelay, selectedDelay, recoverer, moduleAddress: data?.moduleAddress })
   }
 
   return (


### PR DESCRIPTION
## What it solves
https://www.notion.so/safe-global/Safe-recovery-Signing-UX-v2-1f28180fe573806b9a4bff880e8f8016


## How this PR fixes it
- Passes the data correctly between steps

## How to test it
- Setup recovery on an account without recovery
- Change the recovery setup on an account with existing recoverers

## Screenshots
![Screenshot 2025-05-16 at 10 20 34](https://github.com/user-attachments/assets/f4b6e97b-8ea9-45c6-b596-2b0bc1698006)


## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
