### PR TITLE
fix(web): dont show inverified for non-indexed contracts

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
@@ -3,7 +3,6 @@ import NamedAddressInfo, { useAddressName } from '.'
 import { faker } from '@faker-js/faker'
 import { getContract, type ChainInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
-import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import useSafeAddress from '@/hooks/useSafeAddress'
 
 const mockChainInfo = {
@@ -22,16 +21,11 @@ jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
   __esModule: true,
 }))
 
-jest.mock('@/hooks/wallets/web3', () => ({
-  useWeb3ReadOnly: jest.fn(),
-}))
-
 jest.mock('@/hooks/useSafeAddress', () => ({
   __esModule: true,
   default: jest.fn(),
 }))
 
-const mockWeb3ReadOnly = useWeb3ReadOnly as jest.Mock
 const getContractMock = getContract as jest.Mock
 const useSafeAddressMock = useSafeAddress as jest.Mock
 
@@ -132,9 +126,6 @@ describe('useAddressName', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockWeb3ReadOnly.mockReturnValue({
-      getCode: jest.fn().mockResolvedValue('0x'),
-    })
     useSafeAddressMock.mockReturnValue(safeAddress)
   })
 
@@ -154,6 +145,7 @@ describe('useAddressName', () => {
       displayName: 'Contract Display Name',
       name: 'ContractName',
       logoUri: 'contract-logo.png',
+      contractAbi: {},
     })
 
     const { result } = renderHook(() => useAddressName(address))
@@ -169,28 +161,27 @@ describe('useAddressName', () => {
     expect(getContractMock).toHaveBeenCalledWith('4', address)
   })
 
-  it('should handle unverified contracts', async () => {
-    getContractMock.mockRejectedValue(new Error('Contract not found'))
-    mockWeb3ReadOnly.mockReturnValue({
-      getCode: jest.fn().mockResolvedValue('0x123'), // Non-empty bytecode indicates a contract
+  it('should mark contract without ABI as unverified', async () => {
+    getContractMock.mockResolvedValue({
+      displayName: 'Contract Display Name',
+      name: 'ContractName',
+      logoUri: 'contract-logo.png',
+      contractAbi: null,
     })
 
     const { result } = renderHook(() => useAddressName(address))
 
     await waitFor(() => {
       expect(result.current).toEqual({
-        name: 'Unverified contract',
-        logoUri: undefined,
+        name: 'Contract Display Name',
+        logoUri: 'contract-logo.png',
         isUnverifiedContract: true,
       })
     })
   })
 
-  it('should handle EOA addresses (not contracts)', async () => {
+  it('should treat contract lookup errors as verified (not indexed)', async () => {
     getContractMock.mockRejectedValue(new Error('Contract not found'))
-    mockWeb3ReadOnly.mockReturnValue({
-      getCode: jest.fn().mockResolvedValue('0x'), // Empty bytecode indicates EOA
-    })
 
     const { result } = renderHook(() => useAddressName(address))
 

--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -23,7 +23,6 @@ export function useAddressName(address?: string, name?: string | null, customAva
     false,
   )
   const isUnverifiedContract = useIsUnverifiedContract(contract)
-  console.log('UNVERIFIED', isUnverifiedContract)
 
   return useMemo(
     () => ({
@@ -41,7 +40,6 @@ export function useAddressName(address?: string, name?: string | null, customAva
 
 const NamedAddressInfo = ({ address, name, customAvatar, ...props }: EthHashInfoProps) => {
   const { name: finalName, logoUri: finalAvatar } = useAddressName(address, name, customAvatar)
-  console.log('NAME', finalName)
 
   return <EthHashInfo address={address} name={finalName} customAvatar={finalAvatar} {...props} />
 }


### PR DESCRIPTION
## What it solves

- Doesn't show `Unverified Contract` for those that were not indexed by Decoder service

Resolves # [COR-480](https://linear.app/safe-global/issue/COR-480/tx-flow-and-history-remove-unverified-wording-if-the-contract-is-not)

## How this PR fixes it
- only show `Unverified Contract` for the contracts that don't have ABI in the Decoder Service response
- do not show it for the contracts that were not found (not indexed)
- remove the check of  the on-chain bytecode and rely solemnly on Decoder response

## How to test it

Check for Name tag in transaction queue/history. `Unverified Contract` should only be shown for those that do not have ABI

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
