### PR TITLE
fix(web): update balance dynamically in Header top right bar) for active safe

### DIFF
--- a/apps/web/src/components/common/NetworkSelector/__tests__/ChainIndicatorWithFiatBalance.test.tsx
+++ b/apps/web/src/components/common/NetworkSelector/__tests__/ChainIndicatorWithFiatBalance.test.tsx
@@ -1,9 +1,10 @@
 import { ChainIndicatorWithFiatBalance } from '../index'
-import { render, waitFor } from '@/tests/test-utils'
+import { render } from '@/tests/test-utils'
 import { chainBuilder } from '@/tests/builders/chains'
 import * as useChainId from '@/hooks/useChainId'
 import * as gatewayApi from '@/store/api/gateway'
 import * as useBalances from '@/hooks/useBalances'
+import { skipToken } from '@reduxjs/toolkit/query'
 
 const SAFE_ADDRESS = '0x123'
 
@@ -14,41 +15,35 @@ describe('ChainIndicatorWithFiatBalance', () => {
 
   it('uses balances for the current chain', () => {
     const chain = chainBuilder().with({ chainId: '1', chainName: 'Ethereum', shortName: 'eth' }).build()
-
     jest.spyOn(useChainId, 'default').mockReturnValue('1')
     jest.spyOn(useBalances, 'default').mockReturnValue({ balances: { fiatTotal: '100', items: [] }, loading: false })
-
-    const trigger = jest.fn()
-    jest
-      .spyOn(gatewayApi, 'useLazyGetSafeOverviewQuery')
-      .mockReturnValue([trigger, { data: { fiatTotal: '200' } }] as any)
+    const getOverview = jest
+      .spyOn(gatewayApi, 'useGetSafeOverviewQuery')
+      .mockReturnValue({ data: { fiatTotal: '200' } } as any)
 
     const { getByText } = render(
       <ChainIndicatorWithFiatBalance isSelected={false} chain={chain} safeAddress={SAFE_ADDRESS} />,
       { initialReduxState: { chains: { data: [chain], loading: false } } },
     )
 
-    expect(trigger).not.toHaveBeenCalled()
+    expect(getOverview).toHaveBeenCalledWith(skipToken)
     expect(getByText(/100/)).toBeInTheDocument()
   })
 
-  it('fetches overview for inactive chains', async () => {
+  it('fetches overview for inactive chains', () => {
     const chain = chainBuilder().with({ chainId: '10', chainName: 'Optimism', shortName: 'oeth' }).build()
-
     jest.spyOn(useChainId, 'default').mockReturnValue('1')
     jest.spyOn(useBalances, 'default').mockReturnValue({ balances: { fiatTotal: '100', items: [] }, loading: false })
-
-    const trigger = jest.fn()
-    jest
-      .spyOn(gatewayApi, 'useLazyGetSafeOverviewQuery')
-      .mockReturnValue([trigger, { data: { fiatTotal: '50' } }] as any)
+    const getOverview = jest
+      .spyOn(gatewayApi, 'useGetSafeOverviewQuery')
+      .mockReturnValue({ data: { fiatTotal: '50' } } as any)
 
     const { getByText } = render(
       <ChainIndicatorWithFiatBalance isSelected={false} chain={chain} safeAddress={SAFE_ADDRESS} />,
       { initialReduxState: { chains: { data: [chain], loading: false } } },
     )
 
-    await waitFor(() => expect(trigger).toHaveBeenCalled())
+    expect(getOverview).toHaveBeenCalledWith({ safeAddress: SAFE_ADDRESS, chainId: chain.chainId })
     expect(getByText(/50/)).toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/common/NetworkSelector/__tests__/ChainIndicatorWithFiatBalance.test.tsx
+++ b/apps/web/src/components/common/NetworkSelector/__tests__/ChainIndicatorWithFiatBalance.test.tsx
@@ -1,0 +1,54 @@
+import { ChainIndicatorWithFiatBalance } from '../index'
+import { render, waitFor } from '@/tests/test-utils'
+import { chainBuilder } from '@/tests/builders/chains'
+import * as useChainId from '@/hooks/useChainId'
+import * as gatewayApi from '@/store/api/gateway'
+import * as useBalances from '@/hooks/useBalances'
+
+const SAFE_ADDRESS = '0x123'
+
+describe('ChainIndicatorWithFiatBalance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('uses balances for the current chain', () => {
+    const chain = chainBuilder().with({ chainId: '1', chainName: 'Ethereum', shortName: 'eth' }).build()
+
+    jest.spyOn(useChainId, 'default').mockReturnValue('1')
+    jest.spyOn(useBalances, 'default').mockReturnValue({ balances: { fiatTotal: '100', items: [] }, loading: false })
+
+    const trigger = jest.fn()
+    jest
+      .spyOn(gatewayApi, 'useLazyGetSafeOverviewQuery')
+      .mockReturnValue([trigger, { data: { fiatTotal: '200' } }] as any)
+
+    const { getByText } = render(
+      <ChainIndicatorWithFiatBalance isSelected={false} chain={chain} safeAddress={SAFE_ADDRESS} />,
+      { initialReduxState: { chains: { data: [chain], loading: false } } },
+    )
+
+    expect(trigger).not.toHaveBeenCalled()
+    expect(getByText(/100/)).toBeInTheDocument()
+  })
+
+  it('fetches overview for inactive chains', async () => {
+    const chain = chainBuilder().with({ chainId: '10', chainName: 'Optimism', shortName: 'oeth' }).build()
+
+    jest.spyOn(useChainId, 'default').mockReturnValue('1')
+    jest.spyOn(useBalances, 'default').mockReturnValue({ balances: { fiatTotal: '100', items: [] }, loading: false })
+
+    const trigger = jest.fn()
+    jest
+      .spyOn(gatewayApi, 'useLazyGetSafeOverviewQuery')
+      .mockReturnValue([trigger, { data: { fiatTotal: '50' } }] as any)
+
+    const { getByText } = render(
+      <ChainIndicatorWithFiatBalance isSelected={false} chain={chain} safeAddress={SAFE_ADDRESS} />,
+      { initialReduxState: { chains: { data: [chain], loading: false } } },
+    )
+
+    await waitFor(() => expect(trigger).toHaveBeenCalled())
+    expect(getByText(/50/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/common/NetworkSelector/index.tsx
+++ b/apps/web/src/components/common/NetworkSelector/index.tsx
@@ -24,7 +24,6 @@ import useChains, { useCurrentChain } from '@/hooks/useChains'
 import type { NextRouter } from 'next/router'
 import { useRouter } from 'next/router'
 import css from './styles.module.css'
-import { useChainId } from '@/hooks/useChainId'
 import { type ReactElement, useCallback, useMemo, useState, useEffect } from 'react'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
 
@@ -39,12 +38,13 @@ import PlusIcon from '@/public/images/common/plus.svg'
 import useAddressBook from '@/hooks/useAddressBook'
 import { CreateSafeOnSpecificChain } from '@/features/multichain/components/CreateSafeOnNewChain'
 import { useLazyGetSafeOverviewQuery } from '@/store/api/gateway'
+import useChainId from '@/hooks/useChainId'
 import useBalances from '@/hooks/useBalances'
 import { InfoOutlined } from '@mui/icons-material'
 import { selectUndeployedSafe } from '@/store/slices'
 import { hasMultiChainAddNetworkFeature } from '@/features/multichain/utils/utils'
 
-const ChainIndicatorWithFiatBalance = ({
+export const ChainIndicatorWithFiatBalance = ({
   isSelected,
   chain,
   safeAddress,

--- a/apps/web/src/components/common/NetworkSelector/index.tsx
+++ b/apps/web/src/components/common/NetworkSelector/index.tsx
@@ -24,9 +24,8 @@ import useChains, { useCurrentChain } from '@/hooks/useChains'
 import type { NextRouter } from 'next/router'
 import { useRouter } from 'next/router'
 import css from './styles.module.css'
-import { type ReactElement, useCallback, useMemo, useState, useEffect } from 'react'
+import { type ReactElement, useCallback, useMemo, useState } from 'react'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
-
 import { useAllSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGrouped'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
@@ -37,9 +36,10 @@ import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import PlusIcon from '@/public/images/common/plus.svg'
 import useAddressBook from '@/hooks/useAddressBook'
 import { CreateSafeOnSpecificChain } from '@/features/multichain/components/CreateSafeOnNewChain'
-import { useLazyGetSafeOverviewQuery } from '@/store/api/gateway'
+import { useGetSafeOverviewQuery } from '@/store/api/gateway'
 import useChainId from '@/hooks/useChainId'
 import useBalances from '@/hooks/useBalances'
+import { skipToken } from '@reduxjs/toolkit/query'
 import { InfoOutlined } from '@mui/icons-material'
 import { selectUndeployedSafe } from '@/store/slices'
 import { hasMultiChainAddNetworkFeature } from '@/features/multichain/utils/utils'
@@ -58,14 +58,9 @@ export const ChainIndicatorWithFiatBalance = ({
   const isCurrentChain = currentChainId === chain.chainId
 
   const { balances } = useBalances()
-  const [trigger, { data: safeOverview }] = useLazyGetSafeOverviewQuery()
-
-  useEffect(() => {
-    if (!isCurrentChain && !undeployedSafe) {
-      trigger({ safeAddress, chainId: chain.chainId })
-    }
-  }, [trigger, isCurrentChain, undeployedSafe, safeAddress, chain.chainId])
-
+  const { data: safeOverview } = useGetSafeOverviewQuery(
+    !isCurrentChain && !undeployedSafe ? { safeAddress, chainId: chain.chainId } : skipToken,
+  )
   const fiatValue = isCurrentChain ? balances.fiatTotal : safeOverview?.fiatTotal
 
   return <ChainIndicator responsive={isSelected} chainId={chain.chainId} fiatValue={fiatValue} inline />

--- a/apps/web/src/components/common/NetworkSelector/index.tsx
+++ b/apps/web/src/components/common/NetworkSelector/index.tsx
@@ -68,7 +68,7 @@ const ChainIndicatorWithFiatBalance = ({
 
   const fiatValue = isCurrentChain ? balances.fiatTotal : safeOverview?.fiatTotal
 
-  return <ChainIndicator responsive={isSelected} chainId={chain.chainId} fiatValue={fiatValue || undefined} inline />
+  return <ChainIndicator responsive={isSelected} chainId={chain.chainId} fiatValue={fiatValue} inline />
 }
 
 export const getNetworkLink = (router: NextRouter, safeAddress: string, networkShortName: string) => {

--- a/apps/web/src/components/common/NetworkSelector/index.tsx
+++ b/apps/web/src/components/common/NetworkSelector/index.tsx
@@ -25,7 +25,7 @@ import type { NextRouter } from 'next/router'
 import { useRouter } from 'next/router'
 import css from './styles.module.css'
 import { useChainId } from '@/hooks/useChainId'
-import { type ReactElement, useCallback, useMemo, useState } from 'react'
+import { type ReactElement, useCallback, useMemo, useState, useEffect } from 'react'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS, trackEvent } from '@/services/analytics'
 
 import { useAllSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGrouped'
@@ -38,10 +38,10 @@ import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import PlusIcon from '@/public/images/common/plus.svg'
 import useAddressBook from '@/hooks/useAddressBook'
 import { CreateSafeOnSpecificChain } from '@/features/multichain/components/CreateSafeOnNewChain'
-import { useGetSafeOverviewQuery } from '@/store/api/gateway'
+import { useLazyGetSafeOverviewQuery } from '@/store/api/gateway'
+import useBalances from '@/hooks/useBalances'
 import { InfoOutlined } from '@mui/icons-material'
 import { selectUndeployedSafe } from '@/store/slices'
-import { skipToken } from '@reduxjs/toolkit/query'
 import { hasMultiChainAddNetworkFeature } from '@/features/multichain/utils/utils'
 
 const ChainIndicatorWithFiatBalance = ({
@@ -54,18 +54,21 @@ const ChainIndicatorWithFiatBalance = ({
   safeAddress: string
 }) => {
   const undeployedSafe = useAppSelector((state) => selectUndeployedSafe(state, chain.chainId, safeAddress))
-  const { data: safeOverview } = useGetSafeOverviewQuery(
-    undeployedSafe ? skipToken : { safeAddress, chainId: chain.chainId },
-  )
+  const currentChainId = useChainId()
+  const isCurrentChain = currentChainId === chain.chainId
 
-  return (
-    <ChainIndicator
-      responsive={isSelected}
-      chainId={chain.chainId}
-      fiatValue={safeOverview ? safeOverview.fiatTotal : undefined}
-      inline
-    />
-  )
+  const { balances } = useBalances()
+  const [trigger, { data: safeOverview }] = useLazyGetSafeOverviewQuery()
+
+  useEffect(() => {
+    if (!isCurrentChain && !undeployedSafe) {
+      trigger({ safeAddress, chainId: chain.chainId })
+    }
+  }, [trigger, isCurrentChain, undeployedSafe, safeAddress, chain.chainId])
+
+  const fiatValue = isCurrentChain ? balances.fiatTotal : safeOverview?.fiatTotal
+
+  return <ChainIndicator responsive={isSelected} chainId={chain.chainId} fiatValue={fiatValue || undefined} inline />
 }
 
 export const getNetworkLink = (router: NextRouter, safeAddress: string, networkShortName: string) => {

--- a/apps/web/src/store/api/gateway/index.ts
+++ b/apps/web/src/store/api/gateway/index.ts
@@ -99,7 +99,6 @@ export const {
   useCreateSubmissionMutation,
   useGetSafeQuery,
   useGetSafeOverviewQuery,
-  useLazyGetSafeOverviewQuery,
   useGetMultipleSafeOverviewsQuery,
   useGetAllOwnedSafesQuery,
   useGetOwnedSafesQuery,

--- a/apps/web/src/store/api/gateway/index.ts
+++ b/apps/web/src/store/api/gateway/index.ts
@@ -99,6 +99,7 @@ export const {
   useCreateSubmissionMutation,
   useGetSafeQuery,
   useGetSafeOverviewQuery,
+  useLazyGetSafeOverviewQuery,
   useGetMultipleSafeOverviewsQuery,
   useGetAllOwnedSafesQuery,
   useGetOwnedSafesQuery,


### PR DESCRIPTION
## What it solves [OCX-84](https://linear.app/safe-global/issue/OCX-84/ui-value-not-updating-in-top-right-corner-after-transfer)

Resolves #
UI value for fiat balance is not being updated in the Header for an active chain

## How this PR fixes it

For an active chain it is using the value from balances that is being dynamically updated (as in Total Asset Value and Side bar), and for the other ones in the list its lazy-loading the safe overviews

## How to test it

- Perform a send or receive action in the wallet
- Observe that balance got updated in in Total Asset Value, Side bar (left side) and header (top right bar)
- Observe that there was no calls to fetch other save overviews unless you opened the dropdown to switch the network

## Screenshots
<img width="1512" alt="Screenshot 2025-06-25 at 14 05 19" src="https://github.com/user-attachments/assets/d5145617-e3b8-439b-8f55-ccb50cf8d811" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
