### PR TITLE
feat: optimize rpc requests through Multicall3

### DIFF
--- a/apps/web/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.test.ts
+++ b/apps/web/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.test.ts
@@ -580,7 +580,7 @@ describe('useApprovalInfos', () => {
     }
     const fetchMock = jest
       .spyOn(getTokenInfo, 'getERC20TokenInfoOnChain')
-      .mockReturnValue(Promise.resolve(mockTokenInfo))
+      .mockReturnValue(Promise.resolve([mockTokenInfo]))
     const testInterface = new Interface(['function approve(address, uint256)'])
 
     const mockSafeTx = createMockSafeTransaction({

--- a/apps/web/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
+++ b/apps/web/src/components/tx/ApprovalEditor/hooks/useApprovalInfos.ts
@@ -56,7 +56,7 @@ export const useApprovalInfos = (payload: {
 
           if (!tokenInfo) {
             try {
-              tokenInfo = await getERC20TokenInfoOnChain(approval.tokenAddress)
+              tokenInfo = (await getERC20TokenInfoOnChain(approval.tokenAddress))?.[0]
             } catch (e) {
               const isErc721 = await isErc721Token(approval.tokenAddress)
               const symbol = await getErc721Symbol(approval.tokenAddress)

--- a/apps/web/src/hooks/loadables/useLoadSpendingLimits.ts
+++ b/apps/web/src/hooks/loadables/useLoadSpendingLimits.ts
@@ -16,6 +16,8 @@ import { sameString } from '@safe-global/protocol-kit/dist/src/utils'
 import { useAppSelector } from '@/store'
 import { selectTokens } from '@/store/balancesSlice'
 import isEqual from 'lodash/isEqual'
+import { multicall } from '@safe-global/utils/utils/multicall'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
 
 const DEFAULT_TOKEN_INFO = {
   decimals: 18,
@@ -28,40 +30,76 @@ const discardZeroAllowance = (spendingLimit: SpendingLimitState): boolean =>
 const getTokenInfoFromBalances = (tokenInfoFromBalances: TokenInfo[], address: string): TokenInfo | undefined =>
   tokenInfoFromBalances.find((token) => token.address === address)
 
-export const getTokenAllowanceForDelegate = async (
+export const getTokenAllowances = async (
   contract: AllowanceModule,
+  provider: JsonRpcProvider,
   safeAddress: string,
-  delegate: string,
-  token: string,
+  allowanceRequests: { delegate: string; token: string }[],
   tokenInfoFromBalances: TokenInfo[],
-): Promise<SpendingLimitState> => {
-  const tokenAllowance = await contract.getTokenAllowance(safeAddress, delegate, token)
-  const [amount, spent, resetTimeMin, lastResetMin, nonce] = tokenAllowance
-  return {
-    beneficiary: delegate,
-    token: getTokenInfoFromBalances(tokenInfoFromBalances, token) ||
-      (await getERC20TokenInfoOnChain(token)) || { ...DEFAULT_TOKEN_INFO, address: token },
-    amount: amount.toString(),
-    spent: spent.toString(),
-    resetTimeMin: resetTimeMin.toString(),
-    lastResetMin: lastResetMin.toString(),
-    nonce: nonce.toString(),
-  }
+): Promise<SpendingLimitState[]> => {
+  const moduleAddress = await contract.getAddress()
+  const calls = allowanceRequests.map(({ delegate, token }) => ({
+    to: moduleAddress,
+    data: contract.interface.encodeFunctionData('getTokenAllowance', [safeAddress, delegate, token]),
+  }))
+  const results = await multicall(provider, calls)
+
+  const tokenAllowances = results.map(
+    (result) => contract.interface.decodeFunctionResult('getTokenAllowance', result.returnData)[0],
+  )
+
+  const missingTokenAddresses = tokenAllowances
+    .map((_, index) => allowanceRequests[index].token)
+    .filter((tokenAddress) => !getTokenInfoFromBalances(tokenInfoFromBalances, tokenAddress))
+
+  const missingTokenInfos = await getERC20TokenInfoOnChain(missingTokenAddresses)
+
+  return tokenAllowances.map((tokenAllowance, index) => {
+    const { delegate, token } = allowanceRequests[index]
+    const [amount, spent, resetTimeMin, lastResetMin, nonce] = tokenAllowance
+    return {
+      beneficiary: delegate,
+      token: getTokenInfoFromBalances(tokenInfoFromBalances, token) ||
+        missingTokenInfos?.find((tokenInfo) => sameAddress(tokenInfo.address, token)) || {
+          ...DEFAULT_TOKEN_INFO,
+          address: token,
+        },
+      amount: amount.toString(),
+      spent: spent.toString(),
+      resetTimeMin: resetTimeMin.toString(),
+      lastResetMin: lastResetMin.toString(),
+      nonce: nonce.toString(),
+    }
+  })
 }
 
-export const getTokensForDelegate = async (
+export const getTokensForDelegates = async (
   contract: AllowanceModule,
+  provider: JsonRpcProvider,
   safeAddress: string,
-  delegate: string,
+  delegates: string[],
   tokenInfoFromBalances: TokenInfo[],
 ) => {
-  const tokens = await contract.getTokens(safeAddress, delegate)
+  const allowanceAddress = await contract.getAddress()
+  const calls = delegates.map((delegate) => ({
+    to: allowanceAddress,
+    data: contract.interface.encodeFunctionData('getTokens', [safeAddress, delegate]),
+  }))
 
-  return Promise.all(
-    tokens.map(async (token) =>
-      getTokenAllowanceForDelegate(contract, safeAddress, delegate, token, tokenInfoFromBalances),
-    ),
+  const results = await multicall(provider, calls)
+  const tokens = results.map(
+    (result) => contract.interface.decodeFunctionResult('getTokens', result.returnData)[0] as string[],
   )
+
+  const spendingLimitRequests = delegates.flatMap((delegate, idx) => {
+    const tokensForDelegate = tokens[idx]
+    return tokensForDelegate.map((token) => ({
+      delegate,
+      token,
+    }))
+  })
+
+  return getTokenAllowances(contract, provider, safeAddress, spendingLimitRequests, tokenInfoFromBalances)
 }
 
 export const getSpendingLimits = async (
@@ -79,11 +117,14 @@ export const getSpendingLimits = async (
   }
   const delegates = await contract.getDelegates(safeAddress, 0, 100)
 
-  const spendingLimits = await Promise.all(
-    delegates.results.map(async (delegate) =>
-      getTokensForDelegate(contract, safeAddress, delegate, tokenInfoFromBalances),
-    ),
+  const spendingLimits = await getTokensForDelegates(
+    contract,
+    provider,
+    safeAddress,
+    delegates.results,
+    tokenInfoFromBalances,
   )
+
   return spendingLimits.flat().filter(discardZeroAllowance)
 }
 

--- a/apps/web/src/hooks/useSafeTokenAllocation.ts
+++ b/apps/web/src/hooks/useSafeTokenAllocation.ts
@@ -1,7 +1,6 @@
 import { getSafeTokenAddress, getSafeLockingAddress } from '@/components/common/SafeTokenWidget'
 import { IS_PRODUCTION } from '@/config/constants'
 import { ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
-import { isPast } from 'date-fns'
 import { AbiCoder, Interface, type JsonRpcProvider } from 'ethers'
 import { useMemo } from 'react'
 import useAsync, { type AsyncResult } from '@safe-global/utils/hooks/useAsync'
@@ -9,6 +8,7 @@ import useSafeInfo from './useSafeInfo'
 import { getWeb3ReadOnly } from './wallets/web3'
 import memoize from 'lodash/memoize'
 import { cgwDebugStorage } from '@/config/gateway'
+import { multicall } from '../../../../packages/utils/src/utils/multicall'
 
 export const VESTING_URL =
   IS_PRODUCTION || cgwDebugStorage.get()
@@ -58,34 +58,38 @@ export const _getRedeemDeadline = memoize(
  * Add on-chain information to allocation.
  * Fetches if the redeem deadline is expired and the claimed tokens from on-chain
  */
-const completeAllocation = async (allocation: VestingData): Promise<Vesting> => {
+const completeAllocations = async (allocations: VestingData[]): Promise<Vesting[]> => {
   const web3ReadOnly = getWeb3ReadOnly()
   if (!web3ReadOnly) {
-    throw new Error('Cannot fetch vesting without web3 provider')
+    throw new Error('Cannot fetch vestings without web3 provider')
   }
-  const onChainVestingData = await web3ReadOnly.call({
+
+  const calls = allocations.map((allocation) => ({
     to: allocation.contract,
     data: airdropInterface.encodeFunctionData('vestings', [allocation.vestingId]),
+  }))
+  const results = await multicall(web3ReadOnly, calls)
+
+  return allocations.map((allocation, index) => {
+    const result = results[index]
+    if (!result.success) {
+      throw new Error(`Failed to fetch vesting data for ${allocation.vestingId}`)
+    }
+
+    const decodedVestingData = AbiCoder.defaultAbiCoder().decode(
+      // account, curveType, managed, durationWeeks, startDate, amount, amountClaimed, pausingDate, cancelled}
+      ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
+      result.returnData,
+    )
+
+    const isRedeemed = decodedVestingData[0].toLowerCase() !== ZERO_ADDRESS.toLowerCase()
+    if (isRedeemed) {
+      return { ...allocation, isRedeemed, isExpired: false, amountClaimed: decodedVestingData[6] }
+    }
+
+    // All allocations are expired by now. We do not load the redeem deadline anymore
+    return { ...allocation, isRedeemed, isExpired: true, amountClaimed: '0' }
   })
-
-  const decodedVestingData = AbiCoder.defaultAbiCoder().decode(
-    // account, curveType, managed, durationWeeks, startDate, amount, amountClaimed, pausingDate, cancelled}
-    ['address', 'uint8', 'bool', 'uint16', 'uint64', 'uint128', 'uint128', 'uint64', 'bool'],
-    onChainVestingData,
-  )
-
-  const isRedeemed = decodedVestingData[0].toLowerCase() !== ZERO_ADDRESS.toLowerCase()
-  if (isRedeemed) {
-    return { ...allocation, isRedeemed, isExpired: false, amountClaimed: decodedVestingData[6] }
-  }
-
-  // Allocation is not yet redeemed => check the redeemDeadline
-  const redeemDeadline = await _getRedeemDeadline(allocation, web3ReadOnly)
-
-  const redeemDeadlineDate = new Date(Number(BigInt(redeemDeadline) * BigInt(1000)))
-
-  // Allocation is valid if redeem deadline is in future
-  return { ...allocation, isRedeemed, isExpired: isPast(redeemDeadlineDate), amountClaimed: '0' }
 }
 
 const fetchAllocation = async (chainId: string, safeAddress: string): Promise<VestingData[]> => {
@@ -116,41 +120,41 @@ const useSafeTokenAllocation = (): AsyncResult<Vesting[]> => {
   return useAsync<Vesting[] | undefined>(async () => {
     if (!safeAddress) return
     return Promise.all(
-      await fetchAllocation(chainId, safeAddress).then((allocations) =>
-        allocations.map((allocation) => completeAllocation(allocation)),
-      ),
+      await fetchAllocation(chainId, safeAddress).then((allocations) => completeAllocations(allocations)),
     )
     // If the history tag changes we could have claimed / redeemed tokens
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chainId, safeAddress, safe.txHistoryTag])
 }
 
-const fetchTokenBalance = async (chainId: string, safeAddress: string): Promise<string> => {
+const fetchTokenBalances = async (chainId: string, safeAddress: string): Promise<[bigint, bigint]> => {
   try {
     const web3ReadOnly = getWeb3ReadOnly()
     const safeTokenAddress = getSafeTokenAddress(chainId)
-    if (!safeTokenAddress || !web3ReadOnly) return '0'
-
-    return await web3ReadOnly.call({
-      to: safeTokenAddress,
-      data: tokenInterface.encodeFunctionData('balanceOf', [safeAddress]),
-    })
-  } catch (err) {
-    throw Error(`Error fetching Safe Token balance:  ${err}`)
-  }
-}
-const fetchLockingContractBalance = async (chainId: string, safeAddress: string): Promise<string> => {
-  try {
-    const web3ReadOnly = getWeb3ReadOnly()
     const safeLockingAddress = getSafeLockingAddress(chainId)
-    if (!safeLockingAddress || !web3ReadOnly) return '0'
 
-    return await web3ReadOnly.call({
-      to: safeLockingAddress,
-      data: safeLockingInterface.encodeFunctionData('getUserTokenBalance', [safeAddress]),
-    })
+    if (!web3ReadOnly || !safeTokenAddress || !safeLockingAddress) return [BigInt(0), BigInt(0)]
+
+    const calls = [
+      {
+        to: safeTokenAddress,
+        data: tokenInterface.encodeFunctionData('balanceOf', [safeAddress]),
+      },
+      {
+        to: safeLockingAddress,
+        data: safeLockingInterface.encodeFunctionData('getUserTokenBalance', [safeAddress]),
+      },
+    ]
+
+    const results = await multicall(web3ReadOnly, calls)
+
+    if (!results[0].success || !results[1].success) {
+      throw new Error('Failed to fetch token balances')
+    }
+
+    return [BigInt(results[0].returnData), BigInt(results[1].returnData)]
   } catch (err) {
-    throw Error(`Error fetching Safe Token balance in locking contract:  ${err}`)
+    throw Error(`Error fetching Safe Token balances: ${err}`)
   }
 }
 
@@ -162,18 +166,11 @@ export const useSafeVotingPower = (allocationData?: Vesting[]): AsyncResult<bigi
   const { safe, safeAddress } = useSafeInfo()
   const chainId = safe.chainId
 
-  const [balance, balanceError, balanceLoading] = useAsync<bigint>(() => {
-    if (!safeAddress) return
-    const tokenBalancePromise = fetchTokenBalance(chainId, safeAddress)
-    const lockingContractBalancePromise = fetchLockingContractBalance(chainId, safeAddress)
-    return Promise.all([tokenBalancePromise, lockingContractBalancePromise]).then(
-      ([tokenBalance, lockingContractBalance]) => {
-        return BigInt(tokenBalance) + BigInt(lockingContractBalance)
-      },
-    )
-    // If the history tag changes we could have claimed / redeemed tokens
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chainId, safeAddress, safe.txHistoryTag])
+  const [balance, balanceError, balanceLoading] = useAsync<bigint>(async () => {
+    if (!safeAddress) return BigInt(0)
+    const [tokenBalance, lockingContractBalance] = await fetchTokenBalances(chainId, safeAddress)
+    return tokenBalance + lockingContractBalance
+  }, [chainId, safeAddress])
 
   const allocation = useMemo(() => {
     if (balance === undefined) {

--- a/apps/web/src/utils/__tests__/tokens.test.ts
+++ b/apps/web/src/utils/__tests__/tokens.test.ts
@@ -40,7 +40,7 @@ describe('tokens', () => {
           }) as any,
       )
 
-      const result = await getERC20TokenInfoOnChain('0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984')
+      const result = (await getERC20TokenInfoOnChain('0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984'))?.[0]
 
       expect(result?.symbol).toEqual('UNI')
       expect(result?.decimals).toEqual(18)
@@ -68,7 +68,7 @@ describe('tokens', () => {
           }) as any,
       )
 
-      const result = await getERC20TokenInfoOnChain('0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984')
+      const result = (await getERC20TokenInfoOnChain('0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984'))?.[0]
 
       expect(result?.symbol).toEqual('MKR')
       expect(result?.decimals).toEqual(18)

--- a/apps/web/src/utils/tokens.ts
+++ b/apps/web/src/utils/tokens.ts
@@ -4,33 +4,63 @@ import { parseBytes32String } from '@ethersproject/strings'
 import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
 import { ERC721_IDENTIFIER } from '@safe-global/utils/utils/tokens'
 import { type Erc20Token } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { multicall } from '../../../../packages/utils/src/utils/multicall'
+import { type BytesLike } from 'ethers'
 
 /**
  * Fetches ERC20 token symbol and decimals from on-chain.
  * @param address address of erc20 token
  */
 export const getERC20TokenInfoOnChain = async (
-  address: string,
-): Promise<Omit<Erc20Token, 'name' | 'logoUri'> | undefined> => {
+  address: string | string[],
+): Promise<Omit<Erc20Token, 'name' | 'logoUri'>[] | undefined> => {
   const web3 = getWeb3ReadOnly()
   if (!web3) return
 
-  const erc20 = ERC20__factory.connect(address, web3)
+  let tokenAddresses = Array.isArray(address) ? address : [address]
 
-  const symbol = await erc20
-    .symbol()
-    .then((symbol) => symbol)
-    .catch((error) => parseBytes32String(error.value)) // Some older contracts use bytes32 instead of string
-    .finally(() => '')
+  const erc20_interface = ERC20__factory.createInterface()
 
-  const decimals = await erc20.decimals()
+  const calls = tokenAddresses.flatMap((address) => [
+    {
+      to: address,
+      data: erc20_interface.encodeFunctionData('symbol'),
+    },
+    {
+      to: address,
+      data: erc20_interface.encodeFunctionData('decimals'),
+    },
+  ])
 
-  return {
-    address,
-    symbol,
-    decimals: Number(decimals),
-    type: TokenType.ERC20,
+  const results = await multicall(web3, calls)
+
+  const tokenInfos: Omit<Erc20Token, 'name' | 'logoUri'>[] = []
+
+  while (results.length >= 2) {
+    const address = tokenAddresses.shift()
+    if (!address) break
+    let symbol: string
+    try {
+      symbol = erc20_interface.decodeFunctionResult('symbol', results[0].returnData)[0]
+    } catch (error) {
+      // Some older contracts use bytes32 instead of string
+      symbol = parseBytes32String(
+        error && typeof error === 'object' && 'value' in error ? (error.value as BytesLike) : '',
+      )
+    }
+    const decimals = Number(erc20_interface.decodeFunctionResult('decimals', results[1].returnData)[0])
+
+    tokenInfos.push({
+      address,
+      symbol,
+      decimals,
+      type: TokenType.ERC20,
+    })
+
+    results.splice(0, 2)
   }
+
+  return tokenInfos
 }
 
 export const getErc721Symbol = async (address: string) => {

--- a/packages/utils/src/utils/multicall.ts
+++ b/packages/utils/src/utils/multicall.ts
@@ -1,0 +1,68 @@
+import { Contract, AbstractProvider } from 'ethers'
+
+// Multicall contract ABI
+const MULTICALL_ABI = [
+  'function aggregate3(tuple(address target, bool allowFailure, bytes callData)[] calls) payable returns (tuple(bool success, bytes returnData)[] returnData)',
+]
+
+const CANONICAL_MULTICALL_ADDRESSS = '0xca11bde05977b3631167028862be2a173976ca11'
+
+// TODO: Check if there is a deployment list we could use instead of hardcoding
+const UNSUPPORTED_CHAINS = ['324', '232']
+
+/**
+ * Get the multicall contract address for a given chain ID
+ * @param chainId The chain ID to get the multicall address for
+ * @returns The multicall contract address for the given chain ID
+ */
+export const getMultiCallAddress = (chainId: string): string | null => {
+  if (UNSUPPORTED_CHAINS.includes(chainId)) {
+    return null
+  }
+  return CANONICAL_MULTICALL_ADDRESSS
+}
+
+export type Aggregate3Response = { success: boolean; returnData: string }
+
+/**
+ * Execute multiple calls in a single RPC request using the multicall contract
+ * @param provider The ethers provider to use
+ * @param calls Array of calls to execute, each containing target address and call data
+ * @param chainId The chain ID to execute the calls on
+ * @returns Array of return data from each call
+ */
+export const multicall = async (
+  provider: AbstractProvider,
+  calls: { to: string; data: string }[],
+): Promise<{ success: boolean; returnData: string }[]> => {
+  const chainId = (await provider.getNetwork()).chainId.toString()
+
+  const multicallAddress = getMultiCallAddress(chainId)
+  if (!multicallAddress) {
+    // Fallback to consecutive calls if multicall is not supported
+    const results: Aggregate3Response[] = []
+    for (const call of calls) {
+      try {
+        const result = await provider.call(call)
+        results.push({ success: true, returnData: result })
+      } catch (error) {
+        results.push({ success: false, returnData: '0x' })
+      }
+    }
+    return results
+  }
+  const multicallContract = new Contract(multicallAddress, MULTICALL_ABI, provider)
+
+  try {
+    const calls3 = calls.map((call) => ({
+      target: call.to,
+      allowFailure: true,
+      callData: call.data,
+    }))
+
+    const resolverResults: Aggregate3Response[] = await multicallContract.aggregate3.staticCall(calls3)
+    return resolverResults
+  } catch (error) {
+    throw new Error(`Multicall failed: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}


### PR DESCRIPTION
## What it solves

Resolves #5051 

## How this PR fixes it
Data that can be fetched simultanously is being fetched through multicall3:
- SpendingLimits
- ERC20 Token infos
- Safe Token allocations

Introduces a new multicall utility for this.

## How to test it
- Test that Spending Limits are fetched correctly (across multiple chains)
- Test that the Safe Token balance and locked amount is fetched correctly

Everything should look and feel the same but require fewer RPC calls.


## Checklist
- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
