### PR TITLE
Proposal for natural language driven e2e tests

### DIFF
--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Debug PATH
         run: |
+          echo "Initial memory usage:"
+          free -h
           echo "Current PATH:"
           echo $PATH
       - name: Check disk space (initial)
@@ -24,6 +26,8 @@ jobs:
         run: |
           echo "Disk usage after checkout:"
           df -h
+          echo "Memory after checkout:"
+          free -h
       - name: Cache Yarn dependencies
         uses: actions/cache@v4
         with:
@@ -37,6 +41,8 @@ jobs:
         run: |
           echo "Disk usage after yarn install:"
           df -h
+          echo "Memory after yarn install:"
+          free -h
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
@@ -53,6 +59,8 @@ jobs:
         run: |
           echo "Cleaning /tmp and pip cache before StoryCheck:"
           rm -rf /tmp/* ~/.cache/pip || true
+          echo "Memory before cleaning:"
+          free -h
           df -h
       - name: Run StoryCheck
         id: storycheck      
@@ -74,6 +82,8 @@ jobs:
         run: |
           echo "Cleaning /tmp, pip cache, and results after StoryCheck:"
           rm -rf /tmp/* ~/.cache/pip results/* || true
+          echo "Memory after cleaning:"
+          free -h
           df -h
       - name: Check disk space (final)
         if: always()

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -11,6 +11,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - name: Debug PATH
+        run: |
+          echo "Current PATH:"
+          echo $PATH
+      - name: Install Foundry (Fallback)
+        run: |
+          echo "Installing Foundry manually as fallback..."
+          curl -L https://foundry.paradigm.xyz | bash
+          export PATH="$HOME/.foundry/bin:$PATH"
+          foundryup || { echo "Foundry installation failed"; exit 1; }
       - name: Check disk space (initial)
         run: |
           echo "Disk usage before any steps:"
@@ -49,8 +59,10 @@ jobs:
         run: |
           echo "Checking if port 8545 is in use:"
           netstat -tuln | grep :8545 || echo "Port 8545 is free"
-      - name: Verify Anvil installation
+      - name: Verify Foundry and Anvil installation
         run: |
+          echo "Verifying Foundry installation:"
+          foundryup --version || { echo "Foundry not found or failed to run"; exit 1; }
           echo "Verifying Anvil installation:"
           anvil --version || { echo "Anvil not found or failed to run"; exit 1; }
       - name: Clean temporary files (pre-storycheck)
@@ -65,13 +77,11 @@ jobs:
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
           NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 
           STORYCHECK_DISABLE_VIDEOS: 'true'  # Disable video recordings to save disk
-          STORYCHECK_ANVIL_LOG: 'true'  # Enable Anvil logging for debugging
         with:
           storypath: 'user-stories/create-account'
           start-command: 'yarn workspace @safe-global/web start'
           wait-on: 'http://localhost:3000'
           wait-on-timeout: '60'
-          anvil-timeout: '60'  # Increase Anvil timeout to 60 seconds
           app-working-directory: 'user-stories/create-account'
       - name: Check if passed
         if: ${{ steps.storycheck.outputs.passed != 'true' }}

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run StoryCheck
         id: storycheck      
-        uses: GuardianUI/storycheck@v0.1.3
+        uses: GuardianUI/storycheck@v0.1.4
         env: 
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}        
         with:

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -20,11 +20,13 @@ jobs:
         id: storycheck      
         uses: GuardianUI/storycheck@v0.1.4
         env: 
-          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}        
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
+          NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 
+
         with:
           storypath: 'user-stories/create-account'
-          start-command: yarn workspace @safe-global/web serve
-          wait-on: 'http://localhost:8080'
+          start-command: yarn workspace @safe-global/web start
+          wait-on: 'http://localhost:3000'
           wait-on-timeout: '60'
           app-working-directory: 'user-stories/create-account'
       - name: Check if passed

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -15,13 +15,6 @@ jobs:
         run: |
           echo "Current PATH:"
           echo $PATH
-      - name: Install Foundry (Fallback)
-        run: |
-          echo "Installing Foundry manually as fallback..."
-          curl -L https://foundry.paradigm.xyz | bash
-          source /home/runner/.bashrc
-          export PATH="$HOME/.foundry/bin:$PATH"
-          foundryup || { echo "Foundry installation failed"; exit 1; }
       - name: Check disk space (initial)
         run: |
           echo "Disk usage before any steps:"
@@ -56,16 +49,6 @@ jobs:
           path: ~/.cache/huggingface
           key: ${{ runner.os }}-hf-cache-${{ hashFiles('user-stories/create-account/requirements.txt') }}-${{ hashFiles('interpreter/ai/local_refexp.py') }}
           restore-keys: ${{ runner.os }}-hf-cache-
-      - name: Check for port conflicts
-        run: |
-          echo "Checking if port 8545 is in use:"
-          netstat -tuln | grep :8545 || echo "Port 8545 is free"
-      - name: Verify Foundry and Anvil installation
-        run: |
-          echo "Verifying Foundry installation:"
-          foundryup --version || { echo "Foundry not found or failed to run"; exit 1; }
-          echo "Verifying Anvil installation:"
-          anvil --version || { echo "Anvil not found or failed to run"; exit 1; }
       - name: Clean temporary files (pre-storycheck)
         run: |
           echo "Cleaning /tmp and pip cache before StoryCheck:"
@@ -77,7 +60,6 @@ jobs:
         env: 
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
           NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 
-          STORYCHECK_DISABLE_VIDEOS: 'true'  # Disable video recordings to save disk
         with:
           storypath: 'user-stories/create-account'
           start-command: 'yarn workspace @safe-global/web start'

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -15,51 +15,21 @@ jobs:
         run: |
           echo "Current PATH:"
           echo $PATH
-      - name: Check disk space (initial)
-        run: |
-          echo "Disk usage before any steps:"
-          df -h
       - uses: actions/checkout@v5
       - name: Check disk space (post-checkout)
         run: |
           echo "Disk usage after checkout:"
           df -h
-      - name: Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.yarn/cache
-            **/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-
       - uses: ./.github/actions/yarn
       - name: Check disk space (post-yarn)
         run: |
           echo "Disk usage after yarn install:"
           df -h
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('user-stories/create-account/requirements.txt') }}
-          restore-keys: ${{ runner.os }}-playwright-
-      - name: Maximize disk space
-        uses: easimon/maximize-build-space@v10
-        with:
-          remove-dotnet: 'true'  # Remove large .NET SDK if present
-          overprovision-lvm: 'true'  # Expand root if possible
-      - name: Cache Hugging Face model
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/huggingface
-          key: ${{ runner.os }}-hf-cache-${{ hashFiles('user-stories/create-account/requirements.txt') }}-${{ hashFiles('interpreter/ai/local_refexp.py') }}
-          restore-keys: ${{ runner.os }}-hf-cache-
-      - name: Clean temporary files (pre-storycheck)
-        run: |
-          rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true  # Extra cleanup for common large dirs
-          echo "Cleaning /tmp and pip cache before StoryCheck:"
-          rm -rf /tmp/* ~/.cache/pip || true
-          df -h
+      # - name: Maximize disk space
+      #   uses: easimon/maximize-build-space@v10
+      #   with:
+      #     remove-dotnet: 'true'  # Remove large .NET SDK if present
+      #     overprovision-lvm: 'true'  # Expand root if possible
       - name: Run StoryCheck
         id: storycheck      
         uses: GuardianUI/storycheck@v0.1.4
@@ -76,13 +46,6 @@ jobs:
       - name: Check if passed
         if: ${{ steps.storycheck.outputs.passed != 'true' }}
         run: echo "StoryCheck failed!" && exit 1
-      - name: Clean temporary files (post-storycheck)
-        if: always()
-        run: |
-          echo "Cleaning /tmp, pip cache, and results after StoryCheck:"
-          rm -rf /tmp/* ~/.cache/pip results/* || true
-          rm -rf /mnt/hf_cache || true  # Clean relocated cache if needed
-          df -h
       - name: Check disk space (final)
         if: always()
         run: |

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -11,9 +11,15 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check disk space (pre)
-        run: df -h
+      - name: Check disk space (initial)
+        run: |
+          echo "Disk usage before checkout:"
+          df -h
       - uses: actions/checkout@v5
+      - name: Check disk space (post-checkout)
+        run: |
+          echo "Disk usage after checkout:"
+          df -h
       - name: Cache Yarn dependencies
         uses: actions/cache@v4
         with:
@@ -23,28 +29,34 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-
       - uses: ./.github/actions/yarn
+      - name: Check disk space (post-yarn)
+        run: |
+          echo "Disk usage after yarn install:"
+          df -h
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('requirements.txt') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('user-stories/create-account/requirements.txt') }}
           restore-keys: ${{ runner.os }}-playwright-
       - name: Cache Hugging Face model
         uses: actions/cache@v4
         with:
           path: ~/.cache/huggingface
-          key: ${{ runner.os }}-hf-cache-${{ hashFiles('requirements.txt') }}-${{ hashFiles('interpreter/ai/local_refexp.py') }}
+          key: ${{ runner.os }}-hf-cache-${{ hashFiles('user-stories/create-account/requirements.txt') }}-${{ hashFiles('interpreter/ai/local_refexp.py') }}
           restore-keys: ${{ runner.os }}-hf-cache-
-      - name: Check disk space (post)
-        if: always()
-        run: df -h
+      - name: Clean temporary files (pre-storycheck)
+        run: |
+          echo "Cleaning /tmp and pip cache before StoryCheck:"
+          rm -rf /tmp/* ~/.cache/pip || true
+          df -h
       - name: Run StoryCheck
         id: storycheck      
         uses: GuardianUI/storycheck@v0.1.4
         env: 
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
           NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 
-          STORYCHECK_DISABLE_VIDEOS: 'true'  # Disable video recordings in CI to save space
+          STORYCHECK_DISABLE_VIDEOS: 'true'  # Disable video recordings to save disk
         with:
           storypath: 'user-stories/create-account'
           start-command: 'yarn workspace @safe-global/web start'
@@ -54,11 +66,14 @@ jobs:
       - name: Check if passed
         if: ${{ steps.storycheck.outputs.passed != 'true' }}
         run: echo "StoryCheck failed!" && exit 1
-      - name: Clean temporary files
+      - name: Clean temporary files (post-storycheck)
         if: always()
         run: |
-          rm -rf /tmp/* ~/.cache/pip || true
+          echo "Cleaning /tmp, pip cache, and results after StoryCheck:"
+          rm -rf /tmp/* ~/.cache/pip results/* || true
           df -h
-      - name: Check disk space (post)
+      - name: Check disk space (final)
         if: always()
-        run: df -h
+        run: |
+          echo "Final disk usage:"
+          df -h

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -35,7 +35,7 @@ jobs:
         uses: GuardianUI/storycheck@v0.1.4
         env: 
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
-          HF_HOME: /mnt/hf_cache  # Redirect HF model downloads to /mnt (more space)
+          # HF_HOME: /mnt/hf_cache  # Redirect HF model downloads to /mnt (more space)
           NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 
         with:
           storypath: 'user-stories/create-account'

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Debug PATH
         run: |
-          echo "Initial memory usage:"
-          free -h
           echo "Current PATH:"
           echo $PATH
       - name: Check disk space (initial)
@@ -26,8 +24,6 @@ jobs:
         run: |
           echo "Disk usage after checkout:"
           df -h
-          echo "Memory after checkout:"
-          free -h
       - name: Cache Yarn dependencies
         uses: actions/cache@v4
         with:
@@ -41,14 +37,17 @@ jobs:
         run: |
           echo "Disk usage after yarn install:"
           df -h
-          echo "Memory after yarn install:"
-          free -h
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('user-stories/create-account/requirements.txt') }}
           restore-keys: ${{ runner.os }}-playwright-
+      - name: Maximize disk space
+        uses: easimon/maximize-build-space@v10
+        with:
+          remove-dotnet: 'true'  # Remove large .NET SDK if present
+          overprovision-lvm: 'true'  # Expand root if possible
       - name: Cache Hugging Face model
         uses: actions/cache@v4
         with:
@@ -57,16 +56,16 @@ jobs:
           restore-keys: ${{ runner.os }}-hf-cache-
       - name: Clean temporary files (pre-storycheck)
         run: |
+          rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true  # Extra cleanup for common large dirs
           echo "Cleaning /tmp and pip cache before StoryCheck:"
           rm -rf /tmp/* ~/.cache/pip || true
-          echo "Memory before cleaning:"
-          free -h
           df -h
       - name: Run StoryCheck
         id: storycheck      
         uses: GuardianUI/storycheck@v0.1.4
         env: 
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
+          HF_HOME: /mnt/hf_cache  # Redirect HF model downloads to /mnt (more space)
           NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 
         with:
           storypath: 'user-stories/create-account'
@@ -82,8 +81,7 @@ jobs:
         run: |
           echo "Cleaning /tmp, pip cache, and results after StoryCheck:"
           rm -rf /tmp/* ~/.cache/pip results/* || true
-          echo "Memory after cleaning:"
-          free -h
+          rm -rf /mnt/hf_cache || true  # Clean relocated cache if needed
           df -h
       - name: Check disk space (final)
         if: always()

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -12,13 +12,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v5
+
       - uses: ./.github/actions/yarn
 
       - uses: ./.github/actions/build
         with:
           secrets: ${{ inputs.secrets }}
-
-      - uses: actions/checkout@v5
 
       - name: Run StoryCheck
         id: storycheck      

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           echo "Installing Foundry manually as fallback..."
           curl -L https://foundry.paradigm.xyz | bash
+          source /home/runner/.bashrc
           export PATH="$HOME/.foundry/bin:$PATH"
           foundryup || { echo "Foundry installation failed"; exit 1; }
       - name: Check disk space (initial)

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -6,9 +6,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
   push:
-    branches: [main, dev]
+    branches: [dev]
   pull_request:
-    branches: [main, dev]
+    branches: [dev]
 
 jobs:
   check:
@@ -18,10 +18,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-      - name: Check disk space (post-checkout)
-        run: |
-          echo "Disk usage after checkout:"
-          df -h
       - name: Run StoryCheck
         id: storycheck      
         uses: GuardianUI/storycheck@v0.1.4

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -1,0 +1,36 @@
+# File: .github/workflows/storycheck-example.yml
+name: StoryCheck Simple Web3 App
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/yarn
+
+      - uses: ./.github/actions/build
+        with:
+          secrets: ${{ inputs.secrets }}
+
+      - uses: actions/checkout@v5
+
+      - name: Run StoryCheck
+        id: storycheck      
+        uses: GuardianUI/storycheck@v0.1.3
+        env: 
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}        
+        with:
+          storypath: 'user-stories/create-account'
+          start-command: yarn workspace @safe-global/web serve
+          wait-on: 'http://localhost:8080'
+          wait-on-timeout: '60'
+          app-working-directory: 'user-stories/create-account'
+      - name: Check if passed
+        if: ${{ steps.storycheck.outputs.passed != 'true' }}
+        run: echo "StoryCheck failed!" && exit 1

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -1,7 +1,10 @@
 # File: .github/workflows/storycheck-example.yml
-name: StoryCheck Simple Web3 App
+name: StoryCheck SAFE Create Account Example
 
 on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
   push:
     branches: [main, dev]
   pull_request:
@@ -9,45 +12,23 @@ on:
 
 jobs:
   check:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'e2e-test')
+    name: Install and build
     runs-on: ubuntu-latest
     steps:
-      - name: Debug PATH
-        run: |
-          echo "Current PATH:"
-          echo $PATH
-      - uses: actions/checkout@v5
+      - name: Checkout code
+        uses: actions/checkout@v5
       - name: Check disk space (post-checkout)
         run: |
           echo "Disk usage after checkout:"
           df -h
-      - uses: ./.github/actions/yarn
-      - name: Check disk space (post-yarn)
-        run: |
-          echo "Disk usage after yarn install:"
-          df -h
-      # - name: Maximize disk space
-      #   uses: easimon/maximize-build-space@v10
-      #   with:
-      #     remove-dotnet: 'true'  # Remove large .NET SDK if present
-      #     overprovision-lvm: 'true'  # Expand root if possible
       - name: Run StoryCheck
         id: storycheck      
         uses: GuardianUI/storycheck@v0.1.4
         env: 
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
-          # HF_HOME: /mnt/hf_cache  # Redirect HF model downloads to /mnt (more space)
-          NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 
         with:
           storypath: 'user-stories/create-account'
-          start-command: 'yarn workspace @safe-global/web start'
-          wait-on: 'http://localhost:3000'
-          wait-on-timeout: '60'
-          app-working-directory: 'user-stories/create-account'
       - name: Check if passed
         if: ${{ steps.storycheck.outputs.passed != 'true' }}
         run: echo "StoryCheck failed!" && exit 1
-      - name: Check disk space (final)
-        if: always()
-        run: |
-          echo "Final disk usage:"
-          df -h

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Check disk space (initial)
         run: |
-          echo "Disk usage before checkout:"
+          echo "Disk usage before any steps:"
           df -h
       - uses: actions/checkout@v5
       - name: Check disk space (post-checkout)
@@ -45,6 +45,14 @@ jobs:
           path: ~/.cache/huggingface
           key: ${{ runner.os }}-hf-cache-${{ hashFiles('user-stories/create-account/requirements.txt') }}-${{ hashFiles('interpreter/ai/local_refexp.py') }}
           restore-keys: ${{ runner.os }}-hf-cache-
+      - name: Check for port conflicts
+        run: |
+          echo "Checking if port 8545 is in use:"
+          netstat -tuln | grep :8545 || echo "Port 8545 is free"
+      - name: Verify Anvil installation
+        run: |
+          echo "Verifying Anvil installation:"
+          anvil --version || { echo "Anvil not found or failed to run"; exit 1; }
       - name: Clean temporary files (pre-storycheck)
         run: |
           echo "Cleaning /tmp and pip cache before StoryCheck:"
@@ -57,11 +65,13 @@ jobs:
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
           NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 
           STORYCHECK_DISABLE_VIDEOS: 'true'  # Disable video recordings to save disk
+          STORYCHECK_ANVIL_LOG: 'true'  # Enable Anvil logging for debugging
         with:
           storypath: 'user-stories/create-account'
           start-command: 'yarn workspace @safe-global/web start'
           wait-on: 'http://localhost:3000'
           wait-on-timeout: '60'
+          anvil-timeout: '60'  # Increase Anvil timeout to 60 seconds
           app-working-directory: 'user-stories/create-account'
       - name: Check if passed
         if: ${{ steps.storycheck.outputs.passed != 'true' }}

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Run StoryCheck
         id: storycheck      
-        uses: GuardianUI/storycheck@v0.1.4
+        uses: GuardianUI/storycheck@v0.1.5
         env: 
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
           NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -7,28 +7,58 @@ on:
   pull_request:
     branches: [main, dev]
 
-
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - name: Check disk space (pre)
+        run: df -h
       - uses: actions/checkout@v5
-
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.yarn/cache
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
       - uses: ./.github/actions/yarn
-
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-playwright-
+      - name: Cache Hugging Face model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: ${{ runner.os }}-hf-cache-${{ hashFiles('requirements.txt') }}-${{ hashFiles('interpreter/ai/local_refexp.py') }}
+          restore-keys: ${{ runner.os }}-hf-cache-
+      - name: Check disk space (post)
+        if: always()
+        run: df -h
       - name: Run StoryCheck
         id: storycheck      
-        uses: GuardianUI/storycheck@v0.1.5
+        uses: GuardianUI/storycheck@v0.1.4
         env: 
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}       
           NEXT_PUBLIC_MIXPANEL_TOKEN: ${{ secrets.NEXT_PUBLIC_MIXPANEL_TOKEN }} 
-
+          STORYCHECK_DISABLE_VIDEOS: 'true'  # Disable video recordings in CI to save space
         with:
           storypath: 'user-stories/create-account'
-          start-command: yarn workspace @safe-global/web start
+          start-command: 'yarn workspace @safe-global/web start'
           wait-on: 'http://localhost:3000'
           wait-on-timeout: '60'
           app-working-directory: 'user-stories/create-account'
       - name: Check if passed
         if: ${{ steps.storycheck.outputs.passed != 'true' }}
         run: echo "StoryCheck failed!" && exit 1
+      - name: Clean temporary files
+        if: always()
+        run: |
+          rm -rf /tmp/* ~/.cache/pip || true
+          df -h
+      - name: Check disk space (post)
+        if: always()
+        run: df -h

--- a/.github/workflows/storycheck-example.yml
+++ b/.github/workflows/storycheck-example.yml
@@ -16,10 +16,6 @@ jobs:
 
       - uses: ./.github/actions/yarn
 
-      - uses: ./.github/actions/build
-        with:
-          secrets: ${{ inputs.secrets }}
-
       - name: Run StoryCheck
         id: storycheck      
         uses: GuardianUI/storycheck@v0.1.3

--- a/user-stories/create-account/story.md
+++ b/user-stories/create-account/story.md
@@ -6,7 +6,7 @@ This user story walks through creating a new Safe account with 1 signer.
 
 1. Chain
    - Id 11155111
-   - RPC https://sepolia.infura.io/
+   - RPC https://rpc.sepolia.org
    - Block 9013864
 2. Browser
    - Pixel 7
@@ -14,7 +14,7 @@ This user story walks through creating a new Safe account with 1 signer.
 
 ## User Steps
 
-1. Browse to http://localhost:3000/welcome/accounts
+1. Browse to http://app.safe.global/welcome/accounts
 1. Click Accept
 1. Click Connect 
 1. Click MetaMask
@@ -27,7 +27,6 @@ This user story walks through creating a new Safe account with 1 signer.
 1. Click Next
 1. Click Pay Now
 1. Scroll down
-1. Click Connected Wallet radio button
 1. Click Create Account
 1. Wait 5 seconds
 

--- a/user-stories/create-account/story.md
+++ b/user-stories/create-account/story.md
@@ -6,7 +6,7 @@ This user story walks through creating a new Safe account with 1 signer.
 
 1. Chain
    - Id 11155111
-   - RPC https://rpc.sepolia.org
+   - RPC https://sepolia.infura.io/
    - Block 9013864
 2. Browser
    - Pixel 7
@@ -14,7 +14,7 @@ This user story walks through creating a new Safe account with 1 signer.
 
 ## User Steps
 
-1. Browse to http://localhost:8080/welcome/accounts
+1. Browse to http://localhost:3000/welcome/accounts
 1. Click Accept
 1. Click Connect 
 1. Click MetaMask
@@ -27,6 +27,7 @@ This user story walks through creating a new Safe account with 1 signer.
 1. Click Next
 1. Click Pay Now
 1. Scroll down
+1. Click Connected Wallet radio button
 1. Click Create Account
 1. Wait 5 seconds
 

--- a/user-stories/create-account/story.md
+++ b/user-stories/create-account/story.md
@@ -1,0 +1,36 @@
+# Create a new Safe Account
+
+This user story walks through creating a new Safe account with 1 signer.
+
+## Prerequisites
+
+1. Chain
+   - Id 11155111
+   - RPC https://rpc.sepolia.org
+   - Block 9013864
+2. Browser
+   - Pixel 7
+
+
+## User Steps
+
+1. Browse to http://localhost:8080/welcome/accounts
+1. Click Accept
+1. Click Connect 
+1. Click MetaMask
+1. Click Create Account
+1. Click on Name field
+1. Type MyTestAccount
+1. Scroll down
+1. Click Next
+1. Scroll down
+1. Click Next
+1. Click Pay Now
+1. Scroll down
+1. Click Create Account
+1. Wait 5 seconds
+
+## Expected Results
+
+- Verify account created [verifier](verifiers/tx_success.py)
+

--- a/user-stories/create-account/verifiers/tx_success.py
+++ b/user-stories/create-account/verifiers/tx_success.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+from web3 import Web3
+
+def verify(results_dir):
+    manifest_path = Path(results_dir) / "manifest.json"
+    with open(manifest_path, 'r') as f:
+        manifest = json.load(f)
+    tx_snapshot_path = Path(results_dir) / manifest["tx_snapshot"]
+    with open(tx_snapshot_path, 'r') as f:
+        tx_snapshot = json.load(f)
+    tx_hash = tx_snapshot[0]['writeTxResult']
+
+    w3 = Web3(Web3.HTTPProvider('http://127.0.0.1:8545'))
+
+    receipt = w3.eth.get_transaction_receipt(tx_hash)
+
+    if receipt is None or receipt.status != 1:
+        raise Exception('Transaction failed or not found')
+
+    event_sig = w3.keccak(text='ProxyCreation(address,address)').hex()
+    logs = [log for log in receipt.logs if log.topics[0].hex() == event_sig]
+    if not logs:
+        raise Exception('No Safe proxy deployed')
+
+    proxy = '0x' + logs[0].data.hex()[26:66]
+    singleton = '0x' + logs[0].data.hex()[90:130]
+    print(f'Safe proxy deployed at {proxy} with singleton {singleton}')
+
+    return True


### PR DESCRIPTION
## What it solves

- Helps minimize dependency on brittle cypress tests that depend on CSS and HTML selectors that often change
- Helps reduce false failures reported by storybook when layout or colors of components change slightly
- Helps sync documentation with tests
- Helps speed up conversion of user reported problems to tests
- Helps automate continuous manual app testing 

## How this PR fixes it

- Provides an example for creating a SAFE account using natural language instructions and deterministic chain state verifier

## How to test it

- The test runs automatically on dev push/pull request as well as chron and on manual triggers
- The test currently runs against the safe main app web site
  - Currently it fails mid-way because the safe web site errors. See artifacts with video and screenshots here:
  - https://github.com/ivelin/safe-wallet-monorepo/actions/runs/17190306380/artifacts/3838154819
  - https://github.com/ivelin/safe-wallet-monorepo/actions/runs/17189716997
- The same test passes locally against the latest dev branch code. However when run in CI, github runs out of space for some reason. Not sure what exactly takes up so much space. I tried to resolve for a few hours and paused for now:
https://github.com/ivelin/safe-wallet-monorepo/actions/runs/17189716997
- Here is an example of a CI run of a similar test against a simple web3 app which passes:
https://github.com/GuardianUI/storycheck/actions/runs/17179728767/job/48740562478

## Screenshots

<img width="1082" height="2202" alt="1756049159 3150792_click-create-account_annotated_click" src="https://github.com/user-attachments/assets/2ef43abe-1004-49cb-8f59-ae398027206f" />
<img width="1082" height="2202" alt="1756049400 5211275_KBInputStep_type-mytestaccount" src="https://github.com/user-attachments/assets/ddcf90a4-5d0a-470c-bde0-e24e5baaca1f" />



---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
