### PR TITLE
Fix(Dashboard): Update dashboard assets layout

### DIFF
--- a/apps/web/src/components/balances/AssetsTable/FiatChange.tsx
+++ b/apps/web/src/components/balances/AssetsTable/FiatChange.tsx
@@ -4,7 +4,7 @@ import { formatPercentage } from '@safe-global/utils/utils/formatters'
 import ArrowDown from '@/public/images/balances/change-down.svg'
 import ArrowUp from '@/public/images/balances/change-up.svg'
 
-export const FiatChange = ({ balanceItem }: { balanceItem: Balance }) => {
+export const FiatChange = ({ balanceItem, inline = false }: { balanceItem: Balance; inline?: boolean }) => {
   if (!balanceItem.fiatBalance24hChange) {
     return (
       <Typography variant="caption" color="text.secondary" paddingLeft={3} display="block">
@@ -26,9 +26,11 @@ export const FiatChange = ({ balanceItem }: { balanceItem: Balance }) => {
       <Chip
         size="small"
         sx={{
-          backgroundColor,
+          backgroundColor: inline ? 'transparent' : backgroundColor,
           color,
-          padding: '2px 8px',
+          padding: inline ? '0' : '2px 8px',
+          height: inline ? '20px' : 'inherit',
+          '& .MuiChip-label': { pr: inline ? 0 : 1 },
         }}
         label={changeLabel}
         icon={

--- a/apps/web/src/components/balances/AssetsTable/SendButton.tsx
+++ b/apps/web/src/components/balances/AssetsTable/SendButton.tsx
@@ -9,7 +9,7 @@ import { ASSETS_EVENTS } from '@/services/analytics/events/assets'
 import { TokenTransferFlow } from '@/components/tx-flow/flows'
 import { TxModalContext } from '@/components/tx-flow'
 
-const SendButton = ({ tokenInfo, isOutlined }: { tokenInfo: TokenInfo; isOutlined?: boolean }) => {
+const SendButton = ({ tokenInfo, light }: { tokenInfo: TokenInfo; light?: boolean }) => {
   const spendingLimit = useSpendingLimit(tokenInfo)
   const { setTxFlow } = useContext(TxModalContext)
 
@@ -23,9 +23,9 @@ const SendButton = ({ tokenInfo, isOutlined }: { tokenInfo: TokenInfo; isOutline
         <Track {...ASSETS_EVENTS.SEND}>
           <Button
             data-testid="send-button"
-            variant={isOutlined ? 'outlined' : 'contained'}
-            color="primary"
-            size="small"
+            variant="contained"
+            color={light ? 'background.paper' : 'primary'}
+            size="compact"
             startIcon={<ArrowIconNW />}
             onClick={onSendClick}
             disabled={!isOk}

--- a/apps/web/src/components/dashboard/Assets/index.tsx
+++ b/apps/web/src/components/dashboard/Assets/index.tsx
@@ -26,6 +26,7 @@ import StakeButton from '@/features/stake/components/StakeButton'
 import { STAKE_LABELS } from '@/services/analytics/events/stake'
 import useIsStakingFeatureEnabled from '@/features/stake/hooks/useIsStakingFeatureEnabled'
 import { formatPercentage } from '@safe-global/utils/utils/formatters'
+import { percentageOfTotal } from '@safe-global/utils/utils/formatNumber'
 
 const MAX_ASSETS = 5
 
@@ -70,9 +71,8 @@ const AssetRow = ({
   showEarn?: boolean
   showStake?: boolean
 }) => {
-  const fiatTotalNumber = Number(fiatTotal)
-  const percentageOfTotal = Number(item.fiatBalance) / fiatTotalNumber
-  const percentage = formatPercentage(percentageOfTotal)
+  const assetPercentage = percentageOfTotal(item.fiatBalance, fiatTotal)
+  const readablePercentage = formatPercentage(assetPercentage)
 
   return (
     <Box className={css.container} key={item.tokenInfo.address}>
@@ -88,9 +88,9 @@ const AssetRow = ({
 
       <Stack display={['none', 'flex']} direction="row" alignItems="center" gap={1}>
         <Box className={css.bar}>
-          <Typography className={css.barPercentage} component="span" width={`${percentageOfTotal * 100}%`} />
+          <Typography className={css.barPercentage} component="span" width={`${assetPercentage * 100}%`} />
         </Box>
-        <Typography variant="body2">{percentage}</Typography>
+        <Typography variant="body2">{readablePercentage}</Typography>
       </Stack>
 
       <Box flex={1} display="block" textAlign="right">

--- a/apps/web/src/components/dashboard/Assets/index.tsx
+++ b/apps/web/src/components/dashboard/Assets/index.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react'
-import { Box, Skeleton, Typography, Paper } from '@mui/material'
+import { Box, Skeleton, Typography, Paper, Card, Stack } from '@mui/material'
 import useBalances from '@/hooks/useBalances'
 import TokenAmount from '@/components/common/TokenAmount'
 import SwapButton from '@/features/swap/components/SwapButton'
 import { AppRoutes } from '@/config/routes'
-import { WidgetContainer, WidgetBody, ViewAllLink } from '../styled'
+import { ViewAllLink } from '../styled'
 import css from '../PendingTxs/styles.module.css'
 import { useRouter } from 'next/router'
 import { SWAP_LABELS } from '@/services/analytics/events/swaps'
@@ -20,6 +20,12 @@ import EarnButton from '@/features/earn/components/EarnButton'
 import { EARN_LABELS } from '@/services/analytics/events/earn'
 import useIsEarnFeatureEnabled from '@/features/earn/hooks/useIsEarnFeatureEnabled'
 import useChainId from '@/hooks/useChainId'
+import TokenIcon from '@/components/common/TokenIcon'
+import { TokenType } from '@safe-global/safe-gateway-typescript-sdk'
+import StakeButton from '@/features/stake/components/StakeButton'
+import { STAKE_LABELS } from '@/services/analytics/events/stake'
+import useIsStakingFeatureEnabled from '@/features/stake/hooks/useIsStakingFeatureEnabled'
+import { formatPercentage } from '@safe-global/utils/utils/formatters'
 
 const MAX_ASSETS = 5
 
@@ -50,64 +56,84 @@ const NoAssets = () => (
 )
 
 const AssetRow = ({
+  fiatTotal,
   item,
   chainId,
   showSwap,
   showEarn,
+  showStake,
 }: {
+  fiatTotal: string
   item: Balances['items'][number]
   chainId: string
   showSwap?: boolean
   showEarn?: boolean
-}) => (
-  <Box className={css.container} key={item.tokenInfo.address}>
-    <Box flex={1}>
-      <TokenAmount
-        value={item.balance}
-        decimals={item.tokenInfo.decimals}
-        tokenSymbol={item.tokenInfo.symbol}
-        logoUri={item.tokenInfo.logoUri}
-      />
-    </Box>
+  showStake?: boolean
+}) => {
+  const fiatTotalNumber = Number(fiatTotal)
+  const percentageOfTotal = Number(item.fiatBalance) / fiatTotalNumber
+  const percentage = formatPercentage(percentageOfTotal)
 
-    {showEarn && isEligibleEarnToken(chainId, item.tokenInfo.address) && (
-      <Box>
-        <EarnButton tokenInfo={item.tokenInfo} trackingLabel={EARN_LABELS.dashboard_asset} />
+  return (
+    <Box className={css.container} key={item.tokenInfo.address}>
+      <Stack direction="row" gap={1.5} alignItems="center">
+        <TokenIcon tokenSymbol={item.tokenInfo.symbol} logoUri={item.tokenInfo.logoUri ?? undefined} size={32} />
+        <Box>
+          <Typography>{item.tokenInfo.name}</Typography>
+          <Typography variant="body2" className={css.tokenAmount}>
+            <TokenAmount value={item.balance} decimals={item.tokenInfo.decimals} tokenSymbol={item.tokenInfo.symbol} />
+          </Typography>
+        </Box>
+      </Stack>
+
+      <Stack display={['none', 'flex']} direction="row" alignItems="center" gap={1}>
+        <Box className={css.bar}>
+          <Typography className={css.barPercentage} component="span" width={`${percentageOfTotal * 100}%`} />
+        </Box>
+        <Typography variant="body2">{percentage}</Typography>
+      </Stack>
+
+      <Box flex={1} display="block" textAlign="right">
+        <FiatBalance balanceItem={item} />
+        <FiatChange balanceItem={item} inline />
       </Box>
-    )}
 
-    <Box flex={1} display={['none', 'block']} textAlign="right">
-      <FiatBalance balanceItem={item} />
+      <Box className={css.assetButtons}>
+        {showSwap ? (
+          <SwapButton tokenInfo={item.tokenInfo} amount="0" trackingLabel={SWAP_LABELS.dashboard_assets} light />
+        ) : (
+          <SendButton tokenInfo={item.tokenInfo} light />
+        )}
+
+        {showEarn && isEligibleEarnToken(chainId, item.tokenInfo.address) && (
+          <EarnButton tokenInfo={item.tokenInfo} trackingLabel={EARN_LABELS.dashboard_asset} compact={false} />
+        )}
+
+        {showStake && item.tokenInfo.type === TokenType.NATIVE_TOKEN && (
+          <StakeButton tokenInfo={item.tokenInfo} trackingLabel={STAKE_LABELS.asset} compact={false} />
+        )}
+      </Box>
     </Box>
+  )
+}
 
-    <Box display={['none', 'block']} textAlign="right">
-      <FiatChange balanceItem={item} />
-    </Box>
-
-    <Box my={-0.7}>
-      {showSwap ? (
-        <SwapButton tokenInfo={item.tokenInfo} amount="0" trackingLabel={SWAP_LABELS.dashboard_assets} />
-      ) : (
-        <SendButton tokenInfo={item.tokenInfo} isOutlined />
-      )}
-    </Box>
-  </Box>
-)
-
-const AssetList = ({ items }: { items: Balances['items'] }) => {
+const AssetList = ({ items, fiatTotal }: { items: Balances['items']; fiatTotal: string }) => {
   const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
   const isEarnFeatureEnabled = useIsEarnFeatureEnabled()
+  const isStakingFeatureEnabled = useIsStakingFeatureEnabled()
   const chainId = useChainId()
 
   return (
-    <Box display="flex" flexDirection="column" gap={1}>
+    <Box display="flex" flexDirection="column">
       {items.map((item) => (
         <AssetRow
+          fiatTotal={fiatTotal}
           item={item}
           key={item.tokenInfo.address}
           chainId={chainId}
           showSwap={isSwapFeatureEnabled}
           showEarn={isEarnFeatureEnabled}
+          showStake={isStakingFeatureEnabled}
         />
       ))}
     </Box>
@@ -119,7 +145,7 @@ const isNonZeroBalance = (item: Balances['items'][number]) => item.balance !== '
 const AssetsWidget = () => {
   const router = useRouter()
   const { safe } = router.query
-  const { loading } = useBalances()
+  const { loading, balances } = useBalances()
   const visibleAssets = useVisibleAssets()
 
   const items = useMemo(() => {
@@ -135,19 +161,23 @@ const AssetsWidget = () => {
   )
 
   return (
-    <WidgetContainer data-testid="assets-widget">
-      <div className={css.title}>
-        <Typography component="h2" variant="subtitle1" fontWeight={700} mb={2}>
-          Top assets
-        </Typography>
+    <Card data-testid="assets-widget" sx={{ px: 1.5, py: 2.5 }}>
+      <Stack direction="row" justifyContent="space-between" sx={{ px: 1.5, mb: 1 }}>
+        <Typography fontWeight={700}>Top assets</Typography>
 
         {items.length > 0 && <ViewAllLink url={viewAllUrl} text={`View all (${visibleAssets.length})`} />}
-      </div>
+      </Stack>
 
-      <WidgetBody>
-        {loading ? <AssetsDummy /> : items.length > 0 ? <AssetList items={items} /> : <NoAssets />}
-      </WidgetBody>
-    </WidgetContainer>
+      <Box>
+        {loading ? (
+          <AssetsDummy />
+        ) : items.length > 0 ? (
+          <AssetList items={items} fiatTotal={balances.fiatTotal} />
+        ) : (
+          <NoAssets />
+        )}
+      </Box>
+    </Card>
   )
 }
 

--- a/apps/web/src/components/dashboard/PendingTxs/styles.module.css
+++ b/apps/web/src/components/dashboard/PendingTxs/styles.module.css
@@ -2,14 +2,16 @@
   width: 100%;
   padding: 11px 16px;
   background-color: var(--color-background-paper);
-  border: 1px solid var(--color-background-paper);
   border-radius: 8px;
   flex-wrap: nowrap;
-  display: flex;
+  display: grid;
+  grid-template-columns: 200px 1fr 1fr;
   align-items: center;
   gap: var(--space-2);
   min-height: 50px;
+  position: relative;
 }
+
 .innerContainer {
   min-width: 0;
   flex-grow: 1;
@@ -19,9 +21,14 @@
   align-items: center;
   gap: var(--space-2);
 }
+
 .container:hover {
-  background-color: var(--color-background-light);
-  border-color: var(--color-secondary-light);
+  background-color: var(--color-background-main);
+}
+
+.tokenAmount * {
+  font-weight: normal;
+  color: var(--color-primary-light);
 }
 
 .list {
@@ -41,10 +48,46 @@
   justify-content: space-between;
 }
 
+.assetButtons {
+  position: absolute;
+  right: 16px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s;
+  background-color: var(--color-background-main);
+  border-radius: var(--space-1);
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  width: calc(100% - 200px);
+}
+
+.container:hover .assetButtons {
+  opacity: 1;
+  visibility: visible;
+}
+
+.bar {
+  height: 4px;
+  border-radius: 4px;
+  background-color: var(--color-border-light);
+  width: 100px;
+}
+
+.barPercentage {
+  display: block;
+  border-radius: 4px;
+  height: 100%;
+  background: linear-gradient(225deg, #5FDDFF 12.5%, #12FF80 88.07%);
+}
+
 @media (max-width: 600px) {
   .container {
     flex-direction: column;
     align-items: start;
     flex-wrap: wrap;
+    grid-template-columns: 1fr 1fr;
   }
 }

--- a/apps/web/src/components/dashboard/styled.tsx
+++ b/apps/web/src/components/dashboard/styled.tsx
@@ -11,10 +11,6 @@ export const WidgetContainer = styled.section`
   height: 100%;
 `
 
-export const WidgetTitle = styled.h2`
-  margin-top: 0;
-`
-
 export const WidgetBody = styled.div`
   display: flex;
   flex-direction: column;
@@ -37,20 +33,22 @@ export const Card = styled.div`
   }
 `
 
-const StyledLink = styled(Link)`
-  text-decoration: none;
-  font-weight: bold;
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-  margin-bottom: 10px;
-  padding-right: 17px;
-`
-
 export const ViewAllLink = ({ url, text }: { url: LinkProps['href']; text?: string }): ReactElement => (
   <NextLink href={url} passHref legacyBehavior>
-    <StyledLink data-testid="view-all-link">
-      {text || 'View all'} <ChevronRightIcon />
-    </StyledLink>
+    <Link
+      data-testid="view-all-link"
+      sx={{
+        textDecoration: 'none',
+        fontWeight: 'bold',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        color: 'primary.light',
+        fontSize: '14px',
+        '&:hover': { color: 'primary.main' },
+      }}
+    >
+      {text || 'View all'} <ChevronRightIcon fontSize="small" />
+    </Link>
   </NextLink>
 )

--- a/apps/web/src/components/theme/safeTheme.ts
+++ b/apps/web/src/components/theme/safeTheme.ts
@@ -55,6 +55,7 @@ declare module '@mui/material/Button' {
   export interface ButtonPropsColorOverrides {
     background: true
     static: true
+    'background.paper': true
   }
 
   export interface ButtonPropsVariantOverrides {
@@ -113,6 +114,16 @@ const createSafeTheme = (mode: PaletteMode): Theme => {
             style: {
               padding: '12px 48px',
             },
+          },
+          {
+            props: { color: 'background.paper' },
+            style: ({ theme }) => ({
+              backgroundColor: theme.palette.background.paper,
+              color: theme.palette.text.primary,
+              '&:hover': {
+                backgroundColor: theme.palette.background.light,
+              },
+            }),
           },
           {
             props: { variant: 'danger' },

--- a/apps/web/src/features/earn/components/EarnButton/index.tsx
+++ b/apps/web/src/features/earn/components/EarnButton/index.tsx
@@ -15,9 +15,11 @@ import classnames from 'classnames'
 const EarnButton = ({
   tokenInfo,
   trackingLabel,
+  compact = true,
 }: {
   tokenInfo: TokenInfo
   trackingLabel: EARN_LABELS
+  compact?: boolean
 }): ReactElement => {
   const spendingLimit = useSpendingLimit(tokenInfo)
   const chain = useCurrentChain()
@@ -38,12 +40,13 @@ const EarnButton = ({
       {(isOk) => (
         <Track {...EARN_EVENTS.OPEN_EARN_PAGE} label={trackingLabel}>
           <Button
-            className={classnames(css.button, { [css.buttonDisabled]: !isOk })}
+            className={classnames({ [css.button]: compact, [css.buttonDisabled]: !isOk })}
             data-testid="earn-btn"
             aria-label="Earn"
-            variant="text"
-            color="info"
-            size="small"
+            variant={compact ? 'text' : 'contained'}
+            color={compact ? 'info' : 'background.paper'}
+            size={compact ? 'small' : 'compact'}
+            disableElevation
             startIcon={<EarnIcon />}
             onClick={onEarnClick}
             disabled={!isOk}

--- a/apps/web/src/features/stake/components/StakeButton/index.tsx
+++ b/apps/web/src/features/stake/components/StakeButton/index.tsx
@@ -17,9 +17,11 @@ import classnames from 'classnames'
 const StakeButton = ({
   tokenInfo,
   trackingLabel,
+  compact = true,
 }: {
   tokenInfo: TokenInfo
   trackingLabel: STAKE_LABELS
+  compact?: boolean
 }): ReactElement => {
   const spendingLimit = useSpendingLimit(tokenInfo)
   const chain = useCurrentChain()
@@ -30,12 +32,13 @@ const StakeButton = ({
       {(isOk) => (
         <Track {...STAKE_EVENTS.OPEN_STAKE} label={trackingLabel}>
           <Button
-            className={classnames(css.button, { [css.buttonDisabled]: !isOk })}
+            className={classnames({ [css.button]: compact, [css.buttonDisabled]: !isOk })}
             data-testid="stake-btn"
             aria-label="Stake"
-            variant="text"
-            color="info"
-            size="small"
+            variant={compact ? 'text' : 'contained'}
+            color={compact ? 'info' : 'background.paper'}
+            size={compact ? 'small' : 'compact'}
+            disableElevation
             startIcon={<StakeIcon />}
             onClick={() => {
               router.push({

--- a/apps/web/src/features/swap/components/SwapButton/index.tsx
+++ b/apps/web/src/features/swap/components/SwapButton/index.tsx
@@ -14,10 +14,12 @@ const SwapButton = ({
   tokenInfo,
   amount,
   trackingLabel,
+  light = false,
 }: {
   tokenInfo: TokenInfo
   amount: string
   trackingLabel: SWAP_LABELS
+  light?: boolean
 }): ReactElement => {
   const spendingLimit = useSpendingLimit(tokenInfo)
   const router = useRouter()
@@ -28,11 +30,11 @@ const SwapButton = ({
         <Track {...SWAP_EVENTS.OPEN_SWAPS} label={trackingLabel}>
           <Button
             data-testid="swap-btn"
-            variant="outlined"
-            color="primary"
-            size="small"
+            variant="contained"
+            color={light ? 'background.paper' : 'primary'}
+            size="compact"
             startIcon={<SwapIcon />}
-            sx={{ height: 32, px: 2 }}
+            disableElevation
             onClick={() => {
               router.push({
                 pathname: AppRoutes.swap,

--- a/packages/utils/src/utils/__tests__/formatNumber.test.ts
+++ b/packages/utils/src/utils/__tests__/formatNumber.test.ts
@@ -116,7 +116,7 @@ describe('formatNumber', () => {
     })
 
     it('handles non-numeric balances by returning 0', () => {
-      expect(percentageOfTotal('NaN', 100)).toBe(0)
+      expect(percentageOfTotal(NaN, 100)).toBe(0)
     })
 
     it('handles extremely large totals without throwing', () => {

--- a/packages/utils/src/utils/__tests__/formatNumber.test.ts
+++ b/packages/utils/src/utils/__tests__/formatNumber.test.ts
@@ -1,4 +1,10 @@
-import { formatAmountPrecise, formatAmount, formatCurrency, formatCurrencyPrecise } from '@safe-global/utils/utils/formatNumber'
+import {
+  formatAmountPrecise,
+  formatAmount,
+  formatCurrency,
+  formatCurrencyPrecise,
+  percentageOfTotal,
+} from '@safe-global/utils/utils/formatNumber'
 
 describe('formatNumber', () => {
   describe('formatAmountPrecise', () => {
@@ -88,6 +94,33 @@ describe('formatNumber', () => {
     it('should return "NaN" for invalid number input', () => {
       const result = formatCurrencyPrecise('invalid-number', 'USD')
       expect(result).toBe('$NaN ')
+    })
+  })
+
+  describe('percentageOfTotal', () => {
+    it('returns the correct fraction for typical inputs', () => {
+      expect(percentageOfTotal(30, 100)).toBeCloseTo(0.3)
+      expect(percentageOfTotal('75', '150')).toBeCloseTo(0.5)
+    })
+
+    it('handles a zero total by returning 0 (avoids division by 0)', () => {
+      expect(percentageOfTotal(10, 0)).toBe(0)
+    })
+
+    it('handles a negative total by returning 0', () => {
+      expect(percentageOfTotal(10, -50)).toBe(0)
+    })
+
+    it('handles non-numeric totals by returning 0', () => {
+      expect(percentageOfTotal(10, 'not-a-number')).toBe(0)
+    })
+
+    it('handles non-numeric balances by returning 0', () => {
+      expect(percentageOfTotal('NaN', 100)).toBe(0)
+    })
+
+    it('handles extremely large totals without throwing', () => {
+      expect(percentageOfTotal(1, Number.MAX_SAFE_INTEGER)).toBeCloseTo(1 / Number.MAX_SAFE_INTEGER)
     })
   })
 })

--- a/packages/utils/src/utils/formatNumber.ts
+++ b/packages/utils/src/utils/formatNumber.ts
@@ -81,3 +81,23 @@ export const formatCurrencyPrecise = (number: string | number, currency: string)
   const result = getCurrencyFormatter(currency, false, 2, 2).format(Number(number))
   return result.replace(/^(\D+)/, '$1 ')
 }
+
+/**
+ * Safely compute the ratio `balance / total`.
+ *
+ * @param balance  The asset’s fiat balance
+ * @param total    The overall fiat total
+ * @returns A number between 0 and 1.  Returns 0 when the inputs are non-numeric, Infinity, or when total ≤ 0.
+ */
+export function percentageOfTotal(balance: number | string, total: number | string): number {
+  const totalNum = Number(total)
+  const balanceNum = Number(balance)
+
+  // invalid, zero or negative totals → return 0 to avoid division by 0/−n
+  if (!Number.isFinite(totalNum) || totalNum <= 0) return 0
+
+  // invalid balances → treat as 0 so the overall percentage still works
+  if (!Number.isFinite(balanceNum)) return 0
+
+  return balanceNum / totalNum
+}


### PR DESCRIPTION
## What it solves

Resolves [EN-134](https://linear.app/safe-global/issue/EN-134/dashboard-update-top-assets-section)

## How this PR fixes it

- Updates the layout of the dashboard assets table according to Figma
- Adds buttons on hover
- Shows a percentage of total fiat value next to each item
- The percentage is hidden on mobile view

## How to test it

1. Open a Safe dashboard
2. Observe the new design for the assets overview

## Screenshots
<img width="636" alt="Screenshot 2025-06-10 at 15 45 26" src="https://github.com/user-attachments/assets/79946e64-3c7d-4ea6-8262-f18a66e0a32e" />
<img width="630" alt="Screenshot 2025-06-10 at 15 45 36" src="https://github.com/user-attachments/assets/584560c4-59fd-4c54-a57d-ef70d2f01f11" />
<img width="640" alt="Screenshot 2025-06-10 at 15 45 47" src="https://github.com/user-attachments/assets/af3e7738-9191-4a17-a279-e9bdff086ec5" />
<img width="509" alt="Screenshot 2025-06-10 at 15 46 01" src="https://github.com/user-attachments/assets/3dd4f98a-1d26-4ed3-8b7d-77fb39bee4c6" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
