### PR TITLE
Fix(Earn): Rename widget fee to performance fee

### DIFF
--- a/apps/web/src/features/earn/components/VaultDepositConfirmation/index.tsx
+++ b/apps/web/src/features/earn/components/VaultDepositConfirmation/index.tsx
@@ -29,6 +29,10 @@ const AdditionalRewards = ({ txInfo }: { txInfo: VaultDepositTransactionInfo }) 
             {formatPercentage(txInfo.additionalRewardsNrr / 100)}
           </DataRow>,
 
+          <DataRow key="Fees" title="Fees">
+            0%
+          </DataRow>,
+
           <Typography
             key="Powered by"
             variant="caption"
@@ -104,7 +108,7 @@ const ConfirmationHeader = ({ txInfo }: { txInfo: VaultDepositTransactionInfo })
       >
         <Box flex={1}>
           <Typography variant="body2" color="primary.light">
-            Earn
+            Earn (after fees)
           </Typography>
 
           <Typography variant="h4" fontWeight="bold" component="div">
@@ -160,12 +164,12 @@ const VaultDepositConfirmation = ({
           </DataRow>,
 
           <DataRow
-            key="Widget fee"
+            key="Performance fee"
             title={
               <>
-                Widget fee
+                Performance fee
                 <InfoTooltip
-                  title={`The widget fee incurred here is charged by Kiln for the operation of this widget. The fee is calculated automatically. Part of the fee will contribute to a license fee that supports the Safe Community. Neither the Safe Ecosystem Foundation nor ${BRAND_NAME} operates the Kiln Widget and/or Kiln.`}
+                  title={`The performance fee incurred here is charged by Kiln for the operation of this widget. The fee is calculated automatically. Part of the fee will contribute to a license fee that supports the Safe Community. Neither the Safe Ecosystem Foundation nor ${BRAND_NAME} operates the Kiln Widget and/or Kiln.`}
                 />
               </>
             }


### PR DESCRIPTION
## What it solves

Resolves [EN-139](https://linear.app/safe-global/issue/EN-139/kilnmorpho-update-to-reflect-fees-and-apys)

## How this PR fixes it

- Renames widget fee to performance fee
- Shows (after fees) next to the earn percentage
- Shows that there are no fees for the additional rewards

## How to test it

1. Open a Safe and try to deposit funds into a vault
2. Observe the changes

## Screenshots

<img width="709" alt="Screenshot 2025-06-10 at 15 58 23" src="https://github.com/user-attachments/assets/a261f3c0-0524-4b5c-95f1-9d309fb042e5" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
