### PR TITLE
fix(web): disable add proposer button if safe is not activated

### DIFF
--- a/apps/web/src/components/common/OnlyOwner/index.tsx
+++ b/apps/web/src/components/common/OnlyOwner/index.tsx
@@ -3,6 +3,7 @@ import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import useWallet from '@/hooks/wallets/useWallet'
 import useConnectWallet from '../ConnectWallet/useConnectWallet'
 import { Tooltip } from '@mui/material'
+import useSafeInfo from '@/hooks/useSafeInfo'
 
 type CheckWalletProps = {
   children: (ok: boolean) => ReactElement
@@ -11,12 +12,16 @@ type CheckWalletProps = {
 enum Message {
   WalletNotConnected = 'Please connect your wallet',
   NotSafeOwner = 'Your connected wallet is not a signer of this Safe Account',
+  SafeNotActivated = 'You need to activate the Safe before transacting',
 }
 
 const OnlyOwner = ({ children }: CheckWalletProps): ReactElement => {
   const wallet = useWallet()
   const isSafeOwner = useIsSafeOwner()
   const connectWallet = useConnectWallet()
+  const { safe } = useSafeInfo()
+
+  const isUndeployedSafe = !safe.deployed
 
   const message = useMemo(() => {
     if (!wallet) {
@@ -25,6 +30,10 @@ const OnlyOwner = ({ children }: CheckWalletProps): ReactElement => {
 
     if (!isSafeOwner) {
       return Message.NotSafeOwner
+    }
+
+    if (isUndeployedSafe) {
+      return Message.SafeNotActivated
     }
   }, [isSafeOwner, wallet])
 


### PR DESCRIPTION
## What it solves
It Solves Issue: https://github.com/safe-global/safe-wallet-monorepo/issues/4839

## How this PR fixes it
added SafeNotActivated validation in OnlyOwner component, which was only referenced by the Add proposer button. 
Note:  message added in tooltip for SafeNotActivated was referenced from CheckWallet Component which is used by all other features

## How to test it
1. Create a CF safe (pay later)
2. Go to the settings

## Screenshots
add proposer button disabled for inactivate safe
<img width="1507" height="512" alt="image" src="https://github.com/user-attachments/assets/1f4b0afd-7b5d-4e3b-89c1-439e70d3f9f4" />

add proposer button enabled once safe is activated
<img width="1547" height="346" alt="image" src="https://github.com/user-attachments/assets/191cdc08-b3bf-41ee-90d1-259184b218ca" />



## Checklist

- [ ] I've tested the branch on mobile 📱NA
- [ ] I've documented how it affects the analytics (if at all) 📊 NA
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 NA

---

## CLA signature
Devanshu Wadhwani
With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
