### PR TITLE
Fix(assets): consistent fiat value format in assets and positions

### DIFF
--- a/apps/web/src/components/balances/AssetsTable/FiatBalance.tsx
+++ b/apps/web/src/components/balances/AssetsTable/FiatBalance.tsx
@@ -8,7 +8,7 @@ export const FiatBalance = ({ balanceItem }: { balanceItem: Balance }) => {
 
   return (
     <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="flex-end">
-      <FiatValue value={isMissingFiatConversion ? null : balanceItem.fiatBalance} precise />
+      <FiatValue value={isMissingFiatConversion ? null : balanceItem.fiatBalance} />
 
       {isMissingFiatConversion && (
         <Tooltip

--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -93,7 +93,7 @@ const headCells = [
   {
     id: 'asset',
     label: 'Asset',
-    width: '28%',
+    width: '23%',
   },
   {
     id: 'price',
@@ -122,7 +122,7 @@ const headCells = [
         </Typography>
       </Tooltip>
     ),
-    width: '18%',
+    width: '23%',
     align: 'right',
   },
   {
@@ -226,7 +226,7 @@ const AssetsTable = ({
               content: (
                 <Box textAlign="right">
                   <Typography>
-                    <FiatValue value={item.fiatBalance} precise uniformColor />
+                    <FiatValue value={item.fiatBalance} />
                   </Typography>
                   {item.fiatBalance24hChange && (
                     <Typography variant="caption">
@@ -265,7 +265,7 @@ const AssetsTable = ({
               sticky: true,
               collapsed: item.tokenInfo.address === hidingAsset,
               content: (
-                <Stack direction="row" gap={1} alignItems="center" justifyContent="flex-end">
+                <Stack direction="row" gap={1} alignItems="center" justifyContent="flex-end" mr={-1}>
                   <Stack direction="row" gap={1} alignItems="center" bgcolor="background.paper" p={1}>
                     <SendButton tokenInfo={item.tokenInfo} />
 

--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -261,7 +261,7 @@ const AssetsTable = ({
               ),
             },
             actions: {
-              rawValue: Number(item.fiatBalance24hChange),
+              rawValue: '',
               sticky: true,
               collapsed: item.tokenInfo.address === hidingAsset,
               content: (

--- a/apps/web/src/components/balances/AssetsTable/styles.module.css
+++ b/apps/web/src/components/balances/AssetsTable/styles.module.css
@@ -7,8 +7,8 @@
 
 .container td:last-of-type > * {
   position: absolute;
-  left: 0;
-  width: 100%;
+  right: 0;
+  width: 15%;
   opacity: 0;
   transition: opacity 0.2s;
   height: 100% !important;

--- a/apps/web/src/components/common/EnhancedTable/index.tsx
+++ b/apps/web/src/components/common/EnhancedTable/index.tsx
@@ -184,7 +184,6 @@ function EnhancedTable({ rows, headCells, mobileVariant, compact }: EnhancedTabl
                     <TableCell
                       key={key}
                       className={classNames({
-                        sticky: cell.sticky,
                         [css.collapsedCell]: row.collapsed,
                       })}
                     >

--- a/apps/web/src/features/positions/components/PositionsHeader/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsHeader/index.tsx
@@ -42,7 +42,7 @@ const PositionsHeader = ({ protocol, fiatTotal }: { protocol: Protocol; fiatTota
         )}
 
         <Typography fontWeight="bold" mr={1} ml="auto" justifySelf="flex-end">
-          <FiatValue value={protocol.fiatTotal} maxLength={20} precise uniformColor />
+          <FiatValue value={protocol.fiatTotal} maxLength={20} precise />
         </Typography>
       </Stack>
     </>

--- a/apps/web/src/services/analytics/useMixpanel.ts
+++ b/apps/web/src/services/analytics/useMixpanel.ts
@@ -59,7 +59,11 @@ const useMixpanel = () => {
         console.info('[MixPanel] - User opted in')
       }
     } else {
-      mixpanel.opt_out_tracking()
+      try {
+        mixpanel.opt_out_tracking()
+      } catch (e) {
+        // do nothing, opt_out_tracking throws an error if tracking was never enabled
+      }
       if (!IS_PRODUCTION) {
         console.info('[MixPanel] - User opted out')
       }


### PR DESCRIPTION
## What it solves

Resolves [SEV-2](https://linear.app/safe-global/issue/GRO-57/defi-positions-wrong-rounding-for-the-amounts-that-is-easy-to-see)

Fiat value formatting wasn't consistent across assets and defi positions.

## How this PR fixes it

Fiat values are now always abbreviated and w/o cents unless they are in headings.

## Screenshots
<img width="1216" height="461" alt="Screenshot 2025-09-04 at 15 55 37" src="https://github.com/user-attachments/assets/c7840cff-319f-4f97-9a71-9f0a6ecb79bf" />

<img width="1195" height="458" alt="Screenshot 2025-09-04 at 15 55 50" src="https://github.com/user-attachments/assets/300be289-080a-41fa-8291-06f8170e6e9b" />

Precise amount with cents is displayed on hover:

<img width="974" height="213" alt="Screenshot 2025-09-04 at 15 56 07" src="https://github.com/user-attachments/assets/f95d3d01-8707-441a-9c9d-6e7a5c72b07c" />
