### PR TITLE
fix(analytics): enable tracking of swap viewed events from new tx

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxButton.tsx
+++ b/apps/web/src/components/tx-flow/common/TxButton.tsx
@@ -74,18 +74,18 @@ export const MakeASwapButton = () => {
   const onClick = isSwapPage ? () => setTxFlow(undefined) : undefined
 
   return (
-    <Track
-      {...SWAP_EVENTS.OPEN_SWAPS}
-      label={SWAP_LABELS.newTransaction}
-      mixpanelParams={{
-        [MixpanelEventParams.ENTRY_POINT]: GA_LABEL_TO_MIXPANEL_PROPERTY[SWAP_LABELS.newTransaction],
-      }}
-    >
-      <Link href={{ pathname: AppRoutes.swap, query: { safe: router.query.safe } }} passHref legacyBehavior>
+    <Link href={{ pathname: AppRoutes.swap, query: { safe: router.query.safe } }} passHref legacyBehavior>
+      <Track
+        {...SWAP_EVENTS.OPEN_SWAPS}
+        label={SWAP_LABELS.newTransaction}
+        mixpanelParams={{
+          [MixpanelEventParams.ENTRY_POINT]: GA_LABEL_TO_MIXPANEL_PROPERTY[SWAP_LABELS.newTransaction],
+        }}
+      >
         <Button variant="contained" sx={buttonSx} fullWidth onClick={onClick} startIcon={<SwapIcon width={20} />}>
           Swap tokens
         </Button>
-      </Link>
-    </Track>
+      </Track>
+    </Link>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-monorepo/pull/6346#issuecomment-3316413711

## How this PR fixes it

Changes order of Track and Link component, so the event bubbles up correctly.

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [X] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
