### PR TITLE
Fix(Signing UX): execute status + CSS fixes

### DIFF
--- a/apps/web/src/components/transactions/HexEncodedData/__snapshots__/HexEncodedData.test.tsx.snap
+++ b/apps/web/src/components/transactions/HexEncodedData/__snapshots__/HexEncodedData.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`HexEncodedData should not cut the text in case the limit option is high
       style="word-break: break-word;"
     >
       <span
-        class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
       >
         Data (hex-encoded)
       </span>
@@ -61,7 +61,7 @@ exports[`HexEncodedData should not highlight the data if highlight option is fal
       style="word-break: break-word;"
     >
       <span
-        class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
       >
         Some arbitrary data
       </span>
@@ -104,7 +104,7 @@ exports[`HexEncodedData should render the default component markup 1`] = `
       style="word-break: break-word;"
     >
       <span
-        class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
       >
         Data (hex-encoded)
       </span>

--- a/apps/web/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/TxDataRow/index.tsx
@@ -21,21 +21,27 @@ export const generateDataRowValue = (
       const customAvatar = addressInfo?.logoUri
 
       return (
-        <NamedAddressInfo
-          address={value}
-          name={addressInfo?.name}
-          customAvatar={customAvatar}
-          showAvatar={type === 'address'}
-          avatarSize={20}
-          showPrefix={false}
-          shortAddress={type !== 'address'}
-          hasExplorer={hasExplorer}
-          highlight4bytes
-        />
+        <Typography variant="body2" component="span">
+          <NamedAddressInfo
+            address={value}
+            name={addressInfo?.name}
+            customAvatar={customAvatar}
+            showAvatar={type === 'address'}
+            avatarSize={20}
+            showPrefix={false}
+            shortAddress={type !== 'address'}
+            hasExplorer={hasExplorer}
+            highlight4bytes
+          />
+        </Typography>
       )
     case 'rawData':
     case 'bytes':
-      return <HexEncodedData highlightFirstBytes={false} limit={66} hexData={value} />
+      return (
+        <Typography variant="body2" component="span">
+          <HexEncodedData highlightFirstBytes={false} limit={66} hexData={value} />
+        </Typography>
+      )
     default:
       return (
         <Typography variant="body2" sx={{ wordBreak: 'break-all' }} component="span">

--- a/apps/web/src/components/tx-flow/common/TxFlowContent/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxFlowContent/index.tsx
@@ -121,7 +121,7 @@ export const TxFlowContent = ({ children }: { children?: ReactNode[] | ReactNode
             <Grid item xs={12} md={4} className={classnames(css.widget, { [css.active]: statusVisible })}>
               {statusVisible && (
                 <TxStatusWidget
-                  step={step}
+                  isLastStep={step === childrenArray.length - 1}
                   txSummary={txSummary}
                   handleClose={() => setStatusVisible(false)}
                   isBatch={isBatch}

--- a/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
@@ -189,7 +189,7 @@ const TxLayout = ({
                   <Grid item xs={12} md={4} className={classnames(css.widget, { [css.active]: statusVisible })}>
                     {statusVisible && (
                       <TxStatusWidget
-                        step={step}
+                        isLastStep={step === steps.length - 1}
                         txSummary={txSummary}
                         handleClose={() => setStatusVisible(false)}
                         isBatch={isBatch}

--- a/apps/web/src/components/tx-flow/common/TxStatusWidget/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxStatusWidget/index.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react'
 import { Divider, IconButton, List, ListItem, ListItemIcon, ListItemText, Paper, Typography } from '@mui/material'
 import CreatedIcon from '@/public/images/messages/created.svg'
 import SignedIcon from '@/public/images/messages/signed.svg'
-import { type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
+import { TransactionStatus, type TransactionSummary } from '@safe-global/safe-gateway-typescript-sdk'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { isMultisigExecutionInfo, isSignableBy, isConfirmableBy } from '@/utils/transaction-guards'
 import classnames from 'classnames'
@@ -15,17 +15,17 @@ import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import { useIsWalletProposer } from '@/hooks/useProposers'
 
 const TxStatusWidget = ({
-  step,
   txSummary,
   handleClose,
   isBatch = false,
   isMessage = false,
+  isLastStep = false,
 }: {
-  step: number
   txSummary?: TransactionSummary
   handleClose: () => void
   isBatch?: boolean
   isMessage?: boolean
+  isLastStep?: boolean
 }) => {
   const wallet = useWallet()
   const { safe } = useSafeInfo()
@@ -34,6 +34,7 @@ const TxStatusWidget = ({
   const isSafeOwner = useIsSafeOwner()
   const isProposer = useIsWalletProposer()
   const isProposing = isProposer && !isSafeOwner
+  const isAwaitingExecution = txSummary?.txStatus === TransactionStatus.AWAITING_EXECUTION
 
   const { executionInfo = undefined } = txSummary || {}
   const { confirmationsSubmitted = 0 } = isMultisigExecutionInfo(executionInfo) ? executionInfo : {}
@@ -96,7 +97,7 @@ const TxStatusWidget = ({
             </ListItemText>
           </ListItem>
 
-          <ListItem className={classnames({ [css.incomplete]: step < 2 })}>
+          <ListItem className={classnames({ [css.incomplete]: !(isAwaitingExecution && isLastStep) })}>
             <ListItemIcon>
               <SignedIcon />
             </ListItemIcon>

--- a/apps/web/src/components/tx/ConfirmTxDetails/NameChip.test.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/NameChip.test.tsx
@@ -115,22 +115,6 @@ describe('NameChip', () => {
     expect(screen.queryByText(txInfoName)).not.toBeInTheDocument()
   })
 
-  it('should render with background when withBackground prop is true', () => {
-    const mockAddress = faker.finance.ethereumAddress()
-    mockUseAddressName.mockReturnValue({ name: 'Test Contract', logoUri: undefined, isUnverifiedContract: false })
-    mockUseAddressBook.mockReturnValue({})
-
-    const txData = txDataBuilder()
-      .with({
-        to: { value: mockAddress },
-      })
-      .build()
-
-    render(<NameChip txData={txData} withBackground />)
-    const chip = screen.getByTestId('name-chip')
-    expect(chip).toHaveStyle({ backgroundColor: 'rgb(244, 244, 244)' })
-  })
-
   it('should display name and logo when provided', () => {
     const mockAddress = faker.finance.ethereumAddress()
     mockUseAddressName.mockReturnValue({ name: 'Test Contract', logoUri: 'test-logo.png', isUnverifiedContract: false })

--- a/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/NameChip.tsx
@@ -5,15 +5,7 @@ import { isCustomTxInfo } from '@/utils/transaction-guards'
 import { Chip } from '@mui/material'
 import type { TransactionData, TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 
-const NameChip = ({
-  txData,
-  withBackground,
-  txInfo,
-}: {
-  txData?: TransactionData
-  txInfo?: TransactionDetails['txInfo']
-  withBackground?: boolean
-}) => {
+const NameChip = ({ txData, txInfo }: { txData?: TransactionData; txInfo?: TransactionDetails['txInfo'] }) => {
   const addressBook = useAddressBook()
   const toAddress = txData?.to.value
   const customTxInfo = txInfo && isCustomTxInfo(txInfo) ? txInfo : undefined
@@ -33,7 +25,7 @@ const NameChip = ({
     <Chip
       data-testid="name-chip"
       sx={{
-        backgroundColor: isUntrusted ? 'error.background' : withBackground ? 'background.main' : 'background.paper',
+        backgroundColor: isUntrusted ? 'error.background' : 'background.paper',
         color: isUntrusted ? 'error.main' : undefined,
         height: 'unset',
       }}

--- a/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
+++ b/apps/web/src/components/tx/ConfirmTxDetails/Receipt.tsx
@@ -52,7 +52,7 @@ export const Receipt = ({ safeTxData, txData, txDetails, txInfo, grid, withSigna
               <Stack spacing={1} divider={<Divider />}>
                 <TxDetailsRow label="To" grid={grid}>
                   <ToWrapper>
-                    <NameChip txData={txData} txInfo={txInfo} withBackground={grid} />
+                    <NameChip txData={txData} txInfo={txInfo} />
 
                     <Typography
                       variant="body2"

--- a/apps/web/src/components/tx/FieldsGrid/index.tsx
+++ b/apps/web/src/components/tx/FieldsGrid/index.tsx
@@ -19,7 +19,7 @@ const FieldsGrid = ({ title, children }: { title: string | ReactNode; children: 
       ]}
     >
       <Grid item data-testid="tx-row-title" style={{ wordBreak: 'break-word' }} sx={gridSx}>
-        <Typography color="primary.light" variant="body1" component="span">
+        <Typography color="primary.light" variant="body2" component="span">
           {title}
         </Typography>
       </Grid>

--- a/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransaction/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
               style="word-break: break-word;"
             >
               <span
-                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
               >
                 Interacted with
               </span>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/ReviewTransactionContent.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
               style="word-break: break-word;"
             >
               <span
-                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
               >
                 Interacted with
               </span>

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
               style="word-break: break-word;"
             >
               <span
-                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
               >
                 Interacted with
               </span>

--- a/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
+++ b/apps/web/src/components/tx/SignOrExecuteForm/__tests__/__snapshots__/SignOrExecute.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`SignOrExecute should display a confirmation screen 1`] = `
               style="word-break: break-word;"
             >
               <span
-                class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
               >
                 Interacted with
               </span>

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -226,7 +226,7 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
                         style="word-break: break-word;"
                       >
                         <span
-                          class="MuiTypography-root MuiTypography-body1 css-shf88x-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
                         >
                           Created:
                         </span>


### PR DESCRIPTION
## What it solves

* The Execute step was always green on step 2
* Wrong font for tx data rows
* Name chip background

![Screenshot 2025-05-28 at 14 28 46](https://github.com/user-attachments/assets/1caca812-3b08-40f6-9f04-fbeb2aaddc11)
![Screenshot 2025-05-28 at 14 30 46](https://github.com/user-attachments/assets/bb882a79-c911-4ef4-b65c-cf71a9e90321)
![Screenshot 2025-05-28 at 14 30 01](https://github.com/user-attachments/assets/5f3992fe-e8b3-4cd9-b8f7-6a041d925d9b)