### PR TITLE
fix(mobile): align token list with web by removing `excludeSpam` param

### DIFF
--- a/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
@@ -27,7 +27,6 @@ export function TokensContainer() {
           chainId: activeSafe.chainId,
           fiatCode: currency,
           safeAddress: activeSafe.address,
-          excludeSpam: false,
           trusted: true,
         },
     {

--- a/apps/mobile/src/hooks/useBalances.ts
+++ b/apps/mobile/src/hooks/useBalances.ts
@@ -16,7 +16,6 @@ export const useBalances = (poll = false, pollingInterval = POLLING_INTERVAL) =>
           chainId: activeSafe.chainId,
           fiatCode: currency.toUpperCase(),
           safeAddress: activeSafe.address,
-          excludeSpam: false,
           trusted: true,
         },
     {


### PR DESCRIPTION
## What it solves

Resolves [MOB-104](https://linear.app/safe-global/issue/MOB-104/mobile-not-all-trusted-tokens-are-displayed-on-the-mobile)

## How this PR fixes it

Removes the `excludeSpam` parameter from token balance requests in the mobile app to ensure consistency with the web app.

The web app does not use `excludeSpam` when fetching balances (see `useLoadBalances` hook), so this change ensures both platforms return identical token lists.

## Screenshots
<img width="983" alt="Screenshot 2025-07-10 at 10 34 53" src="https://github.com/user-attachments/assets/52f7c602-0944-4951-a526-4ceabfba5c25" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
