### PR TITLE
Fix(Mobile): Update bottom tab navigation style

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -2,12 +2,33 @@ import { Tabs } from 'expo-router'
 import React from 'react'
 import { TabBarIcon } from '@/src/components/navigation/TabBarIcon'
 import { Navbar as AssetsNavbar } from '@/src/features/Assets/components/Navbar/Navbar'
-import { Pressable, StyleSheet } from 'react-native'
+import { Pressable, StyleSheet, useColorScheme } from 'react-native'
+import { getTokenValue } from 'tamagui'
 
 export default function TabLayout() {
+  const colorScheme = useColorScheme()
+
+  let activeTintColor, inactiveTintColor, borderTopColor
+  if (colorScheme === 'light') {
+    activeTintColor = getTokenValue('$color.textPrimaryLight')
+    inactiveTintColor = getTokenValue('$color.primaryLightLight')
+    borderTopColor = getTokenValue('$color.borderLightLight')
+  } else {
+    activeTintColor = getTokenValue('$color.textPrimaryDark')
+    inactiveTintColor = getTokenValue('$color.primaryLightDark')
+    borderTopColor = getTokenValue('$color.borderLightDark')
+  }
+
   return (
     <>
-      <Tabs screenOptions={{ tabBarShowLabel: false, tabBarStyle: styles.tabBar }}>
+      <Tabs
+        screenOptions={{
+          tabBarStyle: { ...styles.tabBar, borderTopColor },
+          tabBarLabelStyle: styles.label,
+          tabBarActiveTintColor: activeTintColor,
+          tabBarInactiveTintColor: inactiveTintColor,
+        }}
+      >
         <Tabs.Screen
           name="index"
           options={{
@@ -21,7 +42,7 @@ export default function TabLayout() {
                 </Pressable>
               )
             },
-            tabBarIcon: ({ color }) => <TabBarIcon name={'token'} color={color} />,
+            tabBarIcon: ({ color }) => <TabBarIcon name={'home'} color={color} />,
           }}
         />
 
@@ -46,9 +67,9 @@ export default function TabLayout() {
           name="settings"
           options={() => {
             return {
-              title: 'Settings',
+              title: 'Account',
               headerShown: false,
-              tabBarButtonTestID: 'settings-tab',
+              tabBarButtonTestID: 'account-tab',
               tabBarButton: ({ children, ...rest }) => {
                 return (
                   <Pressable {...rest} style={styles.tabButton}>
@@ -70,9 +91,19 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    padding: 8,
   },
   tabBar: {
-    width: '60%',
+    width: '100%',
     margin: 'auto',
+    height: 64,
+    boxSizing: 'content-box',
+    borderTopWidth: 1,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: 400,
+    lineHeight: 16,
+    marginTop: 8,
   },
 })


### PR DESCRIPTION
## What it solves

Resolves [MOB-110](https://linear.app/safe-global/issue/MOB-110/mobile-tab-navigation-ui)

## How this PR fixes it

- Shows tab labels
- Uses different icon for home
- Renames Settings to Account

## How to test it

1. Open the app
2. Compare tab navigation with design

## Screenshots

<img width="421" height="234" alt="Screenshot 2025-07-10 at 16 47 05" src="https://github.com/user-attachments/assets/bc760e99-0ab1-4228-a943-974b82cb3c92" />

<img width="424" height="238" alt="Screenshot 2025-07-10 at 16 47 10" src="https://github.com/user-attachments/assets/b9cf6235-d0ae-4f2a-832d-1c968ea32e33" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
