### PR TITLE
fix(Mobile): Poll safe info and update history

### DIFF
--- a/apps/mobile/src/features/ExecuteTx/components/ExecuteProcessing.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ExecuteProcessing.tsx
@@ -9,20 +9,16 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { AbsoluteLinearGradient } from '@/src/components/LinearGradient'
 import { useTheme } from '@/src/theme/hooks/useTheme'
 
-export function ExecuteProcessing({ txId }: { txId: string }) {
+export function ExecuteProcessing() {
   const { bottom } = useSafeAreaInsets()
   const { isDark } = useTheme()
 
   const color = isDark ? getTokenValue('$color.backgroundLightDark') : getTokenValue('$color.backgroundLightLight')
 
   const handleTxPress = () => {
-    router.dismissAll() // Otherwise going back on the confirm screen takes the user back here which is confusing
-    router.navigate({
-      pathname: '/confirm-transaction',
-      params: {
-        txId,
-      },
-    })
+    // Go back to pending transactions
+    router.back()
+    router.back()
   }
 
   const handleHomePress = () => {

--- a/apps/mobile/src/features/ExecuteTx/components/ExecuteProcessing.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ExecuteProcessing.tsx
@@ -16,6 +16,7 @@ export function ExecuteProcessing({ txId }: { txId: string }) {
   const color = isDark ? getTokenValue('$color.backgroundLightDark') : getTokenValue('$color.backgroundLightLight')
 
   const handleTxPress = () => {
+    router.dismissAll() // Otherwise going back on the confirm screen takes the user back here which is confusing
     router.navigate({
       pathname: '/confirm-transaction',
       params: {

--- a/apps/mobile/src/features/ExecuteTx/components/ExecuteTransaction.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ExecuteTransaction.tsx
@@ -44,7 +44,7 @@ export function ExecuteTransaction() {
   }
 
   if (status === ExecutionStatus.PROCESSING) {
-    return <ExecuteProcessing txId={txId} />
+    return <ExecuteProcessing />
   }
 
   return <LoadingScreen title="Executing transaction..." description="It may take a few seconds..." />

--- a/apps/mobile/src/features/TxHistory/TxHistory.container.tsx
+++ b/apps/mobile/src/features/TxHistory/TxHistory.container.tsx
@@ -8,9 +8,11 @@ import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useAppDispatch } from '@/src/store/hooks'
 import { useLocalSearchParams } from 'expo-router'
 import Logger from '@/src/utils/logger'
+import useSafeInfo from '@/src/hooks/useSafeInfo'
 
 export function TxHistoryContainer() {
   const activeSafe = useDefinedActiveSafe()
+  const { safe } = useSafeInfo()
   const dispatch = useAppDispatch()
   const [isRefreshing, setIsRefreshing] = React.useState(false)
   const { fromNotification } = useLocalSearchParams<{ fromNotification?: string }>()
@@ -18,6 +20,7 @@ export function TxHistoryContainer() {
   const queryArgs = {
     chainId: activeSafe.chainId,
     safeAddress: activeSafe.address,
+    reloadTag: safe.txHistoryTag,
   }
 
   const {

--- a/apps/mobile/src/hooks/useSafeInfo.ts
+++ b/apps/mobile/src/hooks/useSafeInfo.ts
@@ -2,6 +2,7 @@ import { useGetSafeQuery } from '@safe-global/store/gateway'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectActiveSafe } from '@/src/store/activeSafeSlice'
 import { defaultSafeInfo } from '@safe-global/store/slices/SafeInfo/utils'
+import { POLLING_INTERVAL } from '@/src/config/constants'
 
 export const useSafeInfo = () => {
   const activeSafe = useAppSelector(selectActiveSafe)
@@ -18,6 +19,7 @@ export const useSafeInfo = () => {
     },
     {
       skip: !activeSafe,
+      pollingInterval: POLLING_INTERVAL,
     },
   )
 


### PR DESCRIPTION
## What it solves

Resolves [MOB-117](https://linear.app/safe-global/issue/MOB-117/mobile-update-safe-info-and-queuehistory-fetch-logic)

## How this PR fixes it

- Adds a `polling_interval` to fetching the safe info
- Adds the `txHistoryTag` as a dependency to the history query
- Adds a `router.dismissAll` when executing a transaction

## How to test it

1. Open the app
2. Execute a transaction
3. Execute another one
4. Observe no error message regarding the nonce
5. Observe the history updates after a transaction has been executed

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
