### PR TITLE
Fix(Assets): sticky cell in Safari

### DIFF
--- a/apps/web/src/components/balances/AssetsTable/index.tsx
+++ b/apps/web/src/components/balances/AssetsTable/index.tsx
@@ -265,7 +265,14 @@ const AssetsTable = ({
               sticky: true,
               collapsed: item.tokenInfo.address === hidingAsset,
               content: (
-                <Stack direction="row" gap={1} alignItems="center" justifyContent="flex-end" mr={-1}>
+                <Stack
+                  direction="row"
+                  gap={1}
+                  alignItems="center"
+                  justifyContent="flex-end"
+                  mr={-1}
+                  className={css.sticky}
+                >
                   <Stack direction="row" gap={1} alignItems="center" bgcolor="background.paper" p={1}>
                     <SendButton tokenInfo={item.tokenInfo} />
 

--- a/apps/web/src/components/balances/AssetsTable/styles.module.css
+++ b/apps/web/src/components/balances/AssetsTable/styles.module.css
@@ -1,12 +1,7 @@
-.container td:last-of-type,
-.container th:last-of-type {
-  width: 0 !important;
-  display: block;
-  padding: 0 !important;
-}
-
-.container td:last-of-type > * {
+.container .sticky {
+  opacity: 0;
   position: absolute;
+  top: 0;
   right: 0;
   width: 15%;
   opacity: 0;
@@ -16,16 +11,16 @@
   align-items: center;
 }
 
-.container tr:hover td:last-of-type > * {
+.container tr:hover .sticky {
   opacity: 1;
 }
 
-.container tr {
+.container td {
   position: relative;
 }
 
 .container tr:last-of-type {
-  border-bottom: 1px solid transparent;
+  border-bottom-color: transparent;
 }
 
 .token {


### PR DESCRIPTION
## What it solves

Safari had a CSS bug that caused the sticky cell to appear under the table on hover.

## Screenshots
<img width="1119" height="584" alt="Screenshot 2025-09-22 at 09 00 50" src="https://github.com/user-attachments/assets/f83a5976-de9e-4085-bf0a-73f5d0fba9e9" />