### PR TITLE
Fix(web): on chain signing confirmation view

### DIFF
--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -68,7 +68,7 @@ export const TxFlow = <T extends unknown>({
       onSubmit?.({ ...props, data })
       trackTimeSpent()
     },
-    [onSubmit, data],
+    [onSubmit, data, trackTimeSpent],
   )
 
   return (

--- a/apps/web/src/components/tx/confirmation-views/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/index.tsx
@@ -6,6 +6,7 @@ import {
   isCustomTxInfo,
   isExecTxData,
   isOnChainConfirmationTxData,
+  isOnChainSignMessageTxData,
   isSafeMigrationTxData,
   isSafeUpdateTxData,
   isSwapOrderTxInfo,
@@ -30,6 +31,7 @@ import { isNestedSafeCreation } from '@/utils/nested-safes'
 import Summary from '@/components/transactions/TxDetails/Summary'
 import TxData from '@/components/transactions/TxDetails/TxData'
 import { isMultiSendCalldata } from '@/utils/transaction-calldata'
+import useChainId from '@/hooks/useChainId'
 
 type ConfirmationViewProps = {
   txDetails?: TransactionDetails
@@ -76,6 +78,7 @@ const getConfirmationViewComponent = ({
 const ConfirmationView = ({ safeTx, txPreview, txDetails, ...props }: ConfirmationViewProps) => {
   const { txFlow } = useContext(TxModalContext)
   const details = txDetails ?? txPreview
+  const chainId = useChainId()
 
   const ConfirmationViewComponent = useMemo(() => {
     return details
@@ -87,7 +90,10 @@ const ConfirmationView = ({ safeTx, txPreview, txDetails, ...props }: Confirmati
       : undefined
   }, [details, txFlow])
 
-  const showTxDetails = details !== undefined && !isMultiSendCalldata(details.txData?.hexData ?? '0x')
+  const showTxDetails =
+    details !== undefined &&
+    !isMultiSendCalldata(details.txData?.hexData ?? '0x') &&
+    !isOnChainSignMessageTxData(details?.txData, chainId)
 
   return (
     <>

--- a/apps/web/src/tests/builders/safeTx.ts
+++ b/apps/web/src/tests/builders/safeTx.ts
@@ -6,9 +6,11 @@ import {
   type Custom,
   DetailedExecutionInfoType,
   type MultisigExecutionInfo,
+  Operation,
   type TransactionInfo,
   TransactionInfoType,
   type TransactionSummary,
+  type TransactionData,
 } from '@safe-global/safe-gateway-typescript-sdk'
 import { TransactionStatus } from '@safe-global/safe-apps-sdk'
 
@@ -109,5 +111,17 @@ export function txInfoBuilder(): IBuilder<TransactionInfo> {
     methodName: faker.string.alpha(),
     to: { value: faker.finance.ethereumAddress() },
     value: faker.number.bigInt({ min: 0, max: 10n ** 18n }).toString(),
+  })
+}
+
+export function txDataBuilder(): IBuilder<TransactionData> {
+  return Builder.new<TransactionData>().with({
+    hexData: faker.string.hexadecimal({ length: faker.number.int({ max: 128 }) }),
+    to: { value: faker.finance.ethereumAddress() },
+    addressInfoIndex: {},
+    value: faker.string.numeric({ length: { min: 1, max: 1000 } }),
+    operation: faker.helpers.enumValue(Operation),
+    trustedDelegateCallTarget: true,
+    dataDecoded: undefined,
   })
 }

--- a/apps/web/src/utils/__tests__/transaction-guards.test.ts
+++ b/apps/web/src/utils/__tests__/transaction-guards.test.ts
@@ -3,12 +3,15 @@ import {
   isExecTxInfo,
   isOnChainConfirmationTxData,
   isOnChainConfirmationTxInfo,
+  isOnChainSignMessageTxData,
   isSafeUpdateTxData,
 } from '../transaction-guards'
 import { faker } from '@faker-js/faker'
-import { Safe__factory } from '@safe-global/utils/types/contracts'
+import { Safe__factory, Sign_message_lib__factory } from '@safe-global/utils/types/contracts'
 import { TransactionInfoType, TransactionTokenType, TransferDirection } from '@safe-global/safe-gateway-typescript-sdk'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
+import { txDataBuilder } from '@/tests/builders/safeTx'
+import { getSignMessageLibDeployment } from '@safe-global/safe-deployments'
 
 describe('transaction-guards', () => {
   describe('isOnChainConfirmationTxData', () => {
@@ -276,6 +279,70 @@ describe('transaction-guards', () => {
       }
 
       expect(isSafeUpdateTxData(mockTxData)).toBeFalsy()
+    })
+  })
+
+  describe('isOnChainSignMessageTxData', () => {
+    it('should return false for undefined', () => {
+      expect(isOnChainSignMessageTxData(undefined, '1')).toBeFalsy()
+    })
+
+    it('should return false for arbitrary txData', () => {
+      expect(isOnChainSignMessageTxData(txDataBuilder().build(), '1')).toBeFalsy()
+    })
+
+    it('should return true for signMessage calls to the SignMessageLib', () => {
+      const signMessageInterface = Sign_message_lib__factory.createInterface()
+      const signMessageLibAddress = getSignMessageLibDeployment({ version: '1.3.0' })?.defaultAddress!
+
+      const mockTxData = txDataBuilder()
+        .with({
+          hexData: signMessageInterface.encodeFunctionData('signMessage', [faker.string.hexadecimal({ length: 64 })]),
+          to: { value: signMessageLibAddress },
+          addressInfoIndex: {},
+          value: '0',
+          operation: 1,
+          trustedDelegateCallTarget: true,
+        })
+        .build()
+
+      expect(isOnChainSignMessageTxData(mockTxData, '1')).toBeTruthy()
+    })
+
+    it('should return false for signMessage calls to a random address', () => {
+      const signMessageInterface = Sign_message_lib__factory.createInterface()
+      const randomAddress = faker.finance.ethereumAddress()
+
+      const mockTxData = txDataBuilder()
+        .with({
+          hexData: signMessageInterface.encodeFunctionData('signMessage', [faker.string.hexadecimal({ length: 64 })]),
+          to: { value: randomAddress },
+          addressInfoIndex: {},
+          value: '0',
+          operation: 1,
+          trustedDelegateCallTarget: true,
+        })
+        .build()
+
+      expect(isOnChainSignMessageTxData(mockTxData, '1')).toBeFalsy()
+    })
+
+    it('should return false for signMessage calls that are not delegate calls', () => {
+      const signMessageInterface = Sign_message_lib__factory.createInterface()
+      const signMessageLibAddress = getSignMessageLibDeployment({ version: '1.3.0' })?.defaultAddress!
+
+      const mockTxData = txDataBuilder()
+        .with({
+          hexData: signMessageInterface.encodeFunctionData('signMessage', [faker.string.hexadecimal({ length: 64 })]),
+          to: { value: signMessageLibAddress },
+          addressInfoIndex: {},
+          value: '0',
+          operation: 0, // Not a delegate call
+          trustedDelegateCallTarget: true,
+        })
+        .build()
+
+      expect(isOnChainSignMessageTxData(mockTxData, '1')).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
## What it solves
https://www.notion.so/safe-global/Messages-sign-onchain-message-Signing-UX-v2-1f28180fe57380cdb1fbf68f905f19b8

## How this PR fixes it
- Hides the Transaction Details for SignMsgLib calls inside the ConfirmationView

## How to test it
- Sign a message on-chain (e.g. by enforcing on-chain sigs in `Settings / Safe Apps`

## Checklist
- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
