### PR TITLE
fix(Signing UX): display nested multiSend actions for an execTransaction call

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/NestedTransaction/ExecTransaction/index.tsx
@@ -14,6 +14,9 @@ import useTxPreview from '@/components/tx/confirmation-views/useTxPreview'
 import TxData from '../..'
 import { TxSimulation, TxSimulationMessage } from '@/components/tx/security/tenderly'
 import useSafeAddress from '@/hooks/useSafeAddress'
+import { isMultiSendTxInfo, isOrderTxInfo } from '@/utils/transaction-guards'
+import Multisend from '../../DecodedData/Multisend'
+import { ErrorBoundary } from '@sentry/react'
 
 const safeInterface = Safe__factory.createInterface()
 
@@ -46,9 +49,11 @@ const extractTransactionData = (data: string): SafeTransaction | undefined => {
 export const ExecTransaction = ({
   data,
   isConfirmationView = false,
+  isExecuted = false,
 }: {
   data?: TransactionData
   isConfirmationView?: boolean
+  isExecuted?: boolean
 }) => {
   const chain = useCurrentChain()
   const safeAddress = useSafeAddress()
@@ -71,7 +76,15 @@ export const ExecTransaction = ({
   )
 
   const decodedNestedTxDataBlock = txPreview ? (
-    <TxData txData={txPreview.txData} txInfo={txPreview.txInfo} trusted imitation={false} />
+    <>
+      <TxData txData={txPreview.txData} txInfo={txPreview.txInfo} trusted imitation={false} />
+
+      {(isMultiSendTxInfo(txPreview.txInfo) || isOrderTxInfo(txPreview.txInfo)) && (
+        <ErrorBoundary fallback={<div>Error parsing data</div>}>
+          <Multisend txData={txPreview.txData} isExecuted={isExecuted} />
+        </ErrorBoundary>
+      )}
+    </>
   ) : null
 
   return (

--- a/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/index.tsx
@@ -117,7 +117,7 @@ const TxData = ({
   }
 
   if (isExecTxData(txData)) {
-    return <ExecTransaction data={txData} />
+    return <ExecTransaction data={txData} isExecuted={!!txDetails?.executedAt} />
   }
 
   if (isSafeUpdateTxData(txData)) {

--- a/apps/web/src/components/tx/confirmation-views/index.tsx
+++ b/apps/web/src/components/tx/confirmation-views/index.tsx
@@ -56,7 +56,8 @@ const getConfirmationViewComponent = ({
   txInfo,
   txData,
   txFlow,
-}: NarrowConfirmationViewProps & { txFlow?: ReactElement }) => {
+  isExecuted,
+}: NarrowConfirmationViewProps & { txFlow?: ReactElement; isExecuted?: boolean }) => {
   if (txData && isManageSignersView(txInfo, txData)) return <ManageSigners txInfo={txInfo} txData={txData} />
 
   if (isChangeThresholdView(txInfo)) return <ChangeThreshold txInfo={txInfo} />
@@ -67,7 +68,7 @@ const getConfirmationViewComponent = ({
 
   if (isOnChainConfirmationTxData(txData)) return <OnChainConfirmation data={txData} isConfirmationView />
 
-  if (isExecTxData(txData)) return <ExecTransaction data={txData} isConfirmationView />
+  if (isExecTxData(txData)) return <ExecTransaction data={txData} isExecuted={isExecuted} isConfirmationView />
 
   if (isSwapOrderTxInfo(txInfo) || isTwapOrderTxInfo(txInfo)) return <SwapOrder txInfo={txInfo} txData={txData} />
 
@@ -118,6 +119,7 @@ const ConfirmationView = ({
       ? getConfirmationViewComponent({
           txInfo: details.txInfo,
           txData: details.txData,
+          isExecuted: !!txDetails?.executedAt,
           txFlow,
         })
       : undefined


### PR DESCRIPTION
## What it solves

Resolves [EN-132](https://linear.app/safe-global/issue/EN-132/the-list-of-actions-for-the-excutetx-nested-tx-is-lost)

## How this PR fixes it

Renders the list of multisend actions for nested tx of an execTransaction call.

## How to test it

See issue description.

🔗 [Example transaction](https://app.safe.global/transactions/tx?safe=sep:0x2a73e61bd15b25B6958b4DA3bfc759ca4db249b9&id=multisig_0x2a73e61bd15b25B6958b4DA3bfc759ca4db249b9_0x083392132c9df9f5b6afc6cceb70f1c2e1005fdcc66ef071e4b86c9ff55ee0d1)

## Screenshots

![Screenshot 2025-06-30 at 12 15 42](https://github.com/user-attachments/assets/b74a88c6-aef2-48c8-aaec-4f790f6c2b58)

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
