### PR TITLE
fix(mobile): bridge tx now displays pending signatures

### DIFF
--- a/apps/mobile/src/components/TxInfo/TxInfo.tsx
+++ b/apps/mobile/src/components/TxInfo/TxInfo.tsx
@@ -130,11 +130,11 @@ function TxInfoComponent({ tx, onPress, ...rest }: TxInfoProps) {
   }
 
   if (isBridgeOrderTxInfo(txInfo)) {
-    return <TxBridgeCard txInfo={txInfo} onPress={onCardPress} executionInfo={tx.executionInfo} />
+    return <TxBridgeCard txInfo={txInfo} onPress={onCardPress} executionInfo={tx.executionInfo} {...rest} />
   }
 
   if (isLifiSwapTxInfo(txInfo)) {
-    return <TxLifiSwapCard txInfo={txInfo} onPress={onCardPress} executionInfo={tx.executionInfo} />
+    return <TxLifiSwapCard txInfo={txInfo} onPress={onCardPress} executionInfo={tx.executionInfo} {...rest} />
   }
 
   return <></>


### PR DESCRIPTION
## What it solves
A picture is worth thousand words they say. Before:
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/f331dfe0-b062-4545-8490-2a3f7e1fd46b" />

After:
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/67640fa7-1049-4e96-93fd-765b8dd5251f" />

Resolves https://linear.app/safe-global/issue/COR-223/get-at-least-rudimentary-decoding-for-bridge-txs

## How this PR fixes it
I think that this was done correctly, but then had to rebase the PR and in the PR i forgot to add the {...rest} part
 
## How to test it
Navigate to pending transactions on a safe with bridge transfers and on the right you should see whether it has been signed or not.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
