### PR TITLE
fix(WalletConnect): prevent URI from being overridden by an empty value

### DIFF
--- a/apps/web/src/features/walletconnect/components/WcInput/index.tsx
+++ b/apps/web/src/features/walletconnect/components/WcInput/index.tsx
@@ -64,7 +64,9 @@ const WcInput = ({ uri }: { uri: string }) => {
 
   // Insert a pre-filled uri
   useEffect(() => {
-    onInput(uri)
+    if (uri) {
+      onInput(uri)
+    }
   }, [onInput, uri])
 
   const onPaste = useCallback(async () => {


### PR DESCRIPTION
## What it solves

Resolves [EN-145](https://linear.app/safe-global/issue/EN-145/christopher-founder-1kx-is-asking)

This fixes the issue where the input field for the WC URI is being cleared when pasting a value. That caused validation errors not being diplayed for invalid URI values. 

## How this PR fixes it

Call `onInput` inside the useEffect hook only if the URI value is not empty/undefined.

## How to test it

1. Open the WC dialog
2. Paste an invalid URI
3. Observe that the input field is not being cleared and an error message is being shown

## Screenshots



![Screenshot 2025-06-20 at 19 34 50](https://github.com/user-attachments/assets/4d250fc3-f2e5-4be7-a797-f5e68e27efe8)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
