### PR TITLE
fix(mobile): sanitize error messages

### DIFF
--- a/apps/mobile/src/features/DataImport/__tests__/useLegacyImport.test.ts
+++ b/apps/mobile/src/features/DataImport/__tests__/useLegacyImport.test.ts
@@ -2,12 +2,35 @@ import { act, renderHook } from '@/src/tests/test-utils'
 import { useLegacyImport } from '../hooks/useLegacyImport'
 import * as DocumentPicker from 'expo-document-picker'
 import * as FileSystem from 'expo-file-system'
-import { decodeLegacyData } from '@/src/utils/legacyData'
+import {
+  decodeLegacyData,
+  LegacyDataPasswordError,
+  LegacyDataFormatError,
+  LegacyDataCorruptedError,
+} from '@/src/utils/legacyData'
 
 jest.mock('expo-document-picker')
 jest.mock('expo-file-system')
 jest.mock('@/src/utils/legacyData', () => ({
   decodeLegacyData: jest.fn(),
+  LegacyDataPasswordError: class LegacyDataPasswordError extends Error {
+    constructor() {
+      super('Invalid password for legacy data')
+      this.name = 'LegacyDataPasswordError'
+    }
+  },
+  LegacyDataFormatError: class LegacyDataFormatError extends Error {
+    constructor() {
+      super('Invalid legacy data format')
+      this.name = 'LegacyDataFormatError'
+    }
+  },
+  LegacyDataCorruptedError: class LegacyDataCorruptedError extends Error {
+    constructor() {
+      super('Legacy data appears to be corrupted')
+      this.name = 'LegacyDataCorruptedError'
+    }
+  },
 }))
 
 describe('useLegacyImport', () => {
@@ -79,7 +102,7 @@ describe('useLegacyImport', () => {
     } as unknown as DocumentPicker.DocumentPickerResult)
     jest.mocked(FileSystem.readAsStringAsync).mockResolvedValue('{}')
     jest.mocked(decodeLegacyData).mockImplementation(() => {
-      throw new Error('decrypt failed')
+      throw new LegacyDataPasswordError()
     })
 
     const { result } = renderHook(() => useLegacyImport())
@@ -97,5 +120,86 @@ describe('useLegacyImport', () => {
     })
 
     expect(result.current.error).toBe('Incorrect password. Please try again.')
+  })
+
+  it('sets error on format error', async () => {
+    jest.mocked(DocumentPicker.getDocumentAsync).mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'uri', name: 'file.json' }],
+    } as unknown as DocumentPicker.DocumentPickerResult)
+    jest.mocked(FileSystem.readAsStringAsync).mockResolvedValue('{}')
+    jest.mocked(decodeLegacyData).mockImplementation(() => {
+      throw new LegacyDataFormatError()
+    })
+
+    const { result } = renderHook(() => useLegacyImport())
+
+    await act(async () => {
+      await result.current.pickFile()
+    })
+
+    act(() => {
+      result.current.handlePasswordChange('pw')
+    })
+
+    await act(async () => {
+      await result.current.handleImport()
+    })
+
+    expect(result.current.error).toBe('Invalid file format. Please select a valid export file.')
+  })
+
+  it('sets error on corrupted data error', async () => {
+    jest.mocked(DocumentPicker.getDocumentAsync).mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'uri', name: 'file.json' }],
+    } as unknown as DocumentPicker.DocumentPickerResult)
+    jest.mocked(FileSystem.readAsStringAsync).mockResolvedValue('{}')
+    jest.mocked(decodeLegacyData).mockImplementation(() => {
+      throw new LegacyDataCorruptedError()
+    })
+
+    const { result } = renderHook(() => useLegacyImport())
+
+    await act(async () => {
+      await result.current.pickFile()
+    })
+
+    act(() => {
+      result.current.handlePasswordChange('pw')
+    })
+
+    await act(async () => {
+      await result.current.handleImport()
+    })
+
+    expect(result.current.error).toBe('Invalid file format. Please select a valid export file.')
+  })
+
+  it('sets generic error for unknown errors', async () => {
+    jest.mocked(DocumentPicker.getDocumentAsync).mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'uri', name: 'file.json' }],
+    } as unknown as DocumentPicker.DocumentPickerResult)
+    jest.mocked(FileSystem.readAsStringAsync).mockResolvedValue('{}')
+    jest.mocked(decodeLegacyData).mockImplementation(() => {
+      throw new Error('Unknown error')
+    })
+
+    const { result } = renderHook(() => useLegacyImport())
+
+    await act(async () => {
+      await result.current.pickFile()
+    })
+
+    act(() => {
+      result.current.handlePasswordChange('pw')
+    })
+
+    await act(async () => {
+      await result.current.handleImport()
+    })
+
+    expect(result.current.error).toBe('Failed to import data. Please check your file and password.')
   })
 })

--- a/apps/mobile/src/features/DataImport/helpers/transforms.ts
+++ b/apps/mobile/src/features/DataImport/helpers/transforms.ts
@@ -111,7 +111,9 @@ export const storeKeys = async (data: LegacyDataStructure, dispatch: AppDispatch
 
       Logger.info(`Imported signer: ${address}`)
     } catch (error) {
-      Logger.error(`Failed to import signer ${key.address}:`, error)
+      Logger.error('Failed to import signer during data import', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
     }
   }
 }

--- a/apps/mobile/src/utils/legacyData.test.ts
+++ b/apps/mobile/src/utils/legacyData.test.ts
@@ -1,6 +1,13 @@
 import crypto from 'crypto'
 jest.mock('react-native-quick-crypto', () => require('crypto'))
-import { decodeLegacyData, SecuredDataFile, SerializedDataFile } from './legacyData'
+import {
+  decodeLegacyData,
+  SecuredDataFile,
+  SerializedDataFile,
+  LegacyDataPasswordError,
+  LegacyDataFormatError,
+  LegacyDataCorruptedError,
+} from './legacyData'
 
 describe('decodeLegacyData', () => {
   it('decodes encrypted file', () => {
@@ -25,7 +32,7 @@ describe('decodeLegacyData', () => {
     expect(decoded).toEqual(data)
   })
 
-  it('throws error for unsupported version', () => {
+  it('throws LegacyDataFormatError for unsupported version', () => {
     const file = {
       version: '2.0',
       algo: 'aes-256-gcm',
@@ -34,10 +41,10 @@ describe('decodeLegacyData', () => {
       data: 'dGVzdC1kYXRh',
     } as unknown as SecuredDataFile
 
-    expect(() => decodeLegacyData(file, 'password')).toThrow('Unsupported file format')
+    expect(() => decodeLegacyData(file, 'password')).toThrow(LegacyDataFormatError)
   })
 
-  it('throws error for unsupported algorithm', () => {
+  it('throws LegacyDataFormatError for unsupported algorithm', () => {
     const file = {
       version: '1.0',
       algo: 'aes-128-cbc',
@@ -46,6 +53,61 @@ describe('decodeLegacyData', () => {
       data: 'dGVzdC1kYXRh',
     } as unknown as SecuredDataFile
 
-    expect(() => decodeLegacyData(file, 'password')).toThrow('Unsupported file format')
+    expect(() => decodeLegacyData(file, 'password')).toThrow(LegacyDataFormatError)
+  })
+
+  it('throws LegacyDataPasswordError for wrong password', () => {
+    const password = 'correct-password'
+    const wrongPassword = 'wrong-password'
+    const data: SerializedDataFile = { version: '1.0', data: { hello: 'world' } }
+    const salt = crypto.randomBytes(32)
+    const key = crypto.pbkdf2Sync(Buffer.from(password, 'utf8'), salt, 100000, 32, 'sha256')
+    const iv = crypto.randomBytes(12)
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+    const encrypted = Buffer.concat([cipher.update(JSON.stringify(data), 'utf8'), cipher.final()])
+    const tag = cipher.getAuthTag()
+    const combined = Buffer.concat([iv, encrypted, tag])
+    const file: SecuredDataFile = {
+      version: '1.0',
+      algo: 'aes-256-gcm',
+      salt: salt.toString('base64'),
+      rounds: 100000,
+      data: combined.toString('base64'),
+    }
+
+    expect(() => decodeLegacyData(file, wrongPassword)).toThrow(LegacyDataPasswordError)
+  })
+
+  it('throws LegacyDataCorruptedError for invalid JSON after successful decryption', () => {
+    const password = 'test-password'
+    const invalidJsonData = 'invalid json content'
+    const salt = crypto.randomBytes(32)
+    const key = crypto.pbkdf2Sync(Buffer.from(password, 'utf8'), salt, 100000, 32, 'sha256')
+    const iv = crypto.randomBytes(12)
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+    const encrypted = Buffer.concat([cipher.update(invalidJsonData, 'utf8'), cipher.final()])
+    const tag = cipher.getAuthTag()
+    const combined = Buffer.concat([iv, encrypted, tag])
+    const file: SecuredDataFile = {
+      version: '1.0',
+      algo: 'aes-256-gcm',
+      salt: salt.toString('base64'),
+      rounds: 100000,
+      data: combined.toString('base64'),
+    }
+
+    expect(() => decodeLegacyData(file, password)).toThrow(LegacyDataCorruptedError)
+  })
+
+  it('throws LegacyDataFormatError for invalid base64 data', () => {
+    const file: SecuredDataFile = {
+      version: '1.0',
+      algo: 'aes-256-gcm',
+      salt: 'dGVzdC1zYWx0',
+      rounds: 100000,
+      data: 'invalid base64!@#$%',
+    }
+
+    expect(() => decodeLegacyData(file, 'password')).toThrow(LegacyDataFormatError)
   })
 })

--- a/apps/mobile/src/utils/legacyData.ts
+++ b/apps/mobile/src/utils/legacyData.ts
@@ -13,18 +13,66 @@ export type SerializedDataFile = {
   data: unknown
 }
 
+// Custom error classes for safe error categorization
+export class LegacyDataPasswordError extends Error {
+  constructor() {
+    super('Invalid password for legacy data')
+    this.name = 'LegacyDataPasswordError'
+  }
+}
+
+export class LegacyDataFormatError extends Error {
+  constructor() {
+    super('Invalid legacy data format')
+    this.name = 'LegacyDataFormatError'
+  }
+}
+
+export class LegacyDataCorruptedError extends Error {
+  constructor() {
+    super('Legacy data appears to be corrupted')
+    this.name = 'LegacyDataCorruptedError'
+  }
+}
+
 export function decodeLegacyData(file: SecuredDataFile, password: string): SerializedDataFile {
   if (file.version !== '1.0' || file.algo !== 'aes-256-gcm') {
-    throw new Error('Unsupported file format')
+    throw new LegacyDataFormatError()
   }
-  const salt = Buffer.from(file.salt, 'base64')
-  const key = crypto.pbkdf2Sync(Buffer.from(password, 'utf8'), salt, file.rounds, 32, 'sha256')
-  const combined = Buffer.from(file.data, 'base64')
-  const iv = combined.subarray(0, 12)
-  const tag = combined.subarray(combined.length - 16)
-  const ciphertext = combined.subarray(12, combined.length - 16)
-  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
-  decipher.setAuthTag(tag)
-  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
-  return JSON.parse(decrypted.toString('utf8'))
+
+  try {
+    const salt = Buffer.from(file.salt, 'base64')
+    const key = crypto.pbkdf2Sync(Buffer.from(password, 'utf8'), salt, file.rounds, 32, 'sha256')
+    const combined = Buffer.from(file.data, 'base64')
+    const iv = combined.subarray(0, 12)
+    const tag = combined.subarray(combined.length - 16)
+    const ciphertext = combined.subarray(12, combined.length - 16)
+
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
+    decipher.setAuthTag(tag)
+
+    let decrypted: Buffer
+    try {
+      decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+    } catch (_cryptoError) {
+      // Authentication tag verification failure or decryption error = wrong password
+      throw new LegacyDataPasswordError()
+    }
+
+    try {
+      return JSON.parse(decrypted.toString('utf8'))
+    } catch (_jsonError) {
+      // Successfully decrypted but invalid JSON = corrupted data
+      throw new LegacyDataCorruptedError()
+    }
+  } catch (error) {
+    // Re-throw our custom errors
+    if (error instanceof LegacyDataPasswordError || error instanceof LegacyDataCorruptedError) {
+      throw error
+    }
+
+    // For any other errors (base64 decode, buffer operations, etc.)
+    // assume it's a format/corruption issue
+    throw new LegacyDataFormatError()
+  }
 }


### PR DESCRIPTION
## What it solves
We were throughing the exception from the import decoding which could expose the data in the import in the logging. We now have more explicit error handling.

Resolves https://linear.app/safe-global/issue/MOB-98/private-keys-could-be-exposed-in-trace-and-logs

## How this PR fixes it
Ads more error classes and uses them and never just dumps the error object to the console

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
