### PR TITLE
feat(Proposer): prevent adding owners as proposer

### DIFF
--- a/apps/web/src/features/proposers/components/UpsertProposer.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.tsx
@@ -14,7 +14,7 @@ import { useAppDispatch } from '@/store'
 import { useAddProposerMutation } from '@/store/api/gateway'
 import { showNotification } from '@/store/notificationsSlice'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
-import { addressIsNotCurrentSafe } from '@safe-global/utils/utils/validation'
+import { addressIsNotCurrentSafe, addressIsNotOwner } from '@safe-global/utils/utils/validation'
 import { isEthSignWallet } from '@/utils/wallets'
 import { Close } from '@mui/icons-material'
 import {
@@ -31,8 +31,9 @@ import {
   Typography,
 } from '@mui/material'
 import type { Delegate } from '@safe-global/safe-gateway-typescript-sdk/dist/types/delegates'
-import { type BaseSyntheticEvent, useState } from 'react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { type BaseSyntheticEvent, useCallback, useState } from 'react'
+import { FormProvider, useForm, type Validate } from 'react-hook-form'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 type UpsertProposerProps = {
   onClose: () => void
@@ -59,6 +60,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
   const chainId = useChainId()
   const wallet = useWallet()
   const safeAddress = useSafeAddress()
+  const { safe } = useSafeInfo()
 
   const methods = useForm<ProposerEntry>({
     defaultValues: {
@@ -68,7 +70,15 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
     mode: 'onChange',
   })
 
-  const notCurrentSafe = addressIsNotCurrentSafe(safeAddress, 'Cannot add Safe Account itself as proposer')
+  const validateAddress = useCallback<Validate<string>>(
+    (value) =>
+      addressIsNotCurrentSafe(safeAddress, 'Cannot add Safe Account itself as proposer')(value) ??
+      addressIsNotOwner(
+        safe.owners.map((owner) => owner.value),
+        'Cannot add Safe Owner as proposer',
+      )(value),
+    [safe.owners, safeAddress],
+  )
 
   const { handleSubmit, formState } = methods
 
@@ -171,7 +181,7 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
                 <AddressBookInput
                   name="address"
                   label="Address"
-                  validate={notCurrentSafe}
+                  validate={validateAddress}
                   variant="outlined"
                   fullWidth
                   required

--- a/apps/web/src/features/proposers/components/UpsertProposer.tsx
+++ b/apps/web/src/features/proposers/components/UpsertProposer.tsx
@@ -31,7 +31,7 @@ import {
   Typography,
 } from '@mui/material'
 import type { Delegate } from '@safe-global/safe-gateway-typescript-sdk/dist/types/delegates'
-import { type BaseSyntheticEvent, useCallback, useState } from 'react'
+import { type BaseSyntheticEvent, useCallback, useMemo, useState } from 'react'
 import { FormProvider, useForm, type Validate } from 'react-hook-form'
 import useSafeInfo from '@/hooks/useSafeInfo'
 
@@ -70,14 +70,13 @@ const UpsertProposer = ({ onClose, onSuccess, proposer }: UpsertProposerProps) =
     mode: 'onChange',
   })
 
+  const safeOwnerAddresses = useMemo(() => safe.owners.map((owner) => owner.value), [safe.owners])
+
   const validateAddress = useCallback<Validate<string>>(
     (value) =>
       addressIsNotCurrentSafe(safeAddress, 'Cannot add Safe Account itself as proposer')(value) ??
-      addressIsNotOwner(
-        safe.owners.map((owner) => owner.value),
-        'Cannot add Safe Owner as proposer',
-      )(value),
-    [safe.owners, safeAddress],
+      addressIsNotOwner(safeOwnerAddresses, 'Cannot add Safe Owner as proposer')(value),
+    [safeAddress, safeOwnerAddresses],
   )
 
   const { handleSubmit, formState } = methods


### PR DESCRIPTION
## What it solves

Resolves [EN-91](https://linear.app/safe-global/issue/EN-97/dont-allow-to-add-an-owner-as-a-delegate)

## How this PR fixes it

Extended address validation in "Add proposer" to prevent adding a Safe owner as proposer.

## How to test it

1. Go to Safe settings and click "Add proposer"
2. Enter the address of an existing Safe owner
3. Observe a validation error:
    > Cannot add Safe Owner as proposer

## Screenshots
<img width="654" alt="Screenshot 2025-06-10 at 13 02 21" src="https://github.com/user-attachments/assets/382c162f-7489-46af-a6fe-47b3452fc189" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
