### PR TITLE
Fix(web): tenderly partial revert warnings

### DIFF
--- a/apps/web/src/components/transactions/QueuedTxSimulation/index.tsx
+++ b/apps/web/src/components/transactions/QueuedTxSimulation/index.tsx
@@ -19,6 +19,26 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useMemo } from 'react'
 import { useCurrentChain } from '@/hooks/useChains'
 
+const getSimulationIconProps = (isCallTraceError: boolean, isSuccess: boolean) => {
+  if (isCallTraceError) {
+    return { color: 'warning' as const, component: WarningIcon }
+  }
+  if (isSuccess) {
+    return { color: 'success' as const, component: CheckIcon }
+  }
+  return { color: 'error' as const, component: CloseIcon }
+}
+
+const getSimulationStatusText = (isCallTraceError: boolean, isSuccess: boolean) => {
+  if (isCallTraceError) {
+    return 'Can execute (with warnings)'
+  }
+  if (isSuccess) {
+    return 'Simulation successful'
+  }
+  return 'Simulation failed'
+}
+
 const CompactSimulationButton = ({
   label,
   iconComponent,
@@ -109,16 +129,11 @@ const InlineTxSimulation = ({ transaction }: { transaction: TransactionDetails }
       <ExternalLink href={simulationLink}>
         <Stack direction="row" alignItems="center" gap={0.5}>
           <SvgIcon
-            color={status.isCallTraceError ? 'warning' : status.isSuccess ? 'success' : 'error'}
-            component={status.isCallTraceError ? WarningIcon : status.isSuccess ? CheckIcon : CloseIcon}
+            {...getSimulationIconProps(status.isCallTraceError, status.isSuccess)}
             inheritViewBox
             sx={{ height: '16px' }}
           />
-          {status.isCallTraceError
-            ? 'Can execute (with warnings)'
-            : status.isSuccess
-              ? 'Simulation successful'
-              : 'Simulation failed'}
+          {getSimulationStatusText(status.isCallTraceError, status.isSuccess)}
         </Stack>
       </ExternalLink>
     )

--- a/apps/web/src/components/transactions/QueuedTxSimulation/index.tsx
+++ b/apps/web/src/components/transactions/QueuedTxSimulation/index.tsx
@@ -114,7 +114,11 @@ const InlineTxSimulation = ({ transaction }: { transaction: TransactionDetails }
             inheritViewBox
             sx={{ height: '16px' }}
           />
-          {status.isCallTraceError ? 'Can execute (with warnings)' : status.isSuccess ? 'Simulation successful' : 'Simulation failed'}
+          {status.isCallTraceError
+            ? 'Can execute (with warnings)'
+            : status.isSuccess
+              ? 'Simulation successful'
+              : 'Simulation failed'}
         </Stack>
       </ExternalLink>
     )

--- a/apps/web/src/components/transactions/QueuedTxSimulation/index.tsx
+++ b/apps/web/src/components/transactions/QueuedTxSimulation/index.tsx
@@ -11,6 +11,7 @@ import { useSigner } from '@/hooks/wallets/useWallet'
 import ExternalLink from '@/components/common/ExternalLink'
 import CheckIcon from '@/public/images/common/check.svg'
 import CloseIcon from '@/public/images/common/close.svg'
+import WarningIcon from '@/public/images/notifications/warning.svg'
 import { getSimulationStatus, isTxSimulationEnabled } from '@safe-global/utils/components/tx/security/tenderly/utils'
 import { useSafeSDK } from '@/hooks/coreSDK/safeCoreSDK'
 import { useIsNestedSafeOwner } from '@/hooks/useIsNestedSafeOwner'
@@ -108,12 +109,12 @@ const InlineTxSimulation = ({ transaction }: { transaction: TransactionDetails }
       <ExternalLink href={simulationLink}>
         <Stack direction="row" alignItems="center" gap={0.5}>
           <SvgIcon
-            color={status.isSuccess ? 'success' : 'error'}
-            component={status.isSuccess ? CheckIcon : CloseIcon}
+            color={status.isCallTraceError ? 'warning' : status.isSuccess ? 'success' : 'error'}
+            component={status.isCallTraceError ? WarningIcon : status.isSuccess ? CheckIcon : CloseIcon}
             inheritViewBox
             sx={{ height: '16px' }}
           />
-          {status.isSuccess ? 'Simulation successful' : 'Simulation failed'}
+          {status.isCallTraceError ? 'Can execute (with warnings)' : status.isSuccess ? 'Simulation successful' : 'Simulation failed'}
         </Stack>
       </ExternalLink>
     )

--- a/apps/web/src/components/tx-flow/TxInfoProvider.tsx
+++ b/apps/web/src/components/tx-flow/TxInfoProvider.tsx
@@ -15,7 +15,7 @@ type SimulationStatus = {
 
 const initialSimulation: UseSimulationReturn = {
   simulateTransaction: () => {},
-  simulation: undefined,
+  simulationData: undefined,
   _simulationRequestStatus: FETCH_STATUS.NOT_ASKED,
   simulationLink: '',
   requestError: undefined,

--- a/apps/web/src/components/tx/security/tenderly/__tests__/useSimulation.test.ts
+++ b/apps/web/src/components/tx/security/tenderly/__tests__/useSimulation.test.ts
@@ -26,9 +26,9 @@ describe('useSimulation()', () => {
 
   it('should have the correct initial values', () => {
     const { result } = renderHook(() => useSimulation())
-    const { simulation, simulationLink, requestError: simulationError, _simulationRequestStatus } = result.current
+    const { simulationData, simulationLink, requestError: simulationError, _simulationRequestStatus } = result.current
 
-    expect(simulation).toBeUndefined()
+    expect(simulationData).toBeUndefined()
     expect(simulationLink).not.toBeUndefined()
     expect(simulationError).toBeUndefined()
     expect(_simulationRequestStatus).toEqual(FETCH_STATUS.NOT_ASKED)
@@ -149,10 +149,10 @@ describe('useSimulation()', () => {
     )
 
     await waitFor(() => {
-      const { _simulationRequestStatus, simulation } = result.current
+      const { _simulationRequestStatus, simulationData } = result.current
       expect(_simulationRequestStatus).toEqual(FETCH_STATUS.SUCCESS)
-      expect(simulation?.simulation.status).toBeTruthy()
-      expect(simulation?.simulation.id).toEqual('123')
+      expect(simulationData?.simulation.status).toBeTruthy()
+      expect(simulationData?.simulation.id).toEqual('123')
     })
 
     expect(mockFetch).toHaveBeenCalledTimes(1)
@@ -162,7 +162,7 @@ describe('useSimulation()', () => {
     })
 
     expect(result.current._simulationRequestStatus).toEqual(FETCH_STATUS.NOT_ASKED)
-    expect(result.current.simulation).toBeUndefined()
+    expect(result.current.simulationData).toBeUndefined()
   })
 
   it('should set simulation for not-executable transaction on success', async () => {
@@ -219,10 +219,10 @@ describe('useSimulation()', () => {
     )
 
     await waitFor(() => {
-      const { _simulationRequestStatus, simulation } = result.current
+      const { _simulationRequestStatus, simulationData } = result.current
       expect(_simulationRequestStatus).toEqual(FETCH_STATUS.SUCCESS)
-      expect(simulation?.simulation.status).toBeTruthy()
-      expect(simulation?.simulation.id).toEqual('123')
+      expect(simulationData?.simulation.status).toBeTruthy()
+      expect(simulationData?.simulation.id).toEqual('123')
     })
 
     expect(mockFetch).toHaveBeenCalledTimes(1)

--- a/apps/web/src/components/tx/security/tenderly/index.tsx
+++ b/apps/web/src/components/tx/security/tenderly/index.tsx
@@ -27,6 +27,43 @@ import { MODALS_EVENTS } from '@/services/analytics'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 import { getSafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 
+const renderSimulationStatus = (isSuccess: boolean, isError: boolean, isCallTraceError: boolean) => {
+  if (!isSuccess || isError) {
+    return (
+      <Typography variant="body2" className={sharedCss.result} sx={{ color: 'error.main' }}>
+        <SvgIcon component={CloseIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
+        Error
+      </Typography>
+    )
+  }
+
+  if (isCallTraceError) {
+    return (
+      <Typography
+        data-testid="simulation-warning-msg"
+        variant="body2"
+        className={sharedCss.result}
+        sx={{ color: 'warning.main' }}
+      >
+        <SvgIcon component={WarningIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
+        Warning
+      </Typography>
+    )
+  }
+
+  return (
+    <Typography
+      data-testid="simulation-success-msg"
+      variant="body2"
+      className={sharedCss.result}
+      sx={{ color: 'success.main' }}
+    >
+      <SvgIcon component={CheckIcon} inheritViewBox fontSize="small" sx={{ verticalAlign: 'middle', mr: 1 }} />
+      Success
+    </Typography>
+  )
+}
+
 export type TxSimulationProps = {
   transactions?: SimulationTxParams['transactions']
   gasLimit?: number
@@ -137,57 +174,7 @@ const TxSimulationBlock = ({
               }}
             />
           ) : isFinished ? (
-            !isSuccess || isError ? (
-              <Typography
-                variant="body2"
-                className={sharedCss.result}
-                sx={{
-                  color: 'error.main',
-                }}
-              >
-                <SvgIcon
-                  component={CloseIcon}
-                  inheritViewBox
-                  fontSize="small"
-                  sx={{ verticalAlign: 'middle', mr: 1 }}
-                />
-                Error
-              </Typography>
-            ) : isCallTraceError ? (
-              <Typography
-                data-testid="simulation-warning-msg"
-                variant="body2"
-                className={sharedCss.result}
-                sx={{
-                  color: 'warning.main',
-                }}
-              >
-                <SvgIcon
-                  component={WarningIcon}
-                  inheritViewBox
-                  fontSize="small"
-                  sx={{ verticalAlign: 'middle', mr: 1 }}
-                />
-                Warning
-              </Typography>
-            ) : (
-              <Typography
-                data-testid="simulation-success-msg"
-                variant="body2"
-                className={sharedCss.result}
-                sx={{
-                  color: 'success.main',
-                }}
-              >
-                <SvgIcon
-                  component={CheckIcon}
-                  inheritViewBox
-                  fontSize="small"
-                  sx={{ verticalAlign: 'middle', mr: 1 }}
-                />
-                Success
-              </Typography>
-            )
+            renderSimulationStatus(isSuccess, isError, isCallTraceError)
           ) : (
             <Track {...MODALS_EVENTS.SIMULATE_TX}>
               <Button
@@ -218,17 +205,14 @@ export const TxSimulation = (props: TxSimulationProps): ReactElement | null => {
   return <TxSimulationBlock {...props} />
 }
 
-// TODO: Test this component
-export const TxSimulationMessage = ({ isNested = false }: { isNested?: boolean }) => {
-  const txInfo = useContext(TxInfoContext)
-
-  const { isFinished, isError, isSuccess, isCallTraceError } = isNested ? txInfo.nestedTx.status : txInfo.status
-  const { simulationLink, simulationData, requestError } = isNested ? txInfo.nestedTx.simulation : txInfo.simulation
-
-  if (!isFinished) {
-    return null
-  }
-
+const renderSimulationMessage = (
+  isSuccess: boolean,
+  isError: boolean,
+  isCallTraceError: boolean,
+  simulationLink: string | undefined,
+  simulationData: any,
+  requestError: string | undefined,
+) => {
   if (!isSuccess || isError) {
     return (
       <Alert severity="error" sx={{ border: 'unset' }}>
@@ -268,4 +252,18 @@ export const TxSimulationMessage = ({ isNested = false }: { isNested?: boolean }
       Full simulation report is available <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.
     </Alert>
   )
+}
+
+// TODO: Test this component
+export const TxSimulationMessage = ({ isNested = false }: { isNested?: boolean }) => {
+  const txInfo = useContext(TxInfoContext)
+
+  const { isFinished, isError, isSuccess, isCallTraceError } = isNested ? txInfo.nestedTx.status : txInfo.status
+  const { simulationLink, simulationData, requestError } = isNested ? txInfo.nestedTx.simulation : txInfo.simulation
+
+  if (!isFinished) {
+    return null
+  }
+
+  return renderSimulationMessage(isSuccess, isError, isCallTraceError, simulationLink, simulationData, requestError)
 }

--- a/apps/web/src/components/tx/security/tenderly/index.tsx
+++ b/apps/web/src/components/tx/security/tenderly/index.tsx
@@ -243,8 +243,8 @@ export const TxSimulationMessage = ({ isNested = false }: { isNested?: boolean }
           <Typography variant="body2">
             The transaction failed during the simulation throwing error{' '}
             <b>{simulationData?.transaction.error_message}</b> in the contract at{' '}
-            <b>{simulationData?.transaction.error_info?.address}</b>.{' '}
-            Full simulation report is available <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.
+            <b>{simulationData?.transaction.error_info?.address}</b>. Full simulation report is available{' '}
+            <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.
           </Typography>
         )}
       </Alert>
@@ -254,11 +254,9 @@ export const TxSimulationMessage = ({ isNested = false }: { isNested?: boolean }
   if (isCallTraceError) {
     return (
       <Alert severity="warning" sx={{ border: 'unset' }}>
-        <Typography fontWeight={700}>
-          Simulation successful with warnings
-        </Typography>
-        Transaction will execute successfully on-chain, but contains internal reverts.
-        Some contract logic may not execute as expected. Full simulation report available{' '}
+        <Typography fontWeight={700}>Simulation successful with warnings</Typography>
+        Transaction will execute successfully on-chain, but contains internal reverts. Some contract logic may not
+        execute as expected. Full simulation report available{' '}
         <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.
       </Alert>
     )
@@ -266,9 +264,7 @@ export const TxSimulationMessage = ({ isNested = false }: { isNested?: boolean }
 
   return (
     <Alert severity="info" sx={{ border: 'unset' }}>
-      <Typography fontWeight={700}>
-        Simulation successful
-      </Typography>
+      <Typography fontWeight={700}>Simulation successful</Typography>
       Full simulation report is available <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.
     </Alert>
   )

--- a/apps/web/src/components/tx/security/tenderly/index.tsx
+++ b/apps/web/src/components/tx/security/tenderly/index.tsx
@@ -21,6 +21,7 @@ import sharedCss from '@/components/tx/security/shared/styles.module.css'
 import { TxInfoContext } from '@/components/tx-flow/TxInfoProvider'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import InfoIcon from '@/public/images/notifications/info.svg'
+import WarningIcon from '@/public/images/notifications/warning.svg'
 import Track from '@/components/common/Track'
 import { MODALS_EVENTS } from '@/services/analytics'
 import useAsync from '@safe-global/utils/hooks/useAsync'
@@ -83,7 +84,7 @@ const TxSimulationBlock = ({
     }
   }
 
-  const { isFinished, isError, isSuccess, isCallTraceError, isLoading } = !!nestedSafe ? nestedTx.status : status
+  const { isFinished, isError, isSuccess, isLoading, isCallTraceError } = !!nestedSafe ? nestedTx.status : status
 
   // Reset simulation if safeTx changes
   useEffect(() => {
@@ -136,7 +137,7 @@ const TxSimulationBlock = ({
               }}
             />
           ) : isFinished ? (
-            !isSuccess || isError || isCallTraceError ? (
+            !isSuccess || isError ? (
               <Typography
                 variant="body2"
                 className={sharedCss.result}
@@ -151,6 +152,23 @@ const TxSimulationBlock = ({
                   sx={{ verticalAlign: 'middle', mr: 1 }}
                 />
                 Error
+              </Typography>
+            ) : isCallTraceError ? (
+              <Typography
+                data-testid="simulation-warning-msg"
+                variant="body2"
+                className={sharedCss.result}
+                sx={{
+                  color: 'warning.main',
+                }}
+              >
+                <SvgIcon
+                  component={WarningIcon}
+                  inheritViewBox
+                  fontSize="small"
+                  sx={{ verticalAlign: 'middle', mr: 1 }}
+                />
+                Warning
               </Typography>
             ) : (
               <Typography
@@ -205,13 +223,13 @@ export const TxSimulationMessage = ({ isNested = false }: { isNested?: boolean }
   const txInfo = useContext(TxInfoContext)
 
   const { isFinished, isError, isSuccess, isCallTraceError } = isNested ? txInfo.nestedTx.status : txInfo.status
-  const { simulationLink, simulation, requestError } = isNested ? txInfo.nestedTx.simulation : txInfo.simulation
+  const { simulationLink, simulationData, requestError } = isNested ? txInfo.nestedTx.simulation : txInfo.simulation
 
   if (!isFinished) {
     return null
   }
 
-  if (!isSuccess || isError || isCallTraceError) {
+  if (!isSuccess || isError) {
     return (
       <Alert severity="error" sx={{ border: 'unset' }}>
         <Typography variant="body1" fontWeight={700}>
@@ -223,15 +241,9 @@ export const TxSimulationMessage = ({ isNested = false }: { isNested?: boolean }
           </Typography>
         ) : (
           <Typography variant="body2">
-            {isCallTraceError ? (
-              <>The transaction failed during the simulation.</>
-            ) : (
-              <>
-                The transaction failed during the simulation throwing error{' '}
-                <b>{simulation?.transaction.error_message}</b> in the contract at{' '}
-                <b>{simulation?.transaction.error_info?.address}</b>.
-              </>
-            )}{' '}
+            The transaction failed during the simulation throwing error{' '}
+            <b>{simulationData?.transaction.error_message}</b> in the contract at{' '}
+            <b>{simulationData?.transaction.error_info?.address}</b>.{' '}
             Full simulation report is available <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.
           </Typography>
         )}
@@ -239,9 +251,22 @@ export const TxSimulationMessage = ({ isNested = false }: { isNested?: boolean }
     )
   }
 
+  if (isCallTraceError) {
+    return (
+      <Alert severity="warning" sx={{ border: 'unset' }}>
+        <Typography fontWeight={700}>
+          Simulation successful with warnings
+        </Typography>
+        Transaction will execute successfully on-chain, but contains internal reverts.
+        Some contract logic may not execute as expected. Full simulation report available{' '}
+        <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.
+      </Alert>
+    )
+  }
+
   return (
     <Alert severity="info" sx={{ border: 'unset' }}>
-      <Typography variant="body2" fontWeight={700}>
+      <Typography fontWeight={700}>
         Simulation successful
       </Typography>
       Full simulation report is available <ExternalLink href={simulationLink}>on Tenderly</ExternalLink>.

--- a/apps/web/src/components/tx/security/tenderly/useSimulation.ts
+++ b/apps/web/src/components/tx/security/tenderly/useSimulation.ts
@@ -53,7 +53,7 @@ export const useSimulation = (): UseSimulationReturn => {
     simulateTransaction,
     // This is only used by the provider
     _simulationRequestStatus: simulationRequestStatus,
-    simulation,
+    simulationData: simulation,
     simulationLink,
     requestError,
     resetSimulation,

--- a/packages/utils/src/components/tx/security/tenderly/__tests__/utils.test.ts
+++ b/packages/utils/src/components/tx/security/tenderly/__tests__/utils.test.ts
@@ -5,12 +5,16 @@ import {
   THRESHOLD_OVERWRITE,
   NONCE_STORAGE_POSITION,
   GUARD_STORAGE_POSITION,
+  getCallTraceErrors,
+  getSimulationStatus,
 } from '../utils'
 import { ImplementationVersionState, type SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeTransaction, SafeSignature } from '@safe-global/types-kit'
 import type { SingleTransactionSimulationParams } from '../utils'
 import { faker } from '@faker-js/faker'
 import { EthSafeSignature } from '@safe-global/protocol-kit'
+import { FETCH_STATUS, type TenderlySimulation } from '../types'
+import type { UseSimulationReturn } from '../useSimulation'
 
 describe('getStateOverwrites', () => {
   const mockOwners = [faker.finance.ethereumAddress(), faker.finance.ethereumAddress(), faker.finance.ethereumAddress()]
@@ -129,6 +133,129 @@ describe('getStateOverwrites', () => {
       [THRESHOLD_STORAGE_POSITION]: THRESHOLD_OVERWRITE,
       [NONCE_STORAGE_POSITION]: toBeHex('0x6', 32),
       [GUARD_STORAGE_POSITION]: toBeHex(ZeroAddress, 32),
+    })
+  })
+})
+
+describe('getCallTraceErrors', () => {
+  it('should return empty array if no simulation', () => {
+    expect(getCallTraceErrors(undefined)).toEqual([])
+  })
+
+  it('should return empty array if simulation status is false', () => {
+    const simulation: TenderlySimulation = {
+      simulation: { status: false },
+      transaction: { call_trace: [] },
+    } as any
+    expect(getCallTraceErrors(simulation)).toEqual([])
+  })
+
+  it('should return calls with errors', () => {
+    const simulation: TenderlySimulation = {
+      simulation: { status: true },
+      transaction: {
+        call_trace: [
+          { error: undefined },
+          { error: 'Execution reverted' },
+          { error: undefined },
+          { error: 'Out of gas' },
+        ],
+      },
+    } as any
+    const errors = getCallTraceErrors(simulation)
+    expect(errors).toHaveLength(2)
+    expect(errors[0].error).toBe('Execution reverted')
+    expect(errors[1].error).toBe('Out of gas')
+  })
+})
+
+describe('getSimulationStatus', () => {
+  it('should return loading status', () => {
+    const simulation: UseSimulationReturn = {
+      _simulationRequestStatus: FETCH_STATUS.LOADING,
+      simulationData: undefined,
+    } as any
+    const status = getSimulationStatus(simulation)
+    expect(status).toEqual({
+      isLoading: true,
+      isFinished: false,
+      isSuccess: false,
+      isCallTraceError: false,
+      isError: false,
+    })
+  })
+
+  it('should return error status', () => {
+    const simulation: UseSimulationReturn = {
+      _simulationRequestStatus: FETCH_STATUS.ERROR,
+      simulationData: undefined,
+    } as any
+    const status = getSimulationStatus(simulation)
+    expect(status).toEqual({
+      isLoading: false,
+      isFinished: true,
+      isSuccess: false,
+      isCallTraceError: false,
+      isError: true,
+    })
+  })
+
+  it('should return success status without errors', () => {
+    const simulation: UseSimulationReturn = {
+      _simulationRequestStatus: FETCH_STATUS.SUCCESS,
+      simulationData: {
+        simulation: { status: true },
+        transaction: { call_trace: [] },
+      } as any,
+    } as any
+    const status = getSimulationStatus(simulation)
+    expect(status).toEqual({
+      isLoading: false,
+      isFinished: true,
+      isSuccess: true,
+      isCallTraceError: false,
+      isError: false,
+    })
+  })
+
+  it('should return partial revert status when simulation succeeds with call trace errors', () => {
+    const simulation: UseSimulationReturn = {
+      _simulationRequestStatus: FETCH_STATUS.SUCCESS,
+      simulationData: {
+        simulation: { status: true },
+        transaction: {
+          call_trace: [
+            { error: undefined },
+            { error: 'Execution reverted' },
+          ],
+        },
+      } as any,
+    } as any
+    const status = getSimulationStatus(simulation)
+    expect(status).toEqual({
+      isLoading: false,
+      isFinished: true,
+      isSuccess: true,
+      isCallTraceError: true,
+      isError: false,
+    })
+  })
+
+  it('should return failed status when simulation status is false', () => {
+    const simulation: UseSimulationReturn = {
+      _simulationRequestStatus: FETCH_STATUS.SUCCESS,
+      simulationData: {
+        simulation: { status: false },
+        transaction: { call_trace: [] },
+      } as any,
+    } as any
+    const status = getSimulationStatus(simulation)
+    expect(status).toEqual({
+      isLoading: false,
+      isFinished: true,
+      isSuccess: false,
+      isCallTraceError: false,
+      isError: false,
     })
   })
 })

--- a/packages/utils/src/components/tx/security/tenderly/useSimulation.ts
+++ b/packages/utils/src/components/tx/security/tenderly/useSimulation.ts
@@ -4,7 +4,7 @@ import type { SimulationTxParams } from '@safe-global/utils/components/tx/securi
 export type UseSimulationReturn =
   | {
       _simulationRequestStatus: FETCH_STATUS.NOT_ASKED | FETCH_STATUS.ERROR | FETCH_STATUS.LOADING
-      simulation: undefined
+      simulationData: undefined
       simulateTransaction: (params: SimulationTxParams) => void
       simulationLink: string
       requestError?: string
@@ -12,7 +12,7 @@ export type UseSimulationReturn =
     }
   | {
       _simulationRequestStatus: FETCH_STATUS.SUCCESS
-      simulation: TenderlySimulation
+      simulationData: TenderlySimulation
       simulateTransaction: (params: SimulationTxParams) => void
       simulationLink: string
       requestError?: string

--- a/packages/utils/src/components/tx/security/tenderly/utils.ts
+++ b/packages/utils/src/components/tx/security/tenderly/utils.ts
@@ -47,10 +47,7 @@ export const isTxSimulationEnabled = (chain?: Pick<Chain, 'features'>): boolean 
 export const getSimulation = async (
   tx: TenderlySimulatePayload,
   customTenderly: EnvState['tenderly'] | undefined,
-): Promise<TenderlySimulation> => {  
-  
-  
-
+): Promise<TenderlySimulation> => {
   const requestObject: RequestInit = {
     method: 'POST',
     body: JSON.stringify(tx),

--- a/packages/utils/src/components/tx/security/tenderly/utils.ts
+++ b/packages/utils/src/components/tx/security/tenderly/utils.ts
@@ -48,47 +48,7 @@ export const getSimulation = async (
   tx: TenderlySimulatePayload,
   customTenderly: EnvState['tenderly'] | undefined,
 ): Promise<TenderlySimulation> => {  
-  // MOCK: Uncomment to test partial revert locally
-  /*
-  console.log('🧪 MOCK: Returning partial revert simulation')
-  return {
-    simulation: { 
-      status: true,
-      id: 'mock-simulation-123'
-    } as any,
-    transaction: {
-      status: true,
-      hash: '0x123',
-      block_number: 1,
-      call_trace: [
-        { 
-          from: '0x123',
-          to: '0x456',
-          input: '0x',
-          output: '0x',
-          gas: 21000,
-          gas_used: 21000,
-          value: '0',
-          error: undefined 
-        },
-        { 
-          from: '0x789',
-          to: '0xabc',
-          input: '0x',
-          output: '0x',
-          gas: 50000,
-          gas_used: 30000,
-          value: '0',
-          error: 'execution reverted' // This creates a partial revert
-        }
-      ] as any,
-      error_message: null,
-      error_info: null
-    } as any,
-    contracts: [],
-    generated_access_list: []
-  } as TenderlySimulation
-  */
+  
   
 
   const requestObject: RequestInit = {
@@ -96,7 +56,7 @@ export const getSimulation = async (
     body: JSON.stringify(tx),
   }
 
-  if (customTenderly && customTenderly.accessToken) {
+  if (customTenderly?.accessToken) {
     requestObject.headers = {
       'content-type': 'application/JSON',
       'X-Access-Key': customTenderly.accessToken,
@@ -219,13 +179,10 @@ export const getSimulationStatus = (simulationResult: UseSimulationReturn): Simu
     simulationResult._simulationRequestStatus === FETCH_STATUS.SUCCESS ||
     simulationResult._simulationRequestStatus === FETCH_STATUS.ERROR
 
-  // Extract the nested status more clearly
-  const tenderlyResponse = simulationResult.simulationData
-  const isSuccess = tenderlyResponse?.simulation.status || false
+  const isSuccess = simulationResult.simulationData?.simulation.status || false
 
   // Safe can emit failure event even though Tenderly simulation succeeds
-
-  const isCallTraceError = isSuccess && getCallTraceErrors(tenderlyResponse).length > 0
+  const isCallTraceError = isSuccess && getCallTraceErrors(simulationResult.simulationData).length > 0
   const isError = simulationResult._simulationRequestStatus === FETCH_STATUS.ERROR
 
   return {

--- a/packages/utils/src/components/tx/security/tenderly/utils.ts
+++ b/packages/utils/src/components/tx/security/tenderly/utils.ts
@@ -47,13 +47,56 @@ export const isTxSimulationEnabled = (chain?: Pick<Chain, 'features'>): boolean 
 export const getSimulation = async (
   tx: TenderlySimulatePayload,
   customTenderly: EnvState['tenderly'] | undefined,
-): Promise<TenderlySimulation> => {
+): Promise<TenderlySimulation> => {  
+  // MOCK: Uncomment to test partial revert locally
+  /*
+  console.log('🧪 MOCK: Returning partial revert simulation')
+  return {
+    simulation: { 
+      status: true,
+      id: 'mock-simulation-123'
+    } as any,
+    transaction: {
+      status: true,
+      hash: '0x123',
+      block_number: 1,
+      call_trace: [
+        { 
+          from: '0x123',
+          to: '0x456',
+          input: '0x',
+          output: '0x',
+          gas: 21000,
+          gas_used: 21000,
+          value: '0',
+          error: undefined 
+        },
+        { 
+          from: '0x789',
+          to: '0xabc',
+          input: '0x',
+          output: '0x',
+          gas: 50000,
+          gas_used: 30000,
+          value: '0',
+          error: 'execution reverted' // This creates a partial revert
+        }
+      ] as any,
+      error_message: null,
+      error_info: null
+    } as any,
+    contracts: [],
+    generated_access_list: []
+  } as TenderlySimulation
+  */
+  
+
   const requestObject: RequestInit = {
     method: 'POST',
     body: JSON.stringify(tx),
   }
 
-  if (customTenderly?.accessToken) {
+  if (customTenderly && customTenderly.accessToken) {
     requestObject.headers = {
       'content-type': 'application/JSON',
       'X-Access-Key': customTenderly.accessToken,
@@ -169,18 +212,21 @@ export type SimulationStatus = {
   isError: boolean
 }
 
-export const getSimulationStatus = (simulation: UseSimulationReturn): SimulationStatus => {
-  const isLoading = simulation._simulationRequestStatus === FETCH_STATUS.LOADING
+export const getSimulationStatus = (simulationResult: UseSimulationReturn): SimulationStatus => {
+  const isLoading = simulationResult._simulationRequestStatus === FETCH_STATUS.LOADING
 
   const isFinished =
-    simulation._simulationRequestStatus === FETCH_STATUS.SUCCESS ||
-    simulation._simulationRequestStatus === FETCH_STATUS.ERROR
+    simulationResult._simulationRequestStatus === FETCH_STATUS.SUCCESS ||
+    simulationResult._simulationRequestStatus === FETCH_STATUS.ERROR
 
-  const isSuccess = simulation.simulation?.simulation.status || false
+  // Extract the nested status more clearly
+  const tenderlyResponse = simulationResult.simulationData
+  const isSuccess = tenderlyResponse?.simulation.status || false
 
   // Safe can emit failure event even though Tenderly simulation succeeds
-  const isCallTraceError = isSuccess && getCallTraceErrors(simulation.simulation).length > 0
-  const isError = simulation._simulationRequestStatus === FETCH_STATUS.ERROR
+
+  const isCallTraceError = isSuccess && getCallTraceErrors(tenderlyResponse).length > 0
+  const isError = simulationResult._simulationRequestStatus === FETCH_STATUS.ERROR
 
   return {
     isLoading,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16675,10 +16675,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001669, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001718":
-  version: 1.0.30001731
-  resolution: "caniuse-lite@npm:1.0.30001731"
-  checksum: 10/ad6771127c0cca13a711ca363bb0165a687f9a5c76f057b2c8c9746608a6bae2f15c7b6955063eefcd4ca0e5733d429f25292cc093a40a189d662f3a8647a020
+"caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001688":
+  version: 1.0.30001689
+  resolution: "caniuse-lite@npm:1.0.30001689"
+  checksum: 10/62dfdd3dc7537b1d812c2f8ee219051f369bc3e93b5bf0380fdb20d4d6dd6f7c21f5332fa7ecc903984bdb6d284b44bc23b4deeada788eb5257b4b2c5f46931c
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001669":
+  version: 1.0.30001686
+  resolution: "caniuse-lite@npm:1.0.30001686"
+  checksum: 10/dc34d4daa992256b94def2894e478ba4d9786581dff3b180d642d74c7578f7d8958be985d9da5d08f09b81dd9811b653e4980616bae26b1896968cfdf8d535da
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001718":
+  version: 1.0.30001720
+  resolution: "caniuse-lite@npm:1.0.30001720"
+  checksum: 10/6557c5052fa17fd531f3e1a8013b5924fb69afcd53d9f3e3b9adc9e31c5a7e436b674c000c53659e097fe1fda1c290d1bd17c7f3f98d13749644386ed722ab5f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16675,24 +16675,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001689
-  resolution: "caniuse-lite@npm:1.0.30001689"
-  checksum: 10/62dfdd3dc7537b1d812c2f8ee219051f369bc3e93b5bf0380fdb20d4d6dd6f7c21f5332fa7ecc903984bdb6d284b44bc23b4deeada788eb5257b4b2c5f46931c
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001669":
-  version: 1.0.30001686
-  resolution: "caniuse-lite@npm:1.0.30001686"
-  checksum: 10/dc34d4daa992256b94def2894e478ba4d9786581dff3b180d642d74c7578f7d8958be985d9da5d08f09b81dd9811b653e4980616bae26b1896968cfdf8d535da
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001718":
-  version: 1.0.30001720
-  resolution: "caniuse-lite@npm:1.0.30001720"
-  checksum: 10/6557c5052fa17fd531f3e1a8013b5924fb69afcd53d9f3e3b9adc9e31c5a7e436b674c000c53659e097fe1fda1c290d1bd17c7f3f98d13749644386ed722ab5f
+"caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001669, caniuse-lite@npm:^1.0.30001688, caniuse-lite@npm:^1.0.30001718":
+  version: 1.0.30001731
+  resolution: "caniuse-lite@npm:1.0.30001731"
+  checksum: 10/ad6771127c0cca13a711ca363bb0165a687f9a5c76f057b2c8c9746608a6bae2f15c7b6955063eefcd4ca0e5733d429f25292cc093a40a189d662f3a8647a020
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

Resolves https://linear.app/safe-global/issue/COR-46/internal-reverts-on-tenderly

Resolves issues with Tenderly transaction simulation warnings for partial reverts - scenarios where a Safe transaction succeeds overall but contains internal call trace errors (e.g., a multicall where some sub-calls revert). This was causing complaints from users and is technically inaccurate as transactions can still execute.

## How this PR fixes it

- isCallTrace edited to show when simulations succeed but also have internal errors.

- Refactored getSimulationStatus() to clearly extract nested simulation data and detect partial revert scenarios
- Fixed confusing double nesting in simulation response handling (simulation.simulation.simulation → cleaner access pattern)
-Added tests for the new partial revert detection logic

-Included mock simulation capability for local testing of partial revert scenarios
How to test it


## How to test it
Execute a Safe transaction that contains multiple calls where some succeed and others revert, or, uncomment the mock data in packages/utils/src/components/tx/security/tenderly/utils.ts:52-90.
Verify the simulation shows appropriate warnings for partial reverts

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
