### PR TITLE
feat(mobile): Add loading indicators for transaction history

### DIFF
--- a/apps/mobile/src/features/TxHistory/components/TxHistorySkeleton/TxHistorySkeleton.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistorySkeleton/TxHistorySkeleton.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { View } from 'tamagui'
+import { useColorScheme } from 'react-native'
+import { Skeleton } from 'moti/skeleton'
+import { Container } from '@/src/components/Container'
+import random from 'lodash/random'
+
+interface TxHistorySkeletonProps {
+  count?: number
+}
+
+export const TxHistorySkeletonItem = () => {
+  const colorScheme = useColorScheme() || undefined
+
+  return (
+    <Container spaced paddingVertical="$5" bordered={false}>
+      <View flexDirection="row" width="100%" alignItems="center" justifyContent="space-between">
+        <View flexDirection="row" maxWidth="55%" alignItems="center" gap="$3">
+          {/* Left icon skeleton */}
+          <Skeleton colorMode={colorScheme} radius="round" height={32} width={32} />
+
+          <View flex={1} gap="$2">
+            {/* Transaction type skeleton */}
+            <Skeleton colorMode={colorScheme} height={10} width={random(60, 100)} />
+
+            {/* Transaction label skeleton */}
+            <Skeleton colorMode={colorScheme} height={18} width={random(60, 180)} />
+          </View>
+        </View>
+
+        {/* Right side skeleton */}
+        <View alignItems="flex-end" gap="$2">
+          <Skeleton colorMode={colorScheme} height={16} width={random(60, 100)} />
+        </View>
+      </View>
+    </Container>
+  )
+}
+
+export const TxHistorySkeleton = ({ count = 6 }: TxHistorySkeletonProps) => {
+  const colorScheme = useColorScheme() || undefined
+
+  return (
+    <Skeleton.Group show={true}>
+      <View gap="$4">
+        {/* Date header skeleton */}
+        <View>
+          <Skeleton colorMode={colorScheme} height={20} width={100} />
+        </View>
+
+        {/* Transaction items skeleton */}
+        {Array.from({ length: count }).map((_, index) => (
+          <TxHistorySkeletonItem key={index} />
+        ))}
+      </View>
+    </Skeleton.Group>
+  )
+}

--- a/apps/mobile/src/features/TxHistory/components/TxHistorySkeleton/index.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistorySkeleton/index.tsx
@@ -1,0 +1,1 @@
+export { TxHistorySkeleton, TxHistorySkeletonItem } from './TxHistorySkeleton'

--- a/apps/mobile/src/features/TxHistory/index.tsx
+++ b/apps/mobile/src/features/TxHistory/index.tsx
@@ -1,2 +1,4 @@
 import { TxHistoryContainer } from './TxHistory.container'
+
 export { TxHistoryContainer }
+export { TxHistorySkeleton, TxHistorySkeletonItem } from './components/TxHistorySkeleton'


### PR DESCRIPTION
## What it solves
Implements proper loading indicators for the transaction history tab to improve user experience during data fetching.

Resolves [COR-326](https://linear.app/safe-global/issue/COR-326/display-loading-indicator)

## How this PR fixes it
- **Initial loading**: Skeleton using `ListEmptyComponent`
- **Pagination loading**: Bottom loading indicator using `ListFooterComponent` 
- **Skeleton components**: Created `TxHistorySkeleton` with Moti animations and randomized widths
- **Enhanced tests**: Added comprehensive test coverage for both loading states

### Loading states
- **First load**: Shows realistic transaction skeleton placeholders (6 items)
- **Load more**: Single skeleton item at bottom during pagination
- **Pull-to-refresh**: Preserved without conflicting loading states

## How to test it

### Initial loading state
1. Navigate to **Transactions** tab
2. **Expected**: See 6 transaction skeleton placeholders

### Pagination loading
1. Wait for initial transactions to load
2. Scroll down to the bottom of the transaction list
3. **Expected**: Single skeleton item appears at bottom while loading more
4. **Expected**: Skeleton disappears when new transactions load

### Pull-to-refresh
1. With transactions loaded, pull down from the top
2. **Expected**: Standard refresh indicator works normally
3. **Expected**: No initial loading skeleton conflicts with refresh

## Screenshots

https://github.com/user-attachments/assets/70fab5b5-d6cd-4867-9a4e-7c22461aae66


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
