### PR TITLE
fix(mobile): wrong background color used for badge_success

### DIFF
--- a/apps/mobile/src/components/Badge/theme.ts
+++ b/apps/mobile/src/components/Badge/theme.ts
@@ -7,7 +7,7 @@ export const badgeTheme = {
   },
   dark_badge_success: {
     color: tokens.color.backgroundMainDark,
-    background: tokens.color.primaryMainDark,
+    background: tokens.color.backgroundLightDark,
   },
   light_badge_success_variant1: {
     background: tokens.color.successBackgroundLight,

--- a/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignSuccess.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignSuccess.tsx
@@ -30,7 +30,6 @@ export default function SignSuccess() {
           <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
             <View flex={1} flexGrow={1} alignItems="center" justifyContent="center" paddingHorizontal="$3">
               <Badge
-                circleProps={{ backgroundColor: '#1B2A22' }}
                 themeName="badge_success"
                 circleSize={64}
                 content={<SafeFontIcon size={32} color="$primary" name="check-filled" />}


### PR DESCRIPTION
## What it solves
The wrong backgroundColor was applied on the light theme

Resolves https://linear.app/safe-global/issue/MOB-52/mobile-transaction-confirmation-success

## How this PR fixes it
Fixes the color in the badge_success

## How to test it
Sign a tx in light and dark mode - the icon should look good.

## Screenshots
before:
<img src="https://github.com/user-attachments/assets/1a2c22a8-930c-4825-be4b-4bfe495ce92f" width="150" />

after
<img src="https://github.com/user-attachments/assets/a2b5b1e1-055d-4886-b2e1-559e97b7163a" width="150" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
