### PR TITLE
fix: use MultiSendCallOnly contract for L2 migration

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/MigrationToL2TxData/index.tsx
@@ -2,7 +2,7 @@ import useAsync from '@safe-global/utils/hooks/useAsync'
 import { useCurrentChain } from '@/hooks/useChains'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
-import { getMultiSendContractDeployment } from '@safe-global/utils/services/contracts/deployments'
+import { getMultiSendCallOnlyContractDeployment } from '@safe-global/utils/services/contracts/deployments'
 import { createTx } from '@/services/tx/tx-sender/create'
 import { Safe__factory } from '@safe-global/utils/types/contracts'
 import { type TransactionDetails } from '@safe-global/safe-gateway-typescript-sdk'
@@ -36,7 +36,7 @@ export const MigrationToL2TxData = ({
     // Search for a Safe Tx to MultiSend contract
     const safeInterface = Safe__factory.createInterface()
     const execTransactionSelector = safeInterface.getFunction('execTransaction').selector.slice(2, 10)
-    const multiSendDeployment = getMultiSendContractDeployment(chain, safe.version)
+    const multiSendDeployment = getMultiSendCallOnlyContractDeployment(chain, safe.version)
     const multiSendAddress = multiSendDeployment?.networkAddresses[chain.chainId]
     if (!multiSendAddress) {
       return undefined


### PR DESCRIPTION
## What it solves

Updates the contract used for migration transaction reconstruction from `MultiSend` to `MultiSendCallOnly`, aligning with Safe{Wallet}'s current security model where only `MultiSendCallOnly` is trusted for delegate calls by default.

## How this PR fixes it

Changes the usage of `getMultiSendContractDeployment` to `getMultiSendCallOnlyContractDeployment` when reconstructing migration transactions in the MigrationToL2TxData component.

## How to test it

## Screenshots
N/A

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
