### PR TITLE
fix(mobile): android UI discrepancies

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -136,7 +136,7 @@
     "@babel/preset-react": "^7.26.3",
     "@eslint/js": "^9.18.0",
     "@faker-js/faker": "^9.0.3",
-    "@gorhom/bottom-sheet": "^5.1.1",
+    "@gorhom/bottom-sheet": "^5.1.8",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-community/datetimepicker": "8.3.0",
     "@react-native-community/slider": "4.5.6",

--- a/apps/mobile/src/app/(tabs)/transactions.tsx
+++ b/apps/mobile/src/app/(tabs)/transactions.tsx
@@ -4,6 +4,7 @@ import { TxHistoryContainer } from '@/src/features/TxHistory'
 import { ComingSoon } from '@/src/components/ComingSoon/ComingSoon'
 import { useNavigation } from 'expo-router'
 import TransactionHeader from '@/src/features/TxHistory/components/TransactionHeader'
+import { Platform } from 'react-native'
 
 const tabItems = [
   {
@@ -26,5 +27,11 @@ export default function TransactionScreen() {
       headerTitle: () => <TransactionHeader title={tabItems[index].title} />,
     })
   }
-  return <SafeTab items={tabItems} containerStyle={{ marginTop: 16 }} onIndexChange={onIndexChange} />
+  return (
+    <SafeTab
+      items={tabItems}
+      containerStyle={{ marginTop: Platform.OS === 'ios' ? 8 : 0 }}
+      onIndexChange={onIndexChange}
+    />
+  )
 }

--- a/apps/mobile/src/components/OptIn/OptIn.tsx
+++ b/apps/mobile/src/components/OptIn/OptIn.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ColorSchemeName, ImageSourcePropType, StyleSheet } from 'react-native'
+import { ColorSchemeName, ImageSourcePropType, Platform, StyleSheet } from 'react-native'
 import { H2, Image, Text, getTokenValue, View } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
 import { WINDOW_HEIGHT } from '@/src/store/constants'
@@ -111,6 +111,7 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: getTokenValue('$4', 'space'),
     justifyContent: 'space-between',
+    paddingBottom: getTokenValue(Platform.OS === 'ios' ? '$0' : '$4'),
   },
   image: {
     width: '100%',

--- a/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
+++ b/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
@@ -9,7 +9,7 @@ import BottomSheet, {
   BottomSheetFooter,
 } from '@gorhom/bottom-sheet'
 import DraggableFlatList, { DragEndParams, RenderItemParams, ScaleDecorator } from 'react-native-draggable-flatlist'
-import { StyleSheet } from 'react-native'
+import { Platform, StyleSheet } from 'react-native'
 import { useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { LoadingTx } from '@/src/features/ConfirmTx/components/LoadingTx'
@@ -97,7 +97,7 @@ export function SafeBottomSheet<T>({
   const renderFooter: React.FC<BottomSheetFooterProps> = useCallback(
     (props) => {
       return (
-        <BottomSheetFooter animatedFooterPosition={props.animatedFooterPosition}>
+        <BottomSheetFooter animatedFooterPosition={props.animatedFooterPosition} bottomInset={insets.bottom}>
           <View
             onLayout={(e) => {
               setFooterHeight(e.nativeEvent.layout.height)
@@ -111,6 +111,7 @@ export function SafeBottomSheet<T>({
     [FooterComponent, setFooterHeight],
   )
 
+  console.log('insets.bottom', insets.bottom)
   return (
     <BottomSheet
       ref={ref}
@@ -124,16 +125,10 @@ export function SafeBottomSheet<T>({
       backdropComponent={() => <BackdropComponent />}
       footerComponent={isSortable ? undefined : renderFooter}
       topInset={insets.top}
+      // bottomInset={Platform.OS === 'android' ? insets.bottom : 0}
       handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
     >
-      <BottomSheetView
-        style={[
-          styles.contentContainer,
-          {
-            paddingBottom: insets.bottom,
-          },
-        ]}
-      >
+      <BottomSheetView style={[styles.contentContainer]}>
         {title && <TitleHeader />}
         {isSortable ? (
           <DraggableFlatList<T>
@@ -148,7 +143,8 @@ export function SafeBottomSheet<T>({
         ) : (
           <BottomSheetScrollView
             style={{
-              marginBottom: (!sortable && FooterComponent ? footerHeight : 0) + 12,
+              marginBottom:
+                (!sortable && FooterComponent ? footerHeight : 0) + getTokenValue(Platform.OS === 'ios' ? '$4' : '$8'),
             }}
             contentContainerStyle={[styles.scrollInnerContainer]}
           >

--- a/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
+++ b/apps/mobile/src/features/AccountsSheet/MyAccounts/MyAccountsFooter.tsx
@@ -1,8 +1,9 @@
 import { Badge } from '@/src/components/Badge'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import React from 'react'
-import { styled, Text, View } from 'tamagui'
+import { styled, Text, View, getTokenValue } from 'tamagui'
 import { Link } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 const MyAccountsFooterContainer = styled(View, {
   borderTopWidth: 1,
   borderTopColor: '$colorSecondary',
@@ -15,12 +16,12 @@ const MyAccountsButton = styled(View, {
   columnGap: '$2',
   alignItems: 'center',
   flexDirection: 'row',
-  padding: '$2',
 })
 
 export function MyAccountsFooter() {
+  const { bottom } = useSafeAreaInsets()
   return (
-    <MyAccountsFooterContainer paddingBottom={'$7'}>
+    <MyAccountsFooterContainer marginBottom={-bottom} paddingBottom={bottom + getTokenValue('$4')}>
       <Link href={'/(import-accounts)'} asChild>
         <MyAccountsButton testID="add-existing-account">
           <View paddingLeft="$2">

--- a/apps/mobile/src/features/GetStarted/GetStarted.tsx
+++ b/apps/mobile/src/features/GetStarted/GetStarted.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import { Link, useRouter } from 'expo-router'
-import { View, Text, YStack, styled } from 'tamagui'
+import { View, Text, YStack, styled, getTokenValue } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -8,6 +8,7 @@ import { BlurView } from 'expo-blur'
 import { getCrashlytics } from '@react-native-firebase/crashlytics'
 import { setAnalyticsCollectionEnabled } from '@/src/services/analytics'
 import { isAndroid } from '@/src/config/constants'
+import { Platform } from 'react-native'
 
 const StyledText = styled(Text, {
   fontSize: '$3',
@@ -35,7 +36,21 @@ export const GetStarted = () => {
 
   return (
     <YStack justifyContent={'flex-end'} flex={1} testID={'get-started-screen'}>
-      <BlurView intensity={100} style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
+      <BlurView
+        intensity={100}
+        style={[
+          {
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+          },
+          Platform.OS === 'android' && {
+            backgroundColor: 'rgba(0, 0, 0, 0.9)',
+          },
+        ]}
+      >
         <View
           flex={1}
           onPress={() => {
@@ -47,7 +62,7 @@ export const GetStarted = () => {
         gap={'$3'}
         paddingHorizontal={'$4'}
         backgroundColor={'$background'}
-        paddingBottom={insets.bottom}
+        paddingBottom={insets.bottom + getTokenValue(Platform.OS === 'ios' ? '$0' : '$4')}
         paddingTop={'$5'}
         borderTopLeftRadius={'$9'}
         borderTopRightRadius={'$9'}

--- a/apps/mobile/src/features/ImportReadOnly/components/AddSignersFormView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/AddSignersFormView.tsx
@@ -3,8 +3,9 @@ import { SafeButton } from '@/src/components/SafeButton'
 import { SignersList } from '@/src/features/Signers/components/SignersList'
 import { type SignerSection } from '@/src/features/Signers/components/SignersList/SignersList'
 import { ToastViewport } from '@tamagui/toast'
-import { View } from 'tamagui'
+import { getTokenValue, View } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Platform } from 'react-native'
 
 type AddSignersFormViewProps = {
   isFetching: boolean
@@ -28,7 +29,7 @@ export const AddSignersFormView = ({
         hasLocalSigners={!!signersGroupedBySection.imported?.data.length}
         signersGroup={signersSections}
       />
-      <View paddingHorizontal={'$4'} paddingTop={'$2'} paddingBottom={bottom || 60}>
+      <View paddingTop={'$2'} paddingBottom={bottom + getTokenValue(Platform.OS === 'ios' ? '$0' : '$4')}>
         <SafeButton onPress={onPress} testID={'continue-button'}>
           Continue
         </SafeButton>

--- a/apps/mobile/src/features/PendingTx/components/PendingTxList/PendingTxList.container.tsx
+++ b/apps/mobile/src/features/PendingTx/components/PendingTxList/PendingTxList.container.tsx
@@ -1,7 +1,7 @@
 import { SafeListItem } from '@/src/components/SafeListItem'
 import React, { useMemo } from 'react'
 import { SectionList, RefreshControl } from 'react-native'
-import { useTheme, View, Text } from 'tamagui'
+import { useTheme, View, Text, getTokenValue } from 'tamagui'
 import { Badge } from '@/src/components/Badge'
 import { NavBarTitle } from '@/src/components/Title/NavBarTitle'
 import { LargeHeaderTitle } from '@/src/components/Title/LargeHeaderTitle'
@@ -12,6 +12,7 @@ import { keyExtractor, renderItem } from '@/src/features/PendingTx/utils'
 import { Loader } from '@/src/components/Loader'
 import { TransactionSkeleton, TransactionSkeletonItem } from '@/src/components/TransactionSkeleton'
 import { CircleSnail } from 'react-native-progress'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export interface GroupedPendingTxsWithTitle {
   title: string
@@ -38,6 +39,7 @@ export function PendingTxListContainer({
   onRefresh,
 }: PendingTxListContainerProps) {
   const theme = useTheme()
+  const { bottom } = useSafeAreaInsets()
   const { handleScroll } = useScrollableHeader({
     children: (
       <>
@@ -154,7 +156,10 @@ export function PendingTxListContainer({
         renderSectionHeader={({ section: { title } }) => <SafeListItem.Header title={title} />}
         onScroll={handleScroll}
         scrollEventThrottle={16}
-        contentContainerStyle={{ paddingHorizontal: 12 }}
+        contentContainerStyle={{
+          paddingHorizontal: 12,
+          paddingBottom: bottom + getTokenValue('$4'),
+        }}
       />
     </>
   )

--- a/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.tsx
+++ b/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, Text, Theme, View, YStack } from 'tamagui'
+import { ScrollView, Text, Theme, View, YStack, getTokenValue } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { SafeFontIcon as Icon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import { Pressable } from 'react-native'
@@ -25,6 +25,7 @@ export const AppSettings = ({ sections }: AppSettingsProps) => {
       <ScrollView
         contentContainerStyle={{
           paddingTop: 10,
+          paddingBottom: insets.bottom + getTokenValue('$4'),
         }}
         contentInset={{ bottom: insets.bottom }}
         keyboardShouldPersistTaps="handled"

--- a/apps/mobile/src/features/Share/components/ShareView.tsx
+++ b/apps/mobile/src/features/Share/components/ShareView.tsx
@@ -24,7 +24,6 @@ type ShareViewProps = {
 export const ShareView = ({ activeSafe, availableChains }: ShareViewProps) => {
   const copyAndDispatchToast = useCopyAndDispatchToast()
   const contact = useAppSelector(selectContactByAddress(activeSafe.address))
-
   const safeAddress = activeSafe.address
 
   const onPressShare = async () => {
@@ -43,7 +42,7 @@ export const ShareView = ({ activeSafe, availableChains }: ShareViewProps) => {
 
   return (
     <>
-      <YStack flex={1}>
+      <YStack flex={1} paddingBottom={'$4'}>
         <YStack flex={1} justifyContent={'flex-end'} alignItems={'center'} marginBottom={'$6'}>
           <H3 fontWeight={600}>{contact ? contact.name : 'Unnamed safe'}</H3>
         </YStack>

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
@@ -6,7 +6,7 @@ import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
 import { TxGroupedCard } from '@/src/components/transactions-list/Card/TxGroupedCard'
 import { TxInfo } from '@/src/components/TxInfo'
 import { TransactionSkeleton, TransactionSkeletonItem } from '@/src/components/TransactionSkeleton'
-import { RefreshControl } from 'react-native'
+import { Platform, RefreshControl } from 'react-native'
 import { CircleSnail } from 'react-native-progress'
 import { formatWithSchema } from '@/src/utils/date'
 import { isDateLabel } from '@/src/utils/transaction-guards'
@@ -54,7 +54,7 @@ const renderItem = ({
         paddingTop={'$2'}
         paddingBottom={isSticky ? '$2' : '0'}
         paddingHorizontal={isSticky ? '$4' : '0'}
-        transform={[{ translateY: isSticky ? TAB_BAR_HEIGHT : 0 }]}
+        transform={Platform.OS === 'ios' ? [{ translateY: isSticky ? TAB_BAR_HEIGHT : 0 }] : undefined}
       >
         <Text fontWeight={500} color="$colorSecondary">
           {dateTitle}
@@ -193,6 +193,7 @@ export function TxHistoryList({
         </View>
       )}
 
+      {Platform.OS === 'android' && <View style={{ height: TAB_BAR_HEIGHT }}></View>}
       <Tabs.FlashList
         testID="tx-history-list"
         data={flatList}
@@ -201,7 +202,7 @@ export function TxHistoryList({
         getItemType={getItemType}
         stickyHeaderIndices={stickyHeaderIndices}
         estimatedItemSize={100}
-        estimatedFirstItemOffset={TAB_BAR_HEIGHT}
+        estimatedFirstItemOffset={Platform.OS === 'ios' ? TAB_BAR_HEIGHT : 0}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         refreshControl={

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from 'react'
-import { useTheme, View, Text } from 'tamagui'
+import { useTheme, View, Text, getTokenValue } from 'tamagui'
 import { Tabs } from 'react-native-collapsible-tab-view'
 import { getGroupHash, getTxHash } from '@/src/features/TxHistory/utils'
 import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
@@ -11,6 +11,7 @@ import { CircleSnail } from 'react-native-progress'
 import { formatWithSchema } from '@/src/utils/date'
 import { isDateLabel } from '@/src/utils/transaction-guards'
 import { groupBulkTxs } from '@/src/utils/transactions'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 interface TxHistoryList {
   transactions?: HistoryTransactionItems[]
@@ -150,7 +151,7 @@ export function TxHistoryList({
   onRefresh,
 }: TxHistoryList) {
   const theme = useTheme()
-
+  const { bottom } = useSafeAreaInsets()
   const flatList: (HistoryTransactionItems | HistoryTransactionItems[])[] = useMemo(() => {
     return groupBulkTxs(transactions || [])
   }, [transactions])
@@ -218,6 +219,7 @@ export function TxHistoryList({
         contentContainerStyle={{
           paddingHorizontal: 16,
           paddingTop: 8,
+          paddingBottom: bottom + getTokenValue('$4'),
         }}
         ListEmptyComponent={renderEmptyComponent}
         ListHeaderComponent={renderHeaderComponent}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6477,9 +6477,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gorhom/bottom-sheet@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@gorhom/bottom-sheet@npm:5.1.1"
+"@gorhom/bottom-sheet@npm:^5.1.8":
+  version: 5.1.8
+  resolution: "@gorhom/bottom-sheet@npm:5.1.8"
   dependencies:
     "@gorhom/portal": "npm:1.0.14"
     invariant: "npm:^2.2.4"
@@ -6489,13 +6489,13 @@ __metadata:
     react: "*"
     react-native: "*"
     react-native-gesture-handler: ">=2.16.1"
-    react-native-reanimated: ">=3.16.0"
+    react-native-reanimated: "*"
   peerDependenciesMeta:
     "@types/react":
       optional: true
     "@types/react-native":
       optional: true
-  checksum: 10/6da29c3927f6a0b6d2a459e2a1cae48ce7c0fce41663b46b0aba98490af15199e31248f83ca18753eeb439faf2c1dd957f26e4eacc9796b4962df44170b1a2d3
+  checksum: 10/16c0de9d0902c994bb099dc173c0d0cf984fd0b47f823e05186b090bd46d885d5b271682dddd0aad1b76d80509c23dddba559d1dc3c39afa0673e5c8ff08d9a1
   languageName: node
   linkType: hard
 
@@ -9327,7 +9327,7 @@ __metadata:
     "@formatjs/intl-locale": "npm:^4.2.10"
     "@formatjs/intl-numberformat": "npm:^8.15.3"
     "@formatjs/intl-pluralrules": "npm:^5.4.3"
-    "@gorhom/bottom-sheet": "npm:^5.1.1"
+    "@gorhom/bottom-sheet": "npm:^5.1.8"
     "@hookform/resolvers": "npm:^4.1.3"
     "@notifee/react-native": "npm:^9.1.8"
     "@react-native-async-storage/async-storage": "npm:2.1.2"


### PR DESCRIPTION
## What it solves
Android now has 3 navigation modes
- Gesture navigation
- 2-button navigation
- 3-button navigation

when 2 and 3 button navigation is selected by the user some views were behind the navigation which created poor user experience. With this PR this problem should be fixed.

<img width="569" height="1190" alt="grafik" src="https://github.com/user-attachments/assets/79cd9552-7486-40df-b2f6-2db7521dd422" />

Resolves https://linear.app/safe-global/issue/COR-384/mobile-bottom-marginpadding-is-non-existent-in-android

## How this PR fixes it
It boils down to using safeAreaInsets even on screens that look fine on iOS. The bottom sheet was a bit tricky as it required some negative margins to hide content that "flies" behind it.

## How to test it
Best would be to run through all screens app with both iOS and andoird next to each other to confirm that everything looks ok on both platforms. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
