### PR TITLE
feat(positions): hide earn button when earn is deactivated

### DIFF
--- a/apps/web/src/features/positions/components/PositionsEmpty/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsEmpty/index.tsx
@@ -7,6 +7,7 @@ import { AppRoutes } from '@/config/routes'
 import Track from '@/components/common/Track'
 import { POSITIONS_EVENTS } from '@/services/analytics/events/positions'
 import { MixPanelEventParams } from '@/services/analytics/mixpanel-events'
+import useIsEarnFeatureEnabled from '@/features/earn/hooks/useIsEarnFeatureEnabled'
 
 type PositionsEmptyProps = {
   entryPoint?: string
@@ -14,6 +15,7 @@ type PositionsEmptyProps = {
 
 const PositionsEmpty = ({ entryPoint = 'Dashboard' }: PositionsEmptyProps) => {
   const router = useRouter()
+  const isEarnFeatureEnabled = useIsEarnFeatureEnabled()
 
   return (
     <Paper elevation={0} sx={{ p: 3, textAlign: 'center' }}>
@@ -23,18 +25,20 @@ const PositionsEmpty = ({ entryPoint = 'Dashboard' }: PositionsEmptyProps) => {
         You have no active DeFi positions yet
       </Typography>
 
-      <Track
-        {...POSITIONS_EVENTS.EMPTY_POSITIONS_EXPLORE_CLICKED}
-        mixpanelParams={{
-          [MixPanelEventParams.ENTRY_POINT]: entryPoint,
-        }}
-      >
-        <Link href={AppRoutes.earn && { pathname: AppRoutes.earn, query: { safe: router.query.safe } }} passHref>
-          <Button size="small" sx={{ mt: 1 }}>
-            Explore Earn
-          </Button>
-        </Link>
-      </Track>
+      {isEarnFeatureEnabled && (
+        <Track
+          {...POSITIONS_EVENTS.EMPTY_POSITIONS_EXPLORE_CLICKED}
+          mixpanelParams={{
+            [MixPanelEventParams.ENTRY_POINT]: entryPoint,
+          }}
+        >
+          <Link href={{ pathname: AppRoutes.earn, query: { safe: router.query.safe } }} passHref>
+            <Button size="small" sx={{ mt: 1 }}>
+              Explore Earn
+            </Button>
+          </Link>
+        </Track>
+      )}
     </Paper>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves https://linear.app/safe-global/issue/COR-543/improve-empty-state

## How this PR fixes it

Removes Earn button when the earn feature is not enabled.

## How to test it

Check Empty Position Widget on a Chain where Earn is disabled.
It should NOT show the Earn button.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
