### PR TITLE
fix(mobile): improve UI when removing signer

### DIFF
--- a/apps/mobile/src/features/PrivateKey/PrivateKey.container.tsx
+++ b/apps/mobile/src/features/PrivateKey/PrivateKey.container.tsx
@@ -28,7 +28,7 @@ export const PrivateKeyContainer = ({ signerAddress }: Props) => {
       const key = await keyStorageService.getPrivateKey(signerAddress)
 
       if (!key) {
-        Alert.alert('Error', 'Private key not found')
+        Alert.alert('Error', 'Biometric authentication failed. Please try again.')
         return
       }
 

--- a/apps/mobile/src/features/PrivateKey/components/PrivateKeyView.tsx
+++ b/apps/mobile/src/features/PrivateKey/components/PrivateKeyView.tsx
@@ -3,7 +3,7 @@ import { ScrollView, View, Text, YStack } from 'tamagui'
 import { Container } from '@/src/components/Container'
 import { CopyButton } from '@/src/components/CopyButton'
 import { SafeButton } from '@/src/components/SafeButton'
-import { KeyboardAvoidingView, ActivityIndicator } from 'react-native'
+import { KeyboardAvoidingView, ActivityIndicator, Platform, StyleSheet } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { SafeInput } from '@/src/components/SafeInput'
 
@@ -41,7 +41,7 @@ export const PrivateKeyView = ({
             editable={false}
             multiline
             numberOfLines={4}
-            style={{ fontFamily: 'monospace' }}
+            style={styles.input}
             right={
               isKeyVisible && privateKey ? (
                 <CopyButton value={privateKey} color={'$colorSecondary'} hitSlop={2} text={'Private key copied'} />
@@ -73,3 +73,12 @@ export const PrivateKeyView = ({
     </YStack>
   )
 }
+
+const styles = StyleSheet.create({
+  input: {
+    fontFamily: 'monospace',
+    boxSizing: Platform.OS === 'android' ? 'content-box' : undefined,
+    paddingBottom: 0,
+    paddingTop: Platform.OS === 'android' ? 0 : 8,
+  },
+})


### PR DESCRIPTION
## What it solves
- wrong alert text when biometric fails
- UI glitch when the viewing the private key on android

Resolves https://linear.app/safe-global/issue/COR-327/implement-private-key-removal

## How to test it
- in the signer settinngs view a private key on android - it should no longer be cut off
- when trying to view the private key if the biometry prompt fails we show "Biometric authentication failed. Please try again"

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
