### PR TITLE
fix(mobile): don't show import account on android

### DIFF
--- a/apps/mobile/src/features/GetStarted/GetStarted.tsx
+++ b/apps/mobile/src/features/GetStarted/GetStarted.tsx
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { BlurView } from 'expo-blur'
 import { getCrashlytics } from '@react-native-firebase/crashlytics'
 import { setAnalyticsCollectionEnabled } from '@/src/services/analytics'
+import { isAndroid } from '@/src/config/constants'
 
 const StyledText = styled(Text, {
   fontSize: '$3',
@@ -70,9 +71,11 @@ export const GetStarted = () => {
         >
           Add account
         </SafeButton>
-        <SafeButton outlined icon={<SafeFontIcon name={'upload'} />} onPress={onPressImportAccount}>
-          Import account
-        </SafeButton>
+        {!isAndroid && (
+          <SafeButton outlined icon={<SafeFontIcon name={'upload'} />} onPress={onPressImportAccount}>
+            Import account
+          </SafeButton>
+        )}
         <View
           paddingHorizontal={'$10'}
           marginTop={'$2'}


### PR DESCRIPTION
## What it solves
The old android app doesn't have export account option therefore import account is not necessary for the new android app.

Resolves https://linear.app/safe-global/issue/MOB-70/disable-the-import-feature-on-android

## How this PR fixes it
Hides the button on android.

## How to test it
Launch the app on android --> you shouldn't see the "Import account" button.
Launch the app on iOS --> the button "Import account" should still be visible.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
