### PR TITLE
fix(mobile): advanced details crashes when no txData

### DIFF
--- a/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.test.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.test.tsx
@@ -77,6 +77,15 @@ describe('formatTxDetails', () => {
     expect(result).toEqual([])
   })
 
+  it('should return empty array when txData is undefined', () => {
+    const txDetails = createMockTxDetails({
+      txData: undefined,
+    } as unknown as TransactionDetails)
+
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
+    expect(result).toEqual([])
+  })
+
   it('should format basic transaction details with To field', () => {
     const mockAddress = faker.finance.ethereumAddress()
     const txDetails = createMockTxDetails({

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
@@ -31,33 +31,35 @@ const formatTxDetails = ({ txDetails, viewOnExplorer }: formatTxDetailsProps): L
   }
 
   // Basic transaction info
-  items.push({
-    label: 'To',
-    render: () => (
-      <>
-        <View width="100%">
-          <Receiver txData={txDetails.txData} />
-        </View>
-        <View width="100%" flexDirection="row" alignItems="center" gap="$2">
-          <Identicon address={txDetails.txData?.to.value as Address} size={24} />
+  if (txDetails.txData?.to.value) {
+    items.push({
+      label: 'To',
+      render: () => (
+        <>
+          <View width="100%">
+            <Receiver txData={txDetails.txData} />
+          </View>
+          <View width="100%" flexDirection="row" alignItems="center" gap="$2">
+            <Identicon address={txDetails.txData?.to.value as Address} size={24} />
 
-          <View flexDirection="row" justifyContent="space-between" alignItems="center">
-            <Text flexWrap="wrap" width="77%">
-              {txDetails.txData?.to.value}
-            </Text>
+            <View flexDirection="row" justifyContent="space-between" alignItems="center">
+              <Text flexWrap="wrap" width="77%">
+                {txDetails.txData?.to.value}
+              </Text>
 
-            <View flexDirection="row" alignItems="center" gap="$3">
-              <CopyButton value={txDetails.txData?.to.value || ''} size={16} color={'$textSecondaryLight'} />
+              <View flexDirection="row" alignItems="center" gap="$3">
+                <CopyButton value={txDetails.txData?.to.value || ''} size={16} color={'$textSecondaryLight'} />
 
-              <TouchableOpacity onPress={viewOnExplorer}>
-                <SafeFontIcon name="external-link" size={16} color="$textSecondaryLight" />
-              </TouchableOpacity>
+                <TouchableOpacity onPress={viewOnExplorer}>
+                  <SafeFontIcon name="external-link" size={16} color="$textSecondaryLight" />
+                </TouchableOpacity>
+              </View>
             </View>
           </View>
-        </View>
-      </>
-    ),
-  })
+        </>
+      ),
+    })
+  }
 
   // Value
   if (txDetails.txData?.value) {

--- a/apps/mobile/src/features/HistoryTransactionDetails/components/HistoryTransactionView/HistoryTransactionView.tsx
+++ b/apps/mobile/src/features/HistoryTransactionDetails/components/HistoryTransactionView/HistoryTransactionView.tsx
@@ -37,7 +37,13 @@ export function HistoryTransactionView({ txDetails }: HistoryTransactionViewProp
   switch (transactionType) {
     case ETxType.TOKEN_TRANSFER:
     case ETxType.NFT_TRANSFER:
-      return <HistoryTokenTransfer txId={txDetails.txId} txInfo={txDetails.txInfo as TransferTransactionInfo} />
+      return (
+        <HistoryTokenTransfer
+          txId={txDetails.txId}
+          txInfo={txDetails.txInfo as TransferTransactionInfo}
+          txData={txDetails.txData as TransactionData}
+        />
+      )
 
     case ETxType.SWAP_ORDER:
       return (

--- a/apps/mobile/src/features/HistoryTransactionDetails/components/history-views/HistoryTokenTransfer.tsx
+++ b/apps/mobile/src/features/HistoryTransactionDetails/components/history-views/HistoryTokenTransfer.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 import { Container } from '@/src/components/Container'
 import { View, YStack, Text } from 'tamagui'
 import { HistoryTransactionHeader } from '@/src/features/HistoryTransactionDetails/components/HistoryTransactionHeader'
-import { TransferTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { TransactionData, TransferTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { useTokenDetails } from '@/src/hooks/useTokenDetails'
-import { Address } from '@/src/types/address'
 import { TokenAmount } from '@/src/components/TokenAmount'
 
 import { HistoryAdvancedDetailsButton } from '@/src/features/HistoryTransactionDetails/components/HistoryAdvancedDetailsButton'
@@ -14,13 +13,14 @@ import { NetworkDisplay } from '../shared'
 interface HistoryTokenTransferProps {
   txId: string
   txInfo: TransferTransactionInfo
+  txData: TransactionData
 }
 
-export function HistoryTokenTransfer({ txId, txInfo }: HistoryTokenTransferProps) {
+export function HistoryTokenTransfer({ txId, txInfo, txData }: HistoryTokenTransferProps) {
   const { value, tokenSymbol, logoUri, decimals } = useTokenDetails(txInfo)
 
   const isOutgoing = txInfo.direction === 'OUTGOING'
-  const address = isOutgoing ? txInfo.recipient.value : txInfo.sender.value
+  const address = isOutgoing ? txInfo.recipient : txInfo.sender
 
   // Determine badge icon based on direction
   const badgeIcon = isOutgoing ? 'transaction-outgoing' : 'transaction-incoming'
@@ -57,12 +57,12 @@ export function HistoryTokenTransfer({ txId, txInfo }: HistoryTokenTransferProps
             <View alignItems="center" flexDirection="row" justifyContent="space-between">
               <Text color="$textSecondaryLight">{fieldLabel}</Text>
 
-              <HashDisplay value={address as Address} />
+              <HashDisplay value={address} />
             </View>
 
             <NetworkDisplay />
 
-            {isOutgoing && <HistoryAdvancedDetailsButton txId={txId} />}
+            {isOutgoing && txData !== null && <HistoryAdvancedDetailsButton txId={txId} />}
           </Container>
         </YStack>
       </View>


### PR DESCRIPTION
## What it solves
Some transactions such as “sent” events due to a swap don’t have txData. For those on web we don’t display any advanced details. Now we do the same. I also added a check to formatTxDetails for txData so that it won’t crash again if we stumble on a tx without any txData.

Resolves https://linear.app/safe-global/issue/COR-517/sent-screen

## How to test it
check this tx: https://safe-wallet-web.dev.5afe.dev/transactions/tx?safe=eth:0x8675B754342754A30A2AeF474D114d8460bca19b&id=transfer_0x8675B754342754A30A2AeF474D114d8460bca19b_eeb34c7a34951dc29cb5eea90a4820810502b5bb21c48b69f162a71cca500745d320

There should be no "transaction details" button anymore. 

## Screenshots
<img width="200" alt="grafik" src="https://github.com/user-attachments/assets/f1f6927c-71b2-484d-9ae7-b1a7412aa5b8" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
