### PR TITLE
Fix(Mobile): UI fixes + copy changes

### DIFF
--- a/apps/mobile/src/app/(tabs)/transactions/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/transactions/(tabs)/_layout.tsx
@@ -23,7 +23,16 @@ export default function TransactionsLayout() {
   const theme = useTheme()
 
   return (
-    <MaterialTopTabs screenOptions={getMaterialTopTabBarScreenOptions({ theme })}>
+    <MaterialTopTabs
+      screenOptions={getMaterialTopTabBarScreenOptions({
+        theme,
+        tabBarItemWidth: 124,
+        tabBarIndicatorWidth: 94,
+        tabBarLabelFontSize: 16,
+        tabBarLabelFontWeight: '700',
+        tabBarItemLeft: 0,
+      })}
+    >
       <MaterialTopTabs.Screen name="index" options={{ title: 'History' }} />
       <MaterialTopTabs.Screen name="messages" options={{ title: 'Messages' }} />
     </MaterialTopTabs>

--- a/apps/mobile/src/app/transaction-parameters/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/transaction-parameters/(tabs)/_layout.tsx
@@ -31,7 +31,7 @@ export default function TransactionsLayout() {
         tabBarIndicatorWidth: 94,
         tabBarLabelFontSize: 16,
         tabBarLabelFontWeight: '700',
-        tabBarItemLeft: -10,
+        tabBarItemLeft: 0,
       })}
     >
       <MaterialTopTabs.Screen initialParams={{ txId }} name="index" options={{ title: 'Data' }} />

--- a/apps/mobile/src/app/transaction-parameters/(tabs)/index.tsx
+++ b/apps/mobile/src/app/transaction-parameters/(tabs)/index.tsx
@@ -6,7 +6,7 @@ import { TxDataContainer } from '@/src/features/AdvancedDetails'
 
 function TransactionParameters() {
   return (
-    <SafeAreaView edges={['bottom']} style={{ flex: 1 }}>
+    <SafeAreaView edges={['bottom']} style={{ flex: 1, paddingHorizontal: 16 }}>
       <TxDataContainer />
     </SafeAreaView>
   )

--- a/apps/mobile/src/app/transaction-parameters/(tabs)/parameters.tsx
+++ b/apps/mobile/src/app/transaction-parameters/(tabs)/parameters.tsx
@@ -8,7 +8,7 @@ function TransactionParameters() {
   const insets = useSafeAreaInsets()
 
   return (
-    <View flex={1} paddingBottom={insets.bottom}>
+    <View flex={1} paddingBottom={insets.bottom} paddingHorizontal={16}>
       <TxParametersContainer />
     </View>
   )

--- a/apps/mobile/src/components/Badge/theme.ts
+++ b/apps/mobile/src/components/Badge/theme.ts
@@ -53,10 +53,12 @@ export const badgeTheme = {
   light_badge_error: {
     color: tokens.color.errorMainLight,
     background: tokens.color.errorBackgroundLight,
+    borderColor: tokens.color.borderBackgroundLight,
   },
   dark_badge_error: {
     color: tokens.color.errorMainDark,
-    background: tokens.color.errorDarkDark,
+    background: tokens.color.errorBackgroundDark,
+    borderColor: tokens.color.borderBackgroundDark,
   },
   light_badge_background_inverted: {
     color: tokens.color.logoBackgroundLight,

--- a/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
+++ b/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
@@ -84,7 +84,7 @@ export function SafeListItem({
             )}
 
             {typeof label === 'string' ? (
-              <Text fontSize="$4" lineHeight={20} fontWeight={600}>
+              <Text fontSize="$4" lineHeight={20} fontWeight={600} letterSpacing={-0.01}>
                 {ellipsis(label, rightNode || inQueue ? 21 : 30)}
               </Text>
             ) : (
@@ -95,17 +95,18 @@ export function SafeListItem({
         </View>
 
         {inQueue && executionInfo && isMultisigExecutionInfo(executionInfo) ? (
-          <View alignItems="center" flexDirection="row">
+          <View alignItems="center" flexDirection="row" gap="$2">
             {isProposedTx ? (
               <ProposalBadge />
             ) : (
               <Badge
+                circleProps={{ paddingHorizontal: 8, paddingVertical: 2 }}
                 circular={false}
                 content={
                   <View alignItems="center" flexDirection="row" gap="$1">
                     <SafeFontIcon size={12} name="owners" />
 
-                    <Text fontWeight={600} color={'$color'}>
+                    <Text fontWeight={600} color={'$color'} fontSize="$2" lineHeight={18}>
                       {executionInfo?.confirmationsSubmitted}/{executionInfo?.confirmationsRequired}
                     </Text>
                   </View>
@@ -118,7 +119,7 @@ export function SafeListItem({
               />
             )}
 
-            <SafeFontIcon name="chevron-right" />
+            <SafeFontIcon name="chevron-right" size={16} />
           </View>
         ) : (
           rightNode

--- a/apps/mobile/src/components/SafeListItem/__snapshots__/SafeListItem.test.tsx.snap
+++ b/apps/mobile/src/components/SafeListItem/__snapshots__/SafeListItem.test.tsx.snap
@@ -179,6 +179,7 @@ exports[`SafeListItem should render bottomContent with proper styling and layout
                 "color": "#121312",
                 "fontFamily": "DMSans-SemiBold",
                 "fontSize": 14,
+                "letterSpacing": -0.01,
                 "lineHeight": 20,
               }
             }

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
@@ -234,6 +234,7 @@ exports[`StakingTxDepositCard renders correctly 1`] = `
                 "color": "#121312",
                 "fontFamily": "DMSans-SemiBold",
                 "fontSize": 14,
+                "letterSpacing": -0.01,
                 "lineHeight": 20,
               }
             }

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
@@ -234,6 +234,7 @@ exports[`StakingTxExitCard matches snapshot 1`] = `
                 "color": "#121312",
                 "fontFamily": "DMSans-SemiBold",
                 "fontSize": 14,
+                "letterSpacing": -0.01,
                 "lineHeight": 20,
               }
             }

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
@@ -234,6 +234,7 @@ exports[`StakingTxWithdrawCard matches snapshot 1`] = `
                 "color": "#121312",
                 "fontFamily": "DMSans-SemiBold",
                 "fontSize": 14,
+                "letterSpacing": -0.01,
                 "lineHeight": 20,
               }
             }

--- a/apps/mobile/src/components/transactions-list/Card/TxBatchCard/__snapshots__/TxBatchCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxBatchCard/__snapshots__/TxBatchCard.test.tsx.snap
@@ -140,6 +140,7 @@ exports[`TxBatchCard should render the default markup 1`] = `
                 "color": "#121312",
                 "fontFamily": "DMSans-SemiBold",
                 "fontSize": 14,
+                "letterSpacing": -0.01,
                 "lineHeight": 20,
               }
             }

--- a/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/__snapshots__/TxSettingCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/__snapshots__/TxSettingCard.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`TxSettingCard should render the default markup 1`] = `
                 "color": "#121312",
                 "fontFamily": "DMSans-SemiBold",
                 "fontSize": 14,
+                "letterSpacing": -0.01,
                 "lineHeight": 20,
               }
             }

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/__snapshots__/VaultTxDepositCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/__snapshots__/VaultTxDepositCard.test.tsx.snap
@@ -225,6 +225,7 @@ exports[`VaultTxDepositCard renders correctly 1`] = `
                 "color": "#121312",
                 "fontFamily": "DMSans-SemiBold",
                 "fontSize": 14,
+                "letterSpacing": -0.01,
                 "lineHeight": 20,
               }
             }

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/__snapshots__/VaultTxRedeemCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/__snapshots__/VaultTxRedeemCard.test.tsx.snap
@@ -225,6 +225,7 @@ exports[`VaultTxRedeemCard renders correctly 1`] = `
                 "color": "#121312",
                 "fontFamily": "DMSans-SemiBold",
                 "fontSize": 14,
+                "letterSpacing": -0.01,
                 "lineHeight": 20,
               }
             }

--- a/apps/mobile/src/features/ActionDetails/utils.tsx
+++ b/apps/mobile/src/features/ActionDetails/utils.tsx
@@ -66,7 +66,8 @@ export const formatActionDetails = ({ txData, action }: formatActionDetailsRetur
         <Badge
           circleProps={badgeProps}
           themeName="badge_background"
-          fontSize={12}
+          fontSize={13}
+          textContentProps={{ fontFamily: 'DM Mono' }}
           circular={false}
           content={getActionName(action)}
         />

--- a/apps/mobile/src/features/AddressBook/Contact/NetworkSelector/AllNetworksItem.tsx
+++ b/apps/mobile/src/features/AddressBook/Contact/NetworkSelector/AllNetworksItem.tsx
@@ -7,15 +7,10 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 interface AllNetworksItemProps {
   isSelected: boolean
   isReadOnly: boolean
-  isVisible: boolean
   onSelectAll: () => void
 }
 
-export const AllNetworksItem = ({ isSelected, isReadOnly, isVisible, onSelectAll }: AllNetworksItemProps) => {
-  if (!isVisible) {
-    return null
-  }
-
+export const AllNetworksItem = ({ isSelected, isReadOnly, onSelectAll }: AllNetworksItemProps) => {
   return (
     <TouchableOpacity style={{ width: '100%' }} onPress={onSelectAll} disabled={isReadOnly}>
       <View

--- a/apps/mobile/src/features/AddressBook/Contact/NetworkSelector/NetworkSelectorContent.tsx
+++ b/apps/mobile/src/features/AddressBook/Contact/NetworkSelector/NetworkSelectorContent.tsx
@@ -29,8 +29,6 @@ export const NetworkSelectorContent = ({
     return selectedChainIds.includes(chainId)
   }
 
-  const shouldShowAllNetworksItem = !isReadOnly && isAllChainsSelected
-
   return (
     <BottomSheetScrollView
       contentContainerStyle={{
@@ -39,12 +37,8 @@ export const NetworkSelectorContent = ({
       }}
     >
       <>
-        <AllNetworksItem
-          isSelected={isAllChainsSelected}
-          isReadOnly={isReadOnly}
-          isVisible={shouldShowAllNetworksItem}
-          onSelectAll={onSelectAll}
-        />
+        <AllNetworksItem isSelected={isAllChainsSelected} isReadOnly={isReadOnly} onSelectAll={onSelectAll} />
+
         {chainsToDisplay.map((chain) => (
           <ChainItem
             key={chain.chainId}

--- a/apps/mobile/src/features/AdvancedDetails/TxData.container.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/TxData.container.tsx
@@ -32,7 +32,7 @@ export function TxDataContainer() {
   }
 
   return (
-    <ScrollView marginTop="$4">
+    <ScrollView marginTop="$2">
       {isFetching || !txDetails ? <LoadingTx /> : <ListTable items={parameters} />}
     </ScrollView>
   )

--- a/apps/mobile/src/features/AdvancedDetails/TxData.container.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/TxData.container.tsx
@@ -7,6 +7,7 @@ import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { Alert } from '@/src/components/Alert'
 import { LoadingTx } from '../ConfirmTx/components/LoadingTx'
 import { formatTxDetails } from './utils/formatTxDetails'
+import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
 
 export function TxDataContainer() {
   const activeSafe = useDefinedActiveSafe()
@@ -21,7 +22,9 @@ export function TxDataContainer() {
     id: txId,
   })
 
-  const parameters = useMemo(() => formatTxDetails({ txDetails }), [txDetails])
+  const viewOnExplorer = useOpenExplorer(txDetails?.txData?.to.value || '')
+
+  const parameters = useMemo(() => formatTxDetails({ txDetails, viewOnExplorer }), [txDetails, viewOnExplorer])
 
   if (isError) {
     return (

--- a/apps/mobile/src/features/AdvancedDetails/TxParameters.container.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/TxParameters.container.tsx
@@ -32,7 +32,7 @@ export function TxParametersContainer() {
   }
 
   return (
-    <ScrollView marginTop="$4">
+    <ScrollView marginTop="$2">
       {isFetching || !txDetails ? <LoadingTx /> : <ListTable items={parameters} />}
     </ScrollView>
   )

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatParameters.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatParameters.tsx
@@ -27,7 +27,8 @@ const formatParameters = ({ txData }: formatParametersProps): ListTableItem[] =>
         <Badge
           circleProps={badgeProps}
           themeName="badge_background"
-          fontSize={12}
+          fontSize={13}
+          textContentProps={{ fontFamily: 'DM Mono' }}
           circular={false}
           content={String(txData?.dataDecoded?.method || txData?.to.value)}
         />

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.test.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.test.tsx
@@ -65,13 +65,15 @@ describe('formatTxDetails', () => {
     jest.clearAllMocks()
   })
 
+  const viewOnExplorer = jest.fn()
+
   it('should return empty array when txDetails is undefined', () => {
-    const result = formatTxDetails({ txDetails: undefined })
+    const result = formatTxDetails({ txDetails: undefined, viewOnExplorer })
     expect(result).toEqual([])
   })
 
   it('should return empty array when txDetails is null', () => {
-    const result = formatTxDetails({ txDetails: null as unknown as TransactionDetails })
+    const result = formatTxDetails({ txDetails: null as unknown as TransactionDetails, viewOnExplorer })
     expect(result).toEqual([])
   })
 
@@ -87,7 +89,7 @@ describe('formatTxDetails', () => {
       },
     })
 
-    const result = formatTxDetails({ txDetails })
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
 
     expect(result.length).toBeGreaterThanOrEqual(1)
     // Check that we have a 'To' field
@@ -105,7 +107,7 @@ describe('formatTxDetails', () => {
       },
     })
 
-    const result = formatTxDetails({ txDetails })
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
 
     // Check that we have a 'Value' field
     expect(result.some((item) => 'label' in item && item.label === 'Value')).toBe(true)
@@ -122,7 +124,7 @@ describe('formatTxDetails', () => {
       },
     })
 
-    const result = formatTxDetails({ txDetails })
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
 
     // Check that we have an 'Operation' field
     expect(result.some((item) => 'label' in item && item.label === 'Operation')).toBe(true)
@@ -151,7 +153,7 @@ describe('formatTxDetails', () => {
 
     isMultisigDetailedExecutionInfo.mockReturnValue(true)
 
-    const result = formatTxDetails({ txDetails })
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
 
     // Check for gas-related fields
     expect(result.some((item) => 'label' in item && item.label === 'SafeTxGas')).toBe(true)
@@ -172,7 +174,7 @@ describe('formatTxDetails', () => {
     // Ensure multisig check returns false for this test
     isMultisigDetailedExecutionInfo.mockReturnValue(false)
 
-    const result = formatTxDetails({ txDetails })
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
 
     // Check that we have a 'Transaction Hash' field
     expect(result.some((item) => 'label' in item && item.label === 'Transaction Hash')).toBe(true)
@@ -191,7 +193,7 @@ describe('formatTxDetails', () => {
 
     isMultisigDetailedExecutionInfo.mockReturnValue(false)
 
-    const result = formatTxDetails({ txDetails })
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
 
     // Should only have the 'To' field
     expect(result).toHaveLength(1)
@@ -223,7 +225,7 @@ describe('formatTxDetails', () => {
 
     isMultisigDetailedExecutionInfo.mockReturnValue(true)
 
-    const result = formatTxDetails({ txDetails })
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
 
     // Should have gas fields but not safe tx hash
     expect(result.some((item) => 'label' in item && item.label === 'SafeTxGas')).toBe(true)
@@ -261,7 +263,7 @@ describe('formatTxDetails', () => {
 
     isMultisigDetailedExecutionInfo.mockReturnValue(true)
 
-    const result = formatTxDetails({ txDetails })
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
 
     // Should have all possible fields
     expect(result.some((item) => 'label' in item && item.label === 'To')).toBe(true)

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
@@ -14,6 +14,7 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { TouchableOpacity } from 'react-native'
 import { Receiver } from '../components/Receiver'
 import { InfoSheet } from '@/src/components/InfoSheet'
+import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
 
 interface formatTxDetailsProps {
   txDetails?: TransactionDetails
@@ -24,6 +25,7 @@ const characterDisplayLimit = 15
 
 const formatTxDetails = ({ txDetails }: formatTxDetailsProps): ListTableItem[] => {
   const items: ListTableItem[] = []
+  const viewOnExplorer = useOpenExplorer(txDetails?.txData?.to.value || '')
 
   if (!txDetails) {
     return items
@@ -48,7 +50,7 @@ const formatTxDetails = ({ txDetails }: formatTxDetailsProps): ListTableItem[] =
             <View flexDirection="row" alignItems="center" gap="$3">
               <CopyButton value={txDetails.txData?.to.value || ''} size={16} color={'$textSecondaryLight'} />
 
-              <TouchableOpacity onPress={() => null}>
+              <TouchableOpacity onPress={viewOnExplorer}>
                 <SafeFontIcon name="external-link" size={16} color="$textSecondaryLight" />
               </TouchableOpacity>
             </View>

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
@@ -37,7 +37,7 @@ const formatTxDetails = ({ txDetails }: formatTxDetailsProps): ListTableItem[] =
         <View width="100%">
           <Receiver txData={txDetails.txData} />
         </View>
-        <View width="100%" flexDirection="row" alignItems="center" gap="$4">
+        <View width="100%" flexDirection="row" alignItems="center" gap="$2">
           <Identicon address={txDetails.txData?.to.value as Address} size={24} />
 
           <View flexDirection="row" justifyContent="space-between" alignItems="center">
@@ -46,10 +46,10 @@ const formatTxDetails = ({ txDetails }: formatTxDetailsProps): ListTableItem[] =
             </Text>
 
             <View flexDirection="row" alignItems="center" gap="$3">
-              <CopyButton value={txDetails.txData?.to.value || ''} size={14} color={'$textSecondaryLight'} />
+              <CopyButton value={txDetails.txData?.to.value || ''} size={16} color={'$textSecondaryLight'} />
 
               <TouchableOpacity onPress={() => null}>
-                <SafeFontIcon name="external-link" size={14} color="$textSecondaryLight" />
+                <SafeFontIcon name="external-link" size={16} color="$textSecondaryLight" />
               </TouchableOpacity>
             </View>
           </View>
@@ -75,7 +75,8 @@ const formatTxDetails = ({ txDetails }: formatTxDetailsProps): ListTableItem[] =
         <Badge
           circleProps={badgeProps}
           themeName="badge_background"
-          fontSize={12}
+          fontSize={13}
+          textContentProps={{ fontFamily: 'DM Mono' }}
           circular={false}
           content={operationText}
         />

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
@@ -14,18 +14,17 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { TouchableOpacity } from 'react-native'
 import { Receiver } from '../components/Receiver'
 import { InfoSheet } from '@/src/components/InfoSheet'
-import { useOpenExplorer } from '@/src/features/ConfirmTx/hooks/useOpenExplorer'
 
 interface formatTxDetailsProps {
   txDetails?: TransactionDetails
+  viewOnExplorer: () => void
 }
 
 const badgeProps: CircleProps = { borderRadius: '$2', paddingHorizontal: '$2', paddingVertical: '$1' }
 const characterDisplayLimit = 15
 
-const formatTxDetails = ({ txDetails }: formatTxDetailsProps): ListTableItem[] => {
+const formatTxDetails = ({ txDetails, viewOnExplorer }: formatTxDetailsProps): ListTableItem[] => {
   const items: ListTableItem[] = []
-  const viewOnExplorer = useOpenExplorer(txDetails?.txData?.to.value || '')
 
   if (!txDetails) {
     return items

--- a/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
@@ -40,37 +40,35 @@ export function Balance({
   const showSkeleton = isLoading || !balanceAmount
 
   return (
-    <View>
-      <View marginBottom="$4">
-        {activeChainId && (
-          <XStack paddingBottom={'$4'} gap={'$1'} alignItems={'center'}>
-            <DropdownLabel
-              label={chainName}
-              leftNode={<ChainsDisplay activeChainId={activeChainId} chains={chains} max={1} />}
-              onPress={() => {
-                router.push('/networks-sheet')
-              }}
-              labelProps={{ fontWeight: 600, fontSize: '$4' }}
-              displayDropDownIcon={chains.length > 1}
-            />
-            <TouchableOpacity onPress={onPressAddressCopy}>
-              <XStack alignItems={'center'} paddingLeft={'$1'}>
-                <Text color={'$colorSecondary'} fontSize={'$4'}>
-                  {shortenAddress(safeAddress)}
-                </Text>
-                <View paddingLeft={'$1'}>
-                  <SafeFontIcon name={'copy'} size={13} color={'$colorSecondary'} />
-                </View>
-              </XStack>
-            </TouchableOpacity>
-          </XStack>
-        )}
-        <Skeleton.Group show={showSkeleton}>
-          <Skeleton colorMode={colorScheme === 'dark' ? 'dark' : 'light'} width={220}>
-            <Fiat value={balanceAmount} currency={currency} precise />
-          </Skeleton>
-        </Skeleton.Group>
-      </View>
+    <View marginBottom="$4">
+      {activeChainId && (
+        <XStack paddingBottom={'$4'} gap={'$1'} alignItems={'center'}>
+          <DropdownLabel
+            label={chainName}
+            leftNode={<ChainsDisplay activeChainId={activeChainId} chains={chains} max={1} />}
+            onPress={() => {
+              router.push('/networks-sheet')
+            }}
+            labelProps={{ fontWeight: 600, fontSize: '$4' }}
+            displayDropDownIcon={chains.length > 1}
+          />
+          <TouchableOpacity onPress={onPressAddressCopy}>
+            <XStack alignItems={'center'} paddingLeft={'$1'}>
+              <Text color={'$colorSecondary'} fontSize={'$4'}>
+                {shortenAddress(safeAddress)}
+              </Text>
+              <View paddingLeft={'$1'}>
+                <SafeFontIcon name={'copy'} size={13} color={'$colorSecondary'} />
+              </View>
+            </XStack>
+          </TouchableOpacity>
+        </XStack>
+      )}
+      <Skeleton.Group show={showSkeleton}>
+        <Skeleton colorMode={colorScheme === 'dark' ? 'dark' : 'light'} width={220}>
+          <Fiat value={balanceAmount} currency={currency} precise />
+        </Skeleton>
+      </Skeleton.Group>
     </View>
   )
 }

--- a/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.tsx
+++ b/apps/mobile/src/features/Assets/components/ReadOnly/ReadOnly.tsx
@@ -9,20 +9,20 @@ export interface ReadOnlyProps {
   marginTop?: DimensionValue | string
 }
 
-export const ReadOnly = ({ signers, marginBottom = '$8', marginTop = '$2' }: ReadOnlyProps) => {
+export const ReadOnly = ({ signers, marginBottom = '$6', marginTop = '$2' }: ReadOnlyProps) => {
   if (signers.length === 0) {
     return (
       <Container
         marginBottom={marginBottom}
         marginTop={marginTop}
-        padding="$3"
+        padding="$2"
         justifyContent="center"
         alignItems="center"
         backgroundColor="$backgroundSecondary"
       >
         <View flexDirection="row" alignItems="center" gap="$2">
-          <SafeFontIcon name="eye-n" size={20} color="$colorLight" />
-          <Text color="$colorLight" fontSize="$5" fontWeight={600}>
+          <SafeFontIcon name="eye-n" size={16} color="$colorLight" />
+          <Text color="$colorLight" fontSize="$4" fontWeight={600} lineHeight={20} letterSpacing={-0.1}>
             This is a read-only account
           </Text>
         </View>

--- a/apps/mobile/src/features/ConfirmTx/components/ConfirmationsInfo/ConfirmationsInfo.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ConfirmationsInfo/ConfirmationsInfo.tsx
@@ -29,14 +29,15 @@ export function ConfirmationsInfo({ detailedExecutionInfo, txId }: Confirmations
       label="Confirmations"
       onPress={onConfirmationsPress}
       rightNode={
-        <View alignItems="center" flexDirection="row">
+        <View alignItems="center" flexDirection="row" gap="$2">
           <Badge
+            circleProps={{ paddingHorizontal: 8, paddingVertical: 2 }}
             circular={false}
             content={
               <View alignItems="center" flexDirection="row" gap="$1">
                 <SafeFontIcon size={12} name="owners" />
 
-                <Text fontWeight={600} color={'$color'}>
+                <Text fontWeight={600} color={'$color'} fontSize="$2" lineHeight={18}>
                   {detailedExecutionInfo?.confirmations?.length}/{detailedExecutionInfo?.confirmationsRequired}
                 </Text>
               </View>
@@ -44,7 +45,7 @@ export function ConfirmationsInfo({ detailedExecutionInfo, txId }: Confirmations
             themeName={hasEnoughConfirmations ? 'badge_success_variant1' : 'badge_warning'}
           />
 
-          <SafeFontIcon name="chevron-right" />
+          <SafeFontIcon name="chevron-right" size={16} />
         </View>
       }
     />

--- a/apps/mobile/src/features/ConfirmTx/components/ParametersButton/ParametersButton.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ParametersButton/ParametersButton.tsx
@@ -18,11 +18,12 @@ export function ParametersButton({ txId }: ParametersButtonProps) {
     <View height="$10" alignItems="center">
       <Button
         paddingHorizontal="$2"
-        height="$10"
-        borderRadius="$3"
+        height="$9"
+        borderRadius={8}
+        borderWidth={0}
         backgroundColor="$borderLight"
-        fontWeight="600"
-        size="$5"
+        fontWeight="700"
+        size="$4"
         fullscreen
         onPress={goToAdvancedDetails}
       >

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/TransactionChecks.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/TransactionChecks.tsx
@@ -29,7 +29,7 @@ export function TransactionChecks({ txId, txDetails }: TransactionChecksProps) {
       onPress={handleTransactionChecksPress}
       leftNode={<TransactionChecksLeftNode security={security} />}
       label={getTransactionChecksLabel(security.isScanning)}
-      rightNode={<SafeFontIcon name="chevron-right" />}
+      rightNode={<SafeFontIcon name="chevron-right" size={16} />}
       bottomContent={shouldShowBottomContent(security) ? <TransactionChecksBottomContent security={security} /> : null}
     />
   )

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/components/TransactionChecksBottomContent.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/components/TransactionChecksBottomContent.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { Alert } from '@/src/components/Alert'
 import { getAlertType, SecurityState } from '../utils/transactionChecksUtils'
-import { View } from 'tamagui'
-import { InfoSheet } from '@/src/components/InfoSheet'
 
 interface TransactionChecksBottomContentProps {
   security: SecurityState
@@ -18,13 +16,7 @@ export const TransactionChecksBottomContent = ({ security }: TransactionChecksBo
 
   // Show warnings for contract management changes (proxy upgrades, ownership changes, etc.)
   if (security.hasContractManagement) {
-    return (
-      <View>
-        <InfoSheet title="Proceed with caution" info="Review details first">
-          <Alert type="warning" message="Contract changes detected" />
-        </InfoSheet>
-      </View>
-    )
+    return <Alert type="warning" info="Review details first" message="Contract changes detected!" orientation="left" />
   }
 
   // Show error if blockaid check failed

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/components/TransactionChecksBottomContent.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/components/TransactionChecksBottomContent.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Alert } from '@/src/components/Alert'
 import { getAlertType, SecurityState } from '../utils/transactionChecksUtils'
+import { View } from 'tamagui'
+import { InfoSheet } from '@/src/components/InfoSheet'
 
 interface TransactionChecksBottomContentProps {
   security: SecurityState
@@ -16,7 +18,13 @@ export const TransactionChecksBottomContent = ({ security }: TransactionChecksBo
 
   // Show warnings for contract management changes (proxy upgrades, ownership changes, etc.)
   if (security.hasContractManagement) {
-    return <Alert type="warning" info="Review details first" message="Contract changes detected!" />
+    return (
+      <View>
+        <InfoSheet title="Proceed with caution" info="Review details first">
+          <Alert type="warning" message="Contract changes detected" />
+        </InfoSheet>
+      </View>
+    )
   }
 
   // Show error if blockaid check failed

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/components/TransactionChecksLeftNode.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/components/TransactionChecksLeftNode.tsx
@@ -12,5 +12,5 @@ export const TransactionChecksLeftNode = ({ security }: TransactionChecksLeftNod
     return <CircleSnail size={16} borderWidth={0} thickness={1} />
   }
 
-  return <SafeFontIcon name={getTransactionChecksIcon(security)} />
+  return <SafeFontIcon name={getTransactionChecksIcon(security)} size={16} />
 }

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/TransactionHeader.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionHeader/TransactionHeader.tsx
@@ -48,9 +48,15 @@ export function TransactionHeader({
         ))
       )}
 
-      <View alignItems="center" gap="$1">
-        {typeof title === 'string' ? <H3 fontWeight={600}>{title}</H3> : title}
-        <Text color="$textSecondaryLight">
+      <View alignItems="center" gap="$2">
+        {typeof title === 'string' ? (
+          <H3 fontWeight={600} fontSize="$7">
+            {title}
+          </H3>
+        ) : (
+          title
+        )}
+        <Text color="$textSecondaryLight" fontSize="$2" lineHeight={16}>
           {date}, {time}
         </Text>
       </View>

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/CancelTx/CancelTx.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/CancelTx/CancelTx.tsx
@@ -61,7 +61,7 @@ export function CancelTx({ txInfo, executionInfo, txId }: CancelTxProps) {
           label="Actions"
           rightNode={
             <View flexDirection="row" alignItems="center" gap="$2">
-              <Badge themeName="badge_background_inverted" content={txInfo.actionCount.toString()} />
+              <Badge themeName="badge_background_inverted" content={txInfo.actionCount.toString()} circleSize="$6" />
 
               <SafeFontIcon name={'chevron-right'} />
             </View>

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/Contract.tsx
@@ -55,9 +55,9 @@ export function Contract({ txInfo, executionInfo, txId }: ContractProps) {
           label="Actions"
           rightNode={
             <View flexDirection="row" alignItems="center" gap="$2">
-              <Badge themeName="badge_background_inverted" content={txInfo.actionCount.toString()} />
+              <Badge themeName="badge_background_inverted" content={txInfo.actionCount.toString()} circleSize="$6" />
 
-              <SafeFontIcon name={'chevron-right'} />
+              <SafeFontIcon name={'chevron-right'} size={16} />
             </View>
           }
           onPress={handleViewActions}

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Contract/utils.tsx
@@ -22,7 +22,8 @@ export const formatContractItems = (txInfo: CustomTransactionInfo, chain: Chain,
         <Badge
           circleProps={mintBadgeProps}
           themeName="badge_background"
-          fontSize={12}
+          fontSize={13}
+          textContentProps={{ fontFamily: 'DM Mono' }}
           circular={false}
           content={txInfo.methodName ?? ''}
         />

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/GenericView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/GenericView.tsx
@@ -63,7 +63,7 @@ export function GenericView({ txInfo, txData, executionInfo, txId }: GenericView
           onPress={handleViewActions}
           rightNode={
             <View flexDirection="row" alignItems="center" gap="$2">
-              <Badge themeName="badge_background_inverted" content={txInfo.actionCount as string} />
+              <Badge themeName="badge_background_inverted" content={txInfo.actionCount as string} circleSize="$6" />
 
               <SafeFontIcon name={'chevron-right'} />
             </View>

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/utils.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/GenericView/utils.tsx
@@ -40,7 +40,8 @@ export const formatGenericViewItems = ({
         <Badge
           circleProps={mintBadgeProps}
           themeName="badge_background"
-          fontSize={12}
+          fontSize={13}
+          textContentProps={{ fontFamily: 'DM Mono' }}
           circular={false}
           content={txData.dataDecoded?.method ?? ''}
         />

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Stake/Deposit/__snapshots__/Deposit.test.tsx.snap
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Stake/Deposit/__snapshots__/Deposit.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`StakingDeposit matches snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "gap": 4,
+            "gap": 8,
           }
         }
       >
@@ -242,6 +242,8 @@ exports[`StakingDeposit matches snapshot 1`] = `
             {
               "color": "#A1A3A7",
               "fontFamily": "DM Sans",
+              "fontSize": 12,
+              "lineHeight": 16,
             }
           }
           suppressHighlighting={true}
@@ -495,23 +497,23 @@ exports[`StakingDeposit matches snapshot 1`] = `
               "alignItems": "center",
               "backgroundColor": "#DCDEE0",
               "borderBottomColor": "transparent",
-              "borderBottomLeftRadius": 7,
-              "borderBottomRightRadius": 7,
-              "borderBottomWidth": 1,
+              "borderBottomLeftRadius": 8,
+              "borderBottomRightRadius": 8,
+              "borderBottomWidth": 0,
               "borderLeftColor": "transparent",
-              "borderLeftWidth": 1,
+              "borderLeftWidth": 0,
               "borderRightColor": "transparent",
-              "borderRightWidth": 1,
+              "borderRightWidth": 0,
               "borderStyle": "solid",
               "borderTopColor": "transparent",
-              "borderTopLeftRadius": 7,
-              "borderTopRightRadius": 7,
-              "borderTopWidth": 1,
+              "borderTopLeftRadius": 8,
+              "borderTopRightRadius": 8,
+              "borderTopWidth": 0,
               "bottom": 0,
               "flexDirection": "row",
               "flexWrap": "nowrap",
-              "fontWeight": "600",
-              "height": 40,
+              "fontWeight": "700",
+              "height": 36,
               "justifyContent": "center",
               "left": 0,
               "paddingLeft": 8,
@@ -530,10 +532,10 @@ exports[`StakingDeposit matches snapshot 1`] = `
                 "color": "#121312",
                 "flexGrow": 0,
                 "flexShrink": 1,
-                "fontFamily": "DMSans-SemiBold",
-                "fontSize": 16,
+                "fontFamily": "DMSans-Bold",
+                "fontSize": 14,
                 "letterSpacing": 0,
-                "lineHeight": 17.6,
+                "lineHeight": 15.400000000000002,
                 "userSelect": "none",
               }
             }

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Stake/Exit/__snapshots__/Exit.test.tsx.snap
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Stake/Exit/__snapshots__/Exit.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`StakingExit matches snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "gap": 4,
+            "gap": 8,
           }
         }
       >
@@ -242,6 +242,8 @@ exports[`StakingExit matches snapshot 1`] = `
             {
               "color": "#A1A3A7",
               "fontFamily": "DM Sans",
+              "fontSize": 12,
+              "lineHeight": 16,
             }
           }
           suppressHighlighting={true}
@@ -333,23 +335,23 @@ exports[`StakingExit matches snapshot 1`] = `
               "alignItems": "center",
               "backgroundColor": "#DCDEE0",
               "borderBottomColor": "transparent",
-              "borderBottomLeftRadius": 7,
-              "borderBottomRightRadius": 7,
-              "borderBottomWidth": 1,
+              "borderBottomLeftRadius": 8,
+              "borderBottomRightRadius": 8,
+              "borderBottomWidth": 0,
               "borderLeftColor": "transparent",
-              "borderLeftWidth": 1,
+              "borderLeftWidth": 0,
               "borderRightColor": "transparent",
-              "borderRightWidth": 1,
+              "borderRightWidth": 0,
               "borderStyle": "solid",
               "borderTopColor": "transparent",
-              "borderTopLeftRadius": 7,
-              "borderTopRightRadius": 7,
-              "borderTopWidth": 1,
+              "borderTopLeftRadius": 8,
+              "borderTopRightRadius": 8,
+              "borderTopWidth": 0,
               "bottom": 0,
               "flexDirection": "row",
               "flexWrap": "nowrap",
-              "fontWeight": "600",
-              "height": 40,
+              "fontWeight": "700",
+              "height": 36,
               "justifyContent": "center",
               "left": 0,
               "paddingLeft": 8,
@@ -368,10 +370,10 @@ exports[`StakingExit matches snapshot 1`] = `
                 "color": "#121312",
                 "flexGrow": 0,
                 "flexShrink": 1,
-                "fontFamily": "DMSans-SemiBold",
-                "fontSize": 16,
+                "fontFamily": "DMSans-Bold",
+                "fontSize": 14,
                 "letterSpacing": 0,
-                "lineHeight": 17.6,
+                "lineHeight": 15.400000000000002,
                 "userSelect": "none",
               }
             }

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Stake/WithdrawRequest/__snapshots__/WithdrawRequest.test.tsx.snap
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/Stake/WithdrawRequest/__snapshots__/WithdrawRequest.test.tsx.snap
@@ -211,7 +211,7 @@ exports[`StakingWithdrawRequest matches snapshot 1`] = `
         style={
           {
             "alignItems": "center",
-            "gap": 4,
+            "gap": 8,
           }
         }
       >
@@ -253,6 +253,8 @@ exports[`StakingWithdrawRequest matches snapshot 1`] = `
             {
               "color": "#A1A3A7",
               "fontFamily": "DM Sans",
+              "fontSize": 12,
+              "lineHeight": 16,
             }
           }
           suppressHighlighting={true}
@@ -422,23 +424,23 @@ exports[`StakingWithdrawRequest matches snapshot 1`] = `
               "alignItems": "center",
               "backgroundColor": "#DCDEE0",
               "borderBottomColor": "transparent",
-              "borderBottomLeftRadius": 7,
-              "borderBottomRightRadius": 7,
-              "borderBottomWidth": 1,
+              "borderBottomLeftRadius": 8,
+              "borderBottomRightRadius": 8,
+              "borderBottomWidth": 0,
               "borderLeftColor": "transparent",
-              "borderLeftWidth": 1,
+              "borderLeftWidth": 0,
               "borderRightColor": "transparent",
-              "borderRightWidth": 1,
+              "borderRightWidth": 0,
               "borderStyle": "solid",
               "borderTopColor": "transparent",
-              "borderTopLeftRadius": 7,
-              "borderTopRightRadius": 7,
-              "borderTopWidth": 1,
+              "borderTopLeftRadius": 8,
+              "borderTopRightRadius": 8,
+              "borderTopWidth": 0,
               "bottom": 0,
               "flexDirection": "row",
               "flexWrap": "nowrap",
-              "fontWeight": "600",
-              "height": 40,
+              "fontWeight": "700",
+              "height": 36,
               "justifyContent": "center",
               "left": 0,
               "paddingLeft": 8,
@@ -457,10 +459,10 @@ exports[`StakingWithdrawRequest matches snapshot 1`] = `
                 "color": "#121312",
                 "flexGrow": 0,
                 "flexShrink": 1,
-                "fontFamily": "DMSans-SemiBold",
-                "fontSize": 16,
+                "fontFamily": "DMSans-Bold",
+                "fontSize": 14,
                 "letterSpacing": 0,
-                "lineHeight": 17.6,
+                "lineHeight": 15.400000000000002,
                 "userSelect": "none",
               }
             }

--- a/apps/mobile/src/features/DataImport/ImportSuccessScreen.container.tsx
+++ b/apps/mobile/src/features/DataImport/ImportSuccessScreen.container.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useRouter } from 'expo-router'
-import { getTokenValue, useTheme } from 'tamagui'
+import { getTokenValue } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
 import { selectAllSafes, SafesSlice } from '@/src/store/safesSlice'
@@ -15,7 +15,6 @@ export const ImportSuccessScreen = () => {
   const dispatch = useAppDispatch()
   const allSafes = useAppSelector(selectAllSafes) as SafesSlice
   const { notImportedKeys } = useDataImportContext()
-  const theme = useTheme()
   const colors: [string, string] = [getTokenValue('$color.successBackgroundLight'), 'transparent']
 
   const handleContinue = () => {

--- a/apps/mobile/src/features/DataImport/ImportSuccessScreen.container.tsx
+++ b/apps/mobile/src/features/DataImport/ImportSuccessScreen.container.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useRouter } from 'expo-router'
-import { useTheme } from 'tamagui'
+import { getTokenValue, useTheme } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
 import { selectAllSafes, SafesSlice } from '@/src/store/safesSlice'
@@ -16,7 +16,7 @@ export const ImportSuccessScreen = () => {
   const allSafes = useAppSelector(selectAllSafes) as SafesSlice
   const { notImportedKeys } = useDataImportContext()
   const theme = useTheme()
-  const colors: [string, string] = [theme.success.get(), 'transparent']
+  const colors: [string, string] = [getTokenValue('$color.successBackgroundLight'), 'transparent']
 
   const handleContinue = () => {
     const safeAddresses = Object.keys(allSafes)

--- a/apps/mobile/src/features/DataImport/components/DataTransferView.tsx
+++ b/apps/mobile/src/features/DataImport/components/DataTransferView.tsx
@@ -48,13 +48,10 @@ export const DataTransferView = ({
           )}
 
           <H2 fontWeight={'600'} textAlign="center">
-            Transfer your data for a quick start
+            Import old app data
           </H2>
 
-          <StyledText>
-            Easily bring over your Safe accounts, signers, and address book from the old app for a smooth start, if you
-            have used it before.
-          </StyledText>
+          <StyledText>Move your Safe accounts, signers, and address book in minutes.</StyledText>
         </YStack>
 
         {/* Phone Mockup */}
@@ -64,7 +61,7 @@ export const DataTransferView = ({
       {/* Bottom Buttons */}
       <YStack gap="$3" paddingHorizontal="$4" paddingBottom={bottomInset} paddingTop="$4">
         <SafeButton primary testID="transfer-data-button" onPress={onPressTransferData}>
-          Transfer data
+          Import data
         </SafeButton>
 
         <SafeButton text testID="start-fresh-button" onPress={onPressStartFresh}>

--- a/apps/mobile/src/features/DataImport/components/EnterPasswordView.tsx
+++ b/apps/mobile/src/features/DataImport/components/EnterPasswordView.tsx
@@ -28,25 +28,17 @@ export const EnterPasswordView = ({
     <KeyboardAvoidingView behavior="padding" style={{ flex: 1 }} keyboardVerticalOffset={bottomInset + topInset}>
       <ScrollView contentContainerStyle={{ flex: 1 }} keyboardShouldPersistTaps="handled">
         <YStack flex={1} testID="enter-password-screen">
-          {/* Content */}
           <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>
             <YStack gap="$6">
-              {/* Title */}
               <H2 fontWeight={'600'} textAlign="center" marginHorizontal={'$4'}>
                 Enter password
               </H2>
 
-              {/* Warning Box */}
               <XStack justifyContent="center">
-                <Alert
-                  type="warning"
-                  message="Make sure to enter the password you used to encrypt the file in the old app."
-                  orientation="left"
-                />
+                <Alert type="warning" message="Use the password you set to encrypt the file." orientation="left" />
               </XStack>
 
-              <YStack gap="$4" marginTop="$8">
-                {/* Hidden Text Input */}
+              <YStack gap="$4">
                 <SafeInput
                   placeholder="Enter the file password"
                   keyboardType="visible-password"
@@ -58,7 +50,6 @@ export const EnterPasswordView = ({
                 />
 
                 <YStack>
-                  {/* File Info */}
                   {fileName && (
                     <Text color="$colorSecondary" fontSize="$3" testID="file-name">
                       File: {fileName}
@@ -68,7 +59,6 @@ export const EnterPasswordView = ({
               </YStack>
             </YStack>
 
-            {/* Bottom Actions */}
             <YStack gap="$4" paddingBottom={bottomInset}>
               <SafeButton
                 primary
@@ -77,7 +67,7 @@ export const EnterPasswordView = ({
                 disabled={!password.length || isLoading}
                 opacity={!password.length || isLoading ? 0.5 : 1}
               >
-                {isLoading ? 'Decrypting...' : 'Decrypt'}
+                {isLoading ? 'Decrypting...' : 'Continue'}
               </SafeButton>
             </YStack>
           </YStack>

--- a/apps/mobile/src/features/DataImport/components/FileSelectionView.tsx
+++ b/apps/mobile/src/features/DataImport/components/FileSelectionView.tsx
@@ -11,13 +11,6 @@ const StyledText = styled(Text, {
   color: '$colorSecondary',
 })
 
-const PrivacyText = styled(Text, {
-  fontSize: '$3',
-  textAlign: 'center',
-  color: '$colorSecondary',
-  paddingHorizontal: '$4',
-})
-
 interface FileSelectionViewProps {
   colorScheme: ColorSchemeName
   bottomInset: number

--- a/apps/mobile/src/features/DataImport/components/FileSelectionView.tsx
+++ b/apps/mobile/src/features/DataImport/components/FileSelectionView.tsx
@@ -28,18 +28,14 @@ interface FileSelectionViewProps {
 export const FileSelectionView = ({ colorScheme, bottomInset, onFileSelect, onImagePress }: FileSelectionViewProps) => {
   return (
     <YStack flex={1} testID="file-selection-screen" paddingBottom={bottomInset}>
-      {/* Content */}
       <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>
         <YStack gap="$4" flex={1}>
-          {/* Title */}
           <H2 fontWeight={'600'} textAlign="center" marginHorizontal={'$4'}>
-            Almost there! Import file to the new app
+            Import your file
           </H2>
 
-          {/* Subtitle */}
-          <StyledText>Locate the exported file from the old app to continue.</StyledText>
+          <StyledText>Find the exported file from your old app to continue.</StyledText>
 
-          {/* Image - Tappable */}
           <YStack flex={1} justifyContent="center" alignItems="center">
             <TouchableOpacity onPress={onImagePress} activeOpacity={0.8}>
               <Image
@@ -51,11 +47,9 @@ export const FileSelectionView = ({ colorScheme, bottomInset, onFileSelect, onIm
           </YStack>
         </YStack>
 
-        {/* Bottom Actions */}
         <YStack gap="$4">
-          <PrivacyText>Don't worry, all your data will stay private and secure during the transfer.</PrivacyText>
           <SafeButton primary testID="select-file-to-import-button" onPress={onFileSelect}>
-            Select file to import
+            Select from files
           </SafeButton>
         </YStack>
       </YStack>

--- a/apps/mobile/src/features/DataImport/components/HelpImportView.tsx
+++ b/apps/mobile/src/features/DataImport/components/HelpImportView.tsx
@@ -29,44 +29,39 @@ interface HelpImportViewProps {
 export const HelpImportView = ({ bottomInset, onPressProceedToImport, onPressNeedHelp }: HelpImportViewProps) => {
   return (
     <YStack flex={1} testID="help-import-screen">
-      {/* Content */}
       <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>
         <YStack gap="$6">
-          {/* Title */}
           <H2 fontWeight={'600'} textAlign="center" marginHorizontal={'$4'}>
-            Here is how to move your data
+            How to move your data
           </H2>
 
-          {/* Steps */}
           <YStack gap="$4">
             <XStack gap="$3" alignItems="center">
               <StepBadge step="1" />
               <StepText>
-                Open the old Safe{'{'}Wallet{'}'} app.
+                Open your old Safe{'{'}Wallet{'}'} app.
               </StepText>
             </XStack>
 
             <XStack gap="$3" alignItems="center">
               <StepBadge step="2" />
               <StepText>
-                Go to <HighlightedText>Settings</HighlightedText> and select{' '}
-                <HighlightedText>Export Data</HighlightedText>.
+                Go to <HighlightedText>Settings</HighlightedText> → <HighlightedText>Export Data</HighlightedText>.
               </StepText>
             </XStack>
 
             <XStack gap="$3" alignItems="center">
               <StepBadge step="3" />
-              <StepText>Follow the instructions to save the file.</StepText>
+              <StepText>Follow the steps to save the file.</StepText>
             </XStack>
 
             <XStack gap="$3" alignItems="center">
               <StepBadge step="4" />
-              <StepText>Return to this app to import the file.</StepText>
+              <StepText>Return here to import it.</StepText>
             </XStack>
           </YStack>
         </YStack>
 
-        {/* Bottom Actions */}
         <YStack gap="$4" paddingBottom={bottomInset}>
           <SafeButton primary testID="proceed-to-import-button" onPress={onPressProceedToImport}>
             Proceed to import

--- a/apps/mobile/src/features/DataImport/components/ImportErrorView.tsx
+++ b/apps/mobile/src/features/DataImport/components/ImportErrorView.tsx
@@ -40,7 +40,7 @@ export const ImportErrorView = ({ colors, bottomInset, onTryAgain }: ImportError
                 </LargeHeaderTitle>
 
                 <Text textAlign="center" fontSize="$4" width="80%">
-                  {'The file could not be processed. Ensure the data meets the required specifications.'}
+                  The file could not be processed. Please check the file details and try again.
                 </Text>
               </View>
             </View>

--- a/apps/mobile/src/features/DataImport/components/ImportProgressScreenView.tsx
+++ b/apps/mobile/src/features/DataImport/components/ImportProgressScreenView.tsx
@@ -16,7 +16,7 @@ export const ImportProgressScreenView = ({ progress, message }: ImportProgressSc
           <YStack gap="$6" alignItems="center" maxWidth={300}>
             {/* Title */}
             <H2 fontWeight={'600'} textAlign="center">
-              Your file is being securely imported
+              Importing data...
             </H2>
 
             {/* Subtitle */}

--- a/apps/mobile/src/features/DataImport/components/ImportSuccessScreenView.tsx
+++ b/apps/mobile/src/features/DataImport/components/ImportSuccessScreenView.tsx
@@ -44,8 +44,9 @@ export const ImportSuccessScreenView = ({
 
                 {/* Subtitle */}
                 <Text fontSize="$4" textAlign="center" marginHorizontal={'$4'} color="$colorSecondary">
-                  Your data has been successfully imported. However, some signers are not associated with your Safe
-                  accounts and won't be added
+                  {notImportedKeys.length > 0
+                    ? "Your data has been successfully imported. However, some signers are not associated with your Safe accounts and won't be added"
+                    : 'Your accounts, signers, and contacts are ready to use.'}
                 </Text>
 
                 {/* Not Imported Keys Section */}

--- a/apps/mobile/src/features/DataImport/components/ReviewDataView.tsx
+++ b/apps/mobile/src/features/DataImport/components/ReviewDataView.tsx
@@ -27,30 +27,25 @@ export const ReviewDataView = ({
   return (
     <ScrollView contentContainerStyle={{ flex: 1 }}>
       <YStack flex={1} testID="review-data-screen">
-        {/* Content */}
         <YStack flex={1} paddingHorizontal="$4" justifyContent="space-between" marginTop={'$4'}>
-          <YStack gap="$6">
-            {/* Title */}
+          <YStack gap="$3">
             <H2 fontWeight={'600'} textAlign="center" marginHorizontal={'$4'}>
               Review data
             </H2>
 
-            {/* Subtitle */}
             <Text fontSize="$4" textAlign="center" marginHorizontal={'$4'}>
-              Review the data you're about to import to ensure everything is correct.
+              Check that everything looks correct before importing.
             </Text>
 
-            <Container gap="$4" marginTop="$8" padding="$4" backgroundColor="$background" borderRadius="$4">
-              {/* Importing section */}
+            <Container gap="$3" marginTop="$4" padding="$4" backgroundColor="$background" borderRadius="$4">
               <Text color="$colorSecondary" fontSize="$3" fontWeight="500">
                 Importing:
               </Text>
 
-              {/* Safe Accounts */}
               <XStack
                 justifyContent="space-between"
                 alignItems="center"
-                paddingVertical="$3"
+                paddingVertical="$1"
                 testID="safe-accounts-summary"
               >
                 <XStack alignItems="center" gap="$3">
@@ -63,18 +58,21 @@ export const ReviewDataView = ({
                     <Text fontSize="$4" fontWeight="500">
                       Safe Accounts
                     </Text>
-                    <Text fontSize="$3" color="$colorSecondary">
+                    <Text fontSize="$2" color="$colorSecondary">
                       Including read-only
                     </Text>
                   </YStack>
                 </XStack>
                 <Text fontSize="$5" fontWeight="600">
-                  {importSummary.safeAccountsCount}
+                  <Badge
+                    themeName="badge_background"
+                    content={<Text fontWeight={600}>{importSummary.safeAccountsCount}</Text>}
+                    circular
+                  />
                 </Text>
               </XStack>
 
-              {/* Signers */}
-              <XStack justifyContent="space-between" alignItems="center" paddingVertical="$3" testID="signers-summary">
+              <XStack justifyContent="space-between" alignItems="center" paddingVertical="$1" testID="signers-summary">
                 <XStack alignItems="center" gap="$3">
                   <Badge
                     themeName="badge_background"
@@ -85,21 +83,24 @@ export const ReviewDataView = ({
                     <Text fontSize="$4" fontWeight="500">
                       Signers
                     </Text>
-                    <Text fontSize="$3" color="$colorSecondary">
+                    <Text fontSize="$2" color="$colorSecondary">
                       Generated and imported
                     </Text>
                   </YStack>
                 </XStack>
                 <Text fontSize="$5" fontWeight="600">
-                  {importSummary.signersCount}
+                  <Badge
+                    themeName="badge_background"
+                    content={<Text fontWeight={600}>{importSummary.signersCount}</Text>}
+                    circular
+                  />
                 </Text>
               </XStack>
 
-              {/* Address Book */}
               <XStack
                 justifyContent="space-between"
                 alignItems="center"
-                paddingVertical="$3"
+                paddingVertical="$1"
                 testID="address-book-summary"
               >
                 <XStack alignItems="center" gap="$3">
@@ -112,21 +113,23 @@ export const ReviewDataView = ({
                     <Text fontSize="$4" fontWeight="500">
                       Address Book
                     </Text>
-                    <Text fontSize="$3" color="$colorSecondary">
+                    <Text fontSize="$2" color="$colorSecondary">
                       All added contacts
                     </Text>
                   </YStack>
                 </XStack>
                 <Text fontSize="$5" fontWeight="600">
-                  {importSummary.addressBookCount}
+                  <Badge
+                    themeName="badge_background"
+                    content={<Text fontWeight={600}>{importSummary.addressBookCount}</Text>}
+                    circular
+                  />
                 </Text>
               </XStack>
             </Container>
           </YStack>
 
-          {/* Bottom section */}
           <YStack gap="$4" paddingBottom={bottomInset}>
-            {/* Privacy notice */}
             <Text
               color="$colorSecondary"
               fontSize="$3"
@@ -134,7 +137,7 @@ export const ReviewDataView = ({
               marginHorizontal={'$4'}
               testID="privacy-notice"
             >
-              Don't worry, all your data will stay private and secure during the transfer.
+              Your data stays private and secure during the transfer.
             </Text>
 
             {/* Continue button */}

--- a/apps/mobile/src/features/Onboarding/components/OnboardingCarousel/items.tsx
+++ b/apps/mobile/src/features/Onboarding/components/OnboardingCarousel/items.tsx
@@ -52,7 +52,7 @@ export const items: CarouselItem[] = [
         </H1>
       </>
     ),
-    description: 'Easily track balances and get real-time updates on account activity - anytime.',
+    description: 'Easily track balances and get real-time updates on account activity — anytime.',
   },
   {
     name: 'signing',
@@ -64,14 +64,11 @@ export const items: CarouselItem[] = [
     title: (
       <>
         <H1 style={styles.textContainer} fontWeight={600} marginHorizontal={windowWidth <= maxGoodWidth ? -10 : 0}>
-          Sign transaction
+          Sign transactions
         </H1>
 
         <H1 style={styles.textContainer} fontWeight={600}>
-          securely on-
-        </H1>
-        <H1 style={styles.textContainer} fontWeight={600}>
-          the-go..
+          on the go
         </H1>
       </>
     ),
@@ -87,10 +84,10 @@ export const items: CarouselItem[] = [
     title: (
       <>
         <H1 style={styles.textContainer} fontWeight={600}>
-          ...and get
+          Get
         </H1>
         <H1 style={styles.textContainer} fontWeight={600}>
-          personalised
+          personalized
         </H1>
         <H1 style={styles.textContainer} fontWeight={600}>
           updates

--- a/apps/mobile/src/features/TransactionChecks/components/TransactionChecksView.tsx
+++ b/apps/mobile/src/features/TransactionChecks/components/TransactionChecksView.tsx
@@ -88,6 +88,7 @@ export const TransactionChecksView = ({ tenderly, blockaid }: Props) => {
               </XStack>
               {tenderly.fetchStatus === FETCH_STATUS.SUCCESS && (
                 <SafeButton
+                  size="$sm"
                   secondary
                   onPress={() => {
                     Linking.openURL(tenderly.simulationLink)

--- a/apps/mobile/src/features/TransactionChecks/components/blockaid/balance/FungibleBalanceChange.tsx
+++ b/apps/mobile/src/features/TransactionChecks/components/blockaid/balance/FungibleBalanceChange.tsx
@@ -32,7 +32,7 @@ export const FungibleBalanceChange = ({
 
   return (
     <XStack alignItems="center" gap="$2">
-      <Logo size={'$5'} logoUri={logoUri} />
+      <Logo size={'$5'} logoUri={logoUri} imageBackground="$background" />
       <Text fontSize={14} fontWeight="700" marginLeft="$1">
         {asset.symbol}
       </Text>

--- a/apps/mobile/src/theme/helpers/tabBarStyles.ts
+++ b/apps/mobile/src/theme/helpers/tabBarStyles.ts
@@ -34,7 +34,7 @@ export const getMaterialTopTabBarScreenOptions = ({
   tabBarIndicatorStyle: {
     backgroundColor: theme?.color?.get(),
     width: tabBarIndicatorWidth,
-    marginLeft: 6,
+    marginLeft: 16,
     alignItems: 'center' as const,
   },
   tabBarLabelStyle: {


### PR DESCRIPTION
## What it solves

Resolves [COR-143](https://linear.app/safe-global/issue/COR-143/mobile-open-address-on-blockexplorer-doesnt-work-on-tx-details-data)

## How this PR fixes it

- Updates confirmation badge sizes
- Various font-size fixes
- Updates copy in onboarding
- Uses DM Mono font where needed
- Aligns UI of top tabs for transactions and transaction data screen
- Always shows the "All networks" button when editing a contact so users can toggle
- Adds an action to the explorer button in the transaction details view

## How to test it

## Screenshots
<img width="405" height="469" alt="Screenshot 2025-07-17 at 23 42 28" src="https://github.com/user-attachments/assets/ac442406-0148-4050-883a-19dbd057f18d" />
<img width="393" height="226" alt="Screenshot 2025-07-17 at 23 42 43" src="https://github.com/user-attachments/assets/fabb127e-80f3-47a8-8850-f5e3b43bc128" />
<img width="386" height="244" alt="Screenshot 2025-07-17 at 23 42 54" src="https://github.com/user-attachments/assets/0122912e-0ce1-40fc-954e-0c85d1728fc3" />
<img width="392" height="376" alt="Screenshot 2025-07-17 at 23 43 10" src="https://github.com/user-attachments/assets/dd52bce4-338d-4d8c-960b-ba1bc53d1217" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
