### PR TITLE
Feat(web)add MixPanel to the web

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -62,6 +62,7 @@ runs:
         NEXT_PUBLIC_FIREBASE_VAPID_KEY_STAGING: ${{ fromJSON(inputs.secrets).NEXT_PUBLIC_FIREBASE_VAPID_KEY_STAGING }}
         NEXT_PUBLIC_SPINDL_SDK_KEY: ${{ fromJSON(inputs.secrets).NEXT_PUBLIC_SPINDL_SDK_KEY }}
         NEXT_PUBLIC_ECOSYSTEM_ID_ADDRESS: ${{ fromJSON(inputs.secrets).NEXT_PUBLIC_ECOSYSTEM_ID_ADDRESS }}
+        NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ fromJSON(inputs.secrets).NEXT_PUBLIC_MIXPANEL_TOKEN }}
 
     - name: Save Next.js Build Cache & Cypress cache
       if: steps.restore-nc.outputs.cache-hit-nc != 'true'

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -49,6 +49,7 @@ import { useVisitedSafes } from '@/features/myAccounts/hooks/useVisitedSafes'
 import OutreachPopup from '@/features/targetedOutreach/components/OutreachPopup'
 import { GATEWAY_URL } from '@/config/gateway'
 import { useDatadog } from '@/services/datadog'
+import useMixpanel from '@/services/analytics/useMixpanel'
 
 const reduxStore = makeStore()
 
@@ -59,6 +60,7 @@ const InitApp = (): null => {
   useAdjustUrl()
   useDatadog()
   useGtm()
+  useMixpanel()
   useNotificationTracking()
   useInitSession()
   useLoadableStores()

--- a/apps/web/src/services/analytics/useMixpanel.ts
+++ b/apps/web/src/services/analytics/useMixpanel.ts
@@ -1,19 +1,27 @@
 import { useEffect } from 'react'
 import mixpanel from 'mixpanel-browser'
 import { IS_PRODUCTION } from '@/config/constants'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
 
 /**
  * Initializes Mixpanel analytics for the web app.
  * Should be called once at app startup.
  */
 const useMixpanel = () => {
+  const isMixpanelEnabled = useHasFeature(FEATURES.MIXPANEL)
+
   useEffect(() => {
     // Only initialize in the browser
     if (typeof window === 'undefined') return
+    
+    // Check if Mixpanel feature is enabled
+    if (!isMixpanelEnabled) return
+    
     const token = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN
     if (!token) return
     mixpanel.init(token, { debug: !IS_PRODUCTION })
-  }, [])
+  }, [isMixpanelEnabled])
 }
 
 export default useMixpanel

--- a/apps/web/src/services/analytics/useMixpanel.ts
+++ b/apps/web/src/services/analytics/useMixpanel.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import mixpanel from 'mixpanel-browser'
+import { IS_PRODUCTION } from '@/config/constants'
+
+/**
+ * Initializes Mixpanel analytics for the web app.
+ * Should be called once at app startup.
+ */
+const useMixpanel = () => {
+  useEffect(() => {
+    // Only initialize in the browser
+    if (typeof window === 'undefined') return
+    const token = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN
+    if (!token) return
+    mixpanel.init(token, { debug: !IS_PRODUCTION })
+  }, [])
+}
+
+export default useMixpanel

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "packageManager": "yarn@4.6.0",
   "dependencies": {
-    "@yarnpkg/types": "^4.0.1"
+    "@yarnpkg/types": "^4.0.1",
+    "mixpanel-browser": "^2.65.0"
   }
 }

--- a/packages/utils/src/utils/chains.ts
+++ b/packages/utils/src/utils/chains.ts
@@ -42,6 +42,7 @@ export enum FEATURES {
   MASS_PAYOUTS = 'MASS_PAYOUTS',
   SPACES = 'SPACES',
   EARN = 'EARN',
+  MIXPANEL = 'MIXPANEL',
 }
 
 const MIN_SAFE_VERSION = '1.3.0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9191,6 +9191,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rrweb/types@npm:^2.0.0-alpha.18":
+  version: 2.0.0-alpha.18
+  resolution: "@rrweb/types@npm:2.0.0-alpha.18"
+  checksum: 10/ddb632d49490ac6c20d011825b7b44e28a3783bbdabdf72f09649fdf2c5e107f756e7d926e5074b827c2311f28562905e8fa1911bbe8119ca014b3e24fb87f72
+  languageName: node
+  linkType: hard
+
+"@rrweb/utils@npm:^2.0.0-alpha.18":
+  version: 2.0.0-alpha.18
+  resolution: "@rrweb/utils@npm:2.0.0-alpha.18"
+  checksum: 10/d0ca790639816b13dcd353b9669059373c1f56585a5ad4a03c7559fd1d6cdae104e63f50f0076053b67ae1635be0f7b0e9bcb42ab9f9e094358952760499133d
+  languageName: node
+  linkType: hard
+
 "@rtk-query/codegen-openapi@npm:^2.0.0":
   version: 2.0.0
   resolution: "@rtk-query/codegen-openapi@npm:2.0.0"
@@ -9494,6 +9508,7 @@ __metadata:
     "@yarnpkg/types": "npm:^4.0.1"
     husky: "npm:^9.1.6"
     lint-staged: "npm:^15.2.10"
+    mixpanel-browser: "npm:^2.65.0"
     msw: "npm:^2.7.3"
     prettier: "npm:^3.4.2"
   dependenciesMeta:
@@ -13003,6 +13018,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/css-font-loading-module@npm:0.0.7":
+  version: 0.0.7
+  resolution: "@types/css-font-loading-module@npm:0.0.7"
+  checksum: 10/f70b9098ee3b2e006f5f6d5cecc627dcc7b898f266bfc594e73a8720636f1a3bc5f8c38fa0e8f7e5b7878038b46fd70da0c797c3288e072af984097210f4c056
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
@@ -14819,6 +14841,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xstate/fsm@npm:^1.4.0":
+  version: 1.6.5
+  resolution: "@xstate/fsm@npm:1.6.5"
+  checksum: 10/deae1501169d41d5395ce1581d7b08bde17911b7dec1533eacd5bee17060d22273055d6d6bc7e8f32222a502e4dcf510cd29064a5c9c5fa5aa2ced0ad60b2512
+  languageName: node
+  linkType: hard
+
 "@xtuc/ieee754@npm:^1.2.0":
   version: 1.2.0
   resolution: "@xtuc/ieee754@npm:1.2.0"
@@ -15935,6 +15964,13 @@ __metadata:
   version: 0.7.0
   resolution: "base64-arraybuffer-es6@npm:0.7.0"
   checksum: 10/48c58e008849ce9e4691beb145021e5bde00032612ef71bed11d7c78ed414ad74c59b55c41c1d1f6f267b58cbdf53ab38576f9e461ba29b379cda7b05a2b8081
+  languageName: node
+  linkType: hard
+
+"base64-arraybuffer@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "base64-arraybuffer@npm:1.0.2"
+  checksum: 10/15e6400d2d028bf18be4ed97702b11418f8f8779fb8c743251c863b726638d52f69571d4cc1843224da7838abef0949c670bde46936663c45ad078e89fee5c62
   languageName: node
   linkType: hard
 
@@ -26820,6 +26856,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mitt@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "mitt@npm:3.0.1"
+  checksum: 10/287c70d8e73ffc25624261a4989c783768aed95ecb60900f051d180cf83e311e3e59865bfd6e9d029cdb149dc20ba2f128a805e9429c5c4ce33b1416c65bbd14
+  languageName: node
+  linkType: hard
+
+"mixpanel-browser@npm:^2.65.0":
+  version: 2.65.0
+  resolution: "mixpanel-browser@npm:2.65.0"
+  dependencies:
+    rrweb: "npm:2.0.0-alpha.18"
+  checksum: 10/0cc14191ef6bc9ec051bba62807f85426cabc48154a7ee8ba0b9770237f5701a10cd8cbc6178c12ee4ddac2ebc037d81335107c41f6c633ed9bd1f8f3d40abc7
+  languageName: node
+  linkType: hard
+
 "mkdirp@npm:^0.5.1":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
@@ -30972,6 +31024,40 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10/095ba0a82811b1866a76d826987743278db0a87c45092656986bfff490326b66187d5f9ff0c24cf8d5682bc470aa00c36654e0044d6b6335ac0c1201b8280880
+  languageName: node
+  linkType: hard
+
+"rrdom@npm:^2.0.0-alpha.18":
+  version: 2.0.0-alpha.18
+  resolution: "rrdom@npm:2.0.0-alpha.18"
+  dependencies:
+    rrweb-snapshot: "npm:^2.0.0-alpha.18"
+  checksum: 10/4b02e60a6828dd29893b2a003e7611f8db275bb21b24a0b8db97ecbfd75020b6d4be26e90ada0cae4a9b28fdc75fa258dd174d21e33d30c33aded797cc23b9bc
+  languageName: node
+  linkType: hard
+
+"rrweb-snapshot@npm:^2.0.0-alpha.18":
+  version: 2.0.0-alpha.18
+  resolution: "rrweb-snapshot@npm:2.0.0-alpha.18"
+  dependencies:
+    postcss: "npm:^8.4.38"
+  checksum: 10/5dbc717cf80057855d43c7afdbffc117af5074dc627c5b1375234512f1b04c03756836605cf8cb9615639a244fe6d5b2a139955a4ab131a2050dab7808332aa2
+  languageName: node
+  linkType: hard
+
+"rrweb@npm:2.0.0-alpha.18":
+  version: 2.0.0-alpha.18
+  resolution: "rrweb@npm:2.0.0-alpha.18"
+  dependencies:
+    "@rrweb/types": "npm:^2.0.0-alpha.18"
+    "@rrweb/utils": "npm:^2.0.0-alpha.18"
+    "@types/css-font-loading-module": "npm:0.0.7"
+    "@xstate/fsm": "npm:^1.4.0"
+    base64-arraybuffer: "npm:^1.0.1"
+    mitt: "npm:^3.0.0"
+    rrdom: "npm:^2.0.0-alpha.18"
+    rrweb-snapshot: "npm:^2.0.0-alpha.18"
+  checksum: 10/44efc0475a70c0a53f8eafc08159ccaaab56396c2cf2233a132bccb4d98c801b555d6d1bab7267a51bf5312766f908952bd75659d3d84e31c1a1e51cc76631ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

Adds MixPanel data tracking in `autocaption` mode. 

## How this PR fixes it

It adds data tracking only to the web version, not to the mobile version.

The NEXT_PUBLIC_MIXPANEL_TOKEN needs to be set in the release automation.

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
