### PR TITLE
Fix(Mobile): Add loading state to tenderly check

### DIFF
--- a/apps/mobile/src/features/TransactionChecks/components/TransactionChecksView.tsx
+++ b/apps/mobile/src/features/TransactionChecks/components/TransactionChecksView.tsx
@@ -18,34 +18,20 @@ import { InfoSheet } from '@/src/components/InfoSheet'
 type Props = {
   tenderly: {
     enabled: boolean
-  } & (
-    | {
-        enabled: true
-        fetchStatus: FETCH_STATUS
-        simulationLink: string
-        simulation?: TenderlySimulation
-      }
-    | {
-        enabled: false
-      }
-  )
-  blockaid?: {
+    fetchStatus: FETCH_STATUS
+    simulationLink: string
+    simulation?: TenderlySimulation
+  }
+  blockaid: {
     enabled: boolean
-  } & (
-    | {
-        enabled: boolean
-        loading: boolean
-        error?: Error
-        payload?: SecurityResponse<BlockaidModuleResponse>
-      }
-    | {
-        enabled: false
-      }
-  )
+    loading: boolean
+    error?: Error
+    payload?: SecurityResponse<BlockaidModuleResponse>
+  }
 }
 
 export const TransactionChecksView = ({ tenderly, blockaid }: Props) => {
-  const { enabled } = tenderly
+  const { enabled, fetchStatus } = tenderly
   const { handleScroll } = useScrollableHeader({
     children: <NavBarTitle>Transaction checks</NavBarTitle>,
   })
@@ -56,17 +42,13 @@ export const TransactionChecksView = ({ tenderly, blockaid }: Props) => {
         <LargeHeaderTitle marginBottom={'$5'}>Transaction checks</LargeHeaderTitle>
       </View>
       <YStack gap={'$4'}>
-        {blockaid && (
-          <>
-            <Container gap={'$3'}>
-              {blockaid.enabled ? (
-                <BlockaidBalanceChanges blockaidResponse={blockaid.payload} fetchStatusLoading={blockaid.loading} />
-              ) : (
-                <Text>Security check is disabled</Text>
-              )}
-            </Container>
-          </>
-        )}
+        <Container gap={'$3'}>
+          {blockaid.enabled ? (
+            <BlockaidBalanceChanges blockaidResponse={blockaid.payload} fetchStatusLoading={blockaid.loading} />
+          ) : (
+            <Text>Security check is disabled</Text>
+          )}
+        </Container>
         <Container gap={'$3'}>
           {enabled ? (
             <>
@@ -79,7 +61,17 @@ export const TransactionChecksView = ({ tenderly, blockaid }: Props) => {
                   />
                 </XStack>
 
-                {tenderly?.simulation?.simulation.status ? (
+                {fetchStatus === FETCH_STATUS.LOADING ? (
+                  <Badge
+                    circular={false}
+                    content={
+                      <XStack gap={'$2'} justifyContent="center" alignItems="center">
+                        <CircleSnail size={12} borderWidth={0} thickness={1} />
+                        <Text fontSize={12}>Loading</Text>
+                      </XStack>
+                    }
+                  />
+                ) : tenderly.simulation?.simulation.status ? (
                   <Badge
                     circular={false}
                     themeName="badge_success_variant1"
@@ -117,7 +109,7 @@ export const TransactionChecksView = ({ tenderly, blockaid }: Props) => {
           )}
         </Container>
 
-        {blockaid && blockaid.enabled && <BlockaidWarning blockaidResponse={blockaid.payload} />}
+        {blockaid.enabled && <BlockaidWarning blockaidResponse={blockaid.payload} />}
       </YStack>
     </ScrollView>
   )


### PR DESCRIPTION
## What it solves

Resolves [MOB-109](https://linear.app/safe-global/issue/MOB-109/mobile-failed-tenderly-state-is-shown-while-loading)

## How this PR fixes it

- Adds a loading state to the tenderly scan
- Simplifies tenderly and blockaid types

## How to test it

1. Open the app
2. Go to a transaction
3. Press the transaction checks button
4. Observe a loading state

## Screenshots

<img width="403" height="208" alt="Screenshot 2025-07-10 at 15 41 58" src="https://github.com/user-attachments/assets/db9617af-21f3-40bd-b86c-427fa65dc53e" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
