### PR TITLE
Fix: Bump version to 1.63.0 for missed release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,7 +2,7 @@
   "name": "@safe-global/web",
   "homepage": "https://github.com/safe-global/safe-wallet-web",
   "license": "GPL-3.0",
-  "version": "1.62.1",
+  "version": "1.63.0",
   "type": "module",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This PR fixes the missing version bump for Release 1.63.0.

The original release PR was merged without updating the package.json version, which caused the GitHub release creation to fail. This PR adds the missing version bump to trigger the release workflow.

## Changes
- Bump apps/web/package.json version from 1.62.1 to 1.63.0

## Context
- Original Release 1.63.0 PR was merged but forgot version bump
- GitHub release workflow only triggers on PR merges, not direct commits
- This will create the missing v1.63.0 tag and GitHub release