### PR TITLE
fix(Tx flow): allow navigation for links that open in a new tab

### DIFF
--- a/apps/web/src/hooks/usePreventNavigation.ts
+++ b/apps/web/src/hooks/usePreventNavigation.ts
@@ -24,7 +24,7 @@ export function usePreventNavigation(onNavigate?: () => boolean): void {
       const href = link?.getAttribute('href')
       const targetAttr = link?.getAttribute('target')
 
-      if (!link || !href || targetAttr === '_blank') return
+      if (!link || !href || targetAttr?.toLowerCase() === '_blank') return
 
       const isAllowedToNavigate = onNavigate()
       if (isAllowedToNavigate) {

--- a/apps/web/src/hooks/usePreventNavigation.ts
+++ b/apps/web/src/hooks/usePreventNavigation.ts
@@ -22,7 +22,9 @@ export function usePreventNavigation(onNavigate?: () => boolean): void {
       const target = e.target as HTMLElement
       const link = target.closest('a')
       const href = link?.getAttribute('href')
-      if (!link || !href) return
+      const targetAttr = link?.getAttribute('target')
+
+      if (!link || !href || targetAttr === '_blank') return
 
       const isAllowedToNavigate = onNavigate()
       if (isAllowedToNavigate) {


### PR DESCRIPTION
## What it solves

Resolves [EN-118](https://linear.app/safe-global/issue/EN-118/tenderly-report-is-opened-in-the-same-tab-as-the-safe-ui)

Allow to open external links in the Tx flow.

## How this PR fixes it

Don't use "prevent navigation" logic when clicking on links with target="_blank".

## How to test it

1. Start a Tx flow, e.g. transfer token
2. Proceed until the confirm step
3. Click on any external link (Safe utils, Tx decoder, Tenderly)
5. Observe that the link opens in a new tab

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
