### PR TITLE
fix: Prevent transaction creation when `signMessageAddress` is undefined

### DIFF
--- a/apps/web/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
+++ b/apps/web/src/components/tx-flow/flows/SignMessageOnChain/ReviewSignMessageOnChain.tsx
@@ -67,7 +67,7 @@ const ReviewSignMessageOnChain = ({ message, method, children, ...props }: SignM
   useEffect(() => {
     let txData
 
-    if (!readOnlySignMessageLibContract) return
+    if (!readOnlySignMessageLibContract || !signMessageAddress) return
 
     if (isTextMessage) {
       txData = readOnlySignMessageLibContract.encode('signMessage', [


### PR DESCRIPTION
## What it solves

Resolves [COR-148](https://linear.app/safe-global/issue/COR-148/invalidaddresserror-on-safe-switch-with-walletconnect-signatures)

The **ReviewSignMessageOnChain** component was attempting to create transactions even when **signMessageAddress** was not yet defined, which sometimes lead to issues in the sign on-chain message flow.

## How this PR fixes it
Added a guard clause in the useEffect hook to ensure that transaction creation only occurs when signMessageAddress is available.

## How to test it

Ensure that the previously reported issue no longer occurs by following the steps below.

### 🐞 Bug reproduction steps (before the fix)

1. **Initiate the flow**: Trigger the `SignMessageOnchain` flow.
2. **Navigate to review**: Proceed to the review step.
3. **Check network requests**:
   - Open your browser's developer tools and inspect the **Network** tab.
   - Observe a failing request to the CGW `/preview` endpoint.
   - The failure occurs because the frontend sends an empty string as the `to` parameter in the payload.
4. **Advance and observe**:
   - Continue to the final step.
   - Eventually, you'll observe that the `to` field in the **receipt** is empty.
   - You may need to repeat this step (go back and forth) several times to reproduce the issue.

### ✅ Expected behavior (after the fix)

- The request to the `/preview` endpoint **should not fail**.
- The `to` field in the final **receipt** should be correctly populated.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
