### PR TITLE
fix(dashboard): don't show 0 balance before balances are loaded

### DIFF
--- a/apps/web/src/components/dashboard/Overview/Overview.tsx
+++ b/apps/web/src/components/dashboard/Overview/Overview.tsx
@@ -21,7 +21,7 @@ import OverviewSkeleton from './OverviewSkeleton'
 
 const Overview = (): ReactElement => {
   const { safe, safeLoading, safeLoaded } = useSafeInfo()
-  const { balances, loading: balancesLoading } = useVisibleBalances()
+  const { balances, loaded: balancesLoaded, loading: balancesLoading } = useVisibleBalances()
   const { setTxFlow } = useContext(TxModalContext)
   const router = useRouter()
   const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
@@ -38,7 +38,7 @@ const Overview = (): ReactElement => {
     return balances.items.filter((item) => item.balance !== '0')
   }, [balances.items])
 
-  const noAssets = !balancesLoading && items.length === 0
+  const noAssets = balancesLoaded && items.length === 0
 
   if (isLoading) return <OverviewSkeleton />
 

--- a/apps/web/src/components/dashboard/index.tsx
+++ b/apps/web/src/components/dashboard/index.tsx
@@ -32,7 +32,7 @@ const Dashboard = (): ReactElement => {
   const showSafeApps = useHasFeature(FEATURES.SAFE_APPS)
   const supportsRecovery = useIsRecoverySupported()
 
-  const { balances, loading: balancesLoading } = useVisibleBalances()
+  const { balances, loaded: balancesLoaded } = useVisibleBalances()
   const items = useMemo(() => {
     return balances.items.filter((item) => item.balance !== '0')
   }, [balances.items])
@@ -48,7 +48,7 @@ const Dashboard = (): ReactElement => {
     isStakingBannerVisible && { id: stakeBannerID, element: StakeBanner },
   ].filter(Boolean) as BannerItem[]
 
-  const noAssets = !balancesLoading && items.length === 0
+  const noAssets = balancesLoaded && items.length === 0
 
   return (
     <>

--- a/apps/web/src/components/safe-apps/AppFrame/__tests__/AppFrame.test.tsx
+++ b/apps/web/src/components/safe-apps/AppFrame/__tests__/AppFrame.test.tsx
@@ -25,6 +25,7 @@ describe('AppFrame', () => {
       initialReduxState: {
         safeInfo: {
           loading: true,
+          loaded: true,
           data: defaultSafeInfo,
         },
         txQueue: {
@@ -67,6 +68,7 @@ describe('AppFrame', () => {
               },
             ],
           },
+          loaded: true,
           loading: false,
           error: undefined,
         },

--- a/apps/web/src/hooks/useBalances.ts
+++ b/apps/web/src/hooks/useBalances.ts
@@ -6,19 +6,21 @@ import type { Balances } from '@safe-global/store/gateway/AUTO_GENERATED/balance
 
 const useBalances = (): {
   balances: Balances
+  loaded: boolean
   loading: boolean
   error?: string
 } => {
   const state = useAppSelector(selectBalances, isEqual)
-  const { data, error, loading } = state
+  const { data, error, loaded, loading } = state
 
   return useMemo(
     () => ({
       balances: data,
       error,
+      loaded,
       loading,
     }),
-    [data, error, loading],
+    [data, error, loaded, loading],
   )
 }
 

--- a/apps/web/src/hooks/useSafeInfo.ts
+++ b/apps/web/src/hooks/useSafeInfo.ts
@@ -12,17 +12,17 @@ const useSafeInfo = (): {
   safeLoading: boolean
   safeError?: string
 } => {
-  const { data, error, loading } = useAppSelector(selectSafeInfo, isEqual)
+  const { data, error, loaded, loading } = useAppSelector(selectSafeInfo, isEqual)
 
   return useMemo(
     () => ({
       safe: data || defaultSafeInfo,
       safeAddress: data?.address.value || '',
-      safeLoaded: !!data,
+      safeLoaded: loaded,
       safeError: error,
       safeLoading: loading,
     }),
-    [data, error, loading],
+    [data, error, loaded, loading],
   )
 }
 

--- a/apps/web/src/hooks/useVisibleBalances.ts
+++ b/apps/web/src/hooks/useVisibleBalances.ts
@@ -42,6 +42,7 @@ const getVisibleFiatTotal = (balances: SafeBalanceResponse, hiddenAssets: string
 
 export const useVisibleBalances = (): {
   balances: SafeBalanceResponse
+  loaded: boolean
   loading: boolean
   error?: string
 } => {

--- a/apps/web/src/store/common.ts
+++ b/apps/web/src/store/common.ts
@@ -3,6 +3,7 @@ import type { RootState } from '@/store/index'
 
 export type Loadable<T> = {
   data: T
+  loaded: boolean
   loading: boolean
   error?: string
 }
@@ -12,6 +13,7 @@ export const makeLoadableSlice = <N extends string, T>(name: N, data: T) => {
 
   const initialState: SliceState = {
     data,
+    loaded: false,
     loading: false,
   }
 
@@ -22,6 +24,7 @@ export const makeLoadableSlice = <N extends string, T>(name: N, data: T) => {
       set: (_, { payload }: PayloadAction<Loadable<T | undefined>>): SliceState => ({
         ...payload,
         data: payload.data ?? initialState.data, // fallback to initialState.data
+        loaded: payload.data !== undefined,
       }),
     },
   })


### PR DESCRIPTION
## What it solves

There was an inconsistent initial state when loading the dashboard. Balances aren't in a _loading_ state initially (`loading: false`) , yet there was initial placeholder data with `items: []`.

<img width="804" height="465" alt="Screenshot 2025-09-03 at 09 11 31" src="https://github.com/user-attachments/assets/9e97c183-641f-4780-bc42-c09099ec52c5" />

## How it solves it

I've added a new piece of state for all "loadable" slices like Balances and Safe Info to indicate whether the data has been loaded or not. The lifecycle of loadable slices is now like this:

1. Initial state:
```
{
  data: { ... }, // placeholder data,
  loaded: false,
  loading: false, // hasn't started loading yet
  error: undefined,
}
```

2. Loading state:
```
{
  data: { ... }, // placeholder data,
  loaded: false,
  loading: true,
  error: undefined,
}
```

3. Finished loading:
```
{
  data: { ... }, // actual data
  loaded: true,
  loading: false,
  error: undefined,
}
```

3. Error state:
```
{
  data: { ... }, // placeholder
  loaded: false,
  loading: false,
  error: 'Some error',
}
```