### PR TITLE
refactor(web): cache reverse ENS lookups

### DIFF
--- a/apps/web/src/components/transactions/SafeCreationTx/index.tsx
+++ b/apps/web/src/components/transactions/SafeCreationTx/index.tsx
@@ -8,6 +8,7 @@ import { generateDataRowValue, TxDataRow } from '@/components/transactions/TxDet
 import { dateString } from '@safe-global/utils/utils/formatters'
 import { isCreationTxInfo } from '@/utils/transaction-guards'
 import { NOT_AVAILABLE } from '@/components/transactions/TxDetails'
+import NamedAddressInfo from '@/components/common/NamedAddressInfo'
 
 type SafeCreationTxProps = {
   txSummary: TransactionSummary
@@ -23,7 +24,13 @@ const SafeCreationTx = ({ txSummary }: SafeCreationTxProps) => {
     <>
       <Box className={css.txCreation}>
         <InfoDetails title="Creator:">
-          <EthHashInfo address={creator.value} shortAddress={false} showCopyButton hasExplorer />
+          <NamedAddressInfo
+            address={creator.value}
+            name={creator.name}
+            shortAddress={false}
+            showCopyButton
+            hasExplorer
+          />
         </InfoDetails>
         <InfoDetails title="Factory:">
           {factory ? (

--- a/apps/web/src/hooks/useAddressResolver.ts
+++ b/apps/web/src/hooks/useAddressResolver.ts
@@ -1,11 +1,14 @@
 import useAddressBook from '@/hooks/useAddressBook'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { lookupAddress } from '@/services/ens'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 import useDebounce from './useDebounce'
 import { useHasFeature } from './useChains'
 import { FEATURES } from '@safe-global/utils/utils/chains'
+import useChainId from './useChainId'
+
+const cache: Record<string, Record<string, string>> = {}
 
 export const useAddressResolver = (address?: string) => {
   const addressBook = useAddressBook()
@@ -14,13 +17,25 @@ export const useAddressResolver = (address?: string) => {
   const addressBookName = address && addressBook[address]
   const isDomainLookupEnabled = useHasFeature(FEATURES.DOMAIN_LOOKUP)
   const shouldResolve = address && !addressBookName && isDomainLookupEnabled && !!ethersProvider && !!debouncedValue
+  const chainId = useChainId()
 
   const [ens, _, isResolving] = useAsync<string | undefined>(() => {
     if (!shouldResolve) return
+    if (chainId && debouncedValue && cache[chainId][debouncedValue]) {
+      return Promise.resolve(cache[chainId][debouncedValue])
+    }
     return lookupAddress(ethersProvider, debouncedValue)
-  }, [ethersProvider, debouncedValue, shouldResolve])
+  }, [chainId, ethersProvider, debouncedValue, shouldResolve])
 
   const resolving = (shouldResolve && isResolving) || false
+
+  // Cache resolved ENS names per chain
+  useEffect(() => {
+    if (chainId && ens && debouncedValue) {
+      cache[chainId] = cache[chainId] || {}
+      cache[chainId][debouncedValue] = ens
+    }
+  }, [chainId, debouncedValue, ens])
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## What it solves

A follow-up for #6281.

Reduce RPC requests and improve performance by caching ENS resolutions in memory.