### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/actions/yarn/action.yml
+++ b/.github/actions/yarn/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     # We require yarn v4 and installing through corepack is the easiest way to get it
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: ./.github/actions/corepack
 

--- a/.github/workflows/mobile-dev-release.yml
+++ b/.github/workflows/mobile-dev-release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/mobile-lint.yml
+++ b/.github/workflows/mobile-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/mobile-unit-tests.yml
+++ b/.github/workflows/mobile-unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/package-utils-unit-tests.yml
+++ b/.github/workflows/package-utils-unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/yarn
 

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -37,7 +37,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/yarn
 

--- a/.github/workflows/web-deploy-dockerhub.yml
+++ b/.github/workflows/web-deploy-dockerhub.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || (github.event_name == 'release' && github.event.action == 'released')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64

--- a/.github/workflows/web-deploy-production.yml
+++ b/.github/workflows/web-deploy-production.yml
@@ -19,7 +19,7 @@ jobs:
       ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/yarn
 

--- a/.github/workflows/web-e2e-full-ondemand.yml
+++ b/.github/workflows/web-e2e-full-ondemand.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/cypress
         with:

--- a/.github/workflows/web-e2e-hp-ondemand.yml
+++ b/.github/workflows/web-e2e-hp-ondemand.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         containers: [1, 2, 3]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/cypress
         with:

--- a/.github/workflows/web-e2e-prod-ondemand.yml
+++ b/.github/workflows/web-e2e-prod-ondemand.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         containers: [1]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/cypress
         with:

--- a/.github/workflows/web-e2e-smoke.yml
+++ b/.github/workflows/web-e2e-smoke.yml
@@ -21,7 +21,7 @@ jobs:
         containers: [1, 2, 3, 4, 5]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/cypress
         with:

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/yarn
 

--- a/.github/workflows/web-nextjs-bundle-analysis.yml
+++ b/.github/workflows/web-nextjs-bundle-analysis.yml
@@ -22,7 +22,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         uses: ./.github/actions/yarn

--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/web-unit-tests.yml
+++ b/.github/workflows/web-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/yarn
 


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0