### PR TITLE
fix(test): fix counting external links 

### DIFF
--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -89,6 +89,7 @@ const recipientsCount = '[data-testid="recipients-count"]'
 const maxBtn = '[data-testid="max-btn"]'
 const tokenAmountSection = '[data-testid="token-amount-section"]'
 const insufficientBalanceError = '[data-testid="insufficient-balance-error"]'
+const signerList = '[data-testid="signer-list"]'
 
 const insufficientFundsErrorStr = 'Insufficient funds'
 const viewTransactionBtn = 'View transaction'
@@ -438,7 +439,7 @@ export function verifyNumberOfCopyIcons(number) {
 }
 
 export function verifyNumberOfExternalLinks(number) {
-  cy.get(explorerBtn)
+  cy.get(signerList).find(explorerBtn)
     //.parent()
     // .parent()
     // .next()

--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -439,7 +439,7 @@ export function verifyNumberOfCopyIcons(number) {
 }
 
 export function verifyNumberOfExternalLinks(number) {
-  cy.get(signerList).find(explorerBtn)
+  cy.get('main').find(explorerBtn)
     //.parent()
     // .parent()
     // .next()

--- a/apps/web/cypress/e2e/regression/spending_limits.cy.js
+++ b/apps/web/cypress/e2e/regression/spending_limits.cy.js
@@ -171,7 +171,7 @@ describe('Spending limits tests', () => {
       })
   })
 
-  it('Verify explorer links contain Sepolia link', () => {
+  it.only('Verify explorer links contain Sepolia link', () => {
     tx.verifyNumberOfExternalLinks(3)
   })
 })

--- a/apps/web/cypress/e2e/regression/spending_limits.cy.js
+++ b/apps/web/cypress/e2e/regression/spending_limits.cy.js
@@ -171,7 +171,7 @@ describe('Spending limits tests', () => {
       })
   })
 
-  it.only('Verify explorer links contain Sepolia link', () => {
+  it('Verify explorer links contain Sepolia link', () => {
     tx.verifyNumberOfExternalLinks(3)
   })
 })


### PR DESCRIPTION
## What it solves
The test counts the amount of external links. The system wasn't finding them

## How this PR fixes it
Makes the system search in the signers list

## How to test it
Run Spending_limit test. The scenario "Verify explorer links contain Sepolia link" should pass

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
