### PR TITLE
Fix(Mobile): Update badge color, fix settings button overlap

### DIFF
--- a/apps/mobile/src/components/Badge/theme.ts
+++ b/apps/mobile/src/components/Badge/theme.ts
@@ -33,14 +33,6 @@ export const badgeTheme = {
     color: tokens.color.warning1ContrastTextDark,
     background: tokens.color.warningBackgroundDark,
   },
-  light_badge_warning_variant1: {
-    color: tokens.color.warning1TextLight,
-    background: tokens.color.warning1ContrastTextLight,
-  },
-  dark_badge_warning_variant1: {
-    color: tokens.color.warning1ContrastTextDark,
-    background: tokens.color.warningDarkDark,
-  },
   light_badge_warning_variant2: {
     color: tokens.color.warning1TextLight,
     background: tokens.color.warning1ContrastTextLight,

--- a/apps/mobile/src/components/transactions-list/Card/AccountCard/AccountCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/AccountCard/AccountCard.tsx
@@ -58,7 +58,8 @@ export function AccountCard({
           <IdenticonWithBadge
             testID="threshold-info-badge"
             size={40}
-            fontSize={owners > 9 ? 8 : 12}
+            badgeSize={24}
+            fontSize={owners > 9 ? 9 : 12}
             address={address}
             badgeContent={`${threshold}/${owners}`}
           />

--- a/apps/mobile/src/components/transactions-list/Card/AssetsCard/AssetsCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/AssetsCard/AssetsCard.tsx
@@ -6,7 +6,7 @@ import { ellipsis } from '@/src/utils/formatters'
 
 interface AssetsCardProps {
   name: string
-  description: string
+  description?: string
   logoUri?: string | null
   rightNode?: string | React.ReactNode
   accessibilityLabel?: string
@@ -33,9 +33,11 @@ export function AssetsCard({
           <Text fontSize="$4" fontWeight={600} lineHeight={20}>
             {name}
           </Text>
-          <Text fontSize="$4" color="$colorSecondary" fontWeight={400} lineHeight={20}>
-            {description}
-          </Text>
+          {description && (
+            <Text fontSize="$4" color="$colorSecondary" fontWeight={400} lineHeight={20}>
+              {description}
+            </Text>
+          )}
         </View>
       }
       transparent={transparent}

--- a/apps/mobile/src/features/AddressBook/Contact/NetworkSelector/ChainItem.tsx
+++ b/apps/mobile/src/features/AddressBook/Contact/NetworkSelector/ChainItem.tsx
@@ -27,7 +27,6 @@ export const ChainItem = ({ chain, isSelected, isReadOnly, onToggle }: ChainItem
         <AssetsCard
           name={chain.chainName}
           logoUri={chain.chainLogoUri}
-          description={chain.description || `Chain ID: ${chain.chainId}`}
           rightNode={!isReadOnly && isSelected && <SafeFontIcon name="check" color="$color" />}
         />
       </View>

--- a/apps/mobile/src/features/AddressBook/Contact/components/ContactNetworkRow.tsx
+++ b/apps/mobile/src/features/AddressBook/Contact/components/ContactNetworkRow.tsx
@@ -37,7 +37,7 @@ export const ContactNetworkRow = ({ onPress, chainIds }: ContactNetworkRowProps)
             <Text fontSize="$4" fontWeight="400" color="$colorSecondary">
               {displayText}
             </Text>
-            <SafeFontIcon name="chevron-right" color="$colorTransparent" size={16} />
+            <SafeFontIcon name="chevron-right" size={16} />
           </View>
         </View>
       </Pressable>

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationsInfo/ConfirmationsInfo.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationsInfo/ConfirmationsInfo.tsx
@@ -41,7 +41,7 @@ export function ConfirmationsInfo({ detailedExecutionInfo, txId }: Confirmations
                 </Text>
               </View>
             }
-            themeName={hasEnoughConfirmations ? 'badge_success_variant1' : 'badge_warning_variant1'}
+            themeName={hasEnoughConfirmations ? 'badge_success_variant1' : 'badge_warning'}
           />
 
           <SafeFontIcon name="chevron-right" />

--- a/apps/mobile/src/features/ConfirmationsSheet/ConfirmationsSheet.container.tsx
+++ b/apps/mobile/src/features/ConfirmationsSheet/ConfirmationsSheet.container.tsx
@@ -76,7 +76,7 @@ export const ConfirmationsSheetContainer = () => {
                     </Text>
                   </View>
                 }
-                themeName={hasSigned ? 'badge_success_variant1' : 'badge_warning_variant1'}
+                themeName={hasSigned ? 'badge_success_variant1' : 'badge_warning'}
               />
             }
           />

--- a/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
@@ -54,14 +54,12 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
           testID={'settings-screen-header-app-settings-button'}
           hitSlop={6}
           onPressIn={() => {
-            console.log('Starting to press')
             try {
               const event = createAppSettingsOpenEvent()
               trackEvent(event)
             } catch (error) {
               console.error('Error tracking app settings open event:', error)
             }
-            console.log('Navigating')
             router.push('/app-settings')
           }}
         >

--- a/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
@@ -47,18 +47,21 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
           alignItems: 'center',
           justifyContent: 'flex-end',
           gap: 10,
+          zIndex: 1,
         }}
       >
         <Pressable
           testID={'settings-screen-header-app-settings-button'}
           hitSlop={6}
           onPressIn={() => {
+            console.log('Starting to press')
             try {
               const event = createAppSettingsOpenEvent()
               trackEvent(event)
             } catch (error) {
               console.error('Error tracking app settings open event:', error)
             }
+            console.log('Navigating')
             router.push('/app-settings')
           }}
         >


### PR DESCRIPTION
## What it solves

Resolves Settings issue

## How this PR fixes it

- The settings button was overlapped by the settings container so I added a zIndex to it
- Replaced all `badge_warning_variant1` with `badge_warning` to fix color issues
- Removes the chain id / description from network items in address book

## How to test it

1. Open the app
2. Go to account
3. Press the settings button
4. It should navigate
5. Go to a pending transaction
6. The confirmations badge should have the correct color

## Screenshots
<img width="386" height="227" alt="Screenshot 2025-07-10 at 20 38 38" src="https://github.com/user-attachments/assets/a717e463-79c0-4b7b-ae17-aae8f905a02d" />
<img width="394" height="176" alt="Screenshot 2025-07-10 at 20 38 56" src="https://github.com/user-attachments/assets/090e2866-51d1-4178-a299-f40c1e5827fb" />
<img width="372" height="247" alt="Screenshot 2025-07-10 at 20 39 04" src="https://github.com/user-attachments/assets/84ede82f-0963-46a6-a887-e7d8ac361a4b" />
<img width="397" height="264" alt="Screenshot 2025-07-10 at 20 39 09" src="https://github.com/user-attachments/assets/1a928b30-bdb8-4df0-a1fa-7e23e7a612fa" />
<img width="374" height="722" alt="Screenshot 2025-07-10 at 20 48 12" src="https://github.com/user-attachments/assets/2d77d131-83a9-4dce-a482-d0ddab56f11a" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
