### PR TITLE
Fix(Spaces): Merge all address books independent of current chain

### DIFF
--- a/apps/web/src/components/common/AddressInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressInput/index.test.tsx
@@ -10,6 +10,7 @@ import useNameResolver from '@/components/common/AddressInput/useNameResolver'
 import { chainBuilder } from '@/tests/builders/chains'
 import { FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
 import userEvent from '@testing-library/user-event'
+import { ContactSource } from '@/hooks/useAllAddressBooks'
 
 const mockChain = chainBuilder()
   .with({ features: [FEATURES.DOMAIN_LOOKUP] })
@@ -295,9 +296,17 @@ describe('AddressInput tests', () => {
     const mockChainId = '11155111'
     const mockSafeName = 'Test Safe'
     const mockAB = { [TEST_ADDRESS_A]: mockSafeName }
+    const mockContact = {
+      name: mockSafeName,
+      address: TEST_ADDRESS_A,
+      chainIds: [mockChainId],
+      createdBy: '',
+      lastUpdatedBy: '',
+      source: ContactSource.local,
+    }
 
     jest.spyOn(urlChainId, 'default').mockImplementation(() => mockChainId)
-    jest.spyOn(allAddressBooks, 'default').mockReturnValue({ [mockChainId]: mockAB })
+    jest.spyOn(allAddressBooks, 'useAddressBookItem').mockReturnValue(mockContact)
     jest.spyOn(addressBook, 'default').mockImplementation(() => mockAB)
 
     const { input, utils } = setup(TEST_ADDRESS_A)
@@ -313,9 +322,17 @@ describe('AddressInput tests', () => {
     const mockChainId = '11155111'
     const mockSafeName = 'Test Safe'
     const mockAB = { [TEST_ADDRESS_A]: mockSafeName }
+    const mockContact = {
+      name: mockSafeName,
+      address: TEST_ADDRESS_A,
+      chainIds: [mockChainId],
+      createdBy: '',
+      lastUpdatedBy: '',
+      source: ContactSource.local,
+    }
 
     jest.spyOn(urlChainId, 'default').mockImplementation(() => mockChainId)
-    jest.spyOn(allAddressBooks, 'default').mockReturnValue({ [mockChainId]: mockAB })
+    jest.spyOn(allAddressBooks, 'useAddressBookItem').mockReturnValue(mockContact)
     jest.spyOn(addressBook, 'default').mockImplementation(() => mockAB)
 
     const { input, utils } = setup(TEST_ADDRESS_A)
@@ -340,9 +357,17 @@ describe('AddressInput tests', () => {
     const mockChainId = '11155111'
     const mockSafeName = 'Test Safe'
     const mockAB = { [TEST_ADDRESS_A]: mockSafeName }
+    const mockContact = {
+      name: mockSafeName,
+      address: TEST_ADDRESS_A,
+      chainIds: [mockChainId],
+      createdBy: '',
+      lastUpdatedBy: '',
+      source: ContactSource.local,
+    }
 
     jest.spyOn(urlChainId, 'default').mockImplementation(() => mockChainId)
-    jest.spyOn(allAddressBooks, 'default').mockReturnValue({ [mockChainId]: mockAB })
+    jest.spyOn(allAddressBooks, 'useAddressBookItem').mockReturnValue(mockContact)
     jest.spyOn(addressBook, 'default').mockImplementation(() => mockAB)
 
     const { input, utils } = setup(TEST_ADDRESS_A, undefined, true)

--- a/apps/web/src/components/common/EthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/index.tsx
@@ -25,8 +25,8 @@ const EthHashInfo = ({
       copyPrefix={settings.shortName.copy}
       {...props}
       name={name}
-      isAddressBookName={!!addressBookItem}
-      addressBookNameSource={addressBookItem?.source}
+      isAddressBookName={props.isAddressBookName || !!addressBookItem}
+      addressBookNameSource={props.addressBookNameSource || addressBookItem?.source}
       customAvatar={props.customAvatar}
       ExplorerButtonProps={{ title: link?.title || '', href: link?.href || '' }}
       avatarSize={avatarSize}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -7,6 +7,7 @@ import NetworkLogosList from '@/features/multichain/components/NetworkLogosList'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import SpaceAddressBookActions from '@/features/spaces/components/SpaceAddressBook/SpaceAddressBookActions'
+import { ContactSource } from '@/hooks/useAllAddressBooks'
 
 const headCells = [
   { id: 'contact', label: 'Contact' },
@@ -27,7 +28,17 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
           <Stack direction="row" spacing={1} alignItems="center">
             <Identicon address={entry.address} size={32} />
             <Stack direction="column" spacing={0.5}>
-              <EthHashInfo showAvatar={false} address={entry.address} shortAddress={false} hasExplorer showCopyButton />
+              <EthHashInfo
+                showAvatar={false}
+                address={entry.address}
+                name={entry.name}
+                shortAddress={false}
+                showPrefix={false}
+                isAddressBookName={true}
+                addressBookNameSource={ContactSource.space}
+                hasExplorer
+                showCopyButton
+              />
             </Stack>
           </Stack>
         ),

--- a/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
+++ b/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
@@ -7,11 +7,11 @@ import {
 } from '@/hooks/useAllAddressBooks'
 import * as spacesQueries from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import * as currentSpaceIdHook from '@/features/spaces/hooks/useCurrentSpaceId'
+import type { AddressBook } from '@/store/addressBookSlice'
 
 let signedIn = false
 let currentSpaceId = '123'
-let chainId = '1'
-let localAddressBook: Record<string, string> = {}
+let localAddressBook: Record<string, AddressBook> = {}
 let remoteContacts: ExtendedContact[] = []
 
 jest.mock('@/store', () => ({
@@ -25,10 +25,6 @@ jest.mock('@/store/authSlice', () => ({
 jest.mock('@/store/addressBookSlice', () => ({
   selectAllAddressBooks: jest.fn(() => localAddressBook),
 }))
-
-jest.mock('@/hooks/useAddressBook', () => () => localAddressBook)
-
-jest.mock('@/hooks/useChainId', () => () => chainId)
 
 describe('useAllAddressBooks', () => {
   describe('useAllMergedAddressBooks', () => {
@@ -53,8 +49,10 @@ describe('useAllAddressBooks', () => {
     it('returns ONLY local contacts when the user is NOT signed in', () => {
       signedIn = false
       localAddressBook = {
-        '0xA': 'Alice',
-        '0xB': 'Bob',
+        '1': {
+          '0xA': 'Alice',
+          '0xB': 'Bob',
+        },
       }
 
       const { result } = renderHook(() => useAllMergedAddressBooks())
@@ -67,8 +65,10 @@ describe('useAllAddressBooks', () => {
     it('merges space & local contacts, filtering duplicates by address', () => {
       signedIn = true
       localAddressBook = {
-        '0xA': 'Alice (local)',
-        '0xB': 'Bob',
+        '1': {
+          '0xA': 'Alice (local)',
+          '0xB': 'Bob',
+        },
       }
 
       remoteContacts = [
@@ -132,7 +132,11 @@ describe('useAllAddressBooks', () => {
     })
 
     it('returns undefined when no chainId is provided', () => {
-      localAddressBook = { '0xB': 'Bob' }
+      localAddressBook = {
+        '1': {
+          '0xB': 'Bob',
+        },
+      }
 
       const { result } = renderHook(() => useAddressBookItem('0xB', undefined))
 


### PR DESCRIPTION
## What it solves

Resolves [COR-493](https://linear.app/safe-global/issue/COR-493/spaces-address-book-names-are-only-visible-if-wallet-is-on-the-correct)

## How this PR fixes it

- Allows overriding `EthHashInfo` address book name source
- Hides the chain prefix for addresses in a space address book
- Updates `useAllMergedAddressBooks` to use all local address books instead of only the current network one

## How to test it

1. Open a space with an address book that has entries on different chains
2. Observe that all names are shown at all times no matter if a wallet is connected or the connected wallets network
3. Observe that the cloud icon is shown at all times
4. Go to added safes on a space that have names in the local and space address book
5. Observe all names are visible and the correct icon is shown

## Screenshots
<img width="874" height="396" alt="Screenshot 2025-08-18 at 16 25 49" src="https://github.com/user-attachments/assets/82a5f4c2-f57f-42f2-a807-09d24b3e2eab" />
<img width="666" height="717" alt="Screenshot 2025-08-18 at 16 26 22" src="https://github.com/user-attachments/assets/19e3c8ab-e6da-48c1-b12d-2e48b0ab4b6d" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
