### PR TITLE
Fix(Tests): Verify a Reject tx cannot be "Added as batch"

### DIFF
--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -142,7 +142,7 @@ export const recordedTxNote = 'Tx note one'
 
 const comboButton = '[data-testid="combo-submit-dropdown"]'
 const comboButtonPopover = '[data-testid="combo-submit-popover"]'
-const comboButtonOptions = {
+export const comboButtonOptions = {
   sign: 'Sign',
   execute: 'Execute',
   addToBatch: 'Add to batch',

--- a/apps/web/cypress/e2e/regression/tx_queue_reject_btn.cy.js
+++ b/apps/web/cypress/e2e/regression/tx_queue_reject_btn.cy.js
@@ -81,7 +81,7 @@ describe('Transaction queue Reject button tests', { defaultCommandTimeout: 30000
     create_tx.verifyTxRejectModalVisible()
     create_tx.clickOnRejectionChoiceBtn(1)
     create_tx.clickOnContinueSignTransactionBtn()
-    create_tx.checkThatComboButtonOptionIsNotPresent(comboButtonOptions.addToBatch)
+    create_tx.checkThatComboButtonOptionIsNotPresent(create_tx.comboButtonOptions.addToBatch)
     navigation.clickOnWalletExpandMoreIcon()
     navigation.clickOnDisconnectBtn()
   })


### PR DESCRIPTION
## What it solves
fix Verify a Reject tx cannot be "Added as batch"
Resolves #
Tests:
* Verify a Reject tx cannot be "Added as batch"
* 
## How this PR fixes it
* Verify a Reject tx cannot be "Added as batch" - export the const and call the cons from the page were missing 
## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
