### PR TITLE
feat(mobile): ssl pinning

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -3,6 +3,17 @@ const IS_DEV = process.env.APP_VARIANT === 'development'
 
 const appleDevTeamId = '86487MHG6V'
 
+const sslPinningDomains = {
+  'safe-client.staging.5afe.dev': [
+    'qrOvKCFoIx4FHtyP9qY8vHF2hjnLwujZUkuOrsFG5Gc=', // 🍃 Leaf cert (Valid: Nov 22 00:00:00 2024 GMT → Dec 21 23:59:59 2025 GMT)
+    'vxRon/El5KuI4vx5ey1DgmsYmRY0nDd5Cg4GfJ8S+bg=', // 🔗 Intermediate (Valid: Aug 23 22:25:30 2022 GMT → Aug 23 22:25:30 2030 GMT)
+  ],
+  'safe-client.safe.global': [
+    'VOstDe9L/YZ7RKPPd7iwAMbsAwCqqblfg3l1IqjUvuE=', // 🍃 Leaf cert (Valid: Jul 12 00:00:00 2025 GMT → Aug 10 23:59:59 2026 GMT)
+    '18tkPyr2nckv4fgo0dhAkaUtJ2hu2831xlO2SKhq8dg=', // 🔗 Intermediate cert (Valid: Aug 23 22:25:30 2022 GMT → Aug 23 22:25:30 2030 GMT)
+  ],
+}
+
 const config = {
   name: IS_DEV ? 'Dev-Safe{Mobile}' : 'Safe{Mobile}',
   slug: 'safe-mobileapp',
@@ -58,6 +69,12 @@ const config = {
   },
   plugins: [
     ['./expo-plugins/withNotificationIcons.js'],
+    [
+      './expo-plugins/ssl-pinning/withSSLPinning.js',
+      {
+        domains: sslPinningDomains,
+      },
+    ],
     'expo-router',
     [
       'expo-font',

--- a/apps/mobile/expo-plugins/ssl-pinning/README.md
+++ b/apps/mobile/expo-plugins/ssl-pinning/README.md
@@ -1,0 +1,134 @@
+# SSL Pinning Expo Config Plugin
+
+This plugin implements SSL certificate pinning for React Native apps using Expo, supporting both iOS and Android platforms.
+
+## Features
+
+- **iOS SSL Pinning**: Uses TrustKit library for secure certificate validation
+- **Android SSL Pinning**: Uses OkHttp's built-in certificate pinner
+- **Automatic native code modification**: Handles all necessary iOS and Android code changes
+
+## How SSL Pinning Works
+
+SSL pinning enhances security by embedding specific certificate hashes directly into your app code. This prevents man-in-the-middle attacks even if an attacker manages to install malicious certificates on the device or compromises a certificate authority.
+
+## Getting Certificate Hashes
+
+Before configuring the plugin, you need to obtain the public key hashes for your domains:
+
+### Method 1: Use the Certificate Extraction Script (Recommended)
+
+```bash
+# This script automatically extracts certificates and provides ready-to-use SSL pinning configuration
+cd apps/mobile
+node scripts/getCertificates.js safe-client.safe.global
+
+# Multiple domains at once
+node scripts/getCertificates.js safe-client.safe.global safe-client.staging.5afe.dev
+```
+
+### Method 2: Manual OpenSSL Commands
+
+#### Step 1: Get Full Certificate Chain
+
+```bash
+# Get the complete certificate chain
+openssl s_client -servername example.com -connect example.com:443 -showcerts > fullchain.pem
+```
+
+#### Step 2: Extract Specific Certificates
+
+```bash
+# Extract leaf certificate (first certificate)
+awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' fullchain.pem | sed -n '1,/END CERTIFICATE/p' > leaf.pem
+
+# Extract intermediate certificate (second certificate)
+awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' fullchain.pem | sed -n '2,/END CERTIFICATE/p' > intermediate.pem
+
+# Extract root certificate (last certificate)
+awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' fullchain.pem | tail -n +2 > root.pem
+```
+
+#### Step 3: Generate Certificate Hashes
+
+```bash
+# Leaf certificate hash
+openssl x509 -in leaf.pem -pubkey -noout | openssl rsa -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
+
+# Intermediate certificate hash (recommended for backup)
+openssl x509 -in intermediate.pem -pubkey -noout | openssl rsa -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
+
+# Root certificate hash
+openssl x509 -in root.pem -pubkey -noout | openssl rsa -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64
+```
+
+## Configuration
+
+### 1. Configure SSL Pinning Domains
+
+Update `apps/mobile/app.config.js` to include your domains and certificate hashes in the SSL pinning plugin configuration:
+
+```javascript
+[
+  './expo-plugins/ssl-pinning/withSSLPinning.js',
+  {
+    domains: {
+      'api.safeglobal.io': [
+        'PRIMARY_CERT_HASH_BASE64'
+      ],
+      'dev-api.safeglobal.io': [
+        'DEV_PRIMARY_CERT_HASH_BASE64'
+      ],
+    },
+  },
+],
+```
+
+### 2. Plugin Configuration
+
+The plugin is already integrated into the app configuration. Simply update the domains object with your certificate hashes.
+
+## Environment Configuration
+
+The plugin uses the same domain configuration for all builds. You can include both production and development/staging domains in the same configuration:
+
+- All configured domains will be pinned across all build variants
+- Include both production and staging/development domains as needed
+- Each domain can have multiple certificate hashes for backup
+
+## Testing SSL Pinning
+
+### Testing Valid Certificates
+
+1. Build and run your app
+2. Make network requests to pinned domains
+3. Requests should work normally
+
+### Testing Invalid Certificates
+
+1. Change one of the certificate hashes to an invalid value (e.g., all A's)
+2. Rebuild the app completely
+3. Clear app cache/data or reinstall
+4. Network requests to pinned domains should fail
+
+**Important**: iOS maintains a TLS session cache, so you may need to:
+
+- Delete and reinstall the app
+- Reset the iOS Simulator
+- Wait for the cache to expire
+
+### Using Proxy Tools
+
+You can test SSL pinning using tools like:
+
+- [Proxyman](https://proxyman.io/)
+- [Charles Proxy](https://www.charlesproxy.com/)
+- [OWASP ZAP](https://owasp.org/www-project-zap/)
+
+When SSL pinning is working correctly, requests through these proxies should fail.
+
+## References
+
+- [Original Callstack SSL Pinning Tutorial](https://www.callstack.com/blog/ssl-pinning-in-react-native-apps)
+- [TrustKit Documentation](https://github.com/datatheorem/TrustKit)
+- [OkHttp Certificate Pinning](https://square.github.io/okhttp/features/https/)

--- a/apps/mobile/expo-plugins/ssl-pinning/withSSLPinning.js
+++ b/apps/mobile/expo-plugins/ssl-pinning/withSSLPinning.js
@@ -1,0 +1,187 @@
+/* eslint-disable no-undef */
+const { withPodfile, withAppDelegate, withMainApplication, withDangerousMod } = require('@expo/config-plugins')
+const fs = require('fs')
+const path = require('path')
+// SSL Pinning Configuration will be passed from app.config.js
+
+function withIOSSSLPinning(config, { domains }) {
+  // Add TrustKit to Podfile
+  config = withPodfile(config, (config) => {
+    const podfileContent = config.modResults.contents
+
+    // Check if TrustKit is already added
+    if (!podfileContent.includes('TrustKit')) {
+      // Add TrustKit pod
+      const podfileLines = podfileContent.split('\n')
+      const targetIndex = podfileLines.findIndex((line) => line.includes('use_expo_modules!'))
+
+      if (targetIndex !== -1) {
+        podfileLines.splice(targetIndex + 1, 0, "  pod 'TrustKit'")
+        config.modResults.contents = podfileLines.join('\n')
+      }
+    }
+
+    return config
+  })
+
+  // Modify AppDelegate.swift to include SSL pinning
+  config = withAppDelegate(config, (config) => {
+    const appDelegateContent = config.modResults.contents
+
+    const domainConfigs = Object.entries(domains)
+      .map(([domain, hashes]) => {
+        const hashesString = hashes.map((hash) => `"${hash}"`).join(', ')
+        return `          "${domain}": [
+            kTSKPublicKeyHashes: [${hashesString}],
+            kTSKEnforcePinning: true,
+            kTSKIncludeSubdomains: true,
+            kTSKReportUris: []
+          ]`
+      })
+      .join(',\n')
+
+    const trustKitConfig = `
+    // SSL Pinning Configuration
+    let trustKitConfig: [String: Any] = [
+      kTSKSwizzleNetworkDelegates: true,
+      kTSKPinnedDomains: [
+${domainConfigs}
+      ]
+    ]
+    
+    TrustKit.initSharedInstance(withConfiguration: trustKitConfig)
+    print("SSL Pinning initialized successfully")
+    `
+
+    // Add TrustKit import if not present
+    if (!appDelegateContent.includes('import TrustKit')) {
+      config.modResults.contents = appDelegateContent.replace(
+        'import ReactAppDependencyProvider',
+        'import ReactAppDependencyProvider\nimport TrustKit',
+      )
+    }
+
+    // Add TrustKit initialization before React Native starts
+    if (!appDelegateContent.includes('TrustKit.initSharedInstance')) {
+      // Primary injection point: before factory.startReactNative
+      const startReactNativePattern = /([ ]+)(factory\.startReactNative\(\s*withModuleName:)/
+
+      if (startReactNativePattern.test(appDelegateContent)) {
+        config.modResults.contents = config.modResults.contents.replace(
+          startReactNativePattern,
+          `${trustKitConfig}
+$1$2`,
+        )
+      } else {
+        // Fallback: after window initialization
+        const windowPattern = /(window = UIWindow\(frame: UIScreen\.main\.bounds\))/
+
+        if (windowPattern.test(appDelegateContent)) {
+          config.modResults.contents = config.modResults.contents.replace(windowPattern, `$1${trustKitConfig}`)
+        } else {
+          console.warn('⚠️ Could not find suitable injection point for SSL Pinning in AppDelegate.swift')
+        }
+      }
+    }
+
+    return config
+  })
+
+  return config
+}
+
+function withAndroidSSLPinning(config, { domains }) {
+  // Create SSLPinningFactory.kt
+  config = withDangerousMod(config, [
+    'android',
+    async (config) => {
+      const packageName = config.android?.package || 'global.safe.mobileapp'
+      const packagePath = packageName.replace(/\./g, '/')
+      const kotlinDir = path.join(config.modRequest.platformProjectRoot, 'app/src/main/java', packagePath)
+
+      // Ensure directory exists
+      if (!fs.existsSync(kotlinDir)) {
+        fs.mkdirSync(kotlinDir, { recursive: true })
+      }
+
+      // domains passed from configuration
+      const pinningConfig = Object.entries(domains)
+        .map(([domain, hashes]) => {
+          const hashesString = hashes.map((hash) => `"sha256/${hash}"`).join(', ')
+          return `            .add("${domain}", ${hashesString})`
+        })
+        .join('\n')
+
+      const sslPinningFactoryContent = `package ${packageName}
+
+import com.facebook.react.modules.network.OkHttpClientFactory
+import com.facebook.react.modules.network.ReactCookieJarContainer
+import okhttp3.CertificatePinner
+import okhttp3.OkHttpClient
+
+class SSLPinningFactory : OkHttpClientFactory {
+    
+    override fun createNewNetworkModuleClient(): OkHttpClient {
+        val certificatePinner = CertificatePinner.Builder()
+${pinningConfig}
+            .build()
+        
+        return OkHttpClient.Builder()
+            .certificatePinner(certificatePinner)
+            .cookieJar(ReactCookieJarContainer())
+            .build()
+    }
+}`
+
+      const sslPinningFactoryPath = path.join(kotlinDir, 'SSLPinningFactory.kt')
+      fs.writeFileSync(sslPinningFactoryPath, sslPinningFactoryContent)
+
+      return config
+    },
+  ])
+
+  // Modify MainApplication.kt
+  config = withMainApplication(config, (config) => {
+    const mainApplicationContent = config.modResults.contents
+    const packageName = config.android?.package || 'global.safe.mobileapp'
+
+    // Add imports if not present
+    if (!mainApplicationContent.includes('import com.facebook.react.modules.network.OkHttpClientProvider')) {
+      config.modResults.contents = mainApplicationContent.replace(
+        'import com.facebook.react.ReactApplication',
+        `import com.facebook.react.ReactApplication
+import com.facebook.react.modules.network.OkHttpClientProvider
+import ${packageName}.SSLPinningFactory`,
+      )
+    }
+
+    // Add SSL pinning initialization in onCreate
+    if (!mainApplicationContent.includes('OkHttpClientProvider.setOkHttpClientFactory')) {
+      const onCreatePattern = /(override fun onCreate\(\) {\s*super\.onCreate\(\))/s
+
+      config.modResults.contents = config.modResults.contents.replace(
+        onCreatePattern,
+        `$1
+    
+    // Initialize SSL Pinning
+    OkHttpClientProvider.setOkHttpClientFactory(SSLPinningFactory())`,
+      )
+    }
+
+    return config
+  })
+
+  return config
+}
+
+module.exports = function withSSLPinning(config, options = {}) {
+  const { domains = {} } = options
+
+  // Apply iOS SSL pinning
+  config = withIOSSSLPinning(config, { domains })
+
+  // Apply Android SSL pinning
+  config = withAndroidSSLPinning(config, { domains })
+
+  return config
+}

--- a/apps/mobile/scripts/getCertificates.js
+++ b/apps/mobile/scripts/getCertificates.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+/* eslint-env node */
+/* eslint-disable no-console, no-undef */
+
+/**
+ * SSL Certificate Extractor for SSL Pinning
+ *
+ * This script extracts certificate hashes needed for SSL pinning configuration.
+ *
+ * Usage: node scripts/getCertificates.js <domain1> [domain2] [domain3] ...
+ */
+
+const https = require('https')
+const crypto = require('crypto')
+
+function getFullCertificateChain(hostname, port = 443) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname,
+      port,
+      method: 'HEAD',
+      rejectUnauthorized: false,
+    }
+
+    const req = https.request(options, (res) => {
+      try {
+        const cert = res.connection.getPeerCertificate(true)
+
+        if (!cert || Object.keys(cert).length === 0) {
+          reject(new Error('No certificate found'))
+          return
+        }
+
+        const chain = []
+        const seenCerts = new Set() // Track certificate fingerprints to prevent loops
+        const MAX_CHAIN_LENGTH = 10 // Reasonable limit for certificate chain
+
+        // Walk the certificate chain
+        let currentCert = cert
+        let chainLength = 0
+
+        while (currentCert && Object.keys(currentCert).length > 0 && chainLength < MAX_CHAIN_LENGTH) {
+          // Create a unique identifier for this certificate
+          const certId = currentCert.fingerprint || `${currentCert.subject?.CN}-${currentCert.issuer?.CN}`
+
+          // Check for circular references
+          if (seenCerts.has(certId)) {
+            console.log(`🔄 Circular reference detected at certificate: ${certId}`)
+            break
+          }
+
+          seenCerts.add(certId)
+          chain.push(currentCert)
+          chainLength++
+
+          // Move to issuer certificate
+          const nextCert = currentCert.issuerCertificate
+
+          // Additional safety checks
+          if (!nextCert || nextCert === currentCert) {
+            break
+          }
+
+          // Check if we've reached the root (self-signed)
+          if (
+            currentCert.subject &&
+            currentCert.issuer &&
+            JSON.stringify(currentCert.subject) === JSON.stringify(currentCert.issuer)
+          ) {
+            console.log(`🌳 Reached self-signed root certificate: ${currentCert.subject?.CN}`)
+            break
+          }
+
+          currentCert = nextCert
+        }
+
+        if (chainLength >= MAX_CHAIN_LENGTH) {
+          console.log(`⚠️  Certificate chain truncated at ${MAX_CHAIN_LENGTH} certificates`)
+        }
+
+        console.log(`📋 Found ${chain.length} certificates in chain`)
+        resolve(chain)
+      } catch (error) {
+        reject(new Error(`Failed to parse certificate chain: ${error.message}`))
+      }
+    })
+
+    req.on('error', reject)
+    req.setTimeout(10000, () => {
+      req.destroy()
+      reject(new Error(`Timeout connecting to ${hostname}:${port}`))
+    })
+
+    req.end()
+  })
+}
+
+function extractCertificateHash(cert) {
+  const publicKeyDer = cert.pubkey
+  return crypto.createHash('sha256').update(publicKeyDer).digest('base64')
+}
+
+function displayCertificateInfo(domain, chain) {
+  console.log(`\n🔐 SSL Certificate Chain for ${domain}`)
+  console.log('='.repeat(60))
+
+  if (chain.length === 0) {
+    console.log('❌ No certificates found')
+    return
+  }
+
+  if (chain.length < 2) {
+    console.log('⚠️  Only root certificate available - no intermediate found')
+    console.log('💡 Consider using the root certificate as backup')
+  }
+
+  const leafCert = chain[0]
+  const intermediateCert = chain[1]
+  const rootCert = chain[chain.length - 1]
+
+  console.log('\n📋 Certificate Chain:')
+  console.log(`🍃 Leaf: ${leafCert.subject.CN || leafCert.subject.O || 'Unknown'}`)
+
+  if (intermediateCert && intermediateCert !== leafCert) {
+    console.log(`🔗 Intermediate: ${intermediateCert.subject.CN || intermediateCert.subject.O || 'Unknown'}`)
+  }
+
+  if (rootCert && rootCert !== leafCert && rootCert !== intermediateCert) {
+    console.log(`🌳 Root: ${rootCert.subject.CN || rootCert.subject.O || 'Unknown'}`)
+  }
+
+  const leafHash = extractCertificateHash(leafCert)
+  const intermediateHash = intermediateCert ? extractCertificateHash(intermediateCert) : null
+  const rootHash = rootCert ? extractCertificateHash(rootCert) : null
+
+  console.log('\n🎯 SSL Pinning Configuration:')
+  console.log('='.repeat(35))
+  console.log(`'${domain}': [`)
+  console.log(`  '${leafHash}', // 🍃 Leaf (primary)`)
+
+  if (intermediateHash && intermediateHash !== leafHash) {
+    console.log(`  '${intermediateHash}', // 🔗 Intermediate (could be used as backup, but need to trust CA authority)`)
+  } else if (rootHash && rootHash !== leafHash) {
+    console.log(`  '${rootHash}', // 🌳 Root (backup)`)
+  }
+
+  console.log(`],`)
+
+  // Show certificate details
+  console.log('\n📜 Certificate Details:')
+  console.log('='.repeat(25))
+
+  console.log(`\n🍃 Leaf Certificate:`)
+  console.log(`   Subject: ${leafCert.subject.CN || leafCert.subject.O}`)
+  console.log(`   Valid: ${leafCert.valid_from} → ${leafCert.valid_to}`)
+  console.log(`   Hash: ${leafHash}`)
+
+  if (intermediateCert && intermediateHash !== leafHash) {
+    console.log(`\n🔗 Intermediate Certificate:`)
+    console.log(`   Subject: ${intermediateCert.subject.CN || intermediateCert.subject.O}`)
+    console.log(`   Valid: ${intermediateCert.valid_from} → ${intermediateCert.valid_to}`)
+    console.log(`   Hash: ${intermediateHash}`)
+    console.log(`   💡 Recommended for backup pinning (more stable than leaf)`)
+  }
+
+  console.log('\n🛠️  Manual OpenSSL Commands:')
+  console.log('='.repeat(30))
+  console.log('# Get full certificate chain:')
+  console.log(`openssl s_client -servername ${domain} -connect ${domain}:443 -showcerts > ${domain}-chain.pem`)
+
+  if (intermediateCert) {
+    console.log('\n# Extract intermediate certificate:')
+    console.log(
+      `awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' ${domain}-chain.pem | sed -n '2,/END CERTIFICATE/p' > ${domain}-intermediate.pem`,
+    )
+    console.log('\n# Get intermediate hash:')
+    console.log(
+      `openssl x509 -in ${domain}-intermediate.pem -pubkey -noout | openssl rsa -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64`,
+    )
+  }
+}
+
+async function main() {
+  const domains = process.argv.slice(2)
+
+  if (domains.length === 0) {
+    console.log('🔐 SSL Certificate Extractor for SSL Pinning')
+    console.log('='.repeat(45))
+    console.log('\nUsage: node scripts/getCertificates.js <domain1> [domain2] [domain3] ...')
+    console.log('\nExamples:')
+    console.log('  node scripts/getCertificates.js safe.global')
+    console.log('  node scripts/getCertificates.js safe-client.safe.global safe-client.staging.5afe.dev')
+    console.log('\nThis script extracts certificate hashes for SSL pinning and recommends')
+    console.log('using intermediate certificates as backup for better stability.')
+    process.exit(1)
+  }
+
+  console.log('🚀 Analyzing SSL certificates for SSL pinning configuration...\n')
+
+  for (const domain of domains) {
+    try {
+      console.log(`🔍 Connecting to ${domain}...`)
+      const chain = await getFullCertificateChain(domain)
+      displayCertificateInfo(domain, chain)
+
+      if (domains.length > 1) {
+        console.log('\n' + '='.repeat(80) + '\n')
+      }
+    } catch (error) {
+      console.error(`❌ Error processing ${domain}: ${error.message}`)
+    }
+  }
+
+  console.log('\n✅ Certificate analysis complete!')
+  console.log('\n💡 SSL Pinning Best Practices:')
+  console.log('- Pin the leaf certificate as primary')
+  console.log('- Intermediate certificate as backup (more stable than leaf, but means you trust the intermediate)')
+  console.log('- Monitor certificate expiration dates')
+  console.log('- Test SSL pinning with invalid hashes to verify it works')
+  console.log('- Update certificates before they expire to avoid app outages')
+  console.log('- Intermediate certificates change less frequently than leaf certificates')
+}
+
+if (require.main === module) {
+  main().catch(console.error)
+}


### PR DESCRIPTION
## What it solves
I’m adding an expo plugin that configures iOS and Android to use pinned certificates for our domains.

Resolves https://linear.app/safe-global/issue/COR-401/implement-ssl-pinning

## How this PR fixes it
The implementation is based on this callstack article
https://www.callstack.com/blog/ssl-pinning-in-react-native-apps

I just wrote the expo plugin to insert the native code in the correct places and small script to extract the hashes of the domains to pin. 

## How to test it
The app should continue to function as is. If you change the hashes to invalide one in the app.config.js, then do `expo prebuild` and run the app network request to CGW are going to fail. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
