### PR TITLE
Fix(Spaces): Respect current chainId when selecting address book item

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -283,6 +283,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = fal
               <EthHashInfo
                 address={address}
                 name={multiSafeAccountItem.name}
+                showName={isSpaceSafe ? !!multiSafeAccountItem.name : true}
                 shortAddress
                 showPrefix={false}
                 showAvatar={false}

--- a/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/SingleAccountItem.tsx
@@ -177,6 +177,7 @@ const SingleAccountItem = ({
           <EthHashInfo
             address={address}
             name={name}
+            showName={isSpaceSafe ? !!safeItem.name : true}
             shortAddress
             chainId={chain?.chainId}
             showAvatar={false}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -2,12 +2,13 @@ import EnhancedTable from '@/components/common/EnhancedTable'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import Identicon from '@/components/common/Identicon'
-import { Box, Stack, Tooltip } from '@mui/material'
+import { Box, Chip, Stack, Tooltip } from '@mui/material'
 import NetworkLogosList from '@/features/multichain/components/NetworkLogosList'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import SpaceAddressBookActions from '@/features/spaces/components/SpaceAddressBook/SpaceAddressBookActions'
 import { ContactSource } from '@/hooks/useAllAddressBooks'
+import useChains from '@/hooks/useChains'
 
 const headCells = [
   { id: 'contact', label: 'Contact', disableSort: true },
@@ -20,6 +21,8 @@ type SpaceAddressBookTableProps = {
 }
 
 function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
+  const chains = useChains()
+
   const rows = entries.map((entry) => ({
     cells: {
       contact: {
@@ -62,7 +65,11 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
               arrow
             >
               <Box sx={{ display: 'inline-block' }}>
-                <NetworkLogosList networks={entry.chainIds.map((chainId) => ({ chainId }))} />
+                {chains.configs.length === entry.chainIds.length ? (
+                  <Chip label="All" size="small" />
+                ) : (
+                  <NetworkLogosList networks={entry.chainIds.map((chainId) => ({ chainId }))} />
+                )}
               </Box>
             </Tooltip>
           </>

--- a/apps/web/src/features/spaces/utils.ts
+++ b/apps/web/src/features/spaces/utils.ts
@@ -1,8 +1,9 @@
 import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import type { SerializedError } from '@reduxjs/toolkit'
 import type { UserWithWallets } from '@safe-global/store/gateway/AUTO_GENERATED/users'
-import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import type { GetSpaceResponse, SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { MemberStatus } from '@/features/spaces/hooks/useSpaceMembers'
+import type { AddressBookState } from '@/store/addressBookSlice'
 
 // TODO: Currently also checks for 404 because the /v1/spaces/<orgId> endpoint does not return 401
 export const isUnauthorized = (error: FetchBaseQueryError | SerializedError | undefined) => {
@@ -24,4 +25,20 @@ export const getNonDeclinedSpaces = (currentUser: UserWithWallets | undefined, s
   const activeSpaces = filterSpacesByStatus(currentUser, spaces || [], MemberStatus.ACTIVE)
 
   return [...pendingInvites, ...activeSpaces]
+}
+
+export const mapSpaceContactsToAddressBookState = (spaceContacts: SpaceAddressBookItemDto[]): AddressBookState => {
+  const addressBooks: AddressBookState = {}
+
+  for (const contact of spaceContacts) {
+    for (const chainId of contact.chainIds) {
+      if (!addressBooks[chainId]) {
+        addressBooks[chainId] = {}
+      }
+
+      addressBooks[chainId][contact.address] = contact.name
+    }
+  }
+
+  return addressBooks
 }

--- a/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
+++ b/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
@@ -103,6 +103,24 @@ describe('useAllAddressBooks', () => {
         '0xB': ContactSource.local,
       })
     })
+
+    it('Uses the name from the correct network if chainId is passed in props', () => {
+      const mockChainId = '11155111'
+      signedIn = false
+      localAddressBook = {
+        '1': {
+          '0xA': 'Alice (mainnet)',
+          '0xB': 'Bob',
+        },
+        '11155111': {
+          '0xA': 'Alice (sepolia)',
+        },
+      }
+
+      const { result } = renderHook(() => useAllMergedAddressBooks(mockChainId))
+      expect(result.current).toHaveLength(2)
+      expect(result.current.map((c) => c.name)).toEqual(['Alice (sepolia)', 'Bob'])
+    })
   })
 
   describe('useAddressBookItem', () => {

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -15,11 +15,11 @@ export enum ContactSource {
 }
 export type ExtendedContact = SpaceAddressBookItemDto & { source: ContactSource }
 
-const mapAllLocalAddressBooks = (allAddressBooks: AddressBookState): ExtendedContact[] => {
+const mapAllLocalAddressBooks = (allAddressBooks: AddressBookState, chainId?: string): ExtendedContact[] => {
   // There can be duplicates with different names across networks so we need a strategy to select only one
   const itemsByAddress: Record<string, SpaceAddressBookItemDto> = {}
 
-  for (const [chainId, addressBook] of Object.entries(allAddressBooks ?? {})) {
+  for (const [addressBookChainId, addressBook] of Object.entries(allAddressBooks ?? {})) {
     for (const [address, name] of Object.entries(addressBook ?? {})) {
       const key = address.toLowerCase()
 
@@ -27,15 +27,15 @@ const mapAllLocalAddressBooks = (allAddressBooks: AddressBookState): ExtendedCon
         itemsByAddress[key] = {
           address,
           name,
-          chainIds: [chainId],
+          chainIds: [addressBookChainId],
           createdBy: '',
           lastUpdatedBy: '',
         }
       } else {
         const existingItem = itemsByAddress[key]
-        // If names differ, prefer the first non-empty we saw (simple, stable rule)
-        if (!existingItem.name && name) existingItem.name = name
-        if (!existingItem.chainIds.includes(chainId)) existingItem.chainIds.push(chainId)
+        // If names differ, prefer the first non-empty we saw or the current network one
+        if ((!existingItem.name && name) || chainId === addressBookChainId) existingItem.name = name
+        if (!existingItem.chainIds.includes(addressBookChainId)) existingItem.chainIds.push(addressBookChainId)
       }
     }
   }
@@ -50,13 +50,17 @@ const mapAllLocalAddressBooks = (allAddressBooks: AddressBookState): ExtendedCon
  * Returns all local address books in the same structure as the Space address book
  * If there are naming conflicts it defaults to the first name it encounters
  */
-const useAllLocalAddressBooks = () => {
+const useAllLocalAddressBooks = (chainId?: string) => {
   const allAddressBooks = useAllAddressBooks()
 
-  return useMemo(() => mapAllLocalAddressBooks(allAddressBooks), [allAddressBooks])
+  return useMemo(() => mapAllLocalAddressBooks(allAddressBooks, chainId), [allAddressBooks, chainId])
 }
 
-export const useAllMergedAddressBooks = (): ExtendedContact[] => {
+/**
+ * Optional chainId in case an address exists on multiple networks locally to decide which name to use
+ * @param chainId
+ */
+export const useAllMergedAddressBooks = (chainId?: string): ExtendedContact[] => {
   const spaceId = useCurrentSpaceId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: addressBook } = useAddressBooksGetAddressBookItemsV1Query(
@@ -73,7 +77,7 @@ export const useAllMergedAddressBooks = (): ExtendedContact[] => {
     }))
   }, [addressBook])
 
-  const localContacts = useAllLocalAddressBooks()
+  const localContacts = useAllLocalAddressBooks(chainId)
 
   // Only include local contacts if they don't already exist in the space address book
   return useMemo<ExtendedContact[]>(() => {
@@ -94,7 +98,7 @@ export const useAllMergedAddressBooks = (): ExtendedContact[] => {
  * @param chainId
  */
 export const useAddressBookItem = (address: string, chainId: string | undefined) => {
-  const allAddressBooks = useAllMergedAddressBooks()
+  const allAddressBooks = useAllMergedAddressBooks(chainId)
 
   return chainId
     ? allAddressBooks.find((entry) => sameAddress(entry.address, address) && entry.chainIds.includes(chainId))

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -1,13 +1,11 @@
 import { useAppSelector } from '@/store'
-import { type AddressBookState, selectAllAddressBooks } from '@/store/addressBookSlice'
-import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
-import { isAuthenticated } from '@/store/authSlice'
-import {
-  type SpaceAddressBookItemDto,
-  useAddressBooksGetAddressBookItemsV1Query,
-} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { type AddressBook, selectAllAddressBooks } from '@/store/addressBookSlice'
+import { type SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useMemo } from 'react'
+import useAddressBook from '@/hooks/useAddressBook'
+import useChainId from '@/hooks/useChainId'
+import useGetSpaceAddressBook from '@/features/spaces/hooks/useGetSpaceAddressBook'
 
 export enum ContactSource {
   space = 'space',
@@ -15,79 +13,46 @@ export enum ContactSource {
 }
 export type ExtendedContact = SpaceAddressBookItemDto & { source: ContactSource }
 
-const mapAllLocalAddressBooks = (allAddressBooks: AddressBookState, chainId?: string): ExtendedContact[] => {
-  // There can be duplicates with different names across networks so we need a strategy to select only one
-  const itemsByAddress: Record<string, SpaceAddressBookItemDto> = {}
-
-  for (const [addressBookChainId, addressBook] of Object.entries(allAddressBooks ?? {})) {
-    for (const [address, name] of Object.entries(addressBook ?? {})) {
-      const key = address.toLowerCase()
-
-      if (!itemsByAddress[key]) {
-        itemsByAddress[key] = {
-          address,
-          name,
-          chainIds: [addressBookChainId],
-          createdBy: '',
-          lastUpdatedBy: '',
-        }
-      } else {
-        const existingItem = itemsByAddress[key]
-        // If names differ, prefer the first non-empty we saw or the current network one
-        if ((!existingItem.name && name) || chainId === addressBookChainId) existingItem.name = name
-        if (!existingItem.chainIds.includes(addressBookChainId)) existingItem.chainIds.push(addressBookChainId)
-      }
-    }
-  }
-
-  return Object.values(itemsByAddress).map((item) => ({
-    ...item,
+const mapAddressBook = (addressBook: AddressBook, chainId: string): ExtendedContact[] => {
+  return Object.entries(addressBook).map(([address, name]) => ({
+    name,
+    address,
+    chainIds: [chainId],
+    createdBy: '',
+    lastUpdatedBy: '',
     source: ContactSource.local,
   }))
 }
 
-/**
- * Returns all local address books in the same structure as the Space address book
- * If there are naming conflicts it defaults to the first name it encounters
- */
-const useAllLocalAddressBooks = (chainId?: string) => {
-  const allAddressBooks = useAllAddressBooks()
+const useLocalAddressBook = (chainId?: string) => {
+  const fallbackChainId = useChainId()
+  const actualChainId = chainId ?? fallbackChainId
+  const addressBook = useAddressBook(actualChainId)
 
-  return useMemo(() => mapAllLocalAddressBooks(allAddressBooks, chainId), [allAddressBooks, chainId])
+  return useMemo(() => mapAddressBook(addressBook, actualChainId), [addressBook, actualChainId])
 }
 
-/**
- * Optional chainId in case an address exists on multiple networks locally to decide which name to use
- * @param chainId
- */
 export const useAllMergedAddressBooks = (chainId?: string): ExtendedContact[] => {
-  const spaceId = useCurrentSpaceId()
-  const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { currentData: addressBook } = useAddressBooksGetAddressBookItemsV1Query(
-    { spaceId: Number(spaceId) },
-    { skip: !isUserSignedIn },
-  )
+  const addressBook = useGetSpaceAddressBook()
 
   const spaceContacts = useMemo<ExtendedContact[]>(() => {
     if (!addressBook) return []
 
-    return addressBook.data.map<ExtendedContact>((entry) => ({
+    return addressBook.map<ExtendedContact>((entry) => ({
       ...entry,
       source: ContactSource.space,
     }))
   }, [addressBook])
 
-  const localContacts = useAllLocalAddressBooks(chainId)
+  const localContacts = useLocalAddressBook(chainId)
 
-  // Only include local contacts if they don't already exist in the space address book
   return useMemo<ExtendedContact[]>(() => {
-    return [
-      ...spaceContacts,
-      ...localContacts.filter(
-        (localContact) =>
-          !spaceContacts.some((spaceContact) => sameAddress(spaceContact.address, localContact.address)),
-      ),
-    ]
+    // Only include local contacts if they don't already exist in the space address book
+    const filteredLocalContacts = localContacts.filter(
+      (localContact) => !spaceContacts.some((spaceContact) => sameAddress(spaceContact.address, localContact.address)),
+    )
+
+    return [...spaceContacts, ...filteredLocalContacts]
   }, [spaceContacts, localContacts])
 }
 


### PR DESCRIPTION
## What it solves

Resolves [COR-493](https://linear.app/safe-global/issue/COR-493/spaces-address-book-names-are-only-visible-if-wallet-is-on-the-correct#comment-9f575331)

## How this PR fixes it

We created a new hook `useAllMergedAddressBooks` that is supposed to combine local and cloud address books. Since the local address books have a different structure we need to map them into the new structure. Since there can also be duplicate entries there with different names we need a strategy to decide on the name we want to use. Previous to this fix we always defaulted with the first name we saw and kept that but this causes issues if the same safe on a different network is open it displays the name from the other network.

This PR fixes that by allowing to pass the chainId into the mapping logic and overwriting the name in case the networks match.

## How to test it

1. Open a Safe that is deployed on at least two networks
2. Add local address book entries for that safe with different names
3. Add both safes to your space
4. Observe either of the two names is displayed within the Space (this is expected)
5. Open the safe on network A and observe the name from network A is used (in the sidebar and the breadcrumbs)
6. Do the same for safe on network B
7. Delete the address book entry on network B
8. Observe the address is shown instead of the name of the entry from network A

## Screenshots

<img width="503" height="166" alt="Screenshot 2025-08-20 at 10 50 55" src="https://github.com/user-attachments/assets/e1e35fc9-2adf-47b6-8bf3-4be8006731ac" />
<img width="528" height="341" alt="Screenshot 2025-08-20 at 10 51 05" src="https://github.com/user-attachments/assets/aa1771dd-c3bc-4ce5-af92-4c8853e3cdf2" />
<img width="607" height="296" alt="Screenshot 2025-08-20 at 10 51 12" src="https://github.com/user-attachments/assets/497241dc-e55a-4d92-96da-73718978a43b" />

After deletion on one network
<img width="863" height="403" alt="Screenshot 2025-08-20 at 10 51 21" src="https://github.com/user-attachments/assets/ed1f4f47-12b4-459f-b981-464d496ece30" />
<img width="519" height="350" alt="Screenshot 2025-08-20 at 10 51 35" src="https://github.com/user-attachments/assets/f0b4fcb7-ee2f-46ae-86bf-41d475f4a8b8" />

Another fix is that we don't show all network logos anymore if a contact is added on all networks but instead a chip:
<img width="1270" height="569" alt="Screenshot 2025-08-20 at 13 55 13" src="https://github.com/user-attachments/assets/999b5e11-856b-482e-8458-c8bc03eac7eb" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
