### PR TITLE
fix(mobile): miscellaneous swap order fixes

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -38,7 +38,7 @@
     "ios": "expo run:ios"
   },
   "dependencies": {
-    "@cowprotocol/app-data": "^2.3.0",
+    "@cowprotocol/app-data": "^3.1.0",
     "@ethersproject/shims": "^5.7.0",
     "@expo/config-plugins": "~10.0.0",
     "@expo/vector-icons": "^14.1.0",

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
@@ -72,6 +72,7 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
     case ETxType.SWAP_ORDER:
       return (
         <SwapOrder
+          txId={txDetails.txId}
           executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
           txInfo={txDetails.txInfo as OrderTransactionInfo}
           decodedData={txDetails.txData?.dataDecoded}

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrder.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrder.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import { SwapOrderHeader } from './SwapOrderHeader'
-import { YStack } from 'tamagui'
+import { View, YStack } from 'tamagui'
 import { formatSwapOrderItems, formatTwapOrderItems } from './utils'
 import { ListTable } from '../../ListTable'
 import { DataDecoded, MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
@@ -13,16 +13,21 @@ import { isSettingTwapFallbackHandler } from '@safe-global/utils/features/swap/h
 import { TwapFallbackHandlerWarning } from '@/src/features/ConfirmTx/components/confirmation-views/SwapOrder/TwapFallbackHandlerWarning'
 import { Alert2 } from '@/src/components/Alert2'
 import { useRecipientItem } from './hooks'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { Badge } from '@/src/components/Badge'
+import { SafeListItem } from '@/src/components/SafeListItem'
+import { useRouter } from 'expo-router'
 
 interface SwapOrderProps {
   executionInfo: MultisigExecutionDetails
   txInfo: OrderTransactionInfo
   decodedData?: DataDecoded | null
+  txId: string
 }
 
-export function SwapOrder({ executionInfo, txInfo, decodedData }: SwapOrderProps) {
+export function SwapOrder({ executionInfo, txInfo, decodedData, txId }: SwapOrderProps) {
   const order = txInfo
-
+  const router = useRouter()
   const isTwapOrder = isTwapOrderTxInfo(order)
 
   const activeSafe = useDefinedActiveSafe()
@@ -40,6 +45,14 @@ export function SwapOrder({ executionInfo, txInfo, decodedData }: SwapOrderProps
 
   const showRecipientWarning = order.receiver && order.owner !== order.receiver
 
+  const handleViewActions = () => {
+    router.push({
+      pathname: '/transaction-actions',
+      params: { txId },
+    })
+  }
+
+  console.log('txInfo', txInfo)
   return (
     <YStack gap="$4">
       {isChangingFallbackHandler && <TwapFallbackHandlerWarning />}
@@ -55,6 +68,29 @@ export function SwapOrder({ executionInfo, txInfo, decodedData }: SwapOrderProps
           title="Order recipient address differs from order owner."
           message="Double check the address to prevent fund loss."
           testID="recipient-warning-alert"
+        />
+      )}
+
+      {decodedData && (
+        <SafeListItem
+          label="Actions"
+          rightNode={
+            <View flexDirection="row" alignItems="center" gap="$2">
+              {decodedData.parameters?.[0]?.valueDecoded && (
+                <Badge
+                  themeName="badge_background_inverted"
+                  content={
+                    Array.isArray(decodedData.parameters[0].valueDecoded)
+                      ? decodedData.parameters[0].valueDecoded.length.toString()
+                      : '1'
+                  }
+                />
+              )}
+
+              <SafeFontIcon name={'chevron-right'} />
+            </View>
+          }
+          onPress={handleViewActions}
         />
       )}
     </YStack>

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrder.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrder.tsx
@@ -52,7 +52,6 @@ export function SwapOrder({ executionInfo, txInfo, decodedData, txId }: SwapOrde
     })
   }
 
-  console.log('txInfo', txInfo)
   return (
     <YStack gap="$4">
       {isChangingFallbackHandler && <TwapFallbackHandlerWarning />}

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrderHeader.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrderHeader.test.tsx
@@ -1,0 +1,222 @@
+import React from 'react'
+import { render } from '@/src/tests/test-utils'
+import { SwapOrderHeader } from './SwapOrderHeader'
+import { OrderTransactionInfo } from '@safe-global/store/gateway/types'
+import { MultisigExecutionDetails, TokenInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+// Mock the date utils
+jest.mock('@/src/utils/date', () => ({
+  formatWithSchema: jest.fn((timestamp: number, format: string) => {
+    const date = new Date(timestamp)
+    if (format === 'MMM d yyyy') {
+      return 'Dec 25 2023'
+    }
+    if (format === 'hh:mm a') {
+      return '10:30 AM'
+    }
+    return date.toISOString()
+  }),
+}))
+
+// Mock the formatters
+jest.mock('@/src/utils/formatters', () => ({
+  formatValue: jest.fn((_amount: string, _decimals: number) => '100.5'),
+  ellipsis: jest.fn((text: string, length: number) => (text.length > length ? `${text.slice(0, length)}...` : text)),
+}))
+
+// Mock the TokenIcon component
+jest.mock('@/src/components/TokenIcon', () => ({
+  TokenIcon: ({ accessibilityLabel }: { logoUri: string; accessibilityLabel: string }) => {
+    const React = require('react')
+    const { View, Text } = require('react-native')
+    return React.createElement(
+      View,
+      { testID: `token-icon-${accessibilityLabel}` },
+      React.createElement(Text, null, accessibilityLabel),
+    )
+  },
+}))
+
+// Mock the SafeFontIcon component
+jest.mock('@/src/components/SafeFontIcon', () => ({
+  SafeFontIcon: ({ name }: { name: string }) => {
+    const React = require('react')
+    const { View, Text } = require('react-native')
+    return React.createElement(View, { testID: `safe-font-icon-${name}` }, React.createElement(Text, null, name))
+  },
+}))
+
+describe('SwapOrderHeader', () => {
+  const mockSellToken: TokenInfo = {
+    address: '0x123',
+    decimals: 18,
+    logoUri: 'https://example.com/eth.png',
+    name: 'Ethereum',
+    symbol: 'ETH',
+    trusted: true,
+  }
+
+  const mockBuyToken: TokenInfo = {
+    address: '0x456',
+    decimals: 6,
+    logoUri: 'https://example.com/usdc.png',
+    name: 'USD Coin',
+    symbol: 'USDC',
+    trusted: true,
+  }
+
+  const mockExecutionInfo: MultisigExecutionDetails = {
+    type: 'MULTISIG',
+    submittedAt: 1703505000000, // Dec 25 2023 10:30 AM
+    nonce: 1,
+    safeTxGas: '100000',
+    baseGas: '21000',
+    gasPrice: '20000000000',
+    gasToken: '0x0',
+    refundReceiver: {
+      value: '0x789',
+      name: 'Refund Receiver',
+      logoUri: null,
+    },
+    safeTxHash: '0xabc123',
+    executor: null,
+    signers: [],
+    confirmationsRequired: 2,
+    confirmations: [],
+    rejectors: [],
+    gasTokenInfo: null,
+    trusted: true,
+    proposer: null,
+    proposedByDelegate: null,
+  }
+
+  const createMockTxInfo = (kind: 'sell' | 'buy'): OrderTransactionInfo => ({
+    type: 'SwapOrder' as const,
+    humanDescription: 'Swap order',
+    uid: 'test-uid',
+    status: 'open' as const,
+    kind,
+    orderClass: 'market' as const,
+    validUntil: 1703591400,
+    sellAmount: '1000000000000000000', // 1 ETH in wei
+    buyAmount: '1500000000', // 1500 USDC (6 decimals)
+    executedSellAmount: '0',
+    executedBuyAmount: '0',
+    sellToken: mockSellToken,
+    buyToken: mockBuyToken,
+    explorerUrl: 'https://explorer.com/order/test-uid',
+    executedFee: '0',
+    executedFeeToken: '0x0',
+    receiver: null,
+    owner: '0x123',
+    fullAppData: null,
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Sell Order', () => {
+    it('should render sell order with correct labels', () => {
+      const sellOrderTxInfo = createMockTxInfo('sell')
+      const { getByText } = render(<SwapOrderHeader txInfo={sellOrderTxInfo} executionInfo={mockExecutionInfo} />)
+
+      // Check date and time display
+      expect(getByText('Dec 25 2023 at 10:30 AM')).toBeTruthy()
+
+      // Check sell order specific labels
+      expect(getByText('Sell')).toBeTruthy()
+      expect(getByText('For at least')).toBeTruthy()
+
+      // Check token amounts are displayed
+      expect(getByText('100.5 ETH')).toBeTruthy()
+      expect(getByText('100.5 USDC')).toBeTruthy()
+    })
+
+    it('should render token icons with correct accessibility labels', () => {
+      const sellOrderTxInfo = createMockTxInfo('sell')
+      const { getByTestId } = render(<SwapOrderHeader txInfo={sellOrderTxInfo} executionInfo={mockExecutionInfo} />)
+
+      expect(getByTestId('token-icon-ETH')).toBeTruthy()
+      expect(getByTestId('token-icon-USDC')).toBeTruthy()
+    })
+
+    it('should render chevron icon', () => {
+      const sellOrderTxInfo = createMockTxInfo('sell')
+      const { getByTestId } = render(<SwapOrderHeader txInfo={sellOrderTxInfo} executionInfo={mockExecutionInfo} />)
+
+      expect(getByTestId('safe-font-icon-chevron-right')).toBeTruthy()
+    })
+  })
+
+  describe('Buy Order', () => {
+    it('should render buy order with correct labels', () => {
+      const buyOrderTxInfo = createMockTxInfo('buy')
+      const { getByText } = render(<SwapOrderHeader txInfo={buyOrderTxInfo} executionInfo={mockExecutionInfo} />)
+
+      // Check date and time display
+      expect(getByText('Dec 25 2023 at 10:30 AM')).toBeTruthy()
+
+      // Check buy order specific labels
+      expect(getByText('For at most')).toBeTruthy()
+      expect(getByText('Buy exactly')).toBeTruthy()
+
+      // Check token amounts are displayed
+      expect(getByText('100.5 ETH')).toBeTruthy()
+      expect(getByText('100.5 USDC')).toBeTruthy()
+    })
+
+    it('should not show sell order labels for buy orders', () => {
+      const buyOrderTxInfo = createMockTxInfo('buy')
+      const { queryByText } = render(<SwapOrderHeader txInfo={buyOrderTxInfo} executionInfo={mockExecutionInfo} />)
+
+      // Sell order labels should not be present
+      expect(queryByText('Sell')).toBeNull()
+      expect(queryByText('For at least')).toBeNull()
+    })
+  })
+
+  describe('Unknown Order Kind', () => {
+    it('should handle unknown order kind gracefully', () => {
+      const unknownOrderTxInfo = createMockTxInfo('sell')
+      unknownOrderTxInfo.kind = 'unknown' as 'buy' | 'sell' | 'unknown'
+
+      const { getByText } = render(<SwapOrderHeader txInfo={unknownOrderTxInfo} executionInfo={mockExecutionInfo} />)
+
+      // Should default to buy order labels when kind is 'unknown'
+      expect(getByText('For at most')).toBeTruthy()
+      expect(getByText('Buy exactly')).toBeTruthy()
+    })
+  })
+
+  describe('Formatters Integration', () => {
+    it('should call formatValue with correct parameters', () => {
+      const sellOrderTxInfo = createMockTxInfo('sell')
+      const { formatValue } = require('@/src/utils/formatters')
+
+      render(<SwapOrderHeader txInfo={sellOrderTxInfo} executionInfo={mockExecutionInfo} />)
+
+      expect(formatValue).toHaveBeenCalledWith('1000000000000000000', 18) // ETH
+      expect(formatValue).toHaveBeenCalledWith('1500000000', 6) // USDC
+    })
+
+    it('should call ellipsis with correct parameters', () => {
+      const sellOrderTxInfo = createMockTxInfo('sell')
+      const { ellipsis } = require('@/src/utils/formatters')
+
+      render(<SwapOrderHeader txInfo={sellOrderTxInfo} executionInfo={mockExecutionInfo} />)
+
+      expect(ellipsis).toHaveBeenCalledWith('100.5', 9)
+    })
+
+    it('should call formatWithSchema with correct parameters', () => {
+      const sellOrderTxInfo = createMockTxInfo('sell')
+      const { formatWithSchema } = require('@/src/utils/date')
+
+      render(<SwapOrderHeader txInfo={sellOrderTxInfo} executionInfo={mockExecutionInfo} />)
+
+      expect(formatWithSchema).toHaveBeenCalledWith(1703505000000, 'MMM d yyyy')
+      expect(formatWithSchema).toHaveBeenCalledWith(1703505000000, 'hh:mm a')
+    })
+  })
+})

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrderHeader.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrderHeader.tsx
@@ -15,12 +15,14 @@ interface SwapOrderHeaderProps {
 }
 
 export function SwapOrderHeader({ txInfo, executionInfo }: SwapOrderHeaderProps) {
-  const { sellToken, buyToken, sellAmount, buyAmount } = txInfo
+  const { sellToken, buyToken, sellAmount, buyAmount, kind } = txInfo
   const date = formatWithSchema(executionInfo.submittedAt, 'MMM d yyyy')
   const time = formatWithSchema(executionInfo.submittedAt, 'hh:mm a')
 
   const sellTokenValue = formatValue(sellAmount, sellToken.decimals)
   const buyTokenValue = formatValue(buyAmount, buyToken.decimals)
+
+  const isSellOrder = kind === 'sell'
 
   return (
     <>
@@ -34,7 +36,7 @@ export function SwapOrderHeader({ txInfo, executionInfo }: SwapOrderHeaderProps)
         <Container flex={1} padding="$4" borderRadius="$3">
           <View alignItems="center" gap="$2">
             <TokenIcon logoUri={sellToken.logoUri} size="$10" accessibilityLabel={sellToken.symbol} />
-            <Text color="$textSecondaryLight">Sell</Text>
+            <Text color="$textSecondaryLight">{isSellOrder ? 'Sell' : 'For at most'}</Text>
             <H5 fontWeight={600}>
               {ellipsis(sellTokenValue, 9)} {sellToken.symbol}
             </H5>
@@ -68,7 +70,7 @@ export function SwapOrderHeader({ txInfo, executionInfo }: SwapOrderHeaderProps)
         <Container flex={1} padding="$4" borderRadius="$3">
           <View alignItems="center" gap="$2">
             <TokenIcon logoUri={buyToken.logoUri} size="$10" accessibilityLabel={buyToken.symbol} />
-            <Text color="$textSecondaryLight">For at least</Text>
+            <Text color="$textSecondaryLight">{isSellOrder ? 'For at least' : 'Buy exactly'}</Text>
             <H5 fontWeight={600}>
               {ellipsis(buyTokenValue, 9)} {buyToken.symbol}
             </H5>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -95,7 +95,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.3.1",
-    "@cowprotocol/app-data": "^2.4.0",
+    "@cowprotocol/app-data": "^3.1.0",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.18.0",
     "@faker-js/faker": "^9.0.3",

--- a/apps/web/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
+++ b/apps/web/src/features/swap/components/SwapOrder/rows/SurplusFee.tsx
@@ -1,5 +1,5 @@
 import type { TwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
-import { getOrderFeeBps } from '@/features/swap/helpers/utils'
+import { getOrderFeeBps } from '@safe-global/utils/features/swap/helpers/utils'
 import { DataRow } from '@/components/common/Table/DataRow'
 import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
 import { HelpIconTooltip } from '@/features/swap/components/HelpIconTooltip'

--- a/apps/web/src/features/swap/components/SwapOrderConfirmationView/OrderFeeConfirmationView.tsx
+++ b/apps/web/src/features/swap/components/SwapOrderConfirmationView/OrderFeeConfirmationView.tsx
@@ -1,5 +1,5 @@
 import type { SwapOrderConfirmationView, TwapOrderConfirmationView } from '@safe-global/safe-gateway-typescript-sdk'
-import { getOrderFeeBps } from '@/features/swap/helpers/utils'
+import { getOrderFeeBps } from '@safe-global/utils/features/swap/helpers/utils'
 import { DataRow } from '@/components/common/Table/DataRow'
 import { BRAND_NAME } from '@/config/constants'
 import { HelpIconTooltip } from '@/features/swap/components/HelpIconTooltip'

--- a/apps/web/src/features/swap/helpers/utils.ts
+++ b/apps/web/src/features/swap/helpers/utils.ts
@@ -1,6 +1,6 @@
 import type { DataDecoded, Order as SwapOrder } from '@safe-global/safe-gateway-typescript-sdk'
 import { formatUnits } from 'ethers'
-import type { AnyAppDataDocVersion, latest, LatestAppDataDocVersion } from '@cowprotocol/app-data'
+import type { AnyAppDataDocVersion, latest } from '@cowprotocol/app-data'
 
 import { TradeType, UiOrderType } from '@safe-global/utils/features/swap/types'
 
@@ -165,13 +165,6 @@ export const getOrderClass = (order: Pick<SwapOrder, 'fullAppData'>): latest.Ord
   const orderClass = (fullAppData?.metadata?.orderClass as latest.OrderClass)?.orderClass
 
   return orderClass || 'market'
-}
-
-export const getOrderFeeBps = (order: Pick<SwapOrder, 'fullAppData'>): number => {
-  const fullAppData = order.fullAppData as unknown as LatestAppDataDocVersion
-  const basisPoints = (fullAppData?.metadata?.partnerFee as latest.PartnerFee)?.bps
-
-  return Number(basisPoints) || 0
 }
 
 export const isOrderPartiallyFilled = (

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,7 +14,7 @@
     "jest": "^29.7.0"
   },
   "dependencies": {
-    "@cowprotocol/app-data": "^2.5.1",
+    "@cowprotocol/app-data": "^3.1.0",
     "ts-node": "^10.9.2"
   },
   "peerDependencies": {

--- a/packages/utils/src/features/swap/helpers/fee.ts
+++ b/packages/utils/src/features/swap/helpers/fee.ts
@@ -1,0 +1,71 @@
+import { v1_4_0, v1_3_0, LatestAppDataDocVersion } from '@cowprotocol/app-data'
+import type { OrderTransactionInfo as SwapOrder } from '@safe-global/store/gateway/types'
+
+type VolumeFee = {
+  volumeBps: v1_4_0.VolumeBasisPointBPS
+  recipient: v1_4_0.PartnerAccount
+}
+
+type SurplusFee = {
+  surplusBps: v1_4_0.SurplusBasisPointBPS
+  maxVolumeBps: v1_4_0.MaxVolumeBasisPointBPS
+  recipient: v1_4_0.PartnerAccount
+}
+
+type PriceImprovementFee = {
+  priceImprovementBps: v1_4_0.PriceImprovementBasisPointBPS
+  maxVolumeBps: v1_4_0.MaxVolumeBasisPointBPS
+  recipient: v1_4_0.PartnerAccount
+}
+
+function isVolumeFee(fee: v1_4_0.PartnerFee): fee is VolumeFee {
+  return typeof (fee as VolumeFee).volumeBps === 'number'
+}
+
+function isSurplusFee(fee: v1_4_0.PartnerFee): fee is SurplusFee {
+  return typeof (fee as SurplusFee).surplusBps === 'number'
+}
+
+function isPriceImprovementFee(fee: v1_4_0.PartnerFee): fee is PriceImprovementFee {
+  return typeof (fee as PriceImprovementFee).priceImprovementBps === 'number'
+}
+
+/**
+ * Right now it doesn't look like we need the surplus and price improvement fees.
+ * and that's why we don't use this function yet.
+ */
+function resolveNewPartnerFeeBps(fee: v1_4_0.PartnerFee): number | null {
+  if (isVolumeFee(fee)) {
+    return fee.volumeBps
+  }
+  if (isSurplusFee(fee)) {
+    return fee.surplusBps
+  }
+  if (isPriceImprovementFee(fee)) {
+    return fee.priceImprovementBps
+  }
+  return null
+}
+
+export const getOrderFeeBps = (order: Pick<SwapOrder, 'fullAppData'>): number => {
+  const fullAppData = order.fullAppData as unknown as LatestAppDataDocVersion
+
+  const oldPartnerFee = fullAppData?.metadata?.partnerFee as unknown as v1_3_0.PartnerFee
+
+  if (typeof oldPartnerFee.bps === 'number') {
+    return Number(oldPartnerFee.bps)
+  }
+
+  const newPartnerFee = fullAppData?.metadata?.partnerFee as unknown as v1_4_0.PartnerFee
+
+  if (Array.isArray(newPartnerFee)) {
+    return newPartnerFee.reduce((acc, fee) => {
+      if (isVolumeFee(fee)) {
+        return acc + Number(fee.volumeBps)
+      }
+      return acc
+    }, 0)
+  }
+
+  return isVolumeFee(newPartnerFee) ? Number(newPartnerFee.volumeBps) : 0
+}

--- a/packages/utils/src/features/swap/helpers/utils.ts
+++ b/packages/utils/src/features/swap/helpers/utils.ts
@@ -1,9 +1,10 @@
 import type { OrderTransactionInfo as SwapOrder } from '@safe-global/store/gateway/types'
 import type { DataDecoded } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { formatUnits } from 'ethers'
-import type { AnyAppDataDocVersion, latest, LatestAppDataDocVersion } from '@cowprotocol/app-data'
+import type { AnyAppDataDocVersion, latest } from '@cowprotocol/app-data'
 
 import { TradeType, UiOrderType } from '@safe-global/utils/features/swap/types'
+import { getOrderFeeBps as getOrderFeeBpsHelper } from '@safe-global/utils/features/swap/helpers/fee'
 
 type Quantity = {
   amount: string | number | bigint
@@ -169,10 +170,7 @@ export const getOrderClass = (order: Pick<SwapOrder, 'fullAppData'>): latest.Ord
 }
 
 export const getOrderFeeBps = (order: Pick<SwapOrder, 'fullAppData'>): number => {
-  const fullAppData = order.fullAppData as unknown as LatestAppDataDocVersion
-  const basisPoints = (fullAppData?.metadata?.partnerFee as latest.PartnerFee)?.bps
-
-  return Number(basisPoints) || 0
+  return getOrderFeeBpsHelper(order)
 }
 
 export const isOrderPartiallyFilled = (

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -17,6 +17,7 @@ const DEPS_TO_CHECK = [
   '@safe-global/safe-deployments',
   '@safe-global/safe-gateway-typescript-sdk',
   '@safe-global/safe-modules-deployments',
+  '@cowprotocol/app-data',
 ]
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2847,9 +2847,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cowprotocol/app-data@npm:^2.3.0, @cowprotocol/app-data@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@cowprotocol/app-data@npm:2.4.0"
+"@cowprotocol/app-data@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@cowprotocol/app-data@npm:3.1.0"
   dependencies:
     ajv: "npm:^8.11.0"
     cross-fetch: "npm:^3.1.5"
@@ -2861,25 +2861,7 @@ __metadata:
     ethers: ^5.0.0
     ipfs-only-hash: ^4.x
     multiformats: ^9.x
-  checksum: 10/3b585f32011d68f2dce1be2003c849f797ffc6ac5eb199f39dc2aeb7ab2d77f8491f52d56857809a3b41dc62ac7c22151d1789bb5ab7048a4321b317f3dbd4ce
-  languageName: node
-  linkType: hard
-
-"@cowprotocol/app-data@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@cowprotocol/app-data@npm:2.5.1"
-  dependencies:
-    ajv: "npm:^8.11.0"
-    cross-fetch: "npm:^3.1.5"
-    ipfs-only-hash: "npm:^4.0.0"
-    json-stringify-deterministic: "npm:^1.0.8"
-    multiformats: "npm:^9.6.4"
-  peerDependencies:
-    cross-fetch: ^3.x
-    ethers: ^5.0.0
-    ipfs-only-hash: ^4.x
-    multiformats: ^9.x
-  checksum: 10/c3f12caad56bd0f5bff8e3f6a399a89fdea2b3f01c9d5ed553c79bca2920cfe66254b17c2070d4d3b6a0e1e8ee41de2f172d0697bca697d704b62ffff78353d0
+  checksum: 10/cd540b7f7578917be115454d307df333f39101614c59a839ff31278a98c70d9a8f3aaf5fcf08f34075f537710a7db1de265249dae6b7ddda08bcba890b423856
   languageName: node
   linkType: hard
 
@@ -9313,7 +9295,7 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.26.0"
     "@babel/preset-react": "npm:^7.26.3"
-    "@cowprotocol/app-data": "npm:^2.3.0"
+    "@cowprotocol/app-data": "npm:^3.1.0"
     "@eslint/js": "npm:^9.18.0"
     "@ethersproject/shims": "npm:^5.7.0"
     "@expo/config-plugins": "npm:~10.0.0"
@@ -9627,7 +9609,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@safe-global/utils@workspace:packages/utils"
   dependencies:
-    "@cowprotocol/app-data": "npm:^2.5.1"
+    "@cowprotocol/app-data": "npm:^3.1.0"
     "@faker-js/faker": "npm:^9.0.3"
     "@types/jest": "npm:^29.5.14"
     ethers: "npm:^6.14.3"
@@ -9645,7 +9627,7 @@ __metadata:
   resolution: "@safe-global/web@workspace:apps/web"
   dependencies:
     "@chromatic-com/storybook": "npm:^1.3.1"
-    "@cowprotocol/app-data": "npm:^2.4.0"
+    "@cowprotocol/app-data": "npm:^3.1.0"
     "@cowprotocol/widget-react": "npm:^0.13.0"
     "@datadog/browser-logs": "npm:^6.6.3"
     "@ducanh2912/next-pwa": "npm:^10.2.9"


### PR DESCRIPTION
## What it solves
- display actions on the swap order screen
- better display for buy orders

Resolves https://linear.app/safe-global/issue/MOB-11/

## Screenshots
<img src="https://github.com/user-attachments/assets/e54c1792-62ba-4cc6-9e3d-097acb0b5093" width="150" />
<img src="https://github.com/user-attachments/assets/3282ab60-96ac-445d-b313-597e1ba57965" width="150" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
