### PR TITLE
fix(analytics): enable tracking of swap viewed events from new tx

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxButton.tsx
+++ b/apps/web/src/components/tx-flow/common/TxButton.tsx
@@ -72,15 +72,19 @@ export const MakeASwapButton = () => {
 
   const isSwapPage = router.pathname === AppRoutes.swap
 
-  const onClick = async () => {
-    trackEvent(SWAP_EVENTS.OPEN_SWAPS, {
-      [MixpanelEventParams.ENTRY_POINT]: GA_LABEL_TO_MIXPANEL_PROPERTY[SWAP_LABELS.newTransaction],
-    })
+  const onClick = () => {
+    trackEvent(
+      { ...SWAP_EVENTS.OPEN_SWAPS, label: SWAP_LABELS.newTransaction },
+      {
+        [MixpanelEventParams.ENTRY_POINT]: GA_LABEL_TO_MIXPANEL_PROPERTY[SWAP_LABELS.newTransaction],
+      },
+    )
 
     if (isSwapPage) {
       setTxFlow(undefined)
     } else {
-      await router.push({
+      setTxFlow(undefined)
+      router.push({
         pathname: AppRoutes.swap,
         query: { safe: router.query.safe },
       })


### PR DESCRIPTION
## What it solves

Resolves https://github.com/safe-global/safe-wallet-monorepo/pull/6346#issuecomment-3316413711

## How this PR fixes it

Uses `router.push` instead of `Link` and adds tracking logic to the `onClick` handler.

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [X] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
