### PR TITLE
Update ChainIndicatorWithFiatBalance logic

### DIFF
--- a/apps/web/src/store/api/gateway/index.ts
+++ b/apps/web/src/store/api/gateway/index.ts
@@ -99,6 +99,7 @@ export const {
   useCreateSubmissionMutation,
   useGetSafeQuery,
   useGetSafeOverviewQuery,
+  useLazyGetSafeOverviewQuery,
   useGetMultipleSafeOverviewsQuery,
   useGetAllOwnedSafesQuery,
   useGetOwnedSafesQuery,


### PR DESCRIPTION
## Summary
- fetch lazy Safe overviews for chains that aren't currently active
- rely on balances slice for fiat value when chain is active
- export `useLazyGetSafeOverviewQuery` from gateway API

## Testing
- `yarn prettier:fix` *(fails: Request was cancelled)*
- `yarn lint` *(fails: Request was cancelled)*
- `yarn test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_685ac4650a44833287b5152f7557fda2