### PR TITLE
fix(web): dont show empty state for assets/pending tx before loaded

### DIFF
--- a/apps/web/src/components/dashboard/Assets/index.tsx
+++ b/apps/web/src/components/dashboard/Assets/index.tsx
@@ -130,7 +130,7 @@ export const isNonZeroBalance = (item: Balances['items'][number]) => item.balanc
 const AssetsWidget = () => {
   const router = useRouter()
   const { safe } = router.query
-  const { loading } = useBalances()
+  const { loading, balances } = useBalances()
   const visibleAssets = useVisibleAssets()
 
   const items = useMemo(() => {
@@ -145,7 +145,11 @@ const AssetsWidget = () => {
     [safe],
   )
 
-  if (loading) return <AssetsSkeleton />
+  // Only show content when data has been fetched (either has items or fiatTotal is set)
+  const hasDataLoaded = visibleAssets.length > 0 || balances.fiatTotal !== ''
+  const isLoading = loading || !hasDataLoaded
+
+  if (isLoading) return <AssetsSkeleton />
 
   return (
     <Card data-testid="assets-widget" sx={{ px: 1.5, py: 2.5 }}>

--- a/apps/web/src/components/dashboard/Assets/index.tsx
+++ b/apps/web/src/components/dashboard/Assets/index.tsx
@@ -145,9 +145,7 @@ const AssetsWidget = () => {
     [safe],
   )
 
-  // Only show content when data has been fetched (either has items or fiatTotal is set)
-  const hasDataLoaded = visibleAssets.length > 0 || balances.fiatTotal !== ''
-  const isLoading = loading || !hasDataLoaded
+  const isLoading = loading || !balances.fiatTotal
 
   if (isLoading) return <AssetsSkeleton />
 

--- a/apps/web/src/components/dashboard/PendingTxs/PendingTxsList.tsx
+++ b/apps/web/src/components/dashboard/PendingTxs/PendingTxsList.tsx
@@ -84,7 +84,7 @@ export function _getTransactionsToDisplay({
 const PendingTxsList = (): ReactElement | null => {
   const router = useRouter()
   const { page, loading } = useTxQueue()
-  const { safe } = useSafeInfo()
+  const { safe, safeLoaded, safeLoading } = useSafeInfo()
   const wallet = useWallet()
   const queuedTxns = useMemo(() => getLatestTransactions(page?.results), [page?.results])
   const recoveryQueue = useRecoveryQueue()
@@ -101,6 +101,9 @@ const PendingTxsList = (): ReactElement | null => {
 
   const totalTxs = recoveryTxs.length + queuedTxs.length
 
+  const isInitialState = !safeLoaded && !safeLoading
+  const isLoading = loading || safeLoading || isInitialState
+
   const queueUrl = useMemo(
     () => ({
       pathname: AppRoutes.transactions.queue,
@@ -109,7 +112,7 @@ const PendingTxsList = (): ReactElement | null => {
     [router.query.safe],
   )
 
-  if (loading) return <PendingTxsSkeleton />
+  if (isLoading) return <PendingTxsSkeleton />
 
   return (
     <Card data-testid="pending-tx-widget" sx={{ px: 1.5, py: 2.5, height: 1 }} component="section">


### PR DESCRIPTION
## What it solves

Resolves #

https://github.com/safe-global/safe-wallet-monorepo/pull/6218#issuecomment-3223953546

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
