### PR TITLE
feat(test): add adv params verification after editing

### DIFF
--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -127,6 +127,7 @@ const enabledBulkExecuteBtnTooltip = 'All highlighted transactions will be inclu
 const bulkExecuteBtnStr = 'Bulk execute'
 
 const batchModalTitle = 'Batch'
+const gasLimit21000 = 'Gas limit must be at least 21000'
 export const swapOrder = 'Swap order settlement'
 export const bulkTxs = 'Bulk transactions'
 export const txStr = 'Transactions'
@@ -152,6 +153,13 @@ const advancedParametersValues = {
   maxFee: '0.5678',
   gasLimit: '300001',
 }
+const advancedParametersInputNames = {
+  walletNonce: 'Wallet nonce',
+  maxPriorityFee: 'Max priority fee (Gwei)',
+  maxFee: 'Max fee (Gwei)',
+  gasLimit: 'Gas limit',
+}
+
 
 // Transaction details on Tx creation
 export const txAccordionDetails = '[data-testid="decoded-tx-details"]'
@@ -780,13 +788,16 @@ export function openExecutionParamsModal() {
 
 export function verifyAndSubmitExecutionParams() {
   cy.contains(executionParamsStr).parents('form').as('Paramsform')
-  const arrayNames = ['Wallet nonce', 'Max priority fee (Gwei)', 'Max fee (Gwei)', 'Gas limit']
+  const arrayNames = [advancedParametersInputNames.walletNonce,
+  advancedParametersInputNames.maxPriorityFee,
+  advancedParametersInputNames.maxFee,
+  advancedParametersInputNames.gasLimit]
   arrayNames.forEach((element) => {
     cy.get('@Paramsform').find('label').contains(`${element}`).next().find('input').should('not.be.disabled')
   })
 
   cy.get('@Paramsform').find(gasLimitInput).clear().type('100').invoke('prop', 'value').should('equal', '100')
-  cy.contains('Gas limit must be at least 21000').should('be.visible')
+  cy.contains(gasLimit21000).should('be.visible')
   cy.get('@Paramsform').find(gasLimitInput).clear().type('300000').invoke('prop', 'value').should('equal', '300000')
   cy.get('@Paramsform').find(gasLimitInput).parent('div').find(rotateLeftIcon).click()
   cy.get('@Paramsform').submit()
@@ -794,10 +805,6 @@ export function verifyAndSubmitExecutionParams() {
 
 export function setAdvncedExecutionParams() {
   cy.contains(executionParamsStr).parents('form').as('Paramsform')
-  const arrayNames = ['Wallet nonce', 'Max priority fee (Gwei)', 'Max fee (Gwei)', 'Gas limit']
-  arrayNames.forEach((element) => {
-    cy.get('@Paramsform').find('label').contains(`${element}`).next().find('input').should('not.be.disabled')
-  })
   cy.get('@Paramsform').find(gasLimitInput).clear().type(advancedParametersValues.gasLimit)
   cy.get('@Paramsform').find(maxPriorityFee).clear().type(advancedParametersValues.maxPriorityFee)
   cy.get('@Paramsform').find(maxFee).clear().type(advancedParametersValues.maxFee)
@@ -806,10 +813,10 @@ export function setAdvncedExecutionParams() {
 }
 
 export function verifyEditedExutionParams() {
-  cy.contains('Wallet nonce').next().should('contain', advancedParametersValues.walletNonce)
-  cy.contains('Gas limit').next().should('contain', advancedParametersValues.gasLimit)
-  cy.contains('Max priority fee (Gwei)').next().should('contain', advancedParametersValues.maxPriorityFee)
-  cy.contains('Max fee (Gwei)').next().should('contain', advancedParametersValues.maxFee)
+  cy.contains(advancedParametersInputNames.walletNonce).next().should('contain', advancedParametersValues.walletNonce)
+  cy.contains(advancedParametersInputNames.gasLimit).next().should('contain', advancedParametersValues.gasLimit)
+  cy.contains(advancedParametersInputNames.maxPriorityFee).next().should('contain', advancedParametersValues.maxPriorityFee)
+  cy.contains(advancedParametersInputNames.maxFee).next().should('contain', advancedParametersValues.maxFee)
 }
 
 export function clickOnNoLaterOption() {

--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -777,12 +777,12 @@ export function clickOnYesOption() {
   cy.contains(yesStr).should('exist').click()
 }
 
-export function displayAdvncedDetails() {
+export function displayAdvancedDetails() {
   cy.contains(estimatedFeeStr).click()
 }
 
 export function openExecutionParamsModal() {
-  displayAdvncedDetails()
+  displayAdvancedDetails()
   cy.contains(editBtnStr).click()
 }
 
@@ -803,7 +803,7 @@ export function verifyAndSubmitExecutionParams() {
   cy.get('@Paramsform').submit()
 }
 
-export function setAdvncedExecutionParams() {
+export function setAdvancedExecutionParams() {
   cy.contains(executionParamsStr).parents('form').as('Paramsform')
   cy.get('@Paramsform').find(gasLimitInput).clear().type(advancedParametersValues.gasLimit)
   cy.get('@Paramsform').find(maxPriorityFee).clear().type(advancedParametersValues.maxPriorityFee)
@@ -812,7 +812,7 @@ export function setAdvncedExecutionParams() {
   cy.get('@Paramsform').submit()
 }
 
-export function verifyEditedExutionParams() {
+export function verifyEditedExcutionParams() {
   cy.contains(advancedParametersInputNames.walletNonce).next().should('contain', advancedParametersValues.walletNonce)
   cy.contains(advancedParametersInputNames.gasLimit).next().should('contain', advancedParametersValues.gasLimit)
   cy.contains(advancedParametersInputNames.maxPriorityFee).next().should('contain', advancedParametersValues.maxPriorityFee)

--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -13,7 +13,10 @@ const tokenAddressInput = 'input[name="recipients.0.tokenAddress"]'
 const amountInput = 'input[name="recipients.0.amount"]'
 const amountInput_ = (index) => `input[name="recipients.${index}.amount"]`
 const nonceInput = 'input[name="nonce"]'
+const walletNonceInput = '[name="userNonce"]'
 const gasLimitInput = '[name="gasLimit"]'
+const maxPriorityFee = '[name="maxPriorityFeePerGas"]'
+const maxFee = '[name="maxFeePerGas"]'
 const rotateLeftIcon = '[data-testid="RotateLeftIcon"]'
 export const transactionItem = '[data-testid="transaction-item"]'
 export const connectedWalletExecMethod = '[data-testid="connected-wallet-execution-method"]'
@@ -141,6 +144,13 @@ const comboButtonOptions = {
   sign: 'Sign',
   execute: 'Execute',
   addToBatch: 'Add to batch',
+}
+
+const advancedParametersValues = {
+  walletNonce: '5500',
+  maxPriorityFee: '0.1234',
+  maxFee: '0.5678',
+  gasLimit: '300001',
 }
 
 // Transaction details on Tx creation
@@ -759,8 +769,12 @@ export function clickOnYesOption() {
   cy.contains(yesStr).should('exist').click()
 }
 
-export function openExecutionParamsModal() {
+export function displayAdvncedDetails() {
   cy.contains(estimatedFeeStr).click()
+}
+
+export function openExecutionParamsModal() {
+  displayAdvncedDetails()
   cy.contains(editBtnStr).click()
 }
 
@@ -776,6 +790,26 @@ export function verifyAndSubmitExecutionParams() {
   cy.get('@Paramsform').find(gasLimitInput).clear().type('300000').invoke('prop', 'value').should('equal', '300000')
   cy.get('@Paramsform').find(gasLimitInput).parent('div').find(rotateLeftIcon).click()
   cy.get('@Paramsform').submit()
+}
+
+export function setAdvncedExecutionParams() {
+  cy.contains(executionParamsStr).parents('form').as('Paramsform')
+  const arrayNames = ['Wallet nonce', 'Max priority fee (Gwei)', 'Max fee (Gwei)', 'Gas limit']
+  arrayNames.forEach((element) => {
+    cy.get('@Paramsform').find('label').contains(`${element}`).next().find('input').should('not.be.disabled')
+  })
+  cy.get('@Paramsform').find(gasLimitInput).clear().type(advancedParametersValues.gasLimit)
+  cy.get('@Paramsform').find(maxPriorityFee).clear().type(advancedParametersValues.maxPriorityFee)
+  cy.get('@Paramsform').find(maxFee).clear().type(advancedParametersValues.maxFee)
+  cy.get('@Paramsform').find(walletNonceInput).clear().type(advancedParametersValues.walletNonce)
+  cy.get('@Paramsform').submit()
+}
+
+export function verifyEditedExutionParams() {
+  cy.contains('Wallet nonce').next().should('contain', advancedParametersValues.walletNonce)
+  cy.contains('Gas limit').next().should('contain', advancedParametersValues.gasLimit)
+  cy.contains('Max priority fee (Gwei)').next().should('contain', advancedParametersValues.maxPriorityFee)
+  cy.contains('Max fee (Gwei)').next().should('contain', advancedParametersValues.maxFee)
 }
 
 export function clickOnNoLaterOption() {

--- a/apps/web/cypress/e2e/regression/create_tx_2.cy.js
+++ b/apps/web/cypress/e2e/regression/create_tx_2.cy.js
@@ -28,8 +28,8 @@ describe('Create transactions tests 2', () => {
     createtx.clickOnNewtransactionBtn()
     createtx.clickOnSendTokensBtn()
   })
-  //TODO: Create test to edit fee and max fee and check those are saved correctly
-  it('Verify advance parameters gas limit input', () => {
+
+  it('Verify advance parameters are saved after editing', () => {
     happyPathToStepTwo()
     createtx.changeNonce('5')
     createtx.clickOnContinueSignTransactionBtn()
@@ -37,6 +37,20 @@ describe('Create transactions tests 2', () => {
     createtx.selectCurrentWallet()
     createtx.openExecutionParamsModal()
     createtx.verifyAndSubmitExecutionParams()
+    createtx.verifyExecutionParamsSaved()
+  }
+  )
+
+  it('Verify advance parameters gas limit input', () => {
+    happyPathToStepTwo()
+    createtx.changeNonce('5')
+    createtx.clickOnContinueSignTransactionBtn()
+    createtx.selectComboButtonOption('execute')
+    createtx.selectCurrentWallet()
+    createtx.openExecutionParamsModal()
+    createtx.setAdvncedExecutionParams()
+    createtx.displayAdvncedDetails()
+    createtx.verifyEditedExutionParams()
   })
 
   it('Verify a transaction shows relayer attempts', () => {

--- a/apps/web/cypress/e2e/regression/create_tx_2.cy.js
+++ b/apps/web/cypress/e2e/regression/create_tx_2.cy.js
@@ -36,8 +36,9 @@ describe('Create transactions tests 2', () => {
     createtx.selectComboButtonOption('execute')
     createtx.selectCurrentWallet()
     createtx.openExecutionParamsModal()
-    createtx.verifyAndSubmitExecutionParams()
-    createtx.verifyExecutionParamsSaved()
+    createtx.setAdvncedExecutionParams()
+    createtx.displayAdvncedDetails()
+    createtx.verifyEditedExutionParams()
   }
   )
 
@@ -48,9 +49,7 @@ describe('Create transactions tests 2', () => {
     createtx.selectComboButtonOption('execute')
     createtx.selectCurrentWallet()
     createtx.openExecutionParamsModal()
-    createtx.setAdvncedExecutionParams()
-    createtx.displayAdvncedDetails()
-    createtx.verifyEditedExutionParams()
+    createtx.verifyAndSubmitExecutionParams()
   })
 
   it('Verify a transaction shows relayer attempts', () => {


### PR DESCRIPTION
## What it solves
Adds a test that was not being done. Checks that the values edited in adv params are correctly saved after submiting the form

## How this PR fixes it
Adds the scenario Verify advance parameters are saved after editing
Creates a new function to set the values and submit and one to get the values once they are set

## How to test it
Run the test create_tx_2.ts and all test should pass

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
