### PR TITLE
feat: migrate to EIP-5792 v2 spec with new atomic field

### DIFF
--- a/apps/web/src/features/walletconnect/WalletConnectContext.tsx
+++ b/apps/web/src/features/walletconnect/WalletConnectContext.tsx
@@ -264,6 +264,9 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
               atomicBatch: {
                 supported: true,
               },
+              atomic: {
+                status: 'supported',
+              },
             },
           },
         }),

--- a/apps/web/src/features/walletconnect/WalletConnectContext.tsx
+++ b/apps/web/src/features/walletconnect/WalletConnectContext.tsx
@@ -258,14 +258,12 @@ export const WalletConnectProvider = ({ children }: { children: ReactNode }) => 
 
     try {
       await walletConnect.approveSession(sessionProposal, chainId, safeAddress, {
+        atomic: JSON.stringify({ status: 'supported' }),
         capabilities: JSON.stringify({
           [safeAddress]: {
             [`0x${Number(chainId).toString(16)}`]: {
               atomicBatch: {
                 supported: true,
-              },
-              atomic: {
-                status: 'supported',
               },
             },
           },

--- a/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -1,37 +1,81 @@
+import { faker } from '@faker-js/faker'
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
-import { toBeHex } from 'ethers'
 import { useContext } from 'react'
 import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { SessionTypes } from '@walletconnect/types'
-
 import { act, fireEvent, render, waitFor } from '@/tests/test-utils'
 import { WalletConnectContext } from '../WalletConnectContext'
 import WalletConnectWallet from '../services/WalletConnectWallet'
-import { WalletConnectProvider } from '../WalletConnectContext'
+import { WalletConnectProvider, WCLoadingState } from '../WalletConnectContext'
 import { safeInfoSlice } from '@/store/safeInfoSlice'
 import { useAppDispatch } from '@/store'
 import * as useSafeWalletProvider from '@/services/safe-wallet-provider/useSafeWalletProvider'
+import * as useLocalStorageHook from '@/services/local-storage/useLocalStorage'
+import { wcPopupStore } from '@/features/walletconnect/components'
 
 jest.mock('@reown/walletkit', () => jest.fn())
 
 jest.mock('@/services/safe-wallet-provider/useSafeWalletProvider')
 
+jest.mock('@/features/walletconnect/components', () => ({
+  wcPopupStore: {
+    useStore: jest.fn(),
+    setStore: jest.fn(),
+  },
+}))
+
 const TestComponent = () => {
-  const { walletConnect, error } = useContext(WalletConnectContext)
+  const { walletConnect, error, loading, sessions, sessionProposal, open } = useContext(WalletConnectContext)
   return (
     <>
       {walletConnect && <p>WalletConnect initialized</p>}
       {error && <p>{error.message}</p>}
+      {loading && <p>Loading: {loading}</p>}
+      {sessions.length > 0 && <p>Sessions: {sessions.length}</p>}
+      {sessionProposal && <p>Session proposal received</p>}
+      {open && <p>Popup is open</p>}
+    </>
+  )
+}
+
+const ContextControlComponent = () => {
+  const { approveSession, rejectSession, setError, setOpen, setLoading } = useContext(WalletConnectContext)
+
+  const handleApprove = async () => {
+    try {
+      await approveSession()
+    } catch (e) {
+      setError(e as Error)
+    }
+  }
+
+  const handleReject = async () => {
+    try {
+      await rejectSession()
+    } catch (e) {
+      setError(e as Error)
+    }
+  }
+
+  return (
+    <>
+      <button onClick={handleApprove}>Approve Session</button>
+      <button onClick={handleReject}>Reject Session</button>
+      <button onClick={() => setError(new Error('Test error'))}>Set Error</button>
+      <button onClick={() => setOpen(true)}>Open Popup</button>
+      <button onClick={() => setLoading(WCLoadingState.CONNECT)}>Set Loading</button>
     </>
   )
 }
 
 describe('WalletConnectProvider', () => {
+  const testSafeAddress = faker.finance.ethereumAddress()
+
   const extendedSafeInfo = {
     ...extendedSafeInfoBuilder().build(),
     address: {
-      value: toBeHex('0x123', 20),
+      value: testSafeAddress,
     },
     chainId: '5',
   }
@@ -39,6 +83,9 @@ describe('WalletConnectProvider', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     jest.restoreAllMocks()
+    ;(wcPopupStore.useStore as jest.Mock).mockReturnValue(false)
+    ;(wcPopupStore.setStore as jest.Mock).mockImplementation(() => {})
+    jest.spyOn(useLocalStorageHook, 'default').mockReturnValue([{}, jest.fn()])
   })
 
   it('sets the walletConnect state', async () => {
@@ -89,12 +136,123 @@ describe('WalletConnectProvider', () => {
     })
   })
 
+  it('does not initialize updateSessions without walletConnect, chainId, or safeAddress', async () => {
+    jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+    const updateSessionsSpy = jest
+      .spyOn(WalletConnectWallet.prototype, 'updateSessions')
+      .mockImplementation(() => Promise.resolve())
+
+    render(
+      <WalletConnectProvider>
+        <TestComponent />
+      </WalletConnectProvider>,
+      {
+        initialReduxState: {
+          safeInfo: {
+            loading: false,
+            data: {
+              ...extendedSafeInfo,
+              chainId: '',
+            },
+          },
+        },
+      },
+    )
+
+    await waitFor(() => {
+      expect(updateSessionsSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  it('manages popup state correctly', async () => {
+    ;(wcPopupStore.useStore as jest.Mock).mockReturnValue(true)
+    jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+    jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+
+    const { getByText } = render(
+      <WalletConnectProvider>
+        <TestComponent />
+        <ContextControlComponent />
+      </WalletConnectProvider>,
+      {
+        initialReduxState: {
+          safeInfo: {
+            loading: false,
+            data: extendedSafeInfo,
+          },
+        },
+      },
+    )
+
+    await waitFor(() => {
+      expect(getByText('Popup is open')).toBeInTheDocument()
+    })
+  })
+
+  it('allows setting error through context', async () => {
+    jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+    jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+
+    const { getByText } = render(
+      <WalletConnectProvider>
+        <TestComponent />
+        <ContextControlComponent />
+      </WalletConnectProvider>,
+      {
+        initialReduxState: {
+          safeInfo: {
+            loading: false,
+            data: extendedSafeInfo,
+          },
+        },
+      },
+    )
+
+    await waitFor(() => {
+      expect(getByText('WalletConnect initialized')).toBeInTheDocument()
+    })
+
+    fireEvent.click(getByText('Set Error'))
+
+    await waitFor(() => {
+      expect(getByText('Test error')).toBeInTheDocument()
+    })
+  })
+
+  it('allows setting loading state through context', async () => {
+    jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+    jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+
+    const { getByText } = render(
+      <WalletConnectProvider>
+        <TestComponent />
+        <ContextControlComponent />
+      </WalletConnectProvider>,
+      {
+        initialReduxState: {
+          safeInfo: {
+            loading: false,
+            data: extendedSafeInfo,
+          },
+        },
+      },
+    )
+
+    await waitFor(() => {
+      expect(getByText('WalletConnect initialized')).toBeInTheDocument()
+    })
+
+    fireEvent.click(getByText('Set Loading'))
+
+    await waitFor(() => {
+      expect(getByText('Loading: Connect')).toBeInTheDocument()
+    })
+  })
+
   describe('updateSessions', () => {
     const extendedSafeInfo = {
       ...extendedSafeInfoBuilder().build(),
-      address: {
-        value: toBeHex('0x123', 20),
-      },
+      address: { value: testSafeAddress },
       chainId: '5',
     }
 
@@ -120,7 +278,7 @@ describe('WalletConnectProvider', () => {
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
 
       const ChainUpdater = getUpdateSafeInfoComponent({
-        address: { value: toBeHex('0x123', 20) },
+        address: { value: testSafeAddress },
         chainId: '1',
       } as SafeInfo)
 
@@ -141,22 +299,23 @@ describe('WalletConnectProvider', () => {
 
       await waitFor(() => {
         expect(getByText('WalletConnect initialized')).toBeInTheDocument()
-        expect(WalletConnectWallet.prototype.updateSessions).toHaveBeenCalledWith('5', toBeHex('0x123', 20))
+        expect(WalletConnectWallet.prototype.updateSessions).toHaveBeenCalledWith('5', testSafeAddress)
       })
 
       fireEvent.click(getByText('update'))
 
       await waitFor(() => {
-        expect(WalletConnectWallet.prototype.updateSessions).toHaveBeenCalledWith('1', toBeHex('0x123', 20))
+        expect(WalletConnectWallet.prototype.updateSessions).toHaveBeenCalledWith('1', testSafeAddress)
       })
     })
 
     it('updates sessions when the safeAddress changes', async () => {
+      const newSafeAddress = faker.finance.ethereumAddress()
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
 
       const AddressUpdater = getUpdateSafeInfoComponent({
-        address: { value: toBeHex('0x456', 20) },
+        address: { value: newSafeAddress },
         chainId: '5',
       } as SafeInfo)
 
@@ -171,9 +330,7 @@ describe('WalletConnectProvider', () => {
               loading: false,
               data: {
                 ...extendedSafeInfo,
-                address: {
-                  value: toBeHex('0x123', 20),
-                },
+                address: { value: testSafeAddress },
                 chainId: '5',
               },
             },
@@ -183,13 +340,13 @@ describe('WalletConnectProvider', () => {
 
       await waitFor(() => {
         expect(getByText('WalletConnect initialized')).toBeInTheDocument()
-        expect(WalletConnectWallet.prototype.updateSessions).toHaveBeenCalledWith('5', toBeHex('0x123', 20))
+        expect(WalletConnectWallet.prototype.updateSessions).toHaveBeenCalledWith('5', testSafeAddress)
       })
 
       fireEvent.click(getByText('update'))
 
       await waitFor(() => {
-        expect(WalletConnectWallet.prototype.updateSessions).toHaveBeenCalledWith('5', toBeHex('0x456', 20))
+        expect(WalletConnectWallet.prototype.updateSessions).toHaveBeenCalledWith('5', newSafeAddress)
       })
     })
 
@@ -209,9 +366,7 @@ describe('WalletConnectProvider', () => {
               loading: false,
               data: {
                 ...extendedSafeInfo,
-                address: {
-                  value: toBeHex('0x123', 20),
-                },
+                address: { value: testSafeAddress },
                 chainId: '5',
               },
             },
@@ -225,12 +380,628 @@ describe('WalletConnectProvider', () => {
     })
   })
 
+  describe('session management', () => {
+    const mockSessions = [
+      {
+        topic: faker.string.alphanumeric(10),
+        peer: { metadata: { url: faker.internet.url() } },
+      } as SessionTypes.Struct,
+      {
+        topic: faker.string.alphanumeric(10),
+        peer: { metadata: { url: faker.internet.url() } },
+      } as SessionTypes.Struct,
+    ]
+
+    it('updates sessions when getActiveSessions changes', async () => {
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => mockSessions)
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(getByText('WalletConnect initialized')).toBeInTheDocument()
+        expect(getByText('Sessions: 2')).toBeInTheDocument()
+      })
+    })
+
+    it('calls getActiveSessions to update session state', async () => {
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      const getActiveSessionsSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'getActiveSessions')
+        .mockImplementation(() => mockSessions)
+
+      render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(getActiveSessionsSpy).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('session proposals', () => {
+    const proposalId = faker.number.int({ min: 1, max: 999999 })
+    const proposalOrigin = faker.internet.url()
+    const sessionTopic = faker.string.alphanumeric(10)
+    const sessionUrl = faker.internet.url()
+
+    const mockSessionProposal = {
+      id: proposalId,
+      verifyContext: {
+        verified: {
+          validation: 'VALID',
+          origin: proposalOrigin,
+          isScam: false,
+        },
+      },
+    } as WalletKitTypes.SessionProposal
+
+    const mockSession = { topic: sessionTopic, peer: { metadata: { url: sessionUrl } } } as SessionTypes.Struct
+
+    it('handles session proposal events', async () => {
+      const onSessionProposeSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'onSessionPropose')
+        .mockImplementation((callback) => {
+          // Simulate receiving a proposal
+          setTimeout(() => callback(mockSessionProposal), 100)
+          return jest.fn()
+        })
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(onSessionProposeSpy).toHaveBeenCalled()
+      })
+
+      await waitFor(() => {
+        expect(getByText('Session proposal received')).toBeInTheDocument()
+      })
+    })
+
+    it('approves a session proposal successfully', async () => {
+      const approveSessionSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'approveSession')
+        .mockImplementation(() => Promise.resolve(mockSession))
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'onSessionPropose').mockImplementation((callback) => {
+        setTimeout(() => callback(mockSessionProposal), 100)
+        return jest.fn()
+      })
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+          <ContextControlComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(getByText('Session proposal received')).toBeInTheDocument()
+      })
+
+      fireEvent.click(getByText('Approve Session'))
+
+      await waitFor(() => {
+        expect(approveSessionSpy).toHaveBeenCalledWith(mockSessionProposal, '5', testSafeAddress, {
+          capabilities: JSON.stringify({
+            [testSafeAddress]: {
+              [`0x${Number(5).toString(16)}`]: {
+                atomicBatch: { supported: true },
+                atomic: {
+                  status: 'supported',
+                },
+              },
+            },
+          }),
+        })
+      })
+    })
+
+    it('rejects a session proposal successfully', async () => {
+      const rejectSessionSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'rejectSession')
+        .mockImplementation(() => Promise.resolve())
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'onSessionPropose').mockImplementation((callback) => {
+        setTimeout(() => callback(mockSessionProposal), 100)
+        return jest.fn()
+      })
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+          <ContextControlComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(getByText('Session proposal received')).toBeInTheDocument()
+      })
+
+      fireEvent.click(getByText('Reject Session'))
+
+      await waitFor(() => {
+        expect(rejectSessionSpy).toHaveBeenCalledWith(mockSessionProposal)
+      })
+    })
+
+    it('handles approval errors correctly', async () => {
+      jest
+        .spyOn(WalletConnectWallet.prototype, 'approveSession')
+        .mockImplementation(() => Promise.reject(new Error('Approval failed')))
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'onSessionPropose').mockImplementation((callback) => {
+        setTimeout(() => callback(mockSessionProposal), 100)
+        return jest.fn()
+      })
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+          <ContextControlComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(getByText('Session proposal received')).toBeInTheDocument()
+      })
+
+      fireEvent.click(getByText('Approve Session'))
+
+      // The component catches errors internally, so just verify the error handler was called
+      await waitFor(() => {
+        expect(WalletConnectWallet.prototype.approveSession).toHaveBeenCalled()
+      })
+    })
+
+    it('handles rejection errors correctly', async () => {
+      jest
+        .spyOn(WalletConnectWallet.prototype, 'rejectSession')
+        .mockImplementation(() => Promise.reject(new Error('Rejection failed')))
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'onSessionPropose').mockImplementation((callback) => {
+        setTimeout(() => callback(mockSessionProposal), 100)
+        return jest.fn()
+      })
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+          <ContextControlComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(getByText('Session proposal received')).toBeInTheDocument()
+      })
+
+      fireEvent.click(getByText('Reject Session'))
+
+      // The component catches errors internally, so just verify the error handler was called
+      await waitFor(() => {
+        expect(WalletConnectWallet.prototype.rejectSession).toHaveBeenCalled()
+      })
+    })
+
+    it('does not approve or reject without session proposal', async () => {
+      const approveSessionSpy = jest.spyOn(WalletConnectWallet.prototype, 'approveSession')
+      const rejectSessionSpy = jest.spyOn(WalletConnectWallet.prototype, 'rejectSession')
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+          <ContextControlComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(getByText('WalletConnect initialized')).toBeInTheDocument()
+      })
+
+      fireEvent.click(getByText('Approve Session'))
+      fireEvent.click(getByText('Reject Session'))
+
+      expect(approveSessionSpy).not.toHaveBeenCalled()
+      expect(rejectSessionSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('session auth (one-click auth)', () => {
+    const authId = faker.number.int({ min: 1, max: 999999 })
+    const authTopic = faker.string.alphanumeric(10)
+    const authOrigin = faker.internet.url()
+    const authDomain = faker.internet.domainName()
+    const authAud = faker.internet.url()
+    const authNonce = faker.string.alphanumeric(10)
+    const appName = faker.company.name()
+    const appDescription = faker.lorem.sentence()
+    const appUrl = faker.internet.url()
+    const appIcon = faker.image.url()
+
+    const mockAuthEvent = {
+      id: authId,
+      topic: authTopic,
+      verifyContext: {
+        verified: {
+          validation: 'VALID' as const,
+          origin: authOrigin,
+          isScam: false,
+        },
+      },
+      params: {
+        expiryTimestamp: Math.floor(Date.now() / 1000) + 3600,
+        authPayload: {
+          chains: ['eip155:5'],
+          domain: authDomain,
+          aud: authAud,
+          version: '1',
+          nonce: authNonce,
+          iat: new Date().toISOString(),
+        },
+        requester: {
+          metadata: {
+            name: appName,
+            description: appDescription,
+            url: appUrl,
+            icons: [appIcon],
+          },
+        },
+      },
+    } as WalletKitTypes.SessionAuthenticate
+
+    it('handles session auth with valid chain', async () => {
+      const siweMessage = faker.lorem.sentence()
+      const mockSignature = faker.string.hexadecimal({ length: 132, prefix: '0x' })
+
+      const formatAuthMessageSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'formatAuthMessage')
+        .mockReturnValue(siweMessage)
+      const approveSessionAuthSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'approveSessionAuth')
+        .mockImplementation(() => Promise.resolve())
+      const onSessionAuthSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'onSessionAuth')
+        .mockImplementation((callback) => {
+          setTimeout(() => callback(mockAuthEvent), 100)
+          return jest.fn()
+        })
+
+      const mockRequest = jest.fn().mockResolvedValue({ result: mockSignature })
+      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
+        () =>
+          ({
+            request: mockRequest,
+          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+      )
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+
+      render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(onSessionAuthSpy).toHaveBeenCalled()
+      })
+
+      await waitFor(() => {
+        expect(formatAuthMessageSpy).toHaveBeenCalledWith(mockAuthEvent.params.authPayload, '5', testSafeAddress)
+        expect(mockRequest).toHaveBeenCalledWith(
+          authId,
+          {
+            method: 'personal_sign',
+            params: [siweMessage, testSafeAddress],
+          },
+          expect.objectContaining({
+            name: appName,
+            url: 'https://apps-portal.safe.global/wallet-connect',
+          }),
+        )
+        expect(approveSessionAuthSpy).toHaveBeenCalledWith(
+          authId,
+          mockAuthEvent.params.authPayload,
+          mockSignature,
+          '5',
+          testSafeAddress,
+        )
+      })
+    })
+
+    it('rejects session auth with wrong chain', async () => {
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockReturnValue({ request: jest.fn() } as unknown as ReturnType<typeof useSafeWalletProvider.default>)
+
+      const wrongChainAuthEvent = {
+        ...mockAuthEvent,
+        params: {
+          ...mockAuthEvent.params,
+          authPayload: {
+            ...mockAuthEvent.params.authPayload,
+            chains: ['eip155:1'], // Wrong chain
+          },
+        },
+      }
+
+      let authCallback: ((event: any) => void) | null = null
+      const onSessionAuthSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'onSessionAuth')
+        .mockImplementation((callback) => {
+          authCallback = callback
+          return jest.fn()
+        })
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(onSessionAuthSpy).toHaveBeenCalled()
+        // Immediately trigger auth after setup
+        if (authCallback) {
+          authCallback(wrongChainAuthEvent)
+        }
+      })
+
+      await waitFor(() => {
+        expect(
+          getByText(`${appName} made a request on a different chain than the one you are connected to`),
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('handles auth request errors', async () => {
+      const signatureError = faker.lorem.sentence()
+      const siweMessage = faker.lorem.sentence()
+
+      const rejectSessionAuthSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'rejectSessionAuth')
+        .mockImplementation(() => Promise.resolve())
+      const onSessionAuthSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'onSessionAuth')
+        .mockImplementation((callback) => {
+          setTimeout(() => callback(mockAuthEvent), 100)
+          return jest.fn()
+        })
+
+      const mockRequest = jest.fn().mockRejectedValue(new Error(signatureError))
+      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
+        () =>
+          ({
+            request: mockRequest,
+          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+      )
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'formatAuthMessage').mockReturnValue(siweMessage)
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(onSessionAuthSpy).toHaveBeenCalled()
+      })
+
+      await waitFor(() => {
+        expect(rejectSessionAuthSpy).toHaveBeenCalledWith(authId)
+        expect(getByText(signatureError)).toBeInTheDocument()
+      })
+    })
+
+    it('handles signature result errors', async () => {
+      const userRejectionError = faker.lorem.sentence()
+      const siweMessage = faker.lorem.sentence()
+
+      const rejectSessionAuthSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'rejectSessionAuth')
+        .mockImplementation(() => Promise.resolve())
+      const onSessionAuthSpy = jest
+        .spyOn(WalletConnectWallet.prototype, 'onSessionAuth')
+        .mockImplementation((callback) => {
+          setTimeout(() => callback(mockAuthEvent), 100)
+          return jest.fn()
+        })
+
+      const mockRequest = jest.fn().mockResolvedValue({ error: { message: userRejectionError } })
+      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
+        () =>
+          ({
+            request: mockRequest,
+          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+      )
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'formatAuthMessage').mockReturnValue(siweMessage)
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(onSessionAuthSpy).toHaveBeenCalled()
+      })
+
+      await waitFor(() => {
+        expect(rejectSessionAuthSpy).toHaveBeenCalledWith(authId)
+        expect(getByText(userRejectionError)).toBeInTheDocument()
+      })
+    })
+
+    it('does not setup auth listener without required dependencies', async () => {
+      const onSessionAuthSpy = jest.spyOn(WalletConnectWallet.prototype, 'onSessionAuth')
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+
+      render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: {
+                ...extendedSafeInfo,
+                chainId: '', // Missing chainId
+              },
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(onSessionAuthSpy).not.toHaveBeenCalled()
+      })
+    })
+  })
+
   describe('onRequest', () => {
+    const requestTopic = faker.string.alphanumeric(10)
+    const requestUrl = faker.internet.url()
+    const requestAppName = faker.company.name()
+
     const extendedSafeInfo = {
       ...extendedSafeInfoBuilder().build(),
-      address: {
-        value: toBeHex('0x123', 20),
-      },
+      address: { value: testSafeAddress },
       chainId: '5',
     }
 
@@ -348,18 +1119,84 @@ describe('WalletConnectProvider', () => {
       })
     })
 
-    it('passes the request onto the Safe Wallet Provider and sends the response to WalletConnect', async () => {
+    it('sets wrong chain error when session exists but chain is wrong', async () => {
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
         {
-          topic: 'topic',
+          topic: requestTopic,
           peer: {
             metadata: {
-              name: 'name',
-              description: 'description',
+              url: requestUrl,
+              name: requestAppName,
+            },
+          },
+        } as unknown as SessionTypes.Struct,
+      ])
+
+      const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
+
+      const mockRequest = jest.fn()
+      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
+        () =>
+          ({
+            request: mockRequest,
+          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+      )
+
+      const { getByText } = render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(onRequestSpy).toHaveBeenCalled()
+      })
+
+      const onRequestHandler = onRequestSpy.mock.calls[0][0]
+
+      act(() => {
+        onRequestHandler({
+          id: 1,
+          topic: requestTopic,
+          params: {
+            request: {},
+            chainId: 'eip155:1', // Mainnet (wrong chain)
+          },
+        } as unknown as WalletKitTypes.SessionRequest)
+      })
+
+      await waitFor(() => {
+        expect(
+          getByText(`${requestAppName} made a request on a different chain than the one you are connected to`),
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('passes the request onto the Safe Wallet Provider and sends the response to WalletConnect', async () => {
+      const peerDescription = faker.lorem.sentence()
+      const peerIcon = faker.image.url()
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
+        {
+          topic: requestTopic,
+          peer: {
+            metadata: {
+              name: requestAppName,
+              description: peerDescription,
               url: 'https://apps-portal.safe.global/wallet-connect',
-              icons: ['iconUrl'],
+              icons: [peerIcon],
             },
           },
         } as unknown as SessionTypes.Struct,
@@ -400,7 +1237,7 @@ describe('WalletConnectProvider', () => {
 
       onRequestHandler({
         id: 1,
-        topic: 'topic',
+        topic: requestTopic,
         params: {
           request: { method: 'fake', params: [] },
           chainId: 'eip155:5', // Goerli
@@ -411,16 +1248,80 @@ describe('WalletConnectProvider', () => {
         1,
         { method: 'fake', params: [] },
         {
-          name: 'name',
-          description: 'description',
+          name: requestAppName,
+          description: peerDescription,
           url: 'https://apps-portal.safe.global/wallet-connect',
-          iconUrl: 'iconUrl',
+          iconUrl: peerIcon,
         },
       )
 
       await waitFor(() => {
-        expect(sendSessionResponseSpy).toHaveBeenCalledWith('topic', {})
+        expect(sendSessionResponseSpy).toHaveBeenCalledWith(requestTopic, {})
       })
+    })
+
+    it('uses fallback peer name when session peer name is not available', async () => {
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
+        {
+          topic: requestTopic,
+          peer: {
+            metadata: {
+              description: faker.lorem.sentence(),
+              icons: [faker.image.url()],
+              // No name or url property to trigger fallback to FALLBACK_PEER_NAME
+            },
+          },
+        } as unknown as SessionTypes.Struct,
+      ])
+
+      const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
+
+      const mockRequest = jest.fn().mockImplementation(() => Promise.resolve({}))
+      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
+        () =>
+          ({
+            request: mockRequest,
+          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+      )
+
+      render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: extendedSafeInfo,
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(onRequestSpy).toHaveBeenCalled()
+      })
+
+      const onRequestHandler = onRequestSpy.mock.calls[0][0]
+
+      onRequestHandler({
+        id: 1,
+        topic: requestTopic,
+        params: {
+          request: { method: 'fake', params: [] },
+          chainId: 'eip155:5',
+        },
+      } as unknown as WalletKitTypes.SessionRequest)
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        1,
+        { method: 'fake', params: [] },
+        expect.objectContaining({
+          name: 'WalletConnect', // Fallback name
+        }),
+      )
     })
 
     it('sets the error state if there is an error requesting', async () => {
@@ -428,13 +1329,13 @@ describe('WalletConnectProvider', () => {
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
         {
-          topic: 'topic',
+          topic: requestTopic,
           peer: {
             metadata: {
-              name: 'name',
-              description: 'description',
+              name: requestAppName,
+              description: faker.lorem.sentence(),
               url: 'https://apps-portal.safe.global/wallet-connect',
-              icons: ['iconUrl'],
+              icons: [faker.image.url()],
             },
           },
         } as unknown as SessionTypes.Struct,
@@ -470,19 +1371,49 @@ describe('WalletConnectProvider', () => {
 
       const onRequestHandler = onRequestSpy.mock.calls[0][0]
 
-      onRequestHandler({
-        id: 1,
-        topic: 'topic',
-        params: {
-          request: {},
-          chainId: 'eip155:5', // Goerli
-        },
-      } as unknown as WalletKitTypes.SessionRequest)
+      act(() => {
+        onRequestHandler({
+          id: 1,
+          topic: requestTopic,
+          params: {
+            request: {},
+            chainId: 'eip155:5', // Goerli
+          },
+        } as unknown as WalletKitTypes.SessionRequest)
+      })
 
       expect(sendSessionResponseSpy).not.toHaveBeenCalled()
 
       await waitFor(() => {
         expect(getByText('Test request failed')).toBeInTheDocument()
+      })
+    })
+
+    it('does not setup request listener without required dependencies', async () => {
+      const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
+
+      jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
+      jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
+
+      render(
+        <WalletConnectProvider>
+          <TestComponent />
+        </WalletConnectProvider>,
+        {
+          initialReduxState: {
+            safeInfo: {
+              loading: false,
+              data: {
+                ...extendedSafeInfo,
+                chainId: '', // Missing chainId
+              },
+            },
+          },
+        },
+      )
+
+      await waitFor(() => {
+        expect(onRequestSpy).not.toHaveBeenCalled()
       })
     })
   })

--- a/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -533,13 +533,11 @@ describe('WalletConnectProvider', () => {
 
       await waitFor(() => {
         expect(approveSessionSpy).toHaveBeenCalledWith(mockSessionProposal, '5', testSafeAddress, {
+          atomic: JSON.stringify({ status: 'supported' }),
           capabilities: JSON.stringify({
             [testSafeAddress]: {
               [`0x${Number(5).toString(16)}`]: {
                 atomicBatch: { supported: true },
-                atomic: {
-                  status: 'supported',
-                },
               },
             },
           }),

--- a/apps/web/src/services/safe-wallet-provider/index.test.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.test.ts
@@ -656,6 +656,7 @@ describe('SafeWalletProvider', () => {
           id: 1,
           jsonrpc: '2.0',
           result: {
+            atomic: true,
             id: params[0],
             chainId: '0x1',
             receipts: [
@@ -669,7 +670,7 @@ describe('SafeWalletProvider', () => {
               },
             ],
             status: 200,
-            version: '1.0',
+            version: '2.0.0',
           },
         })
       })
@@ -710,6 +711,7 @@ describe('SafeWalletProvider', () => {
           id: 1,
           jsonrpc: '2.0',
           result: {
+            atomic: true,
             chainId: '0x1',
             id: params[0],
             receipts: [
@@ -723,7 +725,7 @@ describe('SafeWalletProvider', () => {
               },
             ],
             status: 200,
-            version: '1.0',
+            version: '2.0.0',
           },
         })
       })
@@ -752,10 +754,11 @@ describe('SafeWalletProvider', () => {
           id: 1,
           jsonrpc: '2.0',
           result: {
+            atomic: true,
             chainId: '0x1',
             id: params[0],
             status: 100,
-            version: '1.0',
+            version: '2.0.0',
           },
         })
       })
@@ -790,10 +793,11 @@ describe('SafeWalletProvider', () => {
           id: 1,
           jsonrpc: '2.0',
           result: {
+            atomic: true,
             chainId: '0x1',
             id: params[0],
             status: 100,
-            version: '1.0',
+            version: '2.0.0',
           },
         })
       })

--- a/apps/web/src/services/safe-wallet-provider/index.test.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.test.ts
@@ -833,6 +833,9 @@ describe('SafeWalletProvider', () => {
               atomicBatch: {
                 supported: true,
               },
+              atomic: {
+                status: 'supported',
+              },
             },
           },
         })

--- a/apps/web/src/services/safe-wallet-provider/index.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.ts
@@ -458,6 +458,9 @@ export class SafeWalletProvider {
           atomicBatch: {
             supported: true,
           },
+          atomic: {
+            status: 'supported',
+          },
         },
       }
     }

--- a/apps/web/src/services/safe-wallet-provider/index.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.ts
@@ -18,7 +18,7 @@ type Capability = {
 }
 
 type SendCallsParams = {
-  version: '1.0'
+  version: string
   id?: string
   from?: `0x${string}`
   chainId: `0x${string}`
@@ -412,7 +412,7 @@ export class SafeWalletProvider {
     }
 
     const result: GetCallsResult = {
-      version: '1.0',
+      version: '2.0.0',
       id: safeTxHash,
       chainId: numberToHex(this.safe.chainId),
       status: BundleTxStatuses[tx.txStatus],

--- a/apps/web/src/services/safe-wallet-provider/index.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.ts
@@ -22,6 +22,7 @@ type SendCallsParams = {
   id?: string
   from?: `0x${string}`
   chainId: `0x${string}`
+  atomicRequired: boolean
   calls: Array<{
     to?: `0x${string}`
     data?: `0x${string}`

--- a/apps/web/src/services/safe-wallet-provider/index.ts
+++ b/apps/web/src/services/safe-wallet-provider/index.ts
@@ -44,6 +44,7 @@ type GetCallsResult = {
   id: `0x${string}`
   chainId: `0x${string}`
   status: number // See "Status Codes"
+  atomic: boolean
   receipts?: Array<{
     logs: TransactionReceipt['logs']
     status: `0x${string}` // Hex 1 or 0 for success or failure, respectively
@@ -417,6 +418,7 @@ export class SafeWalletProvider {
       id: safeTxHash,
       chainId: numberToHex(this.safe.chainId),
       status: BundleTxStatuses[tx.txStatus],
+      atomic: true,
     }
 
     if (!tx.txHash) {


### PR DESCRIPTION
## What it solves

[COR-404](https://linear.app/safe-global/issue/COR-404/add-support-for-atomic-capability-in-eip-5792-v2)

Implements support for the `atomic` capability in accordance with the [EIP-5792 v2 specification](https://eips.ethereum.org/EIPS/eip-5792), enabling better compatibility with dApps using the latest version.  
The existing `atomicBatch` field is preserved to ensure backward compatibility with v1 clients.

## How this PR fixes it

Changes to comply with the points outlined in the [migration guide](https://www.eip5792.xyz/reference/migrating-to-v2):

- Adds the `atomic` field to the response of `wallet_getCapabilities` as required by EIP-5792 v2  
- Updates the version field in `wallet_getCallsStatus` results to align with the v2 format  
- Introduces the `atomicRequired` flag to the `SendCallsParams` type for v2 call semantics  
- Adds the `atomic` flag to the `wallet_getCallsStatus` response object, enabling clients to verify atomicity status as per v2

## How to test

1. Connect a dApp and initiate a call to `wallet_getCapabilities`  
   **Expected**: Response should include both `atomic` and `atomicBatch` fields  
2. Submit a batch using `wallet_sendCalls` with `atomicRequired: true`  
   **Expected**: Transaction proceeds according to atomic batch semantics  
3. Call `wallet_getCallsStatus` after submission  
   **Expected**: Response should include the `atomic` flag and version information consistent with v2

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
