### PR TITLE
fix(web): make sure sidebar is pre-rendered in SSG

### DIFF
--- a/apps/web/src/hooks/useIsSidebarRoute.ts
+++ b/apps/web/src/hooks/useIsSidebarRoute.ts
@@ -30,12 +30,11 @@ export function useIsSidebarRoute(pathname?: string): [boolean, boolean] {
   const router = useRouter()
   const clientPathname = usePathname()
   const isSpaceRoute = useIsSpaceRoute()
-  const [hasSafe, setHasSafe] = useState(false)
-
   const route = pathname || clientPathname || ''
   const sidebarQuery = router.query.sidebar === 'true'
   const noSidebar = NO_SIDEBAR_ROUTES.includes(route) && !sidebarQuery
   const toggledSidebar = TOGGLE_SIDEBAR_ROUTES.includes(route) && !sidebarQuery
+  const [hasSafe, setHasSafe] = useState(!noSidebar)
 
   useEffect(() => {
     if (!router.isReady) return


### PR DESCRIPTION
## What it solves

The appearing sidebar was causing flicker on the initial page load.

## How this PR fixes it

Even though we already have a pathname available from SSG, we weren't using it for the initial render.

## How to test it

* Load or hard-refresh any page with a sidebar (e.g. Dashboard)
  - the sidebar should be rendered from the start
* Load or refresh any page without a sidebar (e.g. Welcome)
  - the sidebar should never appear