### PR TITLE
fix: Prefer canonical contract addresses for Safe creation

### DIFF
--- a/apps/web/src/components/new-safe/create/logic/utils.ts
+++ b/apps/web/src/components/new-safe/create/logic/utils.ts
@@ -4,8 +4,6 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { createWeb3ReadOnly, getRpcServiceUrl } from '@/hooks/wallets/web3'
 import { type ReplayedSafeProps } from '@safe-global/utils/features/counterfactual/store/types'
 import { predictAddressBasedOnReplayData } from '@/features/multichain/utils/utils'
-import chains from '@/config/chains'
-import { computeNewSafeAddress } from '.'
 
 export const getAvailableSaltNonce = async (
   customRpcs: {
@@ -35,24 +33,8 @@ export const getAvailableSaltNonce = async (
     if (!web3ReadOnly) {
       throw new Error('Could not initiate RPC')
     }
-    let safeAddress: string
-    // FIXME a new check to indicate ZKsync chain will be added to the config service and available under ChainInfo
-    if (chain.chainId === chains['zksync'] || chain.chainId === chains['lens']) {
-      // ZK-sync is using a different create2 method which is supported by the SDK
-      safeAddress = await computeNewSafeAddress(
-        rpcUrl,
-        {
-          safeAccountConfig: replayedSafe.safeAccountConfig,
-          safeDeploymentConfig: {
-            saltNonce: replayedSafe.saltNonce,
-            safeVersion: replayedSafe.safeVersion,
-          },
-        },
-        chain,
-      )
-    } else {
-      safeAddress = await predictAddressBasedOnReplayData(replayedSafe, web3ReadOnly)
-    }
+    const safeAddress = await predictAddressBasedOnReplayData(replayedSafe, web3ReadOnly)
+
     const isKnown = knownSafeAddresses.some((knownAddress) => sameAddress(knownAddress, safeAddress))
     if (isKnown || (await isSmartContract(safeAddress, web3ReadOnly))) {
       // We found a chain where the nonce is used up

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -6,7 +6,6 @@ import { getTotalFeeFormatted } from '@/hooks/useGasPrice'
 import type { StepRenderProps } from '@/components/new-safe/CardStepper/useCardStepper'
 import type { NewSafeFormData } from '@/components/new-safe/create'
 import {
-  computeNewSafeAddress,
   createNewSafe,
   createNewUndeployedSafeWithoutSalt,
   relaySafeCreation,
@@ -53,9 +52,8 @@ import { selectRpc } from '@/store/settingsSlice'
 import { AppRoutes } from '@/config/routes'
 import { type ReplayedSafeProps } from '@safe-global/utils/features/counterfactual/store/types'
 import { predictAddressBasedOnReplayData } from '@/features/multichain/utils/utils'
-import { createWeb3ReadOnly, getRpcServiceUrl } from '@/hooks/wallets/web3'
+import { createWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { updateAddressBook } from '../../logic/address-book'
-import chains from '@/config/chains'
 import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
 import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
 import { type TransactionOptions } from '@safe-global/types-kit'

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -245,24 +245,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
       const provider = createWeb3ReadOnly(chain, customRpcUrl)
       if (!provider) return
 
-      let safeAddress: string
-
-      // FIXME a new check to indicate ZKsync chain will be added to the config service and available under ChainInfo
-      if (chain.chainId === chains['zksync'] || chain.chainId === chains['lens']) {
-        safeAddress = await computeNewSafeAddress(
-          customRpcUrl || getRpcServiceUrl(chain.rpcUri),
-          {
-            safeAccountConfig: replayedSafeWithNonce.safeAccountConfig,
-            safeDeploymentConfig: {
-              saltNonce: nextAvailableNonce,
-              safeVersion: replayedSafeWithNonce.safeVersion,
-            },
-          },
-          chain,
-        )
-      } else {
-        safeAddress = await predictAddressBasedOnReplayData(replayedSafeWithNonce, provider)
-      }
+      const safeAddress = await predictAddressBasedOnReplayData(replayedSafeWithNonce, provider)
 
       for (const network of data.networks) {
         await createSafe(network, replayedSafeWithNonce, safeAddress)

--- a/packages/utils/src/services/contracts/__tests__/deployments.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/deployments.test.ts
@@ -1,0 +1,67 @@
+import type { SingletonDeploymentV2 } from '@safe-global/safe-deployments'
+import { getCanonicalOrFirstAddress, hasCanonicalDeployment } from '../../contracts/deployments'
+
+describe('deployments utils', () => {
+  const chainId = '1'
+
+  const makeDeployment = (params: Partial<SingletonDeploymentV2>): SingletonDeploymentV2 => {
+    const base: SingletonDeploymentV2 = {
+      version: '1.4.1',
+      contractName: 'Test',
+      deployments: {},
+      networkAddresses: {},
+      abi: [],
+    } as unknown as SingletonDeploymentV2
+
+    return { ...base, ...(params as SingletonDeploymentV2) }
+  }
+
+  describe('hasCanonicalDeployment', () => {
+    it('returns true when canonical address is present in network addresses', () => {
+      const canonical = '0x1111111111111111111111111111111111111111'
+      const deployment = makeDeployment({
+        deployments: { canonical: { address: canonical, codeHash: '0xhash' } } as any,
+        networkAddresses: { [chainId]: [canonical] } as any,
+      })
+      expect(hasCanonicalDeployment(deployment, chainId)).toBe(true)
+    })
+
+    it('returns false when canonical missing or not in network addresses', () => {
+      const canonical = '0x1111111111111111111111111111111111111111'
+      const other = '0x2222222222222222222222222222222222222222'
+      expect(hasCanonicalDeployment(undefined, chainId)).toBe(false)
+      const deployment = makeDeployment({
+        deployments: { canonical: { address: canonical, codeHash: '0xhash' } } as any,
+        networkAddresses: { [chainId]: [other] } as any,
+      })
+      expect(hasCanonicalDeployment(deployment, chainId)).toBe(false)
+    })
+  })
+
+  describe('getCanonicalOrFirstAddress', () => {
+    it('returns canonical when present for chain', () => {
+      const canonical = '0x3333333333333333333333333333333333333333'
+      const first = '0x4444444444444444444444444444444444444444'
+      const deployment = makeDeployment({
+        deployments: { canonical: { address: canonical, codeHash: '0xhash' } } as any,
+        networkAddresses: { [chainId]: [first, canonical] } as any,
+      })
+      expect(getCanonicalOrFirstAddress(deployment, chainId)).toBe(canonical)
+    })
+
+    it('returns first network address when canonical not present for chain', () => {
+      const canonical = '0x3333333333333333333333333333333333333333'
+      const first = '0x4444444444444444444444444444444444444444'
+      const second = '0x5555555555555555555555555555555555555555'
+      const deployment = makeDeployment({
+        deployments: { canonical: { address: canonical, codeHash: '0xhash' } } as any,
+        networkAddresses: { [chainId]: [first, second] } as any,
+      })
+      expect(getCanonicalOrFirstAddress(deployment, chainId)).toBe(first)
+    })
+
+    it('returns undefined when no deployment', () => {
+      expect(getCanonicalOrFirstAddress(undefined, chainId)).toBeUndefined()
+    })
+  })
+})

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -31,6 +31,24 @@ export const hasCanonicalDeployment = (deployment: SingletonDeploymentV2 | undef
 }
 
 /**
+ * Returns the canonical address for a deployment on a given network if available and present,
+ * otherwise returns the first network-specific address. Undefined if no deployment.
+ */
+export const getCanonicalOrFirstAddress = (
+  deployment: SingletonDeploymentV2 | undefined,
+  chainId: string,
+): string | undefined => {
+  if (!deployment) return undefined
+
+  if (hasCanonicalDeployment(deployment, chainId)) {
+    return deployment.deployments.canonical?.address
+  }
+
+  const addresses = toNetworkAddressList(deployment.networkAddresses[chainId] ?? [])
+  return addresses[0]
+}
+
+/**
  * Checks if any of the deployments returned by the `getDeployments` function for the given `network` and `versions` contain a deployment for the `contractAddress`
  *
  * @param getDeployments function to get the contract deployments


### PR DESCRIPTION
## What it solves

[COR-509](https://linear.app/safe-global/issue/COR-509/prefer-canonical-contract-addresses-for-multichain-safe-creation-on)

Prefer the canonical addresses for core contracts when creating a new Safe. This is necessary to ensure the multichain Safe creation works when deploying on zkSync/Lens and an EVM-based chain.

## How this PR fixes it
Introduced `getCanonicalOrFirstAddress` util in packages/utils, refactored web Safe creation to use it for all contracts, and added unit tests.

## How to test it

### 1. Addition of EVM-based network to zkSync or Lens Safe
1. Create multichain Safe on Lens/zkSync
2. Then add Sepolia
3. Expected: No errors due to chain-specific addresses.

### 2. Safe creation
1. Create multichain Safe on Lens/zkSync + Sepolia
2. Expected: No errors due to chain-specific addresses.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
