### PR TITLE
fix(mobile): incorrect loading state on retry signing

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignTransaction.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignTransaction.tsx
@@ -57,12 +57,17 @@ export function SignTransaction() {
     sign()
   }, [sign])
 
+  const retrySignAfterError = useCallback(() => {
+    setSignStepStatus('loading')
+    sign()
+  }, [sign])
+
   if (signStepStatus === 'error') {
-    return <SignError onRetryPress={sign} description="There was an error signing the transaction." />
+    return <SignError onRetryPress={retrySignAfterError} description="There was an error signing the transaction." />
   }
 
   if (isError) {
-    return <SignError onRetryPress={sign} />
+    return <SignError onRetryPress={retrySignAfterError} />
   }
 
   if (isLoading || !data) {


### PR DESCRIPTION
## What it solves
When signing fails we send the user to an error page, but upon pressing retry he is able to sign again, but we stay at the error page and never navigate away. 

Resolves https://linear.app/safe-global/issue/MOB-17/mobile-there-is-no-signing-flow-on-ui-for-the-retry-failed-signing

## How this PR fixes it
We were not reseting the screen state.

## How to test it
Try to sign a tx and keep your face away from the camera. Once you get the face id "cancel" prompt you will land on the error page. Once on the error page hit "retry". You should land back in the loading state and will get prompted to sign again. Once this is done you should end up on the Success screen.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
