### PR TITLE
Fix transactions nav order

### DIFF
--- a/apps/web/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/apps/web/src/components/sidebar/SidebarNavigation/config.tsx
@@ -34,6 +34,11 @@ export const navItems: NavItem[] = [
     href: AppRoutes.balances.index,
   },
   {
+    label: 'Transactions',
+    icon: <SvgIcon component={TransactionIcon} inheritViewBox />,
+    href: AppRoutes.transactions.history,
+  },
+  {
     label: 'Swap',
     icon: <SvgIcon component={SwapIcon} inheritViewBox />,
     href: AppRoutes.swap,
@@ -53,11 +58,6 @@ export const navItems: NavItem[] = [
     icon: <SvgIcon component={EarnIcon} inheritViewBox />,
     href: AppRoutes.earn,
     tag: <Chip label="New" sx={{ backgroundColor: 'secondary.light', color: 'static.main' }} />,
-  },
-  {
-    label: 'Transactions',
-    icon: <SvgIcon component={TransactionIcon} inheritViewBox />,
-    href: AppRoutes.transactions.history,
   },
   {
     label: 'Address book',


### PR DESCRIPTION
## Summary
- reorder Sidebar nav items so Transactions comes after Assets

## Testing
- `yarn test` *(fails: Snapshot Summary: 2 snapshots failed from 1 test suite; Test Suites: 5 failed, 1 skipped, 253 passed, 258 of 259 total)*