### PR TITLE
fix(mobile): tenderly failure status was not shown

### DIFF
--- a/apps/mobile/src/components/InfoSheet/InfoSheet.tsx
+++ b/apps/mobile/src/components/InfoSheet/InfoSheet.tsx
@@ -2,11 +2,20 @@ import React, { useCallback, useRef } from 'react'
 import { BottomSheetView } from '@gorhom/bottom-sheet'
 import { SafeFontIcon } from '../SafeFontIcon'
 import { BottomSheetModal, TouchableOpacity } from '@gorhom/bottom-sheet'
-import { getVariable, Text, View, useTheme } from 'tamagui'
+import { getVariable, Text, View, useTheme, H4, YStack } from 'tamagui'
 import { BackdropComponent, BackgroundComponent } from '@/src/components/Dropdown/sheetComponents'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Badge } from '@/src/components/Badge'
 
-export const InfoSheet = ({ info }: { info: string }) => {
+export const InfoSheet = ({
+  info,
+  title,
+  displayIcon = true,
+}: {
+  info: string
+  title?: string
+  displayIcon?: boolean
+}) => {
   const bottomSheetModalRef = useRef<BottomSheetModal>(null)
   const insets = useSafeAreaInsets()
   const theme = useTheme()
@@ -27,14 +36,23 @@ export const InfoSheet = ({ info }: { info: string }) => {
         backgroundComponent={BackgroundComponent}
         backdropComponent={() => <BackdropComponent shouldNavigateBack={false} />}
         topInset={insets.top}
-        bottomInset={insets.bottom}
         enableDynamicSizing
         handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
       >
-        <BottomSheetView>
-          <View alignItems="center" padding="$4">
-            <Text>{info}</Text>
-          </View>
+        <BottomSheetView style={{ paddingBottom: insets.bottom }}>
+          <YStack gap="$4" padding="$4" alignItems="center" justifyContent="center">
+            {displayIcon && (
+              <Badge
+                themeName="badge_background"
+                circleSize="$10"
+                content={<SafeFontIcon name="info" size={24} color="$color" />}
+              />
+            )}
+            <View gap="$2" alignItems="center">
+              {title && <H4 fontWeight="600">{title}</H4>}
+              <Text textAlign="center">{info}</Text>
+            </View>
+          </YStack>
         </BottomSheetView>
       </BottomSheetModal>
     </>

--- a/apps/mobile/src/features/TransactionChecks/components/TransactionChecksView.tsx
+++ b/apps/mobile/src/features/TransactionChecks/components/TransactionChecksView.tsx
@@ -13,6 +13,7 @@ import { SecurityResponse } from '@safe-global/utils/services/security/modules/t
 import { BlockaidModuleResponse } from '@safe-global/utils/services/security/modules/BlockaidModule'
 import { BlockaidBalanceChanges } from './blockaid/balance/BlockaidBalanceChanges'
 import { BlockaidWarning } from './blockaid/scans/BlockaidWarning'
+import { InfoSheet } from '@/src/components/InfoSheet'
 
 type Props = {
   tenderly: {
@@ -70,8 +71,15 @@ export const TransactionChecksView = ({ tenderly, blockaid }: Props) => {
           {enabled ? (
             <>
               <XStack justifyContent="space-between">
-                <Text fontWeight={600}>Transaction simulation</Text>
-                {tenderly?.simulation?.simulation.status && (
+                <XStack gap={'$2'}>
+                  <Text fontWeight={600}>Transaction simulation</Text>
+                  <InfoSheet
+                    title="Simulation"
+                    info="The transaction can be simulated before execution to ensure that it will succeed. You can view a full detailed report on Tenderly."
+                  />
+                </XStack>
+
+                {tenderly?.simulation?.simulation.status ? (
                   <Badge
                     circular={false}
                     themeName="badge_success_variant1"
@@ -82,6 +90,8 @@ export const TransactionChecksView = ({ tenderly, blockaid }: Props) => {
                       </XStack>
                     }
                   />
+                ) : (
+                  <Badge circular={false} themeName="badge_error" content={<Text fontSize={12}>Failed</Text>} />
                 )}
               </XStack>
               {tenderly.fetchStatus === FETCH_STATUS.SUCCESS && (

--- a/apps/mobile/src/features/TransactionChecks/components/blockaid/balance/BlockaidBalanceChanges.tsx
+++ b/apps/mobile/src/features/TransactionChecks/components/blockaid/balance/BlockaidBalanceChanges.tsx
@@ -71,7 +71,10 @@ export const BlockaidBalanceChanges = ({ blockaidResponse, fetchStatusLoading }:
         <Text fontWeight="700" marginBottom="$2">
           Balance change
         </Text>
-        <InfoSheet info="The balance change gives an overview of the implications of a transaction. You can see which assets will be sent and received after the transaction is executed." />
+        <InfoSheet
+          title="Balance change"
+          info="The balance change gives an overview of the implications of a transaction. You can see which assets will be sent and received after the transaction is executed."
+        />
       </XStack>
       {fetchStatusLoading ? (
         <XStack gap={'$2'}>


### PR DESCRIPTION
## What it solves
If a transaction was failing simulation with tenderly we were not showing a failure badge. 

Resolves https://linear.app/safe-global/issue/MOB-51/mobile-transaction-check-view

## How this PR fixes it
On a status different than true in the tx simulation we display a failure badge. 

## How to test it
Simulate a tx that would fail e.g. this one here: https://safe-wallet-web.dev.5afe.dev/transactions/tx?safe=eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6&id=multisig_0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6_0x75c687359b7212953e3db1bfd56d0e193ee5c4b9cd365d186a1f041fe77acc75

## Screenshots
<img src="https://github.com/user-attachments/assets/df369798-ff0e-4477-ad63-357b8ff14ca0" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
