### PR TITLE
Fix(Mobile): Transaction list icon sizes and fallback image

### DIFF
--- a/apps/mobile/src/components/ChainIndicator/ChainIndicator.tsx
+++ b/apps/mobile/src/components/ChainIndicator/ChainIndicator.tsx
@@ -73,7 +73,7 @@ export const ChainIndicator = ({
         <YStack flex={1}>
           <Text
             testID="chain-name"
-            fontSize="$3"
+            fontSize="$4"
             fontWeight="600"
             color="$color"
             numberOfLines={1}
@@ -91,7 +91,7 @@ export const ChainIndicator = ({
     <View testID="chain-indicator">
       <XStack
         alignItems="center"
-        gap={showLogo ? '$2' : 0}
+        gap={showLogo ? '$1' : 0}
         minWidth={onlyLogo ? undefined : showLogo ? 115 : 70}
         justifyContent={showLogo ? 'flex-start' : 'center'}
       >

--- a/apps/mobile/src/components/Logo/Logo.tsx
+++ b/apps/mobile/src/components/Logo/Logo.tsx
@@ -3,6 +3,7 @@ import { Avatar, Theme, View } from 'tamagui'
 import { IconProps, SafeFontIcon } from '../SafeFontIcon/SafeFontIcon'
 import { Badge } from '../Badge/Badge'
 import { badgeTheme } from '../Badge/theme'
+import useValidLogoUri from '@/src/hooks/useValidLogoUri'
 
 type BadgeThemeKeys = keyof typeof badgeTheme
 type ExtractAfterUnderscore<T extends string> = T extends `${string}_${infer Rest}` ? Rest : never
@@ -27,6 +28,8 @@ export function Logo({
   badgeContent,
   badgeThemeName = 'badge_background',
 }: LogoProps) {
+  const validUri = useValidLogoUri(logoUri)
+
   return (
     <Theme name="logo">
       <View width={size}>
@@ -37,18 +40,26 @@ export function Logo({
         </View>
 
         <Avatar circular size={size}>
-          {logoUri && (
+          {validUri && (
             <Avatar.Image
               testID="logo-image"
               backgroundColor={imageBackground}
               accessibilityLabel={accessibilityLabel}
-              source={{ uri: logoUri }}
+              source={{ uri: validUri }}
             />
           )}
 
           <Avatar.Fallback backgroundColor="$background">
-            <View backgroundColor="$background" padding="$2" borderRadius={100}>
-              <SafeFontIcon testID="logo-fallback-icon" name={fallbackIcon} color="$colorSecondary" />
+            <View
+              backgroundColor="$background"
+              borderRadius={0}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              height={size}
+              width={size}
+            >
+              <SafeFontIcon testID="logo-fallback-icon" name={fallbackIcon} color="$colorSecondary" size={16} />
             </View>
           </Avatar.Fallback>
         </Avatar>

--- a/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
+++ b/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
@@ -69,18 +69,18 @@ export function SafeListItem({
 
           <View>
             {type && (
-              <View flexDirection="row" alignItems="center" gap={4} marginBottom={4}>
+              <View flexDirection="row" alignItems="center" gap={4}>
                 {icon && (
                   <SafeFontIcon testID={`safe-list-${icon}-icon`} name={icon} size={10} color="$colorSecondary" />
                 )}
-                <Text fontSize="$3" color="$colorSecondary" marginBottom={2}>
+                <Text fontSize="$2" lineHeight={20} color="$colorSecondary">
                   {type}
                 </Text>
               </View>
             )}
 
             {typeof label === 'string' ? (
-              <Text fontSize="$4" fontWeight={600}>
+              <Text fontSize="$4" lineHeight={20} fontWeight={600}>
                 {ellipsis(label, rightNode || inQueue ? 21 : 30)}
               </Text>
             ) : (

--- a/apps/mobile/src/components/TxInfo/TxInfo.tsx
+++ b/apps/mobile/src/components/TxInfo/TxInfo.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react'
-import { TransactionInfoType } from '@safe-global/store/gateway/types'
 import { type Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useTransactionType } from '@/src/hooks/useTransactionType'
 import { TxTokenCard } from '@/src/components/transactions-list/Card/TxTokenCard'
@@ -70,7 +69,7 @@ function TxInfoComponent({ tx, onPress, ...rest }: TxInfoProps) {
     return <TxSettingsCard onPress={onCardPress} executionInfo={tx.executionInfo} txInfo={txInfo} {...rest} />
   }
 
-  if (isMultiSendTxInfo(txInfo) && tx.txInfo.type === TransactionInfoType.CUSTOM) {
+  if (isMultiSendTxInfo(txInfo)) {
     return (
       <TxBatchCard
         onPress={onCardPress}

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/StakingTxDepositCard.tsx
@@ -18,7 +18,7 @@ export const StakingTxDepositCard = ({
       rightNode={
         <TokenAmount value={info.value} tokenSymbol={info.tokenInfo.symbol} decimals={info.tokenInfo.decimals} />
       }
-      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} size="$8" />}
       {...rest}
     />
   )

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/StakingTxExitCard.tsx
@@ -21,7 +21,7 @@ export const StakingTxExitCard = ({ info, onPress }: StakingTxExitCardProps) => 
           {info.numValidators} Validator{maybePlural(info.numValidators)}
         </Text>
       }
-      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} size="$8" />}
     />
   )
 }

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/StakingTxWithdrawCard.tsx
@@ -23,7 +23,7 @@ export const StakingTxWithdrawCard = ({ info, onPress }: StakingTxWithdrawCardPr
           decimals={info.tokenInfo.decimals}
         />
       }
-      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} size="$8" />}
     />
   )
 }

--- a/apps/mobile/src/components/transactions-list/Card/TxBatchCard/TxBatchCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxBatchCard/TxBatchCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Avatar, View } from 'tamagui'
+import { Theme, View } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import type { MultiSend } from '@safe-global/store/gateway/types'
@@ -12,23 +12,17 @@ type TxBatchCardProps = {
 } & Partial<SafeListItemProps>
 
 export function TxBatchCard({ txInfo, safeAppInfo, ...rest }: TxBatchCardProps) {
-  const logoUri = safeAppInfo?.logoUri || txInfo.to.logoUri
-
   return (
     <SafeListItem
       label={`${txInfo.actionCount} actions`}
       icon="batch"
       type={safeAppInfo?.name || 'Batch'}
       leftNode={
-        <Avatar circular size="$10">
-          {logoUri && <Avatar.Image accessibilityLabel="Cam" src={logoUri} />}
-
-          <Avatar.Fallback backgroundColor="$borderLight">
-            <View backgroundColor="$borderLightDark" padding="$2" borderRadius={100}>
-              <SafeFontIcon color="$primary" name="batch" />
-            </View>
-          </Avatar.Fallback>
-        </Avatar>
+        <Theme name="logo">
+          <View backgroundColor="$background" padding="$2" borderRadius={100}>
+            <SafeFontIcon name="batch" size={16} />
+          </View>
+        </Theme>
       }
       {...rest}
     />

--- a/apps/mobile/src/components/transactions-list/Card/TxBridgeCard/TxBridgeCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxBridgeCard/TxBridgeCard.tsx
@@ -41,10 +41,12 @@ export function TxBridgeCard({ txInfo, bordered, executionInfo, inQueue, onPress
     <SafeListItem
       label={
         <View flexDirection="row" alignItems="center" gap="$2">
-          <Text>{txInfo.fromToken.symbol}</Text>
+          <Text fontSize="$4" lineHeight={20}>
+            {txInfo.fromToken.symbol}
+          </Text>
           <View flexDirection="row" alignItems="center" gap="$2">
-            <Text>→</Text>
-            {txInfo.toToken?.symbol && <Text>{txInfo.toToken?.symbol}</Text>}
+            <Text lineHeight={20}>→</Text>
+            {txInfo.toToken?.symbol && <Text lineHeight={20}>{txInfo.toToken?.symbol}</Text>}
             <ChainIndicator chainId={txInfo.toChain} onlyLogo={!!txInfo.toToken} imageSize="$4" />
           </View>
         </View>
@@ -57,12 +59,12 @@ export function TxBridgeCard({ txInfo, bordered, executionInfo, inQueue, onPress
       inQueue={inQueue}
       leftNode={
         <Theme name="logo">
-          <View position="relative" width="$10" height="$10">
+          <View position="relative" width="$8" height="$8">
             <View position="absolute" top={0}>
               <TokenIcon
                 logoUri={txInfo.fromToken.logoUri}
                 accessibilityLabel={txInfo.fromToken.name}
-                size="$7"
+                size="$8"
                 imageBackground="$background"
               />
             </View>
@@ -71,7 +73,7 @@ export function TxBridgeCard({ txInfo, bordered, executionInfo, inQueue, onPress
                 <TokenIcon
                   logoUri={txInfo.toToken.logoUri}
                   accessibilityLabel={txInfo.toToken.name}
-                  size="$7"
+                  size="$8"
                   imageBackground="$background"
                 />
               </View>

--- a/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import { Text, Theme } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import { MultiSend } from '@safe-global/store/gateway/types'
-import { SafeAvatar } from '@/src/components/SafeAvatar/SafeAvatar'
 import { CustomTransactionInfo, SafeAppInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { SafeListItemProps } from '@/src/components/SafeListItem/SafeListItem'
+import { Logo } from '@/src/components/Logo'
 
 type TxContractInteractionCardProps = {
   txInfo: CustomTransactionInfo | MultiSend
@@ -13,8 +12,9 @@ type TxContractInteractionCardProps = {
 } & Partial<SafeListItemProps>
 
 export function TxContractInteractionCard({ txInfo, safeAppInfo, ...rest }: TxContractInteractionCardProps) {
-  const logoUri = txInfo.to.logoUri
-  const label = txInfo.to.name || 'Contract interaction'
+  const logoUri = safeAppInfo?.logoUri || txInfo.to.logoUri
+  const label = safeAppInfo?.name || txInfo.to.name || 'Contract interaction'
+
   return (
     <SafeListItem
       label={label}
@@ -22,12 +22,7 @@ export function TxContractInteractionCard({ txInfo, safeAppInfo, ...rest }: TxCo
       type={safeAppInfo?.name || txInfo.methodName || ''}
       leftNode={
         <Theme name="logo">
-          <SafeAvatar
-            size="$10"
-            src={logoUri || ''}
-            label={label}
-            fallbackIcon={<SafeFontIcon name="code-blocks" color="$color" size={16} />}
-          />
+          <Logo size="$8" logoUri={logoUri || ''} fallbackIcon="code-blocks" imageBackground="$background" />
         </Theme>
       }
       rightNode={<Text>{txInfo.methodName}</Text>}

--- a/apps/mobile/src/components/transactions-list/Card/TxCreationCard/TxCreationCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxCreationCard/TxCreationCard.tsx
@@ -18,7 +18,7 @@ export function TxCreationCard({ txInfo, ...rest }: TxCreationCardProps) {
       leftNode={
         <Theme name="logo">
           <View backgroundColor="$background" padding="$2" borderRadius={100}>
-            <SafeFontIcon name="plus" />
+            <SafeFontIcon name="plus" size={16} />
           </View>
         </Theme>
       }

--- a/apps/mobile/src/components/transactions-list/Card/TxLifiSwapCard/TxLifiSwapCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxLifiSwapCard/TxLifiSwapCard.tsx
@@ -33,7 +33,7 @@ export function TxLifiSwapCard({ txInfo, bordered, executionInfo, inQueue, onPre
               <TokenIcon
                 logoUri={txInfo.fromToken.logoUri}
                 accessibilityLabel={txInfo.fromToken.name}
-                size="$7"
+                size="$6"
                 imageBackground="$background"
               />
             </View>
@@ -42,7 +42,7 @@ export function TxLifiSwapCard({ txInfo, bordered, executionInfo, inQueue, onPre
               <TokenIcon
                 logoUri={txInfo.toToken.logoUri}
                 accessibilityLabel={txInfo.toToken.name}
-                size="$7"
+                size="$6"
                 imageBackground="$background"
               />
             </View>

--- a/apps/mobile/src/components/transactions-list/Card/TxOrderCard/SellOrder.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxOrderCard/SellOrder.tsx
@@ -27,7 +27,7 @@ export function SellOrder({ order, type, ...rest }: TxSellOrderCardProps) {
               <TokenIcon
                 logoUri={order.sellToken.logoUri}
                 accessibilityLabel={order.sellToken.name}
-                size="$7"
+                size="$6"
                 imageBackground="$background"
               />
             </View>
@@ -36,7 +36,7 @@ export function SellOrder({ order, type, ...rest }: TxSellOrderCardProps) {
               <TokenIcon
                 logoUri={order.buyToken.logoUri}
                 accessibilityLabel={order.buyToken.name}
-                size="$7"
+                size="$6"
                 imageBackground="$background"
               />
             </View>

--- a/apps/mobile/src/components/transactions-list/Card/TxOrderCard/TwapOrder.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxOrderCard/TwapOrder.tsx
@@ -23,7 +23,7 @@ export const TwapOrder = ({ order, ...rest }: TxTwappOrderCardProps) => {
               <TokenIcon
                 logoUri={order.sellToken.logoUri}
                 accessibilityLabel={order.sellToken.name}
-                size="$7"
+                size="$6"
                 imageBackground="$background"
               />
             </View>
@@ -32,7 +32,7 @@ export const TwapOrder = ({ order, ...rest }: TxTwappOrderCardProps) => {
               <TokenIcon
                 logoUri={order.buyToken.logoUri}
                 accessibilityLabel={order.buyToken.name}
-                size="$7"
+                size="$6"
                 imageBackground="$background"
               />
             </View>

--- a/apps/mobile/src/components/transactions-list/Card/TxRejectionCard/TxRejectionCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxRejectionCard/TxRejectionCard.tsx
@@ -18,7 +18,7 @@ export function TxRejectionCard({ txInfo, ...rest }: TxRejectionCardProps) {
       label={txInfo.methodName || 'On-chain rejection'}
       leftNode={
         <View borderRadius={100} padding="$2" backgroundColor="$errorDark">
-          <SafeFontIcon color="$error" name="close-outlined" />
+          <SafeFontIcon color="$error" name="close-outlined" size={16} />
         </View>
       }
       {...rest}

--- a/apps/mobile/src/components/transactions-list/Card/TxSafeAppCard/TxSafeAppCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxSafeAppCard/TxSafeAppCard.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { Avatar, Text, View } from 'tamagui'
+import { Text } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import type { MultiSend } from '@safe-global/store/gateway/types'
 import type { SafeAppInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { SafeListItemProps } from '@/src/components/SafeListItem/SafeListItem'
+import { Logo } from '@/src/components/Logo'
 
 type TxSafeAppCardProps = {
   safeAppInfo: SafeAppInfo
@@ -17,19 +17,7 @@ export function TxSafeAppCard({ safeAppInfo, txInfo, ...rest }: TxSafeAppCardPro
       label={safeAppInfo.name}
       icon="transaction-contract"
       type="Safe app"
-      leftNode={
-        <Avatar circular size="$10">
-          {safeAppInfo.logoUri && (
-            <Avatar.Image testID="safe-app-image" accessibilityLabel={safeAppInfo.name} src={safeAppInfo.logoUri} />
-          )}
-
-          <Avatar.Fallback backgroundColor="$borderLight">
-            <View backgroundColor="$borderLightDark" padding="$2" borderRadius={100}>
-              <SafeFontIcon testID="safe-app-fallback" name="code-blocks" color="$color" />
-            </View>
-          </Avatar.Fallback>
-        </Avatar>
-      }
+      leftNode={<Logo logoUri={safeAppInfo.logoUri} size="$8" fallbackIcon="code-blocks" />}
       rightNode={<Text>{txInfo.methodName}</Text>}
       {...rest}
     />

--- a/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/TxSettingsCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/TxSettingsCard.tsx
@@ -27,7 +27,7 @@ export function TxSettingsCard({ txInfo, onPress, ...rest }: TxSettingsCardProps
       leftNode={
         <Theme name="logo">
           <View backgroundColor="$background" padding="$2" borderRadius={100}>
-            <SafeFontIcon name="transaction-change-settings" />
+            <SafeFontIcon name="transaction-change-settings" size={16} />
           </View>
         </Theme>
       }

--- a/apps/mobile/src/components/transactions-list/Card/TxTokenCard/TxTokenCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxTokenCard/TxTokenCard.tsx
@@ -27,7 +27,7 @@ export function TxTokenCard({ inQueue, txStatus, txInfo, ...rest }: TxTokenCardP
       label={inQueue ? <TokenAmount value={value} decimals={decimals} tokenSymbol={tokenSymbol} preciseAmount /> : name}
       icon={icon}
       type={type}
-      leftNode={<TokenIcon logoUri={logoUri} accessibilityLabel={name} />}
+      leftNode={<TokenIcon logoUri={logoUri} accessibilityLabel={name} size="$8" imageBackground="$background" />}
       rightNode={
         <TokenAmount
           value={value}

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/VaultTxDepositCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/VaultTxDepositCard.tsx
@@ -17,7 +17,14 @@ export const VaultTxDepositCard = ({ info, ...rest }: VaultTxDepositCardProps) =
       rightNode={
         <TokenAmount value={info.value} tokenSymbol={info.tokenInfo.symbol} decimals={info.tokenInfo.decimals} />
       }
-      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={
+        <TokenIcon
+          logoUri={info.tokenInfo.logoUri}
+          accessibilityLabel={info.tokenInfo.symbol}
+          size="$8"
+          imageBackground="$background"
+        />
+      }
       {...rest}
     />
   )

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/VaultTxRedeemCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/VaultTxRedeemCard.tsx
@@ -17,7 +17,7 @@ export const VaultTxRedeemCard = ({ info, ...rest }: VaultTxRedeemCardProps) => 
       rightNode={
         <TokenAmount value={info.value} tokenSymbol={info.tokenInfo.symbol} decimals={info.tokenInfo.decimals} />
       }
-      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} />}
+      leftNode={<TokenIcon logoUri={info.tokenInfo.logoUri} accessibilityLabel={info.tokenInfo.symbol} size="$8" />}
       {...rest}
     />
   )

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationView/ConfirmationView.tsx
@@ -140,7 +140,13 @@ export function ConfirmationView({ txDetails }: ConfirmationViewProps) {
         />
       )
     case ETxType.BRIDGE_ORDER:
-      return <BridgeTransaction txId={txDetails.txId} txInfo={txDetails.txInfo as BridgeAndSwapTransactionInfo} />
+      return (
+        <BridgeTransaction
+          txId={txDetails.txId}
+          txInfo={txDetails.txInfo as BridgeAndSwapTransactionInfo}
+          decodedData={txDetails.txData?.dataDecoded}
+        />
+      )
     case ETxType.LIFI_SWAP:
       return (
         <LifiSwapTransaction

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/LifiSwapTransaction/LifiSwapTransaction.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/LifiSwapTransaction/LifiSwapTransaction.tsx
@@ -7,6 +7,7 @@ import { EthAddress } from '@/src/components/EthAddress'
 import { type ListTableItem } from '../../ListTable'
 import { LifiSwapHeader } from './LifiSwapHeader'
 import { ParametersButton } from '../../ParametersButton'
+import { formatAmount } from '@safe-global/utils/utils/formatNumber'
 
 interface LifiSwapTransactionProps {
   txId: string
@@ -27,7 +28,7 @@ export function LifiSwapTransaction({ txId, executionInfo, txInfo }: LifiSwapTra
       label: 'Price',
       render: () => (
         <Text>
-          1 {txInfo.fromToken.symbol} = {exchangeRate.toFixed(6)} {txInfo.toToken.symbol}
+          1 {txInfo.fromToken.symbol} = {formatAmount(exchangeRate)} {txInfo.toToken.symbol}
         </Text>
       ),
     })

--- a/apps/mobile/src/hooks/useValidLogoUri.ts
+++ b/apps/mobile/src/hooks/useValidLogoUri.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+import { Image } from 'react-native'
+
+const useValidLogoUri = (logoUri?: string | null) => {
+  const [validUri, setValidUri] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!logoUri) {
+      return
+    }
+
+    Image.getSize(
+      logoUri,
+      () => setValidUri(logoUri),
+      () => setValidUri(null),
+    )
+  }, [logoUri])
+
+  return validUri
+}
+
+export default useValidLogoUri


### PR DESCRIPTION
## What it solves

Resolves part of [COR-223](https://linear.app/safe-global/issue/COR-223/get-at-least-rudemtary-decoding-for-bridge-txs)

## How this PR fixes it

- Reduces the size of all transaction info card icons to 32px instead of 40px
- Adds `useValidLogoUri` hook that returns null in case a logo can't be loaded (404 or 403)
- Fixes amount formatting for bridge and lifi amounts

## How to test it

1. Open an app with pending transaction
2. Click through the pending transaction list and history
3. Observe all icons are the same size and 32px
4. Observe fallback images and no black background for icons
5. Check bridge amount and make sure its formatted the same way as on web

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
