### PR TITLE
fix(web): correct indexing status timestamp

### DIFF
--- a/apps/web/src/components/sidebar/IndexingStatus/index.test.tsx
+++ b/apps/web/src/components/sidebar/IndexingStatus/index.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@/tests/test-utils'
+import IndexingStatus from './index'
+
+jest.mock('date-fns', () => ({
+  formatDistanceToNow: jest.fn(),
+}))
+
+import { formatDistanceToNow } from 'date-fns'
+const mockFormatDistanceToNow = formatDistanceToNow as jest.Mock
+
+jest.mock('@/hooks/useChainId', () => ({
+  __esModule: true,
+  default: jest.fn(() => '1'),
+}))
+
+jest.mock('@/hooks/useIntervalCounter', () => ({
+  __esModule: true,
+  default: jest.fn(() => [0]),
+}))
+
+jest.mock('@safe-global/safe-gateway-typescript-sdk', () => ({
+  __esModule: true,
+  getIndexingStatus: jest.fn(),
+}))
+
+jest.mock('@safe-global/utils/hooks/useAsync', () => ({
+  __esModule: true,
+  default: jest.fn(() => [{ lastSync: 123, synced: true }]),
+}))
+
+describe('IndexingStatus', () => {
+  it('formats lastSync in milliseconds', () => {
+    render(<IndexingStatus />)
+
+    expect(mockFormatDistanceToNow).toHaveBeenCalledWith(123000, { addSuffix: true })
+  })
+})

--- a/apps/web/src/components/sidebar/IndexingStatus/index.tsx
+++ b/apps/web/src/components/sidebar/IndexingStatus/index.tsx
@@ -58,9 +58,10 @@ const IndexingStatus = () => {
     return null
   }
 
-  const status = getStatus(data.synced, data.lastSync)
+  const lastSyncMs = data.lastSync * 1000
+  const status = getStatus(data.synced, lastSyncMs)
 
-  const time = formatDistanceToNow(data.lastSync, { addSuffix: true })
+  const time = formatDistanceToNow(lastSyncMs, { addSuffix: true })
 
   return (
     <Tooltip title={`Last synced with the blockchain ${time}`} placement="right" arrow>


### PR DESCRIPTION
## Summary
- convert indexing status last sync time to milliseconds before formatting
- add unit test for timestamp conversion

## Testing
- `yarn workspace @safe-global/web type-check`
- `yarn workspace @safe-global/web lint`
- `yarn workspace @safe-global/web prettier`
- `yarn workspace @safe-global/web test apps/web/src/components/sidebar/IndexingStatus/index.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68bef48bf094832fa3e228f2d4056596