### PR TITLE
fix(Signing UX): show name for address of Safe itself correctly

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
@@ -1,7 +1,9 @@
-import { render, waitFor } from '@/tests/test-utils'
-import NamedAddressInfo from '.'
+import { render, waitFor, renderHook } from '@/tests/test-utils'
+import NamedAddressInfo, { useAddressName } from '.'
 import { faker } from '@faker-js/faker'
 import { getContract, type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import useSafeAddress from '@/hooks/useSafeAddress'
 
 const mockChainInfo = {
   chainId: '4',
@@ -19,8 +21,27 @@ jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
   __esModule: true,
 }))
 
+jest.mock('@/hooks/wallets/web3', () => ({
+  useWeb3ReadOnly: jest.fn(),
+}))
+
+jest.mock('@/hooks/useSafeAddress', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+
+const mockWeb3ReadOnly = useWeb3ReadOnly as jest.Mock
+const getContractMock = getContract as jest.Mock
+const useSafeAddressMock = useSafeAddress as jest.Mock
+
+const safeAddress = faker.finance.ethereumAddress()
+
 describe('NamedAddressInfo', () => {
-  const getContractMock = getContract as jest.Mock
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useSafeAddressMock.mockReturnValue(safeAddress)
+  })
+
   it('should not fetch contract info if name / logo is given', async () => {
     const result = render(
       <NamedAddressInfo
@@ -63,5 +84,162 @@ describe('NamedAddressInfo', () => {
     })
 
     expect(getContractMock).toHaveBeenCalledWith('4', address)
+  })
+
+  it('should show "This Safe Account" when address matches Safe address', async () => {
+    useSafeAddressMock.mockReturnValue(safeAddress)
+
+    const result = render(<NamedAddressInfo address={safeAddress} />, {
+      initialReduxState: {
+        chains: {
+          loading: false,
+          data: [mockChainInfo],
+        },
+      },
+    })
+
+    expect(result.getByText('This Safe Account')).toBeVisible()
+    expect(getContractMock).not.toHaveBeenCalled()
+  })
+
+  it('should not show "This Safe Account" for different addresses', async () => {
+    const differentAddress = faker.finance.ethereumAddress()
+    useSafeAddressMock.mockReturnValue(safeAddress)
+
+    const result = render(<NamedAddressInfo address={differentAddress} />, {
+      initialReduxState: {
+        chains: {
+          loading: false,
+          data: [mockChainInfo],
+        },
+      },
+    })
+
+    expect(result.queryByText('This Safe Account')).not.toBeInTheDocument()
+  })
+})
+
+describe('useAddressName', () => {
+  const address = faker.finance.ethereumAddress()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockWeb3ReadOnly.mockReturnValue({
+      getCode: jest.fn().mockResolvedValue('0x'),
+    })
+    useSafeAddressMock.mockReturnValue(safeAddress)
+  })
+
+  it('should return name and logo from props if provided', async () => {
+    const { result } = renderHook(() => useAddressName(address, 'Custom Name', 'custom-avatar.png'))
+
+    expect(result.current).toEqual({
+      name: 'Custom Name',
+      logoUri: 'custom-avatar.png',
+      isUnverifiedContract: false,
+    })
+    expect(getContractMock).not.toHaveBeenCalled()
+  })
+
+  it('should fetch and return contract info if no name provided', async () => {
+    getContractMock.mockResolvedValue({
+      displayName: 'Contract Display Name',
+      name: 'ContractName',
+      logoUri: 'contract-logo.png',
+    })
+
+    const { result } = renderHook(() => useAddressName(address))
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        name: 'Contract Display Name',
+        logoUri: 'contract-logo.png',
+        isUnverifiedContract: false,
+      })
+    })
+
+    expect(getContractMock).toHaveBeenCalledWith('4', address)
+  })
+
+  it('should handle unverified contracts', async () => {
+    getContractMock.mockRejectedValue(new Error('Contract not found'))
+    mockWeb3ReadOnly.mockReturnValue({
+      getCode: jest.fn().mockResolvedValue('0x123'), // Non-empty bytecode indicates a contract
+    })
+
+    const { result } = renderHook(() => useAddressName(address))
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        name: 'Unverified contract',
+        logoUri: undefined,
+        isUnverifiedContract: true,
+      })
+    })
+  })
+
+  it('should handle EOA addresses (not contracts)', async () => {
+    getContractMock.mockRejectedValue(new Error('Contract not found'))
+    mockWeb3ReadOnly.mockReturnValue({
+      getCode: jest.fn().mockResolvedValue('0x'), // Empty bytecode indicates EOA
+    })
+
+    const { result } = renderHook(() => useAddressName(address))
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        name: undefined,
+        logoUri: undefined,
+        isUnverifiedContract: false,
+      })
+    })
+  })
+
+  it('should handle undefined address', () => {
+    const { result } = renderHook(() => useAddressName(undefined))
+
+    expect(result.current).toEqual({
+      name: undefined,
+      logoUri: undefined,
+      isUnverifiedContract: false,
+    })
+    expect(getContractMock).not.toHaveBeenCalled()
+  })
+
+  it('should prioritize display name over contract name', async () => {
+    getContractMock.mockResolvedValue({
+      displayName: 'Display Name',
+      name: 'Contract Name',
+      logoUri: 'logo.png',
+    })
+
+    const { result } = renderHook(() => useAddressName(address))
+
+    await waitFor(() => {
+      expect(result.current.name).toBe('Display Name')
+    })
+  })
+
+  it('should fallback to contract name if display name is not available', async () => {
+    getContractMock.mockResolvedValue({
+      name: 'Contract Name',
+      logoUri: 'logo.png',
+    })
+
+    const { result } = renderHook(() => useAddressName(address))
+
+    await waitFor(() => {
+      expect(result.current.name).toBe('Contract Name')
+    })
+  })
+
+  it('should return "This Safe Account" when address matches Safe address', async () => {
+    const { result } = renderHook(() => useAddressName(safeAddress))
+
+    expect(result.current).toEqual({
+      name: 'This Safe Account',
+      logoUri: undefined,
+      isUnverifiedContract: false,
+    })
   })
 })

--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -22,10 +22,12 @@ const useIsUnverifiedContract = (address?: string, error?: Error): boolean => {
 
 export function useAddressName(address?: string, name?: string | null, customAvatar?: string) {
   const chainId = useChainId()
+  const safeAddress = useSafeAddress()
+  const displayName = sameAddress(address, safeAddress) ? 'This Safe Account' : name
 
   const [contract, error] = useAsync(
-    () => (!name && address ? getContract(chainId, address) : undefined),
-    [address, chainId, name],
+    () => (!displayName && address ? getContract(chainId, address) : undefined),
+    [address, chainId, displayName],
     false,
   )
 
@@ -34,19 +36,18 @@ export function useAddressName(address?: string, name?: string | null, customAva
   return useMemo(
     () => ({
       name:
-        name || contract?.displayName || contract?.name || (isUnverifiedContract ? 'Unverified contract' : undefined),
+        displayName ||
+        contract?.displayName ||
+        contract?.name ||
+        (isUnverifiedContract ? 'Unverified contract' : undefined),
       logoUri: customAvatar || contract?.logoUri,
       isUnverifiedContract,
     }),
-    [name, contract, customAvatar, isUnverifiedContract],
+    [displayName, contract, customAvatar, isUnverifiedContract],
   )
 }
 
 const NamedAddressInfo = ({ address, name, customAvatar, ...props }: EthHashInfoProps) => {
-  const safeAddress = useSafeAddress()
-
-  name = sameAddress(address, safeAddress) ? 'This Safe Account' : name
-
   const { name: finalName, logoUri: finalAvatar } = useAddressName(address, name, customAvatar)
 
   return <EthHashInfo address={address} name={finalName} customAvatar={finalAvatar} {...props} />


### PR DESCRIPTION
## What it solves

Resolves [WAL-5951](https://linear.app/safe-global/issue/WAL-5951/verified-on-etherscan-contracts-are-displayed-as-unverified-on-ui)

Show "This Safe Account" when address matches Safe address.

Fixes the issue where the name was shown as "Unverified contract" when the address matched the Safe address.

## How this PR fixes it

Move the address comparison with the current Safe address to the useAddressName hook to ensure that the name is always displayed correctly.

## How to test it

1. Create a transaction that is sent to the Safe itself (e.g. a change threshold transaction)
2. Proceed to the Confirm transaction step and expand the transaction details accordion
3. Observe that the "To" value in the receipt has a "This Safe Account" name tag
4. Continue to the Review step and observe the same in the receipt there
5. Sign or execute the transaction 
6. Open it in the queue
7. Observe the correct name tag in the transaction details there as well

## Screenshots

<img width="970" alt="Screenshot 2025-06-04 at 17 29 15" src="https://github.com/user-attachments/assets/0ebf9387-253b-4e0b-a33f-b045f6d87897" />

<img width="1001" alt="Screenshot 2025-06-04 at 17 28 52" src="https://github.com/user-attachments/assets/cf6c6322-5446-47e6-a5fb-fbd9237f5013" />

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
