### PR TITLE
Fix(Mobile): Display Proposal badge in queue

### DIFF
--- a/apps/mobile/src/components/ProposalBadge/ProposalBadge.stories.tsx
+++ b/apps/mobile/src/components/ProposalBadge/ProposalBadge.stories.tsx
@@ -1,0 +1,15 @@
+import type { StoryObj, Meta } from '@storybook/react'
+import { ProposalBadge } from '@/src/components/ProposalBadge/ProposalBadge'
+
+const meta: Meta<typeof ProposalBadge> = {
+  title: 'ProposalBadge',
+  component: ProposalBadge,
+}
+
+export default meta
+
+type Story = StoryObj<typeof ProposalBadge>
+
+export const Default: Story = {
+  args: {},
+}

--- a/apps/mobile/src/components/ProposalBadge/ProposalBadge.tsx
+++ b/apps/mobile/src/components/ProposalBadge/ProposalBadge.tsx
@@ -1,0 +1,21 @@
+import { Badge } from '@/src/components/Badge'
+import { Text, View } from 'tamagui'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+
+export const ProposalBadge = () => {
+  return (
+    <Badge
+      circular={false}
+      content={
+        <View alignItems="center" flexDirection="row" gap="$1">
+          <SafeFontIcon size={12} name="info" />
+
+          <Text fontWeight={600} color={'$color'}>
+            Proposal
+          </Text>
+        </View>
+      }
+      themeName="badge_background"
+    />
+  )
+}

--- a/apps/mobile/src/components/ProposalBadge/index.tsx
+++ b/apps/mobile/src/components/ProposalBadge/index.tsx
@@ -1,0 +1,1 @@
+export { ProposalBadge } from './ProposalBadge'

--- a/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
+++ b/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
@@ -7,6 +7,7 @@ import { isMultisigExecutionInfo } from '@/src/utils/transaction-guards'
 import { Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { Badge } from '../Badge'
 import { Tag } from '../Tag'
+import { ProposalBadge } from '../ProposalBadge'
 
 interface SafeListItemProps {
   type?: string
@@ -113,24 +114,6 @@ export function SafeListItem({
 
       {children}
     </Container>
-  )
-}
-
-const ProposalBadge = function ProposalBadge() {
-  return (
-    <Badge
-      circular={false}
-      content={
-        <View alignItems="center" flexDirection="row" gap="$1">
-          <SafeFontIcon size={12} name="info" />
-
-          <Text fontWeight={600} color={'$color'}>
-            Proposal
-          </Text>
-        </View>
-      }
-      themeName="badge_background"
-    />
   )
 }
 

--- a/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
+++ b/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
@@ -41,6 +41,9 @@ export function SafeListItem({
   onPress,
   tag,
 }: SafeListItemProps) {
+  // TODO: Replace this with proposedByDelegate once EN-149 is implemented
+  const isProposedTx = isMultisigExecutionInfo(executionInfo) ? executionInfo.confirmationsSubmitted === 0 : false
+
   return (
     <Container
       spaced={spaced}
@@ -80,23 +83,27 @@ export function SafeListItem({
 
       {inQueue && executionInfo && isMultisigExecutionInfo(executionInfo) ? (
         <View alignItems="center" flexDirection="row">
-          <Badge
-            circular={false}
-            content={
-              <View alignItems="center" flexDirection="row" gap="$1">
-                <SafeFontIcon size={12} name="owners" />
+          {isProposedTx ? (
+            <ProposalBadge />
+          ) : (
+            <Badge
+              circular={false}
+              content={
+                <View alignItems="center" flexDirection="row" gap="$1">
+                  <SafeFontIcon size={12} name="owners" />
 
-                <Text fontWeight={600} color={'$color'}>
-                  {executionInfo?.confirmationsSubmitted}/{executionInfo?.confirmationsRequired}
-                </Text>
-              </View>
-            }
-            themeName={
-              executionInfo?.confirmationsRequired === executionInfo?.confirmationsSubmitted
-                ? 'badge_success_variant1'
-                : 'badge_warning_variant1'
-            }
-          />
+                  <Text fontWeight={600} color={'$color'}>
+                    {executionInfo?.confirmationsSubmitted}/{executionInfo?.confirmationsRequired}
+                  </Text>
+                </View>
+              }
+              themeName={
+                executionInfo?.confirmationsRequired === executionInfo?.confirmationsSubmitted
+                  ? 'badge_success_variant1'
+                  : 'badge_warning_variant1'
+              }
+            />
+          )}
 
           <SafeFontIcon name="chevron-right" />
         </View>
@@ -106,6 +113,24 @@ export function SafeListItem({
 
       {children}
     </Container>
+  )
+}
+
+const ProposalBadge = function ProposalBadge() {
+  return (
+    <Badge
+      circular={false}
+      content={
+        <View alignItems="center" flexDirection="row" gap="$1">
+          <SafeFontIcon size={12} name="info" />
+
+          <Text fontWeight={600} color={'$color'}>
+            Proposal
+          </Text>
+        </View>
+      }
+      themeName="badge_background"
+    />
   )
 }
 


### PR DESCRIPTION
## What it solves

Resolves [MOB-32](https://linear.app/safe-global/issue/MOB-32/mobile-define-the-view-of-proposed-tx-without-the-signature-in-the)

## How this PR fixes it

- Adds a `ProposalBadge` component

## How to test it

1. Open a proposed transaction on mobile
2. Observe a badge saying "Proposal" instead of "0/x"

## Screenshots


<img width="390" alt="Screenshot 2025-06-30 at 16 31 50" src="https://github.com/user-attachments/assets/46f61c74-e941-4f92-adfe-1d278a7ce8ce" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
