### PR TITLE
Fix(Spaces): Update spaces dashboard banner layout

### DIFF
--- a/apps/web/src/components/dashboard/index.tsx
+++ b/apps/web/src/components/dashboard/index.tsx
@@ -17,6 +17,7 @@ import useIsStakingBannerEnabled from '@/features/stake/hooks/useIsStakingBanner
 import { UnsupportedMastercopyWarning } from '@/features/multichain/components/UnsupportedMastercopyWarning/UnsupportedMasterCopyWarning'
 import SpacesDashboardWidget from 'src/features/spaces/components/SpacesDashboardWidget'
 import { FEATURES } from '@safe-global/utils/utils/chains'
+import classnames from 'classnames'
 
 const RecoveryHeader = dynamic(() => import('@/features/recovery/components/RecoveryHeader'))
 
@@ -29,18 +30,18 @@ const Dashboard = (): ReactElement => {
 
   return (
     <>
+      {isSpacesFeatureEnabled && (
+        <Grid item xs={12} className={classnames(css.hideIfEmpty, css.topBanner)}>
+          <SpacesDashboardWidget />
+        </Grid>
+      )}
+
       <Grid container spacing={3}>
         {supportsRecovery && <RecoveryHeader />}
 
         <Grid item xs={12} className={css.hideIfEmpty}>
           <InconsistentSignerSetupWarning />
         </Grid>
-
-        {isSpacesFeatureEnabled && (
-          <Grid item xs={12} className={css.hideIfEmpty}>
-            <SpacesDashboardWidget />
-          </Grid>
-        )}
 
         <Grid item xs={12} className={css.hideIfEmpty}>
           <UnsupportedMastercopyWarning />

--- a/apps/web/src/components/dashboard/styles.module.css
+++ b/apps/web/src/components/dashboard/styles.module.css
@@ -1,3 +1,17 @@
 .hideIfEmpty:empty {
   display: none;
 }
+
+.topBanner {
+  margin-left: calc(var(--space-3) * -1);
+  margin-right: calc(var(--space-3) * -1);
+  margin-top: calc(var(--space-3) * -1);
+}
+
+@media (max-width: 599.95px) {
+  .topBanner {
+    margin-left: calc(var(--space-2) * -1);
+    margin-right: calc(var(--space-2) * -1);
+    margin-top: calc(var(--space-2) * -1);
+  }
+}

--- a/apps/web/src/features/spaces/components/SpacesDashboardWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesDashboardWidget/index.tsx
@@ -1,21 +1,15 @@
-import { Box, Button, Chip, IconButton, Stack, Typography } from '@mui/material'
+import { Box, Button, IconButton, Stack, Typography } from '@mui/material'
 import Track from '@/components/common/Track'
-import SpaceInfoModal from '../SpaceInfoModal'
-import { useState } from 'react'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import CloseIcon from '@mui/icons-material/Close'
-
-const gradientBg = {
-  background: 'linear-gradient(225deg, rgba(95, 221, 255, 0.15) 12.5%, rgba(18, 255, 128, 0.15) 88.07%)',
-}
+import css from './styles.module.css'
 
 const hideWidgetLocalStorageKey = 'hideSpacesDashboardWidget'
 
 const SpacesDashboardWidget = () => {
-  const [isInfoOpen, setIsInfoOpen] = useState<boolean>(false)
   const [widgetHidden = false, setWidgetHidden] = useLocalStorage<boolean>(hideWidgetLocalStorageKey)
 
   const onHide = () => {
@@ -25,49 +19,37 @@ const SpacesDashboardWidget = () => {
   if (widgetHidden) return null
 
   return (
-    <>
-      <Stack direction="row" flexWrap="wrap" gap={2} p={3} sx={gradientBg} position="relative">
-        <Box sx={{ position: 'absolute', right: 24, top: 16 }}>
-          <Track {...SPACE_EVENTS.HIDE_DASHBOARD_WIDGET}>
-            <IconButton aria-label="close" onClick={onHide} size="small">
-              <CloseIcon fontSize="medium" />
-            </IconButton>
-          </Track>
-        </Box>
+    <Stack
+      direction={{ xs: 'column', sm: 'row' }}
+      flexWrap="wrap"
+      gap={2}
+      p={2}
+      sx={{ backgroundColor: 'secondary.light' }}
+      position="relative"
+    >
+      <Box flex={1} minWidth="60%">
+        <Typography>
+          🎉 <b>New! Improved Spaces:</b> All your Safe Accounts, finally organized. Streamlined for teams and solo
+          users alike
+        </Typography>
+      </Box>
 
-        <Box flex={1} minWidth="60%">
-          <Chip label="Beta" sx={{ backgroundColor: '#12FF80', borderRadius: '4px' }} size="small" />
-
-          <Typography variant="h6" fontWeight="700" mb={2} mt={1}>
-            Spaces are here!
-          </Typography>
-
-          <Typography variant="body2">
-            Organize your Safe Accounts, all in one place. Collaborate efficiently with your team members and simplify
-            treasury management.
-            <br />
-            Available now in beta.
-          </Typography>
-        </Box>
-
-        <Stack direction="row" gap={2} alignItems="flex-end">
-          <Track {...SPACE_EVENTS.INFO_MODAL} label={SPACE_LABELS.safe_dashboard_banner}>
-            <Button variant="outlined" onClick={() => setIsInfoOpen(true)}>
-              Learn more
+      <Stack className={css.buttons} direction="row" gap={2} alignItems="flex-end">
+        <Track {...SPACE_EVENTS.OPEN_SPACE_LIST_PAGE} label={SPACE_LABELS.safe_dashboard_banner}>
+          <Link href={AppRoutes.welcome.spaces} passHref>
+            <Button variant="text" size="compact">
+              Try now
             </Button>
-          </Track>
+          </Link>
+        </Track>
 
-          <Track {...SPACE_EVENTS.OPEN_SPACE_LIST_PAGE} label={SPACE_LABELS.safe_dashboard_banner}>
-            <Link href={AppRoutes.welcome.spaces} passHref>
-              <Button variant="contained" sx={{ minHeight: '48px' }}>
-                Try now
-              </Button>
-            </Link>
-          </Track>
-        </Stack>
+        <Track {...SPACE_EVENTS.HIDE_DASHBOARD_WIDGET}>
+          <IconButton aria-label="close" onClick={onHide}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Track>
       </Stack>
-      {isInfoOpen && <SpaceInfoModal onClose={() => setIsInfoOpen(false)} />}
-    </>
+    </Stack>
   )
 }
 

--- a/apps/web/src/features/spaces/components/SpacesDashboardWidget/styles.module.css
+++ b/apps/web/src/features/spaces/components/SpacesDashboardWidget/styles.module.css
@@ -1,0 +1,15 @@
+.buttons {
+    position: absolute;
+    right: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+@media (max-width: 1199.95px) {
+    .buttons {
+        position: relative;
+        transform: none;
+        top: 0;
+        right: 0;
+    }
+}


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/235

## How this PR fixes it

- Updates the spaces dashboard banner layout
- Removed the info modal from there

## How to test it

1. Open a safe
2. Go the the dashboard
3. Observe the new banner design
4. It should still be possible to hide it and click on Try now

## Screenshots
<img width="1299" alt="Screenshot 2025-05-16 at 11 35 35" src="https://github.com/user-attachments/assets/1cdf52aa-0eef-446c-8343-3f5516103e50" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
