### PR TITLE
Refactor(positions): Dynamically import positions

### DIFF
--- a/apps/web/src/components/dashboard/index.tsx
+++ b/apps/web/src/components/dashboard/index.tsx
@@ -22,10 +22,10 @@ import EarnBanner, { earnBannerID } from '@/components/dashboard/NewsCarousel/ba
 import SpacesBanner, { spacesBannerID } from '@/components/dashboard/NewsCarousel/banners/SpacesBanner'
 import StakeBanner, { stakeBannerID } from '@/components/dashboard/NewsCarousel/banners/StakeBanner'
 import AddFundsToGetStarted from '@/components/dashboard/AddFundsBanner'
-import PositionsWidget from '@/features/positions/components/PositionsWidget'
 import useIsPositionsFeatureEnabled from '@/features/positions/hooks/useIsPositionsFeatureEnabled'
 
 const RecoveryHeader = dynamic(() => import('@/features/recovery/components/RecoveryHeader'))
+const PositionsWidget = dynamic(() => import('@/features/positions/components/PositionsWidget'))
 
 const Dashboard = (): ReactElement => {
   const { safe } = useSafeInfo()

--- a/apps/web/src/features/positions/components/PositionsSkeleton/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsSkeleton/index.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import { Skeleton, Stack, Typography, Box, Card, Accordion, AccordionSummary, AccordionDetails } from '@mui/material'
+import EnhancedTable, { type EnhancedTableProps } from '@/components/common/EnhancedTable'
+
+const skeletonCells: EnhancedTableProps['rows'][0]['cells'] = {
+  name: {
+    rawValue: '0x0',
+    content: (
+      <Stack direction="row" alignItems="center" gap={1}>
+        <Skeleton variant="rounded" width="32px" height="32px" />
+        <Box>
+          <Typography>
+            <Skeleton width="100px" />
+          </Typography>
+          <Typography variant="body2">
+            <Skeleton width="80px" />
+          </Typography>
+        </Box>
+      </Stack>
+    ),
+  },
+  balance: {
+    rawValue: '0',
+    content: (
+      <Typography textAlign="right">
+        <Skeleton width="60px" />
+      </Typography>
+    ),
+  },
+  value: {
+    rawValue: '0',
+    content: (
+      <Box textAlign="right">
+        <Typography>
+          <Skeleton width="50px" />
+        </Typography>
+        <Typography variant="caption">
+          <Skeleton width="40px" />
+        </Typography>
+      </Box>
+    ),
+  },
+}
+
+const skeletonRows: EnhancedTableProps['rows'] = Array(3).fill({ cells: skeletonCells })
+
+const PositionsSkeleton = () => {
+  return (
+    <Stack gap={2}>
+      <Card sx={{ border: 0 }}>
+        <Accordion disableGutters elevation={0} variant="elevation" defaultExpanded>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon fontSize="small" />}
+            sx={{
+              justifyContent: 'center',
+              overflowX: 'auto',
+              backgroundColor: 'transparent !important',
+            }}
+          >
+            <Stack direction="row" alignItems="center" gap={2} width="100%">
+              <Skeleton variant="rounded" width="40px" height="40px" />
+              <Box flex={1}>
+                <Typography>
+                  <Skeleton width="120px" />
+                </Typography>
+                <Typography variant="body2">
+                  <Skeleton width="80px" />
+                </Typography>
+              </Box>
+              <Typography>
+                <Skeleton width="60px" />
+              </Typography>
+            </Stack>
+          </AccordionSummary>
+          <AccordionDetails sx={{ pt: 0 }}>
+            <Box>
+              <EnhancedTable
+                rows={skeletonRows}
+                headCells={[
+                  { id: 'name', label: 'Loading...', width: '25%', disableSort: true },
+                  { id: 'balance', label: 'Balance', width: '35%', align: 'right', disableSort: true },
+                  { id: 'value', label: 'Value', width: '40%', align: 'right', disableSort: true },
+                ]}
+                compact
+              />
+            </Box>
+          </AccordionDetails>
+        </Accordion>
+      </Card>
+    </Stack>
+  )
+}
+
+export default PositionsSkeleton

--- a/apps/web/src/features/positions/index.tsx
+++ b/apps/web/src/features/positions/index.tsx
@@ -1,4 +1,14 @@
-import { Accordion, AccordionDetails, AccordionSummary, Box, Card, Stack, Typography, Skeleton } from '@mui/material'
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Card,
+  Stack,
+  Typography,
+  Tooltip,
+  Chip,
+} from '@mui/material'
 import PositionsHeader from '@/features/positions/components/PositionsHeader'
 import EnhancedTable from '@/components/common/EnhancedTable'
 import FiatValue from '@/components/common/FiatValue'
@@ -12,108 +22,63 @@ import usePositionsFiatTotal from '@/features/positions/hooks/usePositionsFiatTo
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import React from 'react'
 import PositionsUnavailable from './components/PositionsUnavailable'
-import { type EnhancedTableProps } from '@/components/common/EnhancedTable'
-
-const skeletonCells: EnhancedTableProps['rows'][0]['cells'] = {
-  name: {
-    rawValue: '0x0',
-    content: (
-      <Stack direction="row" alignItems="center" gap={1}>
-        <Skeleton variant="rounded" width="32px" height="32px" />
-        <Box>
-          <Typography>
-            <Skeleton width="100px" />
-          </Typography>
-          <Typography variant="body2">
-            <Skeleton width="80px" />
-          </Typography>
-        </Box>
-      </Stack>
-    ),
-  },
-  balance: {
-    rawValue: '0',
-    content: (
-      <Typography textAlign="right">
-        <Skeleton width="60px" />
-      </Typography>
-    ),
-  },
-  value: {
-    rawValue: '0',
-    content: (
-      <Box textAlign="right">
-        <Typography>
-          <Skeleton width="50px" />
-        </Typography>
-        <Typography variant="caption">
-          <Skeleton width="40px" />
-        </Typography>
-      </Box>
-    ),
-  },
-}
-
-const skeletonRows: EnhancedTableProps['rows'] = Array(3).fill({ cells: skeletonCells })
+import TotalAssetValue from '@/components/balances/TotalAssetValue'
+import PositionsSkeleton from '@/features/positions/components/PositionsSkeleton'
 
 export const Positions = () => {
   const positionsFiatTotal = usePositionsFiatTotal()
   const { data: protocols, error, isLoading } = usePositions()
 
   if (isLoading || (!error && !protocols)) {
-    return (
-      <Stack gap={2}>
-        <Card sx={{ border: 0 }}>
-          <Accordion disableGutters elevation={0} variant="elevation" defaultExpanded>
-            <AccordionSummary
-              expandIcon={<ExpandMoreIcon fontSize="small" />}
-              sx={{
-                justifyContent: 'center',
-                overflowX: 'auto',
-                backgroundColor: 'transparent !important',
-              }}
-            >
-              <Stack direction="row" alignItems="center" gap={2} width="100%">
-                <Skeleton variant="rounded" width="40px" height="40px" />
-                <Box flex={1}>
-                  <Typography>
-                    <Skeleton width="120px" />
-                  </Typography>
-                  <Typography variant="body2">
-                    <Skeleton width="80px" />
-                  </Typography>
-                </Box>
-                <Typography>
-                  <Skeleton width="60px" />
-                </Typography>
-              </Stack>
-            </AccordionSummary>
-            <AccordionDetails sx={{ pt: 0 }}>
-              <Box>
-                <EnhancedTable
-                  rows={skeletonRows}
-                  headCells={[
-                    { id: 'name', label: 'Loading...', width: '25%', disableSort: true },
-                    { id: 'balance', label: 'Balance', width: '35%', align: 'right', disableSort: true },
-                    { id: 'value', label: 'Value', width: '40%', align: 'right', disableSort: true },
-                  ]}
-                  compact
-                />
-              </Box>
-            </AccordionDetails>
-          </Accordion>
-        </Card>
-      </Stack>
-    )
+    return <PositionsSkeleton />
   }
 
   if (error || !protocols) return <PositionsUnavailable />
+
   if (protocols.length === 0) {
     return <PositionsEmpty entryPoint="Positions" />
   }
 
   return (
     <Stack gap={2}>
+      <Box>
+        <Box mb={2}>
+          <TotalAssetValue fiatTotal={positionsFiatTotal} title="Total positions value" />
+        </Box>
+
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Typography variant="h4" fontWeight={700}>
+            Positions
+          </Typography>
+          <Tooltip
+            title="Experimental. Data may be missing or outdated."
+            placement="top"
+            arrow
+            slotProps={{
+              tooltip: {
+                sx: {
+                  maxWidth: { xs: '250px', sm: 'none' },
+                },
+              },
+            }}
+          >
+            <Chip label="Beta" size="small" sx={{ backgroundColor: 'background.lightGrey', letterSpacing: '0.4px' }} />
+          </Tooltip>
+        </Stack>
+
+        <Box mb={1}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'text.secondary',
+              letterSpacing: '1px',
+            }}
+          >
+            Position balances are not included in the total asset value.
+          </Typography>
+        </Box>
+      </Box>
+
       {protocols.map((protocol) => {
         return (
           <Card key={protocol.protocol} sx={{ border: 0 }}>

--- a/apps/web/src/pages/balances/positions.tsx
+++ b/apps/web/src/pages/balances/positions.tsx
@@ -3,14 +3,11 @@ import Head from 'next/head'
 
 import AssetsHeader from '@/components/balances/AssetsHeader'
 import { BRAND_NAME } from '@/config/constants'
-import DefiPositions from '@/features/positions'
-import { Box, Chip, Stack, Tooltip, Typography } from '@mui/material'
-import TotalAssetValue from '@/components/balances/TotalAssetValue'
-import usePositionsFiatTotal from '@/features/positions/hooks/usePositionsFiatTotal'
+import dynamic from 'next/dynamic'
+
+const DefiPositions = dynamic(() => import('@/features/positions'))
 
 const Positions: NextPage = () => {
-  const fiatTotal = usePositionsFiatTotal()
-
   return (
     <>
       <Head>
@@ -20,41 +17,6 @@ const Positions: NextPage = () => {
       <AssetsHeader />
 
       <main>
-        <Box mb={2}>
-          <TotalAssetValue fiatTotal={fiatTotal} title="Total positions value" />
-        </Box>
-
-        <Stack direction="row" alignItems="center" gap={1}>
-          <Typography variant="h4" fontWeight={700}>
-            Positions
-          </Typography>
-          <Tooltip
-            title="Experimental. Data may be missing or outdated."
-            placement="top"
-            arrow
-            slotProps={{
-              tooltip: {
-                sx: {
-                  maxWidth: { xs: '250px', sm: 'none' },
-                },
-              },
-            }}
-          >
-            <Chip label="Beta" size="small" sx={{ backgroundColor: 'background.lightGrey', letterSpacing: '0.4px' }} />
-          </Tooltip>
-        </Stack>
-
-        <Box mb={1}>
-          <Typography
-            variant="caption"
-            sx={{
-              color: 'text.secondary',
-              letterSpacing: '1px',
-            }}
-          >
-            Position balances are not included in the total asset value.
-          </Typography>
-        </Box>
         <DefiPositions />
       </main>
     </>


### PR DESCRIPTION
## What it solves

Part of positions feature

## How this PR fixes it

- Dynamically imports positions and `PositionsWidget`
- Moves UI from positions page into positions component
- Extracts `PositionsSkeleton`

## How to test it

1. Open positions and dashboard
2. Everything should still be as it was

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
