### PR TITLE
refactor(mobile): use proper import for useCompatibleNetworks hook

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/BridgeTransaction/BridgeRecipientWarnings.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/BridgeTransaction/BridgeRecipientWarnings.tsx
@@ -16,9 +16,8 @@ import {
   type BridgeWarningData,
 } from '@safe-global/utils/components/confirmation-views/BridgeTransaction/useBridgeWarningLogic'
 import { useSafeCreationData } from '@/src/hooks/useSafeCreationData'
-import { useCompatibleNetworks } from '@safe-global/web/src/features/multichain/hooks/useCompatibleNetworks'
+import { useCompatibleNetworks } from '@safe-global/utils/features/multichain/hooks/useCompatibleNetworks'
 import { RootState } from '@/src/store'
-import { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
 interface WarningAlertProps {
   warning: BridgeWarning
@@ -44,7 +43,7 @@ export const BridgeRecipientWarnings = ({ txInfo }: BridgeRecipientWarningsProps
   const destinationContact = useAppSelector((state) => selectContactByAddress(txInfo.recipient.value)(state))
   const destinationChain = useAppSelector((state: RootState) => selectChainById(state, txInfo.toChain))
   const [creationData] = useSafeCreationData(activeSafe.chainId)
-  const compatibleNetworks = useCompatibleNetworks(creationData, [destinationChain as ChainInfo])
+  const compatibleNetworks = useCompatibleNetworks(creationData, [destinationChain])
 
   const isSameAddress = sameAddress(txInfo.recipient.value, activeSafe.address)
 

--- a/apps/mobile/src/features/ConfirmTx/components/confirmation-views/BridgeTransaction/__tests__/BridgeRecipientWarnings.test.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/confirmation-views/BridgeTransaction/__tests__/BridgeRecipientWarnings.test.tsx
@@ -26,7 +26,7 @@ jest.mock('@/src/hooks/useSafeCreationData', () => ({
   useSafeCreationData: jest.fn(),
 }))
 
-jest.mock('@safe-global/web/src/features/multichain/hooks/useCompatibleNetworks', () => ({
+jest.mock('@safe-global/utils/features/multichain/hooks/useCompatibleNetworks', () => ({
   useCompatibleNetworks: jest.fn(),
 }))
 
@@ -34,7 +34,7 @@ const { useSafesGetSafeV1Query } = require('@safe-global/store/gateway/AUTO_GENE
 const { useDefinedActiveSafe } = require('@/src/store/hooks/activeSafe')
 const { useAppSelector } = require('@/src/store/hooks')
 const { useSafeCreationData } = require('@/src/hooks/useSafeCreationData')
-const { useCompatibleNetworks } = require('@safe-global/web/src/features/multichain/hooks/useCompatibleNetworks')
+const { useCompatibleNetworks } = require('@safe-global/utils/features/multichain/hooks/useCompatibleNetworks')
 
 // Helper to wrap component with required providers
 const renderWithProviders = (ui: React.ReactElement) => {

--- a/apps/web/src/components/common/NetworkSelector/index.tsx
+++ b/apps/web/src/components/common/NetworkSelector/index.tsx
@@ -30,9 +30,10 @@ import { useAllSafesGrouped } from '@/features/myAccounts/hooks/useAllSafesGroup
 import useSafeAddress from '@/hooks/useSafeAddress'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import uniq from 'lodash/uniq'
-import { useCompatibleNetworks } from '@/features/multichain/hooks/useCompatibleNetworks'
+import { useCompatibleNetworks } from '@safe-global/utils/features/multichain/hooks/useCompatibleNetworks'
 import { useSafeCreationData } from '@/features/multichain/hooks/useSafeCreationData'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { type Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import PlusIcon from '@/public/images/common/plus.svg'
 import useAddressBook from '@/hooks/useAddressBook'
 import { CreateSafeOnSpecificChain } from '@/features/multichain/components/CreateSafeOnNewChain'
@@ -98,9 +99,9 @@ const UndeployedNetworkMenuItem = ({
   isSelected = false,
   onSelect,
 }: {
-  chain: ChainInfo & { available: boolean }
+  chain: Chain & { available: boolean }
   isSelected?: boolean
-  onSelect: (chain: ChainInfo) => void
+  onSelect: (chain: Chain) => void
 }) => {
   const isDisabled = !chain.available
 
@@ -172,7 +173,7 @@ const UndeployedNetworks = ({
   closeNetworkSelect: () => void
 }) => {
   const [open, setOpen] = useState(false)
-  const [replayOnChain, setReplayOnChain] = useState<ChainInfo>()
+  const [replayOnChain, setReplayOnChain] = useState<Chain>()
   const addressBook = useAddressBook()
   const safeName = addressBook[safeAddress]
   const { configs } = useChains()
@@ -184,13 +185,13 @@ const UndeployedNetworks = ({
   const safeCreationResult = useSafeCreationData(safeAddress, deployedChainInfos)
   const [safeCreationData, safeCreationDataError, safeCreationLoading] = safeCreationResult
 
-  const allCompatibleChains = useCompatibleNetworks(safeCreationData, configs)
+  const allCompatibleChains = useCompatibleNetworks(safeCreationData, configs as Chain[])
   const isUnsupportedSafeCreationVersion = Boolean(!allCompatibleChains?.length)
 
   const availableNetworks = useMemo(
     () =>
       allCompatibleChains?.filter(
-        (config) => !deployedChains.includes(config.chainId) && hasMultiChainAddNetworkFeature(config),
+        (config) => !deployedChains.includes(config.chainId) && hasMultiChainAddNetworkFeature(config as ChainInfo),
       ) || [],
     [allCompatibleChains, deployedChains],
   )
@@ -202,7 +203,7 @@ const UndeployedNetworks = ({
 
   const noAvailableNetworks = useMemo(() => availableNetworks.every((config) => !config.available), [availableNetworks])
 
-  const onSelect = (chain: ChainInfo) => {
+  const onSelect = (chain: Chain) => {
     setReplayOnChain(chain)
   }
 
@@ -318,7 +319,7 @@ const UndeployedNetworks = ({
       </Collapse>
       {replayOnChain && safeCreationData && (
         <CreateSafeOnSpecificChain
-          chain={replayOnChain}
+          chain={replayOnChain as ChainInfo}
           safeAddress={safeAddress}
           open
           onClose={onFormClose}

--- a/apps/web/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/apps/web/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -22,9 +22,10 @@ import { useRouter } from 'next/router'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import { type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { useMemo, useState } from 'react'
-import { useCompatibleNetworks } from '../../hooks/useCompatibleNetworks'
+import { useCompatibleNetworks } from '@safe-global/utils/features/multichain/hooks/useCompatibleNetworks'
 import { MULTICHAIN_HELP_ARTICLE } from '@/config/constants'
 import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
+import { type Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 
 type CreateSafeOnNewChainForm = {
   chainId: string
@@ -85,7 +86,7 @@ const ReplaySafeDialog = ({
 
       // We need to create a readOnly provider of the deployed chain
       const customRpcUrl = selectedChain ? customRpc?.[selectedChain.chainId] : undefined
-      const provider = createWeb3ReadOnly(selectedChain, customRpcUrl)
+      const provider = createWeb3ReadOnly(selectedChain as ChainInfo, customRpcUrl)
       if (!provider) {
         return
       }
@@ -210,7 +211,15 @@ const ReplaySafeDialog = ({
               ) : noChainsAvailable ? (
                 <ErrorMessage level="error">This Safe cannot be replayed on any chains.</ErrorMessage>
               ) : (
-                <>{!chain && <NetworkInput required name="chainId" chainConfigs={replayableChains ?? []} />}</>
+                <>
+                  {!chain && (
+                    <NetworkInput
+                      required
+                      name="chainId"
+                      chainConfigs={(replayableChains as (ChainInfo & { available: boolean })[]) ?? []}
+                    />
+                  )}
+                </>
               )}
 
               {creationError && (
@@ -269,12 +278,12 @@ export const CreateSafeOnNewChain = ({
   )
 
   const safeCreationResult = useSafeCreationData(safeAddress, deployedChains)
-  const allCompatibleChains = useCompatibleNetworks(safeCreationResult[0], configs)
+  const allCompatibleChains = useCompatibleNetworks(safeCreationResult[0], configs as Chain[])
   const isUnsupportedSafeCreationVersion = Boolean(!allCompatibleChains?.length)
   const replayableChains = useMemo(
     () =>
       allCompatibleChains?.filter(
-        (config) => !deployedChainIds.includes(config.chainId) && hasMultiChainAddNetworkFeature(config),
+        (config) => !deployedChainIds.includes(config.chainId) && hasMultiChainAddNetworkFeature(config as ChainInfo),
       ) || [],
     [allCompatibleChains, deployedChainIds],
   )

--- a/apps/web/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
+++ b/apps/web/src/features/multichain/hooks/__tests__/useCompatibleNetworks.test.ts
@@ -1,10 +1,11 @@
 import { renderHook } from '@/tests/test-utils'
-import { useCompatibleNetworks } from '../useCompatibleNetworks'
+import { useCompatibleNetworks } from '@safe-global/utils/features/multichain/hooks/useCompatibleNetworks'
 import { type ReplayedSafeProps } from '@safe-global/utils/features/counterfactual/store/types'
 import { faker } from '@faker-js/faker'
 import { EMPTY_DATA, ZERO_ADDRESS } from '@safe-global/protocol-kit/dist/src/utils/constants'
 import { ECOSYSTEM_ID_ADDRESS } from '@/config/constants'
 import { chainBuilder } from '@/tests/builders/chains'
+import { type Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import {
   getSafeSingletonDeployments,
   getSafeL2SingletonDeployments,
@@ -44,7 +45,7 @@ describe('useCompatibleNetworks', () => {
   })
 
   it('should return empty list without any creation data', () => {
-    const { result } = renderHook(() => useCompatibleNetworks(undefined, mockChains))
+    const { result } = renderHook(() => useCompatibleNetworks(undefined, mockChains as Chain[]))
     expect(result.current).toHaveLength(0)
   })
 
@@ -67,7 +68,7 @@ describe('useCompatibleNetworks', () => {
       safeAccountConfig: callData,
       safeVersion: '1.4.1',
     }
-    const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains))
+    const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains as Chain[]))
     expect(result.current.every((config) => config.available)).toEqual(false)
   })
 
@@ -90,7 +91,7 @@ describe('useCompatibleNetworks', () => {
         safeAccountConfig: callData,
         safeVersion: '1.4.1',
       }
-      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains))
+      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains as Chain[]))
       expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
       expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, true, true, false])
@@ -104,7 +105,7 @@ describe('useCompatibleNetworks', () => {
         safeAccountConfig: callData,
         safeVersion: '1.4.1',
       }
-      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains))
+      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains as Chain[]))
       expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
       expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, true, true, false])
@@ -132,7 +133,7 @@ describe('useCompatibleNetworks', () => {
         safeAccountConfig: { ...callData, fallbackHandler: FALLBACK_HANDLER_130_DEPLOYMENTS?.canonical?.address! },
         safeVersion: '1.3.0',
       }
-      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains))
+      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains as Chain[]))
       expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
       expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, true, true, false])
@@ -147,7 +148,7 @@ describe('useCompatibleNetworks', () => {
         safeAccountConfig: { ...callData, fallbackHandler: FALLBACK_HANDLER_130_DEPLOYMENTS?.canonical?.address! },
         safeVersion: '1.3.0',
       }
-      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains))
+      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains as Chain[]))
       expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
       expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, true, true, true])
@@ -162,7 +163,7 @@ describe('useCompatibleNetworks', () => {
         safeAccountConfig: { ...callData, fallbackHandler: FALLBACK_HANDLER_130_DEPLOYMENTS?.eip155?.address! },
         safeVersion: '1.3.0',
       }
-      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains))
+      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains as Chain[]))
       expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
       expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, true, true, false])
@@ -177,7 +178,7 @@ describe('useCompatibleNetworks', () => {
         safeAccountConfig: { ...callData, fallbackHandler: FALLBACK_HANDLER_130_DEPLOYMENTS?.eip155?.address! },
         safeVersion: '1.3.0',
       }
-      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains))
+      const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains as Chain[]))
       expect(result.current).toHaveLength(6)
       expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
       expect(result.current.map((chain) => chain.available)).toEqual([true, true, true, true, true, false])
@@ -203,7 +204,7 @@ describe('useCompatibleNetworks', () => {
       safeAccountConfig: callData,
       safeVersion: '1.1.1',
     }
-    const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains))
+    const { result } = renderHook(() => useCompatibleNetworks(creationData, mockChains as Chain[]))
     expect(result.current).toHaveLength(6)
     expect(result.current.map((chain) => chain.chainId)).toEqual(['1', '10', '100', '324', '480', '10200'])
     expect(result.current.map((chain) => chain.available)).toEqual([false, false, false, false, false, false])

--- a/packages/utils/src/features/multichain/hooks/useCompatibleNetworks.ts
+++ b/packages/utils/src/features/multichain/hooks/useCompatibleNetworks.ts
@@ -9,7 +9,7 @@ import {
   getSafeToL2MigrationDeployments,
   getSafeToL2SetupDeployments,
 } from '@safe-global/safe-deployments'
-import type { ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
+import { type Chain as ChainInfo } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import type { ReplayedSafeProps } from '@safe-global/utils/features/counterfactual/store/types'
 
 const SUPPORTED_VERSIONS: SafeVersion[] = ['1.4.1', '1.3.0']


### PR DESCRIPTION
## What it solves
We were erroneously importing useCompatibleNetworks from apps/web instead of package/utils. 

related to https://linear.app/safe-global/issue/COR-358/mobilelifi-bridging-the-error-message-for-the-old-mastercopies-is

## How this PR fixes it
refactor

## How to test it
Nothing changes, nothing needs to be tested. Tests and linting needs to pass.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
