### PR TITLE
refactor(mobile): do the blockaid check automatically on tx confirmation

### DIFF
--- a/apps/mobile/src/components/Alert2/Alert2.tsx
+++ b/apps/mobile/src/components/Alert2/Alert2.tsx
@@ -25,8 +25,8 @@ const icons = {
 
 export interface Alert2Props {
   type: AlertType
-  title: string
-  message: string
+  title?: string
+  message: string | React.ReactNode
   iconName?: IconName
   testID?: string
 }
@@ -51,12 +51,18 @@ export const Alert2 = ({ type, title, message, iconName, testID }: Alert2Props) 
         </View>
 
         <View flex={1} gap="$1">
-          <Text fontSize="$4" fontWeight="600" fontFamily="$body">
-            {title}
-          </Text>
-          <Text fontSize="$3" fontFamily="$body">
-            {message}
-          </Text>
+          {title && (
+            <Text fontSize="$4" fontWeight="600" fontFamily="$body">
+              {title}
+            </Text>
+          )}
+          {typeof message === 'string' ? (
+            <Text fontSize="$3" fontFamily="$body">
+              {message}
+            </Text>
+          ) : (
+            message
+          )}
         </View>
       </View>
     </Theme>

--- a/apps/mobile/src/components/SafeListItem/SafeListItem.test.tsx
+++ b/apps/mobile/src/components/SafeListItem/SafeListItem.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@/src/tests/test-utils'
 import { SafeListItem } from '.'
 import { Text, View } from 'tamagui'
 import { ellipsis } from '@/src/utils/formatters'
+import { Alert } from '../Alert'
 
 describe('SafeListItem', () => {
   it('should render the default markup', () => {
@@ -64,6 +65,66 @@ describe('SafeListItem', () => {
     expect(container.getByText('Left node')).toBeTruthy()
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('should render bottomContent when provided', () => {
+    const { getByText } = render(
+      <SafeListItem
+        label="A label"
+        leftNode={<Text>Left node</Text>}
+        bottomContent={
+          <View testID="bottom-content">
+            <Text>Bottom content text</Text>
+          </View>
+        }
+      />,
+    )
+
+    expect(getByText('A label')).toBeTruthy()
+    expect(getByText('Left node')).toBeTruthy()
+    expect(getByText('Bottom content text')).toBeTruthy()
+  })
+
+  it('should not render bottomContent when not provided', () => {
+    const { queryByTestId } = render(<SafeListItem label="A label" leftNode={<Text>Left node</Text>} />)
+
+    // Since bottomContent is not provided, there should be no bottom content container
+    expect(queryByTestId('bottom-content')).toBeNull()
+  })
+
+  it('should render bottomContent with proper styling and layout', () => {
+    const container = render(
+      <SafeListItem
+        label="A label"
+        leftNode={<Text>Left node</Text>}
+        bottomContent={
+          <View testID="bottom-content-container">
+            <Text testID="bottom-warning">Transaction warning message</Text>
+          </View>
+        }
+      />,
+    )
+
+    expect(container.getByText('A label')).toBeTruthy()
+    expect(container.getByTestId('bottom-content-container')).toBeTruthy()
+    expect(container.getByText('Transaction warning message')).toBeTruthy()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('should render bottomContent with Alert component', () => {
+    const { getByText } = render(
+      <SafeListItem
+        label="Transaction checks"
+        leftNode={<Text>Shield icon</Text>}
+        bottomContent={<Alert type="warning" message="Contract Changes Detected!" info="Review Details First" />}
+      />,
+    )
+
+    expect(getByText('Transaction checks')).toBeTruthy()
+    expect(getByText('Shield icon')).toBeTruthy()
+    expect(getByText('Contract Changes Detected!')).toBeTruthy()
+    expect(getByText('Review Details First')).toBeTruthy()
   })
 })
 

--- a/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
+++ b/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
@@ -24,6 +24,7 @@ interface SafeListItemProps {
   themeName?: ThemeName
   onPress?: () => void
   tag?: string
+  bottomContent?: React.ReactNode
 }
 
 export function SafeListItem({
@@ -41,6 +42,7 @@ export function SafeListItem({
   themeName,
   onPress,
   tag,
+  bottomContent,
 }: SafeListItemProps) {
   // TODO: Replace this with proposedByDelegate once EN-149 is implemented
   const isProposedTx = isMultisigExecutionInfo(executionInfo) ? executionInfo.confirmationsSubmitted === 0 : false
@@ -53,63 +55,73 @@ export function SafeListItem({
       onPress={onPress}
       transparent={transparent}
       themeName={themeName}
-      alignItems={'center'}
+      alignItems={'flex-start'}
       flexWrap="wrap"
-      flexDirection="row"
-      justifyContent="space-between"
+      flexDirection="column"
+      justifyContent="flex-start"
     >
-      <View flexDirection="row" maxWidth={rightNode ? '55%' : '100%'} alignItems="center" gap={12}>
-        {leftNode}
+      <View flexDirection="row" width="100%" alignItems="center" justifyContent="space-between">
+        <View flexDirection="row" maxWidth={rightNode ? '55%' : '100%'} alignItems="center" gap={12}>
+          {leftNode}
 
-        <View>
-          {type && (
-            <View flexDirection="row" alignItems="center" gap={4} marginBottom={4}>
-              {icon && <SafeFontIcon testID={`safe-list-${icon}-icon`} name={icon} size={10} color="$colorSecondary" />}
-              <Text fontSize="$3" color="$colorSecondary" marginBottom={2}>
-                {type}
+          <View>
+            {type && (
+              <View flexDirection="row" alignItems="center" gap={4} marginBottom={4}>
+                {icon && (
+                  <SafeFontIcon testID={`safe-list-${icon}-icon`} name={icon} size={10} color="$colorSecondary" />
+                )}
+                <Text fontSize="$3" color="$colorSecondary" marginBottom={2}>
+                  {type}
+                </Text>
+              </View>
+            )}
+
+            {typeof label === 'string' ? (
+              <Text fontSize="$4" fontWeight={600}>
+                {ellipsis(label, rightNode || inQueue ? 21 : 30)}
               </Text>
-            </View>
-          )}
-
-          {typeof label === 'string' ? (
-            <Text fontSize="$4" fontWeight={600}>
-              {ellipsis(label, rightNode || inQueue ? 21 : 30)}
-            </Text>
-          ) : (
-            label
-          )}
+            ) : (
+              label
+            )}
+          </View>
+          {tag && <Tag>{tag}</Tag>}
         </View>
-        {tag && <Tag>{tag}</Tag>}
+
+        {inQueue && executionInfo && isMultisigExecutionInfo(executionInfo) ? (
+          <View alignItems="center" flexDirection="row">
+            {isProposedTx ? (
+              <ProposalBadge />
+            ) : (
+              <Badge
+                circular={false}
+                content={
+                  <View alignItems="center" flexDirection="row" gap="$1">
+                    <SafeFontIcon size={12} name="owners" />
+
+                    <Text fontWeight={600} color={'$color'}>
+                      {executionInfo?.confirmationsSubmitted}/{executionInfo?.confirmationsRequired}
+                    </Text>
+                  </View>
+                }
+                themeName={
+                  executionInfo?.confirmationsRequired === executionInfo?.confirmationsSubmitted
+                    ? 'badge_success_variant1'
+                    : 'badge_warning_variant1'
+                }
+              />
+            )}
+
+            <SafeFontIcon name="chevron-right" />
+          </View>
+        ) : (
+          rightNode
+        )}
       </View>
 
-      {inQueue && executionInfo && isMultisigExecutionInfo(executionInfo) ? (
-        <View alignItems="center" flexDirection="row">
-          {isProposedTx ? (
-            <ProposalBadge />
-          ) : (
-            <Badge
-              circular={false}
-              content={
-                <View alignItems="center" flexDirection="row" gap="$1">
-                  <SafeFontIcon size={12} name="owners" />
-
-                  <Text fontWeight={600} color={'$color'}>
-                    {executionInfo?.confirmationsSubmitted}/{executionInfo?.confirmationsRequired}
-                  </Text>
-                </View>
-              }
-              themeName={
-                executionInfo?.confirmationsRequired === executionInfo?.confirmationsSubmitted
-                  ? 'badge_success_variant1'
-                  : 'badge_warning_variant1'
-              }
-            />
-          )}
-
-          <SafeFontIcon name="chevron-right" />
+      {bottomContent && (
+        <View width="100%" marginTop="$3">
+          {bottomContent}
         </View>
-      ) : (
-        rightNode
       )}
 
       {children}

--- a/apps/mobile/src/components/SafeListItem/__snapshots__/SafeListItem.test.tsx.snap
+++ b/apps/mobile/src/components/SafeListItem/__snapshots__/SafeListItem.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`SafeListItem should render a list item with a custom label template 1`]
   <View
     style={
       {
-        "alignItems": "center",
+        "alignItems": "flex-start",
         "backgroundColor": "#FFFFFF",
         "borderBottomLeftRadius": 7,
         "borderBottomRightRadius": 7,
         "borderTopLeftRadius": 7,
         "borderTopRightRadius": 7,
-        "flexDirection": "row",
+        "flexDirection": "column",
         "flexWrap": "wrap",
         "gap": 12,
-        "justifyContent": "space-between",
+        "justifyContent": "flex-start",
         "paddingBottom": 16,
         "paddingLeft": 16,
         "paddingRight": 16,
@@ -27,82 +27,191 @@ exports[`SafeListItem should render a list item with a custom label template 1`]
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "gap": 12,
-          "maxWidth": "100%",
+          "justifyContent": "space-between",
+          "width": "100%",
         }
       }
     >
-      <Text
+      <View
         style={
           {
-            "color": "#121312",
-            "fontFamily": "DM Sans",
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "maxWidth": "100%",
           }
         }
-        suppressHighlighting={true}
       >
-        Left node
-      </Text>
-      <View>
-        <View
+        <Text
           style={
             {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "marginBottom": 4,
+              "color": "#121312",
+              "fontFamily": "DM Sans",
             }
           }
+          suppressHighlighting={true}
         >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
-            style={
-              [
-                {
-                  "color": "#A1A3A7",
-                  "fontSize": 10,
-                },
-                undefined,
-                {
-                  "fontFamily": "SafeIcons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-            testID="safe-list-add-owner-icon"
-          >
-            
-          </Text>
-          <Text
+          Left node
+        </Text>
+        <View>
+          <View
             style={
               {
-                "color": "#A1A3A7",
-                "fontFamily": "DM Sans",
-                "fontSize": 13,
-                "marginBottom": 2,
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 4,
+                "marginBottom": 4,
               }
             }
-            suppressHighlighting={true}
           >
-            some type
-          </Text>
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#A1A3A7",
+                    "fontSize": 10,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "SafeIcons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+              testID="safe-list-add-owner-icon"
+            >
+              
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "#A1A3A7",
+                  "fontFamily": "DM Sans",
+                  "fontSize": 13,
+                  "marginBottom": 2,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              some type
+            </Text>
+          </View>
+          <View>
+            <Text
+              style={
+                {
+                  "color": "#121312",
+                  "fontFamily": "DM Sans",
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Here is my label
+            </Text>
+          </View>
         </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`SafeListItem should render bottomContent with proper styling and layout 1`] = `
+<View>
+  <View
+    style={
+      {
+        "alignItems": "flex-start",
+        "backgroundColor": "#FFFFFF",
+        "borderBottomLeftRadius": 7,
+        "borderBottomRightRadius": 7,
+        "borderTopLeftRadius": 7,
+        "borderTopRightRadius": 7,
+        "flexDirection": "column",
+        "flexWrap": "wrap",
+        "gap": 12,
+        "justifyContent": "flex-start",
+        "paddingBottom": 16,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 16,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "center",
+          "flexDirection": "row",
+          "justifyContent": "space-between",
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "maxWidth": "100%",
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "#121312",
+              "fontFamily": "DM Sans",
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Left node
+        </Text>
         <View>
           <Text
             style={
               {
                 "color": "#121312",
-                "fontFamily": "DM Sans",
+                "fontFamily": "DMSans-SemiBold",
+                "fontSize": 14,
               }
             }
             suppressHighlighting={true}
           >
-            Here is my label
+            A label
           </Text>
         </View>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "marginTop": 12,
+          "width": "100%",
+        }
+      }
+    >
+      <View
+        testID="bottom-content-container"
+      >
+        <Text
+          style={
+            {
+              "color": "#121312",
+              "fontFamily": "DM Sans",
+            }
+          }
+          suppressHighlighting={true}
+          testID="bottom-warning"
+        >
+          Transaction warning message
+        </Text>
       </View>
     </View>
   </View>

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`StakingTxDepositCard renders correctly 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
+        "alignItems": "flex-start",
         "backgroundColor": "#FFFFFF",
         "borderBottomLeftRadius": 7,
         "borderBottomRightRadius": 7,
         "borderTopLeftRadius": 7,
         "borderTopRightRadius": 7,
-        "flexDirection": "row",
+        "flexDirection": "column",
         "flexWrap": "wrap",
         "gap": 12,
-        "justifyContent": "space-between",
+        "justifyContent": "flex-start",
         "paddingBottom": 16,
         "paddingLeft": 16,
         "paddingRight": 16,
@@ -27,49 +27,24 @@ exports[`StakingTxDepositCard renders correctly 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "gap": 12,
-          "maxWidth": "55%",
+          "justifyContent": "space-between",
+          "width": "100%",
         }
       }
     >
       <View
         style={
           {
-            "width": 40,
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "maxWidth": "55%",
           }
         }
       >
         <View
           style={
             {
-              "position": "absolute",
-              "right": -10,
-              "top": -10,
-              "zIndex": 1,
-            }
-          }
-        />
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "borderBottomLeftRadius": 100000,
-              "borderBottomRightRadius": 100000,
-              "borderTopLeftRadius": 100000,
-              "borderTopRightRadius": 100000,
-              "flexDirection": "column",
-              "height": 40,
-              "justifyContent": "center",
-              "maxHeight": 40,
-              "maxWidth": 40,
-              "minHeight": 40,
-              "minWidth": 40,
-              "overflow": "hidden",
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-              "position": "relative",
               "width": 40,
             }
           }
@@ -77,165 +52,201 @@ exports[`StakingTxDepositCard renders correctly 1`] = `
           <View
             style={
               {
-                "bottom": 0,
-                "flexDirection": "column",
-                "left": 0,
                 "position": "absolute",
-                "right": 0,
-                "top": 0,
+                "right": -10,
+                "top": -10,
                 "zIndex": 1,
               }
             }
-          >
-            <Image
-              accessibilityLabel="ETH"
-              fullscreen={true}
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                {
-                  "uri": "https://example.com/eth-logo.png",
-                }
-              }
-              style={
-                {
-                  "backgroundColor": "#121312",
-                  "height": 40,
-                  "width": 40,
-                }
-              }
-              testID="logo-image"
-            />
-          </View>
+          />
           <View
             style={
               {
-                "backgroundColor": "#EEEFF0",
-                "bottom": 0,
+                "alignItems": "center",
+                "borderBottomLeftRadius": 100000,
+                "borderBottomRightRadius": 100000,
+                "borderTopLeftRadius": 100000,
+                "borderTopRightRadius": 100000,
                 "flexDirection": "column",
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "zIndex": 0,
+                "height": 40,
+                "justifyContent": "center",
+                "maxHeight": 40,
+                "maxWidth": 40,
+                "minHeight": 40,
+                "minWidth": 40,
+                "overflow": "hidden",
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "position": "relative",
+                "width": 40,
               }
             }
           >
             <View
               style={
                 {
-                  "backgroundColor": "#EEEFF0",
-                  "borderBottomLeftRadius": 100,
-                  "borderBottomRightRadius": 100,
-                  "borderTopLeftRadius": 100,
-                  "borderTopRightRadius": 100,
-                  "paddingBottom": 8,
-                  "paddingLeft": 8,
-                  "paddingRight": 8,
-                  "paddingTop": 8,
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 1,
                 }
               }
             >
-              <Text
-                allowFontScaling={false}
-                selectable={false}
-                style={
-                  [
-                    {
-                      "color": "#A1A3A7",
-                      "fontSize": 24,
-                    },
-                    undefined,
-                    {
-                      "fontFamily": "SafeIcons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    {},
-                  ]
+              <Image
+                accessibilityLabel="ETH"
+                fullscreen={true}
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  {
+                    "uri": "https://example.com/eth-logo.png",
+                  }
                 }
-                testID="logo-fallback-icon"
+                style={
+                  {
+                    "backgroundColor": "#121312",
+                    "height": 40,
+                    "width": 40,
+                  }
+                }
+                testID="logo-image"
+              />
+            </View>
+            <View
+              style={
+                {
+                  "backgroundColor": "#EEEFF0",
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "#EEEFF0",
+                    "borderBottomLeftRadius": 100,
+                    "borderBottomRightRadius": 100,
+                    "borderTopLeftRadius": 100,
+                    "borderTopRightRadius": 100,
+                    "paddingBottom": 8,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 8,
+                  }
+                }
               >
-                
-              </Text>
+                <Text
+                  allowFontScaling={false}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "#A1A3A7",
+                        "fontSize": 24,
+                      },
+                      undefined,
+                      {
+                        "fontFamily": "SafeIcons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      {},
+                    ]
+                  }
+                  testID="logo-fallback-icon"
+                >
+                  
+                </Text>
+              </View>
             </View>
           </View>
         </View>
-      </View>
-      <View>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "marginBottom": 4,
-            }
-          }
-        >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
+        <View>
+          <View
             style={
-              [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 4,
+                "marginBottom": 4,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#A1A3A7",
+                    "fontSize": 10,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "SafeIcons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+              testID="safe-list-transaction-stake-icon"
+            >
+              
+            </Text>
+            <Text
+              style={
                 {
                   "color": "#A1A3A7",
-                  "fontSize": 10,
-                },
-                undefined,
-                {
-                  "fontFamily": "SafeIcons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-            testID="safe-list-transaction-stake-icon"
-          >
-            
-          </Text>
+                  "fontFamily": "DM Sans",
+                  "fontSize": 13,
+                  "marginBottom": 2,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Stake
+            </Text>
+          </View>
           <Text
             style={
               {
-                "color": "#A1A3A7",
-                "fontFamily": "DM Sans",
-                "fontSize": 13,
-                "marginBottom": 2,
+                "color": "#121312",
+                "fontFamily": "DMSans-SemiBold",
+                "fontSize": 14,
               }
             }
             suppressHighlighting={true}
           >
-            Stake
+            Deposit
           </Text>
         </View>
-        <Text
-          style={
-            {
-              "color": "#121312",
-              "fontFamily": "DMSans-SemiBold",
-              "fontSize": 14,
-            }
-          }
-          suppressHighlighting={true}
-        >
-          Deposit
-        </Text>
       </View>
-    </View>
-    <Text
-      style={
-        {
-          "color": "#121312",
-          "fontFamily": "DMSans-Bold",
+      <Text
+        style={
+          {
+            "color": "#121312",
+            "fontFamily": "DMSans-Bold",
+          }
         }
-      }
-      suppressHighlighting={true}
-    >
-      1
-       
-      ETH
-    </Text>
+        suppressHighlighting={true}
+      >
+        1
+         
+        ETH
+      </Text>
+    </View>
   </View>
 </View>
 `;

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`StakingTxExitCard renders correctly 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
+        "alignItems": "flex-start",
         "backgroundColor": "#FFFFFF",
         "borderBottomLeftRadius": 7,
         "borderBottomRightRadius": 7,
         "borderTopLeftRadius": 7,
         "borderTopRightRadius": 7,
-        "flexDirection": "row",
+        "flexDirection": "column",
         "flexWrap": "wrap",
         "gap": 12,
-        "justifyContent": "space-between",
+        "justifyContent": "flex-start",
         "paddingBottom": 16,
         "paddingLeft": 16,
         "paddingRight": 16,
@@ -27,49 +27,24 @@ exports[`StakingTxExitCard renders correctly 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "gap": 12,
-          "maxWidth": "55%",
+          "justifyContent": "space-between",
+          "width": "100%",
         }
       }
     >
       <View
         style={
           {
-            "width": 40,
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "maxWidth": "55%",
           }
         }
       >
         <View
           style={
             {
-              "position": "absolute",
-              "right": -10,
-              "top": -10,
-              "zIndex": 1,
-            }
-          }
-        />
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "borderBottomLeftRadius": 100000,
-              "borderBottomRightRadius": 100000,
-              "borderTopLeftRadius": 100000,
-              "borderTopRightRadius": 100000,
-              "flexDirection": "column",
-              "height": 40,
-              "justifyContent": "center",
-              "maxHeight": 40,
-              "maxWidth": 40,
-              "minHeight": 40,
-              "minWidth": 40,
-              "overflow": "hidden",
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-              "position": "relative",
               "width": 40,
             }
           }
@@ -77,166 +52,202 @@ exports[`StakingTxExitCard renders correctly 1`] = `
           <View
             style={
               {
-                "bottom": 0,
-                "flexDirection": "column",
-                "left": 0,
                 "position": "absolute",
-                "right": 0,
-                "top": 0,
+                "right": -10,
+                "top": -10,
                 "zIndex": 1,
               }
             }
-          >
-            <Image
-              accessibilityLabel="ETH"
-              fullscreen={true}
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                {
-                  "uri": "https://example.com/eth-logo.png",
-                }
-              }
-              style={
-                {
-                  "backgroundColor": "#121312",
-                  "height": 40,
-                  "width": 40,
-                }
-              }
-              testID="logo-image"
-            />
-          </View>
+          />
           <View
             style={
               {
-                "backgroundColor": "#EEEFF0",
-                "bottom": 0,
+                "alignItems": "center",
+                "borderBottomLeftRadius": 100000,
+                "borderBottomRightRadius": 100000,
+                "borderTopLeftRadius": 100000,
+                "borderTopRightRadius": 100000,
                 "flexDirection": "column",
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "zIndex": 0,
+                "height": 40,
+                "justifyContent": "center",
+                "maxHeight": 40,
+                "maxWidth": 40,
+                "minHeight": 40,
+                "minWidth": 40,
+                "overflow": "hidden",
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "position": "relative",
+                "width": 40,
               }
             }
           >
             <View
               style={
                 {
-                  "backgroundColor": "#EEEFF0",
-                  "borderBottomLeftRadius": 100,
-                  "borderBottomRightRadius": 100,
-                  "borderTopLeftRadius": 100,
-                  "borderTopRightRadius": 100,
-                  "paddingBottom": 8,
-                  "paddingLeft": 8,
-                  "paddingRight": 8,
-                  "paddingTop": 8,
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 1,
                 }
               }
             >
-              <Text
-                allowFontScaling={false}
-                selectable={false}
-                style={
-                  [
-                    {
-                      "color": "#A1A3A7",
-                      "fontSize": 24,
-                    },
-                    undefined,
-                    {
-                      "fontFamily": "SafeIcons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    {},
-                  ]
+              <Image
+                accessibilityLabel="ETH"
+                fullscreen={true}
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  {
+                    "uri": "https://example.com/eth-logo.png",
+                  }
                 }
-                testID="logo-fallback-icon"
+                style={
+                  {
+                    "backgroundColor": "#121312",
+                    "height": 40,
+                    "width": 40,
+                  }
+                }
+                testID="logo-image"
+              />
+            </View>
+            <View
+              style={
+                {
+                  "backgroundColor": "#EEEFF0",
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "#EEEFF0",
+                    "borderBottomLeftRadius": 100,
+                    "borderBottomRightRadius": 100,
+                    "borderTopLeftRadius": 100,
+                    "borderTopRightRadius": 100,
+                    "paddingBottom": 8,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 8,
+                  }
+                }
               >
-                
-              </Text>
+                <Text
+                  allowFontScaling={false}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "#A1A3A7",
+                        "fontSize": 24,
+                      },
+                      undefined,
+                      {
+                        "fontFamily": "SafeIcons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      {},
+                    ]
+                  }
+                  testID="logo-fallback-icon"
+                >
+                  
+                </Text>
+              </View>
             </View>
           </View>
         </View>
-      </View>
-      <View>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "marginBottom": 4,
-            }
-          }
-        >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
+        <View>
+          <View
             style={
-              [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 4,
+                "marginBottom": 4,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#A1A3A7",
+                    "fontSize": 10,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "SafeIcons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+              testID="safe-list-transaction-stake-icon"
+            >
+              
+            </Text>
+            <Text
+              style={
                 {
                   "color": "#A1A3A7",
-                  "fontSize": 10,
-                },
-                undefined,
-                {
-                  "fontFamily": "SafeIcons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-            testID="safe-list-transaction-stake-icon"
-          >
-            
-          </Text>
+                  "fontFamily": "DM Sans",
+                  "fontSize": 13,
+                  "marginBottom": 2,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Stake
+            </Text>
+          </View>
           <Text
             style={
               {
-                "color": "#A1A3A7",
-                "fontFamily": "DM Sans",
-                "fontSize": 13,
-                "marginBottom": 2,
+                "color": "#121312",
+                "fontFamily": "DMSans-SemiBold",
+                "fontSize": 14,
               }
             }
             suppressHighlighting={true}
           >
-            Stake
+            Withdraw
           </Text>
         </View>
-        <Text
-          style={
-            {
-              "color": "#121312",
-              "fontFamily": "DMSans-SemiBold",
-              "fontSize": 14,
-            }
-          }
-          suppressHighlighting={true}
-        >
-          Withdraw
-        </Text>
       </View>
-    </View>
-    <Text
-      style={
-        {
-          "color": "#121312",
-          "fontFamily": "DMSans-SemiBold",
-          "textAlign": "right",
+      <Text
+        style={
+          {
+            "color": "#121312",
+            "fontFamily": "DMSans-SemiBold",
+            "textAlign": "right",
+          }
         }
-      }
-      suppressHighlighting={true}
-    >
-      2
-       Validator
-      s
-    </Text>
+        suppressHighlighting={true}
+      >
+        2
+         Validator
+        s
+      </Text>
+    </View>
   </View>
 </View>
 `;

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`StakingTxWithdrawCard renders correctly 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
+        "alignItems": "flex-start",
         "backgroundColor": "#FFFFFF",
         "borderBottomLeftRadius": 7,
         "borderBottomRightRadius": 7,
         "borderTopLeftRadius": 7,
         "borderTopRightRadius": 7,
-        "flexDirection": "row",
+        "flexDirection": "column",
         "flexWrap": "wrap",
         "gap": 12,
-        "justifyContent": "space-between",
+        "justifyContent": "flex-start",
         "paddingBottom": 16,
         "paddingLeft": 16,
         "paddingRight": 16,
@@ -27,49 +27,24 @@ exports[`StakingTxWithdrawCard renders correctly 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "gap": 12,
-          "maxWidth": "55%",
+          "justifyContent": "space-between",
+          "width": "100%",
         }
       }
     >
       <View
         style={
           {
-            "width": 40,
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "maxWidth": "55%",
           }
         }
       >
         <View
           style={
             {
-              "position": "absolute",
-              "right": -10,
-              "top": -10,
-              "zIndex": 1,
-            }
-          }
-        />
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "borderBottomLeftRadius": 100000,
-              "borderBottomRightRadius": 100000,
-              "borderTopLeftRadius": 100000,
-              "borderTopRightRadius": 100000,
-              "flexDirection": "column",
-              "height": 40,
-              "justifyContent": "center",
-              "maxHeight": 40,
-              "maxWidth": 40,
-              "minHeight": 40,
-              "minWidth": 40,
-              "overflow": "hidden",
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-              "position": "relative",
               "width": 40,
             }
           }
@@ -77,166 +52,202 @@ exports[`StakingTxWithdrawCard renders correctly 1`] = `
           <View
             style={
               {
-                "bottom": 0,
-                "flexDirection": "column",
-                "left": 0,
                 "position": "absolute",
-                "right": 0,
-                "top": 0,
+                "right": -10,
+                "top": -10,
                 "zIndex": 1,
               }
             }
-          >
-            <Image
-              accessibilityLabel="ETH"
-              fullscreen={true}
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                {
-                  "uri": "https://example.com/eth-logo.png",
-                }
-              }
-              style={
-                {
-                  "backgroundColor": "#121312",
-                  "height": 40,
-                  "width": 40,
-                }
-              }
-              testID="logo-image"
-            />
-          </View>
+          />
           <View
             style={
               {
-                "backgroundColor": "#EEEFF0",
-                "bottom": 0,
+                "alignItems": "center",
+                "borderBottomLeftRadius": 100000,
+                "borderBottomRightRadius": 100000,
+                "borderTopLeftRadius": 100000,
+                "borderTopRightRadius": 100000,
                 "flexDirection": "column",
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "zIndex": 0,
+                "height": 40,
+                "justifyContent": "center",
+                "maxHeight": 40,
+                "maxWidth": 40,
+                "minHeight": 40,
+                "minWidth": 40,
+                "overflow": "hidden",
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "position": "relative",
+                "width": 40,
               }
             }
           >
             <View
               style={
                 {
-                  "backgroundColor": "#EEEFF0",
-                  "borderBottomLeftRadius": 100,
-                  "borderBottomRightRadius": 100,
-                  "borderTopLeftRadius": 100,
-                  "borderTopRightRadius": 100,
-                  "paddingBottom": 8,
-                  "paddingLeft": 8,
-                  "paddingRight": 8,
-                  "paddingTop": 8,
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 1,
                 }
               }
             >
-              <Text
-                allowFontScaling={false}
-                selectable={false}
-                style={
-                  [
-                    {
-                      "color": "#A1A3A7",
-                      "fontSize": 24,
-                    },
-                    undefined,
-                    {
-                      "fontFamily": "SafeIcons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    {},
-                  ]
+              <Image
+                accessibilityLabel="ETH"
+                fullscreen={true}
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  {
+                    "uri": "https://example.com/eth-logo.png",
+                  }
                 }
-                testID="logo-fallback-icon"
+                style={
+                  {
+                    "backgroundColor": "#121312",
+                    "height": 40,
+                    "width": 40,
+                  }
+                }
+                testID="logo-image"
+              />
+            </View>
+            <View
+              style={
+                {
+                  "backgroundColor": "#EEEFF0",
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "#EEEFF0",
+                    "borderBottomLeftRadius": 100,
+                    "borderBottomRightRadius": 100,
+                    "borderTopLeftRadius": 100,
+                    "borderTopRightRadius": 100,
+                    "paddingBottom": 8,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 8,
+                  }
+                }
               >
-                
-              </Text>
+                <Text
+                  allowFontScaling={false}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "#A1A3A7",
+                        "fontSize": 24,
+                      },
+                      undefined,
+                      {
+                        "fontFamily": "SafeIcons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      {},
+                    ]
+                  }
+                  testID="logo-fallback-icon"
+                >
+                  
+                </Text>
+              </View>
             </View>
           </View>
         </View>
-      </View>
-      <View>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "marginBottom": 4,
-            }
-          }
-        >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
+        <View>
+          <View
             style={
-              [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 4,
+                "marginBottom": 4,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#A1A3A7",
+                    "fontSize": 10,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "SafeIcons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+              testID="safe-list-transaction-stake-icon"
+            >
+              
+            </Text>
+            <Text
+              style={
                 {
                   "color": "#A1A3A7",
-                  "fontSize": 10,
-                },
-                undefined,
-                {
-                  "fontFamily": "SafeIcons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-            testID="safe-list-transaction-stake-icon"
-          >
-            
-          </Text>
+                  "fontFamily": "DM Sans",
+                  "fontSize": 13,
+                  "marginBottom": 2,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Stake
+            </Text>
+          </View>
           <Text
             style={
               {
-                "color": "#A1A3A7",
-                "fontFamily": "DM Sans",
-                "fontSize": 13,
-                "marginBottom": 2,
+                "color": "#121312",
+                "fontFamily": "DMSans-SemiBold",
+                "fontSize": 14,
               }
             }
             suppressHighlighting={true}
           >
-            Stake
+            Claim
           </Text>
         </View>
-        <Text
-          style={
-            {
-              "color": "#121312",
-              "fontFamily": "DMSans-SemiBold",
-              "fontSize": 14,
-            }
-          }
-          suppressHighlighting={true}
-        >
-          Claim
-        </Text>
       </View>
-    </View>
-    <Text
-      style={
-        {
-          "color": "#121312",
-          "fontFamily": "DMSans-Bold",
+      <Text
+        style={
+          {
+            "color": "#121312",
+            "fontFamily": "DMSans-Bold",
+          }
         }
-      }
-      suppressHighlighting={true}
-      testID="token-amount"
-    >
-      1
-       
-      ETH
-    </Text>
+        suppressHighlighting={true}
+        testID="token-amount"
+      >
+        1
+         
+        ETH
+      </Text>
+    </View>
   </View>
 </View>
 `;

--- a/apps/mobile/src/components/transactions-list/Card/TxBatchCard/__snapshots__/TxBatchCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxBatchCard/__snapshots__/TxBatchCard.test.tsx.snap
@@ -14,16 +14,16 @@ exports[`TxBatchCard should render the default markup 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       {
-        "alignItems": "center",
+        "alignItems": "flex-start",
         "backgroundColor": "#FFFFFF",
         "borderBottomLeftRadius": 7,
         "borderBottomRightRadius": 7,
         "borderTopLeftRadius": 7,
         "borderTopRightRadius": 7,
-        "flexDirection": "row",
+        "flexDirection": "column",
         "flexWrap": "wrap",
         "gap": 12,
-        "justifyContent": "space-between",
+        "justifyContent": "flex-start",
         "paddingBottom": 16,
         "paddingLeft": 16,
         "paddingRight": 16,
@@ -36,8 +36,8 @@ exports[`TxBatchCard should render the default markup 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "gap": 12,
-          "maxWidth": "100%",
+          "justifyContent": "space-between",
+          "width": "100%",
         }
       }
     >
@@ -45,84 +45,129 @@ exports[`TxBatchCard should render the default markup 1`] = `
         style={
           {
             "alignItems": "center",
-            "borderBottomLeftRadius": 100000,
-            "borderBottomRightRadius": 100000,
-            "borderTopLeftRadius": 100000,
-            "borderTopRightRadius": 100000,
-            "flexDirection": "column",
-            "height": 40,
-            "justifyContent": "center",
-            "maxHeight": 40,
-            "maxWidth": 40,
-            "minHeight": 40,
-            "minWidth": 40,
-            "overflow": "hidden",
-            "paddingBottom": 0,
-            "paddingLeft": 0,
-            "paddingRight": 0,
-            "paddingTop": 0,
-            "position": "relative",
-            "width": 40,
+            "flexDirection": "row",
+            "gap": 12,
+            "maxWidth": "100%",
           }
         }
       >
         <View
           style={
             {
-              "bottom": 0,
+              "alignItems": "center",
+              "borderBottomLeftRadius": 100000,
+              "borderBottomRightRadius": 100000,
+              "borderTopLeftRadius": 100000,
+              "borderTopRightRadius": 100000,
               "flexDirection": "column",
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "zIndex": 1,
-            }
-          }
-        >
-          <Image
-            accessibilityLabel="Cam"
-            fullscreen={true}
-            onError={[Function]}
-            onLoad={[Function]}
-            source={
-              {
-                "uri": "http://myAsset.com/asset.png",
-              }
-            }
-            style={
-              {
-                "height": 40,
-                "width": 40,
-              }
-            }
-          />
-        </View>
-        <View
-          style={
-            {
-              "backgroundColor": "#DCDEE0",
-              "bottom": 0,
-              "flexDirection": "column",
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "zIndex": 0,
+              "height": 40,
+              "justifyContent": "center",
+              "maxHeight": 40,
+              "maxWidth": 40,
+              "minHeight": 40,
+              "minWidth": 40,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "paddingLeft": 0,
+              "paddingRight": 0,
+              "paddingTop": 0,
+              "position": "relative",
+              "width": 40,
             }
           }
         >
           <View
             style={
               {
-                "backgroundColor": "#303033",
-                "borderBottomLeftRadius": 100,
-                "borderBottomRightRadius": 100,
-                "borderTopLeftRadius": 100,
-                "borderTopRightRadius": 100,
-                "paddingBottom": 8,
-                "paddingLeft": 8,
-                "paddingRight": 8,
-                "paddingTop": 8,
+                "bottom": 0,
+                "flexDirection": "column",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 1,
+              }
+            }
+          >
+            <Image
+              accessibilityLabel="Cam"
+              fullscreen={true}
+              onError={[Function]}
+              onLoad={[Function]}
+              source={
+                {
+                  "uri": "http://myAsset.com/asset.png",
+                }
+              }
+              style={
+                {
+                  "height": 40,
+                  "width": 40,
+                }
+              }
+            />
+          </View>
+          <View
+            style={
+              {
+                "backgroundColor": "#DCDEE0",
+                "bottom": 0,
+                "flexDirection": "column",
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              style={
+                {
+                  "backgroundColor": "#303033",
+                  "borderBottomLeftRadius": 100,
+                  "borderBottomRightRadius": 100,
+                  "borderTopLeftRadius": 100,
+                  "borderTopRightRadius": 100,
+                  "paddingBottom": 8,
+                  "paddingLeft": 8,
+                  "paddingRight": 8,
+                  "paddingTop": 8,
+                }
+              }
+            >
+              <Text
+                allowFontScaling={false}
+                selectable={false}
+                style={
+                  [
+                    {
+                      "color": "#121312",
+                      "fontSize": 24,
+                    },
+                    undefined,
+                    {
+                      "fontFamily": "SafeIcons",
+                      "fontStyle": "normal",
+                      "fontWeight": "normal",
+                    },
+                    {},
+                  ]
+                }
+              >
+                
+              </Text>
+            </View>
+          </View>
+        </View>
+        <View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 4,
+                "marginBottom": 4,
               }
             }
           >
@@ -132,8 +177,8 @@ exports[`TxBatchCard should render the default markup 1`] = `
               style={
                 [
                   {
-                    "color": "#121312",
-                    "fontSize": 24,
+                    "color": "#A1A3A7",
+                    "fontSize": 10,
                   },
                   undefined,
                   {
@@ -144,71 +189,37 @@ exports[`TxBatchCard should render the default markup 1`] = `
                   {},
                 ]
               }
+              testID="safe-list-batch-icon"
             >
               
             </Text>
-          </View>
-        </View>
-      </View>
-      <View>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "marginBottom": 4,
-            }
-          }
-        >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
-            style={
-              [
+            <Text
+              style={
                 {
                   "color": "#A1A3A7",
-                  "fontSize": 10,
-                },
-                undefined,
-                {
-                  "fontFamily": "SafeIcons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-            testID="safe-list-batch-icon"
-          >
-            
-          </Text>
+                  "fontFamily": "DM Sans",
+                  "fontSize": 13,
+                  "marginBottom": 2,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Batch
+            </Text>
+          </View>
           <Text
             style={
               {
-                "color": "#A1A3A7",
-                "fontFamily": "DM Sans",
-                "fontSize": 13,
-                "marginBottom": 2,
+                "color": "#121312",
+                "fontFamily": "DMSans-SemiBold",
+                "fontSize": 14,
               }
             }
             suppressHighlighting={true}
           >
-            Batch
+            2 actions
           </Text>
         </View>
-        <Text
-          style={
-            {
-              "color": "#121312",
-              "fontFamily": "DMSans-SemiBold",
-              "fontSize": 14,
-            }
-          }
-          suppressHighlighting={true}
-        >
-          2 actions
-        </Text>
       </View>
     </View>
   </View>

--- a/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/__snapshots__/TxSettingCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/__snapshots__/TxSettingCard.test.tsx.snap
@@ -14,16 +14,16 @@ exports[`TxSettingCard should render the default markup 1`] = `
     onStartShouldSetResponder={[Function]}
     style={
       {
-        "alignItems": "center",
+        "alignItems": "flex-start",
         "backgroundColor": "#FFFFFF",
         "borderBottomLeftRadius": 7,
         "borderBottomRightRadius": 7,
         "borderTopLeftRadius": 7,
         "borderTopRightRadius": 7,
-        "flexDirection": "row",
+        "flexDirection": "column",
         "flexWrap": "wrap",
         "gap": 12,
-        "justifyContent": "space-between",
+        "justifyContent": "flex-start",
         "paddingBottom": 16,
         "paddingLeft": 16,
         "paddingRight": 16,
@@ -36,85 +36,96 @@ exports[`TxSettingCard should render the default markup 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "gap": 12,
-          "maxWidth": "100%",
+          "justifyContent": "space-between",
+          "width": "100%",
         }
       }
     >
       <View
         style={
           {
-            "backgroundColor": "#EEEFF0",
-            "borderBottomLeftRadius": 100,
-            "borderBottomRightRadius": 100,
-            "borderTopLeftRadius": 100,
-            "borderTopRightRadius": 100,
-            "paddingBottom": 8,
-            "paddingLeft": 8,
-            "paddingRight": 8,
-            "paddingTop": 8,
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "maxWidth": "100%",
           }
         }
       >
-        <Text
-          allowFontScaling={false}
-          selectable={false}
-          style={
-            [
-              {
-                "color": "#121312",
-                "fontSize": 24,
-              },
-              undefined,
-              {
-                "fontFamily": "SafeIcons",
-                "fontStyle": "normal",
-                "fontWeight": "normal",
-              },
-              {},
-            ]
-          }
-        >
-          
-        </Text>
-      </View>
-      <View>
         <View
           style={
             {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "marginBottom": 4,
+              "backgroundColor": "#EEEFF0",
+              "borderBottomLeftRadius": 100,
+              "borderBottomRightRadius": 100,
+              "borderTopLeftRadius": 100,
+              "borderTopRightRadius": 100,
+              "paddingBottom": 8,
+              "paddingLeft": 8,
+              "paddingRight": 8,
+              "paddingTop": 8,
             }
           }
         >
           <Text
+            allowFontScaling={false}
+            selectable={false}
+            style={
+              [
+                {
+                  "color": "#121312",
+                  "fontSize": 24,
+                },
+                undefined,
+                {
+                  "fontFamily": "SafeIcons",
+                  "fontStyle": "normal",
+                  "fontWeight": "normal",
+                },
+                {},
+              ]
+            }
+          >
+            
+          </Text>
+        </View>
+        <View>
+          <View
             style={
               {
-                "color": "#A1A3A7",
-                "fontFamily": "DM Sans",
-                "fontSize": 13,
-                "marginBottom": 2,
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 4,
+                "marginBottom": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "#A1A3A7",
+                  "fontFamily": "DM Sans",
+                  "fontSize": 13,
+                  "marginBottom": 2,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Settings change
+            </Text>
+          </View>
+          <Text
+            style={
+              {
+                "color": "#121312",
+                "fontFamily": "DMSans-SemiBold",
+                "fontSize": 14,
               }
             }
             suppressHighlighting={true}
           >
-            Settings change
+            mockMethod
           </Text>
         </View>
-        <Text
-          style={
-            {
-              "color": "#121312",
-              "fontFamily": "DMSans-SemiBold",
-              "fontSize": 14,
-            }
-          }
-          suppressHighlighting={true}
-        >
-          mockMethod
-        </Text>
       </View>
     </View>
   </View>

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/__snapshots__/VaultTxDepositCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/__snapshots__/VaultTxDepositCard.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`VaultTxDepositCard renders correctly 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
+        "alignItems": "flex-start",
         "backgroundColor": "#FFFFFF",
         "borderBottomLeftRadius": 7,
         "borderBottomRightRadius": 7,
         "borderTopLeftRadius": 7,
         "borderTopRightRadius": 7,
-        "flexDirection": "row",
+        "flexDirection": "column",
         "flexWrap": "wrap",
         "gap": 12,
-        "justifyContent": "space-between",
+        "justifyContent": "flex-start",
         "paddingBottom": 16,
         "paddingLeft": 16,
         "paddingRight": 16,
@@ -27,49 +27,24 @@ exports[`VaultTxDepositCard renders correctly 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "gap": 12,
-          "maxWidth": "55%",
+          "justifyContent": "space-between",
+          "width": "100%",
         }
       }
     >
       <View
         style={
           {
-            "width": 40,
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "maxWidth": "55%",
           }
         }
       >
         <View
           style={
             {
-              "position": "absolute",
-              "right": -10,
-              "top": -10,
-              "zIndex": 1,
-            }
-          }
-        />
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "borderBottomLeftRadius": 100000,
-              "borderBottomRightRadius": 100000,
-              "borderTopLeftRadius": 100000,
-              "borderTopRightRadius": 100000,
-              "flexDirection": "column",
-              "height": 40,
-              "justifyContent": "center",
-              "maxHeight": 40,
-              "maxWidth": 40,
-              "minHeight": 40,
-              "minWidth": 40,
-              "overflow": "hidden",
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-              "position": "relative",
               "width": 40,
             }
           }
@@ -77,165 +52,201 @@ exports[`VaultTxDepositCard renders correctly 1`] = `
           <View
             style={
               {
-                "bottom": 0,
-                "flexDirection": "column",
-                "left": 0,
                 "position": "absolute",
-                "right": 0,
-                "top": 0,
+                "right": -10,
+                "top": -10,
                 "zIndex": 1,
               }
             }
-          >
-            <Image
-              accessibilityLabel="USDC"
-              fullscreen={true}
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                {
-                  "uri": "https://example.com/eth-logo.png",
-                }
-              }
-              style={
-                {
-                  "backgroundColor": "#121312",
-                  "height": 40,
-                  "width": 40,
-                }
-              }
-              testID="logo-image"
-            />
-          </View>
+          />
           <View
             style={
               {
-                "backgroundColor": "#EEEFF0",
-                "bottom": 0,
+                "alignItems": "center",
+                "borderBottomLeftRadius": 100000,
+                "borderBottomRightRadius": 100000,
+                "borderTopLeftRadius": 100000,
+                "borderTopRightRadius": 100000,
                 "flexDirection": "column",
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "zIndex": 0,
+                "height": 40,
+                "justifyContent": "center",
+                "maxHeight": 40,
+                "maxWidth": 40,
+                "minHeight": 40,
+                "minWidth": 40,
+                "overflow": "hidden",
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "position": "relative",
+                "width": 40,
               }
             }
           >
             <View
               style={
                 {
-                  "backgroundColor": "#EEEFF0",
-                  "borderBottomLeftRadius": 100,
-                  "borderBottomRightRadius": 100,
-                  "borderTopLeftRadius": 100,
-                  "borderTopRightRadius": 100,
-                  "paddingBottom": 8,
-                  "paddingLeft": 8,
-                  "paddingRight": 8,
-                  "paddingTop": 8,
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 1,
                 }
               }
             >
-              <Text
-                allowFontScaling={false}
-                selectable={false}
-                style={
-                  [
-                    {
-                      "color": "#A1A3A7",
-                      "fontSize": 24,
-                    },
-                    undefined,
-                    {
-                      "fontFamily": "SafeIcons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    {},
-                  ]
+              <Image
+                accessibilityLabel="USDC"
+                fullscreen={true}
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  {
+                    "uri": "https://example.com/eth-logo.png",
+                  }
                 }
-                testID="logo-fallback-icon"
+                style={
+                  {
+                    "backgroundColor": "#121312",
+                    "height": 40,
+                    "width": 40,
+                  }
+                }
+                testID="logo-image"
+              />
+            </View>
+            <View
+              style={
+                {
+                  "backgroundColor": "#EEEFF0",
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "#EEEFF0",
+                    "borderBottomLeftRadius": 100,
+                    "borderBottomRightRadius": 100,
+                    "borderTopLeftRadius": 100,
+                    "borderTopRightRadius": 100,
+                    "paddingBottom": 8,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 8,
+                  }
+                }
               >
-                
-              </Text>
+                <Text
+                  allowFontScaling={false}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "#A1A3A7",
+                        "fontSize": 24,
+                      },
+                      undefined,
+                      {
+                        "fontFamily": "SafeIcons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      {},
+                    ]
+                  }
+                  testID="logo-fallback-icon"
+                >
+                  
+                </Text>
+              </View>
             </View>
           </View>
         </View>
-      </View>
-      <View>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "marginBottom": 4,
-            }
-          }
-        >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
+        <View>
+          <View
             style={
-              [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 4,
+                "marginBottom": 4,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#A1A3A7",
+                    "fontSize": 10,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "SafeIcons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+              testID="safe-list-transaction-stake-icon"
+            >
+              
+            </Text>
+            <Text
+              style={
                 {
                   "color": "#A1A3A7",
-                  "fontSize": 10,
-                },
-                undefined,
-                {
-                  "fontFamily": "SafeIcons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-            testID="safe-list-transaction-stake-icon"
-          >
-            
-          </Text>
+                  "fontFamily": "DM Sans",
+                  "fontSize": 13,
+                  "marginBottom": 2,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Earn
+            </Text>
+          </View>
           <Text
             style={
               {
-                "color": "#A1A3A7",
-                "fontFamily": "DM Sans",
-                "fontSize": 13,
-                "marginBottom": 2,
+                "color": "#121312",
+                "fontFamily": "DMSans-SemiBold",
+                "fontSize": 14,
               }
             }
             suppressHighlighting={true}
           >
-            Earn
+            Deposit
           </Text>
         </View>
-        <Text
-          style={
-            {
-              "color": "#121312",
-              "fontFamily": "DMSans-SemiBold",
-              "fontSize": 14,
-            }
-          }
-          suppressHighlighting={true}
-        >
-          Deposit
-        </Text>
       </View>
-    </View>
-    <Text
-      style={
-        {
-          "color": "#121312",
-          "fontFamily": "DMSans-Bold",
+      <Text
+        style={
+          {
+            "color": "#121312",
+            "fontFamily": "DMSans-Bold",
+          }
         }
-      }
-      suppressHighlighting={true}
-    >
-      1
-       
-      USDC
-    </Text>
+        suppressHighlighting={true}
+      >
+        1
+         
+        USDC
+      </Text>
+    </View>
   </View>
 </View>
 `;

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/__snapshots__/VaultTxRedeemCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/__snapshots__/VaultTxRedeemCard.test.tsx.snap
@@ -5,16 +5,16 @@ exports[`VaultTxRedeemCard renders correctly 1`] = `
   <View
     style={
       {
-        "alignItems": "center",
+        "alignItems": "flex-start",
         "backgroundColor": "#FFFFFF",
         "borderBottomLeftRadius": 7,
         "borderBottomRightRadius": 7,
         "borderTopLeftRadius": 7,
         "borderTopRightRadius": 7,
-        "flexDirection": "row",
+        "flexDirection": "column",
         "flexWrap": "wrap",
         "gap": 12,
-        "justifyContent": "space-between",
+        "justifyContent": "flex-start",
         "paddingBottom": 16,
         "paddingLeft": 16,
         "paddingRight": 16,
@@ -27,49 +27,24 @@ exports[`VaultTxRedeemCard renders correctly 1`] = `
         {
           "alignItems": "center",
           "flexDirection": "row",
-          "gap": 12,
-          "maxWidth": "55%",
+          "justifyContent": "space-between",
+          "width": "100%",
         }
       }
     >
       <View
         style={
           {
-            "width": 40,
+            "alignItems": "center",
+            "flexDirection": "row",
+            "gap": 12,
+            "maxWidth": "55%",
           }
         }
       >
         <View
           style={
             {
-              "position": "absolute",
-              "right": -10,
-              "top": -10,
-              "zIndex": 1,
-            }
-          }
-        />
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "borderBottomLeftRadius": 100000,
-              "borderBottomRightRadius": 100000,
-              "borderTopLeftRadius": 100000,
-              "borderTopRightRadius": 100000,
-              "flexDirection": "column",
-              "height": 40,
-              "justifyContent": "center",
-              "maxHeight": 40,
-              "maxWidth": 40,
-              "minHeight": 40,
-              "minWidth": 40,
-              "overflow": "hidden",
-              "paddingBottom": 0,
-              "paddingLeft": 0,
-              "paddingRight": 0,
-              "paddingTop": 0,
-              "position": "relative",
               "width": 40,
             }
           }
@@ -77,165 +52,201 @@ exports[`VaultTxRedeemCard renders correctly 1`] = `
           <View
             style={
               {
-                "bottom": 0,
-                "flexDirection": "column",
-                "left": 0,
                 "position": "absolute",
-                "right": 0,
-                "top": 0,
+                "right": -10,
+                "top": -10,
                 "zIndex": 1,
               }
             }
-          >
-            <Image
-              accessibilityLabel="USDC"
-              fullscreen={true}
-              onError={[Function]}
-              onLoad={[Function]}
-              source={
-                {
-                  "uri": "https://example.com/eth-logo.png",
-                }
-              }
-              style={
-                {
-                  "backgroundColor": "#121312",
-                  "height": 40,
-                  "width": 40,
-                }
-              }
-              testID="logo-image"
-            />
-          </View>
+          />
           <View
             style={
               {
-                "backgroundColor": "#EEEFF0",
-                "bottom": 0,
+                "alignItems": "center",
+                "borderBottomLeftRadius": 100000,
+                "borderBottomRightRadius": 100000,
+                "borderTopLeftRadius": 100000,
+                "borderTopRightRadius": 100000,
                 "flexDirection": "column",
-                "left": 0,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "zIndex": 0,
+                "height": 40,
+                "justifyContent": "center",
+                "maxHeight": 40,
+                "maxWidth": 40,
+                "minHeight": 40,
+                "minWidth": 40,
+                "overflow": "hidden",
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 0,
+                "position": "relative",
+                "width": 40,
               }
             }
           >
             <View
               style={
                 {
-                  "backgroundColor": "#EEEFF0",
-                  "borderBottomLeftRadius": 100,
-                  "borderBottomRightRadius": 100,
-                  "borderTopLeftRadius": 100,
-                  "borderTopRightRadius": 100,
-                  "paddingBottom": 8,
-                  "paddingLeft": 8,
-                  "paddingRight": 8,
-                  "paddingTop": 8,
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 1,
                 }
               }
             >
-              <Text
-                allowFontScaling={false}
-                selectable={false}
-                style={
-                  [
-                    {
-                      "color": "#A1A3A7",
-                      "fontSize": 24,
-                    },
-                    undefined,
-                    {
-                      "fontFamily": "SafeIcons",
-                      "fontStyle": "normal",
-                      "fontWeight": "normal",
-                    },
-                    {},
-                  ]
+              <Image
+                accessibilityLabel="USDC"
+                fullscreen={true}
+                onError={[Function]}
+                onLoad={[Function]}
+                source={
+                  {
+                    "uri": "https://example.com/eth-logo.png",
+                  }
                 }
-                testID="logo-fallback-icon"
+                style={
+                  {
+                    "backgroundColor": "#121312",
+                    "height": 40,
+                    "width": 40,
+                  }
+                }
+                testID="logo-image"
+              />
+            </View>
+            <View
+              style={
+                {
+                  "backgroundColor": "#EEEFF0",
+                  "bottom": 0,
+                  "flexDirection": "column",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "#EEEFF0",
+                    "borderBottomLeftRadius": 100,
+                    "borderBottomRightRadius": 100,
+                    "borderTopLeftRadius": 100,
+                    "borderTopRightRadius": 100,
+                    "paddingBottom": 8,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 8,
+                  }
+                }
               >
-                
-              </Text>
+                <Text
+                  allowFontScaling={false}
+                  selectable={false}
+                  style={
+                    [
+                      {
+                        "color": "#A1A3A7",
+                        "fontSize": 24,
+                      },
+                      undefined,
+                      {
+                        "fontFamily": "SafeIcons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                      {},
+                    ]
+                  }
+                  testID="logo-fallback-icon"
+                >
+                  
+                </Text>
+              </View>
             </View>
           </View>
         </View>
-      </View>
-      <View>
-        <View
-          style={
-            {
-              "alignItems": "center",
-              "flexDirection": "row",
-              "gap": 4,
-              "marginBottom": 4,
-            }
-          }
-        >
-          <Text
-            allowFontScaling={false}
-            selectable={false}
+        <View>
+          <View
             style={
-              [
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 4,
+                "marginBottom": 4,
+              }
+            }
+          >
+            <Text
+              allowFontScaling={false}
+              selectable={false}
+              style={
+                [
+                  {
+                    "color": "#A1A3A7",
+                    "fontSize": 10,
+                  },
+                  undefined,
+                  {
+                    "fontFamily": "SafeIcons",
+                    "fontStyle": "normal",
+                    "fontWeight": "normal",
+                  },
+                  {},
+                ]
+              }
+              testID="safe-list-transaction-stake-icon"
+            >
+              
+            </Text>
+            <Text
+              style={
                 {
                   "color": "#A1A3A7",
-                  "fontSize": 10,
-                },
-                undefined,
-                {
-                  "fontFamily": "SafeIcons",
-                  "fontStyle": "normal",
-                  "fontWeight": "normal",
-                },
-                {},
-              ]
-            }
-            testID="safe-list-transaction-stake-icon"
-          >
-            
-          </Text>
+                  "fontFamily": "DM Sans",
+                  "fontSize": 13,
+                  "marginBottom": 2,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Earn
+            </Text>
+          </View>
           <Text
             style={
               {
-                "color": "#A1A3A7",
-                "fontFamily": "DM Sans",
-                "fontSize": 13,
-                "marginBottom": 2,
+                "color": "#121312",
+                "fontFamily": "DMSans-SemiBold",
+                "fontSize": 14,
               }
             }
             suppressHighlighting={true}
           >
-            Earn
+            Withdraw
           </Text>
         </View>
-        <Text
-          style={
-            {
-              "color": "#121312",
-              "fontFamily": "DMSans-SemiBold",
-              "fontSize": 14,
-            }
-          }
-          suppressHighlighting={true}
-        >
-          Withdraw
-        </Text>
       </View>
-    </View>
-    <Text
-      style={
-        {
-          "color": "#121312",
-          "fontFamily": "DMSans-Bold",
+      <Text
+        style={
+          {
+            "color": "#121312",
+            "fontFamily": "DMSans-Bold",
+          }
         }
-      }
-      suppressHighlighting={true}
-    >
-      1
-       
-      USDC
-    </Text>
+        suppressHighlighting={true}
+      >
+        1
+         
+        USDC
+      </Text>
+    </View>
   </View>
 </View>
 `;

--- a/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
+++ b/apps/mobile/src/features/ConfirmTx/ConfirmTx.container.tsx
@@ -54,7 +54,7 @@ function ConfirmTxContainer() {
         <View paddingHorizontal="$4">
           <ConfirmationView txDetails={data} />
         </View>
-        <TransactionInfo txId={txId} detailedExecutionInfo={detailedExecutionInfo} />
+        <TransactionInfo txId={txId} detailedExecutionInfo={detailedExecutionInfo} txDetails={data} />
       </ScrollView>
 
       <View paddingTop="$1">

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationsInfo/ConfirmationsInfo.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationsInfo/ConfirmationsInfo.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Text, View } from 'tamagui'
+import { Badge } from '@/src/components/Badge'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { SafeListItem } from '@/src/components/SafeListItem'
+import { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { useRouter } from 'expo-router'
+
+interface ConfirmationsInfoProps {
+  detailedExecutionInfo: MultisigExecutionDetails
+  txId: string
+}
+
+export function ConfirmationsInfo({ detailedExecutionInfo, txId }: ConfirmationsInfoProps) {
+  const router = useRouter()
+
+  const hasEnoughConfirmations =
+    detailedExecutionInfo?.confirmationsRequired === detailedExecutionInfo?.confirmations?.length
+
+  const onConfirmationsPress = () => {
+    router.push({
+      pathname: '/confirmations-sheet',
+      params: { txId },
+    })
+  }
+
+  return (
+    <SafeListItem
+      label="Confirmations"
+      onPress={onConfirmationsPress}
+      rightNode={
+        <View alignItems="center" flexDirection="row">
+          <Badge
+            circular={false}
+            content={
+              <View alignItems="center" flexDirection="row" gap="$1">
+                <SafeFontIcon size={12} name="owners" />
+
+                <Text fontWeight={600} color={'$color'}>
+                  {detailedExecutionInfo?.confirmations?.length}/{detailedExecutionInfo?.confirmationsRequired}
+                </Text>
+              </View>
+            }
+            themeName={hasEnoughConfirmations ? 'badge_success_variant1' : 'badge_warning_variant1'}
+          />
+
+          <SafeFontIcon name="chevron-right" />
+        </View>
+      }
+    />
+  )
+}

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationsInfo/index.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationsInfo/index.ts
@@ -1,0 +1,1 @@
+export { ConfirmationsInfo } from './ConfirmationsInfo'

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/TransactionChecks.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/TransactionChecks.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { SafeListItem } from '@/src/components/SafeListItem'
+import { useRouter } from 'expo-router'
+import { IconName } from '@/src/types/iconTypes'
+import { Alert } from '@/src/components/Alert'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { CircleSnail } from 'react-native-progress'
+import { useTransactionSecurity } from './hooks/useTransactionSecurity'
+
+interface TransactionChecksProps {
+  txId: string
+  txDetails?: TransactionDetails
+}
+
+export function TransactionChecks({ txId, txDetails }: TransactionChecksProps) {
+  const router = useRouter()
+
+  // Handle all security scanning internally
+  const security = useTransactionSecurity(txDetails)
+
+  const onTransactionChecksPress = () => {
+    router.push({
+      pathname: '/transaction-checks',
+      params: { txId },
+    })
+  }
+
+  const getTransactionChecksIcon = (): IconName => {
+    if (security.hasError) {
+      return 'shield-crossed'
+    }
+    if (security.isMediumRisk || security.hasContractManagement) {
+      return 'alert-triangle'
+    }
+    return 'shield'
+  }
+
+  const getTransactionChecksLeftNode = () => {
+    if (security.isScanning) {
+      return <CircleSnail size={16} borderWidth={0} thickness={1} />
+    }
+    return <SafeFontIcon name={getTransactionChecksIcon()} />
+  }
+
+  const getTransactionChecksLabel = () => {
+    if (security.isScanning) {
+      return 'Checking transaction...'
+    }
+    return 'Transaction checks'
+  }
+
+  const getAlertType = () => {
+    if (security.isHighRisk) {
+      return 'error'
+    }
+    if (security.isMediumRisk) {
+      return 'warning'
+    }
+    return 'info'
+  }
+
+  const getTransactionChecksBottomContent = () => {
+    if (!security.enabled) {
+      return null
+    }
+
+    // Show warnings for security issues (malicious/warning)
+    if (security.hasIssues) {
+      return <Alert type={getAlertType()} info="Potential risk detected" message="Review details before signing" />
+    }
+
+    // Show warnings for contract management changes (proxy upgrades, ownership changes, etc.)
+    if (security.hasContractManagement) {
+      return <Alert type="warning" info="Review details first" message="Contract changes detected!" />
+    }
+
+    // Show error if blockaid check failed
+    if (security.error) {
+      return (
+        <Alert
+          type="warning"
+          message="Proceed with caution"
+          info="The transaction could not be checked for security alerts. Verify the details and addresses before proceeding."
+        />
+      )
+    }
+
+    return null
+  }
+
+  return (
+    <SafeListItem
+      onPress={onTransactionChecksPress}
+      leftNode={getTransactionChecksLeftNode()}
+      label={getTransactionChecksLabel()}
+      rightNode={<SafeFontIcon name={'chevron-right'} />}
+      bottomContent={getTransactionChecksBottomContent()}
+    />
+  )
+}

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/hooks/__tests__/useTransactionSecurity.test.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/hooks/__tests__/useTransactionSecurity.test.ts
@@ -1,0 +1,389 @@
+import { renderHook, waitFor } from '@testing-library/react-native'
+import { useTransactionSecurity } from '../useTransactionSecurity'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { useBlockaid } from '@/src/features/TransactionChecks/blockaid/useBlockaid'
+import { useSafeInfo } from '@/src/hooks/useSafeInfo'
+import { useHasFeature } from '@/src/hooks/useHasFeature'
+import { createExistingTx } from '@/src/services/tx/tx-sender'
+import extractTxInfo from '@/src/services/tx/extractTx'
+import { SecuritySeverity } from '@safe-global/utils/services/security/modules/types'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import type { SafeTransaction } from '@safe-global/types-kit'
+
+// Mock all dependencies
+jest.mock('@/src/store/hooks/activeSafe')
+jest.mock('@/src/features/TransactionChecks/blockaid/useBlockaid')
+jest.mock('@/src/hooks/useSafeInfo')
+jest.mock('@/src/hooks/useHasFeature')
+jest.mock('@/src/services/tx/tx-sender')
+jest.mock('@/src/services/tx/extractTx')
+
+const mockUseDefinedActiveSafe = useDefinedActiveSafe as jest.MockedFunction<typeof useDefinedActiveSafe>
+const mockUseBlockaid = useBlockaid as jest.MockedFunction<typeof useBlockaid>
+const mockUseSafeInfo = useSafeInfo as jest.MockedFunction<typeof useSafeInfo>
+const mockUseHasFeature = useHasFeature as jest.MockedFunction<typeof useHasFeature>
+const mockCreateExistingTx = createExistingTx as jest.MockedFunction<typeof createExistingTx>
+const mockExtractTxInfo = extractTxInfo as jest.MockedFunction<typeof extractTxInfo>
+
+describe('useTransactionSecurity', () => {
+  const mockTxDetails: TransactionDetails = {
+    txId: 'test-tx-id',
+    safeAddress: '0xSafeAddress',
+    executedAt: null,
+    txStatus: 'AWAITING_CONFIRMATIONS',
+    txInfo: {
+      type: 'Transfer',
+      humanDescription: 'Test transaction',
+      sender: { value: '0xSender' },
+      recipient: { value: '0xRecipient' },
+      direction: 'OUTGOING',
+      transferInfo: {
+        type: 'NATIVE_COIN',
+        value: '1000000000000000000',
+      },
+    },
+    detailedExecutionInfo: {
+      type: 'MULTISIG',
+      submittedAt: Date.now(),
+      nonce: 1,
+      confirmationsRequired: 2,
+      confirmationsSubmitted: 1,
+    },
+  } as unknown as TransactionDetails
+
+  const mockScanTransaction = jest.fn()
+  const mockBlockaidPayload = {
+    severity: SecuritySeverity.MEDIUM,
+    payload: {
+      issues: [
+        {
+          severity: SecuritySeverity.MEDIUM,
+          description: 'Test security issue',
+        },
+      ],
+      contractManagement: [
+        {
+          type: 'PROXY_UPGRADE' as const,
+          after: { address: '0x456' },
+          before: { address: '0x789' },
+        },
+      ],
+      balanceChange: [],
+      error: undefined,
+    },
+  }
+
+  const mockSafeInfo = {
+    safe: {
+      owners: [{ value: '0xOwner1' }, { value: '0xOwner2' }],
+    },
+  } as ReturnType<typeof useSafeInfo>
+
+  const mockSafeTx = {
+    data: {
+      to: '0xRecipient',
+      value: '1000000000000000000',
+      data: '0x',
+    },
+  } as SafeTransaction
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockUseDefinedActiveSafe.mockReturnValue({
+      address: '0xSafeAddress',
+      chainId: '1',
+    })
+
+    mockUseSafeInfo.mockReturnValue(mockSafeInfo)
+
+    mockUseHasFeature.mockReturnValue(true)
+
+    mockUseBlockaid.mockReturnValue({
+      scanTransaction: mockScanTransaction,
+      blockaidPayload: mockBlockaidPayload,
+      error: undefined,
+      loading: false,
+      resetBlockaid: jest.fn(),
+    })
+
+    mockExtractTxInfo.mockReturnValue({
+      txParams: {
+        to: '0xRecipient',
+        value: '1000000000000000000',
+        data: '0x',
+        operation: 0,
+        safeTxGas: '0',
+        baseGas: '0',
+        gasPrice: '0',
+        gasToken: '0x0000000000000000000000000000000000000000',
+        refundReceiver: '0x0000000000000000000000000000000000000000',
+        nonce: 1,
+      },
+      signatures: {},
+    })
+
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+  })
+
+  it('should return initial state when blockaid is disabled', () => {
+    mockUseHasFeature.mockReturnValue(false)
+
+    const { result } = renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    expect(result.current.enabled).toBe(false)
+    expect(result.current.isScanning).toBe(false)
+    expect(result.current.hasError).toBe(false)
+    expect(result.current.isHighRisk).toBe(false) // MEDIUM severity is not HIGH
+    expect(result.current.isMediumRisk).toBe(true)
+    expect(result.current.hasWarnings).toBe(true)
+    expect(result.current.hasIssues).toBe(true)
+    expect(result.current.hasContractManagement).toBe(true)
+  })
+
+  it('should not scan when txDetails is undefined', () => {
+    const { result } = renderHook(() => useTransactionSecurity(undefined))
+
+    expect(mockScanTransaction).not.toHaveBeenCalled()
+    expect(result.current.enabled).toBe(true)
+  })
+
+  it('should scan transaction when enabled and txDetails provided', async () => {
+    renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    await waitFor(() => {
+      expect(mockScanTransaction).toHaveBeenCalledWith({
+        data: expect.any(Object),
+        signer: '0xOwner1',
+      })
+    })
+  })
+
+  it('should handle scanning errors gracefully', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {
+      // Mock implementation for console.error
+    })
+    mockCreateExistingTx.mockRejectedValue(new Error('Scan failed'))
+
+    renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error running blockaid scan:', expect.any(Error))
+    })
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('should correctly identify high risk transactions', () => {
+    mockUseBlockaid.mockReturnValue({
+      scanTransaction: mockScanTransaction,
+      blockaidPayload: {
+        severity: SecuritySeverity.HIGH,
+        payload: {
+          issues: [],
+          contractManagement: [],
+          balanceChange: [],
+          error: undefined,
+        },
+      },
+      error: undefined,
+      loading: false,
+      resetBlockaid: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    expect(result.current.isHighRisk).toBe(true)
+    expect(result.current.isMediumRisk).toBe(false)
+  })
+
+  it('should correctly identify medium risk transactions', () => {
+    mockUseBlockaid.mockReturnValue({
+      scanTransaction: mockScanTransaction,
+      blockaidPayload: {
+        severity: SecuritySeverity.MEDIUM,
+        payload: {
+          issues: [],
+          contractManagement: [],
+          balanceChange: [],
+          error: undefined,
+        },
+      },
+      error: undefined,
+      loading: false,
+      resetBlockaid: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    expect(result.current.isHighRisk).toBe(false)
+    expect(result.current.isMediumRisk).toBe(true)
+  })
+
+  it('should detect security issues correctly', () => {
+    mockUseBlockaid.mockReturnValue({
+      scanTransaction: mockScanTransaction,
+      blockaidPayload: {
+        severity: SecuritySeverity.MEDIUM,
+        payload: {
+          issues: [
+            {
+              severity: SecuritySeverity.MEDIUM,
+              description: 'Suspicious activity detected',
+            },
+          ],
+          contractManagement: [],
+          balanceChange: [],
+          error: undefined,
+        },
+      },
+      error: undefined,
+      loading: false,
+      resetBlockaid: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    expect(result.current.hasIssues).toBe(true)
+    expect(result.current.hasContractManagement).toBe(false)
+    expect(result.current.hasWarnings).toBe(true)
+  })
+
+  it('should detect contract management warnings correctly', () => {
+    mockUseBlockaid.mockReturnValue({
+      scanTransaction: mockScanTransaction,
+      blockaidPayload: {
+        severity: SecuritySeverity.NONE,
+        payload: {
+          issues: [],
+          contractManagement: [
+            {
+              type: 'OWNERSHIP_CHANGE' as const,
+              after: { owners: ['0x456'] },
+              before: { owners: ['0x789'] },
+            },
+          ],
+          balanceChange: [],
+          error: undefined,
+        },
+      },
+      error: undefined,
+      loading: false,
+      resetBlockaid: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    expect(result.current.hasIssues).toBe(false)
+    expect(result.current.hasContractManagement).toBe(true)
+    expect(result.current.hasWarnings).toBe(true)
+  })
+
+  it('should handle both issues and contract management warnings', () => {
+    mockUseBlockaid.mockReturnValue({
+      scanTransaction: mockScanTransaction,
+      blockaidPayload: {
+        severity: SecuritySeverity.MEDIUM,
+        payload: {
+          issues: [
+            {
+              severity: SecuritySeverity.MEDIUM,
+              description: 'Security issue',
+            },
+          ],
+          contractManagement: [
+            {
+              type: 'MODULES_CHANGE' as const,
+              after: { modules: ['0x123'] },
+              before: { modules: ['0x456'] },
+            },
+          ],
+          balanceChange: [],
+          error: undefined,
+        },
+      },
+      error: undefined,
+      loading: false,
+      resetBlockaid: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    expect(result.current.hasIssues).toBe(true)
+    expect(result.current.hasContractManagement).toBe(true)
+    expect(result.current.hasWarnings).toBe(true)
+  })
+
+  it('should handle scanning state correctly', () => {
+    mockUseBlockaid.mockReturnValue({
+      scanTransaction: mockScanTransaction,
+      blockaidPayload: undefined,
+      error: undefined,
+      loading: true,
+      resetBlockaid: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    expect(result.current.isScanning).toBe(true)
+    expect(result.current.payload).toBeUndefined()
+  })
+
+  it('should handle blockaid errors correctly', () => {
+    const mockError = new Error('Blockaid API error')
+    mockUseBlockaid.mockReturnValue({
+      scanTransaction: mockScanTransaction,
+      blockaidPayload: undefined,
+      error: mockError,
+      loading: false,
+      resetBlockaid: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    expect(result.current.hasError).toBe(true)
+    expect(result.current.error).toBe(mockError)
+  })
+
+  it('should not scan twice on re-renders', async () => {
+    const { rerender } = renderHook((txDetails: TransactionDetails | undefined) => useTransactionSecurity(txDetails), {
+      initialProps: mockTxDetails,
+    })
+
+    await waitFor(() => {
+      expect(mockScanTransaction).toHaveBeenCalledTimes(1)
+    })
+
+    // Re-render the hook
+    rerender(mockTxDetails)
+
+    // Should not scan again
+    expect(mockScanTransaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle empty scan results correctly', () => {
+    mockUseBlockaid.mockReturnValue({
+      scanTransaction: mockScanTransaction,
+      blockaidPayload: {
+        severity: SecuritySeverity.NONE,
+        payload: {
+          issues: [],
+          contractManagement: [],
+          balanceChange: [],
+          error: undefined,
+        },
+      },
+      error: undefined,
+      loading: false,
+      resetBlockaid: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useTransactionSecurity(mockTxDetails))
+
+    expect(result.current.isHighRisk).toBe(false)
+    expect(result.current.isMediumRisk).toBe(false)
+    expect(result.current.hasIssues).toBe(false)
+    expect(result.current.hasContractManagement).toBe(false)
+    expect(result.current.hasWarnings).toBe(false)
+  })
+})

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/hooks/useTransactionSecurity.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/hooks/useTransactionSecurity.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { useBlockaid } from '@/src/features/TransactionChecks/blockaid/useBlockaid'
+import { createExistingTx } from '@/src/services/tx/tx-sender'
+import extractTxInfo from '@/src/services/tx/extractTx'
+import { useSafeInfo } from '@/src/hooks/useSafeInfo'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { useHasFeature } from '@/src/hooks/useHasFeature'
+import { SecuritySeverity } from '@safe-global/utils/services/security/modules/types'
+
+export const useTransactionSecurity = (txDetails?: TransactionDetails) => {
+  const activeSafe = useDefinedActiveSafe()
+  const safeInfo = useSafeInfo()
+  const blockaidEnabled = useHasFeature(FEATURES.RISK_MITIGATION) ?? false
+  const [hasScanned, setHasScanned] = useState(false)
+
+  const { scanTransaction, blockaidPayload, error: blockaidError, loading: blockaidLoading } = useBlockaid()
+
+  useEffect(() => {
+    const runBlockaidScan = async () => {
+      if (!blockaidEnabled || !txDetails || hasScanned) {
+        return
+      }
+
+      try {
+        const { txParams, signatures } = extractTxInfo(txDetails, activeSafe.address)
+        const safeTx = await createExistingTx(txParams, signatures)
+        const executionOwner = safeInfo.safe.owners[0].value
+
+        await scanTransaction({
+          data: safeTx,
+          signer: executionOwner,
+        })
+
+        setHasScanned(true)
+      } catch (error) {
+        console.error('Error running blockaid scan:', error)
+        setHasScanned(true)
+      }
+    }
+
+    runBlockaidScan()
+  }, [blockaidEnabled, txDetails, hasScanned, activeSafe.address, safeInfo.safe.owners, scanTransaction])
+
+  // Process scan results
+  const isHighRisk = blockaidPayload?.severity === SecuritySeverity.HIGH
+  const isMediumRisk = blockaidPayload?.severity === SecuritySeverity.MEDIUM
+  const hasIssues = Boolean(blockaidPayload?.payload?.issues && blockaidPayload.payload.issues.length > 0)
+  const hasContractManagement = Boolean(
+    blockaidPayload?.payload?.contractManagement && blockaidPayload.payload.contractManagement.length > 0,
+  )
+  const hasWarnings = hasIssues || hasContractManagement
+
+  return {
+    enabled: blockaidEnabled,
+    isScanning: blockaidLoading,
+    hasError: Boolean(blockaidError),
+    payload: blockaidPayload,
+    error: blockaidError,
+    isHighRisk,
+    isMediumRisk,
+    hasWarnings,
+    hasIssues,
+    hasContractManagement,
+  }
+}

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/index.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/index.ts
@@ -1,0 +1,1 @@
+export { TransactionChecks } from './TransactionChecks'

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionInfo/TransactionInfo.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionInfo/TransactionInfo.tsx
@@ -1,70 +1,23 @@
 import React from 'react'
-import { Text, View, YStack } from 'tamagui'
-import { Badge } from '@/src/components/Badge'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon'
-import { SafeListItem } from '@/src/components/SafeListItem'
-import { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
-import { useRouter } from 'expo-router'
+import { YStack } from 'tamagui'
+import { MultisigExecutionDetails, TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { TransactionChecks } from '../TransactionChecks'
+import { ConfirmationsInfo } from '../ConfirmationsInfo'
 
 export function TransactionInfo({
   detailedExecutionInfo,
   txId,
+  txDetails,
 }: {
   detailedExecutionInfo: MultisigExecutionDetails
   txId: string
+  txDetails?: TransactionDetails
 }) {
-  const hasEnoughConfirmations =
-    detailedExecutionInfo?.confirmationsRequired === detailedExecutionInfo?.confirmations?.length
-
-  const router = useRouter()
-
-  const onConfirmationsPress = () => {
-    router.push({
-      pathname: '/confirmations-sheet',
-      params: { txId },
-    })
-  }
-
-  const onTransactionChecksPress = () => {
-    router.push({
-      pathname: '/transaction-checks',
-      params: { txId },
-    })
-  }
-
   return (
     <YStack paddingHorizontal="$4" gap="$4" marginTop="$4">
-      <SafeListItem
-        onPress={onTransactionChecksPress}
-        leftNode={<SafeFontIcon name="shield" />}
-        label="Transaction checks"
-        rightNode={<SafeFontIcon name={'chevron-right'} />}
-      />
+      <TransactionChecks txId={txId} txDetails={txDetails} />
 
-      <SafeListItem
-        label="Confirmations"
-        onPress={onConfirmationsPress}
-        rightNode={
-          <View alignItems="center" flexDirection="row">
-            <Badge
-              circular={false}
-              content={
-                <View alignItems="center" flexDirection="row" gap="$1">
-                  <SafeFontIcon size={12} name="owners" />
-
-                  <Text fontWeight={600} color={'$color'}>
-                    {detailedExecutionInfo?.confirmations?.length}/{detailedExecutionInfo?.confirmationsRequired}
-                  </Text>
-                </View>
-              }
-              // TODO: Add logic to check if confirmations are enough
-              themeName={hasEnoughConfirmations ? 'badge_success_variant1' : 'badge_warning_variant1'}
-            />
-
-            <SafeFontIcon name="chevron-right" />
-          </View>
-        }
-      />
+      <ConfirmationsInfo detailedExecutionInfo={detailedExecutionInfo} txId={txId} />
     </YStack>
   )
 }

--- a/apps/mobile/src/features/TransactionChecks/components/blockaid/scans/BlockaidWarning.tsx
+++ b/apps/mobile/src/features/TransactionChecks/components/blockaid/scans/BlockaidWarning.tsx
@@ -5,9 +5,10 @@ import { BlockaidModuleResponse } from '@safe-global/utils/services/security/mod
 import { BlockaidMessage } from './BlockaidMessage'
 import { ContractChangeWarning } from './ContractChangeWarning'
 import { PoweredByBlockaid } from '../PoweredByBlockaid'
-import { Alert, AlertType } from '@/src/components/Alert'
+import { AlertType } from '@/src/components/Alert'
 import { BlockaidError } from '@/src/features/TransactionChecks/components/blockaid/scans/BlockaidError'
 import { ResultDescription } from '@/src/features/TransactionChecks/components/blockaid/ResultDescription'
+import { Alert2 } from '@/src/components/Alert2'
 
 type BlockaidWarningProps = {
   blockaidResponse?: {
@@ -39,17 +40,15 @@ export const BlockaidWarning = ({ blockaidResponse }: BlockaidWarningProps) => {
     <YStack gap="$3">
       {blockaidResponse.severity ? (
         <View>
-          <Alert
+          <Alert2
             type={type as AlertType}
             message={
-              <ResultDescription
-                classification={payload?.classification}
-                reason={payload?.reason}
-                description={payload?.description}
-              />
-            }
-            info={
               <>
+                <ResultDescription
+                  classification={payload?.classification}
+                  reason={payload?.reason}
+                  description={payload?.description}
+                />
                 <BlockaidMessage blockaidResponse={blockaidResponse} />
                 <PoweredByBlockaid />
               </>

--- a/apps/mobile/src/features/TransactionChecks/components/blockaid/scans/ContractChangeWarning.tsx
+++ b/apps/mobile/src/features/TransactionChecks/components/blockaid/scans/ContractChangeWarning.tsx
@@ -5,10 +5,10 @@ import type {
   OwnershipChangeManagement,
   ProxyUpgradeManagement,
 } from '@safe-global/utils/services/security/modules/BlockaidModule/types'
-import { Alert } from '@/src/components/Alert'
 import { EthAddress } from '@/src/components/EthAddress'
 import { Address } from '@/src/types/address'
 import { CONTRACT_CHANGE_TITLES_MAPPING } from '@safe-global/utils/components/tx/security/blockaid/utils'
+import { Alert2 } from '@/src/components/Alert2'
 
 const ProxyUpgradeSummary = ({ beforeAddress, afterAddress }: { beforeAddress: string; afterAddress: string }) => {
   return (
@@ -52,5 +52,5 @@ export const ContractChangeWarning = ({
     </>
   )
 
-  return <Alert type="warning" message={title} info={warningContent} />
+  return <Alert2 type="warning" title={title} message={warningContent} />
 }


### PR DESCRIPTION
## What it solves
We were making the blockaid scans first when the user was navigating to the transaction checks screen. Now we start the scans automatically already on the confirm transaction screen. if the scan shows problems we display a warning on the screen.

Resolves https://linear.app/safe-global/issue/MOB-51/mobile-transaction-check-view

## How this PR fixes it
- Refactored teh TransactionInfo component. 
- we have a new transaction-checks component and a hook at that does the heavy lifting on the tx-confirmation screen.
- Some small updates to SafeListItem were necessary to accomodate for the "new design"

## How to test it
Use our dev safe to look failed txs.

## Screenshots
<img src="https://github.com/user-attachments/assets/1762b7f8-3acc-4dee-a37e-db35a2e45722" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
