### PR TITLE
fix: add parameters button in the missing views

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
@@ -29,6 +29,7 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
     case ETxType.TOKEN_TRANSFER:
       return (
         <TokenTransfer
+          txId={txDetails.txId}
           executedAt={txDetails.executedAt || 0}
           executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
           txInfo={txDetails.txInfo as TransferTransactionInfo}
@@ -37,6 +38,7 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
     case ETxType.NFT_TRANSFER:
       return (
         <SendNFT
+          txId={txDetails.txId}
           executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
           txInfo={txDetails.txInfo as TransferTransactionInfo}
         />

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
@@ -46,7 +46,9 @@ export function Contract({ txInfo, executionInfo, txId }: ContractProps) {
         submittedAt={executionInfo.submittedAt}
       />
 
-      <ListTable items={items}>{!txInfo.actionCount && <ParametersButton txId={txId} />}</ListTable>
+      <ListTable items={items}>
+        <ParametersButton txId={txId} />
+      </ListTable>
 
       {txInfo.actionCount && (
         <SafeListItem

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SendNFT/SendNFT.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SendNFT/SendNFT.tsx
@@ -11,13 +11,15 @@ import { useAppSelector } from '@/src/store/hooks'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { selectChainById } from '@/src/store/chains'
 import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
+import { ParametersButton } from '../../ParametersButton'
 
 interface SendNFTProps {
+  txId: string
   txInfo: TransferTransactionInfo
   executionInfo: MultisigExecutionDetails
 }
 
-export function SendNFT({ txInfo, executionInfo }: SendNFTProps) {
+export function SendNFT({ txId, txInfo, executionInfo }: SendNFTProps) {
   const activeSafe = useDefinedActiveSafe()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const viewOnExplorer = useOpenExplorer(txInfo.recipient.value)
@@ -38,7 +40,9 @@ export function SendNFT({ txInfo, executionInfo }: SendNFTProps) {
         submittedAt={executionInfo.submittedAt}
       />
 
-      <ListTable items={items} />
+      <ListTable items={items}>
+        <ParametersButton txId={txId} />
+      </ListTable>
     </YStack>
   )
 }

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
@@ -18,13 +18,16 @@ import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { Address } from '@/src/types/address'
 import { TokenAmount } from '@/src/components/TokenAmount'
 import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
+import { ParametersButton } from '../../ParametersButton'
+
 interface TokenTransferProps {
+  txId: string
   txInfo: TransferTransactionInfo
   executionInfo: MultisigExecutionDetails
   executedAt: number
 }
 
-export function TokenTransfer({ txInfo, executionInfo, executedAt }: TokenTransferProps) {
+export function TokenTransfer({ txId, txInfo, executionInfo, executedAt }: TokenTransferProps) {
   const activeSafe = useDefinedActiveSafe()
   const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const { value, tokenSymbol, logoUri, decimals } = useTokenDetails(txInfo)
@@ -89,6 +92,8 @@ export function TokenTransfer({ txInfo, executionInfo, executedAt }: TokenTransf
                 <Text fontSize="$4">{activeChain?.chainName}</Text>
               </View>
             </View>
+
+            <ParametersButton txId={txId} />
           </Container>
         </YStack>
       </View>


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/wallet-private-tasks/issues/33

## How this PR fixes it
We add the parameters button back. Also added in the missing screens.

## How to test it
Propose different transactions and check if the parameters are displaying as expected. 

## Screenshots
Some of the screens:

<img width="502" alt="Screenshot 2025-05-26 at 14 16 22" src="https://github.com/user-attachments/assets/fdfe44f3-838c-496b-9e4d-10c5a86fb674" />
<img width="502" alt="Screenshot 2025-05-26 at 14 16 27" src="https://github.com/user-attachments/assets/f0e3ecaf-5ee2-45c2-a387-d3788a9f25fd" />
<img width="502" alt="Screenshot 2025-05-26 at 14 16 37" src="https://github.com/user-attachments/assets/699d0fa2-2c4e-4cc2-97e6-6a4b72a82b34" />
<img width="502" alt="Screenshot 2025-05-26 at 14 16 44" src="https://github.com/user-attachments/assets/d59a94c7-359e-479e-b58e-ef93539092b0" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
