### PR TITLE
fix: swap fee was not properly shown in decoding

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -38,7 +38,7 @@
     "ios": "expo run:ios"
   },
   "dependencies": {
-    "@cowprotocol/app-data": "^2.3.0",
+    "@cowprotocol/app-data": "^3.1.0",
     "@ethersproject/shims": "^5.7.0",
     "@expo/config-plugins": "~10.0.0",
     "@expo/vector-icons": "^14.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.3.1",
-    "@cowprotocol/app-data": "^2.4.0",
+    "@cowprotocol/app-data": "^3.1.0",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.18.0",
     "@faker-js/faker": "^9.0.3",

--- a/apps/web/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
+++ b/apps/web/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
@@ -1,5 +1,5 @@
 import type { TwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
-import { getOrderFeeBps } from '@/features/swap/helpers/utils'
+import { getOrderFeeBps } from '@safe-global/utils/features/swap/helpers/utils'
 import { DataRow } from '@/components/common/Table/DataRow'
 import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
 import { HelpIconTooltip } from '@/features/swap/components/HelpIconTooltip'

--- a/apps/web/src/features/swap/components/SwapOrderConfirmationView/OrderFeeConfirmationView.tsx
+++ b/apps/web/src/features/swap/components/SwapOrderConfirmationView/OrderFeeConfirmationView.tsx
@@ -1,5 +1,5 @@
 import type { SwapOrderConfirmationView, TwapOrderConfirmationView } from '@safe-global/safe-gateway-typescript-sdk'
-import { getOrderFeeBps } from '@/features/swap/helpers/utils'
+import { getOrderFeeBps } from '@safe-global/utils/features/swap/helpers/utils'
 import { DataRow } from '@/components/common/Table/DataRow'
 import { BRAND_NAME } from '@/config/constants'
 import { HelpIconTooltip } from '@/features/swap/components/HelpIconTooltip'

--- a/apps/web/src/features/swap/helpers/utils.ts
+++ b/apps/web/src/features/swap/helpers/utils.ts
@@ -1,6 +1,6 @@
 import type { DataDecoded, Order as SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
 import { formatUnits } from 'ethers'
-import type { AnyAppDataDocVersion, latest, LatestAppDataDocVersion } from '@cowprotocol/app-data'
+import type { AnyAppDataDocVersion, latest } from '@cowprotocol/app-data'
 
 import { TradeType, UiOrderType } from '@safe-global/utils/features/swap/types'
 
@@ -165,13 +165,6 @@ export const getOrderClass = (order: Pick<SwapOrder, 'fullAppData'>): latest.Ord
   const orderClass = (fullAppData?.metadata?.orderClass as latest.OrderClass)?.orderClass
 
   return orderClass || 'market'
-}
-
-export const getOrderFeeBps = (order: Pick<SwapOrder, 'fullAppData'>): number => {
-  const fullAppData = order.fullAppData as unknown as LatestAppDataDocVersion
-  const basisPoints = (fullAppData?.metadata?.partnerFee as latest.PartnerFee)?.bps
-
-  return Number(basisPoints) || 0
 }
 
 export const isOrderPartiallyFilled = (

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,7 +14,7 @@
     "jest": "^29.7.0"
   },
   "dependencies": {
-    "@cowprotocol/app-data": "^2.5.1",
+    "@cowprotocol/app-data": "^3.1.0",
     "ts-node": "^10.9.2"
   },
   "peerDependencies": {

--- a/packages/utils/src/features/swap/helpers/fee.ts
+++ b/packages/utils/src/features/swap/helpers/fee.ts
@@ -1,0 +1,71 @@
+import { v1_4_0, v1_3_0, LatestAppDataDocVersion } from '@cowprotocol/app-data'
+import type { OrderTransactionInfo as SwapOrder } from '@safe-global/store/gateway/types'
+
+type VolumeFee = {
+  volumeBps: v1_4_0.VolumeBasisPointBPS
+  recipient: v1_4_0.PartnerAccount
+}
+
+type SurplusFee = {
+  surplusBps: v1_4_0.SurplusBasisPointBPS
+  maxVolumeBps: v1_4_0.MaxVolumeBasisPointBPS
+  recipient: v1_4_0.PartnerAccount
+}
+
+type PriceImprovementFee = {
+  priceImprovementBps: v1_4_0.PriceImprovementBasisPointBPS
+  maxVolumeBps: v1_4_0.MaxVolumeBasisPointBPS
+  recipient: v1_4_0.PartnerAccount
+}
+
+function isVolumeFee(fee: v1_4_0.PartnerFee): fee is VolumeFee {
+  return typeof (fee as VolumeFee).volumeBps === 'number'
+}
+
+function isSurplusFee(fee: v1_4_0.PartnerFee): fee is SurplusFee {
+  return typeof (fee as SurplusFee).surplusBps === 'number'
+}
+
+function isPriceImprovementFee(fee: v1_4_0.PartnerFee): fee is PriceImprovementFee {
+  return typeof (fee as PriceImprovementFee).priceImprovementBps === 'number'
+}
+
+/**
+ * Right now it doesn't look like we need the surplus and price improvement fees.
+ * and that's why we don't use this function yet.
+ */
+function resolveNewPartnerFeeBps(fee: v1_4_0.PartnerFee): number | null {
+  if (isVolumeFee(fee)) {
+    return fee.volumeBps
+  }
+  if (isSurplusFee(fee)) {
+    return fee.surplusBps
+  }
+  if (isPriceImprovementFee(fee)) {
+    return fee.priceImprovementBps
+  }
+  return null
+}
+
+export const getOrderFeeBps = (order: Pick<SwapOrder, 'fullAppData'>): number => {
+  const fullAppData = order.fullAppData as unknown as LatestAppDataDocVersion
+
+  const oldPartnerFee = fullAppData?.metadata?.partnerFee as unknown as v1_3_0.PartnerFee
+
+  if (typeof oldPartnerFee.bps === 'number') {
+    return Number(oldPartnerFee.bps)
+  }
+
+  const newPartnerFee = fullAppData?.metadata?.partnerFee as unknown as v1_4_0.PartnerFee
+
+  if (Array.isArray(newPartnerFee)) {
+    return newPartnerFee.reduce((acc, fee) => {
+      if (isVolumeFee(fee)) {
+        return acc + Number(fee.volumeBps)
+      }
+      return acc
+    }, 0)
+  }
+
+  return isVolumeFee(newPartnerFee) ? Number(newPartnerFee.volumeBps) : 0
+}

--- a/packages/utils/src/features/swap/helpers/utils.ts
+++ b/packages/utils/src/features/swap/helpers/utils.ts
@@ -1,9 +1,10 @@
 import type { OrderTransactionInfo as SwapOrder } from '@safe-global/store/gateway/types'
 import type { DataDecoded } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { formatUnits } from 'ethers'
-import type { AnyAppDataDocVersion, latest, LatestAppDataDocVersion } from '@cowprotocol/app-data'
+import type { AnyAppDataDocVersion, latest } from '@cowprotocol/app-data'
 
 import { TradeType, UiOrderType } from '@safe-global/utils/features/swap/types'
+import { getOrderFeeBps as getOrderFeeBpsHelper } from '@safe-global/utils/features/swap/helpers/fee'
 
 type Quantity = {
   amount: string | number | bigint
@@ -169,10 +170,7 @@ export const getOrderClass = (order: Pick<SwapOrder, 'fullAppData'>): latest.Ord
 }
 
 export const getOrderFeeBps = (order: Pick<SwapOrder, 'fullAppData'>): number => {
-  const fullAppData = order.fullAppData as unknown as LatestAppDataDocVersion
-  const basisPoints = (fullAppData?.metadata?.partnerFee as latest.PartnerFee)?.bps
-
-  return Number(basisPoints) || 0
+  return getOrderFeeBpsHelper(order)
 }
 
 export const isOrderPartiallyFilled = (

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -17,6 +17,7 @@ const DEPS_TO_CHECK = [
   '@safe-global/safe-deployments',
   '@safe-global/safe-gateway-typescript-sdk',
   '@safe-global/safe-modules-deployments',
+  '@cowprotocol/app-data',
 ]
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,9 +2847,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cowprotocol/app-data@npm:^2.3.0, @cowprotocol/app-data@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@cowprotocol/app-data@npm:2.4.0"
+"@cowprotocol/app-data@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@cowprotocol/app-data@npm:3.1.0"
   dependencies:
     ajv: "npm:^8.11.0"
     cross-fetch: "npm:^3.1.5"
@@ -2861,25 +2861,7 @@ __metadata:
     ethers: ^5.0.0
     ipfs-only-hash: ^4.x
     multiformats: ^9.x
-  checksum: 10/3b585f32011d68f2dce1be2003c849f797ffc6ac5eb199f39dc2aeb7ab2d77f8491f52d56857809a3b41dc62ac7c22151d1789bb5ab7048a4321b317f3dbd4ce
-  languageName: node
-  linkType: hard
-
-"@cowprotocol/app-data@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@cowprotocol/app-data@npm:2.5.1"
-  dependencies:
-    ajv: "npm:^8.11.0"
-    cross-fetch: "npm:^3.1.5"
-    ipfs-only-hash: "npm:^4.0.0"
-    json-stringify-deterministic: "npm:^1.0.8"
-    multiformats: "npm:^9.6.4"
-  peerDependencies:
-    cross-fetch: ^3.x
-    ethers: ^5.0.0
-    ipfs-only-hash: ^4.x
-    multiformats: ^9.x
-  checksum: 10/c3f12caad56bd0f5bff8e3f6a399a89fdea2b3f01c9d5ed553c79bca2920cfe66254b17c2070d4d3b6a0e1e8ee41de2f172d0697bca697d704b62ffff78353d0
+  checksum: 10/cd540b7f7578917be115454d307df333f39101614c59a839ff31278a98c70d9a8f3aaf5fcf08f34075f537710a7db1de265249dae6b7ddda08bcba890b423856
   languageName: node
   linkType: hard
 
@@ -9313,7 +9295,7 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/preset-react": "npm:^7.26.3"
-    "@cowprotocol/app-data": "npm:^2.3.0"
+    "@cowprotocol/app-data": "npm:^3.1.0"
     "@eslint/js": "npm:^9.18.0"
     "@ethersproject/shims": "npm:^5.7.0"
     "@expo/config-plugins": "npm:~10.0.0"
@@ -9627,7 +9609,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@safe-global/utils@workspace:packages/utils"
   dependencies:
-    "@cowprotocol/app-data": "npm:^2.5.1"
+    "@cowprotocol/app-data": "npm:^3.1.0"
     "@faker-js/faker": "npm:^9.0.3"
     "@types/jest": "npm:^29.5.14"
     ethers: "npm:^6.14.3"
@@ -9645,7 +9627,7 @@ __metadata:
   resolution: "@safe-global/web@workspace:apps/web"
   dependencies:
     "@chromatic-com/storybook": "npm:^1.3.1"
-    "@cowprotocol/app-data": "npm:^2.4.0"
+    "@cowprotocol/app-data": "npm:^3.1.0"
     "@cowprotocol/widget-react": "npm:^0.13.0"
     "@datadog/browser-logs": "npm:^6.6.3"
     "@ducanh2912/next-pwa": "npm:^10.2.9"


### PR DESCRIPTION
## What it solves
CoW have changed the type of the metadata in one of their latest release. Every swap order has a slightly different metadata structure and now the partnerFee object no longer has a `bps` prop. I've updated our code to detect both old order metadata and the new ones.


related to https://linear.app/safe-global/issue/MOB-11/

## How to test it
Try to swap - in the confirmation view you should see the widget fee displayed in the decoding. 
![grafik](https://github.com/user-attachments/assets/82a2f495-2945-40fe-bb84-538d50cbb1c8)

Also when looking at old swap txs in the history hovering over the "total fee" tooltip should display the explanation and should contain the correct fee applied to the order
![grafik](https://github.com/user-attachments/assets/73ca8451-fe47-4860-9b33-8f8775b1a9be)


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
