### PR TITLE
feat(positions): Add positions page and move positions there

### DIFF
--- a/apps/web/src/components/sidebar/SidebarNavigation/config.tsx
+++ b/apps/web/src/components/sidebar/SidebarNavigation/config.tsx
@@ -97,6 +97,10 @@ export const balancesNavItems = [
     href: AppRoutes.balances.index,
   },
   {
+    label: 'Positions',
+    href: AppRoutes.balances.positions,
+  },
+  {
     label: 'NFTs',
     href: AppRoutes.balances.nfts,
   },

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -24,6 +24,7 @@ export const AppRoutes = {
     bookmarked: '/apps/bookmarked',
   },
   balances: {
+    positions: '/balances/positions',
     nfts: '/balances/nfts',
     index: '/balances',
   },

--- a/apps/web/src/pages/balances/index.tsx
+++ b/apps/web/src/pages/balances/index.tsx
@@ -15,7 +15,6 @@ import StakingBanner from '@/components/dashboard/StakingBanner'
 import useIsStakingBannerEnabled from '@/features/stake/hooks/useIsStakingBannerEnabled'
 import { Box } from '@mui/material'
 import { BRAND_NAME } from '@/config/constants'
-import Positions from '@/features/positions'
 import TotalAssetValue from '@/components/balances/TotalAssetValue'
 
 const Balances: NextPage = () => {
@@ -51,7 +50,6 @@ const Balances: NextPage = () => {
               <TotalAssetValue />
             </Box>
             <AssetsTable setShowHiddenAssets={setShowHiddenAssets} showHiddenAssets={showHiddenAssets} />
-            <Positions />
           </>
         )}
       </main>

--- a/apps/web/src/pages/balances/positions.tsx
+++ b/apps/web/src/pages/balances/positions.tsx
@@ -1,0 +1,40 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+
+import AssetsHeader from '@/components/balances/AssetsHeader'
+import { useState } from 'react'
+import HiddenTokenButton from '@/components/balances/HiddenTokenButton'
+import CurrencySelect from '@/components/balances/CurrencySelect'
+import TokenListSelect from '@/components/balances/TokenListSelect'
+import { BRAND_NAME } from '@/config/constants'
+import DefiPositions from '@/features/positions'
+import { Box } from '@mui/material'
+import TotalAssetValue from '@/components/balances/TotalAssetValue'
+
+const Positions: NextPage = () => {
+  const [showHiddenAssets, setShowHiddenAssets] = useState(false)
+  const toggleShowHiddenAssets = () => setShowHiddenAssets((prev) => !prev)
+
+  return (
+    <>
+      <Head>
+        <title>{`${BRAND_NAME} – Assets`}</title>
+      </Head>
+
+      <AssetsHeader>
+        <HiddenTokenButton showHiddenAssets={showHiddenAssets} toggleShowHiddenAssets={toggleShowHiddenAssets} />
+        <TokenListSelect />
+        <CurrencySelect />
+      </AssetsHeader>
+
+      <main>
+        <Box mb={2}>
+          <TotalAssetValue />
+        </Box>
+        <DefiPositions />
+      </main>
+    </>
+  )
+}
+
+export default Positions


### PR DESCRIPTION
## What it solves

Part of [GRO-33](https://linear.app/safe-global/issue/GRO-33/assets-page)

## How this PR fixes it

- Adds a new page for positions
- Moves the positions table from assets to the new page

## How to test it

1. Open assets
2. Observe a new tab Positions
3. Observe only wallet assets
4. Click on Positions
5. Observe the positions

## Screenshots
<img width="1512" height="658" alt="Screenshot 2025-08-25 at 13 44 55" src="https://github.com/user-attachments/assets/4d9d9290-93ae-48c8-a7bb-7132f9a7806d" />
<img width="1510" height="460" alt="Screenshot 2025-08-25 at 13 45 12" src="https://github.com/user-attachments/assets/d70acacc-840c-4526-a386-ea009a24486a" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
