### PR TITLE
fix(mobile): use generic biometrics term

### DIFF
--- a/apps/mobile/src/app/biometrics-opt-in.tsx
+++ b/apps/mobile/src/app/biometrics-opt-in.tsx
@@ -84,7 +84,7 @@ function BiometricsOptIn() {
       <OptIn
         testID="biometrics-opt-in-screen"
         title="Simplify access, enhance security"
-        description="Enable biometrics to unlock the app quickly and confirm transactions securely using Face ID."
+        description="Enable biometrics to unlock the app quickly and confirm transactions securely using your device's biometric authentication."
         image={image}
         isVisible
         isLoading={isLoading}

--- a/apps/mobile/src/hooks/useBiometrics.ts
+++ b/apps/mobile/src/hooks/useBiometrics.ts
@@ -166,13 +166,13 @@ export function useBiometrics() {
   const getBiometricsUIInfo = useCallback(() => {
     switch (biometricsType) {
       case 'FACE_ID':
-        return { label: 'Enable Face ID', icon: 'face-id' }
+        return { label: 'Biometrics', icon: 'face-id' }
       case 'TOUCH_ID':
-        return { label: 'Enable Touch ID', icon: 'fingerprint' }
+        return { label: 'Biometrics', icon: 'fingerprint' }
       case 'FINGERPRINT':
-        return { label: 'Enable Fingerprint', icon: 'fingerprint' }
+        return { label: 'Biometrics', icon: 'fingerprint' }
       default:
-        return { label: 'Enable Biometrics', icon: 'face-id' }
+        return { label: 'Biometrics', icon: 'face-id' }
     }
   }, [biometricsType])
 


### PR DESCRIPTION
## What it solves
On android there are devices that have both fingerprint and face id. Our detection does not detect which one of them is enabled but rather what is available. There could be a case where a user has enabled touch id but we show face id in the ui. That is why we go for the generic biometrics term.

Resolves https://linear.app/safe-global/issue/MOB-21/mobile-android-only-faceid-looks-strange-on-the-device-with-touch-id

## How this PR fixes it 
Generic term "Biometrics" is used throughout the app.

## How to test it
Check settings they should say "Biometrics" in all scenarios.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
