### PR TITLE
implement ens resolution for safe owner list

### DIFF
--- a/apps/web/src/components/settings/owner/OwnerList/index.tsx
+++ b/apps/web/src/components/settings/owner/OwnerList/index.tsx
@@ -17,26 +17,36 @@ import { TxModalContext } from '@/components/tx-flow'
 import ReplaceOwnerIcon from '@/public/images/settings/setup/replace-owner.svg'
 import DeleteIcon from '@/public/images/common/delete.svg'
 import type { AddressBook } from '@/store/addressBookSlice'
-
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
+import useResolvedOwners from '@/hooks/useResolvedOwners'
 
 export const OwnerList = () => {
   const addressBook = useAddressBook()
   const { safe } = useSafeInfo()
   const { setTxFlow } = useContext(TxModalContext)
+  const owners = useResolvedOwners()
 
   const rows = useMemo(() => {
-    const showRemoveOwnerButton = safe.owners.length > 1
+    const showRemoveOwnerButton = owners.length > 1
 
-    return safe.owners.map((owner) => {
+    return owners.map((owner) => {
       const address = owner.value
-      const name = addressBook[address]
+      let name = addressBook[address] || owner.name || undefined
 
       return {
         cells: {
           owner: {
             rawValue: address,
-            content: <EthHashInfo address={address} showCopyButton shortAddress={false} showName={true} hasExplorer />,
+            content: (
+              <EthHashInfo
+                address={address}
+                showCopyButton
+                shortAddress={false}
+                showName={true}
+                name={name}
+                hasExplorer
+              />
+            ),
           },
           actions: {
             rawValue: '',
@@ -88,7 +98,7 @@ export const OwnerList = () => {
         },
       }
     })
-  }, [safe.owners, safe.chainId, addressBook, setTxFlow])
+  }, [owners, safe.chainId, addressBook, setTxFlow])
 
   return (
     <Box

--- a/apps/web/src/hooks/__tests__/useResolvedOwners.test.ts
+++ b/apps/web/src/hooks/__tests__/useResolvedOwners.test.ts
@@ -1,0 +1,216 @@
+import { renderHook, waitFor } from '@/tests/test-utils'
+import useResolvedOwners from '../useResolvedOwners'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { lookupAddress } from '@/services/ens'
+import { faker } from '@faker-js/faker'
+import { addressExBuilder, extendedSafeInfoBuilder } from '@/tests/builders/safe'
+import { generateRandomArray } from '@/tests/builders/utils'
+import { JsonRpcProvider } from 'ethers'
+
+jest.mock('@/hooks/useSafeInfo')
+jest.mock('@/hooks/wallets/web3')
+jest.mock('@/services/ens')
+
+const mockUseSafeInfo = useSafeInfo as jest.MockedFunction<typeof useSafeInfo>
+const mockUseWeb3ReadOnly = useWeb3ReadOnly as jest.MockedFunction<typeof useWeb3ReadOnly>
+const mockLookupAddress = lookupAddress as jest.MockedFunction<typeof lookupAddress>
+
+describe('useResolvedOwners', () => {
+  const mockProvider = new JsonRpcProvider()
+  const safeAddress = faker.finance.ethereumAddress()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('should return owners without ENS resolution when no provider is available', () => {
+    const owners = generateRandomArray(() => addressExBuilder().build(), { min: 2, max: 3 })
+
+    mockUseSafeInfo.mockReturnValue({
+      safe: extendedSafeInfoBuilder()
+        .with({ address: { value: safeAddress } })
+        .with({ owners })
+        .build(),
+      safeAddress,
+      safeLoaded: true,
+      safeLoading: false,
+    })
+
+    mockUseWeb3ReadOnly.mockReturnValue(undefined)
+
+    const { result } = renderHook(() => useResolvedOwners())
+
+    expect(result.current).toEqual(owners)
+    expect(mockLookupAddress).not.toHaveBeenCalled()
+  })
+
+  it('should return owners without ENS resolution when no owners exist', () => {
+    mockUseSafeInfo.mockReturnValue({
+      safe: extendedSafeInfoBuilder()
+        .with({ address: { value: safeAddress } })
+        .with({ owners: [] })
+        .build(),
+      safeAddress,
+      safeLoaded: true,
+      safeLoading: false,
+    })
+
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+
+    const { result } = renderHook(() => useResolvedOwners())
+
+    expect(result.current).toEqual([])
+    expect(mockLookupAddress).not.toHaveBeenCalled()
+  })
+
+  it('should resolve ENS names for owners when provider is available', async () => {
+    const owners = [
+      addressExBuilder().with({ value: '0x1234567890123456789012345678901234567890', name: '' }).build(),
+      addressExBuilder().with({ value: '0x0987654321098765432109876543210987654321', name: '' }).build(),
+    ]
+
+    mockUseSafeInfo.mockReturnValue({
+      safe: extendedSafeInfoBuilder()
+        .with({ address: { value: safeAddress } })
+        .with({ owners })
+        .build(),
+      safeAddress,
+      safeLoaded: true,
+      safeLoading: false,
+    })
+
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockLookupAddress.mockResolvedValueOnce('alice.eth').mockResolvedValueOnce('bob.eth')
+
+    const { result } = renderHook(() => useResolvedOwners())
+
+    await waitFor(() => {
+      expect(result.current).toEqual([
+        { ...owners[0], name: 'alice.eth' },
+        { ...owners[1], name: 'bob.eth' },
+      ])
+    })
+
+    expect(mockLookupAddress).toHaveBeenCalledTimes(2)
+    expect(mockLookupAddress).toHaveBeenCalledWith(mockProvider, owners[0].value)
+    expect(mockLookupAddress).toHaveBeenCalledWith(mockProvider, owners[1].value)
+  })
+
+  it('should preserve existing names and only resolve missing ones', async () => {
+    const owners = [
+      addressExBuilder().with({ value: '0x1234567890123456789012345678901234567890', name: 'Alice' }).build(),
+      addressExBuilder().with({ value: '0x0987654321098765432109876543210987654321', name: '' }).build(),
+    ]
+
+    mockUseSafeInfo.mockReturnValue({
+      safe: extendedSafeInfoBuilder()
+        .with({ address: { value: safeAddress } })
+        .with({ owners })
+        .build(),
+      safeAddress,
+      safeLoaded: true,
+      safeLoading: false,
+    })
+
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockLookupAddress.mockResolvedValueOnce('bob.eth')
+
+    const { result } = renderHook(() => useResolvedOwners())
+
+    await waitFor(() => {
+      expect(result.current).toEqual([
+        { ...owners[0], name: 'Alice' },
+        { ...owners[1], name: 'bob.eth' },
+      ])
+    })
+
+    expect(mockLookupAddress).toHaveBeenCalledTimes(1)
+    expect(mockLookupAddress).toHaveBeenCalledWith(mockProvider, owners[1].value)
+  })
+
+  it('should handle ENS resolution errors gracefully', async () => {
+    const owners = [
+      addressExBuilder().with({ value: '0x1234567890123456789012345678901234567890', name: undefined }).build(),
+      addressExBuilder().with({ value: '0x0987654321098765432109876543210987654321', name: undefined }).build(),
+    ]
+
+    mockUseSafeInfo.mockReturnValue({
+      safe: extendedSafeInfoBuilder()
+        .with({ address: { value: safeAddress } })
+        .with({ owners })
+        .build(),
+      safeAddress,
+      safeLoaded: true,
+      safeLoading: false,
+    })
+
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockLookupAddress.mockRejectedValueOnce(new Error('ENS resolution failed')).mockResolvedValueOnce('bob.eth')
+
+    const { result } = renderHook(() => useResolvedOwners())
+
+    await waitFor(() => {
+      expect(result.current).toEqual([
+        { ...owners[0], name: undefined },
+        { ...owners[1], name: 'bob.eth' },
+      ])
+    })
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to resolve ENS name for address:',
+      owners[0].value,
+      expect.any(Error),
+    )
+    expect(mockLookupAddress).toHaveBeenCalledTimes(2)
+  })
+
+  it('should handle undefined ENS resolution results', async () => {
+    const owners = [addressExBuilder().with({ value: '0x1234567890123456789012345678901234567890', name: '' }).build()]
+
+    mockUseSafeInfo.mockReturnValue({
+      safe: extendedSafeInfoBuilder()
+        .with({ address: { value: safeAddress } })
+        .with({ owners })
+        .build(),
+      safeAddress,
+      safeLoaded: true,
+      safeLoading: false,
+    })
+
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockLookupAddress.mockResolvedValueOnce(undefined)
+
+    const { result } = renderHook(() => useResolvedOwners())
+
+    await waitFor(() => {
+      expect(result.current).toEqual([{ ...owners[0], name: undefined }])
+    })
+
+    expect(mockLookupAddress).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return original owners when async operation is still pending', () => {
+    const owners = generateRandomArray(() => addressExBuilder().build(), { min: 1, max: 2 })
+
+    mockUseSafeInfo.mockReturnValue({
+      safe: extendedSafeInfoBuilder()
+        .with({ address: { value: safeAddress } })
+        .with({ owners })
+        .build(),
+      safeAddress,
+      safeLoaded: true,
+      safeLoading: false,
+    })
+
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    // Don't resolve the promise immediately to test the fallback
+    mockLookupAddress.mockImplementation(() => new Promise(() => {}))
+
+    const { result } = renderHook(() => useResolvedOwners())
+
+    // Should return original owners while async operation is pending
+    expect(result.current).toEqual(owners)
+  })
+})

--- a/apps/web/src/hooks/useResolvedOwners.ts
+++ b/apps/web/src/hooks/useResolvedOwners.ts
@@ -1,0 +1,36 @@
+import { useWeb3ReadOnly } from './wallets/web3'
+import useSafeInfo from './useSafeInfo'
+import { lookupAddress } from '@/services/ens'
+import useAsync from '@safe-global/utils/hooks/useAsync'
+
+const useResolvedOwners = () => {
+  const { safe } = useSafeInfo()
+  const ethersProvider = useWeb3ReadOnly()
+
+  const [resolvedOwners] = useAsync(async () => {
+    if (!ethersProvider || !safe.owners.length) {
+      return safe.owners
+    }
+
+    return await Promise.all(
+      safe.owners.map(async (owner) => {
+        const address = owner.value
+        let name: string | undefined = owner.name ?? undefined
+
+        if (!name || name === '') {
+          try {
+            name = await lookupAddress(ethersProvider, owner.value)
+          } catch (error) {
+            console.warn('Failed to resolve ENS name for address:', address, error)
+          }
+        }
+
+        return { ...owner, name }
+      }),
+    )
+  }, [safe.owners, ethersProvider])
+
+  return resolvedOwners ?? safe.owners
+}
+
+export default useResolvedOwners


### PR DESCRIPTION
## What it solves

Resolves [https://x.com/austingriffith/status/1961450319411646535](https://x.com/austingriffith/status/1961450319411646535)

## How this PR fixes it

Add an ENS resolution hook for Safe owners

## How to test it

Load a safe -> Settings -> Setup -> Signers

## Screenshots

<img width="869" height="402" alt="safe-signers-with-ens" src="https://github.com/user-attachments/assets/720761d9-69b3-4f85-9fac-4abdebc5fb04" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
