### PR TITLE
feat(web): show commit hash in footer

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -8,6 +8,7 @@ import remarkFrontmatter from 'remark-frontmatter'
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
 import { readFile } from 'fs/promises'
 import { fileURLToPath } from 'url'
+import { execSync } from 'child_process'
 
 const SERVICE_WORKERS_PATH = './src/service-workers'
 
@@ -15,6 +16,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const pkgPath = path.join(__dirname, 'package.json')
 const data = await readFile(pkgPath, 'utf-8')
 const pkg = JSON.parse(data)
+
+let commitHash = process.env.NEXT_PUBLIC_COMMIT_HASH
+if (!commitHash) {
+  try {
+    commitHash = execSync('git rev-parse --short HEAD').toString().trim()
+  } catch {
+    commitHash = ''
+  }
+}
 
 const withPWA = withPWAInit({
   dest: 'public',
@@ -52,6 +62,10 @@ const nextConfig = {
   transpilePackages: ['@safe-global/store'],
   images: {
     unoptimized: true,
+  },
+
+  env: {
+    NEXT_PUBLIC_COMMIT_HASH: commitHash,
   },
 
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],

--- a/apps/web/src/components/common/Footer/index.tsx
+++ b/apps/web/src/components/common/Footer/index.tsx
@@ -10,6 +10,7 @@ import ExternalLink from '../ExternalLink'
 import MUILink from '@mui/material/Link'
 import { useIsOfficialHost } from '@/hooks/useIsOfficialHost'
 import { HELP_CENTER_URL } from '@safe-global/utils/config/constants'
+import { IS_PRODUCTION, COMMIT_HASH } from '@/config/constants'
 
 const footerPages = [
   AppRoutes.welcome.index,
@@ -83,6 +84,16 @@ const Footer = (): ReactElement | null => {
           <ExternalLink href={`${packageJson.homepage}/releases/tag/v${packageJson.version}`} noIcon>
             <SvgIcon component={GitHubIcon} inheritViewBox fontSize="inherit" sx={{ mr: 0.5 }} /> v{packageJson.version}
           </ExternalLink>
+          {!IS_PRODUCTION && COMMIT_HASH && (
+            <>
+              {' '}
+              (
+              <ExternalLink href={`${packageJson.homepage}/commit/${COMMIT_HASH}`} noIcon>
+                {COMMIT_HASH}
+              </ExternalLink>
+              )
+            </>
+          )}
         </li>
       </ul>
     </footer>

--- a/apps/web/src/components/common/Footer/index.tsx
+++ b/apps/web/src/components/common/Footer/index.tsx
@@ -88,8 +88,7 @@ const Footer = (): ReactElement | null => {
             <>
               {' '}
               (
-              <ExternalLink href={`${packageJson.homepage}/commit/${COMMIT_HASH}`} noIcon>
-                {COMMIT_HASH}
+                {COMMIT_HASH.slice(0, 7)}
               </ExternalLink>
               )
             </>

--- a/apps/web/src/components/common/Footer/index.tsx
+++ b/apps/web/src/components/common/Footer/index.tsx
@@ -84,16 +84,15 @@ const Footer = (): ReactElement | null => {
           <ExternalLink href={`${packageJson.homepage}/releases/tag/v${packageJson.version}`} noIcon>
             <SvgIcon component={GitHubIcon} inheritViewBox fontSize="inherit" sx={{ mr: 0.5 }} /> v{packageJson.version}
           </ExternalLink>
-          {!IS_PRODUCTION && COMMIT_HASH && (
-            <>
-              {' '}
-              (
-                {COMMIT_HASH.slice(0, 7)}
-              </ExternalLink>
-              )
-            </>
-          )}
         </li>
+
+        {!IS_PRODUCTION && COMMIT_HASH && (
+          <li>
+            <ExternalLink href={`${packageJson.homepage}/commit/${COMMIT_HASH}`} noIcon>
+              {COMMIT_HASH.slice(0, 7)}
+            </ExternalLink>
+          </li>
+        )}
       </ul>
     </footer>
   )

--- a/apps/web/src/config/constants.ts
+++ b/apps/web/src/config/constants.ts
@@ -3,6 +3,7 @@ import { HELP_CENTER_URL } from '@safe-global/utils/config/constants'
 
 export const IS_PRODUCTION = process.env.NEXT_PUBLIC_IS_PRODUCTION === 'true'
 export const IS_DEV = process.env.NODE_ENV === 'development'
+export const COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH || ''
 
 // default chain ID's as provided to the environment
 export const DEFAULT_TESTNET_CHAIN_ID = +(process.env.NEXT_PUBLIC_DEFAULT_TESTNET_CHAIN_ID ?? chains.sep)


### PR DESCRIPTION
## Summary
- expose commit hash to the web app and show it next to the version

## Why

It's convenient to see what was the last commit that was deployed to the dev/staging site. E.g. you pushed a new feature and want to make sure it's already deployed.

<img width="1121" height="122" alt="Screenshot 2025-09-05 at 11 49 02" src="https://github.com/user-attachments/assets/f567c981-2dfb-46bc-a873-97e42c166e35" />