### PR TITLE
docs: fix minor typo in readme

### DIFF
--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -40,4 +40,4 @@ This will:
 
 - Fetch the OpenAPI schema.
 - Use the configuration provided in the `openapi-config.ts` file.
-- Gerate the API code using **@rtk-query/codegen-openapi**.
+- Generate the API code using **@rtk-query/codegen-openapi**.


### PR DESCRIPTION
Gerate looks like was intended to be Generate