### PR TITLE
fix(Signing UX): duplicate contract interaction info

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -8,7 +8,7 @@ import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants
 import { Receipt } from '@/components/tx/ConfirmTxDetails/Receipt'
 import DecodedData from '../TxData/DecodedData'
 import ColorCodedTxAccordion from '@/components/tx/ColorCodedTxAccordion'
-import { Box, Divider, Typography } from '@mui/material'
+import { Box, Divider, Stack, Typography } from '@mui/material'
 import DecoderLinks from './DecoderLinks'
 import isEqual from 'lodash/isEqual'
 import Multisend from '../TxData/DecodedData/Multisend'
@@ -79,28 +79,26 @@ const Summary = ({ safeTxData, txData, txInfo, txDetails, showMultisend = true }
       {showDetails && (
         <Box mt={2}>
           <ColorCodedTxAccordion txInfo={txInfo} txData={txData}>
-            <Box my={1}>
+            <Stack gap={1} divider={<Divider sx={{ mx: -2, my: 1 }} />}>
               <DecodedData txData={txData} toInfo={toInfo} />
-            </Box>
 
-            <Box>
-              <Divider sx={{ mx: -2, mt: 2.5 }} />
+              <Box>
+                <Typography variant="subtitle2" fontWeight={700} mb={2}>
+                  Advanced details
+                </Typography>
 
-              <Typography variant="subtitle2" fontWeight={700} mt={2.5} mb={2}>
-                Advanced details
-              </Typography>
+                <DecoderLinks />
 
-              <DecoderLinks />
-
-              <Receipt
-                safeTxData={safeTxData}
-                txData={txData}
-                txDetails={txDetails}
-                txInfo={txInfo}
-                withSignatures
-                grid
-              />
-            </Box>
+                <Receipt
+                  safeTxData={safeTxData}
+                  txData={txData}
+                  txDetails={txDetails}
+                  txInfo={txInfo}
+                  withSignatures
+                  grid
+                />
+              </Box>
+            </Stack>
           </ColorCodedTxAccordion>
         </Box>
       )}

--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -20,9 +20,17 @@ interface Props {
   txInfo?: TransactionDetails['txInfo']
   txDetails?: TransactionDetails
   showMultisend?: boolean
+  showDecodedData?: boolean
 }
 
-const Summary = ({ safeTxData, txData, txInfo, txDetails, showMultisend = true }: Props): ReactElement => {
+const Summary = ({
+  safeTxData,
+  txData,
+  txInfo,
+  txDetails,
+  showMultisend = true,
+  showDecodedData = true,
+}: Props): ReactElement => {
   const { txHash, executedAt } = txDetails ?? {}
   const customTxInfo = txInfo && isCustomTxInfo(txInfo) ? txInfo : undefined
   const toInfo = customTxInfo?.to || txData?.addressInfoIndex?.[txData?.to.value] || txData?.to
@@ -80,7 +88,7 @@ const Summary = ({ safeTxData, txData, txInfo, txDetails, showMultisend = true }
         <Box mt={2}>
           <ColorCodedTxAccordion txInfo={txInfo} txData={txData}>
             <Stack gap={1} divider={<Divider sx={{ mx: -2, my: 1 }} />}>
-              <DecodedData txData={txData} toInfo={toInfo} />
+              {showDecodedData && <DecodedData txData={txData} toInfo={toInfo} />}
 
               <Box>
                 <Typography variant="subtitle2" fontWeight={700} mb={2}>

--- a/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/utils/transaction-guards'
 import { SpendingLimits } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
 import { TransactionStatus, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import { PropsWithChildren, type ReactElement } from 'react'
+import type { PropsWithChildren, ReactElement } from 'react'
 import RejectionTxInfo from '@/components/transactions/TxDetails/TxData/Rejection'
 import TransferTxInfo from '@/components/transactions/TxDetails/TxData/Transfer'
 import useChainId from '@/hooks/useChainId'

--- a/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/utils/transaction-guards'
 import { SpendingLimits } from '@/components/transactions/TxDetails/TxData/SpendingLimits'
 import { TransactionStatus, type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
-import { type ReactElement } from 'react'
+import { PropsWithChildren, type ReactElement } from 'react'
 import RejectionTxInfo from '@/components/transactions/TxDetails/TxData/Rejection'
 import TransferTxInfo from '@/components/transactions/TxDetails/TxData/Transfer'
 import useChainId from '@/hooks/useChainId'
@@ -45,13 +45,14 @@ const TxData = ({
   txDetails,
   trusted,
   imitation,
-}: {
+  children,
+}: PropsWithChildren<{
   txInfo: TransactionDetails['txInfo']
   txData: TransactionDetails['txData']
   txDetails?: TransactionDetails
   trusted: boolean
   imitation: boolean
-}): ReactElement => {
+}>): ReactElement => {
   const chainId = useChainId()
 
   if (isOrderTxInfo(txInfo)) {
@@ -123,7 +124,11 @@ const TxData = ({
     return <SafeUpdate txData={txData} />
   }
 
-  return <DecodedData txData={txData} toInfo={isCustomTxInfo(txInfo) ? txInfo.to : txData?.to} />
+  return !!children ? (
+    <>{children}</>
+  ) : (
+    <DecodedData txData={txData} toInfo={isCustomTxInfo(txInfo) ? txInfo.to : txData?.to} />
+  )
 }
 
 export default TxData

--- a/apps/web/src/components/transactions/TxDetails/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/index.tsx
@@ -1,5 +1,5 @@
 import useIsExpiredSwap from '@/features/swap/hooks/useIsExpiredSwap'
-import React, { type ReactElement, useEffect } from 'react'
+import React, { type ReactElement, useEffect, useRef, useState } from 'react'
 import type { TransactionDetails, TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import { Box, CircularProgress, Typography } from '@mui/material'
 
@@ -16,6 +16,7 @@ import {
   isMultisigExecutionInfo,
   isOpenSwapOrder,
   isTxQueued,
+  isCustomTxInfo,
 } from '@/utils/transaction-guards'
 import { InfoDetails } from '@/components/transactions/InfoDetails'
 import NamedAddressInfo from '@/components/common/NamedAddressInfo'
@@ -38,6 +39,7 @@ import { TxNote } from '@/features/tx-notes'
 import { TxShareBlock } from '../TxShareLink'
 import { TxShareButton } from '../TxShareLink/TxShareButton'
 import { FEATURES } from '@safe-global/utils/utils/chains'
+import DecodedData from './TxData/DecodedData'
 
 export const NOT_AVAILABLE = 'n/a'
 
@@ -51,6 +53,17 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
   const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
   const isQueue = isTxQueued(txSummary.txStatus)
   const awaitingExecution = isAwaitingExecution(txSummary.txStatus)
+
+  // Used to check if the decoded data was rendered inside the TxData component
+  // If it was, we hide the decoded data in the Summary to avoid showing it twice
+  const decodedDataRef = useRef(null)
+  const [isDecodedDataVisible, setIsDecodedDataVisible] = useState(false)
+
+  useEffect(() => {
+    // If decodedDataRef.current is not null, the decoded data was rendered inside the TxData component
+    setIsDecodedDataVisible(!!decodedDataRef.current)
+  }, [decodedDataRef.current])
+
   const isUnsigned =
     isMultisigExecutionInfo(txSummary.executionInfo) && txSummary.executionInfo.confirmationsSubmitted === 0
 
@@ -94,7 +107,14 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
               txDetails={txDetails}
               trusted={isTrustedTransfer}
               imitation={isImitationTransaction}
-            />
+            >
+              <Box ref={decodedDataRef}>
+                <DecodedData
+                  txData={txDetails.txData}
+                  toInfo={isCustomTxInfo(txDetails.txInfo) ? txDetails.txInfo.to : txDetails.txData?.to}
+                />
+              </Box>
+            </TxData>
           </ErrorBoundary>
         </div>
 
@@ -117,7 +137,13 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         <div className={css.txSummary}>
           {isUntrusted && !isPending && <UnsignedWarning />}
           <ErrorBoundary fallback={<div>Error parsing data</div>}>
-            <Summary txDetails={txDetails} txData={txDetails.txData} txInfo={txDetails.txInfo} showMultisend={false} />
+            <Summary
+              txDetails={txDetails}
+              txData={txDetails.txData}
+              txInfo={txDetails.txInfo}
+              showMultisend={false}
+              showDecodedData={!isDecodedDataVisible}
+            />
           </ErrorBoundary>
         </div>
 

--- a/apps/web/src/components/transactions/TxDetails/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/index.tsx
@@ -62,7 +62,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
   useEffect(() => {
     // If decodedDataRef.current is not null, the decoded data was rendered inside the TxData component
     setIsDecodedDataVisible(!!decodedDataRef.current)
-  }, [decodedDataRef.current])
+  }, [])
 
   const isUnsigned =
     isMultisigExecutionInfo(txSummary.executionInfo) && txSummary.executionInfo.confirmationsSubmitted === 0

--- a/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
@@ -11,84 +11,88 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
       data-testid="card-content"
     >
       <div
-        class="MuiStack-root css-1sazv7p-MuiStack-root"
+        class="MuiBox-root css-0"
       >
         <div
-          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+          class="MuiStack-root css-1sazv7p-MuiStack-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-            data-testid="tx-row-title"
-            style="word-break: break-word;"
-          >
-            <span
-              class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
-            >
-              Interacted with
-            </span>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-            data-testid="tx-data-row"
+            class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
           >
             <div
-              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+              class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
+              data-testid="tx-row-title"
+              style="word-break: break-word;"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+              >
+                Interacted with
+              </span>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+              data-testid="tx-data-row"
             >
               <div
-                class="container"
+                class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
               >
                 <div
-                  class="avatarContainer"
-                  style="width: 20px; height: 20px;"
+                  class="container"
                 >
                   <div
-                    class="icon"
-                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
-                  />
-                </div>
-                <div
-                  class="MuiBox-root css-1lchl8k"
-                >
-                  <div
-                    class="addressContainer"
+                    class="avatarContainer"
+                    style="width: 20px; height: 20px;"
                   >
                     <div
-                      class="MuiBox-root css-b5p5gz"
+                      class="icon"
+                      style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
+                    />
+                  </div>
+                  <div
+                    class="MuiBox-root css-1lchl8k"
+                  >
+                    <div
+                      class="addressContainer"
                     >
+                      <div
+                        class="MuiBox-root css-b5p5gz"
+                      >
+                        <span
+                          aria-label="Copy to clipboard"
+                          class=""
+                          data-mui-internal-clone-element="true"
+                          style="cursor: pointer;"
+                        >
+                          <span>
+                            0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
+                          </span>
+                        </span>
+                      </div>
                       <span
                         aria-label="Copy to clipboard"
                         class=""
                         data-mui-internal-clone-element="true"
                         style="cursor: pointer;"
                       >
-                        <span>
-                          0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
-                        </span>
+                        <button
+                          aria-label="Copy to clipboard"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <mock-icon
+                            aria-hidden=""
+                            class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                            data-testid="copy-btn-icon"
+                            focusable="false"
+                          />
+                        </button>
                       </span>
+                      <div
+                        class="MuiBox-root css-yjghm1"
+                      />
                     </div>
-                    <span
-                      aria-label="Copy to clipboard"
-                      class=""
-                      data-mui-internal-clone-element="true"
-                      style="cursor: pointer;"
-                    >
-                      <button
-                        aria-label="Copy to clipboard"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <mock-icon
-                          aria-hidden=""
-                          class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                          data-testid="copy-btn-icon"
-                          focusable="false"
-                        />
-                      </button>
-                    </span>
-                    <div
-                      class="MuiBox-root css-yjghm1"
-                    />
                   </div>
                 </div>
               </div>
@@ -173,52 +177,229 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                     data-testid="decoded-tx-details"
                   >
                     <div
-                      class="MuiBox-root css-1xlzx9v"
+                      class="MuiStack-root css-hwnj0i-MuiStack-root"
                     >
                       <div
-                        class="MuiStack-root css-1sazv7p-MuiStack-root"
+                        class="MuiBox-root css-0"
                       >
-                        <div
-                          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+                        <h6
+                          class="MuiTypography-root MuiTypography-subtitle2 css-4lr168-MuiTypography-root"
                         >
-                          <div
-                            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-                            data-testid="tx-row-title"
-                            style="word-break: break-word;"
+                          Advanced details
+                        </h6>
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-gkag80-MuiTypography-root"
+                        >
+                          Cross-verify your transaction data with external tools like
+                           
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
+                            href="https://safeutils.openzeppelin.com"
+                            rel="noreferrer noopener"
+                            target="_blank"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                              class="MuiBox-root css-1vqf8mi"
                             >
-                              Interacted with
+                              Safe Utils
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                data-testid="OpenInNewRoundedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                />
+                              </svg>
                             </span>
-                          </div>
+                          </a>
+                           and
+                           
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
+                            href="https://transaction-decoder.pages.dev"
+                            rel="noreferrer noopener"
+                            target="_blank"
+                          >
+                            <span
+                              class="MuiBox-root css-1vqf8mi"
+                            >
+                              Transaction Decoder
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                data-testid="OpenInNewRoundedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                />
+                              </svg>
+                            </span>
+                          </a>
+                          .
+                        </p>
+                        <div
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-shqplw-MuiPaper-root"
+                          style="--Paper-shadow: none;"
+                        >
                           <div
-                            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-                            data-testid="tx-data-row"
+                            class="MuiStack-root css-1sazv7p-MuiStack-root"
                           >
                             <div
-                              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                              class="MuiStack-root css-1n46f6x-MuiStack-root"
                             >
                               <div
-                                class="container"
+                                aria-label="text alignment"
+                                class="MuiToggleButtonGroup-root MuiToggleButtonGroup-horizontal css-cinseo-MuiToggleButtonGroup-root"
+                                role="group"
+                              >
+                                <button
+                                  aria-pressed="true"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-firstButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="0"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    Data
+                                  </div>
+                                </button>
+                                <button
+                                  aria-pressed="false"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="1"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    Hashes
+                                  </div>
+                                </button>
+                                <button
+                                  aria-pressed="false"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="2"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    JSON
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="MuiBox-root css-e0rnc0"
+                            >
+                              <div
+                                class="MuiStack-root css-jfdv4h-MuiStack-root"
                               >
                                 <div
-                                  class="avatarContainer"
-                                  style="width: 20px; height: 20px;"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    To
+                                  </p>
                                   <div
-                                    class="icon"
-                                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
-                                  />
+                                    class="MuiBox-root css-0"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 css-m9op2-MuiTypography-root"
+                                    >
+                                      <div
+                                        class="container"
+                                      >
+                                        <div
+                                          class="avatarContainer"
+                                          style="width: 20px; height: 20px;"
+                                        >
+                                          <div
+                                            class="icon"
+                                            style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjEzIDY1JSA0OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNTQgNjYlIDU2JSkiIGQ9Ik0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjcgNDElIDYzJSkiIGQ9Ik0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 20px; height: 20px;"
+                                          />
+                                        </div>
+                                        <div
+                                          class="MuiBox-root css-1lchl8k"
+                                        >
+                                          <div
+                                            class="addressContainer"
+                                          >
+                                            <div
+                                              class="MuiBox-root css-b5p5gz"
+                                            >
+                                              <span
+                                                aria-label="Copy to clipboard"
+                                                class=""
+                                                data-mui-internal-clone-element="true"
+                                                style="cursor: pointer;"
+                                              >
+                                                <span>
+                                                  0x
+                                                  <b>
+                                                    0000
+                                                  </b>
+                                                  00000000000000000000000000000000
+                                                  <b>
+                                                    0000
+                                                  </b>
+                                                </span>
+                                              </span>
+                                            </div>
+                                            <div
+                                              class="MuiBox-root css-yjghm1"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </p>
+                                  </div>
                                 </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
                                 <div
-                                  class="MuiBox-root css-1lchl8k"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  <div
-                                    class="addressContainer"
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Value
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    0x0
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Data
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-n5xdb5-MuiTypography-root"
                                   >
                                     <div
-                                      class="MuiBox-root css-b5p5gz"
+                                      class="encodedData MuiBox-root css-0"
+                                      data-testid="tx-hexData"
                                     >
                                       <span
                                         aria-label="Copy to clipboard"
@@ -226,183 +407,102 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                         data-mui-internal-clone-element="true"
                                         style="cursor: pointer;"
                                       >
-                                        <span>
-                                          0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
+                                        <span
+                                          class="monospace"
+                                        >
+                                          <b
+                                            aria-label="The first 4 bytes determine the contract method that is being called"
+                                            class=""
+                                            data-mui-internal-clone-element="true"
+                                          >
+                                            0x
+                                          </b>
+                                           
                                         </span>
                                       </span>
                                     </div>
-                                    <span
-                                      aria-label="Copy to clipboard"
-                                      class=""
-                                      data-mui-internal-clone-element="true"
-                                      style="cursor: pointer;"
-                                    >
-                                      <button
-                                        aria-label="Copy to clipboard"
-                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                                        tabindex="0"
-                                        type="button"
-                                      >
-                                        <mock-icon
-                                          aria-hidden=""
-                                          class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                                          data-testid="copy-btn-icon"
-                                          focusable="false"
-                                        />
-                                      </button>
-                                    </span>
-                                    <div
-                                      class="MuiBox-root css-yjghm1"
-                                    />
-                                  </div>
+                                  </p>
                                 </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="MuiBox-root css-0"
-                    >
-                      <hr
-                        class="MuiDivider-root MuiDivider-fullWidth css-mnly1g-MuiDivider-root"
-                      />
-                      <h6
-                        class="MuiTypography-root MuiTypography-subtitle2 css-1ckyqq0-MuiTypography-root"
-                      >
-                        Advanced details
-                      </h6>
-                      <p
-                        class="MuiTypography-root MuiTypography-body2 css-gkag80-MuiTypography-root"
-                      >
-                        Cross-verify your transaction data with external tools like
-                         
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
-                          href="https://safeutils.openzeppelin.com"
-                          rel="noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="MuiBox-root css-1vqf8mi"
-                          >
-                            Safe Utils
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
-                              data-testid="OpenInNewRoundedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
-                              />
-                            </svg>
-                          </span>
-                        </a>
-                         and
-                         
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
-                          href="https://transaction-decoder.pages.dev"
-                          rel="noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="MuiBox-root css-1vqf8mi"
-                          >
-                            Transaction Decoder
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
-                              data-testid="OpenInNewRoundedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
-                              />
-                            </svg>
-                          </span>
-                        </a>
-                        .
-                      </p>
-                      <div
-                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-shqplw-MuiPaper-root"
-                        style="--Paper-shadow: none;"
-                      >
-                        <div
-                          class="MuiStack-root css-1sazv7p-MuiStack-root"
-                        >
-                          <div
-                            class="MuiStack-root css-1n46f6x-MuiStack-root"
-                          >
-                            <div
-                              aria-label="text alignment"
-                              class="MuiToggleButtonGroup-root MuiToggleButtonGroup-horizontal css-cinseo-MuiToggleButtonGroup-root"
-                              role="group"
-                            >
-                              <button
-                                aria-pressed="true"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-firstButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="0"
-                              >
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
                                 <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  Data
-                                </div>
-                              </button>
-                              <button
-                                aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="1"
-                              >
-                                <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  Hashes
-                                </div>
-                              </button>
-                              <button
-                                aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="2"
-                              >
-                                <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  JSON
-                                </div>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="MuiBox-root css-e0rnc0"
-                          >
-                            <div
-                              class="MuiStack-root css-jfdv4h-MuiStack-root"
-                            >
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  To
-                                </p>
-                                <div
-                                  class="MuiBox-root css-0"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
                                   <p
-                                    class="MuiTypography-root MuiTypography-body2 css-m9op2-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Operation
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1hy3mdy-MuiTypography-root"
+                                  >
+                                    0
+                                     (
+                                    call
+                                    )
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root MuiSvgIcon-colorSuccess MuiSvgIcon-fontSizeInherit css-113mief-MuiSvgIcon-root"
+                                      data-testid="CheckIcon"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                      />
+                                    </svg>
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    SafeTxGas
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    BaseGas
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    GasPrice
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    GasToken
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
                                   >
                                     <div
                                       class="container"
@@ -411,9 +511,9 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                         class="avatarContainer"
                                         style="width: 20px; height: 20px;"
                                       >
-                                        <div
-                                          class="icon"
-                                          style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjEzIDY1JSA0OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNTQgNjYlIDU2JSkiIGQ9Ik0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjcgNDElIDYzJSkiIGQ9Ik0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 20px; height: 20px;"
+                                        <span
+                                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                          style="width: 20px; height: 20px;"
                                         />
                                       </div>
                                       <div
@@ -431,16 +531,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                               data-mui-internal-clone-element="true"
                                               style="cursor: pointer;"
                                             >
-                                              <span>
-                                                0x
-                                                <b>
-                                                  0000
-                                                </b>
-                                                00000000000000000000000000000000
-                                                <b>
-                                                  0000
-                                                </b>
-                                              </span>
+                                              <span />
                                             </span>
                                           </div>
                                           <div
@@ -451,251 +542,75 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                     </div>
                                   </p>
                                 </div>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  Value
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  0x0
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Data
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-n5xdb5-MuiTypography-root"
-                                >
-                                  <div
-                                    class="encodedData MuiBox-root css-0"
-                                    data-testid="tx-hexData"
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
                                   >
-                                    <span
-                                      aria-label="Copy to clipboard"
-                                      class=""
-                                      data-mui-internal-clone-element="true"
-                                      style="cursor: pointer;"
-                                    >
-                                      <span
-                                        class="monospace"
-                                      >
-                                        <b
-                                          aria-label="The first 4 bytes determine the contract method that is being called"
-                                          class=""
-                                          data-mui-internal-clone-element="true"
-                                        >
-                                          0x
-                                        </b>
-                                         
-                                      </span>
-                                    </span>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Operation
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1hy3mdy-MuiTypography-root"
-                                >
-                                  0
-                                   (
-                                  call
-                                  )
-                                  <svg
-                                    aria-hidden="true"
-                                    class="MuiSvgIcon-root MuiSvgIcon-colorSuccess MuiSvgIcon-fontSizeInherit css-113mief-MuiSvgIcon-root"
-                                    data-testid="CheckIcon"
-                                    focusable="false"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <path
-                                      d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
-                                    />
-                                  </svg>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  SafeTxGas
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  BaseGas
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  GasPrice
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  GasToken
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  <div
-                                    class="container"
+                                    RefundReceiver
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
                                   >
                                     <div
-                                      class="avatarContainer"
-                                      style="width: 20px; height: 20px;"
-                                    >
-                                      <span
-                                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
-                                        style="width: 20px; height: 20px;"
-                                      />
-                                    </div>
-                                    <div
-                                      class="MuiBox-root css-1lchl8k"
+                                      class="container"
                                     >
                                       <div
-                                        class="addressContainer"
-                                      >
-                                        <div
-                                          class="MuiBox-root css-b5p5gz"
-                                        >
-                                          <span
-                                            aria-label="Copy to clipboard"
-                                            class=""
-                                            data-mui-internal-clone-element="true"
-                                            style="cursor: pointer;"
-                                          >
-                                            <span />
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="MuiBox-root css-yjghm1"
-                                        />
-                                      </div>
-                                    </div>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  RefundReceiver
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  <div
-                                    class="container"
-                                  >
-                                    <div
-                                      class="avatarContainer"
-                                      style="width: 20px; height: 20px;"
-                                    >
-                                      <span
-                                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                        class="avatarContainer"
                                         style="width: 20px; height: 20px;"
-                                      />
-                                    </div>
-                                    <div
-                                      class="MuiBox-root css-1lchl8k"
-                                    >
-                                      <div
-                                        class="addressContainer"
                                       >
-                                        <div
-                                          class="MuiBox-root css-b5p5gz"
-                                        >
-                                          <span
-                                            aria-label="Copy to clipboard"
-                                            class=""
-                                            data-mui-internal-clone-element="true"
-                                            style="cursor: pointer;"
-                                          >
-                                            <span />
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="MuiBox-root css-yjghm1"
+                                        <span
+                                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                          style="width: 20px; height: 20px;"
                                         />
                                       </div>
+                                      <div
+                                        class="MuiBox-root css-1lchl8k"
+                                      >
+                                        <div
+                                          class="addressContainer"
+                                        >
+                                          <div
+                                            class="MuiBox-root css-b5p5gz"
+                                          >
+                                            <span
+                                              aria-label="Copy to clipboard"
+                                              class=""
+                                              data-mui-internal-clone-element="true"
+                                              style="cursor: pointer;"
+                                            >
+                                              <span />
+                                            </span>
+                                          </div>
+                                          <div
+                                            class="MuiBox-root css-yjghm1"
+                                          />
+                                        </div>
+                                      </div>
                                     </div>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  Nonce
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  100
-                                </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Nonce
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    100
+                                  </p>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
@@ -11,84 +11,88 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
       data-testid="card-content"
     >
       <div
-        class="MuiStack-root css-1sazv7p-MuiStack-root"
+        class="MuiBox-root css-0"
       >
         <div
-          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+          class="MuiStack-root css-1sazv7p-MuiStack-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-            data-testid="tx-row-title"
-            style="word-break: break-word;"
-          >
-            <span
-              class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
-            >
-              Interacted with
-            </span>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-            data-testid="tx-data-row"
+            class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
           >
             <div
-              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+              class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
+              data-testid="tx-row-title"
+              style="word-break: break-word;"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+              >
+                Interacted with
+              </span>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+              data-testid="tx-data-row"
             >
               <div
-                class="container"
+                class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
               >
                 <div
-                  class="avatarContainer"
-                  style="width: 20px; height: 20px;"
+                  class="container"
                 >
                   <div
-                    class="icon"
-                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
-                  />
-                </div>
-                <div
-                  class="MuiBox-root css-1lchl8k"
-                >
-                  <div
-                    class="addressContainer"
+                    class="avatarContainer"
+                    style="width: 20px; height: 20px;"
                   >
                     <div
-                      class="MuiBox-root css-b5p5gz"
+                      class="icon"
+                      style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
+                    />
+                  </div>
+                  <div
+                    class="MuiBox-root css-1lchl8k"
+                  >
+                    <div
+                      class="addressContainer"
                     >
+                      <div
+                        class="MuiBox-root css-b5p5gz"
+                      >
+                        <span
+                          aria-label="Copy to clipboard"
+                          class=""
+                          data-mui-internal-clone-element="true"
+                          style="cursor: pointer;"
+                        >
+                          <span>
+                            0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
+                          </span>
+                        </span>
+                      </div>
                       <span
                         aria-label="Copy to clipboard"
                         class=""
                         data-mui-internal-clone-element="true"
                         style="cursor: pointer;"
                       >
-                        <span>
-                          0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
-                        </span>
+                        <button
+                          aria-label="Copy to clipboard"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <mock-icon
+                            aria-hidden=""
+                            class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                            data-testid="copy-btn-icon"
+                            focusable="false"
+                          />
+                        </button>
                       </span>
+                      <div
+                        class="MuiBox-root css-yjghm1"
+                      />
                     </div>
-                    <span
-                      aria-label="Copy to clipboard"
-                      class=""
-                      data-mui-internal-clone-element="true"
-                      style="cursor: pointer;"
-                    >
-                      <button
-                        aria-label="Copy to clipboard"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <mock-icon
-                          aria-hidden=""
-                          class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                          data-testid="copy-btn-icon"
-                          focusable="false"
-                        />
-                      </button>
-                    </span>
-                    <div
-                      class="MuiBox-root css-yjghm1"
-                    />
                   </div>
                 </div>
               </div>
@@ -173,52 +177,229 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                     data-testid="decoded-tx-details"
                   >
                     <div
-                      class="MuiBox-root css-1xlzx9v"
+                      class="MuiStack-root css-hwnj0i-MuiStack-root"
                     >
                       <div
-                        class="MuiStack-root css-1sazv7p-MuiStack-root"
+                        class="MuiBox-root css-0"
                       >
-                        <div
-                          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+                        <h6
+                          class="MuiTypography-root MuiTypography-subtitle2 css-4lr168-MuiTypography-root"
                         >
-                          <div
-                            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-                            data-testid="tx-row-title"
-                            style="word-break: break-word;"
+                          Advanced details
+                        </h6>
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-gkag80-MuiTypography-root"
+                        >
+                          Cross-verify your transaction data with external tools like
+                           
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
+                            href="https://safeutils.openzeppelin.com"
+                            rel="noreferrer noopener"
+                            target="_blank"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                              class="MuiBox-root css-1vqf8mi"
                             >
-                              Interacted with
+                              Safe Utils
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                data-testid="OpenInNewRoundedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                />
+                              </svg>
                             </span>
-                          </div>
+                          </a>
+                           and
+                           
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
+                            href="https://transaction-decoder.pages.dev"
+                            rel="noreferrer noopener"
+                            target="_blank"
+                          >
+                            <span
+                              class="MuiBox-root css-1vqf8mi"
+                            >
+                              Transaction Decoder
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                data-testid="OpenInNewRoundedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                />
+                              </svg>
+                            </span>
+                          </a>
+                          .
+                        </p>
+                        <div
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-shqplw-MuiPaper-root"
+                          style="--Paper-shadow: none;"
+                        >
                           <div
-                            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-                            data-testid="tx-data-row"
+                            class="MuiStack-root css-1sazv7p-MuiStack-root"
                           >
                             <div
-                              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                              class="MuiStack-root css-1n46f6x-MuiStack-root"
                             >
                               <div
-                                class="container"
+                                aria-label="text alignment"
+                                class="MuiToggleButtonGroup-root MuiToggleButtonGroup-horizontal css-cinseo-MuiToggleButtonGroup-root"
+                                role="group"
+                              >
+                                <button
+                                  aria-pressed="true"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-firstButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="0"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    Data
+                                  </div>
+                                </button>
+                                <button
+                                  aria-pressed="false"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="1"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    Hashes
+                                  </div>
+                                </button>
+                                <button
+                                  aria-pressed="false"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="2"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    JSON
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="MuiBox-root css-e0rnc0"
+                            >
+                              <div
+                                class="MuiStack-root css-jfdv4h-MuiStack-root"
                               >
                                 <div
-                                  class="avatarContainer"
-                                  style="width: 20px; height: 20px;"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    To
+                                  </p>
                                   <div
-                                    class="icon"
-                                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
-                                  />
+                                    class="MuiBox-root css-0"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 css-m9op2-MuiTypography-root"
+                                    >
+                                      <div
+                                        class="container"
+                                      >
+                                        <div
+                                          class="avatarContainer"
+                                          style="width: 20px; height: 20px;"
+                                        >
+                                          <div
+                                            class="icon"
+                                            style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjEzIDY1JSA0OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNTQgNjYlIDU2JSkiIGQ9Ik0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjcgNDElIDYzJSkiIGQ9Ik0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 20px; height: 20px;"
+                                          />
+                                        </div>
+                                        <div
+                                          class="MuiBox-root css-1lchl8k"
+                                        >
+                                          <div
+                                            class="addressContainer"
+                                          >
+                                            <div
+                                              class="MuiBox-root css-b5p5gz"
+                                            >
+                                              <span
+                                                aria-label="Copy to clipboard"
+                                                class=""
+                                                data-mui-internal-clone-element="true"
+                                                style="cursor: pointer;"
+                                              >
+                                                <span>
+                                                  0x
+                                                  <b>
+                                                    0000
+                                                  </b>
+                                                  00000000000000000000000000000000
+                                                  <b>
+                                                    0000
+                                                  </b>
+                                                </span>
+                                              </span>
+                                            </div>
+                                            <div
+                                              class="MuiBox-root css-yjghm1"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </p>
+                                  </div>
                                 </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
                                 <div
-                                  class="MuiBox-root css-1lchl8k"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  <div
-                                    class="addressContainer"
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Value
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    0x0
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Data
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-n5xdb5-MuiTypography-root"
                                   >
                                     <div
-                                      class="MuiBox-root css-b5p5gz"
+                                      class="encodedData MuiBox-root css-0"
+                                      data-testid="tx-hexData"
                                     >
                                       <span
                                         aria-label="Copy to clipboard"
@@ -226,183 +407,102 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                         data-mui-internal-clone-element="true"
                                         style="cursor: pointer;"
                                       >
-                                        <span>
-                                          0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
+                                        <span
+                                          class="monospace"
+                                        >
+                                          <b
+                                            aria-label="The first 4 bytes determine the contract method that is being called"
+                                            class=""
+                                            data-mui-internal-clone-element="true"
+                                          >
+                                            0x
+                                          </b>
+                                           
                                         </span>
                                       </span>
                                     </div>
-                                    <span
-                                      aria-label="Copy to clipboard"
-                                      class=""
-                                      data-mui-internal-clone-element="true"
-                                      style="cursor: pointer;"
-                                    >
-                                      <button
-                                        aria-label="Copy to clipboard"
-                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                                        tabindex="0"
-                                        type="button"
-                                      >
-                                        <mock-icon
-                                          aria-hidden=""
-                                          class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                                          data-testid="copy-btn-icon"
-                                          focusable="false"
-                                        />
-                                      </button>
-                                    </span>
-                                    <div
-                                      class="MuiBox-root css-yjghm1"
-                                    />
-                                  </div>
+                                  </p>
                                 </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="MuiBox-root css-0"
-                    >
-                      <hr
-                        class="MuiDivider-root MuiDivider-fullWidth css-mnly1g-MuiDivider-root"
-                      />
-                      <h6
-                        class="MuiTypography-root MuiTypography-subtitle2 css-1ckyqq0-MuiTypography-root"
-                      >
-                        Advanced details
-                      </h6>
-                      <p
-                        class="MuiTypography-root MuiTypography-body2 css-gkag80-MuiTypography-root"
-                      >
-                        Cross-verify your transaction data with external tools like
-                         
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
-                          href="https://safeutils.openzeppelin.com"
-                          rel="noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="MuiBox-root css-1vqf8mi"
-                          >
-                            Safe Utils
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
-                              data-testid="OpenInNewRoundedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
-                              />
-                            </svg>
-                          </span>
-                        </a>
-                         and
-                         
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
-                          href="https://transaction-decoder.pages.dev"
-                          rel="noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="MuiBox-root css-1vqf8mi"
-                          >
-                            Transaction Decoder
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
-                              data-testid="OpenInNewRoundedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
-                              />
-                            </svg>
-                          </span>
-                        </a>
-                        .
-                      </p>
-                      <div
-                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-shqplw-MuiPaper-root"
-                        style="--Paper-shadow: none;"
-                      >
-                        <div
-                          class="MuiStack-root css-1sazv7p-MuiStack-root"
-                        >
-                          <div
-                            class="MuiStack-root css-1n46f6x-MuiStack-root"
-                          >
-                            <div
-                              aria-label="text alignment"
-                              class="MuiToggleButtonGroup-root MuiToggleButtonGroup-horizontal css-cinseo-MuiToggleButtonGroup-root"
-                              role="group"
-                            >
-                              <button
-                                aria-pressed="true"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-firstButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="0"
-                              >
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
                                 <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  Data
-                                </div>
-                              </button>
-                              <button
-                                aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="1"
-                              >
-                                <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  Hashes
-                                </div>
-                              </button>
-                              <button
-                                aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="2"
-                              >
-                                <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  JSON
-                                </div>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="MuiBox-root css-e0rnc0"
-                          >
-                            <div
-                              class="MuiStack-root css-jfdv4h-MuiStack-root"
-                            >
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  To
-                                </p>
-                                <div
-                                  class="MuiBox-root css-0"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
                                   <p
-                                    class="MuiTypography-root MuiTypography-body2 css-m9op2-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Operation
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1hy3mdy-MuiTypography-root"
+                                  >
+                                    0
+                                     (
+                                    call
+                                    )
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root MuiSvgIcon-colorSuccess MuiSvgIcon-fontSizeInherit css-113mief-MuiSvgIcon-root"
+                                      data-testid="CheckIcon"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                      />
+                                    </svg>
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    SafeTxGas
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    BaseGas
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    GasPrice
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    GasToken
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
                                   >
                                     <div
                                       class="container"
@@ -411,9 +511,9 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                         class="avatarContainer"
                                         style="width: 20px; height: 20px;"
                                       >
-                                        <div
-                                          class="icon"
-                                          style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjEzIDY1JSA0OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNTQgNjYlIDU2JSkiIGQ9Ik0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjcgNDElIDYzJSkiIGQ9Ik0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 20px; height: 20px;"
+                                        <span
+                                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                          style="width: 20px; height: 20px;"
                                         />
                                       </div>
                                       <div
@@ -431,16 +531,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                               data-mui-internal-clone-element="true"
                                               style="cursor: pointer;"
                                             >
-                                              <span>
-                                                0x
-                                                <b>
-                                                  0000
-                                                </b>
-                                                00000000000000000000000000000000
-                                                <b>
-                                                  0000
-                                                </b>
-                                              </span>
+                                              <span />
                                             </span>
                                           </div>
                                           <div
@@ -451,251 +542,75 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                     </div>
                                   </p>
                                 </div>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  Value
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  0x0
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Data
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-n5xdb5-MuiTypography-root"
-                                >
-                                  <div
-                                    class="encodedData MuiBox-root css-0"
-                                    data-testid="tx-hexData"
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
                                   >
-                                    <span
-                                      aria-label="Copy to clipboard"
-                                      class=""
-                                      data-mui-internal-clone-element="true"
-                                      style="cursor: pointer;"
-                                    >
-                                      <span
-                                        class="monospace"
-                                      >
-                                        <b
-                                          aria-label="The first 4 bytes determine the contract method that is being called"
-                                          class=""
-                                          data-mui-internal-clone-element="true"
-                                        >
-                                          0x
-                                        </b>
-                                         
-                                      </span>
-                                    </span>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Operation
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1hy3mdy-MuiTypography-root"
-                                >
-                                  0
-                                   (
-                                  call
-                                  )
-                                  <svg
-                                    aria-hidden="true"
-                                    class="MuiSvgIcon-root MuiSvgIcon-colorSuccess MuiSvgIcon-fontSizeInherit css-113mief-MuiSvgIcon-root"
-                                    data-testid="CheckIcon"
-                                    focusable="false"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <path
-                                      d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
-                                    />
-                                  </svg>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  SafeTxGas
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  BaseGas
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  GasPrice
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  GasToken
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  <div
-                                    class="container"
+                                    RefundReceiver
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
                                   >
                                     <div
-                                      class="avatarContainer"
-                                      style="width: 20px; height: 20px;"
-                                    >
-                                      <span
-                                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
-                                        style="width: 20px; height: 20px;"
-                                      />
-                                    </div>
-                                    <div
-                                      class="MuiBox-root css-1lchl8k"
+                                      class="container"
                                     >
                                       <div
-                                        class="addressContainer"
-                                      >
-                                        <div
-                                          class="MuiBox-root css-b5p5gz"
-                                        >
-                                          <span
-                                            aria-label="Copy to clipboard"
-                                            class=""
-                                            data-mui-internal-clone-element="true"
-                                            style="cursor: pointer;"
-                                          >
-                                            <span />
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="MuiBox-root css-yjghm1"
-                                        />
-                                      </div>
-                                    </div>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  RefundReceiver
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  <div
-                                    class="container"
-                                  >
-                                    <div
-                                      class="avatarContainer"
-                                      style="width: 20px; height: 20px;"
-                                    >
-                                      <span
-                                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                        class="avatarContainer"
                                         style="width: 20px; height: 20px;"
-                                      />
-                                    </div>
-                                    <div
-                                      class="MuiBox-root css-1lchl8k"
-                                    >
-                                      <div
-                                        class="addressContainer"
                                       >
-                                        <div
-                                          class="MuiBox-root css-b5p5gz"
-                                        >
-                                          <span
-                                            aria-label="Copy to clipboard"
-                                            class=""
-                                            data-mui-internal-clone-element="true"
-                                            style="cursor: pointer;"
-                                          >
-                                            <span />
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="MuiBox-root css-yjghm1"
+                                        <span
+                                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                          style="width: 20px; height: 20px;"
                                         />
                                       </div>
+                                      <div
+                                        class="MuiBox-root css-1lchl8k"
+                                      >
+                                        <div
+                                          class="addressContainer"
+                                        >
+                                          <div
+                                            class="MuiBox-root css-b5p5gz"
+                                          >
+                                            <span
+                                              aria-label="Copy to clipboard"
+                                              class=""
+                                              data-mui-internal-clone-element="true"
+                                              style="cursor: pointer;"
+                                            >
+                                              <span />
+                                            </span>
+                                          </div>
+                                          <div
+                                            class="MuiBox-root css-yjghm1"
+                                          />
+                                        </div>
+                                      </div>
                                     </div>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  Nonce
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  100
-                                </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Nonce
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    100
+                                  </p>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -11,84 +11,88 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
       data-testid="card-content"
     >
       <div
-        class="MuiStack-root css-1sazv7p-MuiStack-root"
+        class="MuiBox-root css-0"
       >
         <div
-          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+          class="MuiStack-root css-1sazv7p-MuiStack-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-            data-testid="tx-row-title"
-            style="word-break: break-word;"
-          >
-            <span
-              class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
-            >
-              Interacted with
-            </span>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-            data-testid="tx-data-row"
+            class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
           >
             <div
-              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+              class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
+              data-testid="tx-row-title"
+              style="word-break: break-word;"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+              >
+                Interacted with
+              </span>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+              data-testid="tx-data-row"
             >
               <div
-                class="container"
+                class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
               >
                 <div
-                  class="avatarContainer"
-                  style="width: 20px; height: 20px;"
+                  class="container"
                 >
                   <div
-                    class="icon"
-                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
-                  />
-                </div>
-                <div
-                  class="MuiBox-root css-1lchl8k"
-                >
-                  <div
-                    class="addressContainer"
+                    class="avatarContainer"
+                    style="width: 20px; height: 20px;"
                   >
                     <div
-                      class="MuiBox-root css-b5p5gz"
+                      class="icon"
+                      style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
+                    />
+                  </div>
+                  <div
+                    class="MuiBox-root css-1lchl8k"
+                  >
+                    <div
+                      class="addressContainer"
                     >
+                      <div
+                        class="MuiBox-root css-b5p5gz"
+                      >
+                        <span
+                          aria-label="Copy to clipboard"
+                          class=""
+                          data-mui-internal-clone-element="true"
+                          style="cursor: pointer;"
+                        >
+                          <span>
+                            0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
+                          </span>
+                        </span>
+                      </div>
                       <span
                         aria-label="Copy to clipboard"
                         class=""
                         data-mui-internal-clone-element="true"
                         style="cursor: pointer;"
                       >
-                        <span>
-                          0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
-                        </span>
+                        <button
+                          aria-label="Copy to clipboard"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <mock-icon
+                            aria-hidden=""
+                            class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                            data-testid="copy-btn-icon"
+                            focusable="false"
+                          />
+                        </button>
                       </span>
+                      <div
+                        class="MuiBox-root css-yjghm1"
+                      />
                     </div>
-                    <span
-                      aria-label="Copy to clipboard"
-                      class=""
-                      data-mui-internal-clone-element="true"
-                      style="cursor: pointer;"
-                    >
-                      <button
-                        aria-label="Copy to clipboard"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <mock-icon
-                          aria-hidden=""
-                          class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                          data-testid="copy-btn-icon"
-                          focusable="false"
-                        />
-                      </button>
-                    </span>
-                    <div
-                      class="MuiBox-root css-yjghm1"
-                    />
                   </div>
                 </div>
               </div>
@@ -173,52 +177,229 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                     data-testid="decoded-tx-details"
                   >
                     <div
-                      class="MuiBox-root css-1xlzx9v"
+                      class="MuiStack-root css-hwnj0i-MuiStack-root"
                     >
                       <div
-                        class="MuiStack-root css-1sazv7p-MuiStack-root"
+                        class="MuiBox-root css-0"
                       >
-                        <div
-                          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+                        <h6
+                          class="MuiTypography-root MuiTypography-subtitle2 css-4lr168-MuiTypography-root"
                         >
-                          <div
-                            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-                            data-testid="tx-row-title"
-                            style="word-break: break-word;"
+                          Advanced details
+                        </h6>
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-gkag80-MuiTypography-root"
+                        >
+                          Cross-verify your transaction data with external tools like
+                           
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
+                            href="https://safeutils.openzeppelin.com"
+                            rel="noreferrer noopener"
+                            target="_blank"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                              class="MuiBox-root css-1vqf8mi"
                             >
-                              Interacted with
+                              Safe Utils
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                data-testid="OpenInNewRoundedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                />
+                              </svg>
                             </span>
-                          </div>
+                          </a>
+                           and
+                           
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
+                            href="https://transaction-decoder.pages.dev"
+                            rel="noreferrer noopener"
+                            target="_blank"
+                          >
+                            <span
+                              class="MuiBox-root css-1vqf8mi"
+                            >
+                              Transaction Decoder
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                data-testid="OpenInNewRoundedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                />
+                              </svg>
+                            </span>
+                          </a>
+                          .
+                        </p>
+                        <div
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-shqplw-MuiPaper-root"
+                          style="--Paper-shadow: none;"
+                        >
                           <div
-                            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-                            data-testid="tx-data-row"
+                            class="MuiStack-root css-1sazv7p-MuiStack-root"
                           >
                             <div
-                              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                              class="MuiStack-root css-1n46f6x-MuiStack-root"
                             >
                               <div
-                                class="container"
+                                aria-label="text alignment"
+                                class="MuiToggleButtonGroup-root MuiToggleButtonGroup-horizontal css-cinseo-MuiToggleButtonGroup-root"
+                                role="group"
+                              >
+                                <button
+                                  aria-pressed="true"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-firstButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="0"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    Data
+                                  </div>
+                                </button>
+                                <button
+                                  aria-pressed="false"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="1"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    Hashes
+                                  </div>
+                                </button>
+                                <button
+                                  aria-pressed="false"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="2"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    JSON
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="MuiBox-root css-e0rnc0"
+                            >
+                              <div
+                                class="MuiStack-root css-jfdv4h-MuiStack-root"
                               >
                                 <div
-                                  class="avatarContainer"
-                                  style="width: 20px; height: 20px;"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    To
+                                  </p>
                                   <div
-                                    class="icon"
-                                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
-                                  />
+                                    class="MuiBox-root css-0"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 css-m9op2-MuiTypography-root"
+                                    >
+                                      <div
+                                        class="container"
+                                      >
+                                        <div
+                                          class="avatarContainer"
+                                          style="width: 20px; height: 20px;"
+                                        >
+                                          <div
+                                            class="icon"
+                                            style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjEzIDY1JSA0OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNTQgNjYlIDU2JSkiIGQ9Ik0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjcgNDElIDYzJSkiIGQ9Ik0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 20px; height: 20px;"
+                                          />
+                                        </div>
+                                        <div
+                                          class="MuiBox-root css-1lchl8k"
+                                        >
+                                          <div
+                                            class="addressContainer"
+                                          >
+                                            <div
+                                              class="MuiBox-root css-b5p5gz"
+                                            >
+                                              <span
+                                                aria-label="Copy to clipboard"
+                                                class=""
+                                                data-mui-internal-clone-element="true"
+                                                style="cursor: pointer;"
+                                              >
+                                                <span>
+                                                  0x
+                                                  <b>
+                                                    0000
+                                                  </b>
+                                                  00000000000000000000000000000000
+                                                  <b>
+                                                    0000
+                                                  </b>
+                                                </span>
+                                              </span>
+                                            </div>
+                                            <div
+                                              class="MuiBox-root css-yjghm1"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </p>
+                                  </div>
                                 </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
                                 <div
-                                  class="MuiBox-root css-1lchl8k"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  <div
-                                    class="addressContainer"
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Value
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    0x0
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Data
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-n5xdb5-MuiTypography-root"
                                   >
                                     <div
-                                      class="MuiBox-root css-b5p5gz"
+                                      class="encodedData MuiBox-root css-0"
+                                      data-testid="tx-hexData"
                                     >
                                       <span
                                         aria-label="Copy to clipboard"
@@ -226,183 +407,102 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                         data-mui-internal-clone-element="true"
                                         style="cursor: pointer;"
                                       >
-                                        <span>
-                                          0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
+                                        <span
+                                          class="monospace"
+                                        >
+                                          <b
+                                            aria-label="The first 4 bytes determine the contract method that is being called"
+                                            class=""
+                                            data-mui-internal-clone-element="true"
+                                          >
+                                            0x
+                                          </b>
+                                           
                                         </span>
                                       </span>
                                     </div>
-                                    <span
-                                      aria-label="Copy to clipboard"
-                                      class=""
-                                      data-mui-internal-clone-element="true"
-                                      style="cursor: pointer;"
-                                    >
-                                      <button
-                                        aria-label="Copy to clipboard"
-                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                                        tabindex="0"
-                                        type="button"
-                                      >
-                                        <mock-icon
-                                          aria-hidden=""
-                                          class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                                          data-testid="copy-btn-icon"
-                                          focusable="false"
-                                        />
-                                      </button>
-                                    </span>
-                                    <div
-                                      class="MuiBox-root css-yjghm1"
-                                    />
-                                  </div>
+                                  </p>
                                 </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="MuiBox-root css-0"
-                    >
-                      <hr
-                        class="MuiDivider-root MuiDivider-fullWidth css-mnly1g-MuiDivider-root"
-                      />
-                      <h6
-                        class="MuiTypography-root MuiTypography-subtitle2 css-1ckyqq0-MuiTypography-root"
-                      >
-                        Advanced details
-                      </h6>
-                      <p
-                        class="MuiTypography-root MuiTypography-body2 css-gkag80-MuiTypography-root"
-                      >
-                        Cross-verify your transaction data with external tools like
-                         
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
-                          href="https://safeutils.openzeppelin.com"
-                          rel="noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="MuiBox-root css-1vqf8mi"
-                          >
-                            Safe Utils
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
-                              data-testid="OpenInNewRoundedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
-                              />
-                            </svg>
-                          </span>
-                        </a>
-                         and
-                         
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
-                          href="https://transaction-decoder.pages.dev"
-                          rel="noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="MuiBox-root css-1vqf8mi"
-                          >
-                            Transaction Decoder
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
-                              data-testid="OpenInNewRoundedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
-                              />
-                            </svg>
-                          </span>
-                        </a>
-                        .
-                      </p>
-                      <div
-                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-shqplw-MuiPaper-root"
-                        style="--Paper-shadow: none;"
-                      >
-                        <div
-                          class="MuiStack-root css-1sazv7p-MuiStack-root"
-                        >
-                          <div
-                            class="MuiStack-root css-1n46f6x-MuiStack-root"
-                          >
-                            <div
-                              aria-label="text alignment"
-                              class="MuiToggleButtonGroup-root MuiToggleButtonGroup-horizontal css-cinseo-MuiToggleButtonGroup-root"
-                              role="group"
-                            >
-                              <button
-                                aria-pressed="true"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-firstButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="0"
-                              >
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
                                 <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  Data
-                                </div>
-                              </button>
-                              <button
-                                aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="1"
-                              >
-                                <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  Hashes
-                                </div>
-                              </button>
-                              <button
-                                aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="2"
-                              >
-                                <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  JSON
-                                </div>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="MuiBox-root css-e0rnc0"
-                          >
-                            <div
-                              class="MuiStack-root css-jfdv4h-MuiStack-root"
-                            >
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  To
-                                </p>
-                                <div
-                                  class="MuiBox-root css-0"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
                                   <p
-                                    class="MuiTypography-root MuiTypography-body2 css-m9op2-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Operation
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1hy3mdy-MuiTypography-root"
+                                  >
+                                    0
+                                     (
+                                    call
+                                    )
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root MuiSvgIcon-colorSuccess MuiSvgIcon-fontSizeInherit css-113mief-MuiSvgIcon-root"
+                                      data-testid="CheckIcon"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                      />
+                                    </svg>
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    SafeTxGas
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    BaseGas
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    GasPrice
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    GasToken
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
                                   >
                                     <div
                                       class="container"
@@ -411,9 +511,9 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                         class="avatarContainer"
                                         style="width: 20px; height: 20px;"
                                       >
-                                        <div
-                                          class="icon"
-                                          style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjEzIDY1JSA0OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNTQgNjYlIDU2JSkiIGQ9Ik0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjcgNDElIDYzJSkiIGQ9Ik0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 20px; height: 20px;"
+                                        <span
+                                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                          style="width: 20px; height: 20px;"
                                         />
                                       </div>
                                       <div
@@ -431,16 +531,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                               data-mui-internal-clone-element="true"
                                               style="cursor: pointer;"
                                             >
-                                              <span>
-                                                0x
-                                                <b>
-                                                  0000
-                                                </b>
-                                                00000000000000000000000000000000
-                                                <b>
-                                                  0000
-                                                </b>
-                                              </span>
+                                              <span />
                                             </span>
                                           </div>
                                           <div
@@ -451,251 +542,75 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                                     </div>
                                   </p>
                                 </div>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  Value
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  0x0
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Data
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-n5xdb5-MuiTypography-root"
-                                >
-                                  <div
-                                    class="encodedData MuiBox-root css-0"
-                                    data-testid="tx-hexData"
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
                                   >
-                                    <span
-                                      aria-label="Copy to clipboard"
-                                      class=""
-                                      data-mui-internal-clone-element="true"
-                                      style="cursor: pointer;"
-                                    >
-                                      <span
-                                        class="monospace"
-                                      >
-                                        <b
-                                          aria-label="The first 4 bytes determine the contract method that is being called"
-                                          class=""
-                                          data-mui-internal-clone-element="true"
-                                        >
-                                          0x
-                                        </b>
-                                         
-                                      </span>
-                                    </span>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Operation
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1hy3mdy-MuiTypography-root"
-                                >
-                                  0
-                                   (
-                                  call
-                                  )
-                                  <svg
-                                    aria-hidden="true"
-                                    class="MuiSvgIcon-root MuiSvgIcon-colorSuccess MuiSvgIcon-fontSizeInherit css-113mief-MuiSvgIcon-root"
-                                    data-testid="CheckIcon"
-                                    focusable="false"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <path
-                                      d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
-                                    />
-                                  </svg>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  SafeTxGas
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  BaseGas
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  GasPrice
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  GasToken
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  <div
-                                    class="container"
+                                    RefundReceiver
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
                                   >
                                     <div
-                                      class="avatarContainer"
-                                      style="width: 20px; height: 20px;"
-                                    >
-                                      <span
-                                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
-                                        style="width: 20px; height: 20px;"
-                                      />
-                                    </div>
-                                    <div
-                                      class="MuiBox-root css-1lchl8k"
+                                      class="container"
                                     >
                                       <div
-                                        class="addressContainer"
-                                      >
-                                        <div
-                                          class="MuiBox-root css-b5p5gz"
-                                        >
-                                          <span
-                                            aria-label="Copy to clipboard"
-                                            class=""
-                                            data-mui-internal-clone-element="true"
-                                            style="cursor: pointer;"
-                                          >
-                                            <span />
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="MuiBox-root css-yjghm1"
-                                        />
-                                      </div>
-                                    </div>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  RefundReceiver
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  <div
-                                    class="container"
-                                  >
-                                    <div
-                                      class="avatarContainer"
-                                      style="width: 20px; height: 20px;"
-                                    >
-                                      <span
-                                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                        class="avatarContainer"
                                         style="width: 20px; height: 20px;"
-                                      />
-                                    </div>
-                                    <div
-                                      class="MuiBox-root css-1lchl8k"
-                                    >
-                                      <div
-                                        class="addressContainer"
                                       >
-                                        <div
-                                          class="MuiBox-root css-b5p5gz"
-                                        >
-                                          <span
-                                            aria-label="Copy to clipboard"
-                                            class=""
-                                            data-mui-internal-clone-element="true"
-                                            style="cursor: pointer;"
-                                          >
-                                            <span />
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="MuiBox-root css-yjghm1"
+                                        <span
+                                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                          style="width: 20px; height: 20px;"
                                         />
                                       </div>
+                                      <div
+                                        class="MuiBox-root css-1lchl8k"
+                                      >
+                                        <div
+                                          class="addressContainer"
+                                        >
+                                          <div
+                                            class="MuiBox-root css-b5p5gz"
+                                          >
+                                            <span
+                                              aria-label="Copy to clipboard"
+                                              class=""
+                                              data-mui-internal-clone-element="true"
+                                              style="cursor: pointer;"
+                                            >
+                                              <span />
+                                            </span>
+                                          </div>
+                                          <div
+                                            class="MuiBox-root css-yjghm1"
+                                          />
+                                        </div>
+                                      </div>
                                     </div>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  Nonce
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  100
-                                </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Nonce
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    100
+                                  </p>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
@@ -11,84 +11,88 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
       data-testid="card-content"
     >
       <div
-        class="MuiStack-root css-1sazv7p-MuiStack-root"
+        class="MuiBox-root css-0"
       >
         <div
-          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+          class="MuiStack-root css-1sazv7p-MuiStack-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-            data-testid="tx-row-title"
-            style="word-break: break-word;"
-          >
-            <span
-              class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
-            >
-              Interacted with
-            </span>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-            data-testid="tx-data-row"
+            class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
           >
             <div
-              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+              class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
+              data-testid="tx-row-title"
+              style="word-break: break-word;"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+              >
+                Interacted with
+              </span>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+              data-testid="tx-data-row"
             >
               <div
-                class="container"
+                class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
               >
                 <div
-                  class="avatarContainer"
-                  style="width: 20px; height: 20px;"
+                  class="container"
                 >
                   <div
-                    class="icon"
-                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
-                  />
-                </div>
-                <div
-                  class="MuiBox-root css-1lchl8k"
-                >
-                  <div
-                    class="addressContainer"
+                    class="avatarContainer"
+                    style="width: 20px; height: 20px;"
                   >
                     <div
-                      class="MuiBox-root css-b5p5gz"
+                      class="icon"
+                      style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
+                    />
+                  </div>
+                  <div
+                    class="MuiBox-root css-1lchl8k"
+                  >
+                    <div
+                      class="addressContainer"
                     >
+                      <div
+                        class="MuiBox-root css-b5p5gz"
+                      >
+                        <span
+                          aria-label="Copy to clipboard"
+                          class=""
+                          data-mui-internal-clone-element="true"
+                          style="cursor: pointer;"
+                        >
+                          <span>
+                            0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
+                          </span>
+                        </span>
+                      </div>
                       <span
                         aria-label="Copy to clipboard"
                         class=""
                         data-mui-internal-clone-element="true"
                         style="cursor: pointer;"
                       >
-                        <span>
-                          0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
-                        </span>
+                        <button
+                          aria-label="Copy to clipboard"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                          tabindex="0"
+                          type="button"
+                        >
+                          <mock-icon
+                            aria-hidden=""
+                            class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                            data-testid="copy-btn-icon"
+                            focusable="false"
+                          />
+                        </button>
                       </span>
+                      <div
+                        class="MuiBox-root css-yjghm1"
+                      />
                     </div>
-                    <span
-                      aria-label="Copy to clipboard"
-                      class=""
-                      data-mui-internal-clone-element="true"
-                      style="cursor: pointer;"
-                    >
-                      <button
-                        aria-label="Copy to clipboard"
-                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                        tabindex="0"
-                        type="button"
-                      >
-                        <mock-icon
-                          aria-hidden=""
-                          class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                          data-testid="copy-btn-icon"
-                          focusable="false"
-                        />
-                      </button>
-                    </span>
-                    <div
-                      class="MuiBox-root css-yjghm1"
-                    />
                   </div>
                 </div>
               </div>
@@ -173,52 +177,229 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                     data-testid="decoded-tx-details"
                   >
                     <div
-                      class="MuiBox-root css-1xlzx9v"
+                      class="MuiStack-root css-hwnj0i-MuiStack-root"
                     >
                       <div
-                        class="MuiStack-root css-1sazv7p-MuiStack-root"
+                        class="MuiBox-root css-0"
                       >
-                        <div
-                          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+                        <h6
+                          class="MuiTypography-root MuiTypography-subtitle2 css-4lr168-MuiTypography-root"
                         >
-                          <div
-                            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-                            data-testid="tx-row-title"
-                            style="word-break: break-word;"
+                          Advanced details
+                        </h6>
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-gkag80-MuiTypography-root"
+                        >
+                          Cross-verify your transaction data with external tools like
+                           
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
+                            href="https://safeutils.openzeppelin.com"
+                            rel="noreferrer noopener"
+                            target="_blank"
                           >
                             <span
-                              class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                              class="MuiBox-root css-1vqf8mi"
                             >
-                              Interacted with
+                              Safe Utils
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                data-testid="OpenInNewRoundedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                />
+                              </svg>
                             </span>
-                          </div>
+                          </a>
+                           and
+                           
+                          <a
+                            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
+                            href="https://transaction-decoder.pages.dev"
+                            rel="noreferrer noopener"
+                            target="_blank"
+                          >
+                            <span
+                              class="MuiBox-root css-1vqf8mi"
+                            >
+                              Transaction Decoder
+                              <svg
+                                aria-hidden="true"
+                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
+                                data-testid="OpenInNewRoundedIcon"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                />
+                              </svg>
+                            </span>
+                          </a>
+                          .
+                        </p>
+                        <div
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-shqplw-MuiPaper-root"
+                          style="--Paper-shadow: none;"
+                        >
                           <div
-                            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-                            data-testid="tx-data-row"
+                            class="MuiStack-root css-1sazv7p-MuiStack-root"
                           >
                             <div
-                              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                              class="MuiStack-root css-1n46f6x-MuiStack-root"
                             >
                               <div
-                                class="container"
+                                aria-label="text alignment"
+                                class="MuiToggleButtonGroup-root MuiToggleButtonGroup-horizontal css-cinseo-MuiToggleButtonGroup-root"
+                                role="group"
+                              >
+                                <button
+                                  aria-pressed="true"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-firstButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="0"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    Data
+                                  </div>
+                                </button>
+                                <button
+                                  aria-pressed="false"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="1"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    Hashes
+                                  </div>
+                                </button>
+                                <button
+                                  aria-pressed="false"
+                                  class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
+                                  tabindex="0"
+                                  type="button"
+                                  value="2"
+                                >
+                                  <div
+                                    class="MuiBox-root css-mro3c9"
+                                  >
+                                    JSON
+                                  </div>
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              class="MuiBox-root css-e0rnc0"
+                            >
+                              <div
+                                class="MuiStack-root css-jfdv4h-MuiStack-root"
                               >
                                 <div
-                                  class="avatarContainer"
-                                  style="width: 20px; height: 20px;"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    To
+                                  </p>
                                   <div
-                                    class="icon"
-                                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woOTIgOTYlIDQzJSkiIGQ9Ik0wLDBIOFY4SDB6Ii8+PHBhdGggZmlsbD0iaHNsKDMxMCA4NCUgMzglKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDM1MSA2MSUgNjUlKSIgZD0iTTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
-                                  />
+                                    class="MuiBox-root css-0"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 css-m9op2-MuiTypography-root"
+                                    >
+                                      <div
+                                        class="container"
+                                      >
+                                        <div
+                                          class="avatarContainer"
+                                          style="width: 20px; height: 20px;"
+                                        >
+                                          <div
+                                            class="icon"
+                                            style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjEzIDY1JSA0OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNTQgNjYlIDU2JSkiIGQ9Ik0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjcgNDElIDYzJSkiIGQ9Ik0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 20px; height: 20px;"
+                                          />
+                                        </div>
+                                        <div
+                                          class="MuiBox-root css-1lchl8k"
+                                        >
+                                          <div
+                                            class="addressContainer"
+                                          >
+                                            <div
+                                              class="MuiBox-root css-b5p5gz"
+                                            >
+                                              <span
+                                                aria-label="Copy to clipboard"
+                                                class=""
+                                                data-mui-internal-clone-element="true"
+                                                style="cursor: pointer;"
+                                              >
+                                                <span>
+                                                  0x
+                                                  <b>
+                                                    0000
+                                                  </b>
+                                                  00000000000000000000000000000000
+                                                  <b>
+                                                    0000
+                                                  </b>
+                                                </span>
+                                              </span>
+                                            </div>
+                                            <div
+                                              class="MuiBox-root css-yjghm1"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </p>
+                                  </div>
                                 </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
                                 <div
-                                  class="MuiBox-root css-1lchl8k"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  <div
-                                    class="addressContainer"
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Value
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    0x0
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Data
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-n5xdb5-MuiTypography-root"
                                   >
                                     <div
-                                      class="MuiBox-root css-b5p5gz"
+                                      class="encodedData MuiBox-root css-0"
+                                      data-testid="tx-hexData"
                                     >
                                       <span
                                         aria-label="Copy to clipboard"
@@ -226,183 +407,102 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                                         data-mui-internal-clone-element="true"
                                         style="cursor: pointer;"
                                       >
-                                        <span>
-                                          0xE20CcFf2c38Ef3b64109361D7b7691ff2c7D5f67
+                                        <span
+                                          class="monospace"
+                                        >
+                                          <b
+                                            aria-label="The first 4 bytes determine the contract method that is being called"
+                                            class=""
+                                            data-mui-internal-clone-element="true"
+                                          >
+                                            0x
+                                          </b>
+                                           
                                         </span>
                                       </span>
                                     </div>
-                                    <span
-                                      aria-label="Copy to clipboard"
-                                      class=""
-                                      data-mui-internal-clone-element="true"
-                                      style="cursor: pointer;"
-                                    >
-                                      <button
-                                        aria-label="Copy to clipboard"
-                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                                        tabindex="0"
-                                        type="button"
-                                      >
-                                        <mock-icon
-                                          aria-hidden=""
-                                          class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                                          data-testid="copy-btn-icon"
-                                          focusable="false"
-                                        />
-                                      </button>
-                                    </span>
-                                    <div
-                                      class="MuiBox-root css-yjghm1"
-                                    />
-                                  </div>
+                                  </p>
                                 </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="MuiBox-root css-0"
-                    >
-                      <hr
-                        class="MuiDivider-root MuiDivider-fullWidth css-mnly1g-MuiDivider-root"
-                      />
-                      <h6
-                        class="MuiTypography-root MuiTypography-subtitle2 css-1ckyqq0-MuiTypography-root"
-                      >
-                        Advanced details
-                      </h6>
-                      <p
-                        class="MuiTypography-root MuiTypography-body2 css-gkag80-MuiTypography-root"
-                      >
-                        Cross-verify your transaction data with external tools like
-                         
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
-                          href="https://safeutils.openzeppelin.com"
-                          rel="noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="MuiBox-root css-1vqf8mi"
-                          >
-                            Safe Utils
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
-                              data-testid="OpenInNewRoundedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
-                              />
-                            </svg>
-                          </span>
-                        </a>
-                         and
-                         
-                        <a
-                          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways css-r9pq5a-MuiTypography-root-MuiLink-root"
-                          href="https://transaction-decoder.pages.dev"
-                          rel="noreferrer noopener"
-                          target="_blank"
-                        >
-                          <span
-                            class="MuiBox-root css-1vqf8mi"
-                          >
-                            Transaction Decoder
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-tqxw8e-MuiSvgIcon-root"
-                              data-testid="OpenInNewRoundedIcon"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
-                              />
-                            </svg>
-                          </span>
-                        </a>
-                        .
-                      </p>
-                      <div
-                        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-shqplw-MuiPaper-root"
-                        style="--Paper-shadow: none;"
-                      >
-                        <div
-                          class="MuiStack-root css-1sazv7p-MuiStack-root"
-                        >
-                          <div
-                            class="MuiStack-root css-1n46f6x-MuiStack-root"
-                          >
-                            <div
-                              aria-label="text alignment"
-                              class="MuiToggleButtonGroup-root MuiToggleButtonGroup-horizontal css-cinseo-MuiToggleButtonGroup-root"
-                              role="group"
-                            >
-                              <button
-                                aria-pressed="true"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root Mui-selected MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-firstButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="0"
-                              >
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
                                 <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  Data
-                                </div>
-                              </button>
-                              <button
-                                aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="1"
-                              >
-                                <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  Hashes
-                                </div>
-                              </button>
-                              <button
-                                aria-pressed="false"
-                                class="MuiButtonBase-root MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-u2ogzi-MuiButtonBase-root-MuiToggleButton-root"
-                                tabindex="0"
-                                type="button"
-                                value="2"
-                              >
-                                <div
-                                  class="MuiBox-root css-mro3c9"
-                                >
-                                  JSON
-                                </div>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            class="MuiBox-root css-e0rnc0"
-                          >
-                            <div
-                              class="MuiStack-root css-jfdv4h-MuiStack-root"
-                            >
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  To
-                                </p>
-                                <div
-                                  class="MuiBox-root css-0"
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
                                   <p
-                                    class="MuiTypography-root MuiTypography-body2 css-m9op2-MuiTypography-root"
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Operation
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1hy3mdy-MuiTypography-root"
+                                  >
+                                    0
+                                     (
+                                    call
+                                    )
+                                    <svg
+                                      aria-hidden="true"
+                                      class="MuiSvgIcon-root MuiSvgIcon-colorSuccess MuiSvgIcon-fontSizeInherit css-113mief-MuiSvgIcon-root"
+                                      data-testid="CheckIcon"
+                                      focusable="false"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
+                                      />
+                                    </svg>
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    SafeTxGas
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    BaseGas
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    GasPrice
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
+                                >
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    GasToken
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
                                   >
                                     <div
                                       class="container"
@@ -411,9 +511,9 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                                         class="avatarContainer"
                                         style="width: 20px; height: 20px;"
                                       >
-                                        <div
-                                          class="icon"
-                                          style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjEzIDY1JSA0OSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNTQgNjYlIDU2JSkiIGQ9Ik0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0zLDNoMXYxaC0xek00LDNoMXYxaC0xek0wLDRoMXYxaC0xek03LDRoMXYxaC0xek0yLDRoMXYxaC0xek01LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgzMjcgNDElIDYzJSkiIGQ9Ik0wLDNoMXYxaC0xek03LDNoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDZoMXYxaC0xek03LDZoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 20px; height: 20px;"
+                                        <span
+                                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                          style="width: 20px; height: 20px;"
                                         />
                                       </div>
                                       <div
@@ -431,16 +531,7 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                                               data-mui-internal-clone-element="true"
                                               style="cursor: pointer;"
                                             >
-                                              <span>
-                                                0x
-                                                <b>
-                                                  0000
-                                                </b>
-                                                00000000000000000000000000000000
-                                                <b>
-                                                  0000
-                                                </b>
-                                              </span>
+                                              <span />
                                             </span>
                                           </div>
                                           <div
@@ -451,251 +542,75 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
                                     </div>
                                   </p>
                                 </div>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  Value
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  0x0
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Data
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-n5xdb5-MuiTypography-root"
-                                >
-                                  <div
-                                    class="encodedData MuiBox-root css-0"
-                                    data-testid="tx-hexData"
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
                                   >
-                                    <span
-                                      aria-label="Copy to clipboard"
-                                      class=""
-                                      data-mui-internal-clone-element="true"
-                                      style="cursor: pointer;"
-                                    >
-                                      <span
-                                        class="monospace"
-                                      >
-                                        <b
-                                          aria-label="The first 4 bytes determine the contract method that is being called"
-                                          class=""
-                                          data-mui-internal-clone-element="true"
-                                        >
-                                          0x
-                                        </b>
-                                         
-                                      </span>
-                                    </span>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  Operation
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1hy3mdy-MuiTypography-root"
-                                >
-                                  0
-                                   (
-                                  call
-                                  )
-                                  <svg
-                                    aria-hidden="true"
-                                    class="MuiSvgIcon-root MuiSvgIcon-colorSuccess MuiSvgIcon-fontSizeInherit css-113mief-MuiSvgIcon-root"
-                                    data-testid="CheckIcon"
-                                    focusable="false"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <path
-                                      d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"
-                                    />
-                                  </svg>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  SafeTxGas
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  BaseGas
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  GasPrice
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  GasToken
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  <div
-                                    class="container"
+                                    RefundReceiver
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
                                   >
                                     <div
-                                      class="avatarContainer"
-                                      style="width: 20px; height: 20px;"
-                                    >
-                                      <span
-                                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
-                                        style="width: 20px; height: 20px;"
-                                      />
-                                    </div>
-                                    <div
-                                      class="MuiBox-root css-1lchl8k"
+                                      class="container"
                                     >
                                       <div
-                                        class="addressContainer"
-                                      >
-                                        <div
-                                          class="MuiBox-root css-b5p5gz"
-                                        >
-                                          <span
-                                            aria-label="Copy to clipboard"
-                                            class=""
-                                            data-mui-internal-clone-element="true"
-                                            style="cursor: pointer;"
-                                          >
-                                            <span />
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="MuiBox-root css-yjghm1"
-                                        />
-                                      </div>
-                                    </div>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
-                                >
-                                  RefundReceiver
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  <div
-                                    class="container"
-                                  >
-                                    <div
-                                      class="avatarContainer"
-                                      style="width: 20px; height: 20px;"
-                                    >
-                                      <span
-                                        class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                        class="avatarContainer"
                                         style="width: 20px; height: 20px;"
-                                      />
-                                    </div>
-                                    <div
-                                      class="MuiBox-root css-1lchl8k"
-                                    >
-                                      <div
-                                        class="addressContainer"
                                       >
-                                        <div
-                                          class="MuiBox-root css-b5p5gz"
-                                        >
-                                          <span
-                                            aria-label="Copy to clipboard"
-                                            class=""
-                                            data-mui-internal-clone-element="true"
-                                            style="cursor: pointer;"
-                                          >
-                                            <span />
-                                          </span>
-                                        </div>
-                                        <div
-                                          class="MuiBox-root css-yjghm1"
+                                        <span
+                                          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse css-143xw5x-MuiSkeleton-root"
+                                          style="width: 20px; height: 20px;"
                                         />
                                       </div>
+                                      <div
+                                        class="MuiBox-root css-1lchl8k"
+                                      >
+                                        <div
+                                          class="addressContainer"
+                                        >
+                                          <div
+                                            class="MuiBox-root css-b5p5gz"
+                                          >
+                                            <span
+                                              aria-label="Copy to clipboard"
+                                              class=""
+                                              data-mui-internal-clone-element="true"
+                                              style="cursor: pointer;"
+                                            >
+                                              <span />
+                                            </span>
+                                          </div>
+                                          <div
+                                            class="MuiBox-root css-yjghm1"
+                                          />
+                                        </div>
+                                      </div>
                                     </div>
-                                  </div>
-                                </p>
-                              </div>
-                              <hr
-                                class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
-                              />
-                              <div
-                                class="MuiStack-root css-665wph-MuiStack-root"
-                              >
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  </p>
+                                </div>
+                                <hr
+                                  class="MuiDivider-root MuiDivider-fullWidth css-1facvfi-MuiDivider-root"
+                                />
+                                <div
+                                  class="MuiStack-root css-665wph-MuiStack-root"
                                 >
-                                  Nonce
-                                </p>
-                                <p
-                                  class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                                >
-                                  100
-                                </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-1korokw-MuiTypography-root"
+                                  >
+                                    Nonce
+                                  </p>
+                                  <p
+                                    class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                  >
+                                    100
+                                  </p>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/apps/web/src/components/tx/confirmation-views/SettingsChange/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/SettingsChange/index.tsx
@@ -5,7 +5,7 @@ import { OwnerList } from '@/components/tx-flow/common/OwnerList'
 import MinusIcon from '@/public/images/common/minus.svg'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import useSafeInfo from '@/hooks/useSafeInfo'
-import { SettingsInfoType, type SettingsChange } from '@safe-global/safe-gateway-typescript-sdk'
+import { SettingsInfoType, type SettingsChange as SettingsChangeType } from '@safe-global/safe-gateway-typescript-sdk'
 import { ChangeSignerSetupWarning } from '@/features/multichain/components/SignerSetupWarning/ChangeSignerSetupWarning'
 import { useContext } from 'react'
 import { SettingsChangeContext } from '@/components/tx-flow/flows/AddOwner/context'
@@ -13,7 +13,7 @@ import { maybePlural } from '@safe-global/utils/utils/formatters'
 import { UntrustedFallbackHandlerTxAlert } from '@/components/tx/confirmation-views/SettingsChange/UntrustedFallbackHandlerTxAlert'
 
 export interface SettingsChangeProps extends NarrowConfirmationViewProps {
-  txInfo: SettingsChange
+  txInfo: SettingsChangeType
 }
 
 const SettingsChange: React.FC<SettingsChangeProps> = ({ txInfo: { settingsInfo } }) => {

--- a/apps/web/src/components/tx/confirmation-views/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/index.tsx
@@ -58,7 +58,7 @@ const getConfirmationViewComponent = ({
 
   if (isConfirmBatchView(txFlow)) return <BatchTransactions />
 
-  if (isSettingsChangeView(txInfo)) return <SettingsChange txInfo={txInfo as SettingsChange} />
+  if (isSettingsChangeView(txInfo)) return <SettingsChange txInfo={txInfo} />
 
   if (isOnChainConfirmationTxData(txData)) return <OnChainConfirmation data={txData} isConfirmationView />
 

--- a/apps/web/src/components/tx/confirmation-views/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/index.tsx
@@ -14,7 +14,7 @@ import {
   isVaultDepositTxInfo,
   isVaultRedeemTxInfo,
 } from '@/utils/transaction-guards'
-import { type ReactNode, useContext, useMemo } from 'react'
+import { type ReactNode, useContext, useMemo, useRef, useState, useEffect } from 'react'
 import type { NarrowConfirmationViewProps } from './types'
 import SettingsChange from './SettingsChange'
 import ChangeThreshold from './ChangeThreshold'
@@ -36,6 +36,8 @@ import VaultRedeemConfirmation from '@/features/earn/components/VaultRedeemConfi
 import TxData from '@/components/transactions/TxDetails/TxData'
 import { isMultiSendCalldata } from '@/utils/transaction-calldata'
 import useChainId from '@/hooks/useChainId'
+import { Box } from '@mui/material'
+import DecodedData from '@/components/transactions/TxDetails/TxData/DecodedData'
 
 type ConfirmationViewProps = {
   txDetails?: TransactionDetails
@@ -90,6 +92,16 @@ const ConfirmationView = ({ safeTx, txPreview, txDetails, ...props }: Confirmati
   const details = txDetails ?? txPreview
   const chainId = useChainId()
 
+  // Used to check if the decoded data was rendered inside the TxData component
+  // If it was, we hide the decoded data in the Summary to avoid showing it twice
+  const decodedDataRef = useRef(null)
+  const [isDecodedDataVisible, setIsDecodedDataVisible] = useState(false)
+
+  useEffect(() => {
+    // If decodedDataRef.current is not null, the decoded data was rendered inside the TxData component
+    setIsDecodedDataVisible(!!decodedDataRef.current)
+  }, [decodedDataRef.current])
+
   const ConfirmationViewComponent = useMemo(() => {
     return details
       ? getConfirmationViewComponent({
@@ -109,12 +121,25 @@ const ConfirmationView = ({ safeTx, txPreview, txDetails, ...props }: Confirmati
     <>
       {ConfirmationViewComponent ||
         (details && showTxDetails && (
-          <TxData txData={details?.txData} txInfo={details?.txInfo} txDetails={txDetails} imitation={false} trusted />
+          <TxData txData={details?.txData} txInfo={details?.txInfo} txDetails={txDetails} imitation={false} trusted>
+            <Box ref={decodedDataRef}>
+              <DecodedData
+                txData={details.txData}
+                toInfo={isCustomTxInfo(details.txInfo) ? details.txInfo.to : details.txData?.to}
+              />
+            </Box>
+          </TxData>
         ))}
 
       {props.children}
 
-      <Summary safeTxData={safeTx?.data} txDetails={txDetails} txData={details?.txData} txInfo={details?.txInfo} />
+      <Summary
+        safeTxData={safeTx?.data}
+        txDetails={txDetails}
+        txData={details?.txData}
+        txInfo={details?.txInfo}
+        showDecodedData={!isDecodedDataVisible}
+      />
     </>
   )
 }

--- a/apps/web/src/components/tx/confirmation-views/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/index.tsx
@@ -100,7 +100,7 @@ const ConfirmationView = ({ safeTx, txPreview, txDetails, ...props }: Confirmati
   useEffect(() => {
     // If decodedDataRef.current is not null, the decoded data was rendered inside the TxData component
     setIsDecodedDataVisible(!!decodedDataRef.current)
-  }, [decodedDataRef.current])
+  }, [])
 
   const ConfirmationViewComponent = useMemo(() => {
     return details


### PR DESCRIPTION
## What it solves

Resolves #5780 

Hide the contract interaction info in the transaction details accordion if it is already being rendered above. 

## How to test it

1. Create a transaction that has no custom decoding (e.g. a multiSend transaction)
2. In the confirmation view observe that the transaction details accordion does not show the contract interaction info as it is already being rendered above
3. Same should be the case for a transaction in the queue/history
4. The contract interaction info should still be visible for transactions that have a custom decoding (such as a token transfer)

## Screenshots

### Before
<img width="1022" alt="Screenshot 2025-05-19 at 17 23 16" src="https://github.com/user-attachments/assets/5a40bc0b-26fe-4f72-a0ab-83294be9f049" />

### After

<img width="1018" alt="Screenshot 2025-05-19 at 17 22 55" src="https://github.com/user-attachments/assets/f789183c-fab9-44bb-9ed1-2672d6871a62" />

