### PR TITLE
fix(mobile): tx history not refetched on click on push notification

### DIFF
--- a/apps/mobile/src/features/TxHistory/TxHistory.container.tsx
+++ b/apps/mobile/src/features/TxHistory/TxHistory.container.tsx
@@ -4,11 +4,13 @@ import { useGetTxsHistoryInfiniteQuery } from '@safe-global/store/gateway'
 import type { TransactionItemPage } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { TxHistoryList } from '@/src/features/TxHistory/components/TxHistoryList'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { useLocalSearchParams } from 'expo-router'
 import Logger from '@/src/utils/logger'
 
 export function TxHistoryContainer() {
   const activeSafe = useDefinedActiveSafe()
   const [isRefreshing, setIsRefreshing] = React.useState(false)
+  const { fromNotification } = useLocalSearchParams<{ fromNotification?: string }>()
 
   // Using the infinite query hook
   const { currentData, fetchNextPage, hasNextPage, isFetching, isLoading, isUninitialized, refetch } =
@@ -16,6 +18,14 @@ export function TxHistoryContainer() {
       chainId: activeSafe.chainId,
       safeAddress: activeSafe.address,
     })
+
+  // Force refetch when coming from push notification
+  React.useEffect(() => {
+    if (fromNotification) {
+      Logger.info('TxHistoryContainer: Refetching data due to push notification navigation', { fromNotification })
+      refetch()
+    }
+  }, [fromNotification, refetch])
 
   // Flatten all pages into a single transactions array
   const transactions = React.useMemo(() => {

--- a/apps/mobile/src/services/notifications/__tests__/notificationNavigationHandler.test.ts
+++ b/apps/mobile/src/services/notifications/__tests__/notificationNavigationHandler.test.ts
@@ -108,7 +108,6 @@ describe('NotificationNavigationHandler', () => {
     NotificationNavigationHandler = require('../notificationNavigationHandler').NotificationNavigationHandler
   })
 
-
   describe('switchToSafe', () => {
     it('should switch to the correct safe successfully', async () => {
       await NotificationNavigationHandler.switchToSafe(mockAddress, mockChainId)
@@ -151,7 +150,10 @@ describe('NotificationNavigationHandler', () => {
 
       await NotificationNavigationHandler.navigateToTransactionHistory()
 
-      expect(safeNavigateMock).toHaveBeenCalledWith('/transactions')
+      expect(safeNavigateMock).toHaveBeenCalledWith({
+        pathname: '/transactions',
+        params: { fromNotification: expect.any(String) },
+      })
 
       // Restore original
       NotificationNavigationHandler.safeNavigate = originalSafeNavigate

--- a/apps/mobile/src/services/notifications/notificationNavigationHandler.ts
+++ b/apps/mobile/src/services/notifications/notificationNavigationHandler.ts
@@ -155,7 +155,10 @@ export const NotificationNavigationHandler = {
   },
 
   async navigateToTransactionHistory(): Promise<void> {
-    await this.safeNavigate('/transactions')
+    await this.safeNavigate({
+      pathname: '/transactions',
+      params: { fromNotification: Date.now().toString() },
+    })
   },
 
   async navigateToConfirmTransaction(safeTxHash?: string): Promise<void> {


### PR DESCRIPTION
## What it solves
When navigating from a push notification to the history, the list was not refetched from the server and if the app was in the background it could have stale data.

Resolves https://linear.app/safe-global/issue/COR-368/mobile-fix-refresh-outgoingincoming-transaction-when-app-is-in

## How this PR fixes it
We force a refetch if the user has clicked a push-notification

## How to test it
App should be running, navigate to the history tab, then minimize it. Send a tx to the safe with some amount. Click on the push notification, the app should open on the history tab and should perform a refetch and you should see the incoming transafer in the list.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
