### PR TITLE
fix(mobile): improve currency view

### DIFF
--- a/apps/mobile/src/features/Settings/components/Currency/CurrencyItem/CurrencyItem.tsx
+++ b/apps/mobile/src/features/Settings/components/Currency/CurrencyItem/CurrencyItem.tsx
@@ -10,7 +10,7 @@ export const CurrencyItem: React.FC<CurrencyItemProps> = ({ code, symbol, name, 
       <View flexDirection="row" justifyContent="space-between" alignItems="center">
         <View flex={1}>
           <Text fontSize="$5" fontWeight="600" color="$color">
-            {code} - {symbol}
+            {code} {code !== symbol && `- ${symbol}`}
           </Text>
           <Text fontSize="$4" color="$colorSecondary">
             {name}

--- a/apps/mobile/src/utils/currency.ts
+++ b/apps/mobile/src/utils/currency.ts
@@ -1,8 +1,17 @@
+const cryptoFallBackNames = {
+  BTC: 'Bitcoin',
+  ETH: 'Ethereum',
+}
+
 export const getCurrencyName = (currency: string, locale = 'en') => {
   try {
     if (typeof Intl.DisplayNames === 'function') {
       const displayNames = new Intl.DisplayNames([locale], { type: 'currency' })
-      return displayNames.of(currency) || currency
+      const name = displayNames.of(currency)
+      if (cryptoFallBackNames[name as keyof typeof cryptoFallBackNames]) {
+        return cryptoFallBackNames[name as keyof typeof cryptoFallBackNames]
+      }
+      return name || currency
     }
   } catch (_e) {
     // Fallback to code if Intl.DisplayNames fails


### PR DESCRIPTION
## What it solves
I was too quick to merge the other PR. This ads just a small change to the display so that we don't display the currency synmbol when it is the same as the currency abbreviation.

## Screenshots
<img width="150" src="https://github.com/user-attachments/assets/466c5e89-605b-4024-8593-90e4e3319d96" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
