### PR TITLE
Fix(Earn): Rename reward rate to Earn, remove reward rate from withdraw

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -12,11 +12,11 @@ export default function TabLayout() {
   let activeTintColor, inactiveTintColor, borderTopColor
   if (currentTheme === 'light') {
     activeTintColor = getTokenValue('$color.textPrimaryLight')
-    inactiveTintColor = getTokenValue('$color.primaryLightLight')
+    inactiveTintColor = getTokenValue('$color.borderMainLight')
     borderTopColor = getTokenValue('$color.borderLightLight')
   } else {
     activeTintColor = getTokenValue('$color.textPrimaryDark')
-    inactiveTintColor = getTokenValue('$color.primaryLightDark')
+    inactiveTintColor = getTokenValue('$color.borderMainDark')
     borderTopColor = getTokenValue('$color.borderLightDark')
   }
 

--- a/apps/mobile/src/features/ConfirmTx/components/ListTable/ListTable.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ListTable/ListTable.tsx
@@ -22,15 +22,17 @@ export type ListTableItem = RenderRowItem | LabelValueItem
 interface ListTableProps {
   items: ListTableItem[]
   children?: React.ReactNode
+  padding?: string
+  gap?: string
 }
 
 const isRenderRowItem = (item: ListTableItem): item is RenderRowItem => {
   return (item as RenderRowItem).renderRow !== undefined
 }
 
-export const ListTable = ({ items, children }: ListTableProps) => {
+export const ListTable = ({ items, children, padding = '$4', gap = '$5' }: ListTableProps) => {
   return (
-    <Container padding="$4" gap="$5" borderRadius="$3">
+    <Container padding={padding} gap={gap} borderRadius="$3">
       {items.map((item, index) => {
         return (
           <View

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/VaultDeposit/VaultDeposit.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/VaultDeposit/VaultDeposit.tsx
@@ -27,15 +27,19 @@ const AdditionalRewards = ({ txInfo }: { txInfo: VaultDepositTransactionInfo }) 
 
   return (
     <Container padding="$4" gap="$2">
-      <Text fontWeight="600">Additional reward</Text>
+      <Text fontWeight="600" marginBottom="$2">
+        Additional reward
+      </Text>
       <ListTable
+        padding="0"
+        gap="$4"
         items={[
           {
             label: 'Token',
             value: `${reward.tokenInfo.name} ${reward.tokenInfo.symbol}`,
           },
           {
-            label: 'Reward rate',
+            label: 'Earn',
             value: formatPercentage(txInfo.additionalRewardsNrr / 100),
           },
           {
@@ -44,7 +48,7 @@ const AdditionalRewards = ({ txInfo }: { txInfo: VaultDepositTransactionInfo }) 
           },
         ]}
       />
-      <XStack alignItems="center" gap="$1">
+      <XStack alignItems="center" gap="$1" marginTop="$2">
         <Text fontSize={12} color="$colorSecondary">
           Powered by
         </Text>
@@ -95,7 +99,7 @@ export function VaultDeposit({ txInfo, executionInfo, txId, decodedData }: Vault
         submittedAt={executionInfo.submittedAt}
       />
 
-      <ListTable items={[{ label: 'Earn (after fees)', value: formatPercentage(totalNrr) }, ...items]}>
+      <ListTable items={[{ label: 'Earn (after fees)', value: formatPercentage(totalNrr) }, ...items]} gap="$4">
         <ParametersButton txId={txId} />
       </ListTable>
 

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/VaultRedeem/VaultRedeem.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/VaultRedeem/VaultRedeem.tsx
@@ -27,20 +27,24 @@ const AdditionalRewards = ({ txInfo }: { txInfo: VaultRedeemTransactionInfo }) =
 
   return (
     <Container bordered padding="$4" gap="$2">
-      <Text fontWeight="600">Additional reward</Text>
+      <Text fontWeight="600" marginBottom="$2">
+        Additional reward
+      </Text>
       <ListTable
+        padding="0"
+        gap="$4"
         items={[
           {
             label: 'Token',
             value: `${reward.tokenInfo.name} ${reward.tokenInfo.symbol}`,
           },
           {
-            label: 'Reward rate',
+            label: 'Earn',
             value: formatPercentage(txInfo.additionalRewardsNrr / 100),
           },
         ]}
       />
-      <XStack alignItems="center" gap="$1">
+      <XStack alignItems="center" gap="$1" marginTop="$2">
         <Text fontSize={12} color="$colorSecondary">
           Powered by
         </Text>
@@ -60,8 +64,7 @@ interface VaultRedeemProps {
 }
 
 export function VaultRedeem({ txInfo, executionInfo, txId }: VaultRedeemProps) {
-  const totalNrr = (txInfo.baseNrr + txInfo.additionalRewardsNrr) / 100
-  const items = useMemo(() => formatVaultRedeemItems(txInfo, totalNrr), [txInfo, totalNrr])
+  const items = useMemo(() => formatVaultRedeemItems(txInfo), [txInfo])
 
   return (
     <YStack gap="$4">
@@ -84,7 +87,7 @@ export function VaultRedeem({ txInfo, executionInfo, txId }: VaultRedeemProps) {
         submittedAt={executionInfo.submittedAt}
       />
 
-      <ListTable items={items}>
+      <ListTable items={items} gap="$4">
         <ParametersButton txId={txId} />
       </ListTable>
 

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/VaultRedeem/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/VaultRedeem/utils.tsx
@@ -2,11 +2,10 @@ import React from 'react'
 import { View, Text } from 'tamagui'
 import { VaultRedeemTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { TokenAmount } from '@/src/components/TokenAmount'
-import { formatPercentage } from '@safe-global/utils/utils/formatters'
 import { ListTableItem } from '../../ListTable'
 import { Image } from 'expo-image'
 
-export const formatVaultRedeemItems = (txInfo: VaultRedeemTransactionInfo, totalNrr: number): ListTableItem[] => {
+export const formatVaultRedeemItems = (txInfo: VaultRedeemTransactionInfo): ListTableItem[] => {
   return [
     {
       label: 'Current reward',
@@ -28,10 +27,6 @@ export const formatVaultRedeemItems = (txInfo: VaultRedeemTransactionInfo, total
           </Text>
         </View>
       ),
-    },
-    {
-      label: 'Reward rate',
-      value: formatPercentage(totalNrr),
     },
   ]
 }

--- a/apps/web/src/features/earn/components/VaultDepositConfirmation/index.tsx
+++ b/apps/web/src/features/earn/components/VaultDepositConfirmation/index.tsx
@@ -25,7 +25,7 @@ const AdditionalRewards = ({ txInfo }: { txInfo: VaultDepositTransactionInfo }) 
             </Typography>
           </DataRow>,
 
-          <DataRow key="Reward rate" title="Reward rate">
+          <DataRow key="Earn" title="Earn">
             {formatPercentage(txInfo.additionalRewardsNrr / 100)}
           </DataRow>,
 

--- a/apps/web/src/features/earn/components/VaultDepositTxDetails/index.tsx
+++ b/apps/web/src/features/earn/components/VaultDepositTxDetails/index.tsx
@@ -18,7 +18,7 @@ const VaultDepositTxDetails = ({ info }: { info: VaultDepositTransactionInfo }) 
           decimals={info.tokenInfo.decimals}
         />
       </FieldsGrid>
-      <FieldsGrid title="Reward rate">{formatPercentage(totalNrr)}</FieldsGrid>
+      <FieldsGrid title="Earn (after fees)">{formatPercentage(totalNrr)}</FieldsGrid>
       <VaultDepositConfirmation txInfo={info} isTxDetails />
     </Box>
   )

--- a/apps/web/src/features/earn/components/VaultRedeemConfirmation/index.tsx
+++ b/apps/web/src/features/earn/components/VaultRedeemConfirmation/index.tsx
@@ -8,6 +8,7 @@ import { DataTable } from '@/components/common/Table/DataTable'
 import { DataRow } from '@/components/common/Table/DataRow'
 import IframeIcon from '@/components/common/IframeIcon'
 
+// TODO: Check if additional rewards can actually appear for a withdraw/redeem
 const AdditionalRewards = ({ txInfo }: { txInfo: VaultRedeemTransactionInfo }) => {
   if (!txInfo.additionalRewards[0]) return null
 
@@ -27,7 +28,7 @@ const AdditionalRewards = ({ txInfo }: { txInfo: VaultRedeemTransactionInfo }) =
             </Typography>
           </DataRow>,
 
-          <DataRow key="Reward rate" title="Reward rate">
+          <DataRow key="Earn" title="Earn">
             {formatPercentage(txInfo.additionalRewardsNrr / 100)}
           </DataRow>,
 
@@ -127,13 +128,24 @@ const VaultRedeemConfirmation = ({
   txInfo: VaultRedeemTransactionInfo
   isTxDetails?: boolean
 }) => {
-  const totalNrr = (txInfo.baseNrr + txInfo.additionalRewardsNrr) / 100
-
   return (
     <>
       <DataTable
         rows={[
           <>{!isTxDetails && <ConfirmationHeader txInfo={txInfo} />}</>,
+
+          <>
+            {isTxDetails && (
+              <DataRow key="Current reward" title="Current reward">
+                <TokenAmount
+                  value={txInfo.currentReward}
+                  tokenSymbol={txInfo.tokenInfo.symbol}
+                  decimals={txInfo.tokenInfo.decimals}
+                  logoUri={txInfo.tokenInfo.logoUri ?? undefined}
+                />
+              </DataRow>
+            )}
+          </>,
 
           <DataRow key="Withdraw from" title="Withdraw from">
             <Stack direction="row" alignItems="center">
@@ -142,10 +154,6 @@ const VaultRedeemConfirmation = ({
                 {txInfo.vaultInfo.name}
               </Typography>
             </Stack>
-          </DataRow>,
-
-          <DataRow key="Reward rate" title="Reward rate">
-            {formatPercentage(totalNrr)}
           </DataRow>,
 
           <AdditionalRewards key="Additional rewards" txInfo={txInfo} />,


### PR DESCRIPTION
## What it solves

Resolves [MOB-56](https://linear.app/safe-global/issue/MOB-56/mobile-kilnmorpho-decodingshow-transactions-on-mobile#comment-489578c8)

## How this PR fixes it

- Renames Reward rate to Earn (after fees)
- Renames Reward rate to Earn inside additional reward block
- Adds the current reward to the tx details on web
- Fixes layout issues with additional reward
- Slightly adjusts Tab color on mobile

## How to test it

1. Open the app
2. Go to pending transactions
3. View a deposit and withdraw
4. Observe no reward rate but instead Earn

## Screenshots

<img width="396" height="670" alt="Screenshot 2025-07-11 at 14 40 19" src="https://github.com/user-attachments/assets/cd109f67-404c-433c-9085-7a8f50b5154d" />
<img width="394" height="511" alt="Screenshot 2025-07-11 at 14 40 29" src="https://github.com/user-attachments/assets/f3bc0b63-de5d-4eca-a127-a9499d0883a9" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
