### PR TITLE
fix: Positions feedback

### DIFF
--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -170,7 +170,15 @@ const AssetsTable = ({
                 <div className={css.token}>
                   <TokenIcon logoUri={item.tokenInfo.logoUri} tokenSymbol={item.tokenInfo.symbol} />
 
-                  <Typography>{item.tokenInfo.name}</Typography>
+                  <Stack>
+                    <Typography fontWeight="bold">
+                      {item.tokenInfo.name}
+                      {!isNative && <TokenExplorerLink address={item.tokenInfo.address} />}
+                    </Typography>
+                    <Typography variant="body2" color="primary.light">
+                      {item.tokenInfo.symbol}
+                    </Typography>
+                  </Stack>
 
                   {isStakingFeatureEnabled && item.tokenInfo.type === TokenType.NATIVE_TOKEN && (
                     <StakeButton tokenInfo={item.tokenInfo} trackingLabel={STAKE_LABELS.asset} />
@@ -179,8 +187,6 @@ const AssetsTable = ({
                   {isEarnFeatureEnabled && isEligibleEarnToken(chainId, item.tokenInfo.address) && (
                     <EarnButton tokenInfo={item.tokenInfo} trackingLabel={EARN_LABELS.asset} />
                   )}
-
-                  {!isNative && <TokenExplorerLink address={item.tokenInfo.address} />}
                 </div>
               ),
             },

--- a/apps/web/src/features/positions/components/PositionsHeader/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsHeader/index.tsx
@@ -3,6 +3,7 @@ import IframeIcon from '@/components/common/IframeIcon'
 import FiatValue from '@/components/common/FiatValue'
 import { formatPercentage } from '@safe-global/utils/utils/formatters'
 import type { Protocol } from '@safe-global/store/gateway/AUTO_GENERATED/positions'
+import { Box } from '@mui/system'
 
 const PositionsHeader = ({ protocol, fiatTotal }: { protocol: Protocol; fiatTotal?: number }) => {
   const shareOfFiatTotal = fiatTotal ? formatPercentage(Number(protocol.fiatTotal) / fiatTotal) : null
@@ -10,12 +11,14 @@ const PositionsHeader = ({ protocol, fiatTotal }: { protocol: Protocol; fiatTota
   return (
     <>
       <Stack direction="row" gap={1} alignItems="center" width={1}>
-        <IframeIcon
-          src={protocol.protocol_metadata.icon.url || ''}
-          alt={protocol.protocol_metadata.name}
-          width={32}
-          height={32}
-        />
+        <Box sx={{ borderRadius: '50%', overflow: 'hidden', display: 'flex' }}>
+          <IframeIcon
+            src={protocol.protocol_metadata.icon.url || ''}
+            alt={protocol.protocol_metadata.name}
+            width={32}
+            height={32}
+          />
+        </Box>
 
         <Typography fontWeight="bold" ml={0.5}>
           {protocol.protocol_metadata.name}

--- a/apps/web/src/features/positions/index.tsx
+++ b/apps/web/src/features/positions/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, Stack, Typography } from '@mui/material'
+import { Accordion, AccordionDetails, AccordionSummary, Box, Card, Stack, Typography } from '@mui/material'
 import PositionsHeader from '@/features/positions/components/PositionsHeader'
 import EnhancedTable from '@/components/common/EnhancedTable'
 import FiatValue from '@/components/common/FiatValue'
@@ -9,6 +9,8 @@ import { FiatChange } from '@/components/balances/AssetsTable/FiatChange'
 import usePositions from '@/features/positions/hooks/usePositions'
 import usePositionsFiatTotal from '@/features/positions/hooks/usePositionsFiatTotal'
 import PositionsEmpty from '@/features/positions/components/PositionsEmpty'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import React from 'react'
 
 export const Positions = () => {
   const fiatTotal = usePositionsFiatTotal()
@@ -24,76 +26,89 @@ export const Positions = () => {
     <Stack gap={2}>
       {protocols.map((protocol) => {
         return (
-          <Card key={protocol.protocol} sx={{ p: 2 }}>
-            <PositionsHeader protocol={protocol} fiatTotal={fiatTotal} />
+          <Card key={protocol.protocol} sx={{ border: 0 }}>
+            <Accordion disableGutters elevation={0} variant="elevation" defaultExpanded>
+              <AccordionSummary
+                expandIcon={<ExpandMoreIcon fontSize="small" />}
+                sx={{
+                  justifyContent: 'center',
+                  overflowX: 'auto',
+                  backgroundColor: 'transparent !important',
+                }}
+              >
+                <PositionsHeader protocol={protocol} fiatTotal={fiatTotal} />
+              </AccordionSummary>
+              <AccordionDetails sx={{ pt: 0 }}>
+                {protocol.items.map((positionGroup) => {
+                  const rows = positionGroup.items.map((position) => ({
+                    cells: {
+                      name: {
+                        content: (
+                          <Stack direction="row" alignItems="center" gap={1}>
+                            <IframeIcon
+                              src={position.tokenInfo.logoUri || ''}
+                              alt={position.tokenInfo.name + ' icon'}
+                              width={32}
+                              height={32}
+                            />
 
-            {protocol.items.map((positionGroup) => {
-              const rows = positionGroup.items.map((position) => ({
-                cells: {
-                  name: {
-                    content: (
-                      <Stack direction="row" alignItems="center" gap={1}>
-                        <IframeIcon
-                          src={position.tokenInfo.logoUri || ''}
-                          alt={position.tokenInfo.name + ' icon'}
-                          width={32}
-                          height={32}
-                        />
-
-                        <Box>
-                          <Typography fontWeight="bold">{position.tokenInfo.name}</Typography>
-                          <Typography variant="body2" color="primary.light">
-                            {position.tokenInfo.symbol} •&nbsp; {getReadablePositionType(position.position_type)}
+                            <Box>
+                              <Typography fontWeight="bold">{position.tokenInfo.name}</Typography>
+                              <Typography variant="body2" color="primary.light">
+                                {position.tokenInfo.symbol} •&nbsp; {getReadablePositionType(position.position_type)}
+                              </Typography>
+                            </Box>
+                          </Stack>
+                        ),
+                        rawValue: 'Test',
+                      },
+                      balance: {
+                        content: (
+                          <Typography>
+                            {formatVisualAmount(position.balance, position.tokenInfo.decimals)}{' '}
+                            {position.tokenInfo.symbol}
                           </Typography>
-                        </Box>
-                      </Stack>
-                    ),
-                    rawValue: 'Test',
-                  },
-                  balance: {
-                    content: (
-                      <Typography>
-                        {formatVisualAmount(position.balance, position.tokenInfo.decimals)} {position.tokenInfo.symbol}
-                      </Typography>
-                    ),
-                    rawValue: position.balance,
-                  },
-                  value: {
-                    content: (
-                      <Box textAlign="right">
-                        <Typography>
-                          <FiatValue value={position.fiatBalance} />
-                        </Typography>
-                        <Typography variant="caption">
-                          <FiatChange balanceItem={position} inline />
-                        </Typography>
-                      </Box>
-                    ),
-                    rawValue: position.fiatBalance,
-                  },
-                },
-              }))
+                        ),
+                        rawValue: position.balance,
+                      },
+                      value: {
+                        content: (
+                          <Box textAlign="right">
+                            <Typography>
+                              <FiatValue value={position.fiatBalance} />
+                            </Typography>
+                            <Typography variant="caption">
+                              <FiatChange balanceItem={position} inline />
+                            </Typography>
+                          </Box>
+                        ),
+                        rawValue: position.fiatBalance,
+                      },
+                    },
+                  }))
 
-              const headCells = [
-                {
-                  id: 'name',
-                  label: (
-                    <Typography variant="caption" letterSpacing="0px" fontWeight="bold" color="text.primary">
-                      {positionGroup.name}
-                    </Typography>
-                  ),
-                  disableSort: true,
-                },
-                { id: 'balance', label: 'Balance', disableSort: true },
-                { id: 'value', label: 'Value', align: 'right', disableSort: true },
-              ]
+                  const headCells = [
+                    {
+                      id: 'name',
+                      label: (
+                        <Typography variant="caption" letterSpacing="0px" fontWeight="bold" color="text.primary">
+                          {positionGroup.name}
+                        </Typography>
+                      ),
+                      disableSort: true,
+                    },
+                    { id: 'balance', label: 'Balance', disableSort: true },
+                    { id: 'value', label: 'Value', align: 'right', disableSort: true },
+                  ]
 
-              return (
-                <Box key={positionGroup.name} mt={2}>
-                  <EnhancedTable rows={rows} headCells={headCells} compact />
-                </Box>
-              )
-            })}
+                  return (
+                    <Box key={positionGroup.name}>
+                      <EnhancedTable rows={rows} headCells={headCells} compact />
+                    </Box>
+                  )
+                })}
+              </AccordionDetails>
+            </Accordion>
           </Card>
         )
       })}


### PR DESCRIPTION
## What it solves

Part of [GOR-44](https://linear.app/safe-global/issue/GRO-44/qa-final-round-for-positions)

## How this PR fixes it

- Makes position tables expandable
- Makes position icons round
- Shows the token symbol in the asset table

## How to test it

1. Open positions and assets page
2. Compare with design

## Screenshots
<img width="1260" height="338" alt="Screenshot 2025-08-28 at 15 45 08" src="https://github.com/user-attachments/assets/d1cf6b1d-00f5-45d1-88bf-9ab340a87229" />
<img width="1268" height="627" alt="Screenshot 2025-08-28 at 15 45 19" src="https://github.com/user-attachments/assets/6225ef69-5cb3-4b42-8f14-94e148f3e399" />
<img width="1253" height="529" alt="Screenshot 2025-08-28 at 15 45 35" src="https://github.com/user-attachments/assets/035a1465-b11f-40f8-81b4-1c2746d05286" />



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
