### PR TITLE
fix(mobile): show native token info in Action list screen

### DIFF
--- a/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
+++ b/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
@@ -1,12 +1,16 @@
 import React, { useMemo } from 'react'
 import { Text, View, YStack } from 'tamagui'
-import { TransactionDetails, MultiSend } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { TransactionDetails, MultiSend, NativeToken } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { ActionValueDecoded, AddressInfoIndex } from '@safe-global/store/gateway/types'
-import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import { formatVisualAmount, shortenAddress } from '@safe-global/utils/utils/formatters'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { router } from 'expo-router'
 import { useLocalSearchParams } from 'expo-router'
 import { Container } from '@/src/components/Container'
+import { useTxTokenInfo } from '@safe-global/utils/hooks/useTxTokenInfo'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectActiveChainCurrency } from '@/src/store/chains'
+import { Identicon } from '@/src/components/Identicon'
 
 interface TxActionsListProps {
   txDetails: TransactionDetails
@@ -21,6 +25,57 @@ export const getActionName = (action: ActionValueDecoded | MultiSend, addressInf
   }
 
   return contractName ? `${contractName}: ${name}` : action.dataDecoded?.method || 'contract interaction'
+}
+
+interface TxActionItemProps {
+  action: ActionValueDecoded | MultiSend
+  index: number
+  addressInfoIndex?: AddressInfoIndex
+  txData: TransactionDetails['txData']
+}
+
+const TxActionItem = ({ action, index, addressInfoIndex, txData }: TxActionItemProps) => {
+  const valueDecoded = txData?.dataDecoded?.parameters?.[0].valueDecoded
+  const tx = Array.isArray(valueDecoded) ? valueDecoded[index] : undefined
+  const nativeCurrency = useAppSelector(selectActiveChainCurrency)
+
+  const transferTokenInfo = useTxTokenInfo(
+    tx?.data?.toString() || undefined,
+    tx?.value || undefined,
+    tx?.to || '',
+    nativeCurrency as NativeToken,
+    txData?.tokenInfoIndex ?? {},
+  )
+
+  return (
+    <>
+      <View alignItems="center" flexDirection="row" justifyContent="space-between" gap={'$2'} flexWrap="wrap">
+        <View flexDirection="row" alignItems="center" gap={'$2'} maxWidth="80%">
+          <SafeFontIcon name="transaction-contract" color="$colorSecondary" size={18} />
+          <Text>{index + 1}</Text>
+
+          {transferTokenInfo?.tokenInfo?.symbol ? (
+            <View flexDirection="row" alignItems="center" gap={'$2'}>
+              <Text fontSize="$4" flex={1} numberOfLines={1} ellipsizeMode="tail">
+                Send {formatVisualAmount(transferTokenInfo.transferValue, transferTokenInfo?.tokenInfo?.decimals, 6)}{' '}
+                {transferTokenInfo.tokenInfo.symbol} to
+              </Text>
+              <Identicon address={tx?.to as `0x${string}`} size={20} />{' '}
+              <Text fontSize="$4" numberOfLines={1} ellipsizeMode="tail" flexShrink={1}>
+                {tx?.to}
+              </Text>
+            </View>
+          ) : (
+            <Text fontSize="$4" flexShrink={1} flexWrap="wrap">
+              {getActionName(action, addressInfoIndex as AddressInfoIndex)}
+            </Text>
+          )}
+        </View>
+
+        <SafeFontIcon name="chevron-right" size={18} />
+      </View>
+    </>
+  )
 }
 
 export function TxActionsList({ txDetails }: TxActionsListProps) {
@@ -58,18 +113,7 @@ export function TxActionsList({ txDetails }: TxActionsListProps) {
             borderRadius="$3"
             onPress={() => onActionPress(action)}
           >
-            <View alignItems="center" flexDirection="row" justifyContent="space-between" gap={'$2'} flexWrap="wrap">
-              <View flexDirection="row" alignItems="center" gap={'$3'} maxWidth="90%">
-                <SafeFontIcon name="transaction-contract" color="$colorSecondary" size={18} />
-                <Text marginRight={'$2'}>{index + 1}</Text>
-
-                <Text fontSize="$4" flexShrink={1} flexWrap="wrap">
-                  {getActionName(action, addressInfoIndex as AddressInfoIndex)}
-                </Text>
-              </View>
-
-              <SafeFontIcon name="chevron-right" size={18} />
-            </View>
+            <TxActionItem txData={txDetails.txData} action={action} index={index} />
           </Container>
         )
       })}

--- a/packages/utils/src/hooks/useTxTokenInfo.ts
+++ b/packages/utils/src/hooks/useTxTokenInfo.ts
@@ -1,0 +1,51 @@
+import { type NativeToken, type TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { useMemo } from 'react'
+import { ERC20__factory } from '@safe-global/utils/types/contracts'
+
+import { isEmptyHexData } from '../utils/hex'
+
+const ERC20_INTERFACE = ERC20__factory.createInterface()
+
+export const useTxTokenInfo = (
+  data: string | undefined,
+  value: string | undefined,
+  to: string,
+  nativeTokenInfo: NativeToken,
+  tokenInfoIndex?: NonNullable<TransactionDetails['txData']>['tokenInfoIndex'],
+) => {
+  const isERC20Transfer = Boolean(data?.startsWith(ERC20_INTERFACE.getFunction('transfer').selector))
+  const isNativeTransfer = value !== '0' && (!data || isEmptyHexData(data))
+
+  return useMemo(() => {
+    if (!isERC20Transfer && !isNativeTransfer) {
+      return
+    }
+    try {
+      if (isERC20Transfer) {
+        if (!data) {
+          return
+        }
+        const [recipient, transferValue] = ERC20_INTERFACE.decodeFunctionData('transfer', data)
+        const tokenInfo = isERC20Transfer ? tokenInfoIndex?.[to] : undefined
+
+        if (tokenInfo?.type !== 'ERC20') {
+          return
+        }
+
+        return { recipient, transferValue, tokenInfo }
+      }
+
+      if (!value || value === '0') {
+        return
+      }
+
+      return {
+        recipient: to,
+        transferValue: value,
+        tokenInfo: nativeTokenInfo,
+      }
+    } catch (error) {
+      return
+    }
+  }, [isERC20Transfer, isNativeTransfer, value, nativeTokenInfo, to, data, tokenInfoIndex])
+}

--- a/packages/utils/src/utils/hex.ts
+++ b/packages/utils/src/utils/hex.ts
@@ -1,0 +1,3 @@
+export const isEmptyHexData = (encodedData: string): boolean => encodedData !== '' && isNaN(parseInt(encodedData, 16))
+
+export const numberToHex = (value: number | bigint): `0x${string}` => `0x${value.toString(16)}`


### PR DESCRIPTION
## What it solves
shows native token info in Action list screen

## How this PR fixes it
We take the useTransferTokenInfo hook from web project and implemented an abstraction of it in the `utils` package. Notice that we still need to use it in the web project to avoid having duplicated implementations across the projects.

## How to test it
- Create a batch transaction with native token transfer.
- Go to the pending transaction details
- Click in the "actions" button in the tx
- The token information should be displayed.

## Screenshots
<img width="496" alt="Screenshot 2025-07-08 at 11 53 42" src="https://github.com/user-attachments/assets/e59340cb-ef5d-4bcb-baf0-ea090ca73a00" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
