### PR TITLE
fix(mobile): Scrolling within sheet was not possible

### DIFF
--- a/apps/mobile/src/components/ChainsDisplay/ChainsDisplay.tsx
+++ b/apps/mobile/src/components/ChainsDisplay/ChainsDisplay.tsx
@@ -32,6 +32,7 @@ export function ChainsDisplay({ chains, activeChainId, max }: ChainsDisplayProps
 
       {showBadge && (
         <Badge
+          fontSize={String(chains.length).length > 1 ? 12 : 14}
           testID="more-chains-badge"
           circleSize="$6"
           content={`+${chains.length - max}`}

--- a/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
+++ b/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
@@ -66,11 +66,17 @@ export function SafeBottomSheet<T>({
 
   const TitleHeader = useCallback(
     () => (
-      <View justifyContent="center" marginTop="$3" marginBottom="$4" alignItems="center">
-        <H5 fontWeight={600}>{title}</H5>
+      <View
+        justifyContent="center"
+        paddingTop="$3"
+        paddingBottom="$4"
+        alignItems="center"
+        backgroundColor="$backgroundPaper"
+      >
+        <H5 fontWeight={700}>{title}</H5>
 
         {actions && (
-          <View position="absolute" right={'$4'} top={'$1'}>
+          <View position="absolute" right={'$4'} top={'$3'} justifyContent="center" alignItems="center">
             {actions}
           </View>
         )}
@@ -128,9 +134,9 @@ export function SafeBottomSheet<T>({
       // bottomInset={Platform.OS === 'android' ? insets.bottom : 0}
       handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
     >
-      <BottomSheetView style={[styles.contentContainer]}>
-        {title && <TitleHeader />}
-        {isSortable ? (
+      {isSortable ? (
+        <BottomSheetView style={[styles.contentContainer]}>
+          {title && <TitleHeader />}
           <DraggableFlatList<T>
             data={items}
             style={{ marginBottom: insets.bottom }}
@@ -140,30 +146,32 @@ export function SafeBottomSheet<T>({
             keyExtractor={(item, index) => (keyExtractor ? keyExtractor({ item, index }) : index.toString())}
             renderItem={renderItem}
           />
-        ) : (
-          <BottomSheetScrollView
-            style={{
-              marginBottom:
-                (!sortable && FooterComponent ? footerHeight : 0) + getTokenValue(Platform.OS === 'ios' ? '$4' : '$8'),
-            }}
-            contentContainerStyle={[styles.scrollInnerContainer]}
-          >
-            <View minHeight={200} alignItems="center" paddingVertical="$3">
-              <View alignItems="flex-start" paddingBottom="$4" width="100%">
-                {loading ? (
-                  <LoadingTx />
-                ) : hasCustomItems ? (
-                  items.map((item, index) => (
-                    <Render key={keyExtractor ? keyExtractor({ item, index }) : index} item={item} onClose={onClose} />
-                  ))
-                ) : (
-                  children
-                )}
-              </View>
+        </BottomSheetView>
+      ) : (
+        <BottomSheetScrollView
+          style={{
+            marginBottom:
+              (!sortable && FooterComponent ? footerHeight : 0) + getTokenValue(Platform.OS === 'ios' ? '$4' : '$8'),
+          }}
+          contentContainerStyle={[styles.scrollInnerContainer]}
+          stickyHeaderIndices={[0]}
+        >
+          {title && <TitleHeader />}
+          <View minHeight={200} alignItems="center" paddingVertical="$3">
+            <View alignItems="flex-start" paddingBottom="$4" width="100%">
+              {loading ? (
+                <LoadingTx />
+              ) : hasCustomItems ? (
+                items.map((item, index) => (
+                  <Render key={keyExtractor ? keyExtractor({ item, index }) : index} item={item} onClose={onClose} />
+                ))
+              ) : (
+                children
+              )}
             </View>
-          </BottomSheetScrollView>
-        )}
-      </BottomSheetView>
+          </View>
+        </BottomSheetScrollView>
+      )}
     </BottomSheet>
   )
 }

--- a/apps/mobile/src/components/StatusBanners/PendingTransactions/PendingTransactions.tsx
+++ b/apps/mobile/src/components/StatusBanners/PendingTransactions/PendingTransactions.tsx
@@ -16,7 +16,12 @@ export const PendingTransactions = ({ number, isLoading, fullWidth, onPress }: P
   const startIcon = isLoading ? (
     <Loader size={24} color="$warning1ContrastTextDark" />
   ) : (
-    <Badge content={number} themeName="badge_warning_variant2" circleSize="$6" textContentProps={{ fontWeight: 600 }} />
+    <Badge
+      content={number.length > 3 ? '99+' : number}
+      themeName="badge_warning_variant2"
+      circleSize="$6"
+      textContentProps={{ fontWeight: 600, fontSize: number.length > 2 ? 12 : 14 }}
+    />
   )
   const endIcon = <SafeFontIcon name="chevron-right" size={20} />
 

--- a/apps/mobile/src/features/AccountsSheet/AccountsSheet.container.tsx
+++ b/apps/mobile/src/features/AccountsSheet/AccountsSheet.container.tsx
@@ -36,7 +36,7 @@ export const AccountsSheetContainer = () => {
       onDragEnd={onDragEnd}
       actions={
         <TouchableOpacity onPress={toggleEditMode}>
-          <H6 fontWeight={600}>{isEdit ? 'Done' : 'Edit'}</H6>
+          <H6 fontWeight={700}>{isEdit ? 'Done' : 'Edit'}</H6>
         </TouchableOpacity>
       }
     />


### PR DESCRIPTION
## What it solves
When fixing an Android issue we unfortunately introduced a regression and broke the scrolling within the sheet. This PR fixes this. In addition, I'm reducing the size inside of the badge if the content text length is higher than 2 characters. The circle of the badge can't accomodate more than 3 items at font-size 12.

Resolves https://linear.app/safe-global/issue/COR-418/mobile-can-not-see-the-full-list-of-networks-for-multichain-safe

## How to test it
Test in a safe with a lot of networks. The networks should be scrollable.

## Screenshots
https://github.com/user-attachments/assets/9a17ec32-d6fe-4617-be3f-ee01c755a1b0

## Checklist
- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
