### PR TITLE
fix(web): show address instead of contact in address book entry

### DIFF
--- a/apps/web/src/components/address-book/EntryDialog/index.tsx
+++ b/apps/web/src/components/address-book/EntryDialog/index.tsx
@@ -72,7 +72,7 @@ function EntryDialog({
             <Box>
               <AddressInput
                 name="address"
-                label="Contact"
+                label="Address"
                 variant="outlined"
                 fullWidth
                 required


### PR DESCRIPTION
## What it solves [COR-150](https://linear.app/safe-global/issue/COR-150/web-address-book-contact-is-visible-instead-of-address)

Resolves #

Web Address Book: "Contact" is visible instead of "Address"

## How this PR fixes it

Renamed `Contract` to `Address`

## How to test it

- Open Address Book
- Add a new entry
- Check that Address is shown instead of Contact

## Screenshots
<img width="610" height="386" alt="Screenshot 2025-07-14 at 13 10 08" src="https://github.com/user-attachments/assets/eb0815be-9eb0-4532-9702-cf6cf22493f2" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
