### PR TITLE
Fix(Earn): Align vault name with icon

### DIFF
--- a/apps/web/src/components/common/Table/DataRow.tsx
+++ b/apps/web/src/components/common/Table/DataRow.tsx
@@ -13,7 +13,9 @@ export const DataRow = ({ datatestid, title, children }: DataRowProps): ReactEle
 
   return (
     <FieldsGrid data-testid={datatestid} title={title}>
-      <Typography variant="body1">{children}</Typography>
+      <Typography variant="body1" component="div">
+        {children}
+      </Typography>
     </FieldsGrid>
   )
 }

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -235,11 +235,11 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
                         data-testid="tx-data-row"
                       >
-                        <p
+                        <div
                           class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
                         >
                           9/20/2024, 10:20:15 AM
-                        </p>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/apps/web/src/features/earn/components/VaultDepositConfirmation/index.tsx
+++ b/apps/web/src/features/earn/components/VaultDepositConfirmation/index.tsx
@@ -6,7 +6,6 @@ import { vaultTypeToLabel } from '@/features/earn/utils'
 import { formatPercentage } from '@safe-global/utils/utils/formatters'
 import { DataTable } from '@/components/common/Table/DataTable'
 import { DataRow } from '@/components/common/Table/DataRow'
-import ExternalLink from '@/components/common/ExternalLink'
 import IframeIcon from '@/components/common/IframeIcon'
 import { InfoTooltip } from '@/features/stake/components/InfoTooltip'
 import { BRAND_NAME } from '@/config/constants'
@@ -136,12 +135,12 @@ const VaultDepositConfirmation = ({
           <>{!isTxDetails && <ConfirmationHeader txInfo={txInfo} />}</>,
 
           <DataRow key="Deposit via" title="Deposit via">
-            <ExternalLink href={txInfo.vaultInfo.dashboardUri!}>
+            <Stack direction="row" alignItems="center">
               <IframeIcon src={txInfo.vaultInfo.logoUri} alt="Morpho logo" width={24} height={24} />
               <Typography component="span" ml={1} fontWeight="bold">
                 {txInfo.vaultInfo.name}
               </Typography>
-            </ExternalLink>
+            </Stack>
           </DataRow>,
 
           <DataRow key="Expected annual reward" title="Exp. annual reward">

--- a/apps/web/src/features/earn/components/VaultRedeemConfirmation/index.tsx
+++ b/apps/web/src/features/earn/components/VaultRedeemConfirmation/index.tsx
@@ -6,7 +6,6 @@ import { vaultTypeToLabel } from '@/features/earn/utils'
 import { formatPercentage } from '@safe-global/utils/utils/formatters'
 import { DataTable } from '@/components/common/Table/DataTable'
 import { DataRow } from '@/components/common/Table/DataRow'
-import ExternalLink from '@/components/common/ExternalLink'
 import IframeIcon from '@/components/common/IframeIcon'
 
 const AdditionalRewards = ({ txInfo }: { txInfo: VaultRedeemTransactionInfo }) => {
@@ -135,12 +134,12 @@ const VaultRedeemConfirmation = ({
           <>{!isTxDetails && <ConfirmationHeader txInfo={txInfo} />}</>,
 
           <DataRow key="Withdraw from" title="Withdraw from">
-            <ExternalLink href={txInfo.vaultInfo.dashboardUri!}>
+            <Stack direction="row" alignItems="center">
               <IframeIcon src={txInfo.vaultInfo.logoUri} alt="Morpho logo" width={24} height={24} />
               <Typography component="span" ml={1} fontWeight="bold">
                 {txInfo.vaultInfo.name}
               </Typography>
-            </ExternalLink>
+            </Stack>
           </DataRow>,
 
           <DataRow key="Reward rate" title="Reward rate">


### PR DESCRIPTION
## What it solves

Follow up for https://github.com/safe-global/wallet-private-tasks/issues/212

## How this PR fixes it

- Removes the link to the vault since its not available on prod
- Aligns the icon and name of the vault visually

## How to test it

1. Open a Safe on Base/Mainnet with deposit/withdraw transactions in the history
2. Go to the history and make sure icon and name of the vault are aligned
3. Do the same for the confirmation view

## Screenshots

<img width="603" alt="Screenshot 2025-05-23 at 15 24 17" src="https://github.com/user-attachments/assets/8c016434-18af-4492-8f60-496ae63ec1b4" />
<img width="625" alt="Screenshot 2025-05-23 at 15 24 23" src="https://github.com/user-attachments/assets/883cdab0-ec71-42ff-8efc-2bf64d1226df" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
