### PR TITLE
fix(web): prevent owner list flicker

### DIFF
--- a/apps/web/src/components/common/EnhancedTable/index.tsx
+++ b/apps/web/src/components/common/EnhancedTable/index.tsx
@@ -172,34 +172,38 @@ function EnhancedTable({ rows, headCells, mobileVariant, compact }: EnhancedTabl
           <EnhancedTableHead headCells={headCells} order={order} orderBy={orderBy} onRequestSort={handleRequestSort} />
           <TableBody>
             {pagedRows.length > 0 ? (
-              pagedRows.map((row, index) => (
-                <TableRow
-                  data-testid="table-row"
-                  tabIndex={-1}
-                  key={row.key ?? index}
-                  selected={row.selected}
-                  className={row.collapsed ? css.collapsedRow : undefined}
-                >
-                  {Object.entries(row.cells).map(([key, cell]) => (
-                    <TableCell
-                      key={key}
-                      className={classNames({
-                        [css.collapsedCell]: row.collapsed,
-                      })}
-                    >
-                      <Collapse key={index} in={!row.collapsed} enter={false}>
-                        {cell.mobileLabel ? (
-                          <Typography variant="body2" color="text.secondary" className={css.mobileLabel}>
-                            {cell.mobileLabel}
-                          </Typography>
-                        ) : null}
+              pagedRows.map((row, index) => {
+                const rowKey = row.key ?? index
 
-                        {cell.content}
-                      </Collapse>
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
+                return (
+                  <TableRow
+                    data-testid="table-row"
+                    tabIndex={-1}
+                    key={rowKey}
+                    selected={row.selected}
+                    className={row.collapsed ? css.collapsedRow : undefined}
+                  >
+                    {Object.entries(row.cells).map(([key, cell]) => (
+                      <TableCell
+                        key={key}
+                        className={classNames({
+                          [css.collapsedCell]: row.collapsed,
+                        })}
+                      >
+                        <Collapse in={!row.collapsed} enter={false}>
+                          {cell.mobileLabel ? (
+                            <Typography variant="body2" color="text.secondary" className={css.mobileLabel}>
+                              {cell.mobileLabel}
+                            </Typography>
+                          ) : null}
+
+                          {cell.content}
+                        </Collapse>
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                )
+              })
             ) : (
               // Prevent no `tbody` rows hydration error
               <TableRow>

--- a/apps/web/src/components/settings/owner/OwnerList/index.tsx
+++ b/apps/web/src/components/settings/owner/OwnerList/index.tsx
@@ -33,6 +33,7 @@ export const OwnerList = () => {
       const name = addressBook[address]
 
       return {
+        key: address,
         cells: {
           owner: {
             rawValue: address,


### PR DESCRIPTION
## Summary
- provide explicit row keys for the settings owner table so owner rows persist between updates
- reuse stable identifiers inside the shared EnhancedTable to avoid remounting row content during pagination

## Testing
- yarn workspace @safe-global/web type-check
- yarn workspace @safe-global/web lint
- yarn workspace @safe-global/web prettier
- yarn workspace @safe-global/web test

------
https://chatgpt.com/codex/tasks/task_b_68d0f7cdf604832f85d78f08d33dc3b8