### PR TITLE
Feat(WalletConnect): one-click auth

### DIFF
--- a/apps/web/src/features/walletconnect/components/WalletConnectProvider/index.tsx
+++ b/apps/web/src/features/walletconnect/components/WalletConnectProvider/index.tsx
@@ -6,7 +6,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
 import useSafeWalletProvider from '@/services/safe-wallet-provider/useSafeWalletProvider'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 import { IS_PRODUCTION } from '@/config/constants'
-import { getPeerName, stripEip155Prefix } from '@/features/walletconnect/services/utils'
+import { getEip155ChainId, getPeerName, stripEip155Prefix } from '@/features/walletconnect/services/utils'
 import { trackRequest } from '@/features/walletconnect//services/tracking'
 import { wcPopupStore } from '@/features/walletconnect/components'
 import WalletConnectWallet from '@/features/walletconnect/services/WalletConnectWallet'
@@ -109,6 +109,67 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
       }
     })
   }, [walletConnect, chainId, safeWalletProvider])
+
+  // Subscribe to session auth
+  useEffect(() => {
+    if (!walletConnect || !safeWalletProvider || !chainId) return
+
+    return walletConnect.onSessionAuth(async (event) => {
+      const { authPayload, requester } = event.params
+
+      if (!IS_PRODUCTION) {
+        console.log('[WalletConnect] auth', authPayload, requester)
+      }
+
+      if (!authPayload.chains.includes(getEip155ChainId(chainId))) {
+        setError(getWrongChainError(requester.metadata.name || 'WalletConnect'))
+        return
+      }
+
+      const getSignature = async () => {
+        const message = walletConnect.formatAuthMessage(authPayload, chainId, safeAddress)
+
+        if (!IS_PRODUCTION) {
+          console.log('[WalletConnect] SiWE message', message)
+        }
+
+        const appInfo = {
+          url: LEGACY_WC_APP_URL, // required for server-side analytics
+          name: getPeerName(requester) || 'WalletConnect',
+          description: requester.metadata.description,
+          iconUrl: requester.metadata.icons[0],
+        }
+
+        return safeWalletProvider.request(
+          event.id,
+          {
+            method: 'personal_sign',
+            params: [message, safeAddress],
+          },
+          appInfo,
+        )
+      }
+
+      // Close the popup
+      setOpen(false)
+      setIsLoading(undefined)
+
+      // Get a signature and send it to WalletConnect
+      try {
+        const signature = await getSignature()
+        if ('error' in signature) throw new Error(signature.error.message)
+        await walletConnect?.approveSessionAuth(event.id, authPayload, signature.result as string, chainId, safeAddress)
+      } catch (e) {
+        try {
+          await walletConnect.rejectSessionAuth(event.id)
+        } catch (err) {
+          e = err
+        }
+        setError(asError(e))
+        setOpen(true)
+      }
+    })
+  }, [walletConnect, safeWalletProvider, chainId, safeAddress, setOpen])
 
   return (
     <WalletConnectContext.Provider value={{ walletConnect, error, setError, open, setOpen, isLoading, setIsLoading }}>


### PR DESCRIPTION
## What it solves

Resolves #5586

## How this PR fixes it

* Subscribes to the `session_authenticate` which is an alternative to regular session proposals
* Pops up our message signing flow
* Sends the signature back to WalletConnect and approves the session if successful
* Otherwise, rejects the auth request

## How to test it
Use this test app: https://appkit-lab.reown.com/library/ethers-siwe/

## Screenshots
<img width="641" alt="Screenshot 2025-05-23 at 11 34 20" src="https://github.com/user-attachments/assets/d0889825-9696-41c5-b53f-2ece666f948a" />
