### PR TITLE
test(web): fix 'Verify warning on add owner for one safe in the group'

### DIFF
--- a/apps/web/cypress/e2e/regression/multichain_setup.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_setup.cy.js
@@ -54,17 +54,10 @@ describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
 
   it('Verify warning on add owner for one safe in the group', () => {
     cy.visit(constants.setupUrl + staticSafes.MATIC_STATIC_SAFE_28)
-    owner.openAddOwnerWindow()
-    owner.typeOwnerAddress(constants.SEPOLIA_OWNER_2)
-    owner.clickOnNextBtn()
-    sideBar.checkInconsistentSignersMsgDisplayedConfirmTxView(constants.networks.polygon)
-  })
-
-  it('Verify warning on add owner for one safe in the group', () => {
-    cy.visit(constants.setupUrl + staticSafes.MATIC_STATIC_SAFE_28)
-    owner.openAddOwnerWindow()
-    owner.typeOwnerAddress(constants.SEPOLIA_OWNER_2)
-    owner.clickOnNextBtn()
+    owner.openManageSignersWindow()
+    owner.clickOnAddSignerBtn()
+    owner.typeOwnerAddressManage(1, constants.SEPOLIA_OWNER_2)
+    owner.clickOnNextBtnManage()
     sideBar.checkInconsistentSignersMsgDisplayedConfirmTxView(constants.networks.polygon)
   })
 


### PR DESCRIPTION
## What it solves
 fix 'Verify warning on add owner for one safe in the group'
 
Resolves #

## How this PR fixes it
1. Remove duplication in the  tests
2. Update the test 'Verify warning on add owner for one safe in the group'with relevant steps, because Add owner was replaced by Manage signers form 
## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
