### PR TITLE
chore: add more packages to the dependency check

### DIFF
--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -11,6 +11,12 @@ const DEPS_TO_CHECK = [
   'prettier',
   'jest',
   '@types/jest',
+  '@safe-global/protocol-kit',
+  '@safe-global/safe-apps-sdk',
+  '@safe-global/safe-client-gateway-sdk',
+  '@safe-global/safe-deployments',
+  '@safe-global/safe-gateway-typescript-sdk',
+  '@safe-global/safe-modules-deployments',
 ]
 
 /**


### PR DESCRIPTION
## What it solves
Adding some @safe-global dependencies to the consistency check. This makes sure we won't forget to update them across all packages.  


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
