### PR TITLE
fix(Signing UX): reset signer name when address is cleared

### DIFF
--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -37,6 +37,7 @@ export type AddressInputProps = TextFieldProps & {
   onAddressBookClick?: () => void
   chain?: ChainInfo
   showPrefix?: boolean
+  onReset?: () => void
 }
 
 const AddressInput = ({
@@ -49,6 +50,7 @@ const AddressInput = ({
   deps,
   chain,
   showPrefix = true,
+  onReset,
   ...props
 }: AddressInputProps): ReactElement => {
   const {
@@ -150,6 +152,7 @@ const AddressInput = ({
   const resetName = () => {
     if (!props.disabled && addressBook[watchedValue]) {
       setValue(name, '')
+      onReset?.()
     }
   }
 

--- a/apps/web/src/components/new-safe/OwnerRow/index.tsx
+++ b/apps/web/src/components/new-safe/OwnerRow/index.tsx
@@ -115,6 +115,7 @@ export const OwnerRow = ({
               label="Signer"
               validate={validateOwnerAddress}
               deps={deps}
+              onReset={() => setValue(`${fieldName}.name`, '')}
             />
           </FormControl>
         )}


### PR DESCRIPTION
## What it solves

Reset the signer name when the address field is being cleared.

## How this PR fixes it
* Introduce `onReset` callback in `AddressInput` component.
* Implement onReset in `OwnerRow` to clear the name field when the reset action occurs.

## How to test it
1. Open "Manage signers" flow from settings page
2. Add a signer row
3. Select an address from the address book
4. Observe the name field being populated with the name from the address book
5. Click the address field to clear the value
6. Observe the name field being cleared as well

## Screenshots
https://github.com/user-attachments/assets/041921e2-03aa-44a7-b2fc-ce57aa3e145d

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
