### PR TITLE
fix(e2e): click on share block header to make sure it expands

### DIFF
--- a/apps/web/cypress/e2e/pages/create_tx.pages.js
+++ b/apps/web/cypress/e2e/pages/create_tx.pages.js
@@ -71,6 +71,7 @@ export const altImgSwaps = 'svg[alt="Swap order"]'
 export const altImgLimitOrder = 'svg[alt="Limit order"]'
 export const altImgTwapOrder = 'svg[alt="Twap Order"]'
 export const txShareBlock = '[data-testid="share-block"]'
+export const txShareBlockHeader = '[data-testid="share-block-header"]'
 export const txShareBlockDetails = '[data-testid="share-block-details"]'
 const copyLinkBtn = '[data-testid="copy-link-btn"]'
 export const noteTextField = '[data-testid="tx-note-textfield"]'
@@ -303,7 +304,7 @@ export function verifyCopiedURL() {
 }
 
 export function expandTxShareBlock() {
-  cy.get(txShareBlock).click()
+  cy.get(txShareBlockHeader).click()
   cy.get(txShareBlockDetails).should('be.visible')
 }
 

--- a/apps/web/src/components/transactions/TxShareLink/index.tsx
+++ b/apps/web/src/components/transactions/TxShareLink/index.tsx
@@ -20,7 +20,9 @@ function TxShareAccordion({ noExpand = false }: { noExpand: boolean }) {
   return (
     <Accordion className={css.accordion} onChange={onExpand} disabled={noExpand}>
       <AccordionSummary expandIcon={noExpand ? null : <ExpandMoreIcon />} className={css.summary}>
-        <Typography className={css.header}>Share link{!noExpand && ' with other signers'}</Typography>
+        <Typography data-testid="share-block-header" className={css.header}>
+          Share link{!noExpand && ' with other signers'}
+        </Typography>
       </AccordionSummary>
 
       <AccordionDetails data-testid="share-block-details" className={css.details}>


### PR DESCRIPTION
## What it solves

Fixes the `tx_share_block` e2e tests.

## How this PR fixes it
- Added a new data-testid for the share block header in the TxShareAccordion component.
- Updated the Cypress test to interact with the share block header instead of the whole share block itself.

## How to test it

## Screenshots
<img width="832" height="325" alt="Screenshot 2025-08-15 at 10 37 59" src="https://github.com/user-attachments/assets/9ee98baf-90fc-46d1-9975-b439a70d5843" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
