### PR TITLE
Refactor: Make status page URL configurable via environment variable

### DIFF
--- a/apps/web/src/components/sidebar/IndexingStatus/index.tsx
+++ b/apps/web/src/components/sidebar/IndexingStatus/index.tsx
@@ -5,8 +5,8 @@ import useAsync from '@safe-global/utils/hooks/useAsync'
 import useChainId from '@/hooks/useChainId'
 import useIntervalCounter from '@/hooks/useIntervalCounter'
 import { OpenInNewRounded } from '@mui/icons-material'
+import { STATUS_PAGE } from '@/config/constants'
 
-const STATUS_PAGE = 'https://status.safe.global'
 const MAX_SYNC_DELAY = 1000 * 60 * 5 // 5 minutes
 const POLL_INTERVAL = 1000 * 60 // 1 minute
 

--- a/apps/web/src/config/constants.ts
+++ b/apps/web/src/config/constants.ts
@@ -15,6 +15,9 @@ export const GATEWAY_URL_PRODUCTION =
   process.env.NEXT_PUBLIC_GATEWAY_URL_PRODUCTION || 'https://safe-client.safe.global'
 export const GATEWAY_URL_STAGING = process.env.NEXT_PUBLIC_GATEWAY_URL_STAGING || 'https://safe-client.staging.5afe.dev'
 
+// Indexing status page
+export const STATUS_PAGE = process.env.NEXT_PUBLIC_STATUS_PAGE || 'https://status.safe.global'
+
 // Magic numbers
 export const POLLING_INTERVAL = 15_000
 export const BASE_TX_GAS = 21_000


### PR DESCRIPTION
## What it solves

Resolves #6140

## How this PR fixes it

This PR moves the hardcoded `STATUS_PAGE` constant from the `IndexingStatus` component to the central `apps/web/src/config/constants.ts` file.  
The value is now loaded from an environment variable `NEXT_PUBLIC_STATUS_PAGE` with a fallback to `https://status.safe.global`.  

This makes the app more configurable for different environments, including staging, self-hosted deployments, or alternative status pages.

## How to test it

1. Run the app without setting `NEXT_PUBLIC_STATUS_PAGE` — it should use `https://status.safe.global`.
2. Set a custom `NEXT_PUBLIC_STATUS_PAGE` in the environment and verify that the `IndexingStatus` component links to the new URL.

## Screenshots

N/A — this is a configuration/code-level change without UI modifications.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 N/A
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
