### PR TITLE
fix(web): do not mark address book addresses as untrusted in NameChip

### DIFF
--- a/apps/web/src/components/tx/ConfirmTxDetails/NameChip.test.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/NameChip.test.tsx
@@ -96,6 +96,25 @@ describe('NameChip', () => {
     expect(chip).not.toHaveStyle({ color: COLORS.ERROR_MAIN })
   })
 
+  it('should prioritize address book name over txInfo name', () => {
+    const mockAddress = faker.finance.ethereumAddress()
+    const addressBookName = 'Address Book Name'
+    const txInfoName = 'TxInfo Name'
+
+    mockUseAddressName.mockReturnValue({ name: txInfoName, logoUri: undefined, isUnverifiedContract: false })
+    mockUseAddressBook.mockReturnValue({ [mockAddress]: addressBookName })
+
+    const txData = txDataBuilder()
+      .with({
+        to: { value: mockAddress, name: txInfoName },
+      })
+      .build()
+
+    render(<NameChip txData={txData} />)
+    expect(screen.getByText(addressBookName)).toBeInTheDocument()
+    expect(screen.queryByText(txInfoName)).not.toBeInTheDocument()
+  })
+
   it('should render with background when withBackground prop is true', () => {
     const mockAddress = faker.finance.ethereumAddress()
     mockUseAddressName.mockReturnValue({ name: 'Test Contract', logoUri: undefined, isUnverifiedContract: false })

--- a/apps/web/src/components/tx/ConfirmTxDetails/NameChip.test.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/NameChip.test.tsx
@@ -1,0 +1,130 @@
+import NameChip from './NameChip'
+import useAddressBook from '@/hooks/useAddressBook'
+import { useAddressName } from '@/components/common/NamedAddressInfo'
+import { txDataBuilder } from '@/tests/builders/safeTx'
+import { render, screen } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+
+// Theme color values
+const COLORS = {
+  ERROR_BACKGROUND: '#FFE6EA',
+  ERROR_MAIN: '#FF5F72',
+  BACKGROUND_MAIN: '#F4F4F4',
+} as const
+
+// Mock the hooks
+jest.mock('@/hooks/useAddressBook')
+jest.mock('@/components/common/NamedAddressInfo')
+
+describe('NameChip', () => {
+  const mockUseAddressBook = useAddressBook as jest.MockedFunction<typeof useAddressBook>
+  const mockUseAddressName = useAddressName as jest.MockedFunction<typeof useAddressName>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render nothing when no address is provided', () => {
+    mockUseAddressName.mockReturnValue({ name: undefined, logoUri: undefined, isUnverifiedContract: false })
+    render(<NameChip />)
+    expect(screen.queryByTestId('name-chip')).not.toBeInTheDocument()
+  })
+
+  it('should render nothing when address is provided but no name or logo', () => {
+    const mockAddress = faker.finance.ethereumAddress()
+    mockUseAddressName.mockReturnValue({ name: undefined, logoUri: undefined, isUnverifiedContract: false })
+    mockUseAddressBook.mockReturnValue({})
+
+    const txData = txDataBuilder()
+      .with({
+        to: { value: mockAddress },
+      })
+      .build()
+
+    render(<NameChip txData={txData} />)
+    expect(screen.queryByTestId('name-chip')).not.toBeInTheDocument()
+  })
+
+  it('should render with error color for unverified contracts not in address book', () => {
+    const mockAddress = faker.finance.ethereumAddress()
+    mockUseAddressName.mockReturnValue({ name: 'Unverified contract', logoUri: undefined, isUnverifiedContract: true })
+    mockUseAddressBook.mockReturnValue({})
+
+    const txData = txDataBuilder()
+      .with({
+        to: { value: mockAddress },
+      })
+      .build()
+
+    render(<NameChip txData={txData} />)
+    const chip = screen.getByTestId('name-chip')
+    expect(chip).toHaveStyle({ backgroundColor: COLORS.ERROR_BACKGROUND })
+    expect(chip).toHaveStyle({ color: COLORS.ERROR_MAIN })
+  })
+
+  it('should not render with error color for verified contracts not in address book', () => {
+    const mockAddress = faker.finance.ethereumAddress()
+    mockUseAddressName.mockReturnValue({ name: 'Test Contract', logoUri: undefined, isUnverifiedContract: false })
+    mockUseAddressBook.mockReturnValue({})
+
+    const txData = txDataBuilder()
+      .with({
+        to: { value: mockAddress },
+      })
+      .build()
+
+    render(<NameChip txData={txData} />)
+    const chip = screen.getByTestId('name-chip')
+    expect(chip).not.toHaveStyle({ backgroundColor: COLORS.ERROR_BACKGROUND })
+    expect(chip).not.toHaveStyle({ color: COLORS.ERROR_MAIN })
+  })
+
+  it('should not render with error color for unverified contracts in address book', () => {
+    const mockAddress = faker.finance.ethereumAddress()
+    mockUseAddressName.mockReturnValue({ name: 'Unverified contract', logoUri: undefined, isUnverifiedContract: true })
+    mockUseAddressBook.mockReturnValue({ [mockAddress]: 'Address Book Entry' })
+
+    const txData = txDataBuilder()
+      .with({
+        to: { value: mockAddress },
+      })
+      .build()
+
+    render(<NameChip txData={txData} />)
+    const chip = screen.getByTestId('name-chip')
+    expect(chip).not.toHaveStyle({ backgroundColor: COLORS.ERROR_BACKGROUND })
+    expect(chip).not.toHaveStyle({ color: COLORS.ERROR_MAIN })
+  })
+
+  it('should render with background when withBackground prop is true', () => {
+    const mockAddress = faker.finance.ethereumAddress()
+    mockUseAddressName.mockReturnValue({ name: 'Test Contract', logoUri: undefined, isUnverifiedContract: false })
+    mockUseAddressBook.mockReturnValue({})
+
+    const txData = txDataBuilder()
+      .with({
+        to: { value: mockAddress },
+      })
+      .build()
+
+    render(<NameChip txData={txData} withBackground />)
+    const chip = screen.getByTestId('name-chip')
+    expect(chip).toHaveStyle({ backgroundColor: 'rgb(244, 244, 244)' })
+  })
+
+  it('should display name and logo when provided', () => {
+    const mockAddress = faker.finance.ethereumAddress()
+    mockUseAddressName.mockReturnValue({ name: 'Test Contract', logoUri: 'test-logo.png', isUnverifiedContract: false })
+    mockUseAddressBook.mockReturnValue({})
+
+    const txData = txDataBuilder()
+      .with({
+        to: { value: mockAddress },
+      })
+      .build()
+
+    render(<NameChip txData={txData} />)
+    expect(screen.getByText('Test Contract')).toBeInTheDocument()
+    expect(screen.getByRole('presentation')).toHaveAttribute('src', 'test-logo.png')
+  })
+})

--- a/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
@@ -1,5 +1,6 @@
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { useAddressName } from '@/components/common/NamedAddressInfo'
+import useAddressBook from '@/hooks/useAddressBook'
 import { isCustomTxInfo } from '@/utils/transaction-guards'
 import { Chip } from '@mui/material'
 import type { TransactionData, TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
@@ -22,15 +23,16 @@ const NameChip = ({
   const name = toName || contractInfo?.name
   const logo = toLogo || contractInfo?.logoUri
 
+  const addressBook = useAddressBook()
+  const isInAddressBook = toAddress !== undefined && !!addressBook[toAddress]
+  const isUntrusted = !isInAddressBook && contractInfo.isUnverifiedContract
+
   return toAddress && (name || logo) ? (
     <Chip
+      data-testid="name-chip"
       sx={{
-        backgroundColor: contractInfo?.isUnverifiedContract
-          ? 'error.background'
-          : withBackground
-            ? 'Background.main'
-            : 'background.paper',
-        color: contractInfo?.isUnverifiedContract ? 'error.main' : undefined,
+        backgroundColor: isUntrusted ? 'error.background' : withBackground ? 'background.main' : 'background.paper',
+        color: isUntrusted ? 'error.main' : undefined,
         height: 'unset',
       }}
       label={

--- a/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
@@ -14,17 +14,19 @@ const NameChip = ({
   txInfo?: TransactionDetails['txInfo']
   withBackground?: boolean
 }) => {
+  const addressBook = useAddressBook()
   const toAddress = txData?.to.value
   const customTxInfo = txInfo && isCustomTxInfo(txInfo) ? txInfo : undefined
   const toInfo = customTxInfo?.to || txData?.addressInfoIndex?.[txData?.to.value] || txData?.to
-  const toName = toInfo?.name || (toInfo && 'displayName' in toInfo ? String(toInfo.displayName || '') : undefined)
+  const nameFromAb = toAddress !== undefined ? addressBook[toAddress] : undefined
+  const toName =
+    toInfo?.name || (toInfo && 'displayName' in toInfo ? String(toInfo.displayName || '') : undefined) || nameFromAb
   const toLogo = toInfo?.logoUri
   const contractInfo = useAddressName(toAddress, toName)
   const name = toName || contractInfo?.name
   const logo = toLogo || contractInfo?.logoUri
 
-  const addressBook = useAddressBook()
-  const isInAddressBook = toAddress !== undefined && !!addressBook[toAddress]
+  const isInAddressBook = !!nameFromAb
   const isUntrusted = !isInAddressBook && contractInfo.isUnverifiedContract
 
   return toAddress && (name || logo) ? (

--- a/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
@@ -20,7 +20,7 @@ const NameChip = ({
   const toInfo = customTxInfo?.to || txData?.addressInfoIndex?.[txData?.to.value] || txData?.to
   const nameFromAb = toAddress !== undefined ? addressBook[toAddress] : undefined
   const toName =
-    toInfo?.name || (toInfo && 'displayName' in toInfo ? String(toInfo.displayName || '') : undefined) || nameFromAb
+    nameFromAb || toInfo?.name || (toInfo && 'displayName' in toInfo ? String(toInfo.displayName || '') : undefined)
   const toLogo = toInfo?.logoUri
   const contractInfo = useAddressName(toAddress, toName)
   const name = toName || contractInfo?.name


### PR DESCRIPTION
## What it solves
https://www.notion.so/safe-global/Why-is-the-name-of-an-address-book-item-red-during-transaction-review-Signing-UX-v2-issue-1f38180fe57380c49d55eb1776b1f85e

## How this PR fixes it
### **`NameChip.ts`**
- Does not mark addresses as unverified / untrusted when they are in the address book.
- Adds unit test to component
## How to test it

## Checklist
- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
