### PR TITLE
fix(web): add feature flag for simulation in queue

### DIFF
--- a/apps/web/src/components/transactions/QueuedTxSimulation/index.tsx
+++ b/apps/web/src/components/transactions/QueuedTxSimulation/index.tsx
@@ -11,11 +11,12 @@ import { useSigner } from '@/hooks/wallets/useWallet'
 import ExternalLink from '@/components/common/ExternalLink'
 import CheckIcon from '@/public/images/common/check.svg'
 import CloseIcon from '@/public/images/common/close.svg'
-import { getSimulationStatus } from '@safe-global/utils/components/tx/security/tenderly/utils'
+import { getSimulationStatus, isTxSimulationEnabled } from '@safe-global/utils/components/tx/security/tenderly/utils'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { useIsNestedSafeOwner } from '@/hooks/useIsNestedSafeOwner'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useMemo } from 'react'
+import { useCurrentChain } from '@/hooks/useChains'
 
 const CompactSimulationButton = ({
   label,
@@ -52,7 +53,7 @@ const CompactSimulationButton = ({
   )
 }
 
-export const QueuedTxSimulation = ({ transaction }: { transaction: TransactionDetails }) => {
+const InlineTxSimulation = ({ transaction }: { transaction: TransactionDetails }) => {
   const { safe } = useSafeInfo()
   const isSafeOwner = useIsSafeOwner()
   const isNestedSafeOwner = useIsNestedSafeOwner()
@@ -128,4 +129,14 @@ export const QueuedTxSimulation = ({ transaction }: { transaction: TransactionDe
   }
 
   return null
+}
+
+export const QueuedTxSimulation = ({ transaction }: { transaction: TransactionDetails }) => {
+  const chain = useCurrentChain()
+
+  if (!chain || !isTxSimulationEnabled(chain)) {
+    return null
+  }
+
+  return <InlineTxSimulation transaction={transaction} />
 }


### PR DESCRIPTION
## What it solves
The simulation in the queue is not respecting the simulation feature flag

## How this PR fixes it
Evaluates the feature flag when rendering the simulation in queue.

## How to test it
- Open a Safe on a chain without simulation support
- Observe the simulation not being present in the queue

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
