### PR TITLE
fix: Update top assets layout on dashboard

### DIFF
--- a/apps/web/src/components/dashboard/Assets/index.tsx
+++ b/apps/web/src/components/dashboard/Assets/index.tsx
@@ -59,14 +59,10 @@ const AssetRow = ({
         <TokenIcon tokenSymbol={item.tokenInfo.symbol} logoUri={item.tokenInfo.logoUri ?? undefined} size={32} />
         <Box>
           <Typography fontWeight="600">{item.tokenInfo.name}</Typography>
-          <Typography variant="body2">{item.tokenInfo.symbol}</Typography>
+          <Typography variant="body2" className={css.tokenAmount}>
+            <TokenAmount value={item.balance} decimals={item.tokenInfo.decimals} tokenSymbol={item.tokenInfo.symbol} />
+          </Typography>
         </Box>
-      </Stack>
-
-      <Stack display={['none', 'flex']} direction="row" alignItems="center" gap={1}>
-        <Typography className={css.tokenAmount}>
-          <TokenAmount value={item.balance} decimals={item.tokenInfo.decimals} tokenSymbol={item.tokenInfo.symbol} />
-        </Typography>
       </Stack>
 
       <Box flex={1} display="block" textAlign="right" height="44px">

--- a/apps/web/src/components/dashboard/Assets/styles.module.css
+++ b/apps/web/src/components/dashboard/Assets/styles.module.css
@@ -5,7 +5,7 @@
   border-radius: 8px;
   flex-wrap: nowrap;
   display: grid;
-  grid-template-columns: 200px 1fr 1fr;
+  grid-template-columns: 200px 1fr;
   align-items: center;
   gap: var(--space-2);
   min-height: 50px;
@@ -25,6 +25,7 @@
 
 .tokenAmount * {
   font-weight: normal;
+  color: var(--color-primary-light);
 }
 
 .barPercentage {


### PR DESCRIPTION
## What it solves

Part of [GRO-44](https://linear.app/safe-global/issue/GRO-44/qa-final-round-for-positions)

## How this PR fixes it

- Moves the asset balance under the name instead of its own column

## How to test it

1. Open the dashboard on a safe with assets
2. Compare top assets layout with design

## Screenshots
<img width="839" height="368" alt="Screenshot 2025-08-27 at 15 51 55" src="https://github.com/user-attachments/assets/5d6341c4-d522-4d00-a697-3d2c82e3a7a7" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
