### PR TITLE
Refactor(web): call useAddressResolver in NamedAddressInfo

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
@@ -13,7 +13,8 @@ const mockChainInfo = {
     api: 'https://test.scan.eth/',
     txHash: 'https://test.scan.eth/{txHash}',
   },
-} as ChainInfo
+  features: [],
+} as unknown as ChainInfo
 
 jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
   ...jest.requireActual('@safe-global/safe-gateway-typescript-sdk'),

--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -7,8 +7,7 @@ import useSafeAddress from '@/hooks/useSafeAddress'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { memo, useMemo } from 'react'
 import { isAddress } from 'ethers'
-import { lookupAddress } from '@/services/ens'
-import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { useAddressResolver } from '@/hooks/useAddressResolver'
 
 const useIsUnverifiedContract = (contract?: { contractAbi?: object | null } | null): boolean => {
   return !!contract && !contract.contractAbi
@@ -17,7 +16,6 @@ const useIsUnverifiedContract = (contract?: { contractAbi?: object | null } | nu
 export function useAddressName(address?: string, name?: string | null, customAvatar?: string) {
   const chainId = useChainId()
   const safeAddress = useSafeAddress()
-  const web3 = useWeb3ReadOnly()
   const displayName = sameAddress(address, safeAddress) ? 'This Safe Account' : name
 
   const [contract] = useAsync(
@@ -26,10 +24,7 @@ export function useAddressName(address?: string, name?: string | null, customAva
     false,
   )
 
-  const [ensName] = useAsync(async () => {
-    if (displayName || contract?.displayName || !address || !isAddress(address) || !web3) return undefined
-    return lookupAddress(web3, address)
-  }, [address, web3, displayName, contract])
+  const { ens: ensName } = useAddressResolver((displayName || contract?.displayName) ? undefined : address)
 
   const isUnverifiedContract = useIsUnverifiedContract(contract)
 

--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -24,22 +24,22 @@ export function useAddressName(address?: string, name?: string | null, customAva
     false,
   )
 
-  const { ens: ensName } = useAddressResolver(displayName || contract?.displayName ? undefined : address)
+  const nonEnsName = displayName || contract?.displayName || contract?.name
+
+  const { ens: ensName } = useAddressResolver(nonEnsName ? undefined : address)
 
   const isUnverifiedContract = useIsUnverifiedContract(contract)
 
   return useMemo(
     () => ({
       name:
-        displayName ||
-        contract?.displayName ||
-        contract?.name ||
+        nonEnsName ||
         ensName ||
         (isUnverifiedContract ? 'Unverified contract' : undefined),
       logoUri: customAvatar || contract?.logoUri,
       isUnverifiedContract,
     }),
-    [displayName, contract, customAvatar, isUnverifiedContract, ensName],
+    [nonEnsName, customAvatar, contract?.logoUri, isUnverifiedContract, ensName],
   )
 }
 

--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -24,7 +24,7 @@ export function useAddressName(address?: string, name?: string | null, customAva
     false,
   )
 
-  const { ens: ensName } = useAddressResolver((displayName || contract?.displayName) ? undefined : address)
+  const { ens: ensName } = useAddressResolver(displayName || contract?.displayName ? undefined : address)
 
   const isUnverifiedContract = useIsUnverifiedContract(contract)
 

--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -32,10 +32,7 @@ export function useAddressName(address?: string, name?: string | null, customAva
 
   return useMemo(
     () => ({
-      name:
-        nonEnsName ||
-        ensName ||
-        (isUnverifiedContract ? 'Unverified contract' : undefined),
+      name: nonEnsName || ensName || (isUnverifiedContract ? 'Unverified contract' : undefined),
       logoUri: customAvatar || contract?.logoUri,
       isUnverifiedContract,
     }),

--- a/apps/web/src/components/transactions/TxDetails/TxData/Transfer/index.test.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/Transfer/index.test.tsx
@@ -15,6 +15,7 @@ jest.mock('@/hooks/useChains', () => ({
   useChainId: () => '1',
   useChain: () => chainBuilder().with({ chainId: '1' }).build(),
   useCurrentChain: () => chainBuilder().with({ chainId: '1' }).build(),
+  useHasFeature: () => false,
   default: () => ({
     loading: false,
     loaded: true,

--- a/apps/web/src/hooks/useAddressResolver.ts
+++ b/apps/web/src/hooks/useAddressResolver.ts
@@ -7,13 +7,13 @@ import useDebounce from './useDebounce'
 import { useHasFeature } from './useChains'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 
-export const useAddressResolver = (address: string) => {
+export const useAddressResolver = (address?: string) => {
   const addressBook = useAddressBook()
   const ethersProvider = useWeb3ReadOnly()
   const debouncedValue = useDebounce(address, 200)
-  const addressBookName = addressBook[address]
+  const addressBookName = address && addressBook[address]
   const isDomainLookupEnabled = useHasFeature(FEATURES.DOMAIN_LOOKUP)
-  const shouldResolve = !addressBookName && isDomainLookupEnabled && !!ethersProvider && !!debouncedValue
+  const shouldResolve = address && !addressBookName && isDomainLookupEnabled && !!ethersProvider && !!debouncedValue
 
   const [ens, _, isResolving] = useAsync<string | undefined>(() => {
     if (!shouldResolve) return

--- a/apps/web/src/hooks/useAddressResolver.ts
+++ b/apps/web/src/hooks/useAddressResolver.ts
@@ -20,7 +20,7 @@ export const useAddressResolver = (address?: string) => {
     return lookupAddress(ethersProvider, debouncedValue)
   }, [ethersProvider, debouncedValue, shouldResolve])
 
-  const resolving = shouldResolve && isResolving
+  const resolving = (shouldResolve && isResolving) || false
 
   return useMemo(
     () => ({

--- a/apps/web/src/services/analytics/useMixpanel.ts
+++ b/apps/web/src/services/analytics/useMixpanel.ts
@@ -59,7 +59,11 @@ const useMixpanel = () => {
         console.info('[Mixpanel] - User opted in')
       }
     } else {
-      mixpanel.opt_out_tracking()
+      try {
+        mixpanel.opt_out_tracking()
+      } catch {
+        //do nothing, opt_in_tracking throws an error if tracking was never enabled
+      }
       if (!IS_PRODUCTION) {
         console.info('[Mixpanel] - User opted out')
       }

--- a/apps/web/src/services/analytics/useMixpanel.ts
+++ b/apps/web/src/services/analytics/useMixpanel.ts
@@ -62,7 +62,7 @@ const useMixpanel = () => {
       try {
         mixpanel.opt_out_tracking()
       } catch {
-        //do nothing, opt_in_tracking throws an error if tracking was never enabled
+        // do nothing, opt_out_tracking throws an error if tracking was never enabled
       }
       if (!IS_PRODUCTION) {
         console.info('[Mixpanel] - User opted out')


### PR DESCRIPTION
## What it solves

A small follow up on #6281 – reuse an existing useAddressResolver hook in NamedAddressInfo.

Plus, a small fix for Mixpanel on dev.