### PR TITLE
fix(test): fix token selection in the tx form

### DIFF
--- a/apps/web/cypress/e2e/pages/spending_limits.pages.js
+++ b/apps/web/cypress/e2e/pages/spending_limits.pages.js
@@ -94,7 +94,7 @@ export function verifyMandatoryTokensExist() {
 
 export function selectToken(token) {
   clickOnTokenDropdown()
-  cy.get(tokenItem).contains(token).click()
+  cy.get(tokenItem).contains(token).click({ force: true })
   main.verifyValuesExist(tokenBalance, [token])
 }
 


### PR DESCRIPTION
## How this PR fixes it
Adds a {force:true} to make the click work

## How to test it
Run spending_limit test in the regression folder. the scenario "Verify selecting a native token from the dropdown in new tx" should pass

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
