### PR TITLE
feat(analytics): Standardize CSV export MixPanel parameters

### DIFF
--- a/apps/web/src/components/transactions/CsvTxExportModal/index.tsx
+++ b/apps/web/src/components/transactions/CsvTxExportModal/index.tsx
@@ -24,7 +24,7 @@ import useChainId from '@/hooks/useChainId'
 import type { JobStatusDto } from '@safe-global/store/gateway/AUTO_GENERATED/csv-export'
 import { useCsvExportLaunchExportV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/csv-export'
 import { showNotification } from '@/store/notificationsSlice'
-import { MixPanelEvent, trackMixPanelEvent } from '@/services/analytics'
+import { MixPanelEvent, MixPanelEventParams, trackMixPanelEvent } from '@/services/analytics'
 
 enum DateRangeOption {
   LAST_30_DAYS = '30d',
@@ -170,7 +170,9 @@ const CsvTxExportModal = ({ onClose, onExport, hasActiveFilter }: CsvTxExportMod
       errorNotification()
     }
 
-    trackMixPanelEvent(MixPanelEvent.CSV_TX_EXPORT_SUBMITTED, { Period: DATE_RANGE_LABELS[range as DateRangeOption] })
+    trackMixPanelEvent(MixPanelEvent.CSV_TX_EXPORT_SUBMITTED, {
+      [MixPanelEventParams.PERIOD]: DATE_RANGE_LABELS[range as DateRangeOption],
+    })
     onClose()
   })
 

--- a/apps/web/src/services/analytics/mixpanel-events.ts
+++ b/apps/web/src/services/analytics/mixpanel-events.ts
@@ -35,6 +35,7 @@ export enum MixPanelEventParams {
   SAFE_APP_NAME = 'Safe App Name',
   SAFE_APP_TAGS = 'Safe App Tags',
   LAUNCH_LOCATION = 'Launch Location',
+  PERIOD = 'Period',
 }
 
 export enum SafeAppLaunchLocation {


### PR DESCRIPTION
  Replace custom 'Period' property with standard MixPanelEventParams.PERIOD
  to maintain consistency across analytics tracking system.

## What it solves

Resolves #

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
