### PR TITLE
Feat(Positions): Fix decimals and alignment of asset and positions value

### DIFF
--- a/apps/web/src/components/balances/AssetsTable/FiatBalance.tsx
+++ b/apps/web/src/components/balances/AssetsTable/FiatBalance.tsx
@@ -8,7 +8,7 @@ export const FiatBalance = ({ balanceItem }: { balanceItem: Balance }) => {
 
   return (
     <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="flex-end">
-      <FiatValue value={isMissingFiatConversion ? null : balanceItem.fiatBalance} />
+      <FiatValue value={isMissingFiatConversion ? null : balanceItem.fiatBalance} precise />
 
       {isMissingFiatConversion && (
         <Tooltip

--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -211,7 +211,7 @@ const AssetsTable = ({
               content: (
                 <Box textAlign="left">
                   <Typography>
-                    <FiatValue value={item.fiatBalance} />
+                    <FiatValue value={item.fiatBalance} precise uniformColor />
                   </Typography>
                   {item.fiatBalance24hChange && (
                     <Typography variant="caption">

--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -92,30 +92,31 @@ const headCells = [
   {
     id: 'asset',
     label: 'Asset',
-    width: '40%',
+    width: '20%',
   },
   {
     id: 'price',
     label: 'Price',
-    width: '15%',
-    align: 'left',
+    width: '20%',
+    align: 'right',
   },
   {
     id: 'balance',
     label: 'Balance',
-    width: '15%',
+    width: '20%',
+    align: 'right',
   },
   {
     id: 'value',
     label: 'Value',
-    width: '15%',
-    align: 'left',
+    width: '20%',
+    align: 'right',
   },
   {
     id: 'weight',
     label: 'Weight',
-    width: '15%',
-    align: 'left',
+    width: '20%',
+    align: 'right',
   },
   {
     id: 'actions',
@@ -187,29 +188,33 @@ const AssetsTable = ({
             price: {
               rawValue: rawPriceValue,
               content: (
-                <Typography>
-                  <FiatValue value={item.fiatConversion} />
-                </Typography>
+                <Box textAlign="right">
+                  <Typography>
+                    <FiatValue value={item.fiatConversion} />
+                  </Typography>
+                </Box>
               ),
             },
             balance: {
               rawValue: Number(item.balance) / 10 ** (item.tokenInfo.decimals ?? 0),
               collapsed: item.tokenInfo.address === hidingAsset,
               content: (
-                <Typography sx={{ '& b': { fontWeight: '400' } }}>
-                  <TokenAmount
-                    value={item.balance}
-                    decimals={item.tokenInfo.decimals}
-                    tokenSymbol={item.tokenInfo.symbol}
-                  />
-                </Typography>
+                <Box textAlign="right">
+                  <Typography sx={{ '& b': { fontWeight: '400' } }}>
+                    <TokenAmount
+                      value={item.balance}
+                      decimals={item.tokenInfo.decimals}
+                      tokenSymbol={item.tokenInfo.symbol}
+                    />
+                  </Typography>
+                </Box>
               ),
             },
             value: {
               rawValue: rawFiatValue,
               collapsed: item.tokenInfo.address === hidingAsset,
               content: (
-                <Box textAlign="left">
+                <Box textAlign="right">
                   <Typography>
                     <FiatValue value={item.fiatBalance} precise uniformColor />
                   </Typography>
@@ -224,39 +229,43 @@ const AssetsTable = ({
             weight: {
               rawValue: itemShareOfFiatTotal,
               content: itemShareOfFiatTotal ? (
-                <Stack direction="row" alignItems="center" gap={1} position="relative">
-                  <svg className={css.gradient}>
-                    <defs>
-                      <linearGradient
-                        id="progress_gradient"
-                        x1="21.1648"
-                        y1="8.21591"
-                        x2="-9.95028"
-                        y2="22.621"
-                        gradientUnits="userSpaceOnUse"
-                      >
-                        <stop stopColor="#5FDDFF" />
-                        <stop offset="1" stopColor="#12FF80" />
-                      </linearGradient>
-                    </defs>
-                  </svg>
-                  <CircularProgress
-                    variant="determinate"
-                    value={100}
-                    className={css.circleBg}
-                    size={16}
-                    thickness={6}
-                  />
-                  <CircularProgress
-                    variant="determinate"
-                    value={itemShareOfFiatTotal * 100}
-                    className={css.circleProgress}
-                    size={16}
-                    thickness={6}
-                    sx={{ 'svg circle': { stroke: 'url(#progress_gradient)', strokeLinecap: 'round' } }}
-                  />
-                  <Typography variant="body2">{formatPercentage(itemShareOfFiatTotal)}</Typography>
-                </Stack>
+                <Box textAlign="right">
+                  <Stack direction="row" alignItems="center" gap={0.5} position="relative" display="inline-flex">
+                    <svg className={css.gradient}>
+                      <defs>
+                        <linearGradient
+                          id="progress_gradient"
+                          x1="21.1648"
+                          y1="8.21591"
+                          x2="-9.95028"
+                          y2="22.621"
+                          gradientUnits="userSpaceOnUse"
+                        >
+                          <stop stopColor="#5FDDFF" />
+                          <stop offset="1" stopColor="#12FF80" />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                    <CircularProgress
+                      variant="determinate"
+                      value={100}
+                      className={css.circleBg}
+                      size={16}
+                      thickness={6}
+                    />
+                    <CircularProgress
+                      variant="determinate"
+                      value={itemShareOfFiatTotal * 100}
+                      className={css.circleProgress}
+                      size={16}
+                      thickness={6}
+                      sx={{ 'svg circle': { stroke: 'url(#progress_gradient)', strokeLinecap: 'round' } }}
+                    />
+                    <Typography variant="body2" sx={{ minWidth: '52px', textAlign: 'right' }}>
+                      {formatPercentage(itemShareOfFiatTotal)}
+                    </Typography>
+                  </Stack>
+                </Box>
               ) : (
                 <></>
               ),

--- a/apps/web/src/components/balances/TotalAssetValue/index.tsx
+++ b/apps/web/src/components/balances/TotalAssetValue/index.tsx
@@ -16,7 +16,7 @@ const TotalAssetValue = ({ fiatTotal }: { fiatTotal: number | undefined }) => {
       <Typography component="div" variant="h1" fontSize="44px" lineHeight="1.2" letterSpacing="-0.5px">
         {safe.deployed ? (
           fiatTotal !== undefined ? (
-            <FiatValue value={fiatTotal} />
+            <FiatValue value={fiatTotal} precise />
           ) : (
             <Skeleton variant="text" width={60} />
           )

--- a/apps/web/src/components/common/FiatValue/index.tsx
+++ b/apps/web/src/components/common/FiatValue/index.tsx
@@ -11,10 +11,12 @@ const FiatValue = ({
   value,
   maxLength,
   precise,
+  uniformColor,
 }: {
   value: string | number | null
   maxLength?: number
   precise?: boolean
+  uniformColor?: boolean
 }): ReactElement => {
   const currency = useAppSelector(selectCurrency)
 
@@ -46,7 +48,12 @@ const FiatValue = ({
           <>
             {whole}
             {decimals && (
-              <Typography component="span" color="text.secondary" fontSize="inherit" fontWeight="inherit">
+              <Typography
+                component="span"
+                color={uniformColor ? 'inherit' : 'text.secondary'}
+                fontSize="inherit"
+                fontWeight="inherit"
+              >
                 {decimals}
               </Typography>
             )}

--- a/apps/web/src/features/positions/components/PositionsHeader/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsHeader/index.tsx
@@ -24,7 +24,7 @@ const PositionsHeader = ({ protocol, fiatTotal }: { protocol: Protocol; fiatTota
         {shareOfFiatTotal && <Chip variant="filled" size="tiny" label={shareOfFiatTotal} />}
 
         <Typography fontWeight="bold" mr={1} ml="auto" justifySelf="flex-end">
-          <FiatValue value={protocol.fiatTotal} maxLength={20} precise />
+          <FiatValue value={protocol.fiatTotal} maxLength={20} precise uniformColor />
         </Typography>
       </Stack>
     </>

--- a/apps/web/src/features/positions/index.tsx
+++ b/apps/web/src/features/positions/index.tsx
@@ -52,9 +52,12 @@ export const Positions = () => {
                   },
                   balance: {
                     content: (
-                      <Typography>
-                        {formatVisualAmount(position.balance, position.tokenInfo.decimals)} {position.tokenInfo.symbol}
-                      </Typography>
+                      <Box textAlign="right">
+                        <Typography>
+                          {formatVisualAmount(position.balance, position.tokenInfo.decimals)}{' '}
+                          {position.tokenInfo.symbol}
+                        </Typography>
+                      </Box>
                     ),
                     rawValue: position.balance,
                   },
@@ -82,11 +85,11 @@ export const Positions = () => {
                       {positionGroup.name}
                     </Typography>
                   ),
-                  width: '40%',
+                  width: '25%',
                   disableSort: true,
                 },
-                { id: 'balance', label: 'Balance', width: '40%', disableSort: true },
-                { id: 'value', label: 'Value', width: '20%', align: 'right', disableSort: true },
+                { id: 'balance', label: 'Balance', width: '35%', align: 'right', disableSort: true },
+                { id: 'value', label: 'Value', width: '40%', align: 'right', disableSort: true },
               ]
 
               return (


### PR DESCRIPTION
## What it solves

* Shows decimals when they are required.
* Aligns columns of Asset and Positions view to the right.

## How this PR fixes it

## How to test it

1. Look at Asset and Position view. 
2. Observe decimals.
3. Observe alignment.

## Screenshots

<img width="1968" height="783" alt="grafik" src="https://github.com/user-attachments/assets/c6027b85-4a8d-4189-bb3f-6700ef97df74" />

<img width="1961" height="676" alt="grafik" src="https://github.com/user-attachments/assets/cfa1b976-d53c-489f-92de-a1686f524efd" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
