### PR TITLE
fix(mobile): display notification even when app in quit state

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -157,9 +157,6 @@ const config = {
     'app.notifee.notification-event': {
       backgroundMode: ['processing', 'remote-notification'],
     },
-    ReactNativeFirebaseMessagingHeadlessTask: {
-      backgroundMode: ['processing', 'remote-notification'],
-    },
   },
 }
 

--- a/apps/mobile/docs/push-notifications.md
+++ b/apps/mobile/docs/push-notifications.md
@@ -86,6 +86,7 @@ When the app starts, `NotificationService.initializeNotificationHandlers()` sets
 ### iOS
 
 - Uses a **Notification Service Extension** (`NotificationService.swift`) to intercept the push payload when the app is in the background. The extension reads data stored via `startNotificationExtensionSync` and rewrites the notification title/body.
+- None of the background tasks are being executed as the notification service is intercepting the notifications before they reach the background tasks
 - Opening the notification settings uses `Linking.openURL('app-settings:')`.
 - iOS badges are updated with `notifee` and can show a banner or list presentation when the app is active.
 
@@ -94,6 +95,7 @@ When the app starts, `NotificationService.initializeNotificationHandlers()` sets
 - Notifications are handled directly by Notifee using FCM. There is no additional extension layer.
 - Device settings are opened with `Linking.openSettings()`.
 - Android uses channels defined in `notificationChannels` with importance `HIGH` and visibility `PUBLIC` to display alerts.
+- When the app is in background or in quit state the background handlers are being executed in headless mode.
 
 Both platforms share the same subscription logic and redux state but differ in how the underlying OS displays and processes the notification payload.
 

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -1,10 +1,4 @@
-//@ts-ignore
-globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true
-import { registerRootComponent } from 'expo'
+// Initialize all background notification handlers FIRST - must be self-contained, no app dependencies
+import '@/src/services/notifications/backgroundHandlers'
 
-import App from './App'
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App)
+import 'expo-router/entry'

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/mobile",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "version": "1.0.0",
   "doctor": {
     "reactNativeDirectoryCheck": {

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -24,11 +24,10 @@ import Logger, { LogLevel } from '@/src/utils/logger'
 import { useInitWeb3 } from '@/src/hooks/useInitWeb3'
 import { useInitSafeCoreSDK } from '@/src/hooks/coreSDK/useInitSafeCoreSDK'
 import NotificationsService from '@/src/services/notifications/NotificationService'
-import { startNotificationExtensionSync } from '@/src/services/notifications/extensionSync'
+import { startNotificationExtensionSync } from '@/src/services/notifications/store-sync/sync'
 import { useScreenTracking } from '@/src/hooks/useScreenTracking'
 import { useAnalytics } from '@/src/hooks/useAnalytics'
 import { DataFetchProvider } from '../theme/provider/DataFetchProvider'
-import { Platform } from 'react-native'
 import { config, actions } from '@/src/platform/security'
 import { useFreeRasp } from 'freerasp-react-native'
 import { SafeStatusBar } from '@/src/theme/SafeStatusBar'
@@ -39,9 +38,7 @@ Logger.setLevel(__DEV__ ? LogLevel.TRACE : LogLevel.ERROR)
 // Initialize all notification handlers
 NotificationsService.initializeNotificationHandlers()
 
-if (Platform.OS === 'ios') {
-  startNotificationExtensionSync()
-}
+startNotificationExtensionSync()
 
 configureReanimatedLogger({
   level: ReanimatedLogLevel.warn,

--- a/apps/mobile/src/services/notifications/NotificationService.ts
+++ b/apps/mobile/src/services/notifications/NotificationService.ts
@@ -349,30 +349,9 @@ class NotificationsService {
   initializeNotificationHandlers(): void {
     // Core Firebase handlers
     this.listenForMessagesForeground() // FCM foreground messages
-    this.registerFirebaseBackgroundHandler() // FCM background messages
     this.registerFirebaseNotificationOpenedHandler() // App opened from notification
 
-    // Core Notifee handlers
-    this.registerNotifeeBackgroundHandler() // Notifee interactions (press, dismiss, etc.)
-
     Logger.info('NotificationService: Successfully initialized simplified notification handlers')
-  }
-
-  /**
-   * Registers the Notifee background event handler
-   */
-  private registerNotifeeBackgroundHandler(): void {
-    notifee.onBackgroundEvent(async ({ type, detail }) => {
-      if (type === EventType.PRESS) {
-        await this.handleNotificationPress({ detail })
-      } else if (type === EventType.DELIVERED) {
-        await this.incrementBadgeCount(1)
-      } else if (type === EventType.DISMISSED) {
-        Logger.info('User dismissed notification:', detail.notification?.id)
-      }
-
-      return Promise.resolve()
-    })
   }
 
   private listenForMessagesForeground = (): UnsubscribeFunc => {
@@ -419,26 +398,6 @@ class NotificationsService {
           }
         }
       })
-  }
-
-  /**
-   * Registers the Firebase messaging background handler
-   */
-  private registerFirebaseBackgroundHandler(): void {
-    getMessaging().setBackgroundMessageHandler(async (remoteMessage) => {
-      Logger.info('Message handled in the background!', remoteMessage)
-
-      // Display the notification using Notifee
-      const parsed = parseNotification(remoteMessage.data)
-      await this.displayNotification({
-        channelId: ChannelId.DEFAULT_NOTIFICATION_CHANNEL_ID,
-        title: parsed?.title || remoteMessage.notification?.title || '',
-        body: parsed?.body || remoteMessage.notification?.body || '',
-        data: remoteMessage.data,
-      })
-
-      return Promise.resolve()
-    })
   }
 }
 

--- a/apps/mobile/src/services/notifications/backgroundHandlers.ts
+++ b/apps/mobile/src/services/notifications/backgroundHandlers.ts
@@ -1,0 +1,59 @@
+import messaging from '@react-native-firebase/messaging'
+import notifee from '@notifee/react-native'
+
+/**
+ * The background handlers here are only used by the Android version of the app.
+ * On iOS, the Notification Service Extension is intercepting the notifications and those
+ * functions here never get called.
+ */
+messaging().setBackgroundMessageHandler(async (remoteMessage) => {
+  const messageId = remoteMessage.messageId || `${remoteMessage.data?.type}-${Date.now()}`
+  console.log('[Firebase Background] Processing message:', messageId)
+
+  try {
+    // Check for message deduplication and mark as processed
+    const { checkAndMarkMessageProcessed } = await import('@/src/services/notifications/utils/messageDeduplication')
+
+    if (checkAndMarkMessageProcessed(messageId)) {
+      console.log('[Firebase Background] Message already processed, acknowledging:', messageId)
+      return // Already processed - acknowledge and skip
+    }
+
+    console.log('[Firebase Background] Displaying notification for message:', messageId)
+
+    // Use regular parser with automatic fallback to extension MMKV storage
+    const { parseNotification } = await import('./notificationParser')
+    const NotificationsService = (await import('./NotificationService')).default
+    const { ChannelId } = await import('@/src/utils/notifications')
+
+    const parsed = parseNotification(remoteMessage.data)
+
+    // Add timeout to prevent hanging
+    await NotificationsService.displayNotification({
+      channelId: ChannelId.DEFAULT_NOTIFICATION_CHANNEL_ID,
+      title: parsed?.title || remoteMessage.notification?.title || '',
+      body: parsed?.body || remoteMessage.notification?.body || '',
+      data: remoteMessage.data,
+    })
+
+    console.log('[Firebase Background] Successfully processed message:', messageId)
+  } catch (error) {
+    console.error('[Firebase Background] Error processing message:', messageId, error)
+  }
+
+  return Promise.resolve()
+})
+
+notifee.onBackgroundEvent(async ({ type, detail }) => {
+  console.log('[Notifee Background] Event received:', type)
+
+  try {
+    // Delegate to NotificationService for consistent logic
+    const NotificationsService = (await import('./NotificationService')).default
+    await NotificationsService.handleNotificationEvent({ type, detail })
+
+    console.log('[Notifee Background] Event processed successfully')
+  } catch (error) {
+    console.error('[Notifee Background] Error processing event:', error)
+  }
+})

--- a/apps/mobile/src/services/notifications/store-sync/const.ts
+++ b/apps/mobile/src/services/notifications/store-sync/const.ts
@@ -1,0 +1,9 @@
+import { MMKV } from 'react-native-mmkv'
+
+/**
+ * Shared MMKV instance for extension storage
+ *
+ * Fun fact: it's named extensionStorage, because it was supposed to be used only in
+ * ios's service extension. Now it is also used on Android, but in headless mode.
+ */
+export const extensionStorage = new MMKV({ id: 'extension' })

--- a/apps/mobile/src/services/notifications/store-sync/read.ts
+++ b/apps/mobile/src/services/notifications/store-sync/read.ts
@@ -1,0 +1,25 @@
+import { STORAGE_IDS } from '@/src/store/constants'
+import { extensionStorage } from './const'
+
+interface ExtensionStore {
+  chains: Record<string, { name: string; symbol: string; decimals: number }>
+  contacts: Record<string, string>
+}
+
+/**
+ * Read extension data from MMKV storage
+ * This function is separate from extensionSync.ts to avoid require cycles
+ * It only reads data and has no dependencies on the Redux store
+ */
+export function getExtensionData(): ExtensionStore | null {
+  try {
+    const data = extensionStorage.getString(STORAGE_IDS.NOTIFICATION_EXTENSION_DATA)
+    if (!data) {
+      return null
+    }
+    return JSON.parse(data) as ExtensionStore
+  } catch (error) {
+    console.error('extensionDataReader: Failed to get extension data', error)
+    return null
+  }
+}

--- a/apps/mobile/src/services/notifications/store-sync/sync.ts
+++ b/apps/mobile/src/services/notifications/store-sync/sync.ts
@@ -2,24 +2,30 @@ import { store } from '@/src/store'
 import { selectAllContacts } from '@/src/store/addressBookSlice'
 import { selectAllChains } from '@/src/store/chains'
 import { STORAGE_IDS } from '@/src/store/constants'
-import { MMKV } from 'react-native-mmkv'
-
-const extensionStorage = new MMKV({ id: 'extension' })
+import { extensionStorage } from './const'
 
 /**
  * On iOS we need to intercept the push notification payload and
  * modify the title and body withing the ExtensionService. This happens
  * on the native side. We need to sync the data to the extension storage
  * so that the ExtensionService can use it on the native side.
+ *
+ * On Android we run in a Headless service, we could theoretically init the redux store,
+ * but using MMKV directly for the push notifications is easier.
  */
 export function syncNotificationExtensionData() {
   const state = store.getState()
   const contacts = selectAllContacts(state)
   const chains = selectAllChains(state)
 
-  const chainMap: Record<string, string> = {}
+  // Store enhanced chain data including native currency info for proper symbol handling
+  const chainMap: Record<string, { name: string; symbol: string; decimals: number }> = {}
   chains.forEach((c) => {
-    chainMap[c.chainId] = c.chainName
+    chainMap[c.chainId] = {
+      name: c.chainName,
+      symbol: c.nativeCurrency?.symbol ?? 'ETH',
+      decimals: c.nativeCurrency?.decimals ?? 18,
+    }
   })
 
   const contactMap: Record<string, string> = {}

--- a/apps/mobile/src/services/notifications/utils/messageDeduplication.ts
+++ b/apps/mobile/src/services/notifications/utils/messageDeduplication.ts
@@ -1,0 +1,51 @@
+import { MMKV } from 'react-native-mmkv'
+
+let processedMessagesStorage: MMKV | null = null
+
+const getProcessedMessagesStorage = (): MMKV => {
+  if (!processedMessagesStorage) {
+    processedMessagesStorage = new MMKV({ id: 'processed-messages' })
+  }
+  return processedMessagesStorage
+}
+
+/**
+ * Check if a Firebase message has already been processed and mark it as processed
+ * @param messageId - The Firebase message ID or fallback identifier
+ * @param maxStoredMessages - Maximum number of processed messages to keep (default: 50)
+ * @returns true if message was already processed (should skip), false if new (should process)
+ */
+export const checkAndMarkMessageProcessed = (messageId: string, maxStoredMessages = 50): boolean => {
+  const storage = getProcessedMessagesStorage()
+  const processedKey = `processed_${messageId}`
+
+  // Check if message was already processed
+  if (storage.getBoolean(processedKey)) {
+    console.log('[MessageDeduplication] Message already processed, skipping:', messageId)
+    return true // Already processed - should skip
+  }
+
+  // Mark message as processed IMMEDIATELY to prevent redelivery
+  storage.set(processedKey, true)
+  console.log('[MessageDeduplication] Message marked as processed:', messageId)
+
+  // Cleanup old processed messages to avoid memory bloat
+  const allKeys = storage.getAllKeys().filter((key) => key.startsWith('processed_'))
+  if (allKeys.length > maxStoredMessages) {
+    const oldKeys = allKeys.slice(0, allKeys.length - maxStoredMessages)
+    oldKeys.forEach((key) => storage.delete(key))
+    console.log('[MessageDeduplication] Cleaned up', oldKeys.length, 'old processed messages')
+  }
+
+  return false // New message - should process
+}
+
+/**
+ * Clear all processed message records (useful for testing or reset)
+ */
+export const clearProcessedMessages = (): void => {
+  const storage = getProcessedMessagesStorage()
+  const allKeys = storage.getAllKeys().filter((key) => key.startsWith('processed_'))
+  allKeys.forEach((key) => storage.delete(key))
+  console.log('[MessageDeduplication] Cleared all processed messages:', allKeys.length, 'records')
+}


### PR DESCRIPTION
## What it solves
On Android when the app was completely killed no push notification was shown. The way iOS and Android handle push notifications is slightly different. 
On IOS we rely on an Extension Service (in native code) to handle notifications when app is in background or in quit state. 
on Android we have a "headless" mode with background handlers. Those handlers don't have access to UI and data and have to be initialized very early in the app life cycle. We were initializing them too late and when the app was in quit state they were no longer working. 
Now I've moved the initialization to before we render any UI. Also since we don't have access to redux, we rely on our synced MMKV state in the handlers. The MMKV state is also used on iOS, so we no longer need to start the sync storage only on iOS, but can use it on Android as well. 

Resolves https://linear.app/safe-global/issue/COR-343/pressing-a-notification-should-open-the-correct-screen

## How this PR fixes it
- initialises the background handlers earlier in the startup process
- uses MMKV to read any notification state

Note: when opening the app on Android from quit state, it doesn't navigate to the correct screen but stays on the start screen. I couldn't figure out why this happens, so it will stay like this for now.

## How to test it
Test both on iOS and Android please

- Foreground notifications
- Background notifications
- Quit state notifications

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
