### PR TITLE
feat(Spaces): leave a space

### DIFF
--- a/apps/web/src/features/spaces/components/MembersList/index.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.tsx
@@ -7,11 +7,12 @@ import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import MemberName from './MemberName'
 import RemoveMemberDialog from './RemoveMemberDialog'
 import { useState } from 'react'
-import { MemberRole, useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
+import { useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
 import EditMemberDialog from '@/features/spaces/components/MembersList/EditMemberDialog'
-import { MemberStatus } from '../../hooks/useSpaceMembers'
+import { isAdmin as checkIsAdmin, isActiveAdmin, MemberStatus } from '@/features/spaces/hooks/useSpaceMembers'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
+import { useAdminCount } from '@/features/spaces/hooks/useIsLastActiveAdmin'
 
 const headCells = [
   {
@@ -91,10 +92,10 @@ export const RemoveMemberButton = ({
 
 const MembersList = ({ members }: { members: Member[] }) => {
   const isAdmin = useIsAdmin()
-  const adminCount = members.filter((member) => member.role === MemberRole.ADMIN).length
+  const adminCount = useAdminCount(members)
 
   const rows = members.map((member) => {
-    const isLastAdmin = adminCount === 1 && member.role === MemberRole.ADMIN
+    const isLastAdmin = adminCount === 1 && isActiveAdmin(member)
     const isInvite = member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED
     const isDeclined = member.status === MemberStatus.DECLINED
     const isDisabled = isAdmin && isLastAdmin && !isInvite
@@ -121,7 +122,7 @@ const MembersList = ({ members }: { members: Member[] }) => {
           content: (
             <Chip
               size="small"
-              label={member.role === MemberRole.ADMIN ? 'Admin' : 'Member'}
+              label={checkIsAdmin(member) ? 'Admin' : 'Member'}
               sx={{ backgroundColor: 'background.lightgrey', borderRadius: 0.5 }}
             />
           ),

--- a/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
@@ -49,7 +49,7 @@ const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefi
     <ModalDialog dialogTitle="Leave space" hideChainIndicator open onClose={onClose}>
       <DialogContent sx={{ mt: 2 }}>
         <Typography mb={2}>
-          Are you sure you want like to leave this space? You won’t be able to access its data anymore.
+          Are you sure you want to leave this space? You won’t be able to access its data anymore.
         </Typography>
 
         {error && (

--- a/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
@@ -1,0 +1,72 @@
+import { Alert, Button, DialogActions, DialogContent, Typography } from '@mui/material'
+import ModalDialog from '@/components/common/ModalDialog'
+import { type GetSpaceResponse, useMembersSelfRemoveV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { AppRoutes } from '@/config/routes'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { showNotification } from '@/store/notificationsSlice'
+import { useAppDispatch } from '@/store'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { trackEvent } from '@/services/analytics'
+
+const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefined; onClose: () => void }) => {
+  const [error, setError] = useState<string>()
+  const router = useRouter()
+  const dispatch = useAppDispatch()
+  const [leaveSpace] = useMembersSelfRemoveV1Mutation()
+
+  const onLeave = async () => {
+    if (!space) return
+
+    setError(undefined)
+
+    try {
+      const res = await leaveSpace({ spaceId: space.id })
+
+      if (res.error) {
+        throw new Error(JSON.stringify(res.error))
+      }
+
+      onClose()
+
+      trackEvent({ ...SPACE_EVENTS.LEAVE_SPACE })
+      dispatch(
+        showNotification({
+          message: `Left space ${space.name}.`,
+          variant: 'success',
+          groupKey: 'leave-space-success',
+        }),
+      )
+
+      router.push({ pathname: AppRoutes.welcome.spaces })
+    } catch (e) {
+      console.error(e)
+      setError('Error leaving the space. Please try again.')
+    }
+  }
+
+  return (
+    <ModalDialog dialogTitle="Leave space" hideChainIndicator open onClose={onClose}>
+      <DialogContent sx={{ mt: 2 }}>
+        <Typography mb={2}>
+          Are you sure you want like to leave this space? You won’t be able to access its data anymore.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button data-testid="space-confirm-leave-button" variant="danger" onClick={onLeave}>
+          Leave space
+        </Button>
+      </DialogActions>
+    </ModalDialog>
+  )
+}
+
+export default LeaveSpaceDialog

--- a/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
@@ -1,5 +1,5 @@
 import { useAppSelector } from '@/store'
-import { Button, Card, Grid2, Typography } from '@mui/material'
+import { Button, Card, Grid2, Stack, Tooltip, Typography } from '@mui/material'
 import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useState } from 'react'
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
@@ -12,14 +12,18 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import ExternalLink from '@/components/common/ExternalLink'
 import { AppRoutes } from '@/config/routes'
+import LeaveSpaceDialog from './LeaveSpaceDialog'
+import { useIsLastActiveAdmin } from '../../hooks/useIsLastActiveAdmin'
 
 const SpaceSettings = () => {
   const [deleteSpaceOpen, setDeleteSpaceOpen] = useState(false)
+  const [leaveSpaceOpen, setLeaveSpaceOpen] = useState(false)
   const isAdmin = useIsAdmin()
   const spaceId = useCurrentSpaceId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: space } = useSpacesGetOneV1Query({ id: Number(spaceId) }, { skip: !isUserSignedIn || !spaceId })
   const isInvited = useIsInvited()
+  const isLastActiveAdmin = useIsLastActiveAdmin()
 
   return (
     <div>
@@ -49,21 +53,42 @@ const SpaceSettings = () => {
           <Grid2 size={{ xs: 12, md: 8 }}>
             <Typography mb={2}>This action cannot be undone.</Typography>
 
-            <Button
-              data-testid="space-delete-button"
-              variant="danger"
-              onClick={() => {
-                setDeleteSpaceOpen(true)
-                trackEvent({ ...SPACE_EVENTS.DELETE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
-              }}
-              disabled={!isAdmin}
-            >
-              Delete space
-            </Button>
+            <Stack direction="row" spacing={2}>
+              <Tooltip title={isLastActiveAdmin ? 'You are the last active admin and cannot leave the space.' : ''}>
+                <span>
+                  <Button
+                    data-testid="space-leave-button"
+                    onClick={() => {
+                      setLeaveSpaceOpen(true)
+                      trackEvent({ ...SPACE_EVENTS.LEAVE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
+                    }}
+                    variant={isAdmin ? 'outlined' : 'danger'}
+                    color="error"
+                    disabled={isLastActiveAdmin}
+                  >
+                    Leave space
+                  </Button>
+                </span>
+              </Tooltip>
+
+              {isAdmin && (
+                <Button
+                  data-testid="space-delete-button"
+                  variant="danger"
+                  onClick={() => {
+                    setDeleteSpaceOpen(true)
+                    trackEvent({ ...SPACE_EVENTS.DELETE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
+                  }}
+                >
+                  Delete space
+                </Button>
+              )}
+            </Stack>
           </Grid2>
         </Grid2>
       </Card>
       {deleteSpaceOpen && <DeleteSpaceDialog space={space} onClose={() => setDeleteSpaceOpen(false)} />}
+      {leaveSpaceOpen && <LeaveSpaceDialog space={space} onClose={() => setLeaveSpaceOpen(false)} />}
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
@@ -4,7 +4,7 @@ import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATE
 import { useState } from 'react'
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
 import { isAuthenticated } from '@/store/authSlice'
-import { useIsAdmin, useIsInvited } from '@/features/spaces/hooks/useSpaceMembers'
+import { useIsAdmin, useIsInvited, useIsActiceMember } from '@/features/spaces/hooks/useSpaceMembers'
 import PreviewInvite from '@/features/spaces/components/InviteBanner/PreviewInvite'
 import DeleteSpaceDialog from '@/features/spaces/components/SpaceSettings/DeleteSpaceDialog'
 import UpdateSpaceForm from '@/features/spaces/components/SpaceSettings/UpdateSpaceForm'
@@ -24,6 +24,7 @@ const SpaceSettings = () => {
   const { currentData: space } = useSpacesGetOneV1Query({ id: Number(spaceId) }, { skip: !isUserSignedIn || !spaceId })
   const isInvited = useIsInvited()
   const isLastActiveAdmin = useIsLastActiveAdmin()
+  const isActiveMember = useIsActiceMember()
 
   return (
     <div>
@@ -64,7 +65,7 @@ const SpaceSettings = () => {
                     }}
                     variant={isAdmin ? 'outlined' : 'danger'}
                     color="error"
-                    disabled={isLastActiveAdmin}
+                    disabled={isLastActiveAdmin || !isActiveMember}
                   >
                     Leave space
                   </Button>

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
@@ -16,6 +16,7 @@ export type DynamicNavItem = {
   tag?: ReactElement
   disabled?: boolean
   adminOnly?: boolean
+  activeMemberOnly?: boolean
 }
 
 export const navItems: DynamicNavItem[] = [
@@ -52,6 +53,6 @@ export const navItems: DynamicNavItem[] = [
     label: 'Settings',
     icon: <SvgIcon component={SettingsIcon} inheritViewBox />,
     href: AppRoutes.spaces.settings,
-    adminOnly: true,
+    activeMemberOnly: true,
   },
 ]

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
@@ -15,7 +15,6 @@ export type DynamicNavItem = {
   href: string
   tag?: ReactElement
   disabled?: boolean
-  adminOnly?: boolean
   activeMemberOnly?: boolean
 }
 

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/index.tsx
@@ -9,18 +9,19 @@ import {
   SidebarListItemText,
 } from '@/components/sidebar/SidebarList'
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
-import { useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
+import { useIsActiceMember, useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
 import { navItems } from './config'
 
 const Navigation = (): ReactElement => {
   const router = useRouter()
   const spaceId = useCurrentSpaceId()
   const isAdmin = useIsAdmin()
+  const isActiveMember = useIsActiceMember()
 
   return (
     <SidebarList>
       {navItems.map((item) => {
-        const hideItem = item.adminOnly && !isAdmin
+        const hideItem = (item.adminOnly && !isAdmin) || (item.activeMemberOnly && !isActiveMember)
         const isSelected = router.pathname === item.href
 
         if (hideItem) return null

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/index.tsx
@@ -9,19 +9,18 @@ import {
   SidebarListItemText,
 } from '@/components/sidebar/SidebarList'
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
-import { useIsActiceMember, useIsAdmin } from '@/features/spaces/hooks/useSpaceMembers'
+import { useIsActiceMember } from '@/features/spaces/hooks/useSpaceMembers'
 import { navItems } from './config'
 
 const Navigation = (): ReactElement => {
   const router = useRouter()
   const spaceId = useCurrentSpaceId()
-  const isAdmin = useIsAdmin()
   const isActiveMember = useIsActiceMember()
 
   return (
     <SidebarList>
       {navItems.map((item) => {
-        const hideItem = (item.adminOnly && !isAdmin) || (item.activeMemberOnly && !isActiveMember)
+        const hideItem = item.activeMemberOnly && !isActiveMember
         const isSelected = router.pathname === item.href
 
         if (hideItem) return null

--- a/apps/web/src/features/spaces/hooks/useIsLastActiveAdmin.ts
+++ b/apps/web/src/features/spaces/hooks/useIsLastActiveAdmin.ts
@@ -9,11 +9,9 @@ export const useAdminCount = (members?: Member[]) => {
   return useMemo(() => membersToUse.filter(isAdmin).length, [membersToUse])
 }
 
-export const useIsLastActiveAdmin = (member?: Member) => {
+export const useIsLastActiveAdmin = () => {
   const adminCount = useAdminCount()
   const currentMembership = useCurrentMembership()
 
-  const memberToUse = member ?? currentMembership
-
-  return adminCount === 1 && !!memberToUse && isActiveAdmin(memberToUse)
+  return adminCount === 1 && !!currentMembership && isActiveAdmin(currentMembership)
 }

--- a/apps/web/src/features/spaces/hooks/useIsLastActiveAdmin.ts
+++ b/apps/web/src/features/spaces/hooks/useIsLastActiveAdmin.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react'
+import { isActiveAdmin, isAdmin, useSpaceMembersByStatus } from './useSpaceMembers'
+import type { Member } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useCurrentMembership } from './useSpaceMembers'
+
+export const useAdminCount = (members?: Member[]) => {
+  const { activeMembers } = useSpaceMembersByStatus()
+  const membersToUse = members ?? activeMembers
+  return useMemo(() => membersToUse.filter(isAdmin).length, [membersToUse])
+}
+
+export const useIsLastActiveAdmin = (member?: Member) => {
+  const adminCount = useAdminCount()
+  const currentMembership = useCurrentMembership()
+
+  const memberToUse = member ?? currentMembership
+
+  return adminCount === 1 && !!memberToUse && isActiveAdmin(memberToUse)
+}

--- a/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
@@ -1,4 +1,4 @@
-import { useMembersGetUsersV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useMembersGetUsersV1Query, type Member } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useCurrentSpaceId } from 'src/features/spaces/hooks/useCurrentSpaceId'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
@@ -14,6 +14,10 @@ export enum MemberRole {
   ADMIN = 'ADMIN',
   MEMBER = 'MEMBER',
 }
+
+export const isAdmin = (member: Member) => member.role === MemberRole.ADMIN
+
+export const isActiveAdmin = (member: Member) => isAdmin(member) && member.status === MemberStatus.ACTIVE
 
 const useAllMembers = (spaceId?: number) => {
   const currentSpaceId = useCurrentSpaceId()
@@ -34,7 +38,7 @@ export const useSpaceMembersByStatus = () => {
   return { activeMembers, invitedMembers }
 }
 
-const useCurrentMembership = (spaceId?: number) => {
+export const useCurrentMembership = (spaceId?: number) => {
   const allMembers = useAllMembers(spaceId)
   const { currentData: user } = useUsersGetWithWalletsV1Query()
   return allMembers.find((member) => member.user.id === user?.id)
@@ -42,7 +46,7 @@ const useCurrentMembership = (spaceId?: number) => {
 
 export const useIsAdmin = (spaceId?: number) => {
   const currentMembership = useCurrentMembership(spaceId)
-  return currentMembership?.role === MemberRole.ADMIN && currentMembership?.status === MemberStatus.ACTIVE
+  return !!currentMembership && isActiveAdmin(currentMembership)
 }
 
 export const useIsInvited = () => {

--- a/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
@@ -44,6 +44,11 @@ export const useCurrentMembership = (spaceId?: number) => {
   return allMembers.find((member) => member.user.id === user?.id)
 }
 
+export const useIsActiceMember = (spaceId?: number) => {
+  const currentMembership = useCurrentMembership(spaceId)
+  return !!currentMembership && currentMembership.status === MemberStatus.ACTIVE
+}
+
 export const useIsAdmin = (spaceId?: number) => {
   const currentMembership = useCurrentMembership(spaceId)
   return !!currentMembership && isActiveAdmin(currentMembership)

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -103,6 +103,14 @@ export const SPACE_EVENTS = {
     action: 'Submit delete space',
     category: SPACE_CATEGORY,
   },
+  LEAVE_SPACE_MODAL: {
+    action: 'Open leave space modal',
+    category: SPACE_CATEGORY,
+  },
+  LEAVE_SPACE: {
+    action: 'Submit leave space',
+    category: SPACE_CATEGORY,
+  },
   VIEW_ALL_ACCOUNTS: {
     action: 'View all accounts',
     category: SPACE_CATEGORY,

--- a/packages/store/scripts/api-schema/schema.json
+++ b/packages/store/scripts/api-schema/schema.json
@@ -2707,6 +2707,39 @@
           }
         },
         "tags": ["spaces"]
+      },
+      "delete": {
+        "description": "Remove own membership from a space.",
+        "operationId": "membersSelfRemoveV1",
+        "parameters": [
+          {
+            "name": "spaceId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Membership deleted"
+          },
+          "401": {
+            "description": "Signer address not provided"
+          },
+          "403": {
+            "description": "Signer not authorized"
+          },
+          "404": {
+            "description": "Signer or space not found"
+          },
+          "409": {
+            "description": "Cannot remove last admin"
+          }
+        },
+        "summary": "Leave a space",
+        "tags": ["spaces"]
       }
     },
     "/v1/spaces/{spaceId}/members/{userId}/role": {

--- a/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
@@ -74,6 +74,10 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/v1/spaces/${queryArg.spaceId}/members` }),
         providesTags: ['spaces'],
       }),
+      membersSelfRemoveV1: build.mutation<MembersSelfRemoveV1ApiResponse, MembersSelfRemoveV1ApiArg>({
+        query: (queryArg) => ({ url: `/v1/spaces/${queryArg.spaceId}/members`, method: 'DELETE' }),
+        invalidatesTags: ['spaces'],
+      }),
       membersUpdateRoleV1: build.mutation<MembersUpdateRoleV1ApiResponse, MembersUpdateRoleV1ApiArg>({
         query: (queryArg) => ({
           url: `/v1/spaces/${queryArg.spaceId}/members/${queryArg.userId}/role`,
@@ -143,6 +147,10 @@ export type MembersDeclineInviteV1ApiArg = {
 }
 export type MembersGetUsersV1ApiResponse = /** status 200 Space and members list */ MembersDto
 export type MembersGetUsersV1ApiArg = {
+  spaceId: number
+}
+export type MembersSelfRemoveV1ApiResponse = unknown
+export type MembersSelfRemoveV1ApiArg = {
   spaceId: number
 }
 export type MembersUpdateRoleV1ApiResponse = unknown
@@ -266,6 +274,7 @@ export const {
   useMembersDeclineInviteV1Mutation,
   useMembersGetUsersV1Query,
   useLazyMembersGetUsersV1Query,
+  useMembersSelfRemoveV1Mutation,
   useMembersUpdateRoleV1Mutation,
   useMembersRemoveUserV1Mutation,
 } = injectedRtkApi


### PR DESCRIPTION
## What it solves

Resolves [#116](https://github.com/safe-global/wallet-private-tasks/issues/116) - Allow active members to leave a space voluntarily
https://linear.app/safe-global/issue/EN-29/spaces-allow-members-to-leave-a-space
This PR enables users who are active members of a space to remove themselves from that space. Safeguards are included to prevent the last active admin from leaving.

> 🔗 **Note:** This change works in conjunction with related CGW updates [#2600](https://github.com/safe-global/safe-client-gateway/pull/2600).


## How this PR fixes it

### UI updates
- Added a “Leave space” button to the `SpaceSettings` view.
- Display a tooltip explaining why the button is disabled for the last active admin.
- Introduced `LeaveSpaceDialog` to confirm the action before proceeding.
- Display the Settings page in the sidebar navigation for all active members, not just active admins.
  - Otherwise the "leave space" functionality would not be reachable for non-admins.

### Logic & hooks
- Created a `useIsActiveMember` hook to determine if the user is considered active.
- Added utility functions in `useSpaceMembers` to assess admin roles and active member count.
- Implemented logic to detect whether the current user is the last active admin.

### Behavioral updates
- Disabled the leave button for users who are not active members or are the last active admin.
- Ensured `MembersList` leverages the new hooks for accurate admin role detection.

### Analytics
- Track user actions related to leaving a space.

## How to test it

### ✅ Scenario 1: Active member
1. Log into a space as an active member or admin (with at least one other active admin).
2. Navigate to **Settings**.
3. Confirm that a **"Leave space"** button is visible.
4. Click the button – a confirmation dialog should appear.
5. Confirm the dialog – the user should be removed from the space.

### ⚠️ Scenario 2: Last active admin
1. Log in as the sole active admin in a space.
2. Navigate to **Settings**.
3. **"Leave space"** button should be disabled.
4. Tooltip on hover explains that the last active admin cannot leave.

### 🚫 Scenario 3: Invited user
1. Log in as a user who has only been invited (not yet accepted).
2. **Settings** should not appear in the sidebar.

## Screenshots

### Scenario 1 (active member - not admin)
<img width="904" alt="Screenshot 2025-05-27 at 23 57 06" src="https://github.com/user-attachments/assets/ad99b0f6-ac41-40e8-bb8d-4080b9b50bde" />

### Scenario 1 (active admin)
<img width="1384" alt="Screenshot 2025-05-28 at 00 01 59" src="https://github.com/user-attachments/assets/37df5efd-c6a5-4010-ad04-d115099b2219" />

### Scenario 2 (last active admin)
<img width="905" alt="Screenshot 2025-05-28 at 00 02 39" src="https://github.com/user-attachments/assets/6739f8a8-0039-4a4b-b4c4-81c7fd7051ae" />

### Scenario 3 (invited user)
<img width="1383" alt="Screenshot 2025-05-28 at 00 00 25" src="https://github.com/user-attachments/assets/b6afb35c-1625-41a2-96a6-f53dd49a7ac9" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
