### PR TITLE
fix(Signing UX): remove duplicate NFT transfer info

### DIFF
--- a/apps/web/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
+++ b/apps/web/src/components/tx-flow/flows/NftTransfer/ReviewNftBatch.tsx
@@ -30,7 +30,7 @@ const ReviewNftBatch = ({ onSubmit, children }: ReviewTransactionProps): ReactEl
   }, [safeAddress, tokens, data, setSafeTx, setSafeTxError])
 
   return (
-    <ReviewTransaction onSubmit={onSubmit}>
+    <ReviewTransaction onSubmit={onSubmit} withDecodedData={false}>
       <SendToBlock address={data?.recipient || ''} />
 
       <FieldsGrid title={`NFT${maybePlural(tokens)}`}>

--- a/apps/web/src/components/tx/confirmation-views/SettingsChange/SettingsChange.test.tsx
+++ b/apps/web/src/components/tx/confirmation-views/SettingsChange/SettingsChange.test.tsx
@@ -17,7 +17,7 @@ describe('SettingsChange', () => {
     )
 
     expect(container).toMatchSnapshot()
-    expect(getByText('New signer')).toBeInTheDocument()
+    expect(getByText('Add owner')).toBeInTheDocument()
     expect(getByText(ownerAddress)).toBeInTheDocument()
   })
 

--- a/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.test.tsx.snap
@@ -90,14 +90,14 @@ exports[`SettingsChange should display the SettingsChange component with newOwne
     style="--Paper-shadow: none;"
   >
     <p
-      class="MuiTypography-root MuiTypography-body1 css-14yu9oo-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 css-1950vt0-MuiTypography-root"
     >
       <mock-icon
         aria-hidden=""
         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1hr8a3z-MuiSvgIcon-root"
         focusable="false"
       />
-      New signer
+      Add owner
     </p>
     <div
       class="container"
@@ -181,14 +181,14 @@ exports[`SettingsChange should display the SettingsChange component with owner d
     style="--Paper-shadow: none;"
   >
     <p
-      class="MuiTypography-root MuiTypography-body1 css-14yu9oo-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 css-1950vt0-MuiTypography-root"
     >
       <mock-icon
         aria-hidden=""
         class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1hr8a3z-MuiSvgIcon-root"
         focusable="false"
       />
-      New signer
+      Add owner
     </p>
     <div
       class="container"


### PR DESCRIPTION
## What it solves

Resolves [this comment](https://github.com/safe-global/safe-wallet-monorepo/pull/5917#issuecomment-2909304894)

## How this PR fixes it

Disable decoded data display in ReviewNftBatch component

## How to test it

1. Create a new NFT transfer transaction
2. In the confirmation screen observe that there is no duplicate NFT transfer info anymore

## Screenshots

### Before
![Screenshot 2025-05-26 at 15 04 58](https://github.com/user-attachments/assets/c84392f7-a606-49b4-a903-a5aaf1069977)

### After
![Screenshot 2025-05-26 at 14 56 26](https://github.com/user-attachments/assets/47009da4-351f-4a46-aec0-1b5cc467401a)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
