### PR TITLE
Fix(Mobile): Centralize StatusBar and theme logic

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -3,12 +3,10 @@ import React from 'react'
 import { TabBarIcon } from '@/src/components/navigation/TabBarIcon'
 import { Navbar as AssetsNavbar } from '@/src/features/Assets/components/Navbar/Navbar'
 import { Pressable, StyleSheet, Platform } from 'react-native'
-import { StatusBar } from 'expo-status-bar'
 
 export default function TabLayout() {
   return (
     <>
-      <StatusBar style="auto" />
       <Tabs screenOptions={{ tabBarShowLabel: false }}>
         <Tabs.Screen
           name="index"

--- a/apps/mobile/src/features/DataImport/components/DataTransferView.tsx
+++ b/apps/mobile/src/features/DataImport/components/DataTransferView.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Text, YStack, Image, styled, H2, H5, getTokenValue } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
-import { StatusBar } from 'expo-status-bar'
 import TransferOldAppDark from '@/assets/images/transfer-old-app-dark.png'
 import TransferOldAppLight from '@/assets/images/transfer-old-app-light.png'
 import { ColorSchemeName } from 'react-native'
@@ -27,8 +26,6 @@ export const DataTransferView = ({
 }: DataTransferViewProps) => {
   return (
     <YStack flex={1} paddingTop={'$4'} testID="data-transfer-screen">
-      <StatusBar style="light" />
-
       {/* Content */}
       <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginBottom={'$4'}>
         <YStack gap="$4" alignItems="center">

--- a/apps/mobile/src/features/DataImport/components/EnterPasswordView.tsx
+++ b/apps/mobile/src/features/DataImport/components/EnterPasswordView.tsx
@@ -4,7 +4,6 @@ import { SafeButton } from '@/src/components/SafeButton'
 import { KeyboardAvoidingView } from 'react-native'
 import { Alert } from '@/src/components/Alert'
 import { SafeInput } from '@/src/components/SafeInput'
-import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 interface EnterPasswordViewProps {
   topInset: number
@@ -29,8 +28,6 @@ export const EnterPasswordView = ({
     <KeyboardAvoidingView behavior="padding" style={{ flex: 1 }} keyboardVerticalOffset={bottomInset + topInset}>
       <ScrollView contentContainerStyle={{ flex: 1 }}>
         <YStack flex={1} testID="enter-password-screen">
-          <SafeStatusBar />
-
           {/* Content */}
           <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>
             <YStack gap="$6">

--- a/apps/mobile/src/features/DataImport/components/FileSelectionView.tsx
+++ b/apps/mobile/src/features/DataImport/components/FileSelectionView.tsx
@@ -4,7 +4,6 @@ import { SafeButton } from '@/src/components/SafeButton'
 import ImportDataSelectFilesDark from '@/assets/images/import-data-select-files-dark.png'
 import ImportDataSelectFilesLight from '@/assets/images/import-data-select-files-light.png'
 import { ColorSchemeName, TouchableOpacity } from 'react-native'
-import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 const StyledText = styled(Text, {
   fontSize: '$4',
@@ -29,8 +28,6 @@ interface FileSelectionViewProps {
 export const FileSelectionView = ({ colorScheme, bottomInset, onFileSelect, onImagePress }: FileSelectionViewProps) => {
   return (
     <YStack flex={1} testID="file-selection-screen" paddingBottom={bottomInset}>
-      <SafeStatusBar />
-
       {/* Content */}
       <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>
         <YStack gap="$4" flex={1}>

--- a/apps/mobile/src/features/DataImport/components/HelpImportView.tsx
+++ b/apps/mobile/src/features/DataImport/components/HelpImportView.tsx
@@ -3,7 +3,6 @@ import { Text, YStack, XStack, styled, H2 } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
 import { TouchableOpacity } from 'react-native'
 import { Badge } from '@/src/components/Badge'
-import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 const StepText = styled(Text, {
   fontSize: '$4',
@@ -30,8 +29,6 @@ interface HelpImportViewProps {
 export const HelpImportView = ({ bottomInset, onPressProceedToImport, onPressNeedHelp }: HelpImportViewProps) => {
   return (
     <YStack flex={1} testID="help-import-screen">
-      <SafeStatusBar />
-
       {/* Content */}
       <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>
         <YStack gap="$6">

--- a/apps/mobile/src/features/DataImport/components/ImportProgressScreenView.tsx
+++ b/apps/mobile/src/features/DataImport/components/ImportProgressScreenView.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Text, YStack, H2, ScrollView, View } from 'tamagui'
 import { Bar } from 'react-native-progress'
-import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 interface ImportProgressScreenViewProps {
   progress: number
@@ -11,8 +10,6 @@ export const ImportProgressScreenView = ({ progress }: ImportProgressScreenViewP
   return (
     <ScrollView contentContainerStyle={{ flex: 1 }}>
       <YStack flex={1} testID="import-progress-screen">
-        <SafeStatusBar />
-
         {/* Content */}
         <YStack flex={1} paddingHorizontal="$4" justifyContent="center" alignItems="center">
           <YStack gap="$6" alignItems="center" maxWidth={300}>

--- a/apps/mobile/src/features/DataImport/components/ReviewDataView.tsx
+++ b/apps/mobile/src/features/DataImport/components/ReviewDataView.tsx
@@ -4,7 +4,6 @@ import { SafeButton } from '@/src/components/SafeButton'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Container } from '@/src/components/Container'
 import { Badge } from '@/src/components/Badge'
-import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
 
 interface ImportSummary {
   safeAccountsCount: number
@@ -28,8 +27,6 @@ export const ReviewDataView = ({
   return (
     <ScrollView contentContainerStyle={{ flex: 1 }}>
       <YStack flex={1} testID="review-data-screen">
-        <SafeStatusBar />
-
         {/* Content */}
         <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>
           <YStack gap="$6">

--- a/apps/mobile/src/features/Onboarding/components/OnboardingCarousel/OnboardingCarousel.tsx
+++ b/apps/mobile/src/features/Onboarding/components/OnboardingCarousel/OnboardingCarousel.tsx
@@ -9,7 +9,6 @@ import { useRouter } from 'expo-router'
 import { useAppDispatch } from '@/src/store/hooks'
 import { updateSettings } from '@/src/store/settingsSlice'
 import { ONBOARDING_VERSION } from '@/src/config/constants'
-import { StatusBar } from 'expo-status-bar'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 interface OnboardingCarouselProps {
@@ -42,7 +41,6 @@ export function OnboardingCarousel({ items }: OnboardingCarouselProps) {
         paddingBottom={'$4'}
         paddingTop={'$4'}
       >
-        <StatusBar style="light" />
         <View flex={1}>
           <Tabs.Container
             onTabChange={(event) => setActiveTab(event.tabName)}

--- a/apps/mobile/src/theme/SafeStatusBar.tsx
+++ b/apps/mobile/src/theme/SafeStatusBar.tsx
@@ -21,5 +21,9 @@ export const SafeStatusBar = () => {
 
   const isDarkScreen = DARK_SCREENS.includes(currentRoute)
 
-  return <StatusBar style={isDarkScreen ? 'light' : currentTheme === 'dark' ? 'light' : 'dark'} />
+  if (isDarkScreen) {
+    return <StatusBar style="light" />
+  }
+
+  return <StatusBar style={currentTheme === 'dark' ? 'light' : 'dark'} />
 }

--- a/apps/mobile/src/theme/SafeStatusBar.tsx
+++ b/apps/mobile/src/theme/SafeStatusBar.tsx
@@ -1,8 +1,25 @@
 import { StatusBar } from 'expo-status-bar'
+import { useSegments } from 'expo-router'
 import { useTheme } from '@/src/theme/hooks/useTheme'
+
+const DARK_SCREENS = [
+  'onboarding',
+  'enter-password',
+  'file-selection',
+  'help-import',
+  'import-error',
+  'import-progress',
+  'import-success',
+  'import-data',
+  'review-data',
+]
 
 export const SafeStatusBar = () => {
   const { currentTheme } = useTheme()
+  const segments = useSegments()
+  const currentRoute = segments[segments.length - 1]
 
-  return <StatusBar style={currentTheme === 'dark' ? 'light' : 'dark'} />
+  const isDarkScreen = DARK_SCREENS.includes(currentRoute)
+
+  return <StatusBar style={isDarkScreen ? 'light' : currentTheme === 'dark' ? 'light' : 'dark'} />
 }

--- a/apps/mobile/src/theme/__tests__/SafeStatusBar.test.tsx
+++ b/apps/mobile/src/theme/__tests__/SafeStatusBar.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { StatusBar } from 'expo-status-bar'
+import { SafeStatusBar } from '../SafeStatusBar'
+
+const mockUseTheme = jest.fn()
+jest.mock('@/src/theme/hooks/useTheme', () => ({
+  useTheme: () => ({ currentTheme: mockUseTheme() }),
+}))
+
+const mockUseSegments = jest.fn()
+jest.mock('expo-router', () => ({
+  useSegments: () => mockUseSegments(),
+}))
+
+describe('SafeStatusBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders light style for dark screens regardless of theme', () => {
+    mockUseTheme.mockReturnValue('dark')
+    mockUseSegments.mockReturnValue(['root', 'onboarding'])
+    const { UNSAFE_getByType } = render(<SafeStatusBar />)
+
+    expect(UNSAFE_getByType(StatusBar).props.style).toBe('light')
+  })
+
+  it('renders light style when theme is dark and not dark screen', () => {
+    mockUseTheme.mockReturnValue('dark')
+    mockUseSegments.mockReturnValue(['home'])
+    const { UNSAFE_getByType } = render(<SafeStatusBar />)
+
+    expect(UNSAFE_getByType(StatusBar).props.style).toBe('light')
+  })
+
+  it('renders dark style when theme is light and not dark screen', () => {
+    mockUseTheme.mockReturnValue('light')
+    mockUseSegments.mockReturnValue(['home'])
+    const { UNSAFE_getByType } = render(<SafeStatusBar />)
+
+    expect(UNSAFE_getByType(StatusBar).props.style).toBe('dark')
+  })
+})


### PR DESCRIPTION
## What it solves

Resolves [MOB-107](https://linear.app/safe-global/issue/MOB-107/mobile-light-mode-status-bar-is-white)

## How this PR fixes it

- Removes all `StatusBar` except the one in _layout
- Adds `DARK_SCREENS` array
- Checks in `SafeStatusBar` if current screen should be dark or light

## How to test it

1. Open the app and go to the onboarding screen
2. Toggle with cmd+shift+a
3. Observe the Status bar doesn't change
4. Go into the app and select light/dark mode in settings
5. Toggle with cmd+shift+a
6. Observe the status bar not changing

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
