### PR TITLE
Fix(Earn): Block earn page for undeployed safes

### DIFF
--- a/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
@@ -31,7 +31,13 @@ const getSubdirectory = (pathname: string): string => {
 
 const geoBlockedRoutes = [AppRoutes.bridge, AppRoutes.swap, AppRoutes.stake, AppRoutes.earn]
 
-const undeployedSafeBlockedRoutes = [AppRoutes.bridge, AppRoutes.swap, AppRoutes.stake, AppRoutes.apps.index]
+const undeployedSafeBlockedRoutes = [
+  AppRoutes.bridge,
+  AppRoutes.swap,
+  AppRoutes.stake,
+  AppRoutes.apps.index,
+  AppRoutes.earn,
+]
 
 const customSidebarEvents: { [key: string]: { event: any; label: string } } = {
   [AppRoutes.bridge]: { event: BRIDGE_EVENTS.OPEN_BRIDGE, label: BRIDGE_LABELS.sidebar },


### PR DESCRIPTION
## What it solves

Resolves [EN-126](https://linear.app/safe-global/issue/EN-126/kilnmorpho-earn-link-is-accesible-for-non-deployed-safes)

## How this PR fixes it

- Adds the earn page to the blocked pages for counterfactual safes

## How to test it

1. Open the app with an undeployed safe
2. Observe the Earn route is disabled

## Screenshots

<img width="524" alt="Screenshot 2025-06-04 at 19 37 17" src="https://github.com/user-attachments/assets/ca7ca812-ea50-4f75-b28c-623996a22de5" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
