### PR TITLE
Fix(Mobile): Remove READ_MEDIA_IMAGES permission

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -143,7 +143,7 @@ const config = {
     [
       'react-native-capture-protection',
       {
-        captureType: 'fullMediaCapture',
+        captureType: 'restrictedCapture',
       },
     ],
   ],


### PR DESCRIPTION
## What it solves

Resolves [COR-427](https://linear.app/safe-global/issue/COR-427/mobile-android-remove-the-use-of-read-media-images-permission)

## How this PR fixes it

The `react-native-capture-protection` package with `fullMediaCapture` option was adding permission to read image files to support Android 13 and lower. Google now only allows this permission for apps that need "broad access to photos" which is not the case for the safe mobile app. The package also allows `restrictedCapture` to remove this permission and lose support for Android 13 and lower which is now activated.

## How to test it

- Try taking a screenshot on the signer screen with android 14+ and observe its still blocked

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
