### PR TITLE
Fix missing default case in order type mapping

### DIFF
--- a/packages/utils/src/features/swap/helpers/utils.ts
+++ b/packages/utils/src/features/swap/helpers/utils.ts
@@ -198,6 +198,8 @@ export const UiOrderTypeToOrderType = (orderType: UiOrderType): TradeType => {
       return TradeType.LIMIT
     case UiOrderType.TWAP:
       return TradeType.ADVANCED
+    default:
+      throw new Error(`Unsupported order type: ${orderType}`)
   }
 }
 


### PR DESCRIPTION
## Summary
- fix missing default case in `UiOrderTypeToOrderType`

## Testing
- `yarn test` *(fails: unable to download yarn packages)*