### PR TITLE
chore(web): share web CI build artifact across workflows

### DIFF
--- a/.github/actions/cypress/action.yml
+++ b/.github/actions/cypress/action.yml
@@ -27,6 +27,11 @@ inputs:
     description: 'Cypress cloud tag key'
     required: false
 
+  skip-build:
+    description: 'Skip building the app'
+    required: false
+    default: 'false'
+
 runs:
   using: 'composite'
   steps:
@@ -39,6 +44,7 @@ runs:
         sudo apt-get install ./google-chrome-stable_current_amd64.deb
 
     - uses: ./.github/actions/build
+      if: inputs.skip-build != 'true'
       with:
         secrets: ${{ inputs.secrets }}
 

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -1,0 +1,37 @@
+name: Web Build
+
+on:
+  pull_request:
+    paths:
+      - apps/web/**
+      - packages/**
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - apps/web/**
+      - packages/**
+  release:
+    types: [published]
+
+jobs:
+  build:
+    permissions:
+      contents: read
+      actions: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/yarn
+      - uses: ./.github/actions/build
+        with:
+          secrets: ${{ toJSON(secrets) }}
+          prod: ${{ github.event_name == 'release' }}
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-build
+          path: |
+            apps/web/out
+            apps/web/.next

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -11,7 +11,13 @@ concurrency:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'release' }}
+    if: |
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event != 'release' &&
+        (github.event.workflow_run.event != 'pull_request' ||
+         github.event.workflow_run.head_repository.full_name == github.repository)
+      }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -1,15 +1,9 @@
 name: Web Deploy to dev/staging
 
 on:
-  pull_request:
-
-  push:
-    branches:
-      - dev
-      - main
-    paths:
-      - apps/web/**
-      - packages/**
+  workflow_run:
+    workflows: ['Web Build']
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,19 +11,23 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'release' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       id-token: write
+      actions: read
+      contents: read
 
     name: Deploy to dev/staging
 
     steps:
       # Post a PR comment before deploying
       - name: Post a comment while building
-        if: github.event.number
+        if: github.event.workflow_run.event == 'pull_request'
         uses: mshick/add-pr-comment@v2
         with:
+          pr: ${{ github.event.workflow_run.pull_requests[0].number }}
           message-id: praul
           message: |
             ## Branch preview
@@ -41,10 +39,12 @@ jobs:
 
       - uses: ./.github/actions/yarn
 
-      - uses: ./.github/actions/build
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          secrets: ${{ toJSON(secrets) }}
-          # if: startsWith(github.ref, 'refs/heads/main')
+          name: web-build
+          path: apps/web
+          run-id: ${{ github.event.workflow_run.id }}
 
       #- uses: ./.github/workflows/build-storybook
 
@@ -78,15 +78,18 @@ jobs:
 
       # Extract branch name
       - name: Extract branch name
+        if: github.event.workflow_run.event == 'pull_request'
         shell: bash
-        ## Cut off "refs/heads/", only allow alphanumeric characters and convert to lower case,
-        ## e.g. "refs/heads/features/hello-1.2.0" -> "features_hello_1_2_0"
-        run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig' | sed 's/[A-Z]/\L&/g')" >> $GITHUB_OUTPUT
+        env:
+          PR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        ## Only allow alphanumeric characters and convert to lower case,
+        ## e.g. "features/hello-1.2.0" -> "features_hello_1_2_0"
+        run: echo "branch=$(echo $PR_BRANCH | sed 's/[^a-z0-9]/_/ig' | sed 's/[A-Z]/\L&/g')" >>$GITHUB_OUTPUT
         id: extract_branch
 
       # Deploy to S3
       - name: Deploy PR branch
-        if: github.event.number
+        if: github.event.workflow_run.event == 'pull_request'
         env:
           BUCKET: s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/walletweb/${{ steps.extract_branch.outputs.branch }}
         working-directory: apps/web
@@ -94,9 +97,10 @@ jobs:
 
       # Comment
       - name: Post a deployment link in the PR
-        if: always() && github.event.number
+        if: always() && github.event.workflow_run.event == 'pull_request'
         uses: mshick/add-pr-comment@v2
         with:
+          pr: ${{ github.event.workflow_run.pull_requests[0].number }}
           message-id: praul
           message: |
             ## Branch preview
@@ -110,3 +114,5 @@ jobs:
           message-failure: |
             ## Branch preview
             ❌  Deploy failed!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]'

--- a/.github/workflows/web-deploy-production.yml
+++ b/.github/workflows/web-deploy-production.yml
@@ -18,11 +18,18 @@ jobs:
 
     name: Deploy release
 
-    env:
-      ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.event.workflow_run.head_branch }}
-
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Determine release tag
+        run: |
+          git fetch --tags
+          TAG_NAME=$(git tag --points-at HEAD)
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+          echo "ARCHIVE_NAME=${{ github.event.repository.name }}-$TAG_NAME" >> $GITHUB_ENV
 
       - uses: ./.github/actions/yarn
 
@@ -39,7 +46,7 @@ jobs:
           curl -sL \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
-            ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${{ github.event.workflow_run.head_branch }} \
+            ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${TAG_NAME} \
             > release.json
           echo "upload_url=$(jq -r .upload_url release.json)" >> $GITHUB_ENV
 
@@ -81,7 +88,7 @@ jobs:
       # Script to upload release files
       - name: Upload release build files for production
         env:
-          BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.workflow_run.head_branch }}
+          BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ env.TAG_NAME }}
           CHECKSUM_FILE: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
         run: bash ./scripts/github/s3_upload.sh
         working-directory: apps/web
@@ -93,4 +100,4 @@ jobs:
         env:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
-          VERSION_TAG: ${{ github.event.workflow_run.head_branch }}
+          VERSION_TAG: ${{ env.TAG_NAME }}

--- a/.github/workflows/web-deploy-production.yml
+++ b/.github/workflows/web-deploy-production.yml
@@ -1,32 +1,47 @@
 name: Web Release
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ['Web Build']
+    types: [completed]
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'release' }}
     permissions:
       attestations: write
       contents: write
       id-token: write
+      actions: read
 
     runs-on: ubuntu-latest
 
     name: Deploy release
 
     env:
-      ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}
+      ARCHIVE_NAME: ${{ github.event.repository.name }}-${{ github.event.workflow_run.head_branch }}
 
     steps:
       - uses: actions/checkout@v5
 
       - uses: ./.github/actions/yarn
 
-      - uses: ./.github/actions/build
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          secrets: ${{ toJSON(secrets) }}
-          prod: ${{ true }}
+          name: web-build
+          path: apps/web
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Fetch release info
+        id: release
+        run: |
+          curl -sL \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            ${{ github.api_url }}/repos/${{ github.repository }}/releases/tags/${{ github.event.workflow_run.head_branch }} \
+            > release.json
+          echo "upload_url=$(jq -r .upload_url release.json)" >> $GITHUB_ENV
 
       - name: Add SRI to scripts
         run: node ./scripts/integrity-hashes.cjs
@@ -48,13 +63,13 @@ jobs:
       - name: Upload archive as release asset
         uses: shogo82148/actions-upload-release-asset@v1
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          upload_url: ${{ env.upload_url }}
           asset_path: apps/web/${{ env.ARCHIVE_NAME }}.tar.gz
 
       - name: Upload archive as release asset
         uses: shogo82148/actions-upload-release-asset@v1
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          upload_url: ${{ env.upload_url }}
           asset_path: apps/web/${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
 
       - name: Configure AWS credentials
@@ -66,7 +81,7 @@ jobs:
       # Script to upload release files
       - name: Upload release build files for production
         env:
-          BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.release.tag_name }}
+          BUCKET: s3://${{ secrets.AWS_STAGING_BUCKET_NAME }}/releases/${{ github.event.workflow_run.head_branch }}
           CHECKSUM_FILE: ${{ env.ARCHIVE_NAME }}-sha256-checksum.txt
         run: bash ./scripts/github/s3_upload.sh
         working-directory: apps/web
@@ -78,4 +93,4 @@ jobs:
         env:
           PROD_DEPLOYMENT_HOOK_TOKEN: ${{ secrets.PROD_DEPLOYMENT_HOOK_TOKEN }}
           PROD_DEPLOYMENT_HOOK_URL: ${{ secrets.PROD_DEPLOYMENT_HOOK_URL }}
-          VERSION_TAG: ${{ github.event.release.tag_name }}
+          VERSION_TAG: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/web-e2e-full-ondemand.yml
+++ b/.github/workflows/web-e2e-full-ondemand.yml
@@ -1,6 +1,9 @@
 name: Web Full Regression on demand tests
 
 on:
+  workflow_run:
+    workflows: ['Web Build']
+    types: [completed]
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * 1-5'
@@ -11,6 +14,7 @@ concurrency:
 
 jobs:
   e2e:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     name: Cypress Full Regression on demand tests
@@ -20,6 +24,14 @@ jobs:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v5
+
+      - name: Download build artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: apps/web
+          run-id: ${{ github.event.workflow_run.id }}
 
       - uses: ./.github/actions/cypress
         with:
@@ -31,6 +43,7 @@ jobs:
             cypress/e2e/smoke/*.cy.js
           group: 'Full Regression on demand tests'
           tag: 'full_regression'
+          skip-build: ${{ github.event_name == 'workflow_run' }}
 
       - name: Python setup
         if: always()

--- a/.github/workflows/web-e2e-full-ondemand.yml
+++ b/.github/workflows/web-e2e-full-ondemand.yml
@@ -8,13 +8,27 @@ on:
   schedule:
     - cron: '0 3 * * 1-5'
 
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   e2e:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      ${{
+        github.event_name != 'workflow_run' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          (
+            github.event.workflow_run.event != 'pull_request' ||
+            github.event.workflow_run.head_repository.full_name == github.repository
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     name: Cypress Full Regression on demand tests

--- a/.github/workflows/web-e2e-hp-ondemand.yml
+++ b/.github/workflows/web-e2e-hp-ondemand.yml
@@ -8,13 +8,27 @@ on:
   schedule:
     - cron: '0 4 * * 3'
 
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   e2e:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      ${{
+        github.event_name != 'workflow_run' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          (
+            github.event.workflow_run.event != 'pull_request' ||
+            github.event.workflow_run.head_repository.full_name == github.repository
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     name: Cypress Happy path on demand tests

--- a/.github/workflows/web-e2e-hp-ondemand.yml
+++ b/.github/workflows/web-e2e-hp-ondemand.yml
@@ -1,6 +1,9 @@
 name: Web Happy path on demand tests
 
 on:
+  workflow_run:
+    workflows: ['Web Build']
+    types: [completed]
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * 3'
@@ -11,6 +14,7 @@ concurrency:
 
 jobs:
   e2e:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     name: Cypress Happy path on demand tests
@@ -21,6 +25,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Download build artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: apps/web
+          run-id: ${{ github.event.workflow_run.id }}
+
       - uses: ./.github/actions/cypress
         with:
           secrets: ${{ toJSON(secrets) }}
@@ -28,6 +40,7 @@ jobs:
             cypress/e2e/happypath/*.cy.js
           group: 'Happy path on demand tests'
           tag: 'happypath'
+          skip-build: ${{ github.event_name == 'workflow_run' }}
 
       - name: Python setup
         if: always()

--- a/.github/workflows/web-e2e-prod-ondemand.yml
+++ b/.github/workflows/web-e2e-prod-ondemand.yml
@@ -1,6 +1,9 @@
 name: Web Production health check tests
 
 on:
+  workflow_run:
+    workflows: ['Web Build']
+    types: [completed]
   workflow_dispatch:
 
 concurrency:
@@ -9,6 +12,7 @@ concurrency:
 
 jobs:
   e2e:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Cypress production health check tests
     strategy:
@@ -18,6 +22,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Download build artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: apps/web
+          run-id: ${{ github.event.workflow_run.id }}
+
       - uses: ./.github/actions/cypress
         with:
           secrets: ${{ toJSON(secrets) }}
@@ -25,6 +37,7 @@ jobs:
             cypress/e2e/prodhealthcheck/*.cy.js
           group: 'Production health check tests'
           tag: 'production'
+          skip-build: ${{ github.event_name == 'workflow_run' }}
 
       - name: Python setup
         if: always()

--- a/.github/workflows/web-e2e-prod-ondemand.yml
+++ b/.github/workflows/web-e2e-prod-ondemand.yml
@@ -6,13 +6,27 @@ on:
     types: [completed]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   e2e:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      ${{
+        github.event_name != 'workflow_run' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          (
+            github.event.workflow_run.event != 'pull_request' ||
+            github.event.workflow_run.head_repository.full_name == github.repository
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     name: Cypress production health check tests
     strategy:

--- a/.github/workflows/web-e2e-smoke.yml
+++ b/.github/workflows/web-e2e-smoke.yml
@@ -4,13 +4,16 @@ on:
   workflow_run:
     workflows: ['Web Build']
     types: [completed]
+permissions:
+  contents: read
+  actions: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   e2e:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Cypress Smoke tests

--- a/.github/workflows/web-e2e-smoke.yml
+++ b/.github/workflows/web-e2e-smoke.yml
@@ -1,16 +1,16 @@
 name: Web Smoke tests
 
 on:
-  pull_request:
-    paths:
-      - apps/web/**
-      - packages/**
+  workflow_run:
+    workflows: ['Web Build']
+    types: [completed]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   e2e:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Cypress Smoke tests
@@ -23,9 +23,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-build
+          path: apps/web
+          run-id: ${{ github.event.workflow_run.id }}
+
       - uses: ./.github/actions/cypress
         with:
           secrets: ${{ toJSON(secrets) }}
           spec: cypress/e2e/smoke/*.cy.js
           group: 'Smoke tests'
           tag: 'smoke'
+          skip-build: true

--- a/.github/workflows/web-nextjs-bundle-analysis.yml
+++ b/.github/workflows/web-nextjs-bundle-analysis.yml
@@ -14,7 +14,13 @@ permissions:
 
 jobs:
   analyze:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'release' }}
+    if: |
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event != 'release' &&
+        (github.event.workflow_run.event != 'pull_request' ||
+         github.event.workflow_run.head_repository.full_name == github.repository)
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/web-nextjs-bundle-analysis.yml
+++ b/.github/workflows/web-nextjs-bundle-analysis.yml
@@ -4,15 +4,9 @@
 name: 'Web Next.js Bundle Analysis'
 
 on:
-  pull_request:
-    paths:
-      - apps/web/**
-  push:
-    branches:
-      - dev
-    paths:
-      - apps/web/**
-      - packages/**
+  workflow_run:
+    workflows: ['Web Build']
+    types: [completed]
 permissions:
   contents: read # for checkout repository
   actions: read # for fetching base branch bundle stats
@@ -20,6 +14,7 @@ permissions:
 
 jobs:
   analyze:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'release' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -27,10 +22,12 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/yarn
 
-      - name: Build next.js app
-        uses: ./.github/actions/build
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          secrets: ${{ toJSON(secrets) }}
+          name: web-build
+          path: apps/web
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Analyze bundle
         run: |
@@ -67,14 +64,14 @@ jobs:
         run: unzip artifact.zip -d apps/web/.next/analyze/base && mkdir -p apps/web/.next/analyze/base/bundle && mv apps/web/.next/analyze/base/__bundle_analysis.json apps/web/.next/analyze/base/bundle/
 
       - name: Compare with base branch bundle
-        if: success() && github.event.number
+        if: success() && github.event.workflow_run.event == 'pull_request'
         run: |
           cd apps/web
           ls -laR .next/analyze/base && npx -p nextjs-bundle-analysis compare
 
       - name: Get Comment Body
         id: get-comment-body
-        if: success() && github.event.number
+        if: success() && github.event.workflow_run.event == 'pull_request'
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
         run: |
           cd apps/web
@@ -83,7 +80,9 @@ jobs:
           echo EOF >> $GITHUB_OUTPUT
 
       - name: Comment
+        if: github.event.workflow_run.event == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: next-bundle-analysis
           message: ${{ steps.get-comment-body.outputs.body }}
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Summary
- add dedicated `Web Build` workflow that uploads build output as an artifact
- reuse the build artifact in deploy, analysis, and e2e workflows via `workflow_run`

## Testing
- `yarn install`
- `yarn prettier:fix`


------
https://chatgpt.com/codex/tasks/task_b_68be879aa584832f804a8b5e02662725