### PR TITLE
feat(analytics): CSV export dual tracking and parameter improvements

### DIFF
--- a/apps/web/src/components/transactions/CsvTxExportButton/__tests__/index.test.tsx
+++ b/apps/web/src/components/transactions/CsvTxExportButton/__tests__/index.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@/tests/test-utils'
+import { trackEvent } from '@/services/analytics'
+import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
+import CsvTxExportButton from '../index'
+import * as csvExportQueries from '@safe-global/store/gateway/AUTO_GENERATED/csv-export'
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('@/components/common/OnlyOwner', () => {
+  return function MockOnlyOwner({ children }: { children: (isOk: boolean) => React.ReactNode }) {
+    return <>{children(true)}</>
+  }
+})
+
+const mockTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>
+
+describe('CsvTxExportButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(csvExportQueries, 'useCsvExportGetExportStatusV1Query').mockImplementation(() => ({
+      data: undefined,
+      refetch: jest.fn(),
+    }))
+  })
+
+  it('should track CSV_EXPORT_CLICKED event when export button is clicked', () => {
+    const { getByText } = render(<CsvTxExportButton hasActiveFilter={false} />)
+
+    const exportButton = getByText('Export CSV')
+    fireEvent.click(exportButton)
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(TX_LIST_EVENTS.CSV_EXPORT_CLICKED)
+  })
+
+  it('should render export button correctly', () => {
+    const { getByText } = render(<CsvTxExportButton hasActiveFilter={false} />)
+
+    expect(getByText('Export CSV')).toBeInTheDocument()
+  })
+
+  it('should open CSV export modal when export button is clicked', () => {
+    const { getByText } = render(<CsvTxExportButton hasActiveFilter={false} />)
+
+    const exportButton = getByText('Export CSV')
+    fireEvent.click(exportButton)
+
+    expect(screen.getByLabelText('Date range')).toBeInTheDocument()
+    expect(
+      screen.getByText('The CSV includes transactions from the selected period, suitable for reporting.'),
+    ).toBeInTheDocument()
+  })
+
+  it('should pass hasActiveFilter prop to modal correctly', () => {
+    const { getByText } = render(<CsvTxExportButton hasActiveFilter={true} />)
+
+    const exportButton = getByText('Export CSV')
+    fireEvent.click(exportButton)
+
+    expect(screen.getByText("Transaction history filters won't apply here.")).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/transactions/CsvTxExportButton/index.tsx
+++ b/apps/web/src/components/transactions/CsvTxExportButton/index.tsx
@@ -10,7 +10,8 @@ import { OnboardingTooltip } from '@/components/common/OnboardingTooltip'
 import { Chip } from '@/components/common/Chip'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import OnlyOwner from '@/components/common/OnlyOwner'
-import { MixPanelEvent, trackMixPanelEvent } from '@/services/analytics'
+import { trackEvent } from '@/services/analytics'
+import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 
 const getCsvExportFileName = () => {
   const today = new Date().toISOString().slice(0, 10)
@@ -46,7 +47,7 @@ const CsvTxExportButton = ({ hasActiveFilter }: CsvTxExportProps): ReactElement 
 
   const onClick = () => {
     setOpenExportModal(true)
-    trackMixPanelEvent(MixPanelEvent.CSV_TX_EXPORT_CLICKED, {})
+    trackEvent(TX_LIST_EVENTS.CSV_EXPORT_CLICKED)
   }
 
   useEffect(() => {

--- a/apps/web/src/components/transactions/CsvTxExportModal/CsvTxExportModal.test.tsx
+++ b/apps/web/src/components/transactions/CsvTxExportModal/CsvTxExportModal.test.tsx
@@ -1,13 +1,40 @@
 import React, { act } from 'react'
 import { render, screen, fireEvent, waitFor } from '@/tests/test-utils'
+import { trackEvent } from '@/services/analytics'
+import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
+import { MixPanelEventParams } from '@/services/analytics/mixpanel-events'
 import CsvTxExportModal from './index'
+import * as csvExportQueries from '@safe-global/store/gateway/AUTO_GENERATED/csv-export'
 
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+  MixPanelEventParams: {
+    DATE_RANGE: 'Date Range',
+  },
+}))
+
+const mockLaunchFunction = jest.fn().mockImplementation(() => ({
+  unwrap: jest.fn().mockResolvedValue({ id: 'test-job-id', status: 'SUBMITTED' }),
+}))
+const mockTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>
 const onClose = jest.fn()
 const onExport = jest.fn()
 
 describe('CsvTxExportModal', () => {
   const renderComponent = (hasActiveFilter: boolean = false) =>
     render(<CsvTxExportModal onClose={onClose} onExport={onExport} hasActiveFilter={hasActiveFilter} />)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    jest.spyOn(csvExportQueries, 'useCsvExportLaunchExportV1Mutation').mockReturnValue([
+      mockLaunchFunction,
+      {
+        isLoading: false,
+        reset: jest.fn(),
+      },
+    ])
+  })
 
   it('renders modal with message and disabled export button', () => {
     renderComponent()
@@ -91,5 +118,21 @@ describe('CsvTxExportModal', () => {
     renderComponent(true)
 
     expect(screen.getByText("Transaction history filters won't apply here.")).toBeInTheDocument()
+  })
+
+  it('should track CSV_EXPORT_SUBMITTED event with DATE_RANGE parameter when form is submitted', async () => {
+    renderComponent()
+
+    act(() => fireEvent.mouseDown(screen.getByLabelText('Date range')))
+    act(() => fireEvent.click(screen.getByRole('option', { name: 'Last 30 days' })))
+
+    const exportBtn = screen.getByRole('button', { name: 'Export' })
+    await act(async () => fireEvent.click(exportBtn))
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(TX_LIST_EVENTS.CSV_EXPORT_SUBMITTED, {
+        [MixPanelEventParams.DATE_RANGE]: 'Last 30 days',
+      })
+    })
   })
 })

--- a/apps/web/src/components/transactions/CsvTxExportModal/index.tsx
+++ b/apps/web/src/components/transactions/CsvTxExportModal/index.tsx
@@ -24,7 +24,8 @@ import useChainId from '@/hooks/useChainId'
 import type { JobStatusDto } from '@safe-global/store/gateway/AUTO_GENERATED/csv-export'
 import { useCsvExportLaunchExportV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/csv-export'
 import { showNotification } from '@/store/notificationsSlice'
-import { MixPanelEvent, MixPanelEventParams, trackMixPanelEvent } from '@/services/analytics'
+import { trackEvent, MixPanelEventParams } from '@/services/analytics'
+import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 
 enum DateRangeOption {
   LAST_30_DAYS = '30d',
@@ -170,8 +171,8 @@ const CsvTxExportModal = ({ onClose, onExport, hasActiveFilter }: CsvTxExportMod
       errorNotification()
     }
 
-    trackMixPanelEvent(MixPanelEvent.CSV_TX_EXPORT_SUBMITTED, {
-      [MixPanelEventParams.PERIOD]: DATE_RANGE_LABELS[range as DateRangeOption],
+    trackEvent(TX_LIST_EVENTS.CSV_EXPORT_SUBMITTED, {
+      [MixPanelEventParams.DATE_RANGE]: DATE_RANGE_LABELS[range as DateRangeOption],
     })
     onClose()
   })

--- a/apps/web/src/services/analytics/events/txList.ts
+++ b/apps/web/src/services/analytics/events/txList.ts
@@ -75,6 +75,16 @@ export const TX_LIST_EVENTS = {
     event: EventType.CLICK,
     // label: 'hide' | 'show',
   },
+  CSV_EXPORT_CLICKED: {
+    action: 'CSV Export Clicked',
+    category: TX_LIST_CATEGORY,
+    event: EventType.CLICK,
+  },
+  CSV_EXPORT_SUBMITTED: {
+    action: 'CSV Export Submitted',
+    category: TX_LIST_CATEGORY,
+    event: EventType.CLICK,
+  },
 }
 
 export const MESSAGE_EVENTS = {

--- a/apps/web/src/services/analytics/ga-mixpanel-mapping.ts
+++ b/apps/web/src/services/analytics/ga-mixpanel-mapping.ts
@@ -3,6 +3,7 @@ import { CREATE_SAFE_EVENTS } from './events/createLoadSafe'
 import { WALLET_EVENTS } from './events/wallet'
 import { SAFE_APPS_EVENTS } from './events/safeApps'
 import { WALLETCONNECT_EVENTS } from './events/walletconnect'
+import { TX_LIST_EVENTS } from './events/txList'
 
 // If an event is mapped here, it will be tracked in Mixpanel
 export const GA_TO_MIXPANEL_MAPPING: Record<string, string> = {
@@ -11,4 +12,6 @@ export const GA_TO_MIXPANEL_MAPPING: Record<string, string> = {
   [WALLET_EVENTS.CONNECT.action]: MixPanelEvent.WALLET_CONNECTED,
   [SAFE_APPS_EVENTS.OPEN_APP.action]: MixPanelEvent.SAFE_APP_LAUNCHED,
   [WALLETCONNECT_EVENTS.CONNECTED.action]: MixPanelEvent.WC_CONNECTED,
+  [TX_LIST_EVENTS.CSV_EXPORT_CLICKED.action]: MixPanelEvent.CSV_TX_EXPORT_CLICKED,
+  [TX_LIST_EVENTS.CSV_EXPORT_SUBMITTED.action]: MixPanelEvent.CSV_TX_EXPORT_SUBMITTED,
 }

--- a/apps/web/src/services/analytics/mixpanel-events.ts
+++ b/apps/web/src/services/analytics/mixpanel-events.ts
@@ -37,7 +37,7 @@ export enum MixPanelEventParams {
   SAFE_APP_TAGS = 'Safe App Tags',
   LAUNCH_LOCATION = 'Launch Location',
   APP_URL = 'App URL',
-  PERIOD = 'Period',
+  DATE_RANGE = 'Date Range',
 }
 
 export enum SafeAppLaunchLocation {


### PR DESCRIPTION
## What it solves

The CSV Export events were only tracked in Mixpanel, while we want to track analytics in Google Analytics and Mixpanel.


## How this PR fixes it
  - **CSV Export Tracking**: Add GA events and mapping for dual GA/MixPanel tracking of CSV
  export interactions
  - **Parameter Rename**: `PERIOD` → `DATE_RANGE` for better clarity


## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
