### PR TITLE
fix: Check spaceId query param for address book source

### DIFF
--- a/apps/web/src/components/common/AddressBookSourceProvider/index.tsx
+++ b/apps/web/src/components/common/AddressBookSourceProvider/index.tsx
@@ -10,10 +10,10 @@ const AddressBookSourceContext = createContext<AddressBookSource>(DEFAULT_SOURCE
 export const useAddressBookSource = () => useContext(AddressBookSourceContext)
 
 const deriveSourceFromURL = (router: NextRouter) => {
-  const { safe } = router.query
-  const querySafe = Array.isArray(safe) ? safe[0] : safe
+  const { spaceId } = router.query
+  const querySpaceId = Array.isArray(spaceId) ? spaceId[0] : spaceId
 
-  return querySafe ? 'merged' : 'spaceOnly'
+  return querySpaceId ? 'spaceOnly' : 'merged'
 }
 
 /**


### PR DESCRIPTION
## What it solves

Part of [COR-493](https://linear.app/safe-global/issue/COR-493/spaces-address-book-names-are-only-visible-if-wallet-is-on-the-correct)

## How this PR fixes it

When deciding on the source of address books we previously checked if the `safe` url query parameter was present and in that case used a **merged** approach and otherwise only accessed entries from the space. This doesn't work for non-safe and non-space routes such as safe creation. In those cases we still want to have a **merged** approach but since the safe query param doesn't exist there either we have to come up with a different strategy.

- Check for `spaceId` query parameter in order to decide `spaceOnly`
- Otherwise go with merged approach

This works because we don't keep the `spaceId` parameter when users navigate within a safe but instead access this data through the local storage.

## How to test it

1. Add local AB entries for address A
2. Create a new safe where A is an owner
3. Observe the local name is shown

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
