### PR TITLE
fix(mobile): token icon was blurry

### DIFF
--- a/apps/mobile/src/components/TokenIcon/TokenIcon.test.tsx
+++ b/apps/mobile/src/components/TokenIcon/TokenIcon.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@/src/tests/test-utils'
+import { TokenIcon } from './TokenIcon'
+
+describe('TokenIcon', () => {
+  it('should render with optimized CoinGecko URLs', () => {
+    const thumbnailUrl = 'https://coin-images.coingecko.com/coins/images/25244/thumb/Optimism.png'
+    const container = render(<TokenIcon logoUri={thumbnailUrl} accessibilityLabel="Token logo" />)
+
+    const logoImage = container.getByTestId('logo-image')
+    expect(logoImage.props.source.uri).toBe('https://coin-images.coingecko.com/coins/images/25244/large/Optimism.png')
+  })
+
+  it('should pass through non-CoinGecko URLs unchanged', () => {
+    const regularUrl = 'https://example.com/token-logo.png'
+    const container = render(<TokenIcon logoUri={regularUrl} accessibilityLabel="Token logo" />)
+
+    const logoImage = container.getByTestId('logo-image')
+    expect(logoImage.props.source.uri).toBe(regularUrl)
+  })
+
+  it('should render fallback icon when no logoUri is provided', () => {
+    const container = render(<TokenIcon accessibilityLabel="Token" />)
+
+    expect(container.queryByTestId('logo-image')).not.toBeTruthy()
+    expect(container.queryByTestId('logo-fallback-icon')).toBeTruthy()
+  })
+
+  it('should use token icon as default fallback', () => {
+    const container = render(<TokenIcon accessibilityLabel="Token" />)
+
+    // Just verify the fallback icon is rendered - the default fallback for TokenIcon should be 'token'
+    expect(container.getByTestId('logo-fallback-icon')).toBeTruthy()
+  })
+
+  it('should pass all props to Logo component', () => {
+    const props = {
+      logoUri: 'https://example.com/logo.png',
+      accessibilityLabel: 'Custom token',
+      size: '$8',
+      imageBackground: '$blue',
+      fallbackIcon: 'nft' as const,
+    }
+
+    const container = render(<TokenIcon {...props} />)
+
+    expect(container.getByLabelText('Custom token')).toBeTruthy()
+  })
+})

--- a/apps/mobile/src/components/TokenIcon/TokenIcon.tsx
+++ b/apps/mobile/src/components/TokenIcon/TokenIcon.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { Logo } from '../Logo/Logo'
+import { BadgeThemeTypes } from '../Logo/Logo'
+import { IconProps } from '../SafeFontIcon/SafeFontIcon'
+import { upgradeCoinGeckoThumbToQuality } from '@safe-global/utils/utils/image'
+
+interface TokenIconProps {
+  logoUri?: string | null
+  accessibilityLabel?: string
+  fallbackIcon?: IconProps['name']
+  imageBackground?: string
+  size?: string
+  badgeContent?: React.ReactElement
+  badgeThemeName?: BadgeThemeTypes
+}
+
+export function TokenIcon({
+  logoUri,
+  accessibilityLabel,
+  size = '$10',
+  imageBackground = '$color',
+  fallbackIcon = 'token',
+  badgeContent,
+  badgeThemeName = 'badge_background',
+}: TokenIconProps) {
+  const optimizedLogoUri = React.useMemo(() => {
+    return upgradeCoinGeckoThumbToQuality(logoUri, 'large')
+  }, [logoUri])
+
+  return (
+    <Logo
+      logoUri={optimizedLogoUri}
+      accessibilityLabel={accessibilityLabel}
+      size={size}
+      imageBackground={imageBackground}
+      fallbackIcon={fallbackIcon}
+      badgeContent={badgeContent}
+      badgeThemeName={badgeThemeName}
+    />
+  )
+}

--- a/apps/mobile/src/components/TokenIcon/index.ts
+++ b/apps/mobile/src/components/TokenIcon/index.ts
@@ -1,0 +1,2 @@
+import { TokenIcon } from './TokenIcon'
+export { TokenIcon }

--- a/apps/mobile/src/components/transactions-list/Card/AssetsCard/AssetsCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/AssetsCard/AssetsCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Text, View } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { Logo } from '@/src/components/Logo'
+import { TokenIcon } from '@/src/components/TokenIcon'
 import { ellipsis } from '@/src/utils/formatters'
 
 interface AssetsCardProps {
@@ -39,7 +39,9 @@ export function AssetsCard({
         </View>
       }
       transparent={transparent}
-      leftNode={<Logo imageBackground={imageBackground} logoUri={logoUri} accessibilityLabel={accessibilityLabel} />}
+      leftNode={
+        <TokenIcon imageBackground={imageBackground} logoUri={logoUri} accessibilityLabel={accessibilityLabel} />
+      }
       rightNode={
         typeof rightNode === 'string' ? (
           <Text fontSize="$4" fontWeight={400} color="$color">

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.tsx
@@ -1,7 +1,7 @@
 import type { NativeStakingDepositTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { TokenAmount } from '@/src/components/TokenAmount'
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { Logo } from '@/src/components/Logo'
+import { TokenIcon } from '@/src/components/TokenIcon'
 
 export const StakingTxDepositCard = ({ info }: { info: NativeStakingDepositTransactionInfo }) => {
   return (
@@ -12,7 +12,7 @@ export const StakingTxDepositCard = ({ info }: { info: NativeStakingDepositTrans
       rightNode={
         <TokenAmount value={info.value} tokenSymbol={info.tokenInfo.symbol} decimals={info.tokenInfo.decimals} />
       }
-      leftNode={<Logo logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
     />
   )
 }

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`StakingTxDepositCard renders correctly 1`] = `
                 }
                 testID="logo-fallback-icon"
               >
-                
+                
               </Text>
             </View>
           </View>

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.tsx
@@ -1,6 +1,6 @@
 import type { NativeStakingValidatorsExitTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { Logo } from '@/src/components/Logo'
+import { TokenIcon } from '@/src/components/TokenIcon'
 import { maybePlural } from '@safe-global/utils/utils/formatters'
 import { Text } from 'tamagui'
 
@@ -15,7 +15,7 @@ export const StakingTxExitCard = ({ info }: { info: NativeStakingValidatorsExitT
           {info.numValidators} Validator{maybePlural(info.numValidators)}
         </Text>
       }
-      leftNode={<Logo logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
     />
   )
 }

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`StakingTxExitCard renders correctly 1`] = `
                 }
                 testID="logo-fallback-icon"
               >
-                
+                
               </Text>
             </View>
           </View>

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.tsx
@@ -1,7 +1,7 @@
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { TokenAmount } from '@/src/components/TokenAmount'
 import { NativeStakingWithdrawTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
-import { Logo } from '@/src/components/Logo'
+import { TokenIcon } from '@/src/components/TokenIcon'
 
 export const StakingTxWithdrawCard = ({ info }: { info: NativeStakingWithdrawTransactionInfo }) => {
   return (
@@ -17,7 +17,7 @@ export const StakingTxWithdrawCard = ({ info }: { info: NativeStakingWithdrawTra
           decimals={info.tokenInfo.decimals}
         />
       }
-      leftNode={<Logo logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
     />
   )
 }

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`StakingTxWithdrawCard renders correctly 1`] = `
                 }
                 testID="logo-fallback-icon"
               >
-                
+                
               </Text>
             </View>
           </View>

--- a/apps/mobile/src/components/transactions-list/Card/TxOrderCard/SellOrder.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxOrderCard/SellOrder.tsx
@@ -1,6 +1,7 @@
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { Avatar, Text, Theme, View } from 'tamagui'
+import { Text, Theme, View } from 'tamagui'
 import { ellipsis, formatValue } from '@/src/utils/formatters'
+import { TokenIcon } from '@/src/components/TokenIcon'
 import React from 'react'
 import {
   SwapOrderTransactionInfo,
@@ -30,27 +31,23 @@ export function SellOrder({ order, type, bordered, executionInfo, inQueue, onPre
       leftNode={
         <Theme name="logo">
           <View position="relative" width="$10" height="$10">
-            <Avatar circular size="$7" position="absolute" top={0}>
-              {order.sellToken.logoUri && (
-                <Avatar.Image
-                  backgroundColor="$background"
-                  accessibilityLabel={order.sellToken.name}
-                  src={order.sellToken.logoUri}
-                />
-              )}
-              <Avatar.Fallback backgroundColor="$background" />
-            </Avatar>
+            <View position="absolute" top={0}>
+              <TokenIcon
+                logoUri={order.sellToken.logoUri}
+                accessibilityLabel={order.sellToken.name}
+                size="$7"
+                imageBackground="$background"
+              />
+            </View>
 
-            <Avatar circular size="$7" position="absolute" bottom={0} right={0} backgroundColor="$color">
-              {order.buyToken.logoUri && (
-                <Avatar.Image
-                  accessibilityLabel={order.buyToken.name}
-                  backgroundColor="$background"
-                  src={order.buyToken.logoUri}
-                />
-              )}
-              <Avatar.Fallback backgroundColor="$background" />
-            </Avatar>
+            <View position="absolute" bottom={0} right={0}>
+              <TokenIcon
+                logoUri={order.buyToken.logoUri}
+                accessibilityLabel={order.buyToken.name}
+                size="$7"
+                imageBackground="$background"
+              />
+            </View>
           </View>
         </Theme>
       }

--- a/apps/mobile/src/components/transactions-list/Card/TxOrderCard/TwapOrder.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxOrderCard/TwapOrder.tsx
@@ -1,7 +1,8 @@
 import { Transaction, TwapOrderTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { Avatar, Text, Theme, View } from 'tamagui'
+import { Text, Theme, View } from 'tamagui'
 import { ellipsis, formatValue } from '@/src/utils/formatters'
+import { TokenIcon } from '@/src/components/TokenIcon'
 import React from 'react'
 
 interface TxTwappOrderCardProps {
@@ -25,27 +26,23 @@ export const TwapOrder = ({ order, bordered, executionInfo, inQueue, onPress }: 
       leftNode={
         <Theme name="logo">
           <View position="relative" width="$10" height="$10">
-            <Avatar circular size="$7" position="absolute" top={0}>
-              {order.sellToken.logoUri && (
-                <Avatar.Image
-                  backgroundColor="$background"
-                  accessibilityLabel={order.sellToken.name}
-                  src={order.sellToken.logoUri}
-                />
-              )}
-              <Avatar.Fallback backgroundColor="$background" />
-            </Avatar>
+            <View position="absolute" top={0}>
+              <TokenIcon
+                logoUri={order.sellToken.logoUri}
+                accessibilityLabel={order.sellToken.name}
+                size="$7"
+                imageBackground="$background"
+              />
+            </View>
 
-            <Avatar circular size="$7" position="absolute" bottom={0} right={0} backgroundColor="$color">
-              {order.buyToken.logoUri && (
-                <Avatar.Image
-                  accessibilityLabel={order.buyToken.name}
-                  backgroundColor="$background"
-                  src={order.buyToken.logoUri}
-                />
-              )}
-              <Avatar.Fallback backgroundColor="$background" />
-            </Avatar>
+            <View position="absolute" bottom={0} right={0}>
+              <TokenIcon
+                logoUri={order.buyToken.logoUri}
+                accessibilityLabel={order.buyToken.name}
+                size="$7"
+                imageBackground="$background"
+              />
+            </View>
           </View>
         </Theme>
       }

--- a/apps/mobile/src/components/transactions-list/Card/TxTokenCard/TxTokenCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxTokenCard/TxTokenCard.tsx
@@ -3,7 +3,7 @@ import { SafeListItem } from '@/src/components/SafeListItem'
 import { isERC721Transfer, isOutgoingTransfer, isTxQueued } from '@/src/utils/transaction-guards'
 import { TransferDirection } from '@safe-global/store/gateway/types'
 import { TransferTransactionInfo, Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
-import { Logo } from '@/src/components/Logo'
+import { TokenIcon } from '@/src/components/TokenIcon'
 import { useTokenDetails } from '@/src/hooks/useTokenDetails'
 import { TokenAmount } from '@/src/components/TokenAmount'
 interface TxTokenCardProps {
@@ -32,7 +32,7 @@ export function TxTokenCard({ bordered, inQueue, txStatus, executionInfo, txInfo
       type={type}
       onPress={onPress}
       bordered={bordered}
-      leftNode={<Logo logoUri={logoUri} accessibilityLabel={name} />}
+      leftNode={<TokenIcon logoUri={logoUri} accessibilityLabel={name} />}
       rightNode={
         <TokenAmount
           value={value}

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/VaultTxDepositCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/VaultTxDepositCard.tsx
@@ -1,7 +1,7 @@
 import type { VaultDepositTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { TokenAmount } from '@/src/components/TokenAmount'
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { Logo } from '@/src/components/Logo'
+import { TokenIcon } from '@/src/components/TokenIcon'
 
 export const VaultTxDepositCard = ({ info }: { info: VaultDepositTransactionInfo }) => {
   return (
@@ -12,7 +12,7 @@ export const VaultTxDepositCard = ({ info }: { info: VaultDepositTransactionInfo
       rightNode={
         <TokenAmount value={info.value} tokenSymbol={info.tokenInfo.symbol} decimals={info.tokenInfo.decimals} />
       }
-      leftNode={<Logo logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
     />
   )
 }

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/__snapshots__/VaultTxDepositCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/__snapshots__/VaultTxDepositCard.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`VaultTxDepositCard renders correctly 1`] = `
                 }
                 testID="logo-fallback-icon"
               >
-                
+                
               </Text>
             </View>
           </View>

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/VaultTxRedeemCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/VaultTxRedeemCard.tsx
@@ -1,7 +1,7 @@
 import type { VaultRedeemTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { TokenAmount } from '@/src/components/TokenAmount'
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { Logo } from '@/src/components/Logo'
+import { TokenIcon } from '@/src/components/TokenIcon'
 
 export const VaultTxRedeemCard = ({ info }: { info: VaultRedeemTransactionInfo }) => {
   return (
@@ -12,7 +12,7 @@ export const VaultTxRedeemCard = ({ info }: { info: VaultRedeemTransactionInfo }
       rightNode={
         <TokenAmount value={info.value} tokenSymbol={info.tokenInfo.symbol} decimals={info.tokenInfo.decimals} />
       }
-      leftNode={<Logo logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
     />
   )
 }

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/__snapshots__/VaultTxRedeemCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/__snapshots__/VaultTxRedeemCard.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`VaultTxRedeemCard renders correctly 1`] = `
                 }
                 testID="logo-fallback-icon"
               >
-                
+                
               </Text>
             </View>
           </View>

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrderHeader.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrderHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Text, View, H5 } from 'tamagui'
 import { Container } from '@/src/components/Container'
-import { Logo } from '@/src/components/Logo'
+import { TokenIcon } from '@/src/components/TokenIcon'
 import { ellipsis, formatValue } from '@/src/utils/formatters'
 import { Badge } from '@/src/components/Badge'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
@@ -33,7 +33,7 @@ export function SwapOrderHeader({ txInfo, executionInfo }: SwapOrderHeaderProps)
       <View flexDirection="row" gap="$2" position="relative">
         <Container flex={1} padding="$4" borderRadius="$3">
           <View alignItems="center" gap="$2">
-            <Logo logoUri={sellToken.logoUri} size="$10" />
+            <TokenIcon logoUri={sellToken.logoUri} size="$10" accessibilityLabel={sellToken.symbol} />
             <Text color="$textSecondaryLight">Sell</Text>
             <H5 fontWeight={600}>
               {ellipsis(sellTokenValue, 9)} {sellToken.symbol}
@@ -67,7 +67,7 @@ export function SwapOrderHeader({ txInfo, executionInfo }: SwapOrderHeaderProps)
 
         <Container flex={1} padding="$4" borderRadius="$3">
           <View alignItems="center" gap="$2">
-            <Logo logoUri={buyToken.logoUri} size="$10" />
+            <TokenIcon logoUri={buyToken.logoUri} size="$10" accessibilityLabel={buyToken.symbol} />
             <Text color="$textSecondaryLight">For at least</Text>
             <H5 fontWeight={600}>
               {ellipsis(buyTokenValue, 9)} {buyToken.symbol}

--- a/apps/web/src/components/common/TokenIcon/index.tsx
+++ b/apps/web/src/components/common/TokenIcon/index.tsx
@@ -1,10 +1,9 @@
 import { useMemo, type ReactElement } from 'react'
 import ImageFallback from '../ImageFallback'
 import css from './styles.module.css'
+import { upgradeCoinGeckoThumbToQuality } from '@safe-global/utils/utils/image'
 
 const FALLBACK_ICON = '/images/common/token-placeholder.svg'
-const COINGECKO_THUMB = '/thumb/'
-const COINGECKO_SMALL = '/small/'
 
 const TokenIcon = ({
   logoUri,
@@ -18,7 +17,7 @@ const TokenIcon = ({
   fallbackSrc?: string
 }): ReactElement => {
   const src = useMemo(() => {
-    return logoUri?.replace(COINGECKO_THUMB, COINGECKO_SMALL)
+    return upgradeCoinGeckoThumbToQuality(logoUri, 'small')
   }, [logoUri])
 
   return (

--- a/packages/utils/src/utils/__tests__/image.test.ts
+++ b/packages/utils/src/utils/__tests__/image.test.ts
@@ -1,0 +1,54 @@
+import { upgradeCoinGeckoThumbToQuality } from '../image'
+
+describe('upgradeCoinGeckoThumbToQuality', () => {
+  it('should replace CoinGecko thumbnail URLs with large versions', () => {
+    const thumbnailUrl = 'https://coin-images.coingecko.com/coins/images/25244/thumb/Optimism.png'
+    const expectedUrl = 'https://coin-images.coingecko.com/coins/images/25244/large/Optimism.png'
+
+    expect(upgradeCoinGeckoThumbToQuality(thumbnailUrl, 'large')).toBe(expectedUrl)
+  })
+
+  it('should replace CoinGecko thumbnail URLs with small versions', () => {
+    const thumbnailUrl = 'https://coin-images.coingecko.com/coins/images/25244/thumb/Optimism.png'
+    const expectedUrl = 'https://coin-images.coingecko.com/coins/images/25244/small/Optimism.png'
+
+    expect(upgradeCoinGeckoThumbToQuality(thumbnailUrl, 'small')).toBe(expectedUrl)
+  })
+
+  it('should use small as default quality', () => {
+    const thumbnailUrl = 'https://coin-images.coingecko.com/coins/images/25244/thumb/Optimism.png'
+    const expectedUrl = 'https://coin-images.coingecko.com/coins/images/25244/small/Optimism.png'
+
+    expect(upgradeCoinGeckoThumbToQuality(thumbnailUrl)).toBe(expectedUrl)
+  })
+
+  it('should return unchanged URL if it does not contain /thumb/', () => {
+    const coingeckoUrl = 'https://coin-images.coingecko.com/coins/images/25244/small/Optimism.png'
+
+    expect(upgradeCoinGeckoThumbToQuality(coingeckoUrl, 'large')).toBe(coingeckoUrl)
+  })
+
+  it('should return unchanged URL if it is not from coingecko.com', () => {
+    const regularUrl = 'https://example.com/token-logo.png'
+
+    expect(upgradeCoinGeckoThumbToQuality(regularUrl, 'large')).toBe(regularUrl)
+  })
+
+  it('should return unchanged URL for non-CoinGecko URLs with /thumb/', () => {
+    const nonCoingeckoUrl = 'https://example.com/assets/thumb/token.png'
+
+    expect(upgradeCoinGeckoThumbToQuality(nonCoingeckoUrl, 'large')).toBe(nonCoingeckoUrl)
+  })
+
+  it('should handle null input', () => {
+    expect(upgradeCoinGeckoThumbToQuality(null, 'large')).toBeUndefined()
+  })
+
+  it('should handle undefined input', () => {
+    expect(upgradeCoinGeckoThumbToQuality(undefined, 'large')).toBeUndefined()
+  })
+
+  it('should handle empty string', () => {
+    expect(upgradeCoinGeckoThumbToQuality('', 'large')).toBe('')
+  })
+})

--- a/packages/utils/src/utils/image.ts
+++ b/packages/utils/src/utils/image.ts
@@ -1,0 +1,19 @@
+const COINGECKO_THUMB = '/thumb/'
+const COINGECKO_DOMAIN = 'coingecko.com'
+
+type CoinGeckoImageQuality = 'small' | 'large'
+
+export const upgradeCoinGeckoThumbToQuality = (
+  logoUri?: string | null,
+  quality: CoinGeckoImageQuality = 'small',
+): string | undefined => {
+  if (logoUri === null || logoUri === undefined) {
+    return undefined
+  }
+
+  if (logoUri === '' || !logoUri.includes(COINGECKO_DOMAIN)) {
+    return logoUri
+  }
+
+  return logoUri.replace(COINGECKO_THUMB, `/${quality}/`)
+}


### PR DESCRIPTION
## What it solves
The default token icon was of too low quality. We are now switching to large icons - they look better on mobile screens.

Resolves https://linear.app/safe-global/issue/MOB-7/token-icons-have-bad-quality

## How this PR fixes it
We are now doing the same thing as in the web app. We parse the url and replace /small/ with /large/ which loads an image with better quality. I also refactored the code so that web and mobile share the same replace function. 

## How to test it

## Screenshots
before:
<img src="https://github.com/user-attachments/assets/9ce2009d-9a8b-4b02-bb4f-93295016307e" width="150" />

now
<img src="https://github.com/user-attachments/assets/705dd591-1434-415a-bac2-b5669d5709dc" width="150" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
