### PR TITLE
Hotfix(Earn): Only access extra rewards if they exist

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,7 +2,7 @@
   "name": "@safe-global/web",
   "homepage": "https://github.com/safe-global/safe-wallet-web",
   "license": "GPL-3.0",
-  "version": "1.60.0",
+  "version": "1.60.1",
   "type": "module",
   "scripts": {
     "dev": "next dev",

--- a/apps/web/src/features/earn/components/VaultDepositConfirmation/index.tsx
+++ b/apps/web/src/features/earn/components/VaultDepositConfirmation/index.tsx
@@ -12,6 +12,8 @@ import { InfoTooltip } from '@/features/stake/components/InfoTooltip'
 import { BRAND_NAME } from '@/config/constants'
 
 const AdditionalRewards = ({ txInfo }: { txInfo: VaultDepositTransactionInfo }) => {
+  if (!txInfo.additionalRewards[0]) return null
+
   return (
     <Stack sx={{ border: '1px solid #ddd', borderRadius: '6px', padding: '12px', mt: 1 }}>
       <DataTable

--- a/apps/web/src/features/earn/components/VaultRedeemConfirmation/index.tsx
+++ b/apps/web/src/features/earn/components/VaultRedeemConfirmation/index.tsx
@@ -11,7 +11,8 @@ import IframeIcon from '@/components/common/IframeIcon'
 
 const AdditionalRewards = ({ txInfo }: { txInfo: VaultRedeemTransactionInfo }) => {
   const additionalRewardsClaimable = Number(txInfo.additionalRewards[0].claimable) > 0
-  if (!additionalRewardsClaimable) return null
+
+  if (!additionalRewardsClaimable || !txInfo.additionalRewards[0]) return null
 
   return (
     <Stack sx={{ border: '1px solid #ddd', borderRadius: '6px', padding: '12px', mt: 1 }}>


### PR DESCRIPTION
## What it solves

Only accesses tokenInfo of extra rewards if they exist
