### PR TITLE
fix(AddressInput): consistent avatar size for address book entries

### DIFF
--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -179,9 +179,9 @@ const AddressInput = ({
             <InputAdornment position="end" sx={{ ml: 0 }}>
               <Box mr={1}>
                 {watchedValue && !fieldError ? (
-                  <Identicon address={watchedValue} size={32} />
+                  <Identicon address={watchedValue} size={40} />
                 ) : (
-                  <Skeleton variant="circular" width={32} height={32} animation={false} />
+                  <Skeleton variant="circular" width={40} height={40} animation={false} />
                 )}
               </Box>
 

--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -179,9 +179,9 @@ const AddressInput = ({
             <InputAdornment position="end" sx={{ ml: 0 }}>
               <Box mr={1}>
                 {watchedValue && !fieldError ? (
-                  <Identicon address={watchedValue} size={40} />
+                  <Identicon address={watchedValue} size={32} />
                 ) : (
-                  <Skeleton variant="circular" width={40} height={40} animation={false} />
+                  <Skeleton variant="circular" width={32} height={32} animation={false} />
                 )}
               </Box>
 

--- a/apps/web/src/components/common/AddressInputReadOnly/index.tsx
+++ b/apps/web/src/components/common/AddressInputReadOnly/index.tsx
@@ -22,6 +22,7 @@ const AddressInputReadOnly = ({
             copyAddress={false}
             chainId={chainId}
             showPrefix={showPrefix}
+            avatarSize={32}
           />
         </Typography>
       </InputAdornment>


### PR DESCRIPTION
## What it solves

Resolves [EN-140](https://linear.app/safe-global/issue/EN-140/owners-icons-look-smaller-if-they-dont-have-a-ab-name-set-for-them)

Set avatar size of readonly address input (when showing an address book entry) to 32px for consistency with regular address input.

<img width="521" alt="Screenshot 2025-07-01 at 16 38 56" src="https://github.com/user-attachments/assets/2ef97ae9-ccc7-4a70-afa4-85f682b73895" />

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
