### PR TITLE
Fix(web): do not show "Unverified contract" for EoAs

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -7,33 +7,44 @@ import { memo, useMemo } from 'react'
 import { isAddress } from 'ethers'
 import { useAddressResolver } from '@/hooks/useAddressResolver'
 import { useContractsGetContractV1Query as useGetContractQuery } from '@safe-global/store/gateway/AUTO_GENERATED/contracts'
+import { isSmartContract } from '@/utils/wallets'
+import useAsync from '@safe-global/utils/hooks/useAsync'
 
-const useIsUnverifiedContract = (contract?: { contractAbi?: object | null } | null): boolean => {
-  return !!contract && !contract.contractAbi
+const useIsUnverifiedContract = (contract?: { address: string; contractAbi?: object | null } | null): boolean => {
+  const address = contract?.address
+  const [isContract = false] = useAsync(() => (address ? isSmartContract(address) : undefined), [address])
+  return isContract && !!contract && !contract.contractAbi
 }
+
+const THIS_SAFE_ACCOUNT = 'This Safe Account'
+const UNVERIFIED_CONTRACT = 'Unverified contract'
 
 export function useAddressName(address?: string, name?: string | null, customAvatar?: string) {
   const chainId = useChainId()
   const safeAddress = useSafeAddress()
-  const displayName = sameAddress(address, safeAddress) ? 'This Safe Account' : name
+  const displayName = sameAddress(address, safeAddress) ? THIS_SAFE_ACCOUNT : name
+  const { ens: ensName } = useAddressResolver(displayName ? undefined : address)
 
-  const shouldSkip = !!displayName || !address || !isAddress(address)
+  const shouldSkip = Boolean(displayName || ensName) || !address || !isAddress(address)
   const { data: contract } = useGetContractQuery({ chainId, contractAddress: address as string }, { skip: shouldSkip })
-
   const contractData = shouldSkip ? undefined : contract
-  const nonEnsName = displayName || contractData?.displayName || contractData?.name
-
-  const { ens: ensName } = useAddressResolver(nonEnsName ? undefined : address)
-
   const isUnverifiedContract = useIsUnverifiedContract(contractData)
+
+  const finalName =
+    displayName ||
+    ensName ||
+    contractData?.displayName ||
+    contractData?.name ||
+    (isUnverifiedContract ? UNVERIFIED_CONTRACT : undefined)
+  const logoUri = customAvatar || contractData?.logoUri
 
   return useMemo(
     () => ({
-      name: nonEnsName || ensName || (isUnverifiedContract ? 'Unverified contract' : undefined),
-      logoUri: customAvatar || contractData?.logoUri,
+      name: finalName,
+      logoUri,
       isUnverifiedContract,
     }),
-    [nonEnsName, customAvatar, contractData?.logoUri, isUnverifiedContract, ensName],
+    [finalName, logoUri, isUnverifiedContract],
   )
 }
 

--- a/apps/web/src/components/settings/owner/OwnerList/index.tsx
+++ b/apps/web/src/components/settings/owner/OwnerList/index.tsx
@@ -30,7 +30,7 @@ export const OwnerList = () => {
 
     return safe.owners.map((owner) => {
       const address = owner.value
-      const name = addressBook[address]
+      const name = addressBook[address] ?? owner.name
 
       return {
         cells: {


### PR DESCRIPTION
## What it solves

Resolves https://linear.app/safe-global/issue/COR-602/ens-for-owners-and-delegates

## How this PR fixes it

Apparently, the `/contracts` CGW endpoint returns an object for any address, even if it's not a contract. I think it wasn't the case before. I've added an RPC call to fetch contract code for a given address to determine if it's a contract.