### PR TITLE
feat(utils): overwrite guard with zero address when simulating

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,6 +8,7 @@
     "test:coverage": "jest --coverage"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.0.3",
     "@types/jest": "^29.5.14",
     "ethers": "^6.13.4",
     "jest": "^29.7.0"

--- a/packages/utils/src/components/tx/security/tenderly/__tests__/utils.test.ts
+++ b/packages/utils/src/components/tx/security/tenderly/__tests__/utils.test.ts
@@ -1,0 +1,134 @@
+import { ethers, toBeHex, ZeroAddress } from 'ethers'
+import {
+  getStateOverwrites,
+  THRESHOLD_STORAGE_POSITION,
+  THRESHOLD_OVERWRITE,
+  NONCE_STORAGE_POSITION,
+  GUARD_STORAGE_POSITION,
+} from '../utils'
+import { ImplementationVersionState, type SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import type { SafeTransaction, SafeSignature } from '@safe-global/types-kit'
+import type { SingleTransactionSimulationParams } from '../utils'
+import { faker } from '@faker-js/faker'
+import { EthSafeSignature } from '@safe-global/protocol-kit'
+
+describe('getStateOverwrites', () => {
+  const mockOwners = [faker.finance.ethereumAddress(), faker.finance.ethereumAddress(), faker.finance.ethereumAddress()]
+  const safeAddress = faker.finance.ethereumAddress()
+  const mockSafe = {
+    address: { value: safeAddress },
+    chainId: '1',
+    nonce: 5,
+    threshold: 2,
+    guard: { value: ZeroAddress },
+    version: '1.4.1',
+    owners: mockOwners.map((owner) => ({ value: owner })),
+    implementation: { value: ZeroAddress },
+    implementationVersionState: ImplementationVersionState.UP_TO_DATE,
+    modules: [],
+    fallbackHandler: { value: ZeroAddress },
+    collectiblesTag: '0',
+    txQueuedTag: '0',
+    txHistoryTag: '0',
+    messagesTag: '0',
+  }
+  const mockSafeWithGuard = {
+    ...mockSafe,
+    guard: { value: faker.finance.ethereumAddress() },
+  }
+
+  const mockSignature = new EthSafeSignature(mockOwners[0], faker.string.hexadecimal({ length: 66 }))
+
+  const mockTransaction: SafeTransaction = {
+    data: {
+      to: faker.finance.ethereumAddress(),
+      value: '0',
+      data: '0x',
+      operation: 0,
+      safeTxGas: '0',
+      baseGas: '0',
+      gasPrice: '0',
+      gasToken: ZeroAddress,
+      refundReceiver: ZeroAddress,
+      nonce: 5,
+    },
+    signatures: new Map<string, SafeSignature>(),
+    getSignature: () => undefined,
+    addSignature: () => {},
+    encodedSignatures: () => '',
+  }
+
+  mockTransaction.signatures.set(mockOwners[0], mockSignature)
+
+  it('should return empty object when no overwrites are needed', () => {
+    // Threshold 2, one signature in the tx and the execution owner is the second owner
+    const params: SingleTransactionSimulationParams = {
+      safe: mockSafe,
+      executionOwner: mockOwners[1],
+      transactions: mockTransaction,
+    }
+
+    const result = getStateOverwrites(params)
+    expect(result).toEqual({})
+  })
+
+  it('should include threshold overwrite when signatures are below threshold', () => {
+    const params: SingleTransactionSimulationParams = {
+      safe: { ...mockSafe, threshold: 3 },
+      executionOwner: mockOwners[1],
+      transactions: mockTransaction,
+    }
+
+    const result = getStateOverwrites(params)
+    expect(result).toEqual({
+      [THRESHOLD_STORAGE_POSITION]: THRESHOLD_OVERWRITE,
+    })
+  })
+
+  it('should include nonce overwrite when transaction nonce is higher than safe nonce', () => {
+    const params: SingleTransactionSimulationParams = {
+      safe: mockSafe,
+      executionOwner: mockOwners[1],
+      transactions: { ...mockTransaction, data: { ...mockTransaction.data, nonce: 6 } },
+    }
+
+    const result = getStateOverwrites(params)
+    expect(result).toEqual({
+      [NONCE_STORAGE_POSITION]: toBeHex('0x6', 32),
+    })
+  })
+
+  it('should include guard overwrite when safe has a guard', () => {
+    const params: SingleTransactionSimulationParams = {
+      safe: mockSafeWithGuard,
+      executionOwner: mockOwners[1],
+      transactions: mockTransaction,
+    }
+
+    const result = getStateOverwrites(params)
+    expect(result).toEqual({
+      [GUARD_STORAGE_POSITION]: toBeHex(ZeroAddress, 32),
+    })
+  })
+
+  it('should combine multiple overwrites when multiple conditions are met', () => {
+    const params: SingleTransactionSimulationParams = {
+      safe: { ...mockSafe, guard: { value: faker.finance.ethereumAddress() }, threshold: 3 },
+      executionOwner: mockOwners[1],
+      transactions: {
+        ...mockTransaction,
+        data: {
+          ...mockTransaction.data,
+          nonce: 6,
+        },
+      },
+    }
+
+    const result = getStateOverwrites(params)
+    expect(result).toEqual({
+      [THRESHOLD_STORAGE_POSITION]: THRESHOLD_OVERWRITE,
+      [NONCE_STORAGE_POSITION]: toBeHex('0x6', 32),
+      [GUARD_STORAGE_POSITION]: toBeHex(ZeroAddress, 32),
+    })
+  })
+})

--- a/packages/utils/src/components/tx/security/tenderly/utils.ts
+++ b/packages/utils/src/components/tx/security/tenderly/utils.ts
@@ -13,7 +13,7 @@ import type {
   TenderlySimulation,
 } from '@safe-global/utils/components/tx/security/tenderly/types'
 import type { EnvState } from '@safe-global/store/settingsSlice'
-import { toBeHex } from 'ethers'
+import { toBeHex, ZeroAddress } from 'ethers'
 
 export const getSimulationLink = (simulationId: string): string => {
   return `https://dashboard.tenderly.co/public/${TENDERLY_ORG_NAME}/${TENDERLY_PROJECT_NAME}/simulator/${simulationId}`
@@ -115,6 +115,12 @@ const getNonceOverwrite = (params: SimulationTxParams): number | undefined => {
     return txNonce
   }
 }
+const getGuardOverwrite = (params: SimulationTxParams): string | undefined => {
+  const hasGuard = params.safe.guard?.value !== undefined && params.safe.guard.value !== ZeroAddress
+  if (hasGuard) {
+    return ZeroAddress
+  }
+}
 /* We need to overwrite the threshold stored in smart contract storage to 1
   to do a proper simulation that takes transaction guards into account.
   The threshold is stored in storage slot 4 and uses full 32 bytes slot.
@@ -123,10 +129,13 @@ const getNonceOverwrite = (params: SimulationTxParams): number | undefined => {
 export const THRESHOLD_STORAGE_POSITION = toBeHex('0x4', 32)
 export const THRESHOLD_OVERWRITE = toBeHex('0x1', 32)
 export const NONCE_STORAGE_POSITION = toBeHex('0x5', 32)
+/** keccak256("guard_manager.guard.address" */
+export const GUARD_STORAGE_POSITION = '0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8'
+
 export const getStateOverwrites = (params: SimulationTxParams) => {
   const nonceOverwrite = getNonceOverwrite(params)
   const isThresholdOverwrite = isOverwriteThreshold(params)
-
+  const guardOverwrite = getGuardOverwrite(params)
   const storageOverwrites: Record<string, string> = {} as Record<string, string>
 
   if (isThresholdOverwrite) {
@@ -134,6 +143,9 @@ export const getStateOverwrites = (params: SimulationTxParams) => {
   }
   if (nonceOverwrite !== undefined) {
     storageOverwrites[NONCE_STORAGE_POSITION] = toBeHex('0x' + BigInt(nonceOverwrite).toString(16), 32)
+  }
+  if (guardOverwrite !== undefined) {
+    storageOverwrites[GUARD_STORAGE_POSITION] = toBeHex(guardOverwrite, 32)
   }
 
   return storageOverwrites

--- a/yarn.lock
+++ b/yarn.lock
@@ -8415,6 +8415,7 @@ __metadata:
   resolution: "@safe-global/utils@workspace:packages/utils"
   dependencies:
     "@cowprotocol/app-data": "npm:^2.5.1"
+    "@faker-js/faker": "npm:^9.0.3"
     "@types/jest": "npm:^29.5.14"
     ethers: "npm:^6.13.4"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
## What it solves
Resolves https://github.com/safe-global/wallet-private-tasks/issues/226

## How this PR fixes it
When a guard is present, we overwrite the guard slot with the zero address it when simulating transactions.

## How to test it
- Setup a Safe with a Guard that blocks some transaction
- Queue a transaction that meets the blocking criteria
- Observe a successful simulation despite the guard

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
