### PR TITLE
fix(ManageSigners): create address book entries for signers on submit

### DIFF
--- a/apps/web/src/components/tx-flow/flows/AddOwner/ReviewOwner.tsx
+++ b/apps/web/src/components/tx-flow/flows/AddOwner/ReviewOwner.tsx
@@ -43,7 +43,7 @@ export const ReviewOwner = ({
     promise.then(setSafeTx).catch(setSafeTxError)
   }, [removedOwner, newOwner, threshold, setSafeTx, setSafeTxError, chain, safe.deployed])
 
-  const addAddressBookEntryAndSubmit = () => {
+  const addAddressBookEntry = () => {
     if (typeof newOwner.name !== 'undefined') {
       dispatch(
         upsertAddressBookEntries({
@@ -59,7 +59,7 @@ export const ReviewOwner = ({
   }
 
   const handleSubmit = () => {
-    addAddressBookEntryAndSubmit()
+    addAddressBookEntry()
     onSubmit?.()
   }
 

--- a/apps/web/src/components/tx-flow/flows/ManagerSigners/ReviewSigners.tsx
+++ b/apps/web/src/components/tx-flow/flows/ManagerSigners/ReviewSigners.tsx
@@ -41,7 +41,7 @@ export function ReviewSigners({ onSubmit, ...props }: ReviewTransactionContentPr
     createSafeTx().then(setSafeTx).catch(setSafeTxError)
   }, [data, safe, setSafeTx, setSafeTxError])
 
-  const addAddressBookEntryAndSubmit = () => {
+  const addAddressBookEntry = () => {
     if (!data) return
 
     // Add address book entries for new owners with names
@@ -59,7 +59,7 @@ export function ReviewSigners({ onSubmit, ...props }: ReviewTransactionContentPr
   }
 
   const handleSubmit = () => {
-    addAddressBookEntryAndSubmit()
+    addAddressBookEntry()
     onSubmit()
   }
 


### PR DESCRIPTION
## What it solves

When submitting the "Manage signers" flow, create address book entries for the signers with names.

Note: This fix does NOT make the signer names show up on the review transaction step in the manage signers flow.

## How this PR fixes it
- Updated ReviewSigners component to include functionality for adding address book entries for new owners with names.
- Refactored the submit handler to incorporate address book entry creation before the main submission process.

## How to test it

1. Open the manage signers flow
2. Add at least one signer with a name
3. Submit the flow
4. Navigate to the address book
5. Observe that address book entries for the submitted signers were created/updated using the corresponding names

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
