### PR TITLE
fix(ExecTransaction): replace Summary component with TxData

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
@@ -11,7 +11,7 @@ import type { SafeTransaction } from '@safe-global/safe-core-sdk-types'
 import ExternalLink from '@/components/common/ExternalLink'
 import { NestedTransaction } from '../NestedTransaction'
 import useTxPreview from '@/components/tx/confirmation-views/useTxPreview'
-import Summary from '../../../Summary'
+import TxData from '../..'
 import { TxSimulation, TxSimulationMessage } from '@/components/tx/security/tenderly'
 import useSafeAddress from '@/hooks/useSafeAddress'
 
@@ -70,7 +70,9 @@ export const ExecTransaction = ({
     data?.to.value,
   )
 
-  const decodedNestedTxDataBlock = txPreview ? <Summary {...txPreview} safeTxData={childSafeTx?.data} /> : null
+  const decodedNestedTxDataBlock = txPreview ? (
+    <TxData txData={txPreview.txData} txInfo={txPreview.txInfo} trusted imitation={false} />
+  ) : null
 
   return (
     <NestedTransaction txData={data} isConfirmationView={isConfirmationView}>


### PR DESCRIPTION
## What it solves

Resolves #5901

There are several issues with how nested transaction details are displayed for `execTransaction` calls:

1. The receipt shows a nonce of -1 for the nested transaction.
2. The Hashes tab only displays the Domain hash. Both the Message hash and safeTxHash are missing.
3. Switching to the JSON tab in the receipt causes the content to disappear, showing the error message: "Error parsing data".

For an execTransaction call we don't have all the data required to display the full nested transaction with the advanced tx details. 

## How this PR fixes it

Update the nestedTransaction data display for execTransaction calls to use the `TxData` component instead of `Summary`.

## How to test it
See the steps listed in #5901

## Screenshots
<img width="762" alt="Screenshot 2025-05-20 at 09 15 44" src="https://github.com/user-attachments/assets/f0071219-aed9-4ca7-80d3-024c987f4f04" />