### PR TITLE
chore: Create release-notes script for a table layout

### DIFF
--- a/apps/web/docs/release-procedure.md
+++ b/apps/web/docs/release-procedure.md
@@ -19,6 +19,11 @@ When it's time to make a release, we "freeze" the code by creating a release bra
   > ```bash
   > git log origin/main..origin/dev --pretty=format:'* %s'
   > ```
+  > 
+  > To generate a more structured table layout:
+  > ```
+  > bash ./scripts/release-notes.sh <target branch> <source branch>
+  > ```
 
 ```bash
 git checkout release # switch to the release branch

--- a/apps/web/scripts/release-notes.sh
+++ b/apps/web/scripts/release-notes.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Generate grouped release notes as Markdown tables from commit messages
+# Usage: ./release-notes.sh main dev
+
+BASE_BRANCH=${1:-main}
+COMPARE_BRANCH=${2:-dev}
+
+# Arrays for grouping
+features=()
+fixes=()
+others=()
+
+# Process commits (short hash + subject)
+while IFS="|" read -r hash subject; do
+  # Extract PR if exists
+  if [[ $subject =~ \(#([0-9]+)\) ]]; then
+    PR="#${BASH_REMATCH[1]}"
+    DESC=$(echo "$subject" | sed -E 's/ \(#([0-9]+)\)//')
+  else
+    PR="$hash"   # fallback to commit hash
+    DESC="$subject"
+  fi
+
+  # Group by prefix
+  if [[ $DESC =~ ^([Ff]eat) ]]; then
+    features+=("| $DESC | $PR |")
+  elif [[ $DESC =~ ^([Ff]ix) ]]; then
+    fixes+=("| $DESC | $PR |")
+  else
+    others+=("| $DESC | $PR |")
+  fi
+done < <(git log origin/"$BASE_BRANCH"..origin/"$COMPARE_BRANCH" --pretty=format:'%h|%s')
+
+# Function to print a table
+print_table () {
+  local title=$1
+  shift
+  local rows=("$@")
+  if [ ${#rows[@]} -gt 0 ]; then
+    echo "### $title"
+    echo ""
+    echo "| Change | PR/Commit |"
+    echo "|--------|-----------|"
+    for row in "${rows[@]}"; do
+      echo "$row"
+    done
+    echo ""
+  fi
+}
+
+# Print grouped tables
+print_table "🚀 Features" "${features[@]}"
+print_table "🐛 Fixes" "${fixes[@]}"
+print_table "📦 Other" "${others[@]}"


### PR DESCRIPTION
## What it solves

Github always expands the PR numbers so the description looks duplicated. This adds a script to generate a structured table layout for release notes that are more readable and updates our release-procedure doc with instructions.

The script either uses the PR number or if there was no PR it uses the commit hash. It splits the commits into 3 categories: Features, Fixes and Other

## Screenshots

<img width="668" height="328" alt="Screenshot 2025-08-05 at 11 45 47" src="https://github.com/user-attachments/assets/e5858f10-e8f6-4dbc-ba2f-f40f73b78dc6" />



