### PR TITLE
fix(tests): update Etherscan API URLs in tests and mocks

### DIFF
--- a/apps/mobile/src/store/middleware/__tests__/notificationSync.test.ts
+++ b/apps/mobile/src/store/middleware/__tests__/notificationSync.test.ts
@@ -155,7 +155,7 @@ describe('notificationSyncMiddleware', () => {
                 blockExplorerUriTemplate: {
                   address: 'https://etherscan.io/address/{{address}}',
                   txHash: 'https://etherscan.io/tx/{{txHash}}',
-                  api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+                  api: 'https://api.etherscan.io/v2/api?chainid=1&module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
                 },
                 nativeCurrency: {
                   name: 'Ether',
@@ -170,7 +170,7 @@ describe('notificationSyncMiddleware', () => {
                 gasPrice: [
                   {
                     type: 'ORACLE',
-                    uri: 'https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=YourApiKeyToken',
+                    uri: 'https://api.etherscan.io/v2/api?chainid=1&module=gastracker&action=gasoracle&apikey=YourApiKeyToken',
                     gasParameter: 'SafeGasPrice',
                     gweiFactor: '1000000000.000000000',
                   },

--- a/apps/web/src/hooks/__tests__/useGasPrice.test.ts
+++ b/apps/web/src/hooks/__tests__/useGasPrice.test.ts
@@ -22,7 +22,7 @@ const currentChain = {
   gasPrice: [
     {
       type: 'oracle',
-      uri: 'https://api.etherscan.io/api?module=gastracker&action=gasoracle',
+      uri: 'https://api.etherscan.io/v2/api?chainid=4&module=gastracker&action=gasoracle',
       gasParameter: 'FastGasPrice',
       gweiFactor: '1000000000.000000000',
     },
@@ -82,7 +82,7 @@ describe('useGasPrice', () => {
       await Promise.resolve()
     })
 
-    expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/api?module=gastracker&action=gasoracle')
+    expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/v2/api?chainid=4&module=gastracker&action=gasoracle')
 
     // assert the hook is not loading
     expect(result.current[2]).toBe(false)
@@ -123,7 +123,7 @@ describe('useGasPrice', () => {
       await Promise.resolve()
     })
 
-    expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/api?module=gastracker&action=gasoracle')
+    expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/v2/api?chainid=4&module=gastracker&action=gasoracle')
 
     // assert the hook is not loading
     expect(result.current[2]).toBe(false)
@@ -164,7 +164,7 @@ describe('useGasPrice', () => {
       // assert the hook is not loading
       expect(result.current[2]).toBe(false)
 
-      expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/api?module=gastracker&action=gasoracle')
+      expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/v2/api?chainid=4&module=gastracker&action=gasoracle')
       expect(fetch).toHaveBeenCalledWith('https://ethgasstation.info/json/ethgasAPI.json')
     })
 
@@ -195,7 +195,7 @@ describe('useGasPrice', () => {
       await Promise.resolve()
     })
 
-    expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/api?module=gastracker&action=gasoracle')
+    expect(fetch).toHaveBeenCalledWith('https://api.etherscan.io/v2/api?chainid=4&module=gastracker&action=gasoracle')
     expect(fetch).toHaveBeenCalledWith('https://ethgasstation.info/json/ethgasAPI.json')
 
     // assert the hook is not loading

--- a/apps/web/src/tests/mocks/chains.ts
+++ b/apps/web/src/tests/mocks/chains.ts
@@ -30,7 +30,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
     blockExplorerUriTemplate: {
       address: 'https://etherscan.io/address/{{address}}',
       txHash: 'https://etherscan.io/tx/{{txHash}}',
-      api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+      api: 'https://api.etherscan.io/v2/api?chainid=1&module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
     },
     nativeCurrency: {
       name: 'Ether',
@@ -43,7 +43,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
     gasPrice: [
       {
         type: GAS_PRICE_TYPE.ORACLE,
-        uri: 'https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1',
+        uri: 'https://api.etherscan.io/v2/api?chainid=1&module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1',
         gasParameter: 'FastGasPrice',
         gweiFactor: '1000000000.000000000',
       },
@@ -471,7 +471,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
     blockExplorerUriTemplate: {
       address: 'https://optimistic.etherscan.io/address/{{address}}',
       txHash: 'https://optimistic.etherscan.io/tx/{{txHash}}',
-      api: 'https://api-optimistic.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+      api: 'https://api-optimistic.etherscan.io/v2/api?chainid=10&module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
     },
     nativeCurrency: {
       name: 'Ether',
@@ -522,7 +522,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
     blockExplorerUriTemplate: {
       address: 'https://goerli.etherscan.io/address/{{address}}',
       txHash: 'https://goerli.etherscan.io/tx/{{txHash}}',
-      api: 'https://api-goerli.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+      api: 'https://api-goerli.etherscan.io/v2/api?chainid=5&module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
     },
     nativeCurrency: {
       name: 'Görli Ether',
@@ -578,7 +578,7 @@ const CONFIG_SERVICE_CHAINS: ChainInfo[] = [
     blockExplorerUriTemplate: {
       address: 'https://rinkeby.etherscan.io/address/{{address}}',
       txHash: 'https://rinkeby.etherscan.io/tx/{{txHash}}',
-      api: 'https://api-rinkeby.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+      api: 'https://api-rinkeby.etherscan.io/v2/api?chainid=4&module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
     },
     nativeCurrency: {
       name: 'Ether',

--- a/packages/utils/src/utils/__tests__/gateway.test.ts
+++ b/packages/utils/src/utils/__tests__/gateway.test.ts
@@ -25,7 +25,7 @@ describe('gateway', () => {
       const result = getHashedExplorerUrl(txHash, {
         address: 'https://etherscan.io/address/{{address}}',
         txHash: 'https://etherscan.io/tx/{{txHash}}',
-        api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+        api: 'https://api.etherscan.io/v2/api?chainid=1&module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
       })
 
       expect(result).toEqual(
@@ -38,7 +38,7 @@ describe('gateway', () => {
       const result = getHashedExplorerUrl(address, {
         address: 'https://etherscan.io/address/{{address}}',
         txHash: 'https://etherscan.io/tx/{{txHash}}',
-        api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+        api: 'https://api.etherscan.io/v2/api?chainid=1&module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
       })
 
       expect(result).toEqual('https://etherscan.io/address/0xabcdbc2ecb47642ee8cf52fd7b88fa42fbb69f98')
@@ -52,7 +52,7 @@ describe('gateway', () => {
       const { href, title } = getExplorerLink(address, {
         address: 'https://etherscan.io/address/{{address}}',
         txHash: 'https://etherscan.io/tx/{{txHash}}',
-        api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+        api: 'https://api.etherscan.io/v2/api?chainid=1&module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
       })
 
       expect(href).toEqual('https://etherscan.io/address/0xabcdbc2ecb47642ee8cf52fd7b88fa42fbb69f98')


### PR DESCRIPTION
## What it solves
This pull request updates the Etherscan URL used in test files to ensure they reference the correct and current endpoint.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
