### PR TITLE
feat(web): allow batching of batch txs

### DIFF
--- a/apps/web/cypress/support/localstorage_data.js
+++ b/apps/web/cypress/support/localstorage_data.js
@@ -132,7 +132,7 @@ export const batchData = {
                 name: null,
                 logoUri: null,
               },
-              value: '1000000000000000',
+              value: '2000000000000000',
               operation: 0,
               trustedDelegateCallTarget: null,
               addressInfoIndex: null,

--- a/apps/web/src/components/batch/BatchSidebar/BatchTxItem.tsx
+++ b/apps/web/src/components/batch/BatchSidebar/BatchTxItem.tsx
@@ -61,18 +61,20 @@ const BatchTxItem = ({
     <ListItem disablePadding sx={{ gap: 2, alignItems: 'flex-start' }}>
       <div className={css.number}>{count}</div>
       {txDecoded ? (
-        <SingleTxDecoded
-          actionTitle=""
-          tx={txDecoded}
-          txData={transactionDetails}
-          actions={
-            onDelete ? (
-              <ButtonBase onClick={handleDelete} title="Delete transaction" sx={{ p: 0.5 }}>
-                <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" />
-              </ButtonBase>
-            ) : undefined
-          }
-        />
+        <div className={css.accordion}>
+          <SingleTxDecoded
+            actionTitle=""
+            tx={txDecoded}
+            txData={transactionDetails}
+            actions={
+              onDelete ? (
+                <ButtonBase onClick={handleDelete} title="Delete transaction" sx={{ p: 0.5 }}>
+                  <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" />
+                </ButtonBase>
+              ) : undefined
+            }
+          />
+        </div>
       ) : (
         <Skeleton width="100%" height="56px" />
       )}

--- a/apps/web/src/components/batch/BatchSidebar/BatchTxItem.tsx
+++ b/apps/web/src/components/batch/BatchSidebar/BatchTxItem.tsx
@@ -1,34 +1,49 @@
 import { type SyntheticEvent, useMemo, useCallback } from 'react'
-import { Accordion, AccordionDetails, AccordionSummary, Box, ButtonBase, ListItem, SvgIcon } from '@mui/material'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { ButtonBase, ListItem, Skeleton, SvgIcon } from '@mui/material'
 import css from './styles.module.css'
 import { type DraftBatchItem } from '@/store/batchSlice'
-import TxType from '@/components/transactions/TxType'
-import TxInfo from '@/components/transactions/TxInfo'
+
 import DeleteIcon from '@/public/images/common/delete.svg'
-import TxData from '@/components/transactions/TxDetails/TxData'
-import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
-import { TxDataRow } from '@/components/transactions/TxDetails/Summary/TxDataRow'
-import { dateString } from '@safe-global/utils/utils/formatters'
 import { BATCH_EVENTS, trackEvent } from '@/services/analytics'
+import SingleTxDecoded from '@/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded'
+import {
+  type AddressEx,
+  Operation,
+  type TransactionData,
+  type InternalTransaction,
+} from '@safe-global/safe-gateway-typescript-sdk'
+import { type TokenInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
 type BatchTxItemProps = DraftBatchItem & {
   id: string
   count: number
   onDelete?: (id: string) => void
+  txDecoded?: InternalTransaction
+  addressInfoIndex: Record<string, AddressEx>
+  tokenInfoIndex: Record<string, TokenInfo>
 }
 
-const BatchTxItem = ({ id, count, timestamp, txDetails, onDelete }: BatchTxItemProps) => {
-  const txSummary = useMemo(
+const BatchTxItem = ({
+  id,
+  count,
+  txData,
+  txDecoded,
+  onDelete,
+  addressInfoIndex,
+  tokenInfoIndex,
+}: BatchTxItemProps) => {
+  const transactionDetails: TransactionData = useMemo(
     () => ({
-      timestamp,
-      id: txDetails.txId,
-      txInfo: txDetails.txInfo,
-      txStatus: txDetails.txStatus,
-      safeAppInfo: txDetails.safeAppInfo,
-      txHash: txDetails.txHash || null,
+      operation: Operation.CALL,
+      to: { value: txData.to },
+      value: txData.value,
+      hexData: txData.data,
+      trustedDelegateCallTarget: false,
+      dataDecoded: txDecoded?.dataDecoded,
+      addressInfoIndex,
+      tokenInfoIndex,
     }),
-    [timestamp, txDetails],
+    [addressInfoIndex, tokenInfoIndex, txData.data, txData.to, txData.value, txDecoded?.dataDecoded],
   )
 
   const handleDelete = useCallback(
@@ -42,63 +57,25 @@ const BatchTxItem = ({ id, count, timestamp, txDetails, onDelete }: BatchTxItemP
     [onDelete, id],
   )
 
-  const handleExpand = () => {
-    trackEvent(BATCH_EVENTS.BATCH_EXPAND_TX)
-  }
-
   return (
     <ListItem disablePadding sx={{ gap: 2, alignItems: 'flex-start' }}>
       <div className={css.number}>{count}</div>
-      <Accordion elevation={0} sx={{ flex: 1 }} onChange={handleExpand}>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />} className={css.accordion}>
-          <Box
-            sx={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-              py: 0.4,
-              width: '100%',
-            }}
-          >
-            <TxType tx={txSummary} />
-
-            <Box flex={1}>
-              <TxInfo info={txDetails.txInfo} />
-            </Box>
-
-            {onDelete && (
-              <>
-                <Box className={css.separator} />
-
-                <ButtonBase onClick={handleDelete} title="Delete transaction" sx={{ p: 0.5 }}>
-                  <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" />
-                </ButtonBase>
-
-                <Box className={css.separator} mr={2} />
-              </>
-            )}
-          </Box>
-        </AccordionSummary>
-
-        <AccordionDetails>
-          <div className={css.details}>
-            <TxData
-              txInfo={txDetails.txInfo}
-              txData={txDetails.txData}
-              txDetails={txDetails}
-              trusted
-              imitation={false}
-            />
-
-            <TxDataRow title="Created:">{timestamp ? dateString(timestamp) : null}</TxDataRow>
-
-            {txDetails.txData?.dataDecoded && (
-              <MethodDetails data={txDetails.txData.dataDecoded} addressInfoIndex={txDetails.txData.addressInfoIndex} />
-            )}
-          </div>
-        </AccordionDetails>
-      </Accordion>
+      {txDecoded ? (
+        <SingleTxDecoded
+          actionTitle=""
+          tx={txDecoded}
+          txData={transactionDetails}
+          actions={
+            onDelete ? (
+              <ButtonBase onClick={handleDelete} title="Delete transaction" sx={{ p: 0.5 }}>
+                <SvgIcon component={DeleteIcon} inheritViewBox fontSize="small" />
+              </ButtonBase>
+            ) : undefined
+          }
+        />
+      ) : (
+        <Skeleton width="100%" height="56px" />
+      )}
     </ListItem>
   )
 }

--- a/apps/web/src/components/batch/BatchSidebar/BatchTxList.tsx
+++ b/apps/web/src/components/batch/BatchSidebar/BatchTxList.tsx
@@ -2,12 +2,70 @@ import type { DraftBatchItem } from '@/store/batchSlice'
 import BatchTxItem from './BatchTxItem'
 import { List } from '@mui/material'
 
+import { isMultiSendCalldata } from '@/utils/transaction-calldata'
+import useTxPreview from '@/components/tx/confirmation-views/useTxPreview'
+import { createMultiSendCallOnlyTx, createTx } from '@/services/tx/tx-sender'
+import useAsync from '@safe-global/utils/hooks/useAsync'
+import { type TransactionPreview, type InternalTransaction, Operation } from '@safe-global/safe-gateway-typescript-sdk'
+import { type SafeTransaction } from '@safe-global/types-kit'
+
+const extractMultiSendActions = (txPreview: TransactionPreview | undefined): InternalTransaction[] => {
+  if (!txPreview) {
+    return []
+  }
+
+  const txData = txPreview.txData
+  if (!txData.hexData || !isMultiSendCalldata(txData.hexData)) {
+    return [
+      {
+        data: txData.hexData ?? '0x',
+        operation: Operation.CALL,
+        to: txData.to.value,
+        value: txData.value,
+        dataDecoded: txData.dataDecoded,
+      },
+    ]
+  }
+
+  const multiSendActions = txData.dataDecoded?.parameters?.[0].valueDecoded
+  if (!multiSendActions) {
+    return []
+  }
+
+  return multiSendActions
+}
+
 const BatchTxList = ({ txItems, onDelete }: { txItems: DraftBatchItem[]; onDelete?: (id: string) => void }) => {
+  const [batchSafeTx] = useAsync(() => {
+    const createSafeTx = async (): Promise<SafeTransaction> => {
+      const isMultiSend = txItems.length > 1
+      const tx = isMultiSend
+        ? await createMultiSendCallOnlyTx(txItems.map((tx) => tx.txData))
+        : await createTx(txItems[0].txData)
+      return tx
+    }
+
+    return createSafeTx()
+  }, [txItems])
+
+  const [decodedBatch] = useTxPreview(batchSafeTx?.data)
+
+  const multiSendActions = extractMultiSendActions(decodedBatch)
+
   return (
     <>
       <List sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         {txItems.map((item, index) => (
-          <BatchTxItem key={item.id} count={index + 1} {...item} onDelete={onDelete} />
+          <BatchTxItem
+            key={item.id}
+            count={index + 1}
+            {...item}
+            txDecoded={multiSendActions?.[index]}
+            onDelete={onDelete}
+            addressInfoIndex={decodedBatch?.txData.addressInfoIndex ?? {}}
+            // @ts-ignore
+            tokenInfoIndex={decodedBatch?.txData.tokenInfoIndex ?? {}}
+          />
         ))}
       </List>
     </>

--- a/apps/web/src/components/batch/BatchSidebar/styles.module.css
+++ b/apps/web/src/components/batch/BatchSidebar/styles.module.css
@@ -98,6 +98,7 @@
 
 .accordion {
   opacity: 1 !important;
+  width: 100%;
 }
 
 .accordion :global .MuiAccordionSummary-content {

--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/index.tsx
@@ -1,7 +1,7 @@
 import { isEmptyHexData } from '@/utils/hex'
 import { type InternalTransaction, type TransactionData } from '@safe-global/safe-gateway-typescript-sdk'
 import type { AccordionProps } from '@mui/material/Accordion/Accordion'
-import { Accordion, AccordionDetails, AccordionSummary, Stack, Typography } from '@mui/material'
+import { Accordion, AccordionDetails, AccordionSummary, Box, Stack, Typography } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import css from './styles.module.css'
 import accordionCss from '@/styles/accordion.module.css'
@@ -22,6 +22,7 @@ type SingleTxDecodedProps = {
   expanded?: boolean
   onChange?: AccordionProps['onChange']
   isExecuted?: boolean
+  actions?: React.ReactNode
 }
 
 export const SingleTxDecoded = ({
@@ -32,6 +33,7 @@ export const SingleTxDecoded = ({
   expanded,
   onChange,
   isExecuted = false,
+  actions,
 }: SingleTxDecodedProps) => {
   const chain = useCurrentChain()
   const isNativeTransfer = tx.value !== '0' && (!tx.data || isEmptyHexData(tx.data))
@@ -77,6 +79,8 @@ export const SingleTxDecoded = ({
             </Typography>
           )}
         </div>
+
+        {actions !== undefined && <Box className={css.actions}>{actions}</Box>}
       </AccordionSummary>
 
       <AccordionDetails>

--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/styles.module.css
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/SingleTxDecoded/styles.module.css
@@ -3,3 +3,15 @@
   gap: 8px;
   align-items: center;
 }
+
+.actions {
+  margin-left: auto;
+  border-left: 1px solid var(--color-border-light);
+  border-right: 1px solid var(--color-border-light);
+  margin-right: 16px;
+  padding: 8px;
+  margin-top: -16px;
+  margin-bottom: -16px;
+  align-items: center;
+  display: flex;
+}

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -14,6 +14,7 @@ import { BATCH_EVENTS, trackEvent } from '@/services/analytics'
 import { TxCardActions } from '../../common/TxCard'
 import { Box, Divider } from '@mui/material'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
+import { isMultiSendCalldata } from '@/utils/transaction-calldata'
 
 const Batching = ({
   onSubmit,
@@ -84,6 +85,7 @@ const useShouldRegisterSlot = () => {
   const isOwner = useIsSafeOwner()
   const { safeTx } = useContext(SafeTxContext)
   const isDelegateCall = safeTx ? checkIsDelegateCall(safeTx) : false
+  const isMultiSend = Boolean(safeTx && isMultiSendCalldata(safeTx?.data.data))
 
   return (
     isOwner &&
@@ -92,7 +94,7 @@ const useShouldRegisterSlot = () => {
     !isCounterfactualSafe &&
     !willExecuteThroughRole &&
     !isProposing &&
-    !isDelegateCall &&
+    (!isDelegateCall || isMultiSend) &&
     isBatchable
   )
 }

--- a/apps/web/src/components/tx-flow/actions/Batching/index.tsx
+++ b/apps/web/src/components/tx-flow/actions/Batching/index.tsx
@@ -15,6 +15,7 @@ import { TxCardActions } from '../../common/TxCard'
 import { Box, Divider } from '@mui/material'
 import commonCss from '@/components/tx-flow/common/styles.module.css'
 import { isMultiSendCalldata } from '@/utils/transaction-calldata'
+import { SafeAppsName } from '@/config/constants'
 
 const Batching = ({
   onSubmit,
@@ -81,11 +82,12 @@ const Batching = ({
 
 const useShouldRegisterSlot = () => {
   const isCounterfactualSafe = useIsCounterfactualSafe()
-  const { isBatch, isProposing, willExecuteThroughRole, isCreation, isBatchable } = useContext(TxFlowContext)
+  const { isBatch, isProposing, willExecuteThroughRole, isCreation, isBatchable, data } = useContext(TxFlowContext)
   const isOwner = useIsSafeOwner()
   const { safeTx } = useContext(SafeTxContext)
   const isDelegateCall = safeTx ? checkIsDelegateCall(safeTx) : false
   const isMultiSend = Boolean(safeTx && isMultiSendCalldata(safeTx?.data.data))
+  const isFromTxBuilder = data?.app?.name === SafeAppsName.TRANSACTION_BUILDER
 
   return (
     isOwner &&
@@ -94,7 +96,7 @@ const useShouldRegisterSlot = () => {
     !isCounterfactualSafe &&
     !willExecuteThroughRole &&
     !isProposing &&
-    (!isDelegateCall || isMultiSend) &&
+    (!isDelegateCall || (isMultiSend && isFromTxBuilder)) &&
     isBatchable
   )
 }

--- a/apps/web/src/components/tx-flow/flows/ConfirmBatch/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmBatch/index.tsx
@@ -1,9 +1,6 @@
 import { useContext, useEffect } from 'react'
-import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import { createMultiSendCallOnlyTx } from '@/services/tx/tx-sender'
 import { SafeTxContext } from '../../SafeTxProvider'
-import type { MetaTransactionData } from '@safe-global/types-kit'
-import { OperationType } from '@safe-global/types-kit'
 import BatchIcon from '@/public/images/common/batch.svg'
 import { useDraftBatch } from '@/hooks/useDraftBatch'
 import { maybePlural } from '@safe-global/utils/utils/formatters'
@@ -15,21 +12,12 @@ type ConfirmBatchProps = {
   onSubmit: () => void
 }
 
-const getData = (txDetails: TransactionDetails): MetaTransactionData => {
-  return {
-    to: txDetails.txData?.to.value ?? '',
-    value: txDetails.txData?.value ?? '0',
-    data: txDetails.txData?.hexData ?? '0x',
-    operation: OperationType.Call, // only calls can be batched
-  }
-}
-
 const ConfirmBatch = (props: ReviewTransactionProps) => {
   const { setSafeTx, setSafeTxError } = useContext(SafeTxContext)
   const batchTxs = useDraftBatch()
 
   useEffect(() => {
-    const calls = batchTxs.map((tx) => getData(tx.txDetails))
+    const calls = batchTxs.map((tx) => tx.txData)
     createMultiSendCallOnlyTx(calls).then(setSafeTx).catch(setSafeTxError)
   }, [batchTxs, setSafeTx, setSafeTxError])
 

--- a/apps/web/src/components/tx-flow/flows/SafeAppsTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SafeAppsTx/index.tsx
@@ -52,6 +52,7 @@ const SafeAppsTxFlow = ({
 
   return (
     <TxFlow
+      initialData={data}
       onSubmit={handleSubmit}
       subtitle={<AppTitle name={data.app?.name} logoUri={data.app?.iconUrl} txs={data.txs} />}
       ReviewTransactionComponent={ReviewTransactionComponent}

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/BatchTransactions.stories.tsx
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/BatchTransactions.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Paper, ThemeProvider } from '@mui/material'
 import { StoreDecorator } from '@/stories/storeDecorator'
 import BatchTransactions from './index'
-import { mockedDarftBatch } from './mockData'
+import { mockedDraftBatch } from './mockData'
 import createSafeTheme from '@/components/theme/safeTheme'
 
 const meta = {
@@ -18,7 +18,7 @@ const meta = {
             chains: { data: [{ chainId: '11155111' }] },
             batch: {
               '11155111': {
-                '': [mockedDarftBatch[0], mockedDarftBatch[0]],
+                '': [mockedDraftBatch[0], mockedDraftBatch[0]],
               },
             },
           }}

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/BatchTransactions.test.tsx
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/BatchTransactions.test.tsx
@@ -1,11 +1,53 @@
 import { render } from '@/tests/test-utils'
 import BatchTransactions from '.'
 import * as useDraftBatch from '@/hooks/useDraftBatch'
-import { mockedDarftBatch } from './mockData'
+import * as useTxPreview from '@/components/tx/confirmation-views/useTxPreview'
+import { mockedDraftBatch } from './mockData'
+import {
+  type TransactionPreview,
+  Operation,
+  TransactionInfoType,
+  TransferDirection,
+  TransactionTokenType,
+} from '@safe-global/safe-gateway-typescript-sdk'
 
-jest.spyOn(useDraftBatch, 'useDraftBatch').mockImplementation(() => mockedDarftBatch)
+jest.spyOn(useDraftBatch, 'useDraftBatch').mockImplementation(() => mockedDraftBatch)
+
+const mockUseTxPreview = jest.spyOn(useTxPreview, 'default')
+
+const mockTxPreview: TransactionPreview = {
+  txData: {
+    hexData: '0x',
+    dataDecoded: undefined,
+    to: { value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6', name: 'GnosisSafeProxy', logoUri: undefined },
+    value: '1000000000000',
+    operation: Operation.CALL,
+    trustedDelegateCallTarget: false,
+    addressInfoIndex: {
+      '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6': {
+        value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+        name: 'GnosisSafeProxy',
+        logoUri: undefined,
+      },
+    },
+  },
+  txInfo: {
+    type: TransactionInfoType.TRANSFER,
+    humanDescription: undefined,
+    sender: { value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6', name: undefined, logoUri: undefined },
+    recipient: { value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6', name: 'GnosisSafeProxy', logoUri: undefined },
+    direction: TransferDirection.OUTGOING,
+    transferInfo: { type: TransactionTokenType.NATIVE_COIN, value: '1000000000000' },
+  },
+}
 
 describe('BatchTransactions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockUseTxPreview.mockImplementation(() => [mockTxPreview, undefined, false] as any)
+  })
+
   it('should render a list of batch transactions', () => {
     const { container, getByText } = render(<BatchTransactions />)
 

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
         1
       </div>
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-1147gyl-MuiPaper-root-MuiAccordion-root"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-1gdgqta-MuiPaper-root-MuiAccordion-root"
         style="--Paper-shadow: none;"
       >
         <h3
@@ -23,6 +23,7 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
           <button
             aria-expanded="false"
             class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters accordion css-10sjung-MuiButtonBase-root-MuiAccordionSummary-root"
+            data-testid="action-item"
             tabindex="0"
             type="button"
           >
@@ -30,39 +31,76 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
               class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-1r0e0ir-MuiAccordionSummary-content"
             >
               <div
-                class="MuiBox-root css-mvjamn"
+                class="summary"
               >
-                <div
-                  class="txType MuiBox-root css-0"
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                  data-testid="CodeIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
                 >
-                  <img
-                    alt="Send"
-                    height="16"
-                    src="/images/transactions/outgoing.svg"
-                    width="16"
+                  <path
+                    d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6zm5.2 0 4.6-4.6-4.6-4.6L16 6l6 6-6 6z"
                   />
-                  <span
-                    class="txTypeText"
+                </svg>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
+                />
+                <div
+                  class="MuiStack-root css-kdc3n8-MuiStack-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
                   >
                     Send
-                  </span>
-                </div>
-                <div
-                  class="MuiBox-root css-1rr4qq7"
-                >
+                  </p>
                   <span
-                    aria-label="1000000000000"
+                    aria-label="0.000001 ETH"
                     class="container"
                     data-mui-internal-clone-element="true"
                   >
                     <b
                       class="tokenText"
                     >
-                      -
-                      1000000000000
+                      &lt; 0.00001
                        
+                      ETH
                     </b>
                   </span>
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
+                  >
+                    to
+                  </p>
+                  <div
+                    class="container"
+                  >
+                    <div
+                      class="avatarContainer"
+                      style="width: 16px; height: 16px;"
+                    >
+                      <div
+                        class="icon"
+                        style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjI2IDc1JSA0NCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg3MCA1NyUgNTYlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDMzMSA4NiUgNDglKSIgZD0iTTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTIsN2gxdjFoLTF6TTUsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 16px; height: 16px;"
+                      />
+                    </div>
+                    <div
+                      class="inline MuiBox-root css-1lchl8k"
+                    >
+                      <div
+                        class="addressContainer inline"
+                      >
+                        <div
+                          class="MuiBox-root css-b5p5gz"
+                        >
+                          <span>
+                            0xA77D...98b6
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </span>
@@ -101,145 +139,192 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
                   class="MuiAccordionDetails-root css-w74p4c-MuiAccordionDetails-root"
                 >
                   <div
-                    class="details"
+                    class="MuiStack-root css-jfdv4h-MuiStack-root"
                   >
                     <div
-                      class="MuiBox-root css-1821gv5"
+                      class="MuiStack-root css-1sazv7p-MuiStack-root"
                     >
                       <div
-                        class="MuiBox-root css-8v90jo"
-                      >
-                        Send
-                         
-                        <b>
-                          <span
-                            aria-label="1000000000000"
-                            class="container"
-                            data-mui-internal-clone-element="true"
-                          >
-                            <b
-                              class="tokenText"
-                            >
-                              1000000000000
-                               
-                            </b>
-                          </span>
-                        </b>
-                         to
-                      </div>
-                      <div
-                        class="MuiBox-root css-7pf6at"
+                        class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
                       >
                         <div
-                          class="container"
+                          class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
+                          data-testid="tx-row-title"
+                          style="word-break: break-word;"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
+                          >
+                            Interacted with
+                          </span>
+                        </div>
+                        <div
+                          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+                          data-testid="tx-data-row"
                         >
                           <div
-                            class="avatarContainer"
-                            style="width: 40px; height: 40px;"
+                            class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
                           >
                             <div
-                              class="icon"
-                              style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjI2IDc1JSA0NCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg3MCA1NyUgNTYlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDMzMSA4NiUgNDglKSIgZD0iTTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTIsN2gxdjFoLTF6TTUsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 40px; height: 40px;"
-                            />
-                          </div>
-                          <div
-                            class="MuiBox-root css-1lchl8k"
-                          >
-                            <div
-                              class="ethHashInfo-name MuiBox-root css-171onha"
-                              title="GnosisSafeProxy"
+                              class="container"
                             >
                               <div
-                                class="MuiBox-root css-1o4wo1x"
+                                class="avatarContainer"
+                                style="width: 20px; height: 20px;"
                               >
-                                GnosisSafeProxy
+                                <div
+                                  class="icon"
+                                  style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjI2IDc1JSA0NCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg3MCA1NyUgNTYlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDMzMSA4NiUgNDglKSIgZD0iTTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTIsN2gxdjFoLTF6TTUsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
+                                />
+                              </div>
+                              <div
+                                class="MuiBox-root css-1lchl8k"
+                              >
+                                <div
+                                  class="ethHashInfo-name MuiBox-root css-171onha"
+                                  title="GnosisSafeProxy"
+                                >
+                                  <div
+                                    class="MuiBox-root css-1o4wo1x"
+                                  >
+                                    GnosisSafeProxy
+                                  </div>
+                                </div>
+                                <div
+                                  class="addressContainer"
+                                >
+                                  <div
+                                    class="MuiBox-root css-b5p5gz"
+                                  >
+                                    <span
+                                      aria-label="Copy to clipboard"
+                                      class=""
+                                      data-mui-internal-clone-element="true"
+                                      style="cursor: pointer;"
+                                    >
+                                      <span>
+                                        0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6
+                                      </span>
+                                    </span>
+                                  </div>
+                                  <span
+                                    aria-label="Copy to clipboard"
+                                    class=""
+                                    data-mui-internal-clone-element="true"
+                                    style="cursor: pointer;"
+                                  >
+                                    <button
+                                      aria-label="Copy to clipboard"
+                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                                      tabindex="0"
+                                      type="button"
+                                    >
+                                      <mock-icon
+                                        aria-hidden=""
+                                        class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                                        data-testid="copy-btn-icon"
+                                        focusable="false"
+                                      />
+                                    </button>
+                                  </span>
+                                  <div
+                                    class="MuiBox-root css-yjghm1"
+                                  />
+                                </div>
                               </div>
                             </div>
-                            <div
-                              class="addressContainer"
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+                      >
+                        <div
+                          class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
+                          data-testid="tx-row-title"
+                          style="word-break: break-word;"
+                        >
+                          <span
+                            class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
+                          >
+                            Value
+                          </span>
+                        </div>
+                        <div
+                          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+                          data-testid="tx-data-row"
+                        >
+                          <div
+                            class="MuiBox-root css-axw7ok"
+                          >
+                            <img
+                              alt="ETH"
+                              class="image"
+                              height="26"
+                              loading="lazy"
+                              referrerpolicy="no-referrer"
+                            />
+                            <p
+                              class="MuiTypography-root MuiTypography-body2 css-1ct9qkn-MuiTypography-root"
                             >
-                              <div
-                                class="MuiBox-root css-b5p5gz"
-                              >
-                                <span
-                                  aria-label="Copy to clipboard"
-                                  class=""
-                                  data-mui-internal-clone-element="true"
-                                  style="cursor: pointer;"
-                                >
-                                  <span>
-                                    0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6
-                                  </span>
-                                </span>
-                              </div>
+                              ETH
+                            </p>
+                            <p
+                              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                              data-testid="token-amount"
+                            >
+                              0.000001
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                        data-testid="hexData"
+                      >
+                        <div
+                          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+                        >
+                          <div
+                            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
+                            data-testid="tx-row-title"
+                            style="word-break: break-word;"
+                          >
+                            <span
+                              class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
+                            >
+                              Data
+                            </span>
+                          </div>
+                          <div
+                            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+                            data-testid="tx-data-row"
+                          >
+                            <div
+                              class="encodedData MuiBox-root css-0"
+                              data-testid="tx-hexData"
+                            >
                               <span
                                 aria-label="Copy to clipboard"
                                 class=""
                                 data-mui-internal-clone-element="true"
                                 style="cursor: pointer;"
                               >
-                                <button
-                                  aria-label="Copy to clipboard"
-                                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                                  tabindex="0"
-                                  type="button"
+                                <span
+                                  class="monospace"
                                 >
-                                  <mock-icon
-                                    aria-hidden=""
-                                    class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                                    data-testid="copy-btn-icon"
-                                    focusable="false"
-                                  />
-                                </button>
+                                  <b
+                                    aria-label="The first 4 bytes determine the contract method that is being called"
+                                    class=""
+                                    data-mui-internal-clone-element="true"
+                                  >
+                                    0x
+                                  </b>
+                                   
+                                </span>
                               </span>
-                              <div
-                                class="MuiBox-root css-yjghm1"
-                              />
-                              <button
-                                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeSmall css-1bg1tw1-MuiButtonBase-root-MuiIconButton-root"
-                                tabindex="0"
-                                type="button"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1ktsa7m-MuiSvgIcon-root"
-                                  data-testid="MoreHorizIcon"
-                                  focusable="false"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
-                                  />
-                                </svg>
-                              </button>
                             </div>
                           </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
-                      data-testid=""
-                    >
-                      <div
-                        class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-                        data-testid="tx-row-title"
-                        style="word-break: break-word;"
-                      >
-                        <span
-                          class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
-                        >
-                          Created:
-                        </span>
-                      </div>
-                      <div
-                        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-                        data-testid="tx-data-row"
-                      >
-                        <div
-                          class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
-                        >
-                          9/20/2024, 10:20:15 AM
                         </div>
                       </div>
                     </div>
@@ -250,6 +335,19 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
           </div>
         </div>
       </div>
+    </li>
+    <li
+      class="MuiListItem-root MuiListItem-gutters css-rqnn2j-MuiListItem-root"
+    >
+      <div
+        class="number"
+      >
+        2
+      </div>
+      <span
+        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1daydue-MuiSkeleton-root"
+        style="width: 100%; height: 56px;"
+      />
     </li>
   </ul>
 </div>

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -260,13 +260,17 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
                             <div
                               class="MuiBox-root css-axw7ok"
                             >
-                              <img
-                                alt="ETH"
-                                class="image"
-                                height="26"
-                                loading="lazy"
-                                referrerpolicy="no-referrer"
-                              />
+                              <div
+                                class="MuiBox-root css-olq4e8"
+                              >
+                                <img
+                                  alt="ETH"
+                                  class="image"
+                                  height="26"
+                                  loading="lazy"
+                                  referrerpolicy="no-referrer"
+                                />
+                              </div>
                               <p
                                 class="MuiTypography-root MuiTypography-body2 css-1ct9qkn-MuiTypography-root"
                               >

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -14,273 +14,138 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
         1
       </div>
       <div
-        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-1gdgqta-MuiPaper-root-MuiAccordion-root"
-        style="--Paper-shadow: none;"
+        class="accordion"
       >
-        <h3
-          class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-1gdgqta-MuiPaper-root-MuiAccordion-root"
+          style="--Paper-shadow: none;"
         >
-          <button
-            aria-expanded="false"
-            class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters accordion css-10sjung-MuiButtonBase-root-MuiAccordionSummary-root"
-            data-testid="action-item"
-            tabindex="0"
-            type="button"
+          <h3
+            class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
           >
-            <span
-              class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-1r0e0ir-MuiAccordionSummary-content"
+            <button
+              aria-expanded="false"
+              class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters accordion css-10sjung-MuiButtonBase-root-MuiAccordionSummary-root"
+              data-testid="action-item"
+              tabindex="0"
+              type="button"
             >
-              <div
-                class="summary"
+              <span
+                class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-1r0e0ir-MuiAccordionSummary-content"
               >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                  data-testid="CodeIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6zm5.2 0 4.6-4.6-4.6-4.6L16 6l6 6-6 6z"
-                  />
-                </svg>
-                <p
-                  class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
-                />
                 <div
-                  class="MuiStack-root css-kdc3n8-MuiStack-root"
+                  class="summary"
                 >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                    data-testid="CodeIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6zm5.2 0 4.6-4.6-4.6-4.6L16 6l6 6-6 6z"
+                    />
+                  </svg>
                   <p
                     class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
-                  >
-                    Send
-                  </p>
-                  <span
-                    aria-label="0.000001 ETH"
-                    class="container"
-                    data-mui-internal-clone-element="true"
-                  >
-                    <b
-                      class="tokenText"
-                    >
-                      &lt; 0.00001
-                       
-                      ETH
-                    </b>
-                  </span>
-                  <p
-                    class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
-                  >
-                    to
-                  </p>
+                  />
                   <div
-                    class="container"
+                    class="MuiStack-root css-kdc3n8-MuiStack-root"
                   >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
+                    >
+                      Send
+                    </p>
+                    <span
+                      aria-label="0.000001 ETH"
+                      class="container"
+                      data-mui-internal-clone-element="true"
+                    >
+                      <b
+                        class="tokenText"
+                      >
+                        &lt; 0.00001
+                         
+                        ETH
+                      </b>
+                    </span>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-v6lhhw-MuiTypography-root"
+                    >
+                      to
+                    </p>
                     <div
-                      class="avatarContainer"
-                      style="width: 16px; height: 16px;"
+                      class="container"
                     >
                       <div
-                        class="icon"
-                        style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjI2IDc1JSA0NCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg3MCA1NyUgNTYlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDMzMSA4NiUgNDglKSIgZD0iTTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTIsN2gxdjFoLTF6TTUsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 16px; height: 16px;"
-                      />
-                    </div>
-                    <div
-                      class="inline MuiBox-root css-1lchl8k"
-                    >
-                      <div
-                        class="addressContainer inline"
+                        class="avatarContainer"
+                        style="width: 16px; height: 16px;"
                       >
                         <div
-                          class="MuiBox-root css-b5p5gz"
+                          class="icon"
+                          style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjI2IDc1JSA0NCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg3MCA1NyUgNTYlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDMzMSA4NiUgNDglKSIgZD0iTTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTIsN2gxdjFoLTF6TTUsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 16px; height: 16px;"
+                        />
+                      </div>
+                      <div
+                        class="inline MuiBox-root css-1lchl8k"
+                      >
+                        <div
+                          class="addressContainer inline"
                         >
-                          <span>
-                            0xA77D...98b6
-                          </span>
+                          <div
+                            class="MuiBox-root css-b5p5gz"
+                          >
+                            <span>
+                              0xA77D...98b6
+                            </span>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </span>
-            <span
-              class="MuiAccordionSummary-expandIconWrapper css-1wqf3nl-MuiAccordionSummary-expandIconWrapper"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1dhtbeh-MuiSvgIcon-root"
-                data-testid="ExpandMoreIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
+              </span>
+              <span
+                class="MuiAccordionSummary-expandIconWrapper css-1wqf3nl-MuiAccordionSummary-expandIconWrapper"
               >
-                <path
-                  d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                />
-              </svg>
-            </span>
-          </button>
-        </h3>
-        <div
-          class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
-          style="min-height: 0px;"
-        >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1dhtbeh-MuiSvgIcon-root"
+                  data-testid="ExpandMoreIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </h3>
           <div
-            class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+            class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+            style="min-height: 0px;"
           >
             <div
-              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+              class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
             >
               <div
-                class="MuiAccordion-region"
-                role="region"
+                class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
               >
                 <div
-                  class="MuiAccordionDetails-root css-w74p4c-MuiAccordionDetails-root"
+                  class="MuiAccordion-region"
+                  role="region"
                 >
                   <div
-                    class="MuiStack-root css-jfdv4h-MuiStack-root"
+                    class="MuiAccordionDetails-root css-w74p4c-MuiAccordionDetails-root"
                   >
                     <div
-                      class="MuiStack-root css-1sazv7p-MuiStack-root"
+                      class="MuiStack-root css-jfdv4h-MuiStack-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
-                      >
-                        <div
-                          class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-                          data-testid="tx-row-title"
-                          style="word-break: break-word;"
-                        >
-                          <span
-                            class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
-                          >
-                            Interacted with
-                          </span>
-                        </div>
-                        <div
-                          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-                          data-testid="tx-data-row"
-                        >
-                          <div
-                            class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                          >
-                            <div
-                              class="container"
-                            >
-                              <div
-                                class="avatarContainer"
-                                style="width: 20px; height: 20px;"
-                              >
-                                <div
-                                  class="icon"
-                                  style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjI2IDc1JSA0NCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg3MCA1NyUgNTYlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDMzMSA4NiUgNDglKSIgZD0iTTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTIsN2gxdjFoLTF6TTUsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
-                                />
-                              </div>
-                              <div
-                                class="MuiBox-root css-1lchl8k"
-                              >
-                                <div
-                                  class="ethHashInfo-name MuiBox-root css-171onha"
-                                  title="GnosisSafeProxy"
-                                >
-                                  <div
-                                    class="MuiBox-root css-1o4wo1x"
-                                  >
-                                    GnosisSafeProxy
-                                  </div>
-                                </div>
-                                <div
-                                  class="addressContainer"
-                                >
-                                  <div
-                                    class="MuiBox-root css-b5p5gz"
-                                  >
-                                    <span
-                                      aria-label="Copy to clipboard"
-                                      class=""
-                                      data-mui-internal-clone-element="true"
-                                      style="cursor: pointer;"
-                                    >
-                                      <span>
-                                        0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6
-                                      </span>
-                                    </span>
-                                  </div>
-                                  <span
-                                    aria-label="Copy to clipboard"
-                                    class=""
-                                    data-mui-internal-clone-element="true"
-                                    style="cursor: pointer;"
-                                  >
-                                    <button
-                                      aria-label="Copy to clipboard"
-                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                                      tabindex="0"
-                                      type="button"
-                                    >
-                                      <mock-icon
-                                        aria-hidden=""
-                                        class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
-                                        data-testid="copy-btn-icon"
-                                        focusable="false"
-                                      />
-                                    </button>
-                                  </span>
-                                  <div
-                                    class="MuiBox-root css-yjghm1"
-                                  />
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
-                      >
-                        <div
-                          class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
-                          data-testid="tx-row-title"
-                          style="word-break: break-word;"
-                        >
-                          <span
-                            class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
-                          >
-                            Value
-                          </span>
-                        </div>
-                        <div
-                          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
-                          data-testid="tx-data-row"
-                        >
-                          <div
-                            class="MuiBox-root css-axw7ok"
-                          >
-                            <img
-                              alt="ETH"
-                              class="image"
-                              height="26"
-                              loading="lazy"
-                              referrerpolicy="no-referrer"
-                            />
-                            <p
-                              class="MuiTypography-root MuiTypography-body2 css-1ct9qkn-MuiTypography-root"
-                            >
-                              ETH
-                            </p>
-                            <p
-                              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                              data-testid="token-amount"
-                            >
-                              0.000001
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
-                        data-testid="hexData"
+                        class="MuiStack-root css-1sazv7p-MuiStack-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
@@ -293,7 +158,7 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
                             <span
                               class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
                             >
-                              Data
+                              Interacted with
                             </span>
                           </div>
                           <div
@@ -301,28 +166,167 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
                             data-testid="tx-data-row"
                           >
                             <div
-                              class="encodedData MuiBox-root css-0"
-                              data-testid="tx-hexData"
+                              class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                            >
+                              <div
+                                class="container"
+                              >
+                                <div
+                                  class="avatarContainer"
+                                  style="width: 20px; height: 20px;"
+                                >
+                                  <div
+                                    class="icon"
+                                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjI2IDc1JSA0NCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg3MCA1NyUgNTYlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTIsMGgxdjFoLTF6TTUsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTAsMmgxdjFoLTF6TTcsMmgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTMsNWgxdjFoLTF6TTQsNWgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTIsNmgxdjFoLTF6TTUsNmgxdjFoLTF6TTAsN2gxdjFoLTF6TTcsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDMzMSA4NiUgNDglKSIgZD0iTTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTIsN2gxdjFoLTF6TTUsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 20px; height: 20px;"
+                                  />
+                                </div>
+                                <div
+                                  class="MuiBox-root css-1lchl8k"
+                                >
+                                  <div
+                                    class="ethHashInfo-name MuiBox-root css-171onha"
+                                    title="GnosisSafeProxy"
+                                  >
+                                    <div
+                                      class="MuiBox-root css-1o4wo1x"
+                                    >
+                                      GnosisSafeProxy
+                                    </div>
+                                  </div>
+                                  <div
+                                    class="addressContainer"
+                                  >
+                                    <div
+                                      class="MuiBox-root css-b5p5gz"
+                                    >
+                                      <span
+                                        aria-label="Copy to clipboard"
+                                        class=""
+                                        data-mui-internal-clone-element="true"
+                                        style="cursor: pointer;"
+                                      >
+                                        <span>
+                                          0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6
+                                        </span>
+                                      </span>
+                                    </div>
+                                    <span
+                                      aria-label="Copy to clipboard"
+                                      class=""
+                                      data-mui-internal-clone-element="true"
+                                      style="cursor: pointer;"
+                                    >
+                                      <button
+                                        aria-label="Copy to clipboard"
+                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                                        tabindex="0"
+                                        type="button"
+                                      >
+                                        <mock-icon
+                                          aria-hidden=""
+                                          class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-gvpe62-MuiSvgIcon-root"
+                                          data-testid="copy-btn-icon"
+                                          focusable="false"
+                                        />
+                                      </button>
+                                    </span>
+                                    <div
+                                      class="MuiBox-root css-yjghm1"
+                                    />
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+                        >
+                          <div
+                            class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
+                            data-testid="tx-row-title"
+                            style="word-break: break-word;"
+                          >
+                            <span
+                              class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
+                            >
+                              Value
+                            </span>
+                          </div>
+                          <div
+                            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+                            data-testid="tx-data-row"
+                          >
+                            <div
+                              class="MuiBox-root css-axw7ok"
+                            >
+                              <img
+                                alt="ETH"
+                                class="image"
+                                height="26"
+                                loading="lazy"
+                                referrerpolicy="no-referrer"
+                              />
+                              <p
+                                class="MuiTypography-root MuiTypography-body2 css-1ct9qkn-MuiTypography-root"
+                              >
+                                ETH
+                              </p>
+                              <p
+                                class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                                data-testid="token-amount"
+                              >
+                                0.000001
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiTypography-root MuiTypography-body2 css-17vdyq3-MuiTypography-root"
+                          data-testid="hexData"
+                        >
+                          <div
+                            class="MuiGrid-root MuiGrid-container css-1yff1ei-MuiGrid-root"
+                          >
+                            <div
+                              class="MuiGrid-root MuiGrid-item css-ezmk0c-MuiGrid-root"
+                              data-testid="tx-row-title"
+                              style="word-break: break-word;"
                             >
                               <span
-                                aria-label="Copy to clipboard"
-                                class=""
-                                data-mui-internal-clone-element="true"
-                                style="cursor: pointer;"
+                                class="MuiTypography-root MuiTypography-body2 css-1ew0eu5-MuiTypography-root"
+                              >
+                                Data
+                              </span>
+                            </div>
+                            <div
+                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true css-1vd824g-MuiGrid-root"
+                              data-testid="tx-data-row"
+                            >
+                              <div
+                                class="encodedData MuiBox-root css-0"
+                                data-testid="tx-hexData"
                               >
                                 <span
-                                  class="monospace"
+                                  aria-label="Copy to clipboard"
+                                  class=""
+                                  data-mui-internal-clone-element="true"
+                                  style="cursor: pointer;"
                                 >
-                                  <b
-                                    aria-label="The first 4 bytes determine the contract method that is being called"
-                                    class=""
-                                    data-mui-internal-clone-element="true"
+                                  <span
+                                    class="monospace"
                                   >
-                                    0x
-                                  </b>
-                                   
+                                    <b
+                                      aria-label="The first 4 bytes determine the contract method that is being called"
+                                      class=""
+                                      data-mui-internal-clone-element="true"
+                                    >
+                                      0x
+                                    </b>
+                                     
+                                  </span>
                                 </span>
-                              </span>
+                              </div>
                             </div>
                           </div>
                         </div>

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/mockData.ts
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/mockData.ts
@@ -1,23 +1,24 @@
+import { faker } from '@faker-js/faker'
 import type { DraftBatchItem } from '@/store/batchSlice'
 import { OperationType } from '@safe-global/types-kit'
 
 export const mockedDraftBatch: DraftBatchItem[] = [
   {
-    id: '6283sw7pzyk',
+    id: faker.string.alphanumeric(10),
     timestamp: 1726820415651,
     txData: {
-      to: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
-      value: '1000000000000',
+      to: faker.finance.ethereumAddress(),
+      value: faker.number.bigInt({ min: 1000000000000n, max: 10000000000000n }).toString(),
       data: '0x',
       operation: OperationType.Call,
     },
   },
   {
-    id: 'abc123def456',
+    id: faker.string.alphanumeric(10),
     timestamp: 1726820415652,
     txData: {
-      to: '0x1234567890123456789012345678901234567890',
-      value: '500000000000',
+      to: faker.finance.ethereumAddress(),
+      value: faker.number.bigInt({ min: 1000000000000n, max: 10000000000000n }).toString(),
       data: '0x',
       operation: OperationType.Call,
     },

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/mockData.ts
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/mockData.ts
@@ -1,121 +1,25 @@
 import type { DraftBatchItem } from '@/store/batchSlice'
+import { OperationType } from '@safe-global/types-kit'
 
-export const mockedDarftBatch = [
+export const mockedDraftBatch: DraftBatchItem[] = [
   {
     id: '6283sw7pzyk',
     timestamp: 1726820415651,
-    txDetails: {
-      safeAddress: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
-      txId: 'multisig_0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6_0x876e728deafcc9ba46461cc63078a521f520b620b0a3c2e4b40a5f1f69358f6c',
-      executedAt: null,
-      txStatus: 'AWAITING_CONFIRMATIONS',
-      txInfo: {
-        type: 'Transfer',
-        humanDescription: null,
-        sender: {
-          value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
-          name: null,
-          logoUri: null,
-        },
-        recipient: {
-          value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
-          name: 'GnosisSafeProxy',
-          logoUri: null,
-        },
-        direction: 'OUTGOING',
-        transferInfo: {
-          type: 'NATIVE_COIN',
-          value: '1000000000000',
-        },
-      },
-      txData: {
-        hexData: null,
-        dataDecoded: null,
-        to: {
-          value: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
-          name: 'GnosisSafeProxy',
-          logoUri: null,
-        },
-        value: '1000000000000',
-        operation: 0,
-        trustedDelegateCallTarget: null,
-        addressInfoIndex: null,
-      },
-      txHash: null,
-      detailedExecutionInfo: {
-        type: 'MULTISIG',
-        submittedAt: 1726820406700,
-        nonce: 45,
-        safeTxGas: '0',
-        baseGas: '0',
-        gasPrice: '0',
-        gasToken: '0x0000000000000000000000000000000000000000',
-        refundReceiver: {
-          value: '0x0000000000000000000000000000000000000000',
-          name: null,
-          logoUri: null,
-        },
-        safeTxHash: '0x876e728deafcc9ba46461cc63078a521f520b620b0a3c2e4b40a5f1f69358f6c',
-        executor: null,
-        signers: [
-          {
-            value: '0xDa5e9FA404881Ff36DDa97b41Da402dF6430EE6b',
-            name: null,
-            logoUri: null,
-          },
-          {
-            value: '0xEe91F585eA6ABc2822FaD082a095B46939059a31',
-            name: null,
-            logoUri: null,
-          },
-          {
-            value: '0x3819b800c67Be64029C1393c8b2e0d0d627dADE2',
-            name: null,
-            logoUri: null,
-          },
-          {
-            value: '0xd8BBcB76BC9AeA78972ED4773A5EB67B413f26A5',
-            name: null,
-            logoUri: null,
-          },
-          {
-            value: '0x21D62C6894741DE97944D7844ED44D7782C66ABC',
-            name: null,
-            logoUri: null,
-          },
-          {
-            value: '0xD33dD066fC8a0BC70269AC06B0ED98B00BFA3A0a',
-            name: null,
-            logoUri: null,
-          },
-          {
-            value: '0xC2e333cb4aFfD6067D1d46ff80A6e631EC7B5A17',
-            name: null,
-            logoUri: null,
-          },
-          {
-            value: '0xbc2BB26a6d821e69A38016f3858561a1D80d4182',
-            name: null,
-            logoUri: null,
-          },
-          {
-            value: '0x474e5Ded6b5D078163BFB8F6dBa355C3aA5478C8',
-            name: null,
-            logoUri: null,
-          },
-        ],
-        confirmationsRequired: 2,
-        confirmations: [],
-        rejectors: [],
-        gasTokenInfo: null,
-        trusted: false,
-        proposer: {
-          value: '0xDa5e9FA404881Ff36DDa97b41Da402dF6430EE6b',
-          name: null,
-          logoUri: null,
-        },
-      },
-      safeAppInfo: null,
+    txData: {
+      to: '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+      value: '1000000000000',
+      data: '0x',
+      operation: OperationType.Call,
     },
   },
-] as unknown as DraftBatchItem[]
+  {
+    id: 'abc123def456',
+    timestamp: 1726820415652,
+    txData: {
+      to: '0x1234567890123456789012345678901234567890',
+      value: '500000000000',
+      data: '0x',
+      operation: OperationType.Call,
+    },
+  },
+]

--- a/apps/web/src/config/constants.ts
+++ b/apps/web/src/config/constants.ts
@@ -67,6 +67,7 @@ export enum SafeAppsTag {
 // Safe Apps names
 export enum SafeAppsName {
   CSV = 'CSV Airdrop',
+  TRANSACTION_BUILDER = 'Transaction Builder',
 }
 
 export const RECOVERY_FEEDBACK_FORM =

--- a/apps/web/src/hooks/useDraftBatch.ts
+++ b/apps/web/src/hooks/useDraftBatch.ts
@@ -3,12 +3,15 @@ import { useCallback } from 'react'
 import { useAppDispatch, useAppSelector } from '@/store'
 import useChainId from './useChainId'
 import useSafeAddress from './useSafeAddress'
-import type { DraftBatchItem } from '@/store/batchSlice'
+import type { CallOnlyTxData, DraftBatchItem } from '@/store/batchSlice'
 import { selectBatchBySafe, addTx, removeTx } from '@/store/batchSlice'
 import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import { BATCH_EVENTS, trackEvent } from '@/services/analytics'
 import { txDispatch, TxEvent } from '@/services/tx/txEvents'
 import { shallowEqual } from 'react-redux'
+import { isMultiSendCalldata } from '@/utils/transaction-calldata'
+import { decodeMultiSendData } from '@safe-global/protocol-kit/dist/src/utils'
+import { OperationType } from '@safe-global/types-kit'
 
 export const useUpdateBatch = () => {
   const chainId = useChainId()
@@ -17,13 +20,37 @@ export const useUpdateBatch = () => {
 
   const onAdd = useCallback(
     async (txDetails: TransactionDetails): Promise<void> => {
-      dispatch(
-        addTx({
-          chainId,
-          safeAddress,
-          txDetails,
-        }),
-      )
+      let txs: CallOnlyTxData[]
+      // If it is a multisend, we decode the data to get the individual transactions
+      if (txDetails.txData?.hexData && isMultiSendCalldata(txDetails.txData?.hexData)) {
+        const decodedTxs = decodeMultiSendData(txDetails.txData?.hexData)
+        txs = decodedTxs.map((tx) => ({
+          to: tx.to,
+          value: tx.value,
+          data: tx.data,
+          operation: OperationType.Call,
+        }))
+      } else {
+        txs = txDetails.txData
+          ? [
+              {
+                to: txDetails.txData.to.value,
+                value: txDetails.txData.value ?? '0',
+                operation: OperationType.Call,
+                data: txDetails.txData.hexData ?? '0x',
+              },
+            ]
+          : []
+      }
+      txs.forEach((tx) => {
+        dispatch(
+          addTx({
+            chainId,
+            safeAddress,
+            txData: tx,
+          }),
+        )
+      })
 
       if (isMultisigExecutionInfo(txDetails.detailedExecutionInfo)) {
         txDispatch(TxEvent.BATCH_ADD, { txId: txDetails.txId, nonce: txDetails.detailedExecutionInfo.nonce })

--- a/apps/web/src/services/ls-migration/batch.ts
+++ b/apps/web/src/services/ls-migration/batch.ts
@@ -1,0 +1,23 @@
+import { type BatchTxsState } from '@/store/batchSlice'
+import { OperationType } from '@safe-global/types-kit'
+
+export const migrateBatchTxs = (batchSliceState: BatchTxsState) => {
+  // Iterate over all batches and migrate txDetails to txData
+  Object.keys(batchSliceState).forEach((chainId) => {
+    Object.keys(batchSliceState[chainId]).forEach((safeAddress) => {
+      batchSliceState[chainId][safeAddress].forEach((batch) => {
+        if (batch.txDetails && batch.txDetails.txData && !batch.txData) {
+          batch.txData = {
+            to: batch.txDetails.txData.to.value,
+            value: batch.txDetails.txData.value ?? '0',
+            data: batch.txDetails.txData.hexData ?? '0x',
+            operation: OperationType.Call, // We only support calls
+          }
+          delete batch.txDetails
+        }
+      })
+    })
+  })
+
+  return batchSliceState
+}

--- a/apps/web/src/services/ls-migration/batch.ts
+++ b/apps/web/src/services/ls-migration/batch.ts
@@ -4,6 +4,7 @@ import { OperationType } from '@safe-global/types-kit'
 export const migrateBatchTxs = (batchSliceState: BatchTxsState) => {
   // Iterate over all batches and migrate txDetails to txData
   Object.keys(batchSliceState).forEach((chainId) => {
+    if (!batchSliceState[chainId]) return
     Object.keys(batchSliceState[chainId]).forEach((safeAddress) => {
       batchSliceState[chainId][safeAddress].forEach((batch) => {
         if (batch.txDetails && batch.txDetails.txData && !batch.txData) {

--- a/apps/web/src/store/batchSlice.ts
+++ b/apps/web/src/store/batchSlice.ts
@@ -2,16 +2,19 @@ import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolki
 import type { RootState } from '.'
 import { selectChainIdAndSafeAddress } from '@/store/common'
 import type { MetaTransactionData, OperationType } from '@safe-global/types-kit'
+import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 
 export type CallOnlyTxData = MetaTransactionData & { operation: OperationType.Call }
 
 export type DraftBatchItem = {
   id: string
   timestamp: number
+  // For Backwards compatibility we handle txDetails as well
+  txDetails?: TransactionDetails
   txData: CallOnlyTxData
 }
 
-type BatchTxsState = {
+export type BatchTxsState = {
   [chainId: string]: {
     [safeAddress: string]: DraftBatchItem[]
   }

--- a/apps/web/src/store/batchSlice.ts
+++ b/apps/web/src/store/batchSlice.ts
@@ -1,12 +1,14 @@
 import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit'
-import type { TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
 import type { RootState } from '.'
 import { selectChainIdAndSafeAddress } from '@/store/common'
+import type { MetaTransactionData, OperationType } from '@safe-global/types-kit'
+
+export type CallOnlyTxData = MetaTransactionData & { operation: OperationType.Call }
 
 export type DraftBatchItem = {
   id: string
   timestamp: number
-  txDetails: TransactionDetails
+  txData: CallOnlyTxData
 }
 
 type BatchTxsState = {
@@ -27,17 +29,16 @@ export const batchSlice = createSlice({
       action: PayloadAction<{
         chainId: string
         safeAddress: string
-        txDetails: TransactionDetails
+        txData: CallOnlyTxData
       }>,
     ) => {
-      const { chainId, safeAddress, txDetails } = action.payload
+      const { chainId, safeAddress, txData } = action.payload
       state[chainId] = state[chainId] || {}
       state[chainId][safeAddress] = state[chainId][safeAddress] || []
-      // @ts-expect-error
       state[chainId][safeAddress].push({
         id: Math.random().toString(36).slice(2),
         timestamp: Date.now(),
-        txDetails,
+        txData,
       })
     },
 

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -31,6 +31,7 @@ import { version as termsVersion } from '@/markdown/terms/version'
 import { cgwClient, setBaseUrl } from '@safe-global/store/gateway/cgwClient'
 import { GATEWAY_URL } from '@/config/gateway'
 import { setupListeners } from '@reduxjs/toolkit/query'
+import { migrateBatchTxs } from '@/services/ls-migration/batch'
 
 const rootReducer = combineReducers({
   [slices.chainsSlice.name]: slices.chainsSlice.reducer,
@@ -124,6 +125,9 @@ export const _hydrationReducer: typeof rootReducer = (state, action) => {
         ...cookiesAndTermsInitialState,
       }
     }
+
+    // Migrate batchSlice txDetails to txData
+    nextState[slices.batchSlice.name] = migrateBatchTxs(nextState[slices.batchSlice.name])
 
     return nextState
   }

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -127,7 +127,9 @@ export const _hydrationReducer: typeof rootReducer = (state, action) => {
     }
 
     // Migrate batchSlice txDetails to txData
-    nextState[slices.batchSlice.name] = migrateBatchTxs(nextState[slices.batchSlice.name])
+    if (nextState[slices.batchSlice.name]) {
+      nextState[slices.batchSlice.name] = migrateBatchTxs(nextState[slices.batchSlice.name])
+    }
 
     return nextState
   }


### PR DESCRIPTION
## What it solves

Resolves COR-29

## How this PR fixes it
- Changes BatchTx datastructure to just contain `{ to, data, value, operation}`
- Allows batching multiSend delegateCalls coming from the Transaction Builder by decoding the multiSends and adding its individual transactions to the batch

## How to test it
- Create a Batch
- Add a Multisend from the Transaction Builder to the batch

## Screenshots

https://github.com/user-attachments/assets/5130168c-3058-4b7c-a110-5a0ce923b68c

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

