### PR TITLE
Fix(Mobile): Signer context menu icons on android

### DIFF
--- a/apps/mobile/assets/android/drawable/baseline_content_copy_24.xml
+++ b/apps/mobile/assets/android/drawable/baseline_content_copy_24.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:tint="#000000" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:pathData="M9,7V4C9,2.895 9.895,2 11,2H19C20.105,2 21,2.895 21,4V15C21,16.105 20.105,17 19,17H15V20C15,21.105 14.105,22 13,22H5C3.895,22 3,21.105 3,20V9C3,7.895 3.895,7 5,7H9ZM15,15H19V4H11V7H13C14.105,7 15,7.895 15,9V15ZM5,20V9H13V20H5Z" android:fillColor="@android:color/white" />
+</vector>

--- a/apps/mobile/src/features/Signers/components/SignersList/hooks/useSignersActions.ts
+++ b/apps/mobile/src/features/Signers/components/SignersList/hooks/useSignersActions.ts
@@ -14,7 +14,7 @@ export const useSignersActions = (disableImport: boolean) => {
           ios: 'pencil',
           android: 'baseline_create_24',
         }),
-        imageColor: Platform.select({ ios: color, android: '#000' }),
+        imageColor: Platform.select({ ios: color, android: color }),
       },
       {
         id: 'copy',
@@ -23,7 +23,7 @@ export const useSignersActions = (disableImport: boolean) => {
           ios: 'doc.on.doc',
           android: 'baseline_content_copy_24',
         }),
-        imageColor: Platform.select({ ios: color, android: '#000' }),
+        imageColor: Platform.select({ ios: color, android: color }),
       },
       !disableImport && {
         id: 'import',
@@ -32,7 +32,7 @@ export const useSignersActions = (disableImport: boolean) => {
           ios: 'square.and.arrow.up.on.square',
           android: 'baseline_arrow_outward_24',
         }),
-        imageColor: Platform.select({ ios: color, android: '#000' }),
+        imageColor: Platform.select({ ios: color, android: color }),
       },
     ],
     [color, disableImport],


### PR DESCRIPTION
## What it solves

Resolves [COR-357](https://linear.app/safe-global/issue/COR-357/mobile-android-no-icon-and-black-icons-in-the-signer-menu)

## How this PR fixes it

- Adds the missing copy icon as an android vector
- Updates the color instead of hard-coding black

## How to test it

1. Open the signers page on android
2. Press the three-dot menu
3. Observe all icons are visible and look correct in dark/light mode

## Screenshots
<img width="365" height="233" alt="Screenshot 2025-08-04 at 17 13 08" src="https://github.com/user-attachments/assets/ca9ac2c7-2bb1-475f-875b-19e126607e11" />
<img width="363" height="218" alt="Screenshot 2025-08-04 at 17 13 01" src="https://github.com/user-attachments/assets/90b0df0e-3397-4de7-be56-79b4090fc0d4" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
