### PR TITLE
Fix(Spaces): Disable address book table sort

### DIFF
--- a/apps/web/src/components/common/EnhancedTable/index.tsx
+++ b/apps/web/src/components/common/EnhancedTable/index.tsx
@@ -36,6 +36,7 @@ type EnhancedHeadCell = {
   width?: string
   align?: string
   sticky?: boolean
+  disableSort?: boolean
 }
 
 function descendingComparator(a: string | number, b: string | number) {
@@ -91,7 +92,9 @@ function EnhancedTableHead(props: EnhancedTableHeadProps) {
             }}
             className={classNames({ sticky: headCell.sticky })}
           >
-            {headCell.label && (
+            {headCell.disableSort ? (
+              headCell.label
+            ) : (
               <>
                 <TableSortLabel
                   active={orderBy === headCell.id}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -9,8 +9,8 @@ import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GE
 import SpaceAddressBookActions from '@/features/spaces/components/SpaceAddressBook/SpaceAddressBookActions'
 
 const headCells = [
-  { id: 'contact', label: 'Contact' },
-  { id: 'networks', label: 'Networks' },
+  { id: 'contact', label: 'Contact', disableSort: true },
+  { id: 'networks', label: 'Networks', disableSort: true },
   { id: 'actions', label: '' },
 ]
 


### PR DESCRIPTION
## What it solves

Resolves [COR-490](https://linear.app/safe-global/issue/COR-490/spaces-sorting-by-name-doesnt-work-in-the-addressbook)

## How this PR fixes it

- Adds a new `disableSort` value to the EnhancedTable header cells
- Disables sorting for address book table

## How to test it

1. Open a space with an address book
2. Observe the table has no sortable headers

## Screenshots
<img width="1249" height="315" alt="Screenshot 2025-08-18 at 16 33 54" src="https://github.com/user-attachments/assets/d5e2cb41-7286-4875-b4b4-ad5e0e45a9cd" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
