### PR TITLE
Fix(Mobile): Show truncated data in bottom sheet

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -25,13 +25,13 @@ import { useInitWeb3 } from '@/src/hooks/useInitWeb3'
 import { useInitSafeCoreSDK } from '@/src/hooks/coreSDK/useInitSafeCoreSDK'
 import NotificationsService from '@/src/services/notifications/NotificationService'
 import { startNotificationExtensionSync } from '@/src/services/notifications/extensionSync'
-import { StatusBar } from 'expo-status-bar'
 import { useScreenTracking } from '@/src/hooks/useScreenTracking'
 import { useAnalytics } from '@/src/hooks/useAnalytics'
 import { DataFetchProvider } from '../theme/provider/DataFetchProvider'
 import { Platform } from 'react-native'
 import { config, actions } from '@/src/platform/security'
 import { useFreeRasp } from 'freerasp-react-native'
+import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 Logger.setLevel(__DEV__ ? LogLevel.TRACE : LogLevel.ERROR)
 // Initialize all notification handlers
@@ -200,7 +200,7 @@ function RootLayout() {
                           />
                           <Stack.Screen name="+not-found" />
                         </Stack>
-                        <StatusBar />
+                        <SafeStatusBar />
                       </NavigationGuardHOC>
                     </SafeToastProvider>
                   </BottomSheetModalProvider>

--- a/apps/mobile/src/components/InfoSheet/InfoSheet.tsx
+++ b/apps/mobile/src/components/InfoSheet/InfoSheet.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useRef } from 'react'
-import { BottomSheetView } from '@gorhom/bottom-sheet'
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet'
 import { SafeFontIcon } from '../SafeFontIcon'
 import { BottomSheetModal, TouchableOpacity } from '@gorhom/bottom-sheet'
-import { getVariable, Text, View, useTheme, H4, YStack, ScrollView } from 'tamagui'
+import { getVariable, Text, View, useTheme, H4, YStack } from 'tamagui'
 import { BackdropComponent, BackgroundComponent } from '@/src/components/Dropdown/sheetComponents'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Badge } from '@/src/components/Badge'
@@ -42,23 +42,21 @@ export const InfoSheet = ({
         enableDynamicSizing
         handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
       >
-        <BottomSheetView style={{ paddingBottom: insets.bottom }}>
-          <ScrollView>
-            <YStack gap="$4" padding="$4" alignItems="center" justifyContent="center">
-              {displayIcon && (
-                <Badge
-                  themeName="badge_background"
-                  circleSize="$10"
-                  content={<SafeFontIcon name="info" size={24} color="$color" />}
-                />
-              )}
-              <View gap="$2" alignItems="center">
-                {title && <H4 fontWeight="600">{title}</H4>}
-                <Text textAlign="center">{info}</Text>
-              </View>
-            </YStack>
-          </ScrollView>
-        </BottomSheetView>
+        <BottomSheetScrollView contentContainerStyle={{ paddingBottom: insets.bottom }}>
+          <YStack gap="$4" padding="$4" alignItems="center" justifyContent="center">
+            {displayIcon && (
+              <Badge
+                themeName="badge_background"
+                circleSize="$10"
+                content={<SafeFontIcon name="info" size={24} color="$color" />}
+              />
+            )}
+            <View gap="$2" alignItems="center">
+              {title && <H4 fontWeight="600">{title}</H4>}
+              <Text textAlign="center">{info}</Text>
+            </View>
+          </YStack>
+        </BottomSheetScrollView>
       </BottomSheetModal>
     </>
   )

--- a/apps/mobile/src/components/InfoSheet/InfoSheet.tsx
+++ b/apps/mobile/src/components/InfoSheet/InfoSheet.tsx
@@ -11,10 +11,12 @@ export const InfoSheet = ({
   info,
   title,
   displayIcon = true,
+  children,
 }: {
   info: string
   title?: string
   displayIcon?: boolean
+  children?: string | React.ReactElement
 }) => {
   const bottomSheetModalRef = useRef<BottomSheetModal>(null)
   const insets = useSafeAreaInsets()
@@ -28,7 +30,8 @@ export const InfoSheet = ({
   return (
     <>
       <TouchableOpacity onPress={handlePresentModalPress}>
-        <SafeFontIcon name="info" size={16} color="$colorSecondary" />
+        {!children && <SafeFontIcon name="info" size={16} color="$colorSecondary" />}
+        {children}
       </TouchableOpacity>
 
       <BottomSheetModal

--- a/apps/mobile/src/components/InfoSheet/InfoSheet.tsx
+++ b/apps/mobile/src/components/InfoSheet/InfoSheet.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef } from 'react'
 import { BottomSheetView } from '@gorhom/bottom-sheet'
 import { SafeFontIcon } from '../SafeFontIcon'
 import { BottomSheetModal, TouchableOpacity } from '@gorhom/bottom-sheet'
-import { getVariable, Text, View, useTheme, H4, YStack } from 'tamagui'
+import { getVariable, Text, View, useTheme, H4, YStack, ScrollView } from 'tamagui'
 import { BackdropComponent, BackgroundComponent } from '@/src/components/Dropdown/sheetComponents'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Badge } from '@/src/components/Badge'
@@ -43,19 +43,21 @@ export const InfoSheet = ({
         handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
       >
         <BottomSheetView style={{ paddingBottom: insets.bottom }}>
-          <YStack gap="$4" padding="$4" alignItems="center" justifyContent="center">
-            {displayIcon && (
-              <Badge
-                themeName="badge_background"
-                circleSize="$10"
-                content={<SafeFontIcon name="info" size={24} color="$color" />}
-              />
-            )}
-            <View gap="$2" alignItems="center">
-              {title && <H4 fontWeight="600">{title}</H4>}
-              <Text textAlign="center">{info}</Text>
-            </View>
-          </YStack>
+          <ScrollView>
+            <YStack gap="$4" padding="$4" alignItems="center" justifyContent="center">
+              {displayIcon && (
+                <Badge
+                  themeName="badge_background"
+                  circleSize="$10"
+                  content={<SafeFontIcon name="info" size={24} color="$color" />}
+                />
+              )}
+              <View gap="$2" alignItems="center">
+                {title && <H4 fontWeight="600">{title}</H4>}
+                <Text textAlign="center">{info}</Text>
+              </View>
+            </YStack>
+          </ScrollView>
         </BottomSheetView>
       </BottomSheetModal>
     </>

--- a/apps/mobile/src/features/AdvancedDetails/formatters/singleValue.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/formatters/singleValue.tsx
@@ -6,6 +6,7 @@ import { CopyButton } from '@/src/components/CopyButton'
 import { EthAddress } from '@/src/components/EthAddress'
 import { Address } from '@/src/types/address'
 import { Identicon } from '@/src/components/Identicon'
+import { InfoSheet } from '@/src/components/InfoSheet'
 
 export const characterDisplayLimit = 15
 
@@ -46,8 +47,14 @@ export const formatValueTemplate = (param: DataDecodedParameter): ListTableItem 
     }
   }
 
+  const value = String(param.value)
+
   return {
     label: param.name,
-    render: () => <DisplayValue type={param.type} value={String(param.value)} />,
+    render: () => (
+      <InfoSheet title={param.name} info={value}>
+        <DisplayValue type={param.type} value={value} />
+      </InfoSheet>
+    ),
   }
 }

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatParameters.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatParameters.tsx
@@ -7,6 +7,8 @@ import { CopyButton } from '@/src/components/CopyButton'
 import { characterDisplayLimit, formatValueTemplate } from '../formatters/singleValue'
 import { formatArrayValue } from '../formatters/arrayValue'
 import { Badge } from '@/src/components/Badge'
+import { InfoSheet } from '@/src/components/InfoSheet'
+import React from 'react'
 
 interface formatParametersProps {
   txData?: TransactionDetails['txData']
@@ -53,13 +55,17 @@ const formatParameters = ({ txData }: formatParametersProps): ListTableItem[] =>
   }
 
   if (txData?.hexData) {
+    const hexData = txData.hexData
+
     items.push({
       label: 'Hex Data:',
       render: () => (
-        <View flexDirection="row" alignItems="center" gap="$1">
-          <Text>{shortenText(txData?.hexData || '', characterDisplayLimit)}</Text>
-          <CopyButton value={txData?.hexData || ''} color={'$textSecondaryLight'} text="Data copied." />
-        </View>
+        <InfoSheet title="Hex Data" info={hexData}>
+          <View flexDirection="row" alignItems="center" gap="$1">
+            <Text>{shortenText(txData?.hexData || '', characterDisplayLimit)}</Text>
+            <CopyButton value={txData?.hexData || ''} color={'$textSecondaryLight'} text="Data copied." />
+          </View>
+        </InfoSheet>
       ),
     })
   }

--- a/apps/mobile/src/features/DataImport/EnterPassword.container.tsx
+++ b/apps/mobile/src/features/DataImport/EnterPassword.container.tsx
@@ -1,14 +1,12 @@
 import React, { useCallback } from 'react'
 import { useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useColorScheme } from 'react-native'
 import { useDataImportContext } from './context/DataImportProvider'
 import { EnterPasswordView } from './components/EnterPasswordView'
 
 export const EnterPassword = () => {
   const router = useRouter()
   const insets = useSafeAreaInsets()
-  const colorScheme = useColorScheme()
   const { handlePasswordChange, handleImport, password, isLoading, fileName } = useDataImportContext()
 
   const handleDecrypt = useCallback(async () => {
@@ -24,7 +22,6 @@ export const EnterPassword = () => {
 
   return (
     <EnterPasswordView
-      colorScheme={colorScheme}
       topInset={insets.top}
       bottomInset={insets.bottom}
       password={password}

--- a/apps/mobile/src/features/DataImport/HelpImport.container.tsx
+++ b/apps/mobile/src/features/DataImport/HelpImport.container.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback } from 'react'
 import { useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useColorScheme, Linking } from 'react-native'
+import { Linking } from 'react-native'
 import { HelpCenterArticle } from '@safe-global/utils/config/constants'
 import { HelpImportView } from './components/HelpImportView'
 
 export const HelpImport = () => {
   const router = useRouter()
   const insets = useSafeAreaInsets()
-  const colorScheme = useColorScheme()
 
   const onPressProceedToImport = useCallback(() => {
     // Navigate to file selection screen
@@ -21,7 +20,6 @@ export const HelpImport = () => {
 
   return (
     <HelpImportView
-      colorScheme={colorScheme}
       bottomInset={insets.bottom}
       onPressProceedToImport={onPressProceedToImport}
       onPressNeedHelp={onPressNeedHelp}

--- a/apps/mobile/src/features/DataImport/ImportProgressScreen.container.tsx
+++ b/apps/mobile/src/features/DataImport/ImportProgressScreen.container.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react'
 import { useRouter } from 'expo-router'
-import { useColorScheme } from 'react-native'
 import { useDataImportContext } from './context/DataImportProvider'
 import { useAppDispatch } from '@/src/store/hooks'
 import Logger from '@/src/utils/logger'
@@ -9,7 +8,6 @@ import { ImportProgressScreenView } from './components/ImportProgressScreenView'
 
 export const ImportProgressScreen = () => {
   const router = useRouter()
-  const colorScheme = useColorScheme()
   const { importedData } = useDataImportContext()
   const dispatch = useAppDispatch()
 
@@ -55,5 +53,5 @@ export const ImportProgressScreen = () => {
     performImport()
   }, [importedData, dispatch, router])
 
-  return <ImportProgressScreenView colorScheme={colorScheme} progress={progress} />
+  return <ImportProgressScreenView progress={progress} />
 }

--- a/apps/mobile/src/features/DataImport/ReviewData.container.tsx
+++ b/apps/mobile/src/features/DataImport/ReviewData.container.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 import { useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useColorScheme } from 'react-native'
 import { useDataImportContext } from './context/DataImportProvider'
 import { ReviewDataView } from './components/ReviewDataView'
 import { LegacyDataStructure } from './helpers/transforms'
@@ -9,7 +8,6 @@ import { LegacyDataStructure } from './helpers/transforms'
 export const ReviewData = () => {
   const router = useRouter()
   const insets = useSafeAreaInsets()
-  const colorScheme = useColorScheme()
   const { importedData } = useDataImportContext()
 
   const importSummary = useMemo(() => {
@@ -47,7 +45,6 @@ export const ReviewData = () => {
 
   return (
     <ReviewDataView
-      colorScheme={colorScheme}
       bottomInset={insets.bottom}
       importSummary={importSummary}
       isImportDataAvailable={!!importedData}

--- a/apps/mobile/src/features/DataImport/components/EnterPasswordView.tsx
+++ b/apps/mobile/src/features/DataImport/components/EnterPasswordView.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import { Text, YStack, H2, XStack, ScrollView } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
-import { StatusBar } from 'expo-status-bar'
-import { ColorSchemeName, KeyboardAvoidingView } from 'react-native'
+import { KeyboardAvoidingView } from 'react-native'
 import { Alert } from '@/src/components/Alert'
 import { SafeInput } from '@/src/components/SafeInput'
+import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 interface EnterPasswordViewProps {
-  colorScheme: ColorSchemeName
   topInset: number
   bottomInset: number
   password: string
@@ -18,7 +17,6 @@ interface EnterPasswordViewProps {
 }
 
 export const EnterPasswordView = ({
-  colorScheme,
   topInset,
   bottomInset,
   password,
@@ -31,7 +29,7 @@ export const EnterPasswordView = ({
     <KeyboardAvoidingView behavior="padding" style={{ flex: 1 }} keyboardVerticalOffset={bottomInset + topInset}>
       <ScrollView contentContainerStyle={{ flex: 1 }}>
         <YStack flex={1} testID="enter-password-screen">
-          <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+          <SafeStatusBar />
 
           {/* Content */}
           <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>

--- a/apps/mobile/src/features/DataImport/components/FileSelectionView.tsx
+++ b/apps/mobile/src/features/DataImport/components/FileSelectionView.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Text, YStack, Image, styled, H2 } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
-import { StatusBar } from 'expo-status-bar'
 import ImportDataSelectFilesDark from '@/assets/images/import-data-select-files-dark.png'
 import ImportDataSelectFilesLight from '@/assets/images/import-data-select-files-light.png'
 import { ColorSchemeName, TouchableOpacity } from 'react-native'
+import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 const StyledText = styled(Text, {
   fontSize: '$4',
@@ -29,7 +29,7 @@ interface FileSelectionViewProps {
 export const FileSelectionView = ({ colorScheme, bottomInset, onFileSelect, onImagePress }: FileSelectionViewProps) => {
   return (
     <YStack flex={1} testID="file-selection-screen" paddingBottom={bottomInset}>
-      <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+      <SafeStatusBar />
 
       {/* Content */}
       <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>

--- a/apps/mobile/src/features/DataImport/components/HelpImportView.tsx
+++ b/apps/mobile/src/features/DataImport/components/HelpImportView.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Text, YStack, XStack, styled, H2 } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
-import { StatusBar } from 'expo-status-bar'
-import { ColorSchemeName, TouchableOpacity } from 'react-native'
+import { TouchableOpacity } from 'react-native'
 import { Badge } from '@/src/components/Badge'
+import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 const StepText = styled(Text, {
   fontSize: '$4',
@@ -22,21 +22,15 @@ const StepBadge = ({ step }: { step: string }) => {
 }
 
 interface HelpImportViewProps {
-  colorScheme: ColorSchemeName
   bottomInset: number
   onPressProceedToImport: () => void
   onPressNeedHelp: () => void
 }
 
-export const HelpImportView = ({
-  colorScheme,
-  bottomInset,
-  onPressProceedToImport,
-  onPressNeedHelp,
-}: HelpImportViewProps) => {
+export const HelpImportView = ({ bottomInset, onPressProceedToImport, onPressNeedHelp }: HelpImportViewProps) => {
   return (
     <YStack flex={1} testID="help-import-screen">
-      <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+      <SafeStatusBar />
 
       {/* Content */}
       <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>

--- a/apps/mobile/src/features/DataImport/components/ImportProgressScreenView.tsx
+++ b/apps/mobile/src/features/DataImport/components/ImportProgressScreenView.tsx
@@ -1,19 +1,17 @@
 import React from 'react'
 import { Text, YStack, H2, ScrollView, View } from 'tamagui'
-import { StatusBar } from 'expo-status-bar'
-import { ColorSchemeName } from 'react-native'
 import { Bar } from 'react-native-progress'
+import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 interface ImportProgressScreenViewProps {
-  colorScheme: ColorSchemeName
   progress: number
 }
 
-export const ImportProgressScreenView = ({ colorScheme, progress }: ImportProgressScreenViewProps) => {
+export const ImportProgressScreenView = ({ progress }: ImportProgressScreenViewProps) => {
   return (
     <ScrollView contentContainerStyle={{ flex: 1 }}>
       <YStack flex={1} testID="import-progress-screen">
-        <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+        <SafeStatusBar />
 
         {/* Content */}
         <YStack flex={1} paddingHorizontal="$4" justifyContent="center" alignItems="center">

--- a/apps/mobile/src/features/DataImport/components/ReviewDataView.tsx
+++ b/apps/mobile/src/features/DataImport/components/ReviewDataView.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { Text, YStack, H2, XStack, ScrollView } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
-import { StatusBar } from 'expo-status-bar'
-import { ColorSchemeName } from 'react-native'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Container } from '@/src/components/Container'
 import { Badge } from '@/src/components/Badge'
+import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 interface ImportSummary {
   safeAccountsCount: number
@@ -14,7 +13,6 @@ interface ImportSummary {
 }
 
 interface ReviewDataViewProps {
-  colorScheme: ColorSchemeName
   bottomInset: number
   importSummary: ImportSummary
   isImportDataAvailable: boolean
@@ -22,7 +20,6 @@ interface ReviewDataViewProps {
 }
 
 export const ReviewDataView = ({
-  colorScheme,
   bottomInset,
   importSummary,
   isImportDataAvailable,
@@ -31,7 +28,7 @@ export const ReviewDataView = ({
   return (
     <ScrollView contentContainerStyle={{ flex: 1 }}>
       <YStack flex={1} testID="review-data-screen">
-        <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+        <SafeStatusBar />
 
         {/* Content */}
         <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>

--- a/apps/mobile/src/theme/SafeStatusBar.tsx
+++ b/apps/mobile/src/theme/SafeStatusBar.tsx
@@ -1,0 +1,8 @@
+import { StatusBar } from 'expo-status-bar'
+import { useTheme } from '@/src/theme/hooks/useTheme'
+
+export const SafeStatusBar = () => {
+  const { currentTheme } = useTheme()
+
+  return <StatusBar style={currentTheme === 'dark' ? 'light' : 'dark'} />
+}


### PR DESCRIPTION
## What it solves

Resolves [MOB-40](https://linear.app/safe-global/issue/MOB-40/display-more-data-in-modal)
Resolves [MOB-107](https://linear.app/safe-global/issue/MOB-107/mobile-light-mode-status-bar-is-white)

## How this PR fixes it

- Updates `InfoSheet` to accept children
- Adds `InfoSheet` to transaction data
- Extracts `StatusBar` into `SafeStatusBar` and handles theme changes

## How to test it

1. Open a transaction
2. Go to transaction details
3. Press on truncated data
4. Observe a sheet opening at the bottom of the screen that contains the full data

## Screenshots

<img width="419" alt="Screenshot 2025-07-09 at 15 50 50" src="https://github.com/user-attachments/assets/4f5b0c56-127d-4653-a754-23afe4fe2586" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
