### PR TITLE
fix(positions): Compute weight based on fiat total, add tooltips

### DIFF
--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -30,6 +30,7 @@ import { isEligibleEarnToken } from '@/features/earn/utils'
 import useChainId from '@/hooks/useChainId'
 import FiatValue from '@/components/common/FiatValue'
 import { formatPercentage } from '@safe-global/utils/utils/formatters'
+import useFiatTotal from '@/hooks/useFiatTotal'
 
 const skeletonCells: EnhancedTableProps['rows'][0]['cells'] = {
   asset: {
@@ -113,7 +114,13 @@ const headCells = [
   },
   {
     id: 'weight',
-    label: 'Weight',
+    label: (
+      <Tooltip title="Based on total portfolio value">
+        <Typography variant="caption" letterSpacing="normal" color="primary.light">
+          Weight
+        </Typography>
+      </Tooltip>
+    ),
     width: '15%',
     align: 'left',
   },
@@ -133,6 +140,7 @@ const AssetsTable = ({
   setShowHiddenAssets: (hidden: boolean) => void
 }): ReactElement => {
   const { balances, loading } = useBalances()
+  const fiatTotal = useFiatTotal()
   const chainId = useChainId()
   const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
   const isStakingFeatureEnabled = useIsStakingFeatureEnabled()
@@ -146,8 +154,6 @@ const AssetsTable = ({
   const visibleAssets = showHiddenAssets ? balances.items : visible
   const hasNoAssets = !loading && balances.items.length === 1 && balances.items[0].balance === '0'
   const selectedAssetCount = visibleAssets?.filter((item) => isAssetSelected(item.tokenInfo.address)).length || 0
-
-  const fiatTotal = balances.fiatTotal ? Number(balances.fiatTotal) : null
 
   const rows = loading
     ? skeletonRows

--- a/apps/web/src/features/positions/components/PositionsHeader/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Chip, Stack, Typography } from '@mui/material'
+import { Chip, Stack, Tooltip, Typography } from '@mui/material'
 import IframeIcon from '@/components/common/IframeIcon'
 import FiatValue from '@/components/common/FiatValue'
 import { formatPercentage } from '@safe-global/utils/utils/formatters'
@@ -21,7 +21,11 @@ const PositionsHeader = ({ protocol, fiatTotal }: { protocol: Protocol; fiatTota
           {protocol.protocol_metadata.name}
         </Typography>
 
-        {shareOfFiatTotal && <Chip variant="filled" size="tiny" label={shareOfFiatTotal} />}
+        {shareOfFiatTotal && (
+          <Tooltip title="Based on total portfolio value">
+            <Chip variant="filled" size="tiny" label={shareOfFiatTotal} />
+          </Tooltip>
+        )}
 
         <Typography fontWeight="bold" mr={1} ml="auto" justifySelf="flex-end">
           <FiatValue value={protocol.fiatTotal} maxLength={20} precise />

--- a/apps/web/src/features/positions/index.tsx
+++ b/apps/web/src/features/positions/index.tsx
@@ -7,11 +7,11 @@ import { getReadablePositionType } from '@/features/positions/utils'
 import IframeIcon from '@/components/common/IframeIcon'
 import { FiatChange } from '@/components/balances/AssetsTable/FiatChange'
 import usePositions from '@/features/positions/hooks/usePositions'
-import usePositionsFiatTotal from '@/features/positions/hooks/usePositionsFiatTotal'
 import PositionsEmpty from '@/features/positions/components/PositionsEmpty'
+import useFiatTotal from '@/hooks/useFiatTotal'
 
 export const Positions = () => {
-  const fiatTotal = usePositionsFiatTotal()
+  const fiatTotal = useFiatTotal()
   const protocols = usePositions()
 
   if (!protocols) return null


### PR DESCRIPTION
## What it solves

Part of [GRO-44](https://linear.app/safe-global/issue/GRO-44/qa-final-round-for-positions)

## How this PR fixes it

- Computes weights based on fiat total
- Shows tooltip to explain this

## How to test it

1. Open a safe with positions and assets
2. Go to balances
3. Hover the weight column header
4. Observe a tooltip
5. Do the same for positions

## Screenshots
<img width="623" height="410" alt="Screenshot 2025-08-28 at 12 26 22" src="https://github.com/user-attachments/assets/0cbd3a07-e076-4d28-9ce2-e298f93ffe89" />
<img width="1252" height="393" alt="Screenshot 2025-08-28 at 12 26 09" src="https://github.com/user-attachments/assets/7f8c28db-f750-4d32-9ffe-150899288629" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
