### PR TITLE
fix(WalletConnect): update WcProposalForm to handle unsupported chains correctly

### DIFF
--- a/apps/web/src/features/walletconnect/components/WcProposalForm/index.tsx
+++ b/apps/web/src/features/walletconnect/components/WcProposalForm/index.tsx
@@ -117,7 +117,7 @@ const WcProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): R
         <CompatibilityWarning proposal={proposal} chainIds={chainIds} />
       </div>
 
-      {!isBlocked && isHighRisk && (
+      {!isBlocked && isHighRisk && !isUnsupportedChain && (
         <FormControlLabel
           className={css.checkbox}
           control={<Checkbox checked={understandsRisk} onChange={onCheckboxClick} />}
@@ -132,13 +132,20 @@ const WcProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): R
       <Divider flexItem className={css.divider} />
 
       <div className={css.buttons}>
-        <Button variant="danger" onClick={onReject} className={css.button} disabled={!!loading}>
-          {loading === WCLoadingState.REJECT ? <CircularProgress size={20} /> : 'Reject'}
+        <Button
+          variant={isUnsupportedChain ? 'text' : 'danger'}
+          onClick={onReject}
+          className={css.button}
+          disabled={!!loading}
+        >
+          {loading === WCLoadingState.REJECT ? <CircularProgress size={20} /> : isUnsupportedChain ? 'Close' : 'Reject'}
         </Button>
 
-        <Button variant="contained" onClick={onApprove} className={css.button} disabled={disabled}>
-          {loading === WCLoadingState.APPROVE ? <CircularProgress size={20} /> : 'Approve'}
-        </Button>
+        {!isUnsupportedChain && (
+          <Button variant="contained" onClick={onApprove} className={css.button} disabled={disabled}>
+            {loading === WCLoadingState.APPROVE ? <CircularProgress size={20} /> : 'Approve'}
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/features/walletconnect/components/WcProposalForm/index.tsx
+++ b/apps/web/src/features/walletconnect/components/WcProposalForm/index.tsx
@@ -132,6 +132,12 @@ const WcProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): R
       <Divider flexItem className={css.divider} />
 
       <div className={css.buttons}>
+        {!isUnsupportedChain && (
+          <Button variant="contained" onClick={onApprove} className={css.button} disabled={disabled}>
+            {loading === WCLoadingState.APPROVE ? <CircularProgress size={20} /> : 'Approve'}
+          </Button>
+        )}
+
         <Button
           variant={isUnsupportedChain ? 'text' : 'danger'}
           onClick={onReject}
@@ -140,12 +146,6 @@ const WcProposalForm = ({ proposal, onApprove, onReject }: ProposalFormProps): R
         >
           {loading === WCLoadingState.REJECT ? <CircularProgress size={20} /> : isUnsupportedChain ? 'Close' : 'Reject'}
         </Button>
-
-        {!isUnsupportedChain && (
-          <Button variant="contained" onClick={onApprove} className={css.button} disabled={disabled}>
-            {loading === WCLoadingState.APPROVE ? <CircularProgress size={20} /> : 'Approve'}
-          </Button>
-        )}
       </div>
     </div>
   )

--- a/apps/web/src/features/walletconnect/components/WcProposalForm/styles.module.css
+++ b/apps/web/src/features/walletconnect/components/WcProposalForm/styles.module.css
@@ -64,6 +64,7 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
+  flex-direction: row-reverse;
 }
 
 .button {


### PR DESCRIPTION
## What it solves

Fixes issue [EN-144](https://linear.app/safe-global/issue/EN-144/wc-checking-the-i-accept-the-risk-wont-allow-me-to-connect-to-the-dapp) where the WalletConnect risk acceptance checkbox appears even when connecting to an unsupported chain, creating a confusing UX where users can check the risk checkbox but still cannot proceed due to network incompatibility.

## How this PR fixes it

Improves the WalletConnect proposal form UX when dealing with unsupported chains by:

1. **Hiding the risk acceptance checkbox** when the network compatibility warning is present
2. **Simplifying the button layout** to show only a "Close" button when on unsupported chains
3. **Improving button styling** by using a text variant for the close action

## How to test it

1. Initiate a WC session
   Use a Safe on a network unsupported by the target dApp (e.g., Sepolia Safe + the dApp https://app.openocean.finance)
2. Observe connection behavior
   * Paste the WC connection URL in the input field
   * Notice that the “I understand the risk…” checkbox is not displayed
   * Instead of the expected “Approve” and “Reject” buttons, only a “Close” button is shown

## Screenshots
<img width="602" alt="Screenshot 2025-07-08 at 10 46 23" src="https://github.com/user-attachments/assets/bfa2a154-2ad5-43ad-bc01-b2e65f8b1e6e" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
