### PR TITLE
Refactor(AB): Address book hooks to handle multiple sources

### DIFF
--- a/apps/web/src/components/common/AddressBookInput/index.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.tsx
@@ -10,7 +10,7 @@ import css from './styles.module.css'
 import inputCss from '@/styles/inputs.module.css'
 import { isValidAddress } from '@safe-global/utils/utils/validation'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
-import { useAllMergedAddressBooks } from '@/hooks/useAllAddressBooks'
+import { useMergedAddressBooks } from '@/hooks/useAllAddressBooks'
 
 const abFilterOptions = createFilterOptions({
   stringify: (option: { label: string; name: string }) => option.name + ' ' + option.label,
@@ -22,14 +22,14 @@ const abFilterOptions = createFilterOptions({
 const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canAdd?: boolean }): ReactElement => {
   const [open, setOpen] = useState(false)
   const [openAddressBook, setOpenAddressBook] = useState<boolean>(false)
-  const mergedAddressBook = useAllMergedAddressBooks()
+  const mergedAddressBook = useMergedAddressBooks()
 
   const { setValue, control } = useFormContext()
   const addressValue = useWatch({ name, control })
 
   const allAddressBookEntries = useMemo(
     () =>
-      mergedAddressBook.map((entry) => ({
+      mergedAddressBook.list.map((entry) => ({
         label: entry.address,
         name: entry.name,
       })),

--- a/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -32,7 +32,6 @@ export type EthHashInfoProps = {
   children?: ReactNode
   trusted?: boolean
   ExplorerButtonProps?: ExplorerButtonProps
-  isAddressBookName?: boolean
   addressBookNameSource?: ContactSource
   highlight4bytes?: boolean
 }
@@ -56,7 +55,6 @@ const SrcEthHashInfo = ({
   ExplorerButtonProps,
   children,
   trusted = true,
-  isAddressBookName = false,
   addressBookNameSource,
   highlight4bytes = false,
 }: EthHashInfoProps): ReactElement => {
@@ -106,7 +104,7 @@ const SrcEthHashInfo = ({
               {name}
             </Box>
 
-            {isAddressBookName && (
+            {!!addressBookNameSource && (
               <Tooltip title={`From your ${addressBookNameSource} address book`} placement="top">
                 <span style={{ lineHeight: 0 }}>
                   <SvgIcon

--- a/apps/web/src/components/common/EthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/index.tsx
@@ -25,7 +25,6 @@ const EthHashInfo = ({
       copyPrefix={settings.shortName.copy}
       {...props}
       name={name}
-      isAddressBookName={props.isAddressBookName || !!addressBookItem}
       addressBookNameSource={props.addressBookNameSource || addressBookItem?.source}
       customAvatar={props.customAvatar}
       ExplorerButtonProps={{ title: link?.title || '', href: link?.href || '' }}

--- a/apps/web/src/components/tx-flow/flows/NestedTxSuccessScreen/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/NestedTxSuccessScreen/index.tsx
@@ -80,12 +80,7 @@ const NestedTxSuccessScreen = ({ txId }: Props) => {
             <Typography variant="body2" color="text.secondary">
               Parent Safe
             </Typography>
-            <EthHashInfo
-              address={cachedPendingTx.signerAddress}
-              name={parentSafeAddress}
-              isAddressBookName={Boolean(parentSafeAddress)}
-              shortAddress={false}
-            />
+            <EthHashInfo address={cachedPendingTx.signerAddress} name={parentSafeAddress} shortAddress={false} />
           </Box>
           <Stack direction="row" spacing={2} alignItems="center" pl={1}>
             <SvgIcon component={ArrowDownIcon} fontSize="medium" color="border" inheritViewBox />
@@ -109,12 +104,7 @@ const NestedTxSuccessScreen = ({ txId }: Props) => {
             <Typography variant="body2" color="text.secondary">
               Current Safe
             </Typography>
-            <EthHashInfo
-              address={cachedPendingTx.safeAddress}
-              name={currentSafeAddress}
-              isAddressBookName={Boolean(currentSafeAddress)}
-              shortAddress={false}
-            />
+            <EthHashInfo address={cachedPendingTx.safeAddress} name={currentSafeAddress} shortAddress={false} />
           </Box>
         </Stack>
         <Track {...MODALS_EVENTS.OPEN_PARENT_TX}>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/EditContactDialog.tsx
@@ -122,7 +122,7 @@ const EditContactDialog = ({ entry, onClose }: EditContactDialogProps) => {
             <Typography mb={2}>Edit contact details. Anyone in the space can see it.</Typography>
             <Stack spacing={3}>
               <Box pt={1}>
-                <AddressInputReadOnly address={entry.address} />
+                <AddressInputReadOnly address={entry.address} chainId={entry.chainIds[0]} />
               </Box>
 
               <NameInput name="name" label="Name" required />

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -38,7 +38,6 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
                 name={entry.name}
                 shortAddress={false}
                 showPrefix={false}
-                isAddressBookName={true}
                 addressBookNameSource={ContactSource.space}
                 hasExplorer
                 showCopyButton

--- a/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
+++ b/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import {
-  useAllMergedAddressBooks,
+  useMergedAddressBooks,
   useAddressBookItem,
   ContactSource,
   type ExtendedContact,
@@ -24,6 +24,7 @@ jest.mock('@/store/authSlice', () => ({
 
 jest.mock('@/store/addressBookSlice', () => ({
   selectAllAddressBooks: jest.fn(() => localAddressBook),
+  selectAddressBookByChain: jest.fn(() => localAddressBook),
 }))
 
 jest.mock('@/hooks/useAddressBook', () => () => localAddressBook)
@@ -58,11 +59,11 @@ describe('useAllAddressBooks', () => {
         '0xB': 'Bob',
       }
 
-      const { result } = renderHook(() => useAllMergedAddressBooks(mockChainId))
+      const { result } = renderHook(() => useMergedAddressBooks(mockChainId))
 
-      expect(result.current).toHaveLength(2)
-      expect(result.current.map((c) => c.address)).toEqual(['0xA', '0xB'])
-      result.current.forEach((c) => expect(c.source).toBe(ContactSource.local))
+      expect(result.current.list).toHaveLength(2)
+      expect(result.current.list.map((c) => c.address)).toEqual(['0xA', '0xB'])
+      result.current.list.forEach((c) => expect(c.source).toBe(ContactSource.local))
     })
 
     it('returns undefined when no chainId is provided', () => {
@@ -100,12 +101,12 @@ describe('useAllAddressBooks', () => {
         },
       ]
 
-      const { result } = renderHook(() => useAllMergedAddressBooks(mockChainId))
+      const { result } = renderHook(() => useMergedAddressBooks(mockChainId))
 
-      expect(result.current).toHaveLength(3)
-      expect(result.current.map((c) => c.address)).toEqual(['0xA', '0xC', '0xB'])
+      expect(result.current.list).toHaveLength(3)
+      expect(result.current.list.map((c) => c.address)).toEqual(['0xA', '0xC', '0xB'])
 
-      const addressToSource = Object.fromEntries(result.current.map((c) => [c.address, c.source]))
+      const addressToSource = Object.fromEntries(result.current.list.map((c) => [c.address, c.source]))
 
       expect(addressToSource).toEqual({
         '0xA': ContactSource.space,
@@ -129,7 +130,7 @@ describe('useAllAddressBooks', () => {
         {
           name: 'Alice',
           address: '0xA',
-          chainIds: ['1', '5'],
+          chainIds: ['1'],
           createdBy: '',
           lastUpdatedBy: '',
           source: ContactSource.space,

--- a/apps/web/src/hooks/useAddressBook.ts
+++ b/apps/web/src/hooks/useAddressBook.ts
@@ -1,10 +1,34 @@
-import { useAppSelector } from '@/store'
-import { selectAddressBookByChain } from '@/store/addressBookSlice'
+import { useMemo } from 'react'
+import { type AddressBook } from '@/store/addressBookSlice'
 import useChainId from './useChainId'
+import { ContactSource, useMergedAddressBooks } from '@/hooks/useAllAddressBooks'
+import { useSearchParams } from 'next/navigation'
 
-const useAddressBook = (chainId?: string) => {
-  const currentChainId = useChainId()
-  return useAppSelector((state) => selectAddressBookByChain(state, chainId ?? currentChainId))
+/**
+ * Returns an address book for a given chain adhering to the merge logic from spaces and local
+ */
+const useAddressBook = (chainId?: string): AddressBook => {
+  const fallbackChainId = useChainId()
+  const querySafe = useSearchParams().get('safe')
+  const actualChainId = chainId || fallbackChainId
+  const source = querySafe ? 'merged' : 'spaceOnly'
+  const mergedAddressBook = useMergedAddressBooks(actualChainId)
+
+  return useMemo<AddressBook>(() => {
+    const out: AddressBook = {}
+
+    for (const contact of mergedAddressBook.list) {
+      if (!contact.chainIds.includes(actualChainId)) continue
+      if (source === 'spaceOnly' && contact.source !== ContactSource.space) continue
+
+      const key = contact.address
+      if (out[key] == null && contact.name?.trim()) {
+        out[key] = contact.name
+      }
+    }
+
+    return out
+  }, [mergedAddressBook, actualChainId, source])
 }
 
 export default useAddressBook

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -1,19 +1,20 @@
 import { useAppSelector } from '@/store'
-import { type AddressBook, selectAllAddressBooks } from '@/store/addressBookSlice'
+import { type AddressBook, selectAddressBookByChain, selectAllAddressBooks } from '@/store/addressBookSlice'
 import { type SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useMemo } from 'react'
-import useAddressBook from '@/hooks/useAddressBook'
 import useChainId from '@/hooks/useChainId'
 import useGetSpaceAddressBook from '@/features/spaces/hooks/useGetSpaceAddressBook'
+import { useSearchParams } from 'next/navigation'
 
 export enum ContactSource {
   space = 'space',
   local = 'local',
 }
+
 export type ExtendedContact = SpaceAddressBookItemDto & { source: ContactSource }
 
-const mapAddressBook = (addressBook: AddressBook, chainId: string): ExtendedContact[] => {
+const mapLocalToContacts = (addressBook: AddressBook, chainId: string): ExtendedContact[] => {
   return Object.entries(addressBook).map(([address, name]) => ({
     name,
     address,
@@ -24,40 +25,63 @@ const mapAddressBook = (addressBook: AddressBook, chainId: string): ExtendedCont
   }))
 }
 
-const useLocalAddressBook = (chainId: string) => {
-  const addressBook = useAddressBook(chainId)
+const mapSpaceToContacts = (addressBook: SpaceAddressBookItemDto[]): ExtendedContact[] => {
+  if (!addressBook) return []
 
-  return useMemo(() => mapAddressBook(addressBook, chainId), [addressBook, chainId])
+  return addressBook.map<ExtendedContact>((entry) => ({
+    ...entry,
+    source: ContactSource.space,
+  }))
 }
 
-export const useAllMergedAddressBooks = (chainId?: string): ExtendedContact[] => {
+const addressBookKey = (address: string, chainId: string) => `${chainId}:${address.toLowerCase()}`
+
+export type MergedAddressBook = {
+  list: ExtendedContact[]
+  get: (address: string, chainId: string) => ExtendedContact | undefined
+  has: (address: string, chainId: string) => boolean
+}
+
+export const useMergedAddressBooks = (chainId?: string): MergedAddressBook => {
   const fallbackChainId = useChainId()
   const actualChainId = chainId ?? fallbackChainId
-  const addressBook = useGetSpaceAddressBook()
+  const spaceAddressBook = useGetSpaceAddressBook()
+  const localAddressBook = useAppSelector((state) => selectAddressBookByChain(state, actualChainId))
 
-  const spaceContacts = useMemo<ExtendedContact[]>(() => {
-    if (!addressBook) return []
+  return useMemo<MergedAddressBook>(() => {
+    const byKey = new Map<string, ExtendedContact>()
 
-    return addressBook.map<ExtendedContact>((entry) => ({
-      ...entry,
-      source: ContactSource.space,
-    }))
-  }, [addressBook])
+    const spaceContacts = mapSpaceToContacts(spaceAddressBook)
+    const localContacts = mapLocalToContacts(localAddressBook, actualChainId)
 
-  const localContacts = useLocalAddressBook(actualChainId)
+    for (const spaceContact of spaceContacts) {
+      for (const chainId of spaceContact.chainIds) {
+        byKey.set(addressBookKey(spaceContact.address, chainId), { ...spaceContact, chainIds: [chainId] })
+      }
+    }
 
-  return useMemo<ExtendedContact[]>(() => {
+    for (const localContact of localContacts) {
+      const key = addressBookKey(localContact.address, actualChainId)
+
+      if (!byKey.has(key)) {
+        byKey.set(key, localContact)
+      }
+    }
+
     // Only include local contacts if they don't already exist in the space address book
-    const filteredLocalContacts = localContacts.filter(
-      (localContact) =>
+    const filteredLocal = localContacts.filter(
+      (local) =>
         !spaceContacts.some(
-          (spaceContact) =>
-            sameAddress(spaceContact.address, localContact.address) && spaceContact.chainIds.includes(actualChainId),
+          (space) => sameAddress(space.address, local.address) && space.chainIds.includes(actualChainId),
         ),
     )
 
-    return [...spaceContacts, ...filteredLocalContacts]
-  }, [localContacts, spaceContacts, actualChainId])
+    const list = [...spaceContacts, ...filteredLocal]
+    const get = (address: string, chainId: string) => byKey.get(addressBookKey(address, chainId))
+    const has = (address: string, chainId: string) => byKey.has(addressBookKey(address, chainId))
+
+    return { list, get, has }
+  }, [actualChainId, localAddressBook, spaceAddressBook])
 }
 
 /**
@@ -66,16 +90,29 @@ export const useAllMergedAddressBooks = (chainId?: string): ExtendedContact[] =>
  * @param address
  * @param chainId
  */
-export const useAddressBookItem = (address: string, chainId: string | undefined) => {
-  const allAddressBooks = useAllMergedAddressBooks(chainId)
+export const useAddressBookItem = (address: string, chainId: string | undefined): ExtendedContact | undefined => {
+  const searchParams = useSearchParams()
+  const querySafe = searchParams.get('safe')
+  const { get } = useMergedAddressBooks(chainId)
+  const source = querySafe ? 'merged' : 'spaceOnly'
 
-  return chainId
-    ? allAddressBooks.find((entry) => sameAddress(entry.address, address) && entry.chainIds.includes(chainId))
-    : undefined
+  return useMemo<ExtendedContact | undefined>(() => {
+    if (!chainId) return undefined
+
+    if (source === 'merged') {
+      return get(address, chainId)
+    }
+
+    if (source === 'spaceOnly') {
+      const item = get(address, chainId)
+      return item?.source === ContactSource.space ? item : undefined
+    }
+
+    return undefined
+  }, [address, chainId, source, get])
 }
 
-const useAllAddressBooks = () => {
-  return useAppSelector(selectAllAddressBooks)
-}
+// Returns all local address books
+const useAllAddressBooks = () => useAppSelector(selectAllAddressBooks)
 
 export default useAllAddressBooks


### PR DESCRIPTION
## What it solves

Resolves [COR-493](https://linear.app/safe-global/issue/COR-493/spaces-address-book-names-are-only-visible-if-wallet-is-on-the-correct)

## How this PR fixes it

- Updates `useAddressBook` to respect multiple address book sources
- Makes address book hooks context aware of spaces

## How to test it

- Within spaces any address name should only come from the space address book
- Within a safe any address name should either come from the space address book or from the local one in that order

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
