### PR TITLE
Feat(Tx flow): restore JSON view + copy button

### DIFF
--- a/apps/web/src/components/common/PaperViewToggle/index.tsx
+++ b/apps/web/src/components/common/PaperViewToggle/index.tsx
@@ -21,7 +21,10 @@ export const PaperViewToggle = ({ children, leftAlign, activeView = 0 }: PaperVi
     (index: number) => {
       // Avoid height change when switching between views
       setMinHeight((prev) => {
-        return Math.max(prev, stackRef.current?.offsetHeight || 0)
+        if (!prev && stackRef.current) {
+          return stackRef.current.offsetHeight
+        }
+        return prev
       })
 
       setActive(index)
@@ -39,7 +42,7 @@ export const PaperViewToggle = ({ children, leftAlign, activeView = 0 }: PaperVi
         pb: 1.5,
       }}
     >
-      <Stack spacing={2} minHeight={`${minHeight}px`} ref={stackRef}>
+      <Stack spacing={2} height={`${minHeight}px`} ref={stackRef}>
         <Stack direction={leftAlign ? 'row' : 'row-reverse'} justifyContent="space-between" px={2} py={1}>
           <ToggleButtonGroup onChange={onChangeView}>{children}</ToggleButtonGroup>
         </Stack>

--- a/apps/web/src/components/tx/ConfirmTxDetails/JsonView.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/JsonView.tsx
@@ -5,7 +5,7 @@ import CopyButton from '@/components/common/CopyButton'
 const containerSx = { backgroundColor: 'background.paper', borderRadius: 1, padding: 2 }
 const codeSx = { wordWrap: 'break-word', whiteSpace: 'pre-wrap' }
 
-export const JsonView = ({ data }: { data: Object }) => {
+export const JsonView = ({ data }: { data: unknown }) => {
   const json = useMemo(() => JSON.stringify(data, null, 2), [data])
 
   return (

--- a/apps/web/src/components/tx/ConfirmTxDetails/JsonView.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/JsonView.tsx
@@ -1,0 +1,22 @@
+import { useMemo } from 'react'
+import { Stack, Box, Typography } from '@mui/material'
+import CopyButton from '@/components/common/CopyButton'
+
+const containerSx = { backgroundColor: 'background.paper', borderRadius: 1, padding: 2 }
+const codeSx = { wordWrap: 'break-word', whiteSpace: 'pre-wrap' }
+
+export const JsonView = ({ data }: { data: Object }) => {
+  const json = useMemo(() => JSON.stringify(data, null, 2), [data])
+
+  return (
+    <Stack sx={containerSx}>
+      <Box alignSelf="flex-end" m={-1}>
+        <CopyButton text={json} />
+      </Box>
+
+      <Typography variant="caption" component="code" sx={codeSx}>
+        {json}
+      </Typography>
+    </Stack>
+  )
+}

--- a/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
@@ -24,7 +24,7 @@ type TxDetailsProps = {
   withSignatures?: boolean
 }
 
-const ContentWrapper = ({ children }: { children: ReactElement | ReactElement[] }) => (
+const ScrollWrapper = ({ children }: { children: ReactElement | ReactElement[] }) => (
   <Box sx={{ maxHeight: '550px', flex: 1, overflowY: 'auto', px: 2, pt: 1, mt: '0 !important' }}>{children}</Box>
 )
 
@@ -47,7 +47,7 @@ export const Receipt = ({ safeTxData, txData, txDetails, grid, withSignatures = 
         {
           title: 'Data',
           content: (
-            <ContentWrapper>
+            <ScrollWrapper>
               <Stack spacing={1} divider={<Divider />}>
                 <TxDetailsRow label="To" grid={grid}>
                   <ToWrapper>
@@ -151,13 +151,13 @@ export const Receipt = ({ safeTxData, txData, txDetails, grid, withSignatures = 
                       ),
                   )}
               </Stack>
-            </ContentWrapper>
+            </ScrollWrapper>
           ),
         },
         {
           title: 'Hashes',
           content: (
-            <ContentWrapper>
+            <ScrollWrapper>
               <Stack spacing={1} divider={<Divider />}>
                 {domainHash && (
                   <TxDetailsRow label="Domain hash" grid={grid}>
@@ -183,15 +183,15 @@ export const Receipt = ({ safeTxData, txData, txDetails, grid, withSignatures = 
                   </TxDetailsRow>
                 )}
               </Stack>
-            </ContentWrapper>
+            </ScrollWrapper>
           ),
         },
         {
           title: 'JSON',
           content: (
-            <ContentWrapper>
+            <ScrollWrapper>
               <JsonView data={safeTxData} />
-            </ContentWrapper>
+            </ScrollWrapper>
           ),
         },
       ]}

--- a/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
@@ -14,6 +14,7 @@ import {
 import TxDetailsRow from './TxDetailsRow'
 import NameChip from './NameChip'
 import { isMultisigDetailedExecutionInfo } from '@/utils/transaction-guards'
+import { JsonView } from './JsonView'
 
 type TxDetailsProps = {
   safeTxData: SafeTransaction['data']
@@ -182,6 +183,14 @@ export const Receipt = ({ safeTxData, txData, txDetails, grid, withSignatures = 
                   </TxDetailsRow>
                 )}
               </Stack>
+            </ContentWrapper>
+          ),
+        },
+        {
+          title: 'JSON',
+          content: (
+            <ContentWrapper>
+              <JsonView data={safeTxData} />
             </ContentWrapper>
           ),
         },

--- a/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                         style="--Paper-shadow: none;"
                       >
                         <div
-                          class="MuiStack-root css-eh7dui-MuiStack-root"
+                          class="MuiStack-root css-1uvd2my-MuiStack-root"
                         >
                           <div
                             class="MuiStack-root css-1n46f6x-MuiStack-root"
@@ -358,7 +358,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                               </button>
                               <button
                                 aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
                                 tabindex="0"
                                 type="button"
                                 value="1"
@@ -367,6 +367,19 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                   class="MuiBox-root css-mro3c9"
                                 >
                                   Hashes
+                                </div>
+                              </button>
+                              <button
+                                aria-pressed="false"
+                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                tabindex="0"
+                                type="button"
+                                value="2"
+                              >
+                                <div
+                                  class="MuiBox-root css-mro3c9"
+                                >
+                                  JSON
                                 </div>
                               </button>
                             </div>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                         style="--Paper-shadow: none;"
                       >
                         <div
-                          class="MuiStack-root css-eh7dui-MuiStack-root"
+                          class="MuiStack-root css-1uvd2my-MuiStack-root"
                         >
                           <div
                             class="MuiStack-root css-1n46f6x-MuiStack-root"
@@ -358,7 +358,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                               </button>
                               <button
                                 aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
                                 tabindex="0"
                                 type="button"
                                 value="1"
@@ -367,6 +367,19 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                   class="MuiBox-root css-mro3c9"
                                 >
                                   Hashes
+                                </div>
+                              </button>
+                              <button
+                                aria-pressed="false"
+                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                tabindex="0"
+                                type="button"
+                                value="2"
+                              >
+                                <div
+                                  class="MuiBox-root css-mro3c9"
+                                >
+                                  JSON
                                 </div>
                               </button>
                             </div>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                         style="--Paper-shadow: none;"
                       >
                         <div
-                          class="MuiStack-root css-eh7dui-MuiStack-root"
+                          class="MuiStack-root css-1uvd2my-MuiStack-root"
                         >
                           <div
                             class="MuiStack-root css-1n46f6x-MuiStack-root"
@@ -358,7 +358,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                               </button>
                               <button
                                 aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
                                 tabindex="0"
                                 type="button"
                                 value="1"
@@ -367,6 +367,19 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                   class="MuiBox-root css-mro3c9"
                                 >
                                   Hashes
+                                </div>
+                              </button>
+                              <button
+                                aria-pressed="false"
+                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                tabindex="0"
+                                type="button"
+                                value="2"
+                              >
+                                <div
+                                  class="MuiBox-root css-mro3c9"
+                                >
+                                  JSON
                                 </div>
                               </button>
                             </div>

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                         style="--Paper-shadow: none;"
                       >
                         <div
-                          class="MuiStack-root css-eh7dui-MuiStack-root"
+                          class="MuiStack-root css-1uvd2my-MuiStack-root"
                         >
                           <div
                             class="MuiStack-root css-1n46f6x-MuiStack-root"
@@ -358,7 +358,7 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                               </button>
                               <button
                                 aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
                                 tabindex="0"
                                 type="button"
                                 value="1"
@@ -367,6 +367,19 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                                   class="MuiBox-root css-mro3c9"
                                 >
                                   Hashes
+                                </div>
+                              </button>
+                              <button
+                                aria-pressed="false"
+                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                tabindex="0"
+                                type="button"
+                                value="2"
+                              >
+                                <div
+                                  class="MuiBox-root css-mro3c9"
+                                >
+                                  JSON
                                 </div>
                               </button>
                             </div>


### PR DESCRIPTION
## What it solves
* Restore a JSON tab in the Receipt component
* Add a copy button

<img width="657" alt="Screenshot 2025-05-16 at 11 57 13" src="https://github.com/user-attachments/assets/20b163b4-9123-4156-af59-ef95554f692c" />
