### PR TITLE
fix(mobile): remove unnecessary corner style

### DIFF
--- a/apps/mobile/src/components/Camera/QrCamera.tsx
+++ b/apps/mobile/src/components/Camera/QrCamera.tsx
@@ -230,7 +230,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     width: CORNER_SIZE,
     height: CORNER_SIZE,
-    borderColor: '#00FF00',
   },
   topLeft: {
     top: 0,


### PR DESCRIPTION
## What it solves
On android, when user goes to the add safe flow, the camera is reflecting the "denied" permission but the corner of it is green. This PR removes the unnecessary property in the corner styles which were causing this problem.

## Screenshots
![Screenshot 2025-06-11 at 14 10 54](https://github.com/user-attachments/assets/d912b4e3-eb5f-46f6-973c-8053fb021985)

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
