### PR TITLE
Fix(Mobile): Show safe tx data in JSON view when confirming txs

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/tabs/JSONTab.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/tabs/JSONTab.tsx
@@ -1,16 +1,21 @@
-import React from 'react'
 import { Text, View } from 'tamagui'
 import { Tabs } from 'react-native-collapsible-tab-view'
 import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { Container } from '@/src/components/Container'
 import { CopyButton } from '@/src/components/CopyButton'
+import useSafeTx from '@/src/hooks/useSafeTx'
 
 interface JSONTabProps {
   txDetails: TransactionDetails
 }
 
 export function JSONTab({ txDetails }: JSONTabProps) {
-  const jsonData = JSON.stringify(txDetails, null, 2)
+  const safeTx = useSafeTx(txDetails)
+  const jsonData = safeTx ? JSON.stringify(safeTx.data, null, 2) : undefined
+
+  if (!jsonData) {
+    return null
+  }
 
   return (
     <Tabs.ScrollView contentContainerStyle={{ padding: 16, marginTop: 16 }}>

--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/hooks/useTransactionSecurity.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/hooks/useTransactionSecurity.ts
@@ -25,6 +25,8 @@ export const useTransactionSecurity = (txDetails?: TransactionDetails) => {
 
       try {
         const { txParams, signatures } = extractTxInfo(txDetails, activeSafe.address)
+
+        // TODO: There is now a hook useSafeTx to get this so it can be refactored
         const safeTx = await createExistingTx(txParams, signatures)
         const executionOwner = safeInfo.safe.owners[0].value
 

--- a/apps/mobile/src/features/TransactionChecks/TransactionChecks.container.tsx
+++ b/apps/mobile/src/features/TransactionChecks/TransactionChecks.container.tsx
@@ -37,6 +37,7 @@ export const TransactionChecksContainer = () => {
 
       const { txParams, signatures } = extractTxInfo(txDetails, activeSafe.address)
 
+      // TODO: There is now a hook useSafeTx to get this so it can be refactored
       const safeTx = await createExistingTx(txParams, signatures)
       const executionOwner = activeSigner ? activeSigner.value : safeInfo.safe.owners[0].value
 

--- a/apps/mobile/src/hooks/useSafeTx.ts
+++ b/apps/mobile/src/hooks/useSafeTx.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import { SafeTransaction } from '@safe-global/types-kit'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import extractTxInfo from '@/src/services/tx/extractTx'
+import { createExistingTx } from '@/src/services/tx/tx-sender'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+const useSafeTx = (txDetails: TransactionDetails) => {
+  const [safeTx, setSafeTx] = useState<SafeTransaction>()
+  const activeSafe = useDefinedActiveSafe()
+
+  useEffect(() => {
+    const getSafeTxData = async () => {
+      try {
+        const { txParams, signatures } = extractTxInfo(txDetails, activeSafe.address)
+        const safeTx = await createExistingTx(txParams, signatures)
+        setSafeTx(safeTx)
+      } catch (e) {
+        console.error(e)
+      }
+    }
+
+    getSafeTxData()
+  }, [txDetails, activeSafe.address])
+
+  return safeTx
+}
+
+export default useSafeTx


### PR DESCRIPTION
## What it solves

Resolves [COR-158](https://linear.app/safe-global/issue/COR-158/mobile-updated-queue-summary-screen-a-la-signing-improvements-on-web)

## How this PR fixes it

- Displays the SafeTx JSON in the JSON tab to match the implementation on web
- Creates a new hook `useSafeTx` to get the safe tx through the txDetails

## How to test it

1. Open a safe on mobile
2. Go to a pending transaction and confirm
3. Observe the JSON tab matches web 

## Screenshots
<img width="374" height="694" alt="Screenshot 2025-08-04 at 15 13 46" src="https://github.com/user-attachments/assets/734d6887-e77a-42e7-a7d6-ae6a445c3420" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
