### PR TITLE
Fix(web): check contract code for unverified contracts

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
@@ -27,6 +27,10 @@ jest.mock('@/hooks/useSafeAddress', () => ({
 }))
 const useSafeAddressMock = useSafeAddress as jest.Mock
 
+jest.mock('@/utils/wallets', () => ({
+  isSmartContract: jest.fn().mockResolvedValue(true),
+}))
+
 const safeAddress = faker.finance.ethereumAddress()
 
 describe('NamedAddressInfo', () => {


### PR DESCRIPTION
## What it solves

An alternative to #6344 (merge one and close the other).
Resolves [COR-602](https://linear.app/safe-global/issue/COR-602/ens-for-owners-and-delegates)

## How this PR fixes it

Apparently, the `/contracts` CGW endpoint returns an object for any address, even if it's not a contract. I think it wasn't the case before.

I've added a check for contract code via RPC before fetching contract data from CGW.