### PR TITLE
feat(positions): remove positions from total value

### DIFF
--- a/apps/web/src/hooks/useFiatTotal.ts
+++ b/apps/web/src/hooks/useFiatTotal.ts
@@ -1,13 +1,11 @@
 import { useVisibleBalances } from '@/hooks/useVisibleBalances'
-import usePositionsFiatTotal from '@/features/positions/hooks/usePositionsFiatTotal'
 
 const useFiatTotal = () => {
   const { balances } = useVisibleBalances()
-  const positionsFiatTotal = usePositionsFiatTotal()
 
   if (!balances.fiatTotal) return
 
-  return Number(balances.fiatTotal) + positionsFiatTotal
+  return Number(balances.fiatTotal)
 }
 
 export default useFiatTotal


### PR DESCRIPTION
## What it solves

We had a double-accounting issue when calculation the total portfolio value by summing up assets and positions. Some positions are represented with tokens, and would such affect the total calculation twice. 

## How this PR fixes it

Removes positions from the total value calculation.

## How to test it

Observe the total value and make sure the positions don't count into it.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
