### PR TITLE
fix(web): EIP-7702 accounts are treated as smart accounts

### DIFF
--- a/apps/web/src/utils/__tests__/wallets.test.ts
+++ b/apps/web/src/utils/__tests__/wallets.test.ts
@@ -1,48 +1,99 @@
 import { type JsonRpcProvider, toBeHex } from 'ethers'
+import { EMPTY_DATA } from '@safe-global/protocol-kit/dist/src/utils/constants'
 
 import * as web3 from '@/hooks/wallets/web3'
-import { isSmartContractWallet } from '@/utils/wallets'
+import {
+  isSmartContractWallet,
+  isSmartContract,
+  isEIP7702DelegatedAccount,
+  EIP_7702_DELEGATED_ACCOUNT_PREFIX,
+} from '@/utils/wallets'
 
 describe('wallets', () => {
+  const getCodeMock = jest.fn()
+
+  beforeEach(() => {
+    isSmartContractWallet.cache.clear?.()
+
+    jest.clearAllMocks()
+
+    jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(() => {
+      return {
+        getCode: getCodeMock,
+      } as unknown as JsonRpcProvider
+    })
+  })
+
+  describe('isSmartContract', () => {
+    it('should return true for accounts with bytecode', async () => {
+      getCodeMock.mockResolvedValue('0x608060405234801561001057600080fd5b5')
+
+      const result = await isSmartContract(toBeHex('0x1', 20))
+
+      expect(result).toBe(true)
+      expect(getCodeMock).toHaveBeenCalledWith(toBeHex('0x1', 20))
+    })
+
+    it('should return false for EOAs (empty bytecode)', async () => {
+      getCodeMock.mockResolvedValue(EMPTY_DATA)
+
+      const result = await isSmartContract(toBeHex('0x1', 20))
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('isEIP7702DelegatedAccount', () => {
+    it('should return true for EIP-7702 delegated accounts', async () => {
+      const eip7702Code = EIP_7702_DELEGATED_ACCOUNT_PREFIX + '1234567890abcdef1234567890abcdef12345678'
+      getCodeMock.mockResolvedValue(eip7702Code)
+
+      const result = await isEIP7702DelegatedAccount(toBeHex('0x1', 20))
+
+      expect(result).toBe(true)
+    })
+
+    it('should return false for regular smart contracts', async () => {
+      getCodeMock.mockResolvedValue('0x608060405234801561001057600080fd5b5')
+
+      const result = await isEIP7702DelegatedAccount(toBeHex('0x1', 20))
+
+      expect(result).toBe(false)
+    })
+
+    it('should return false for EOAs', async () => {
+      getCodeMock.mockResolvedValue(EMPTY_DATA)
+
+      const result = await isEIP7702DelegatedAccount(toBeHex('0x1', 20))
+
+      expect(result).toBe(false)
+    })
+  })
+
   describe('isSmartContractWallet', () => {
-    const getCodeMock = jest.fn()
+    it('should return true for regular smart contracts (not EIP-7702)', async () => {
+      getCodeMock.mockResolvedValue('0x608060405234801561001057600080fd5b5') // Regular smart contract bytecode
 
-    beforeEach(() => {
-      // Clear memoization cache
-      isSmartContractWallet.cache.clear?.()
+      const result = await isSmartContractWallet('1', toBeHex('0x1', 20))
 
-      jest.clearAllMocks()
-
-      jest.spyOn(web3, 'getWeb3ReadOnly').mockImplementation(() => {
-        return {
-          getCode: getCodeMock,
-        } as unknown as JsonRpcProvider
-      })
+      expect(result).toBe(true)
     })
 
-    it('should should only call the provider once per address on a chain', async () => {
-      for await (const _ of Array.from({ length: 10 })) {
-        await isSmartContractWallet('1', toBeHex('0x1', 20))
-      }
+    it('should return false for EIP-7702 delegated accounts', async () => {
+      const eip7702Code = EIP_7702_DELEGATED_ACCOUNT_PREFIX + '1234567890abcdef1234567890abcdef12345678'
+      getCodeMock.mockResolvedValue(eip7702Code)
 
-      expect(getCodeMock).toHaveBeenCalledTimes(1)
+      const result = await isSmartContractWallet('1', toBeHex('0x1', 20))
+
+      expect(result).toBe(false)
     })
 
-    it('should not memoize different addresses on the same chain', async () => {
-      const chainId = '1'
+    it('should return false for EOAs (empty bytecode)', async () => {
+      getCodeMock.mockResolvedValue(EMPTY_DATA)
 
-      await isSmartContractWallet(chainId, toBeHex('0x1', 20))
-      await isSmartContractWallet(chainId, toBeHex('0x2', 20))
+      const result = await isSmartContractWallet('1', toBeHex('0x1', 20))
 
-      expect(getCodeMock).toHaveBeenCalledTimes(2)
-    })
-
-    it('should not memoize the same address on difference chains', async () => {
-      for await (const i of Array.from({ length: 10 }, (_, i) => i + 1)) {
-        await isSmartContractWallet(i.toString(), toBeHex('0x1', 20))
-      }
-
-      expect(getCodeMock).toHaveBeenCalledTimes(10)
+      expect(result).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## What it solves
If an EOA has been upgraded to an EIP-7702 account, then this EOA was not able to sign off-chain signatures. Our checks were treating such account as a smart account and those have to submit on-chain signratures.

Resolves #

## How this PR fixes it
Our isSmartContract check returns true whenever getCode returns anything other than an empty data. For EIP-7702 accounts we do have data which is prefixed with 0xef0100. Those accounts are both smart accounts and EOAs. The user is still able to use them as EOAs. Now when we want to know if the wallet is an EOA we also check if the getCode returned is prefixed with 0xef0100

## How to test it
Use for example MM and upgrade an EOA to a smart acocunt. 
Now try to sign a tx - you should get a signrature prompt in MM instead of a on-chain tx request. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
