### PR TITLE
fix(web:e2e): TxBuilder tx creation

### DIFF
--- a/apps/web/cypress/e2e/happypath_2/tx-builder.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/tx-builder.cy.js
@@ -64,7 +64,6 @@ describe('Transaction Builder happy path tests', { defaultCommandTimeout: 20000 
       })
 
       createtx.clickOnContinueSignTransactionBtn()
-      createtx.clickOnAcknowledgement()
       createtx.clickOnSignTransactionBtn()
       createtx.clickViewTransaction()
       navigation.clickOnWalletExpandMoreIcon()
@@ -73,9 +72,7 @@ describe('Transaction Builder happy path tests', { defaultCommandTimeout: 20000 
       wallet.connectSigner(signer2)
       navigation.verifyTxBtnStatus(constants.enabledStates.enabled)
       createtx.clickOnConfirmTransactionBtn()
-      createtx.clickOnNoLaterOption()
       createtx.clickOnContinueSignTransactionBtn()
-      createtx.clickOnAcknowledgement()
       createtx.clickOnSignTransactionBtn()
       navigation.clickOnWalletExpandMoreIcon()
       navigation.clickOnDisconnectBtn()

--- a/apps/web/cypress/support/utils/gtag.js
+++ b/apps/web/cypress/support/utils/gtag.js
@@ -62,7 +62,7 @@ export const events = {
   txCreatedTxBuilder: {
     category: 'transactions',
     action: 'Confirm transaction',
-    eventLabel: 'https://safe-apps.dev.5afe.dev/tx-builder',
+    eventLabel: 'walletconnect',
     eventType: 'tx_created',
     event: 'tx_created',
   },
@@ -70,7 +70,7 @@ export const events = {
   txConfirmedTxBuilder: {
     category: 'transactions',
     action: 'Confirm transaction',
-    eventLabel: 'https://safe-apps.dev.5afe.dev/tx-builder',
+    eventLabel: 'walletconnect',
     eventType: 'tx_confirmed',
     event: 'tx_confirmed',
   },


### PR DESCRIPTION
## What it solves
The test looks for 2 specific events to be present after a tx creation with the tx builder

Resolves #

## How this PR fixes it
The EventLable has changed in the site, so I changed it in the values used to compare in the test

NOTE: We have to be sure that the eventLabel in the app was changed on purpose or not.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
