### PR TITLE
fix(mobile): useScan test was failing

### DIFF
--- a/apps/mobile/src/features/ImportReadOnly/hooks/useScan/useScan.test.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/hooks/useScan/useScan.test.tsx
@@ -20,6 +20,7 @@ jest.mock('react-native-vision-camera', () => ({
 
 // Mock React Navigation
 jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
   useFocusEffect: jest.fn((callback: () => (() => void) | void) => {
     mockFocusCallback = callback
     // Don't call the callback immediately - only store it for manual testing


### PR DESCRIPTION
## What it solves
The test was failing because we wanted to mock a single function, but the other functions in the navigation object were wiped out by the mock. 

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
