### PR TITLE
fix(mobile): fix android UI glitches

### DIFF
--- a/apps/mobile/src/app/import-signers/private-key-error.tsx
+++ b/apps/mobile/src/app/import-signers/private-key-error.tsx
@@ -2,14 +2,15 @@ import { StyleSheet } from 'react-native'
 import { LinearGradient } from 'expo-linear-gradient'
 import { ImportError } from '@/src/features/ImportPrivateKey/components/ImportError'
 import React from 'react'
-import { useTheme, View } from 'tamagui'
+import { getTokenValue, useTheme, View } from 'tamagui'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export default function App() {
   const theme = useTheme()
   const colors: [string, string] = [theme.errorDark.get(), 'transparent']
-
+  const { bottom } = useSafeAreaInsets()
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1 }} paddingBottom={Math.max(bottom, getTokenValue('$4'))}>
       <LinearGradient colors={colors} style={styles.background} />
 
       <ImportError />

--- a/apps/mobile/src/components/transactions-list/Card/TxGroupedCard/TxGroupedCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxGroupedCard/TxGroupedCard.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { Theme, View } from 'tamagui'
-import { SafeListItem } from '@/src/components/SafeListItem'
+import { Theme, Text, View } from 'tamagui'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import { TxInfo } from '@/src/components/TxInfo'
 import { getOrderClass } from '@/src/hooks/useTransactionType'
 import { isSwapTransferOrderTxInfo } from '@/src/utils/transaction-guards'
 import { OrderTransactionInfo } from '@safe-global/store/gateway/types'
 import { TransactionQueuedItem, TransactionItem } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { Container } from '@/src/components/Container'
 
 interface TxGroupedCard {
   transactions: (TransactionItem | TransactionQueuedItem)[]
@@ -31,24 +31,33 @@ function TxGroupedCardComponent({ transactions, inQueue }: TxGroupedCard) {
   const label = isSwapTransfer ? getSettlementOrderTitle(firstTxInfo) : 'Bulk transactions'
 
   return (
-    <SafeListItem
-      label={label}
-      leftNode={
+    <Container>
+      <View flexDirection="row" alignItems="center" gap="$2">
         <Theme name="logo">
-          <View backgroundColor="$background" padding="$2" borderRadius={100}>
-            <SafeFontIcon name="batch" />
+          <View
+            backgroundColor="$background"
+            padding="$2"
+            borderRadius={100}
+            height={32}
+            width={32}
+            justifyContent="center"
+            alignItems="center"
+          >
+            <SafeFontIcon name="batch" size={16} />
           </View>
         </Theme>
-      }
-    >
-      <View width="100%">
+        <Text fontSize="$4" fontWeight={600}>
+          {label}
+        </Text>
+      </View>
+      <View>
         {transactions.map((item, index) => (
-          <View width="100%" testID="tx-group-info" key={`${item.transaction.id}-${index}`} marginTop={12}>
+          <View testID="tx-group-info" key={`${item.transaction.id}-${index}`} marginTop={12}>
             <TxInfo inQueue={inQueue} bordered tx={item.transaction} />
           </View>
         ))}
       </View>
-    </SafeListItem>
+    </Container>
   )
 }
 


### PR DESCRIPTION
## What it solves
- bulk txs were shown outside of the screen on android
- wrong padding bottom on private key error screen

Resolves https://linear.app/safe-global/issue/COR-399/mobile-bulk-tx-looks-broken-in-the-history-tab
Resolves https://linear.app/safe-global/issue/COR-384/mobile-bottom-marginpadding-is-non-existent-in-android#comment-0d55c7c7

## How this PR fixes it

## How to test it

## Screenshots
without this PR:
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/b13fb09f-982c-4f37-b05c-98f843bfd6ec" />
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/c6286a82-58d7-45b1-804f-f0bf72d81891" />


with this PR:
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/8579199b-83d9-46f8-94bd-a75f6c68e592" />

<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/a1b45524-a17b-4d15-a5ca-76dde463ca00" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
