### PR TITLE
fix(mobile): add transaction details to confirmation details

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -108,7 +108,10 @@ function RootLayout() {
                             <Stack.Screen name="pending-transactions" options={{ headerShown: true, title: '' }} />
                             <Stack.Screen name="notifications-center" options={{ headerShown: true, title: '' }} />
                             <Stack.Screen name="notifications-settings" options={{ headerShown: true, title: '' }} />
-                            <Stack.Screen name="transaction-parameters" options={{ headerShown: true, title: '' }} />
+                            <Stack.Screen
+                              name="transaction-parameters"
+                              options={{ headerShown: true, title: 'Transaction Details' }}
+                            />
                             <Stack.Screen name="transaction-actions" options={{ headerShown: true, title: '' }} />
                             <Stack.Screen name="action-details" options={{ headerShown: true, title: '' }} />
                             <Stack.Screen name="address-book" options={{ headerShown: true, title: '' }} />

--- a/apps/mobile/src/app/pending-transactions.tsx
+++ b/apps/mobile/src/app/pending-transactions.tsx
@@ -3,11 +3,7 @@ import React from 'react'
 import { PendingTxContainer } from '@/src/features/PendingTx'
 
 function PendingScreen() {
-  return (
-    <View paddingHorizontal={'$3'}>
-      <PendingTxContainer />
-    </View>
-  )
+  return <PendingTxContainer />
 }
 
 export default PendingScreen

--- a/apps/mobile/src/app/pending-transactions.tsx
+++ b/apps/mobile/src/app/pending-transactions.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { View } from 'tamagui'
 
 import { PendingTxContainer } from '@/src/features/PendingTx'
 

--- a/apps/mobile/src/app/transaction-parameters/_layout.tsx
+++ b/apps/mobile/src/app/transaction-parameters/_layout.tsx
@@ -14,13 +14,7 @@ export default function TransactionsParametersLayout() {
       <Stack.Screen
         name="(tabs)"
         options={() => ({
-          headerTitle: (props) => (
-            <View width="100%" flex={1} marginTop={2}>
-              <LargeHeaderTitle fontWeight={600} {...props}>
-                Transaction details
-              </LargeHeaderTitle>
-            </View>
-          ),
+          headerShown: false,
         })}
       />
     </Stack>

--- a/apps/mobile/src/app/transaction-parameters/_layout.tsx
+++ b/apps/mobile/src/app/transaction-parameters/_layout.tsx
@@ -1,7 +1,5 @@
 import { Stack } from 'expo-router'
 import React from 'react'
-import { View } from 'tamagui'
-import { LargeHeaderTitle } from '@/src/components/Title'
 
 export default function TransactionsParametersLayout() {
   return (

--- a/apps/mobile/src/components/transactions-list/Card/TxBridgeCard/TxBridgeCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxBridgeCard/TxBridgeCard.tsx
@@ -21,7 +21,7 @@ export function TxBridgeCard({ txInfo, bordered, executionInfo, inQueue, onPress
 
   const fromAmountFormatted = formatUnits(actualFromAmount, txInfo.fromToken.decimals)
   const toAmountFormatted =
-    txInfo.toAmount && txInfo.toToken ? formatUnits(txInfo.toAmount, txInfo.toToken.decimals) : '?'
+    txInfo.toAmount && txInfo.toToken ? formatUnits(txInfo.toAmount, txInfo.toToken.decimals) : ''
 
   const statusText = (() => {
     switch (txInfo.status) {
@@ -81,9 +81,11 @@ export function TxBridgeCard({ txInfo, bordered, executionInfo, inQueue, onPress
       }
       rightNode={
         <View alignItems="flex-end">
-          <Text color="$primary">
-            +{ellipsis(toAmountFormatted, 10)} {txInfo.toToken?.symbol ?? '?'}
-          </Text>
+          {(txInfo.toAmount || txInfo.toToken) && (
+            <Text color="$primary">
+              +{ellipsis(toAmountFormatted, 10)} {txInfo.toToken?.symbol ?? ''}
+            </Text>
+          )}
           <Text fontSize="$3">
             −{ellipsis(fromAmountFormatted, 10)} {txInfo.fromToken.symbol}
           </Text>

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
@@ -140,13 +140,7 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
         />
       )
     case ETxType.BRIDGE_ORDER:
-      return (
-        <BridgeTransaction
-          txId={txDetails.txId}
-          executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
-          txInfo={txDetails.txInfo as BridgeAndSwapTransactionInfo}
-        />
-      )
+      return <BridgeTransaction txId={txDetails.txId} txInfo={txDetails.txInfo as BridgeAndSwapTransactionInfo} />
     case ETxType.LIFI_SWAP:
       return (
         <LifiSwapTransaction

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
@@ -142,16 +142,16 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
     case ETxType.BRIDGE_ORDER:
       return (
         <BridgeTransaction
-          _txId={txDetails.txId}
-          _executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
+          txId={txDetails.txId}
+          executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
           txInfo={txDetails.txInfo as BridgeAndSwapTransactionInfo}
         />
       )
     case ETxType.LIFI_SWAP:
       return (
         <LifiSwapTransaction
-          _txId={txDetails.txId}
-          _executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
+          txId={txDetails.txId}
+          executionInfo={txDetails.detailedExecutionInfo as MultisigExecutionDetails}
           txInfo={txDetails.txInfo as SwapTransactionInfo}
         />
       )

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/BridgeTransaction/BridgeTransaction.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/BridgeTransaction/BridgeTransaction.tsx
@@ -15,14 +15,15 @@ import { type ListTableItem } from '../../ListTable'
 import { Alert2 } from '@/src/components/Alert2'
 import { BridgeRecipientWarnings } from './BridgeRecipientWarnings'
 import { ChainIndicator } from '@/src/components/ChainIndicator'
+import { ParametersButton } from '../../ParametersButton'
 
 interface BridgeTransactionProps {
-  _txId: string
-  _executionInfo: MultisigExecutionDetails
+  txId: string
+  executionInfo: MultisigExecutionDetails
   txInfo: BridgeAndSwapTransactionInfo
 }
 
-export function BridgeTransaction({ _txId, _executionInfo, txInfo }: BridgeTransactionProps) {
+export function BridgeTransaction({ txId, txInfo }: BridgeTransactionProps) {
   const activeSafe = useDefinedActiveSafe()
   const chain = useAppSelector((state) => selectChainById(state, activeSafe.chainId))
 
@@ -153,7 +154,9 @@ export function BridgeTransaction({ _txId, _executionInfo, txInfo }: BridgeTrans
 
   return (
     <YStack gap="$4">
-      <ListTable items={bridgeItems} />
+      <ListTable items={bridgeItems}>
+        <ParametersButton txId={txId} />
+      </ListTable>
 
       <BridgeRecipientWarnings txInfo={txInfo} />
 

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/BridgeTransaction/BridgeTransaction.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/BridgeTransaction/BridgeTransaction.tsx
@@ -1,10 +1,7 @@
 import React, { useMemo } from 'react'
 import { YStack, Text, View } from 'tamagui'
 import { ListTable } from '../../ListTable'
-import {
-  MultisigExecutionDetails,
-  BridgeAndSwapTransactionInfo,
-} from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { BridgeAndSwapTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectChainById } from '@/src/store/chains'
@@ -19,7 +16,6 @@ import { ParametersButton } from '../../ParametersButton'
 
 interface BridgeTransactionProps {
   txId: string
-  executionInfo: MultisigExecutionDetails
   txInfo: BridgeAndSwapTransactionInfo
 }
 

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/LifiSwapTransaction/LifiSwapTransaction.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/LifiSwapTransaction/LifiSwapTransaction.tsx
@@ -6,14 +6,15 @@ import { formatUnits } from 'ethers'
 import { EthAddress } from '@/src/components/EthAddress'
 import { type ListTableItem } from '../../ListTable'
 import { LifiSwapHeader } from './LifiSwapHeader'
+import { ParametersButton } from '../../ParametersButton'
 
 interface LifiSwapTransactionProps {
-  _txId: string
-  _executionInfo: MultisigExecutionDetails
+  txId: string
+  executionInfo: MultisigExecutionDetails
   txInfo: SwapTransactionInfo
 }
 
-export function LifiSwapTransaction({ _txId, _executionInfo, txInfo }: LifiSwapTransactionProps) {
+export function LifiSwapTransaction({ txId, executionInfo, txInfo }: LifiSwapTransactionProps) {
   const lifiSwapItems = useMemo(() => {
     const items: ListTableItem[] = []
 
@@ -63,8 +64,10 @@ export function LifiSwapTransaction({ _txId, _executionInfo, txInfo }: LifiSwapT
 
   return (
     <YStack gap="$4">
-      <LifiSwapHeader txInfo={txInfo} executionInfo={_executionInfo} />
-      <ListTable items={lifiSwapItems} />
+      <LifiSwapHeader txInfo={txInfo} executionInfo={executionInfo} />
+      <ListTable items={lifiSwapItems}>
+        <ParametersButton txId={txId} />
+      </ListTable>
     </YStack>
   )
 }

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrder.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/SwapOrder/SwapOrder.tsx
@@ -17,6 +17,7 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Badge } from '@/src/components/Badge'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { useRouter } from 'expo-router'
+import { ParametersButton } from '@/src/features/ConfirmTx/components/ParametersButton'
 
 interface SwapOrderProps {
   executionInfo: MultisigExecutionDetails
@@ -57,7 +58,9 @@ export function SwapOrder({ executionInfo, txInfo, decodedData, txId }: SwapOrde
       {isChangingFallbackHandler && <TwapFallbackHandlerWarning />}
       <SwapOrderHeader executionInfo={executionInfo} txInfo={txInfo} />
 
-      <ListTable items={swapItems} />
+      <ListTable items={swapItems}>
+        <ParametersButton txId={txId} />
+      </ListTable>
       {recipientItems.length > 0 && <ListTable items={recipientItems} />}
       {isTwapOrder && <ListTable items={twapItems} />}
 

--- a/apps/mobile/src/features/PendingTx/components/PendingTxList/PendingTxList.container.tsx
+++ b/apps/mobile/src/features/PendingTx/components/PendingTxList/PendingTxList.container.tsx
@@ -69,6 +69,7 @@ export function PendingTxListContainer({
       renderSectionHeader={({ section: { title } }) => <SafeListItem.Header title={title} />}
       onScroll={handleScroll}
       scrollEventThrottle={16}
+      contentContainerStyle={{ paddingHorizontal: 12 }}
     />
   )
 }


### PR DESCRIPTION
## What it solves
- adds tx details button to swap txs
- adds tx details buttons to bridge txs
- move padding to inside the scrollview (this way the scrollview bars are attached to the edge of the screen and not 12px in the middle)

related to https://linear.app/safe-global/issue/MOB-11/


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
