### PR TITLE
fix: copy button being overlaped in sign tx screen

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/TokenTransfer/TokenTransfer.tsx
@@ -63,20 +63,18 @@ export function TokenTransfer({ txId, txInfo, executionInfo, executedAt }: Token
             <View alignItems="center" flexDirection="row" justifyContent="space-between">
               <Text color="$textSecondaryLight">To</Text>
 
-              <View flexDirection="row" alignItems="center">
-                <View flexDirection="row" alignItems="center" gap="$2">
-                  <Identicon address={recipientAddress} size={24} />
-                  <EthAddress
-                    address={recipientAddress}
-                    copy
-                    copyProps={{ color: '$textSecondaryLight', size: 18 }}
-                    textProps={{ fontSize: '$4' }}
-                  />
-                </View>
+              <View flexDirection="row" alignItems="center" gap="$2">
+                <Identicon address={recipientAddress} size={24} />
+                <EthAddress
+                  address={recipientAddress}
+                  copy
+                  copyProps={{ color: '$textSecondaryLight', size: 18 }}
+                  textProps={{ fontSize: '$4' }}
+                />
                 <Button
                   onPress={viewOnExplorer}
+                  marginLeft={-10}
                   height={18}
-                  style={{ marginLeft: -12 }}
                   pressStyle={{ backgroundColor: 'transparent' }}
                 >
                   <SafeFontIcon name="external-link" color="$textSecondaryLight" size={16} />


### PR DESCRIPTION
## What it solves
It fixes the buttons overlap problem in the sign tx screen

## How to test it
Open any token transaction in the pending transactions screen.

## Screenshots
<img width="502" alt="Screenshot 2025-06-19 at 14 16 01" src="https://github.com/user-attachments/assets/537c0d78-01cd-4bba-b5ed-c695f94d7b9e" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
