### PR TITLE
feat: added transaction context aware urls

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/Summary/DecoderLinks.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/DecoderLinks.tsx
@@ -3,13 +3,74 @@ import { Typography } from '@mui/material'
 
 const TX_DECODER_URL = 'https://transaction-decoder.pages.dev'
 const SAFE_UTILS_URL = 'https://safeutils.openzeppelin.com'
+const CYFRIN_SAFE_HASH_URL = 'https://tools.cyfrin.io/safe-hash'
+const CYFRIN_ABI_ENCODING_URL = 'https://tools.cyfrin.io/abi-encoding'
 
-const DecoderLinks = () => (
-  <Typography variant="body2" color="primary.light" mb={3}>
-    Cross-verify your transaction data with external tools like{' '}
-    <ExternalLink href={SAFE_UTILS_URL}>Safe Utils</ExternalLink> and{' '}
-    <ExternalLink href={TX_DECODER_URL}>Transaction Decoder</ExternalLink>.
-  </Typography>
-)
+type SafeWalletData = {
+  safeAddress?: string
+  chainId?: string
+  safeVersion?: string
+  nonce?: number
+}
+
+type TransactionData = {
+  to?: string
+  value?: string
+  data?: string
+  operation?: string
+  safeTxGas?: string
+  baseGas?: string
+  gasPrice?: string
+  gasToken?: string
+  refundReceiver?: string
+}
+
+type DecoderLinksProps = {
+  safeWallet?: SafeWalletData
+  transaction?: TransactionData
+}
+
+const DecoderLinks = ({ safeWallet, transaction }: DecoderLinksProps = {}) => {
+  const buildSafeHashUrl = () => {
+    if (!safeWallet || !transaction) return CYFRIN_SAFE_HASH_URL
+    
+    const params = new URLSearchParams()
+    if (safeWallet.safeAddress) params.append('safeAddress', safeWallet.safeAddress)
+    if (safeWallet.chainId) params.append('chainId', safeWallet.chainId)
+    if (safeWallet.safeVersion) params.append('safeVersion', safeWallet.safeVersion)
+    if (safeWallet.nonce !== undefined) params.append('nonce', safeWallet.nonce.toString())
+    if (transaction.to) params.append('to', transaction.to)
+    if (transaction.value) params.append('value', transaction.value)
+    if (transaction.data) params.append('data', transaction.data)
+    if (transaction.operation) params.append('operation', transaction.operation)
+    if (transaction.safeTxGas) params.append('safeTxGas', transaction.safeTxGas)
+    if (transaction.baseGas) params.append('baseGas', transaction.baseGas)
+    if (transaction.gasPrice) params.append('gasPrice', transaction.gasPrice)
+    if (transaction.gasToken) params.append('gasToken', transaction.gasToken)
+    if (transaction.refundReceiver) params.append('refundReceiver', transaction.refundReceiver)
+    
+    return `${CYFRIN_SAFE_HASH_URL}?${params.toString()}`
+  }
+
+  const buildAbiEncodingUrl = () => {
+    if (!transaction?.data) return CYFRIN_ABI_ENCODING_URL
+    
+    const params = new URLSearchParams()
+    params.append('data', transaction.data)
+    
+    return `${CYFRIN_ABI_ENCODING_URL}?${params.toString()}`
+  }
+
+  const safeUtilsUrl = buildSafeHashUrl()
+  const transactionDecoderUrl = buildAbiEncodingUrl()
+
+  return (
+    <Typography variant="body2" color="primary.light" mb={3}>
+      Cross-verify your transaction data with external tools like{' '}
+      <ExternalLink href={safeUtilsUrl}>Safe Hash Calculator</ExternalLink> and{' '}
+      <ExternalLink href={transactionDecoderUrl}>Transaction Decoder</ExternalLink>.
+    </Typography>
+  )
+}
 
 export default DecoderLinks

--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -42,7 +42,7 @@ const Summary = ({
 
   let baseGas, gasPrice, gasToken, safeTxGas, refundReceiver, submittedAt, nonce
   if (txDetails && isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)) {
-    ;({ baseGas, gasPrice, gasToken, safeTxGas, submittedAt, nonce } = txDetails.detailedExecutionInfo)
+    ; ({ baseGas, gasPrice, gasToken, safeTxGas, submittedAt, nonce } = txDetails.detailedExecutionInfo)
     refundReceiver = txDetails.detailedExecutionInfo.refundReceiver?.value
   }
 
@@ -101,7 +101,7 @@ const Summary = ({
                   Advanced details
                 </Typography>
 
-                <DecoderLinks 
+                <DecoderLinks
                   transaction={{
                     to: safeTxData.to,
                     value: safeTxData.value,
@@ -116,7 +116,7 @@ const Summary = ({
                   safeWallet={{
                     safeAddress: safe.address.value,
                     chainId,
-                    safeVersion: safe.version,
+                    safeVersion: safe.version ?? undefined,
                     nonce: safeTxData.nonce
                   }}
                 />

--- a/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.tsx
@@ -13,6 +13,8 @@ import DecoderLinks from './DecoderLinks'
 import isEqual from 'lodash/isEqual'
 import Multisend from '../TxData/DecodedData/Multisend'
 import { isMultiSendCalldata } from '@/utils/transaction-calldata'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import useChainId from '@/hooks/useChainId'
 
 interface Props {
   safeTxData?: SafeTransactionData
@@ -31,6 +33,8 @@ const Summary = ({
   showMultisend = true,
   showDecodedData = true,
 }: Props): ReactElement => {
+  const { safe } = useSafeInfo()
+  const chainId = useChainId()
   const { txHash, executedAt } = txDetails ?? {}
   const customTxInfo = txInfo && isCustomTxInfo(txInfo) ? txInfo : undefined
   const toInfo = customTxInfo?.to || txData?.addressInfoIndex?.[txData?.to.value] || txData?.to
@@ -97,7 +101,25 @@ const Summary = ({
                   Advanced details
                 </Typography>
 
-                <DecoderLinks />
+                <DecoderLinks 
+                  transaction={{
+                    to: safeTxData.to,
+                    value: safeTxData.value,
+                    data: safeTxData.data,
+                    operation: safeTxData.operation.toString(),
+                    safeTxGas: safeTxData.safeTxGas,
+                    baseGas: safeTxData.baseGas,
+                    gasPrice: safeTxData.gasPrice,
+                    gasToken: safeTxData.gasToken,
+                    refundReceiver: safeTxData.refundReceiver
+                  }}
+                  safeWallet={{
+                    safeAddress: safe.address.value,
+                    chainId,
+                    safeVersion: safe.version,
+                    nonce: safeTxData.nonce
+                  }}
+                />
 
                 <Receipt
                   safeTxData={safeTxData}


### PR DESCRIPTION
## What it solves

Added transaction context aware URLs for decoding tx data and calculating safe hashes.

## How this PR fixes it

When a user goes to safe utils or transaction decoder, they have to manually enter all the information. This PRs allows these tools to be populated (using tools.cyfrin.io) already, to make users lives easier.

They _should_ still populate these themselves, but at least they will be able to see very quickly if the Safe UI is compromised, because when they enter the data, it'll be different.

## How to test it

1. Create a transaction
2. Click the links generated
3. You'll be brought to a tool that has all the fields already populated. You can see the links here:

- [Example transaction decoded](https://tools.cyfrin.io/abi-encoding?data=0x6a76120200000000000000000000000078e30497a3c7527d953c6b1e3541b021a98ac43c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000084617ba0370000000000000000000000005a7d6b2f92c77fad6ccabd7ee0624e64907eaf3e000000000000000000000000000000000000000000000002b5e3af16b18800000000000000000000000000009467919138e36f0252886519f34a0f8016ddb3a30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041000000000000000000000000F8Cade19b26a2B970F2dEF5eA9ECcF1bda3d118600000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000)
- [Example Safe Hash Calculator](https://tools.cyfrin.io/safe-hash?safeAddress=0x1c694Fc3006D81ff4a56F97E1b99529066a23725&chainId=ethereum&safeVersion=1.4.1&nonce=63&to=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&value=0&data=0xa9059cbb00000000000000000000000092d0ebaf7eb707f0650f9471e61348f4656c29bc00000000000000000000000000000000000000000000000000000005d21dba00&operation=0&safeTxGas=0&baseGas=0&gasPrice=0&gasToken=0x0000000000000000000000000000000000000000&refundReceiver=0x0000000000000000000000000000000000000000)

## Screenshots

These links would now be transaction context aware, and populate the tools with data already.

<img width="479" alt="Screenshot 2025-06-12 at 5 22 11 PM" src="https://github.com/user-attachments/assets/71a27221-97d3-4eba-8215-8e56b9ab9114" />

## Checklist

Would love a hand testing it...

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

Note: I know this removes the current links, and I'd love to keep them because both teams do great work, but I'm wondering where the best place for them to fit in would be...