### PR TITLE
fix(security): log error message only if it exists in useBlockaid hook

### DIFF
--- a/apps/web/src/components/tx/security/blockaid/useBlockaid.ts
+++ b/apps/web/src/components/tx/security/blockaid/useBlockaid.ts
@@ -55,7 +55,9 @@ export const useBlockaid = (
   const errorMsg = useMemo(() => blockaidErrors ?? blockaidPayload?.payload?.error, [blockaidErrors, blockaidPayload])
 
   useEffect(() => {
-    logError(Errors._201, errorMsg)
+    if (errorMsg) {
+      logError(Errors._201, errorMsg)
+    }
   }, [errorMsg])
 
   return [blockaidPayload, errorMsg, loading]


### PR DESCRIPTION
## What it solves

Resolves a potential issue where the useBlockaid hook could attempt to log an undefined or null error message, leading to misleading logs or runtime noise.

## How this PR fixes it

This PR adds a conditional check in the `useBlockaid` hook to ensure the error message is only logged if it exists. This prevents unnecessary or confusing log entries when the error object does not include a message.

## How to test it

1.	Simulate a transaction.
2.	Confirm that:
    - When there is an error, the error with a message is logged as expected.
    - When the simulation is successful: No error is logged.
4.	Check console logs during testing to ensure no “undefined” or blank messages are logged.

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
