### PR TITLE
feat(mobile): integrate address book with Receiver component in transaction details

### DIFF
--- a/apps/mobile/src/components/Logo/Logo.test.tsx
+++ b/apps/mobile/src/components/Logo/Logo.test.tsx
@@ -14,4 +14,46 @@ describe('Logo', () => {
     expect(container.queryByTestId('logo-image')).not.toBeTruthy()
     expect(container.queryByTestId('logo-fallback-icon')).toBeTruthy()
   })
+
+  it('should show fallback when logoUri is not provided', () => {
+    const container = render(<Logo logoUri={null} />)
+
+    expect(container.queryByTestId('logo-image')).not.toBeTruthy()
+    expect(container.queryByTestId('logo-fallback-icon')).toBeTruthy()
+  })
+
+  it('should show fallback when logoUri is empty string', () => {
+    const container = render(<Logo logoUri="" />)
+
+    expect(container.queryByTestId('logo-image')).not.toBeTruthy()
+    expect(container.queryByTestId('logo-fallback-icon')).toBeTruthy()
+  })
+
+  it('should use custom fallback icon when specified', () => {
+    const container = render(<Logo fallbackIcon="wallet" />)
+
+    const fallbackIcon = container.getByTestId('logo-fallback-icon')
+    expect(fallbackIcon).toBeTruthy()
+  })
+
+  it('should render with custom size', () => {
+    const container = render(<Logo logoUri="http://something.com/my-image.png" size="$6" />)
+
+    // Initially, only fallback should be visible until image loads
+    expect(container.queryByTestId('logo-fallback-icon')).toBeTruthy()
+  })
+
+  it('should render with badge content when provided', () => {
+    const badgeContent = <span data-testid="badge-content">Badge</span>
+    const container = render(<Logo logoUri="http://something.com/my-image.png" badgeContent={badgeContent} />)
+
+    // Component should render without errors
+    expect(container.queryByTestId('logo-fallback-icon')).toBeTruthy()
+  })
+
+  it('should handle different image backgrounds', () => {
+    const container = render(<Logo logoUri="http://something.com/my-image.png" imageBackground="$colorPrimary" />)
+
+    expect(container.queryByTestId('logo-fallback-icon')).toBeTruthy()
+  })
 })

--- a/apps/mobile/src/components/Logo/Logo.tsx
+++ b/apps/mobile/src/components/Logo/Logo.tsx
@@ -15,6 +15,7 @@ interface LogoProps {
   logoUri?: string | null
   accessibilityLabel?: string
   fallbackIcon?: IconProps['name']
+  fallbackContent?: React.ReactNode
   imageBackground?: string
   size?: string
   badgeContent?: React.ReactElement
@@ -27,6 +28,7 @@ export function Logo({
   size = '$10',
   imageBackground = '$color',
   fallbackIcon = 'nft',
+  fallbackContent,
   badgeContent,
   badgeThemeName = 'badge_background',
 }: LogoProps) {
@@ -60,9 +62,11 @@ export function Logo({
           )}
 
           <Avatar.Fallback backgroundColor="$background">
-            <View backgroundColor="$background" padding="$2" borderRadius={100}>
-              <SafeFontIcon testID="logo-fallback-icon" name={fallbackIcon} color="$colorSecondary" />
-            </View>
+            {fallbackContent || (
+              <View backgroundColor="$background" padding="$2" borderRadius={100}>
+                <SafeFontIcon testID="logo-fallback-icon" name={fallbackIcon} color="$colorSecondary" />
+              </View>
+            )}
           </Avatar.Fallback>
         </Avatar>
       </View>

--- a/apps/mobile/src/components/Logo/Logo.tsx
+++ b/apps/mobile/src/components/Logo/Logo.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Avatar, Theme, View } from 'tamagui'
+import { Avatar, AvatarImageProps, Theme, View } from 'tamagui'
 import { IconProps, SafeFontIcon } from '../SafeFontIcon/SafeFontIcon'
 import { Badge } from '../Badge/Badge'
 import { badgeTheme } from '../Badge/theme'
@@ -7,6 +7,9 @@ import { badgeTheme } from '../Badge/theme'
 type BadgeThemeKeys = keyof typeof badgeTheme
 type ExtractAfterUnderscore<T extends string> = T extends `${string}_${infer Rest}` ? Rest : never
 export type BadgeThemeTypes = ExtractAfterUnderscore<BadgeThemeKeys>
+
+// Local loading status type
+type LoadingStatus = Parameters<Exclude<AvatarImageProps['onLoadingStatusChange'], undefined>>[0]
 
 interface LogoProps {
   logoUri?: string | null
@@ -27,6 +30,15 @@ export function Logo({
   badgeContent,
   badgeThemeName = 'badge_background',
 }: LogoProps) {
+  const [status, setStatus] = React.useState<LoadingStatus>('idle')
+
+  // Reset status when logoUri changes
+  React.useEffect(() => {
+    setStatus('idle')
+  }, [logoUri])
+
+  const shouldShowImage = logoUri && status !== 'error'
+
   return (
     <Theme name="logo">
       <View width={size}>
@@ -37,12 +49,13 @@ export function Logo({
         </View>
 
         <Avatar circular size={size}>
-          {logoUri && (
+          {shouldShowImage && (
             <Avatar.Image
               testID="logo-image"
               backgroundColor={imageBackground}
               accessibilityLabel={accessibilityLabel}
-              source={{ uri: logoUri }}
+              src={logoUri}
+              onLoadingStatusChange={setStatus}
             />
           )}
 

--- a/apps/mobile/src/components/Logo/Logo.tsx
+++ b/apps/mobile/src/components/Logo/Logo.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Avatar, AvatarImageProps, Theme, View } from 'tamagui'
+import { Avatar, Theme, View } from 'tamagui'
 import { IconProps, SafeFontIcon } from '../SafeFontIcon/SafeFontIcon'
 import { Badge } from '../Badge/Badge'
 import { badgeTheme } from '../Badge/theme'
@@ -7,9 +7,6 @@ import { badgeTheme } from '../Badge/theme'
 type BadgeThemeKeys = keyof typeof badgeTheme
 type ExtractAfterUnderscore<T extends string> = T extends `${string}_${infer Rest}` ? Rest : never
 export type BadgeThemeTypes = ExtractAfterUnderscore<BadgeThemeKeys>
-
-// Local loading status type
-type LoadingStatus = Parameters<Exclude<AvatarImageProps['onLoadingStatusChange'], undefined>>[0]
 
 interface LogoProps {
   logoUri?: string | null
@@ -32,15 +29,6 @@ export function Logo({
   badgeContent,
   badgeThemeName = 'badge_background',
 }: LogoProps) {
-  const [status, setStatus] = React.useState<LoadingStatus>('idle')
-
-  // Reset status when logoUri changes
-  React.useEffect(() => {
-    setStatus('idle')
-  }, [logoUri])
-
-  const shouldShowImage = logoUri && status !== 'error'
-
   return (
     <Theme name="logo">
       <View width={size}>
@@ -51,13 +39,12 @@ export function Logo({
         </View>
 
         <Avatar circular size={size}>
-          {shouldShowImage && (
+          {logoUri && (
             <Avatar.Image
               testID="logo-image"
               backgroundColor={imageBackground}
               accessibilityLabel={accessibilityLabel}
-              src={logoUri}
-              onLoadingStatusChange={setStatus}
+              source={{ uri: logoUri }}
             />
           )}
 

--- a/apps/mobile/src/features/AdvancedDetails/components/Receiver/Receiver.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/components/Receiver/Receiver.tsx
@@ -3,6 +3,7 @@ import { View, Text } from 'tamagui'
 import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { Logo } from '@/src/components/Logo'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { Identicon } from '@/src/components/Identicon'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectContactByAddress } from '@/src/store/addressBookSlice'
 
@@ -32,7 +33,11 @@ export function Receiver({ txData }: ReceiverProps) {
       gap="$2"
       alignSelf="flex-start"
     >
-      <Logo logoUri={logoUri} size="$4" />
+      <Logo
+        logoUri={logoUri}
+        size="$4"
+        fallbackContent={value ? <Identicon address={value as `0x${string}`} size={16} /> : undefined}
+      />
       <Text fontWeight={600}>{content}</Text>
       <SafeFontIcon name="check-oulined" color="$success" size={16} style={{ marginLeft: 'auto' }} />
     </View>

--- a/apps/mobile/src/features/AdvancedDetails/components/Receiver/Receiver.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/components/Receiver/Receiver.tsx
@@ -3,13 +3,19 @@ import { View, Text } from 'tamagui'
 import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { Logo } from '@/src/components/Logo'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectContactByAddress } from '@/src/store/addressBookSlice'
 
 interface ReceiverProps {
   txData: TransactionDetails['txData']
 }
 
 export function Receiver({ txData }: ReceiverProps) {
-  const content = txData?.to.name
+  const { to: { value = '', name, logoUri } = {} } = txData || {}
+
+  const contact = useAppSelector(selectContactByAddress(value))
+
+  const content = contact?.name || name
 
   if (!content) {
     return null
@@ -26,7 +32,7 @@ export function Receiver({ txData }: ReceiverProps) {
       gap="$2"
       alignSelf="flex-start"
     >
-      <Logo logoUri={txData?.to.logoUri} size="$4" />
+      <Logo logoUri={logoUri} size="$4" />
       <Text fontWeight={600}>{content}</Text>
       <SafeFontIcon name="check-oulined" color="$success" size={16} style={{ marginLeft: 'auto' }} />
     </View>

--- a/apps/mobile/src/features/AdvancedDetails/components/Receiver/__tests__/Receiver.test.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/components/Receiver/__tests__/Receiver.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import { render } from '@/src/tests/test-utils'
+import { Receiver } from '../Receiver'
+import { faker } from '@faker-js/faker'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { useAppSelector } from '@/src/store/hooks'
+
+// Mock the store hooks
+jest.mock('@/src/store/hooks', () => ({
+  useAppSelector: jest.fn(),
+  useAppDispatch: jest.fn(() => jest.fn()),
+}))
+
+// Mock the useTheme hook
+jest.mock('@/src/theme/hooks/useTheme', () => ({
+  useTheme: jest.fn(() => ({ currentTheme: 'light' })),
+}))
+
+describe('Receiver', () => {
+  const mockAddress = faker.finance.ethereumAddress()
+
+  const mockContact = {
+    value: mockAddress,
+    name: 'My Custom Safe',
+    chainIds: ['1'],
+    logoUri: null,
+  }
+
+  const mockTo = {
+    value: mockAddress,
+    name: 'GnosisSafeProxy',
+    logoUri: 'https://example.com/logo.png',
+  }
+
+  const createMockTxData = (overrides?: Partial<TransactionDetails['txData']>): TransactionDetails['txData'] => ({
+    operation: 0,
+    to: { ...mockTo, ...overrides?.to },
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should display contact name from address book when contact exists', () => {
+    jest.mocked(useAppSelector).mockReturnValue(mockContact)
+
+    const txData = createMockTxData()
+    const { getByText, queryByText } = render(<Receiver txData={txData} />)
+
+    // Should show contact name from addressbook, not transaction data name
+    expect(getByText(mockContact.name)).toBeTruthy()
+    expect(queryByText(mockTo.name)).toBeNull()
+  })
+
+  it('should fall back to transaction data name when no contact exists in address book', () => {
+    jest.mocked(useAppSelector).mockReturnValue(null)
+
+    const txData = createMockTxData()
+    const { getByText } = render(<Receiver txData={txData} />)
+
+    // Should show transaction data name as fallback
+    expect(getByText(mockTo.name)).toBeTruthy()
+  })
+
+  it.each([
+    {
+      name: 'no contact name and no transaction data name',
+      txData: createMockTxData({
+        to: {
+          value: mockAddress,
+          name: null,
+          logoUri: null,
+        },
+      }),
+    },
+    {
+      name: 'txData is null',
+      txData: null,
+    },
+    {
+      name: 'txData is undefined',
+      txData: undefined,
+    },
+  ])('should not render when $name', ({ txData }) => {
+    jest.mocked(useAppSelector).mockReturnValue(null)
+
+    const { queryByText } = render(<Receiver txData={txData} />)
+
+    // Should not render anything
+    expect(queryByText(mockContact.name)).toBeNull()
+    expect(queryByText(mockTo.name)).toBeNull()
+  })
+
+  it('should handle missing logoUri gracefully', () => {
+    jest.mocked(useAppSelector).mockReturnValue(mockContact)
+
+    const txData = createMockTxData({
+      to: {
+        value: mockAddress,
+        name: 'Contract Name',
+        logoUri: null,
+      },
+    })
+    const { getByText } = render(<Receiver txData={txData} />)
+
+    // Should still render the component even without logoUri
+    expect(getByText(mockContact.name)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What it solves

Resolves [MOB-94](https://linear.app/safe-global/issue/MOB-94/use-names-from-the-addressbook-on-the-tx-details)
This PR enhances the transaction details to display contact names from the address book when available.

## How this PR fixes it
The `Receiver` component now prioritizes contact names from the address book over transaction data. Falls back to transaction data names when no contact exists.

## How to test it
1. Create a transaction to an address that is also in the address book (e.g. to the Safe itself)
2. Navigate to the queued transaction
3. Open the transaction details
4. Observe the address book name above the address value in the `to` field

## Screenshots
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2025-07-16 at 18 12 29" src="https://github.com/user-attachments/assets/004caddd-c52f-41a1-a0c9-1f71549c378a" />

## Checklist
- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
