### PR TITLE
fix(assets): fix horizontal scroll in assets table

### DIFF
--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -93,24 +93,24 @@ const headCells = [
   {
     id: 'asset',
     label: 'Asset',
-    width: '30%',
+    width: '28%',
   },
   {
     id: 'price',
     label: 'Price',
-    width: '20%',
+    width: '18%',
     align: 'right',
   },
   {
     id: 'balance',
     label: 'Balance',
-    width: '20%',
+    width: '18%',
     align: 'right',
   },
   {
     id: 'value',
     label: 'Value',
-    width: '20%',
+    width: '18%',
     align: 'right',
   },
   {
@@ -122,7 +122,7 @@ const headCells = [
         </Typography>
       </Tooltip>
     ),
-    width: '20%',
+    width: '18%',
     align: 'right',
   },
   {

--- a/apps/web/src/components/common/EnhancedTable/index.tsx
+++ b/apps/web/src/components/common/EnhancedTable/index.tsx
@@ -160,7 +160,7 @@ function EnhancedTable({ rows, headCells, mobileVariant, compact }: EnhancedTabl
         component={Paper}
         sx={{
           width: '100%',
-          overflowX: 'hidden',
+          overflowX: ['auto', 'hidden'],
           borderBottomLeftRadius: showPagination ? 0 : '6px',
           borderBottomRightRadius: showPagination ? 0 : '6px',
         }}

--- a/apps/web/src/components/common/EnhancedTable/index.tsx
+++ b/apps/web/src/components/common/EnhancedTable/index.tsx
@@ -160,6 +160,7 @@ function EnhancedTable({ rows, headCells, mobileVariant, compact }: EnhancedTabl
         component={Paper}
         sx={{
           width: '100%',
+          overflowX: 'hidden',
           borderBottomLeftRadius: showPagination ? 0 : '6px',
           borderBottomRightRadius: showPagination ? 0 : '6px',
         }}


### PR DESCRIPTION
## What it solves

The assets table was scrolling horizontally due to an added column (DeFi positions).

* Reduce the width of columns to add up to 100%
* Add `overflowX: hidden`