### PR TITLE
fix(web:e2e): fix test id for safe loading and safe creation

### DIFF
--- a/apps/web/cypress/e2e/pages/load_safe.pages.js
+++ b/apps/web/cypress/e2e/pages/load_safe.pages.js
@@ -10,7 +10,7 @@ const invalidAddressNameLengthErrorMsg = 'Maximum 50 symbols'
 
 const safeDataForm = '[data-testid=load-safe-form]'
 const removeOwnerBtn = '[data-testid="remove-owner-btn"]'
-const addOwnerBtn = '[data-testid="add-owner-btn"]'
+const addOwnerBtn = '[data-testid="add-new-signer"]'
 const ownerPolicyStepForm = '[data-testid="owner-policy-step-form"]'
 const addressItem = '[data-testid="address-item"]'
 const nameInput = 'input[name="name"]'

--- a/apps/web/src/components/new-safe/create/steps/OwnerPolicyStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/OwnerPolicyStep/index.tsx
@@ -110,7 +110,7 @@ const OwnerPolicyStep = ({
             />
           ))}
           <Button
-            data-testid="add-owner-btn"
+            data-testid="add-new-signer"
             variant="text"
             onClick={() => appendOwner({ name: '', address: '' }, { shouldFocus: true })}
             startIcon={<SvgIcon component={AddIcon} inheritViewBox fontSize="small" />}


### PR DESCRIPTION
## What it solves
The multichain and load safe test were failing because the test id for the "Add new  signer" was change during Manage signer feature implementation
Resolves #

## How this PR fixes it
The test Id for the "add new signer" was updated to the same that is used in the Manage signers flow to escape managing 2 test id for the same logical element 
## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
