### PR TITLE
fix(mobile): revert custom pull-to-refresh spinner in transaction history

### DIFF
--- a/apps/mobile/src/components/TransactionSkeleton/TransactionSkeleton.tsx
+++ b/apps/mobile/src/components/TransactionSkeleton/TransactionSkeleton.tsx
@@ -63,9 +63,9 @@ export const TransactionSkeleton = ({
 
   return (
     <Skeleton.Group show={true}>
-      <View gap="$4">
+      <View>
         {sections.map((sectionTitle, sectionIndex) => (
-          <View key={sectionIndex}>
+          <View key={sectionIndex} gap="$4">
             {/* Section header skeleton - only show if we have a title */}
             {showSections && sectionTitle && (
               <View marginBottom="$2">

--- a/apps/mobile/src/features/TxHistory/TxHistory.container.test.tsx
+++ b/apps/mobile/src/features/TxHistory/TxHistory.container.test.tsx
@@ -295,54 +295,6 @@ describe('TxHistoryContainer', () => {
       expect(screen.getByTestId('tx-history-list')).toBeTruthy()
     })
 
-    it('shows progress indicator when refreshing', async () => {
-      render(<TxHistoryContainer />)
-
-      // Wait for initial transactions to load
-      await waitFor(() => {
-        expect(screen.getByText('Received')).toBeTruthy()
-      })
-
-      // Reset server to use delayed response for refresh, so we can capture the refreshing state
-      server.use(
-        http.get(`${GATEWAY_URL}/v1/chains/:chainId/safes/:safeAddress/transactions/history`, async () => {
-          // Add delay to capture refreshing state
-          await new Promise((resolve) => setTimeout(resolve, 100))
-          return HttpResponse.json({
-            next: null,
-            previous: null,
-            results: mockTransactions,
-          })
-        }),
-      )
-
-      const list = screen.getByTestId('tx-history-list')
-
-      // Trigger refresh
-      await act(async () => {
-        fireEvent(list, 'onRefresh')
-      })
-
-      // Check if custom progress indicator is shown during refresh
-      await waitFor(
-        () => {
-          expect(screen.getByTestId('tx-history-progress-indicator')).toBeTruthy()
-        },
-        { timeout: 500 },
-      )
-
-      // Wait for refresh to complete and progress indicator to disappear
-      await waitFor(
-        () => {
-          expect(screen.queryByTestId('tx-history-progress-indicator')).toBeNull()
-        },
-        { timeout: 2000 },
-      )
-
-      // Verify the list is still functional after refresh
-      expect(screen.getByText('Received')).toBeTruthy()
-    }, 10000)
-
     it('does not show initial skeleton when refreshing', async () => {
       render(<TxHistoryContainer />)
 

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from 'react'
-import { useTheme, View, Text, getTokenValue } from 'tamagui'
+import { View, Text, getTokenValue } from 'tamagui'
 import { Tabs } from 'react-native-collapsible-tab-view'
 import { getGroupHash, getTxHash } from '@/src/features/TxHistory/utils'
 import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
@@ -149,7 +149,6 @@ export function TxHistoryList({
   refreshing,
   onRefresh,
 }: TxHistoryList) {
-  const theme = useTheme()
   const { bottom } = useSafeAreaInsets()
   const flatList: (HistoryTransactionItems | HistoryTransactionItems[])[] = useMemo(() => {
     return groupBulkTxs(transactions || [])

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
@@ -7,7 +7,6 @@ import { TxGroupedCard } from '@/src/components/transactions-list/Card/TxGrouped
 import { TxInfo } from '@/src/components/TxInfo'
 import { TransactionSkeleton, TransactionSkeletonItem } from '@/src/components/TransactionSkeleton'
 import { Platform, RefreshControl } from 'react-native'
-import { CircleSnail } from 'react-native-progress'
 import { formatWithSchema } from '@/src/utils/date'
 import { isDateLabel } from '@/src/utils/transaction-guards'
 import { groupBulkTxs } from '@/src/utils/transactions'
@@ -179,21 +178,6 @@ export function TxHistoryList({
 
   return (
     <View position="relative" flex={1}>
-      {!!refreshing && (
-        <View
-          position="absolute"
-          top={64}
-          alignSelf="center"
-          zIndex={1000}
-          backgroundColor="$background"
-          borderRadius={20}
-          padding="$2"
-          testID="tx-history-progress-indicator"
-        >
-          <CircleSnail size={24} color={theme.color.get()} thickness={2} duration={600} spinDuration={1500} />
-        </View>
-      )}
-
       {Platform.OS === 'android' && <View style={{ height: TAB_BAR_HEIGHT }}></View>}
       <Tabs.FlashList
         testID="tx-history-list"
@@ -206,16 +190,7 @@ export function TxHistoryList({
         estimatedFirstItemOffset={Platform.OS === 'ios' ? TAB_BAR_HEIGHT : 0}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
-        refreshControl={
-          <RefreshControl
-            refreshing={!!refreshing}
-            onRefresh={onRefresh}
-            tintColor="transparent" // Hide default spinner
-            colors={['transparent']} // Hide default spinner on Android
-            progressBackgroundColor="transparent"
-            style={{ backgroundColor: 'transparent' }}
-          />
-        }
+        refreshControl={<RefreshControl refreshing={!!refreshing} onRefresh={onRefresh} />}
         contentContainerStyle={{
           paddingHorizontal: 16,
           paddingTop: 8,


### PR DESCRIPTION
## What it solves

[COR-378](https://linear.app/safe-global/issue/COR-378/mobile-android-history-dont-the-day-at-the-top-and-2-loading-icons-on)

Reverts to the native default spinner for the transaction history on both iOS and Android. 

The previously introduced custom spinner from #6145 has been removed. Although the custom spinner was visually distinct, it introduced a poor UX in fast-loading scenarios. It often appeared only for a brief moment (a few milliseconds), making it feel abrupt. The native spinner offers a smoother and more consistent experience across platforms.

## How to test it

1. Open the transaction history
2. Pull down from the top of the list to trigger a refresh
3. Expected: The platform's native loading spinner appears during the refresh process

## Screenshots

https://github.com/user-attachments/assets/375c3d23-b360-4b90-b18e-cc4e084f6917

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
