### PR TITLE
chore(mobile): bump mobile version number

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -128,7 +128,7 @@ const config = {
       '@safe-global/notification-service-ios',
       {
         iosDeploymentTarget: '15.1',
-        apsEnvMode: 'development',
+        apsEnvMode: IS_DEV ? 'development' : 'production',
         appleDevTeamId: appleDevTeamId,
       },
     ],

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -7,7 +7,7 @@ const config = {
   name: IS_DEV ? 'Safe{Wallet} MVP - Development' : 'Safe{Wallet} MVP',
   slug: 'safe-mobileapp',
   owner: 'safeglobal',
-  version: '1.0.0',
+  version: '1.0.1',
   extra: {
     storybookEnabled: process.env.STORYBOOK_ENABLED,
     eas: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@safe-global/safe-wallet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "workspaces": [
     "expo-plugins/*",
     "apps/*",


### PR DESCRIPTION
## What it solves
We need to bump the version number as apple won't accept new versions with the same version number, because 1.0.0 was approved. 

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
