### PR TITLE
Feat(Positions): Use visible balance for total asset balance.

### DIFF
--- a/apps/web/src/pages/balances/index.tsx
+++ b/apps/web/src/pages/balances/index.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head'
 
 import AssetsTable from '@/components/balances/AssetsTable'
 import AssetsHeader from '@/components/balances/AssetsHeader'
-import useBalances from '@/hooks/useBalances'
+import { useVisibleBalances } from '@/hooks/useVisibleBalances'
 import { useState } from 'react'
 
 import PagePlaceholder from '@/components/common/PagePlaceholder'
@@ -18,7 +18,7 @@ import { BRAND_NAME } from '@/config/constants'
 import TotalAssetValue from '@/components/balances/TotalAssetValue'
 
 const Balances: NextPage = () => {
-  const { balances, error } = useBalances()
+  const { balances, error } = useVisibleBalances()
   const [showHiddenAssets, setShowHiddenAssets] = useState(false)
   const toggleShowHiddenAssets = () => setShowHiddenAssets((prev) => !prev)
   const isStakingBannerEnabled = useIsStakingBannerEnabled()


### PR DESCRIPTION
## What it solves

The total balance at assets was not reduced by hiding tokens.

## How this PR fixes it

Now the total balance at assets is reduced by hiding tokens.

## How to test it

1. Go to assets.
2. Observe the total balance.
3. Hide a token.
4. Observe that the total balance got decreased.

## Screenshots

<img width="1983" height="507" alt="grafik" src="https://github.com/user-attachments/assets/1cd0202d-f4cc-46fd-b159-774b6515a358" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
