### PR TITLE
Fix(Mobile): Tab color when switching theme

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -2,14 +2,15 @@ import { Tabs } from 'expo-router'
 import React from 'react'
 import { TabBarIcon } from '@/src/components/navigation/TabBarIcon'
 import { Navbar as AssetsNavbar } from '@/src/features/Assets/components/Navbar/Navbar'
-import { Pressable, StyleSheet, useColorScheme } from 'react-native'
+import { Pressable, StyleSheet } from 'react-native'
 import { getTokenValue } from 'tamagui'
+import { useTheme } from '@/src/theme/hooks/useTheme'
 
 export default function TabLayout() {
-  const colorScheme = useColorScheme()
+  const { currentTheme } = useTheme()
 
   let activeTintColor, inactiveTintColor, borderTopColor
-  if (colorScheme === 'light') {
+  if (currentTheme === 'light') {
     activeTintColor = getTokenValue('$color.textPrimaryLight')
     inactiveTintColor = getTokenValue('$color.primaryLightLight')
     borderTopColor = getTokenValue('$color.borderLightLight')


### PR DESCRIPTION
## What it solves

Resolves [MOB-110](https://linear.app/safe-global/issue/MOB-110/mobile-tab-navigation-ui)

## How this PR fixes it

- Uses `useTheme` for setting the colors in the tab navigation

## How to test it

1. Open the app
2. Switch to light or dark mode
3. Observe that the tab navigation color is correct

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
