### PR TITLE
fix(tests): TS errors in WalletConnectContext tests

### DIFF
--- a/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
 import { useContext } from 'react'
-import type { SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { SessionTypes } from '@walletconnect/types'
 import { act, fireEvent, render, waitFor } from '@/tests/test-utils'
@@ -13,6 +12,7 @@ import { useAppDispatch } from '@/store'
 import * as useSafeWalletProvider from '@/services/safe-wallet-provider/useSafeWalletProvider'
 import * as useLocalStorageHook from '@/services/local-storage/useLocalStorage'
 import { wcPopupStore } from '@/features/walletconnect/components'
+import type { ExtendedSafeInfo } from '@safe-global/store/slices/SafeInfo/types'
 
 jest.mock('@reown/walletkit', () => jest.fn())
 
@@ -196,7 +196,7 @@ describe('WalletConnectProvider', () => {
   describe('updateSessions', () => {
     const extendedSafeInfo = { ...extendedSafeInfoBuilder().build(), address: { value: testSafeAddress }, chainId: '5' }
 
-    const getUpdateSafeInfoComponent = (safeInfo: SafeInfo) => {
+    const getUpdateSafeInfoComponent = (safeInfo: ExtendedSafeInfo) => {
       // eslint-disable-next-line react/display-name
       return () => {
         const dispatch = useAppDispatch()
@@ -214,7 +214,11 @@ describe('WalletConnectProvider', () => {
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
 
-      const ChainUpdater = getUpdateSafeInfoComponent({ address: { value: testSafeAddress }, chainId: '1' } as SafeInfo)
+      const ChainUpdater = getUpdateSafeInfoComponent({
+        ...extendedSafeInfoBuilder().build(),
+        address: { value: testSafeAddress },
+        chainId: '1',
+      })
 
       const { getByText } = render(
         <WalletConnectProvider>
@@ -242,9 +246,10 @@ describe('WalletConnectProvider', () => {
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
 
       const AddressUpdater = getUpdateSafeInfoComponent({
+        ...extendedSafeInfoBuilder().build(),
         address: { value: newSafeAddress },
         chainId: '5',
-      } as SafeInfo)
+      })
 
       const { getByText } = render(
         <WalletConnectProvider>

--- a/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -18,12 +18,7 @@ jest.mock('@reown/walletkit', () => jest.fn())
 
 jest.mock('@/services/safe-wallet-provider/useSafeWalletProvider')
 
-jest.mock('@/features/walletconnect/components', () => ({
-  wcPopupStore: {
-    useStore: jest.fn(),
-    setStore: jest.fn(),
-  },
-}))
+jest.mock('@/features/walletconnect/components', () => ({ wcPopupStore: { useStore: jest.fn(), setStore: jest.fn() } }))
 
 const TestComponent = () => {
   const { walletConnect, error, loading, sessions, sessionProposal, open } = useContext(WalletConnectContext)
@@ -72,13 +67,7 @@ const ContextControlComponent = () => {
 describe('WalletConnectProvider', () => {
   const testSafeAddress = faker.finance.ethereumAddress()
 
-  const extendedSafeInfo = {
-    ...extendedSafeInfoBuilder().build(),
-    address: {
-      value: testSafeAddress,
-    },
-    chainId: '5',
-  }
+  const extendedSafeInfo = { ...extendedSafeInfoBuilder().build(), address: { value: testSafeAddress }, chainId: '5' }
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -96,15 +85,7 @@ describe('WalletConnectProvider', () => {
       <WalletConnectProvider>
         <TestComponent />
       </WalletConnectProvider>,
-      {
-        initialReduxState: {
-          safeInfo: {
-            loading: false,
-            loaded: true,
-            data: extendedSafeInfo,
-          },
-        },
-      },
+      { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
     )
 
     await waitFor(() => {
@@ -122,15 +103,7 @@ describe('WalletConnectProvider', () => {
       <WalletConnectProvider>
         <TestComponent />
       </WalletConnectProvider>,
-      {
-        initialReduxState: {
-          safeInfo: {
-            loading: false,
-            loaded: true,
-            data: extendedSafeInfo,
-          },
-        },
-      },
+      { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
     )
 
     await waitFor(() => {
@@ -148,17 +121,7 @@ describe('WalletConnectProvider', () => {
       <WalletConnectProvider>
         <TestComponent />
       </WalletConnectProvider>,
-      {
-        initialReduxState: {
-          safeInfo: {
-            loading: false,
-            data: {
-              ...extendedSafeInfo,
-              chainId: '',
-            },
-          },
-        },
-      },
+      { initialReduxState: { safeInfo: { loading: false, loaded: true, data: { ...extendedSafeInfo, chainId: '' } } } },
     )
 
     await waitFor(() => {
@@ -176,14 +139,7 @@ describe('WalletConnectProvider', () => {
         <TestComponent />
         <ContextControlComponent />
       </WalletConnectProvider>,
-      {
-        initialReduxState: {
-          safeInfo: {
-            loading: false,
-            data: extendedSafeInfo,
-          },
-        },
-      },
+      { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
     )
 
     await waitFor(() => {
@@ -200,14 +156,7 @@ describe('WalletConnectProvider', () => {
         <TestComponent />
         <ContextControlComponent />
       </WalletConnectProvider>,
-      {
-        initialReduxState: {
-          safeInfo: {
-            loading: false,
-            data: extendedSafeInfo,
-          },
-        },
-      },
+      { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
     )
 
     await waitFor(() => {
@@ -230,14 +179,7 @@ describe('WalletConnectProvider', () => {
         <TestComponent />
         <ContextControlComponent />
       </WalletConnectProvider>,
-      {
-        initialReduxState: {
-          safeInfo: {
-            loading: false,
-            data: extendedSafeInfo,
-          },
-        },
-      },
+      { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
     )
 
     await waitFor(() => {
@@ -252,11 +194,7 @@ describe('WalletConnectProvider', () => {
   })
 
   describe('updateSessions', () => {
-    const extendedSafeInfo = {
-      ...extendedSafeInfoBuilder().build(),
-      address: { value: testSafeAddress },
-      chainId: '5',
-    }
+    const extendedSafeInfo = { ...extendedSafeInfoBuilder().build(), address: { value: testSafeAddress }, chainId: '5' }
 
     const getUpdateSafeInfoComponent = (safeInfo: SafeInfo) => {
       // eslint-disable-next-line react/display-name
@@ -264,11 +202,7 @@ describe('WalletConnectProvider', () => {
         const dispatch = useAppDispatch()
         const updateSafeInfo = () => {
           dispatch(
-            safeInfoSlice.actions.set({
-              loading: false,
-              loaded: true,
-              data: { ...extendedSafeInfo, ...safeInfo },
-            }),
+            safeInfoSlice.actions.set({ loading: false, loaded: true, data: { ...extendedSafeInfo, ...safeInfo } }),
           )
         }
 
@@ -280,25 +214,14 @@ describe('WalletConnectProvider', () => {
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
 
-      const ChainUpdater = getUpdateSafeInfoComponent({
-        address: { value: testSafeAddress },
-        chainId: '1',
-      } as SafeInfo)
+      const ChainUpdater = getUpdateSafeInfoComponent({ address: { value: testSafeAddress }, chainId: '1' } as SafeInfo)
 
       const { getByText } = render(
         <WalletConnectProvider>
           <TestComponent />
           <ChainUpdater />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              loaded: true,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -333,11 +256,7 @@ describe('WalletConnectProvider', () => {
             safeInfo: {
               loading: false,
               loaded: true,
-              data: {
-                ...extendedSafeInfo,
-                address: { value: testSafeAddress },
-                chainId: '5',
-              },
+              data: { ...extendedSafeInfo, address: { value: testSafeAddress }, chainId: '5' },
             },
           },
         },
@@ -370,11 +289,7 @@ describe('WalletConnectProvider', () => {
             safeInfo: {
               loading: false,
               loaded: true,
-              data: {
-                ...extendedSafeInfo,
-                address: { value: testSafeAddress },
-                chainId: '5',
-              },
+              data: { ...extendedSafeInfo, address: { value: testSafeAddress }, chainId: '5' },
             },
           },
         },
@@ -407,14 +322,7 @@ describe('WalletConnectProvider', () => {
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -434,14 +342,7 @@ describe('WalletConnectProvider', () => {
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -458,13 +359,7 @@ describe('WalletConnectProvider', () => {
 
     const mockSessionProposal = {
       id: proposalId,
-      verifyContext: {
-        verified: {
-          validation: 'VALID',
-          origin: proposalOrigin,
-          isScam: false,
-        },
-      },
+      verifyContext: { verified: { validation: 'VALID', origin: proposalOrigin, isScam: false } },
     } as WalletKitTypes.SessionProposal
 
     const mockSession = { topic: sessionTopic, peer: { metadata: { url: sessionUrl } } } as SessionTypes.Struct
@@ -485,14 +380,7 @@ describe('WalletConnectProvider', () => {
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -521,14 +409,7 @@ describe('WalletConnectProvider', () => {
           <TestComponent />
           <ContextControlComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -541,11 +422,7 @@ describe('WalletConnectProvider', () => {
         expect(approveSessionSpy).toHaveBeenCalledWith(mockSessionProposal, '5', testSafeAddress, {
           atomic: JSON.stringify({ status: 'supported' }),
           capabilities: JSON.stringify({
-            [testSafeAddress]: {
-              [`0x${Number(5).toString(16)}`]: {
-                atomicBatch: { supported: true },
-              },
-            },
+            [testSafeAddress]: { [`0x${Number(5).toString(16)}`]: { atomicBatch: { supported: true } } },
           }),
         })
       })
@@ -568,14 +445,7 @@ describe('WalletConnectProvider', () => {
           <TestComponent />
           <ContextControlComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -606,14 +476,7 @@ describe('WalletConnectProvider', () => {
           <TestComponent />
           <ContextControlComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -645,14 +508,7 @@ describe('WalletConnectProvider', () => {
           <TestComponent />
           <ContextControlComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -679,14 +535,7 @@ describe('WalletConnectProvider', () => {
           <TestComponent />
           <ContextControlComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -716,13 +565,7 @@ describe('WalletConnectProvider', () => {
     const mockAuthEvent = {
       id: authId,
       topic: authTopic,
-      verifyContext: {
-        verified: {
-          validation: 'VALID' as const,
-          origin: authOrigin,
-          isScam: false,
-        },
-      },
+      verifyContext: { verified: { validation: 'VALID' as const, origin: authOrigin, isScam: false } },
       params: {
         expiryTimestamp: Math.floor(Date.now() / 1000) + 3600,
         authPayload: {
@@ -733,14 +576,7 @@ describe('WalletConnectProvider', () => {
           nonce: authNonce,
           iat: new Date().toISOString(),
         },
-        requester: {
-          metadata: {
-            name: appName,
-            description: appDescription,
-            url: appUrl,
-            icons: [appIcon],
-          },
-        },
+        requester: { metadata: { name: appName, description: appDescription, url: appUrl, icons: [appIcon] } },
       },
     } as WalletKitTypes.SessionAuthenticate
 
@@ -762,12 +598,11 @@ describe('WalletConnectProvider', () => {
         })
 
       const mockRequest = jest.fn().mockResolvedValue({ result: mockSignature })
-      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
-        () =>
-          ({
-            request: mockRequest,
-          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
-      )
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockImplementation(
+          () => ({ request: mockRequest }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+        )
 
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
@@ -776,14 +611,7 @@ describe('WalletConnectProvider', () => {
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -794,14 +622,8 @@ describe('WalletConnectProvider', () => {
         expect(formatAuthMessageSpy).toHaveBeenCalledWith(mockAuthEvent.params.authPayload, '5', testSafeAddress)
         expect(mockRequest).toHaveBeenCalledWith(
           authId,
-          {
-            method: 'personal_sign',
-            params: [siweMessage, testSafeAddress],
-          },
-          expect.objectContaining({
-            name: appName,
-            url: 'https://apps-portal.safe.global/wallet-connect',
-          }),
+          { method: 'personal_sign', params: [siweMessage, testSafeAddress] },
+          expect.objectContaining({ name: appName, url: 'https://apps-portal.safe.global/wallet-connect' }),
         )
         expect(approveSessionAuthSpy).toHaveBeenCalledWith(
           authId,
@@ -844,14 +666,7 @@ describe('WalletConnectProvider', () => {
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -884,12 +699,11 @@ describe('WalletConnectProvider', () => {
         })
 
       const mockRequest = jest.fn().mockRejectedValue(new Error(signatureError))
-      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
-        () =>
-          ({
-            request: mockRequest,
-          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
-      )
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockImplementation(
+          () => ({ request: mockRequest }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+        )
 
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
@@ -899,14 +713,7 @@ describe('WalletConnectProvider', () => {
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -934,12 +741,11 @@ describe('WalletConnectProvider', () => {
         })
 
       const mockRequest = jest.fn().mockResolvedValue({ error: { message: userRejectionError } })
-      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
-        () =>
-          ({
-            request: mockRequest,
-          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
-      )
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockImplementation(
+          () => ({ request: mockRequest }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+        )
 
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
@@ -949,14 +755,7 @@ describe('WalletConnectProvider', () => {
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -983,6 +782,7 @@ describe('WalletConnectProvider', () => {
           initialReduxState: {
             safeInfo: {
               loading: false,
+              loaded: true,
               data: {
                 ...extendedSafeInfo,
                 chainId: '', // Missing chainId
@@ -1003,11 +803,7 @@ describe('WalletConnectProvider', () => {
     const requestUrl = faker.internet.url()
     const requestAppName = faker.company.name()
 
-    const extendedSafeInfo = {
-      ...extendedSafeInfoBuilder().build(),
-      address: { value: testSafeAddress },
-      chainId: '5',
-    }
+    const extendedSafeInfo = { ...extendedSafeInfoBuilder().build(), address: { value: testSafeAddress }, chainId: '5' }
 
     it('does not continue with the request if there is no matching topic', async () => {
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
@@ -1018,26 +814,17 @@ describe('WalletConnectProvider', () => {
       const sendSessionResponseSpy = jest.spyOn(WalletConnectWallet.prototype, 'sendSessionResponse')
 
       const mockRequest = jest.fn()
-      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
-        () =>
-          ({
-            request: mockRequest,
-          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
-      )
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockImplementation(
+          () => ({ request: mockRequest }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+        )
 
       render(
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              loaded: true,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -1078,26 +865,17 @@ describe('WalletConnectProvider', () => {
       const sendSessionResponseSpy = jest.spyOn(WalletConnectWallet.prototype, 'sendSessionResponse')
 
       const mockRequest = jest.fn()
-      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
-        () =>
-          ({
-            request: mockRequest,
-          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
-      )
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockImplementation(
+          () => ({ request: mockRequest }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+        )
 
       render(
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              loaded: true,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -1128,40 +906,29 @@ describe('WalletConnectProvider', () => {
     it('sets wrong chain error when session exists but chain is wrong', async () => {
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
-      jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
-        {
-          topic: requestTopic,
-          peer: {
-            metadata: {
-              url: requestUrl,
-              name: requestAppName,
-            },
-          },
-        } as unknown as SessionTypes.Struct,
-      ])
+      jest
+        .spyOn(WalletConnectWallet.prototype, 'getActiveSessions')
+        .mockImplementation(() => [
+          {
+            topic: requestTopic,
+            peer: { metadata: { url: requestUrl, name: requestAppName } },
+          } as unknown as SessionTypes.Struct,
+        ])
 
       const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
 
       const mockRequest = jest.fn()
-      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
-        () =>
-          ({
-            request: mockRequest,
-          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
-      )
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockImplementation(
+          () => ({ request: mockRequest }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+        )
 
       const { getByText } = render(
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -1194,44 +961,37 @@ describe('WalletConnectProvider', () => {
 
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
-      jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
-        {
-          topic: requestTopic,
-          peer: {
-            metadata: {
-              name: requestAppName,
-              description: peerDescription,
-              url: 'https://apps-portal.safe.global/wallet-connect',
-              icons: [peerIcon],
+      jest
+        .spyOn(WalletConnectWallet.prototype, 'getActiveSessions')
+        .mockImplementation(() => [
+          {
+            topic: requestTopic,
+            peer: {
+              metadata: {
+                name: requestAppName,
+                description: peerDescription,
+                url: 'https://apps-portal.safe.global/wallet-connect',
+                icons: [peerIcon],
+              },
             },
-          },
-        } as unknown as SessionTypes.Struct,
-      ])
+          } as unknown as SessionTypes.Struct,
+        ])
 
       const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
       const sendSessionResponseSpy = jest.spyOn(WalletConnectWallet.prototype, 'sendSessionResponse')
 
       const mockRequest = jest.fn().mockImplementation(() => Promise.resolve({}))
-      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
-        () =>
-          ({
-            request: mockRequest,
-          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
-      )
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockImplementation(
+          () => ({ request: mockRequest }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+        )
 
       render(
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              loaded: true,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await act(() => Promise.resolve())
@@ -1286,25 +1046,17 @@ describe('WalletConnectProvider', () => {
       const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
 
       const mockRequest = jest.fn().mockImplementation(() => Promise.resolve({}))
-      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
-        () =>
-          ({
-            request: mockRequest,
-          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
-      )
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockImplementation(
+          () => ({ request: mockRequest }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
+        )
 
       render(
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -1316,10 +1068,7 @@ describe('WalletConnectProvider', () => {
       onRequestHandler({
         id: 1,
         topic: requestTopic,
-        params: {
-          request: { method: 'fake', params: [] },
-          chainId: 'eip155:5',
-        },
+        params: { request: { method: 'fake', params: [] }, chainId: 'eip155:5' },
       } as unknown as WalletKitTypes.SessionRequest)
 
       expect(mockRequest).toHaveBeenCalledWith(
@@ -1334,26 +1083,30 @@ describe('WalletConnectProvider', () => {
     it('sets the error state if there is an error requesting', async () => {
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
-      jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
-        {
-          topic: requestTopic,
-          peer: {
-            metadata: {
-              name: requestAppName,
-              description: faker.lorem.sentence(),
-              url: 'https://apps-portal.safe.global/wallet-connect',
-              icons: [faker.image.url()],
+      jest
+        .spyOn(WalletConnectWallet.prototype, 'getActiveSessions')
+        .mockImplementation(() => [
+          {
+            topic: requestTopic,
+            peer: {
+              metadata: {
+                name: requestAppName,
+                description: faker.lorem.sentence(),
+                url: 'https://apps-portal.safe.global/wallet-connect',
+                icons: [faker.image.url()],
+              },
             },
-          },
-        } as unknown as SessionTypes.Struct,
-      ])
+          } as unknown as SessionTypes.Struct,
+        ])
 
-      jest.spyOn(useSafeWalletProvider, 'default').mockImplementation(
-        () =>
-          ({
-            request: () => Promise.reject(new Error('Test request failed')),
-          }) as unknown as ReturnType<typeof useSafeWalletProvider.default>,
-      )
+      jest
+        .spyOn(useSafeWalletProvider, 'default')
+        .mockImplementation(
+          () =>
+            ({ request: () => Promise.reject(new Error('Test request failed')) }) as unknown as ReturnType<
+              typeof useSafeWalletProvider.default
+            >,
+        )
 
       const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
       const sendSessionResponseSpy = jest.spyOn(WalletConnectWallet.prototype, 'sendSessionResponse')
@@ -1362,15 +1115,7 @@ describe('WalletConnectProvider', () => {
         <WalletConnectProvider>
           <TestComponent />
         </WalletConnectProvider>,
-        {
-          initialReduxState: {
-            safeInfo: {
-              loading: false,
-              loaded: true,
-              data: extendedSafeInfo,
-            },
-          },
-        },
+        { initialReduxState: { safeInfo: { loading: false, loaded: true, data: extendedSafeInfo } } },
       )
 
       await waitFor(() => {
@@ -1411,6 +1156,7 @@ describe('WalletConnectProvider', () => {
           initialReduxState: {
             safeInfo: {
               loading: false,
+              loaded: true,
               data: {
                 ...extendedSafeInfo,
                 chainId: '', // Missing chainId

--- a/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
+++ b/apps/web/src/features/walletconnect/__tests__/WalletConnectContext.test.tsx
@@ -911,14 +911,12 @@ describe('WalletConnectProvider', () => {
     it('sets wrong chain error when session exists but chain is wrong', async () => {
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
-      jest
-        .spyOn(WalletConnectWallet.prototype, 'getActiveSessions')
-        .mockImplementation(() => [
-          {
-            topic: requestTopic,
-            peer: { metadata: { url: requestUrl, name: requestAppName } },
-          } as unknown as SessionTypes.Struct,
-        ])
+      jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
+        {
+          topic: requestTopic,
+          peer: { metadata: { url: requestUrl, name: requestAppName } },
+        } as unknown as SessionTypes.Struct,
+      ])
 
       const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
 
@@ -966,21 +964,19 @@ describe('WalletConnectProvider', () => {
 
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
-      jest
-        .spyOn(WalletConnectWallet.prototype, 'getActiveSessions')
-        .mockImplementation(() => [
-          {
-            topic: requestTopic,
-            peer: {
-              metadata: {
-                name: requestAppName,
-                description: peerDescription,
-                url: 'https://apps-portal.safe.global/wallet-connect',
-                icons: [peerIcon],
-              },
+      jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
+        {
+          topic: requestTopic,
+          peer: {
+            metadata: {
+              name: requestAppName,
+              description: peerDescription,
+              url: 'https://apps-portal.safe.global/wallet-connect',
+              icons: [peerIcon],
             },
-          } as unknown as SessionTypes.Struct,
-        ])
+          },
+        } as unknown as SessionTypes.Struct,
+      ])
 
       const onRequestSpy = jest.spyOn(WalletConnectWallet.prototype, 'onRequest')
       const sendSessionResponseSpy = jest.spyOn(WalletConnectWallet.prototype, 'sendSessionResponse')
@@ -1088,21 +1084,19 @@ describe('WalletConnectProvider', () => {
     it('sets the error state if there is an error requesting', async () => {
       jest.spyOn(WalletConnectWallet.prototype, 'init').mockImplementation(() => Promise.resolve())
       jest.spyOn(WalletConnectWallet.prototype, 'updateSessions').mockImplementation(() => Promise.resolve())
-      jest
-        .spyOn(WalletConnectWallet.prototype, 'getActiveSessions')
-        .mockImplementation(() => [
-          {
-            topic: requestTopic,
-            peer: {
-              metadata: {
-                name: requestAppName,
-                description: faker.lorem.sentence(),
-                url: 'https://apps-portal.safe.global/wallet-connect',
-                icons: [faker.image.url()],
-              },
+      jest.spyOn(WalletConnectWallet.prototype, 'getActiveSessions').mockImplementation(() => [
+        {
+          topic: requestTopic,
+          peer: {
+            metadata: {
+              name: requestAppName,
+              description: faker.lorem.sentence(),
+              url: 'https://apps-portal.safe.global/wallet-connect',
+              icons: [faker.image.url()],
             },
-          } as unknown as SessionTypes.Struct,
-        ])
+          },
+        } as unknown as SessionTypes.Struct,
+      ])
 
       jest
         .spyOn(useSafeWalletProvider, 'default')


### PR DESCRIPTION
## What it solves

[COR-404](https://linear.app/safe-global/issue/COR-404/add-support-for-atomic-capability-in-eip-5792-v2)

Fixes TS errors that were accidently introduced with #6176 due to long time between last commit and merge.

https://github.com/safe-global/safe-wallet-monorepo/actions/runs/17614934370/job/50045523019

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
