### PR TITLE
fix(web): yarn lint was failing

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -75,7 +75,7 @@
     "blo": "^1.1.1",
     "classnames": "^2.5.1",
     "date-fns": "^2.30.0",
-    "ethers": "^6.14.3",
+    "ethers": "6.14.3",
     "exponential-backoff": "^3.1.0",
     "firebase": "^11.1.0",
     "fuse.js": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "prettier:fix": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\""
   },
   "resolutions": {
-    "@safe-global/safe-core-sdk-types/ethers": "6.13.4",
-    "@safe-global/protocol-kit/ethers": "6.13.4",
-    "@safe-global/api-kit/ethers": "6.13.4",
-    "@gnosis.pm/zodiac/ethers": "6.13.4",
+    "@safe-global/safe-core-sdk-types/ethers": "6.14.3",
+    "@safe-global/protocol-kit/ethers": "6.14.3",
+    "@safe-global/api-kit/ethers": "6.14.3",
+    "@ledgerhq/context-module/ethers": "6.14.3",
+    "@gnosis.pm/zodiac/ethers": "6.14.3",
+    "@ledgerhq/device-signer-kit-ethereum/ethers": "6.14.3",
     "@cowprotocol/events": "1.3.0",
     "@ethersproject/signing-key/elliptic": "^6.6.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8520,7 +8520,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^5.2.1"
     eslint-plugin-storybook: "npm:^0.11.0"
     eslint-plugin-unused-imports: "npm:^4.1.4"
-    ethers: "npm:^6.14.3"
+    ethers: "npm:6.14.3"
     exponential-backoff: "npm:^3.1.0"
     fake-indexeddb: "npm:^4.0.2"
     firebase: "npm:^11.1.0"
@@ -18440,22 +18440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:6.13.4":
-  version: 6.13.4
-  resolution: "ethers@npm:6.13.4"
-  dependencies:
-    "@adraffy/ens-normalize": "npm:1.10.1"
-    "@noble/curves": "npm:1.2.0"
-    "@noble/hashes": "npm:1.3.2"
-    "@types/node": "npm:22.7.5"
-    aes-js: "npm:4.0.0-beta.5"
-    tslib: "npm:2.7.0"
-    ws: "npm:8.17.1"
-  checksum: 10/221192fed93f6b0553f3e5e72bfd667d676220577d34ff854f677e955d6f608e60636a9c08b5d54039c532a9b9b7056384f0d7019eb6e111d53175806f896ac6
-  languageName: node
-  linkType: hard
-
-"ethers@npm:^6.14.3":
+"ethers@npm:6.14.3, ethers@npm:^6.14.3":
   version: 6.14.3
   resolution: "ethers@npm:6.14.3"
   dependencies:


### PR DESCRIPTION
## What it solves
We were resolving to different versions of ethers across the project and this was causing type mismatch.

Now `yarn lint` and `yarn build` work again.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
