### PR TITLE
fix(useIsSidebarRoute): move `router.isReady` into useEffect to fix hydration error

### DIFF
--- a/apps/web/src/hooks/useIsSidebarRoute.ts
+++ b/apps/web/src/hooks/useIsSidebarRoute.ts
@@ -2,6 +2,7 @@ import { AppRoutes } from '@/config/routes'
 import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
 import { usePathname } from 'next/navigation'
 import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
 
 const NO_SIDEBAR_ROUTES = [
   AppRoutes.share.safeApp,
@@ -29,11 +30,17 @@ export function useIsSidebarRoute(pathname?: string): [boolean, boolean] {
   const router = useRouter()
   const clientPathname = usePathname()
   const isSpaceRoute = useIsSpaceRoute()
+  const [hasSafe, setHasSafe] = useState(false)
+
   const route = pathname || clientPathname || ''
   const sidebarQuery = router.query.sidebar === 'true'
   const noSidebar = NO_SIDEBAR_ROUTES.includes(route) && !sidebarQuery
   const toggledSidebar = TOGGLE_SIDEBAR_ROUTES.includes(route) && !sidebarQuery
-  const hasSafe = !router.isReady || !!router.query.safe
+
+  useEffect(() => {
+    if (!router.isReady) return
+    setHasSafe(!!router.query.safe)
+  }, [router.isReady, router.query.safe])
 
   const displaySidebar = (!noSidebar && hasSafe) || isSpaceRoute
 


### PR DESCRIPTION
Fixes a hydration error that occurs when loading a global settings page, such as `/settings/appearance`.

![Screenshot 2025-05-19 at 11 21 15](https://github.com/user-attachments/assets/d4a96976-482c-4ea6-bb65-c88283e02403)

The issue is caused by different values of the `hasSafe` variable inside useIsSidebarRoute hook on client and server. This happens because `router.isReady` is always false on the server, while in the client it's true.

Moving the `router.isReady` check into an useEffect fixes it and is also recommended in the Next.js docs ([ref](https://nextjs.org/docs/pages/api-reference/functions/use-router#router-object)).

