### PR TITLE
fix(tests): regression test tx_history_4

### DIFF
--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -427,11 +427,11 @@ export function verifyNumberOfCopyIcons(number) {
 }
 
 export function verifyNumberOfExternalLinks(number) {
-  cy.get(copyIcon)
-    .parent()
-    .parent()
-    .next()
-    .children('a')
+  cy.get(explorerBtn)
+    //.parent()
+    // .parent()
+    // .next()
+    //.children('a')
     .then(($links) => {
       expect($links.length).to.be.at.least(number)
       for (let i = 0; i < number; i++) {

--- a/apps/web/cypress/e2e/regression/tx_history_4.cy.js
+++ b/apps/web/cypress/e2e/regression/tx_history_4.cy.js
@@ -67,8 +67,8 @@ describe('Incoming tx history details tests', () => {
       typeReceive.altImage,
       typeReceive.altToken,
     )
-    createTx.verifyExpandedDetails([typeReceive.senderAddressEth, typeReceive.txHashEth, typeReceive.executionDateEth]),
-      createTx.verifyNumberOfExternalLinks(2)
+    createTx.verifyExpandedDetails([typeReceive.senderAddressEth, typeReceive.txHashEth, typeReceive.executionDateEth])
+    createTx.verifyNumberOfExternalLinks(2)
   })
 
   it('Verify add to the address book for the sender in the incoming tx', () => {

--- a/apps/web/cypress/e2e/regression/tx_history_4.cy.js
+++ b/apps/web/cypress/e2e/regression/tx_history_4.cy.js
@@ -67,8 +67,8 @@ describe('Incoming tx history details tests', () => {
       typeReceive.altImage,
       typeReceive.altToken,
     )
-    createTx.verifyExpandedDetails([typeReceive.senderAddressEth, typeReceive.txHashEth, typeReceive.executionDateEth])
-    createTx.verifyNumberOfExternalLinks(2)
+    createTx.verifyExpandedDetails([typeReceive.senderAddressEth, typeReceive.txHashEth, typeReceive.executionDateEth]),
+      createTx.verifyNumberOfExternalLinks(2)
   })
 
   it('Verify add to the address book for the sender in the incoming tx', () => {
@@ -79,6 +79,7 @@ describe('Incoming tx history details tests', () => {
     address_book.typeInName(senderName)
     address_book.clickOnSaveEntryBtn()
     cy.visit(constants.addressBookUrl + safe)
+    cy.get('body').should('be.visible')
     cy.contains(senderName)
   })
 })

--- a/apps/web/cypress/fixtures/txhistory_data_data.json
+++ b/apps/web/cypress/fixtures/txhistory_data_data.json
@@ -59,9 +59,9 @@
       "txHashDAI": "0x7156...3e47",
       "nftHash": "0x3873...6d0b",
       "txHashEth": "0xdc6b...f250",
-      "executionDateDAI": "10/30/2023, 2:37:11 AM",
-      "executionDateNFT": "9/28/2023, 2:48:11 AM",
-      "executionDateEth": "8/19/2020, 8:51:31 AM"
+      "executionDateDAI": "10/30/2023",
+      "executionDateNFT": "9/28/2023",
+      "executionDateEth": "8/19/2020"
     },
     "send": {
       "title": "Sent",


### PR DESCRIPTION
## What it solves
fixes for the regression tx_history_4 e2e suite
Resolves #

## How this PR fixes it
1. Removed the time check from the tests as it depends on the timezone.
2. Updated the check for the "Etherscan" link, since the copy button was removed from the transaction details.
3. Added a wait for the address book page body to load.
## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
