### PR TITLE
Fix: Add mobile label to address book tables

### DIFF
--- a/apps/web/src/components/address-book/AddressBookTable/index.tsx
+++ b/apps/web/src/components/address-book/AddressBookTable/index.tsx
@@ -90,9 +90,11 @@ function AddressBookTable({ chain, setTxFlow }: AddressBookTableProps) {
       name: {
         rawValue: name,
         content: name,
+        mobileLabel: 'Name',
       },
       address: {
         rawValue: address,
+        mobileLabel: 'Address',
         content: <EthHashInfo address={address} showName={false} shortAddress={false} hasExplorer showCopyButton />,
       },
       actions: {

--- a/apps/web/src/components/common/EnhancedTable/index.tsx
+++ b/apps/web/src/components/common/EnhancedTable/index.tsx
@@ -15,12 +15,13 @@ import { visuallyHidden } from '@mui/utils'
 import classNames from 'classnames'
 
 import css from './styles.module.css'
-import { Collapse } from '@mui/material'
+import { Collapse, Typography } from '@mui/material'
 
 type EnhancedCell = {
   content: ReactNode
   rawValue: string | number | null
   sticky?: boolean
+  mobileLabel?: string
 }
 
 type EnhancedRow = {
@@ -171,6 +172,12 @@ function EnhancedTable({ rows, headCells, mobileVariant }: EnhancedTableProps) {
                       })}
                     >
                       <Collapse key={index} in={!row.collapsed} enter={false}>
+                        {cell.mobileLabel ? (
+                          <Typography variant="body2" color="text.secondary" className={css.mobileLabel}>
+                            {cell.mobileLabel}
+                          </Typography>
+                        ) : null}
+
                         {cell.content}
                       </Collapse>
                     </TableCell>

--- a/apps/web/src/components/common/EnhancedTable/styles.module.css
+++ b/apps/web/src/components/common/EnhancedTable/styles.module.css
@@ -18,18 +18,28 @@
   gap: var(--space-1);
 }
 
+.mobileLabel {
+  display: none;
+}
+
 @media (max-width: 899.95px) {
   .mobileColumn thead th {
     display: none;
   }
 
-  .mobileColumn thead th:first-of-type {
-    display: block;
-  }
-
   .mobileColumn tbody td {
     display: block;
-    padding-left: var(--space-2) !important;
+    padding: 0 !important;
+    margin: 12px var(--space-3) !important;
     background: inherit;
+  }
+
+  .mobileLabel {
+    display: block;
+    margin-bottom: var(--space-1);
+  }
+
+  .actions {
+    justify-content: flex-start;
   }
 }

--- a/apps/web/src/features/spaces/components/AddAccounts/SafesList.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/SafesList.tsx
@@ -119,9 +119,9 @@ const SafesList = ({ safes }: { safes: AllSafeItems }) => {
                   sx={{ mr: 2 }}
                   disabled={alreadyAdded}
                 />
-                <Box className={css.safeRow}>
+                <Box className={css.safeRow} pr={4}>
                   <EthHashInfo address={safe.address} copyAddress={false} showPrefix={false} />
-                  <Box sx={{ justifySelf: 'flex-start' }}>
+                  <Box sx={{ justifySelf: 'flex-start', pl: 2 }}>
                     <MultichainIndicator safes={safe.safes} />
                   </Box>
                 </Box>

--- a/apps/web/src/features/spaces/components/AddAccounts/styles.module.css
+++ b/apps/web/src/features/spaces/components/AddAccounts/styles.module.css
@@ -1,6 +1,6 @@
 .safeRow {
   display: grid;
-  grid-template-columns: 8fr 3fr;
+  grid-template-columns: 8fr auto;
   align-items: center;
   width: 100%;
 }

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/ContactsList.tsx
@@ -74,12 +74,14 @@ const ContactsList = ({ contactItems }: { contactItems: ContactItem[] }) => {
                       <ListItemText
                         primary={
                           <Box className={css.safeRow}>
-                            <EthHashInfo
-                              address={contactItem.address}
-                              chainId={contactItem.chainId}
-                              name={contactItem.name}
-                              copyAddress={false}
-                            />
+                            <Box overflow="auto">
+                              <EthHashInfo
+                                address={contactItem.address}
+                                chainId={contactItem.chainId}
+                                name={contactItem.name}
+                                copyAddress={false}
+                              />
+                            </Box>
                             <ChainIndicator chainId={contactItem.chainId} responsive onlyLogo />
                           </Box>
                         }

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -23,6 +23,7 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
     cells: {
       contact: {
         rawValue: entry.address,
+        mobileLabel: 'Contact',
         content: (
           <Stack direction="row" spacing={1} alignItems="center">
             <Identicon address={entry.address} size={32} />
@@ -34,6 +35,7 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
       },
       networks: {
         rawValue: entry.chainIds.length,
+        mobileLabel: 'Networks',
         content: (
           <>
             <Tooltip


### PR DESCRIPTION
## What it solves

Resolves [COR-466](https://linear.app/safe-global/issue/COR-466/spaces-address-book-mobile-view)

## How this PR fixes it

- Adds a `mobileLabel` prop to the `EnhancedTable`
- Adds mobile labels to both address book tables
- Fixes the import address book dialog on mobile

## How to test it

1. Open a space with address book entries
2. Switch to mobile view
3. Observe the new layout
4. Try to import address book entries
5. Observe all icons are within the layout

Figma: https://www.figma.com/design/PeChIDi5UKPjf58IOChtET/Spaces?node-id=4817-16264&m=dev

## Screenshots

<img width="398" height="700" alt="Screenshot 2025-08-19 at 09 26 32" src="https://github.com/user-attachments/assets/2334b616-69e6-49df-a61b-67c54b4812a7" />
<img width="411" height="700" alt="Screenshot 2025-08-19 at 09 26 55" src="https://github.com/user-attachments/assets/d82715fa-8527-45b6-8ccf-75c239980ac0" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
