### PR TITLE
feat(positions): add more precise error message

### DIFF
--- a/apps/web/src/features/positions/components/PositionsUnavailable/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsUnavailable/index.tsx
@@ -1,19 +1,25 @@
 import { Paper, Typography } from '@mui/material'
 import DefiIcon from '@/public/images/balances/defi.svg'
 
-// This component is displayed when the positions feature flag IS enabled,
-// but the API does not return data from CGW (Client Gateway).
-const PositionsUnavailable = () => {
+// This component is displayed when the positions feature flag is enabled,
+// but the API does not return data from CGW (Client Gateway), or errors out.
+const PositionsUnavailable = ({ hasError = false }: { hasError?: boolean }) => {
+  const title = hasError ? 'There was an error loading your positions' : 'Positions are not available on this network'
+
+  const subtitle = hasError
+    ? 'Please try again later or contact support if the problem persists'
+    : 'Positions feature is still in beta and will be available soon'
+
   return (
     <Paper elevation={0} sx={{ p: 3, textAlign: 'center' }}>
       <DefiIcon />
 
       <Typography data-testid="positions-unavailable-text" variant="body1" color="primary.light">
-        Positions are not available on this network
+        {title}
       </Typography>
 
       <Typography variant="caption" color="primary.light" sx={{ mt: 1, display: 'block' }}>
-        Positions feature is still in beta and will be available soon
+        {subtitle}
       </Typography>
     </Paper>
   )

--- a/apps/web/src/features/positions/index.tsx
+++ b/apps/web/src/features/positions/index.tsx
@@ -23,7 +23,7 @@ export const Positions = () => {
     return <PositionsSkeleton />
   }
 
-  if (error || !protocols) return <PositionsUnavailable />
+  if (error || !protocols) return <PositionsUnavailable hasError={!!error} />
 
   if (protocols.length === 0) {
     return <PositionsEmpty entryPoint="Positions" />


### PR DESCRIPTION
## What it solves

Resolves https://linear.app/safe-global/issue/GRO-71/possitions-is-not-available-for-one-safe-on-ethereum-and-wrong-error

## How this PR fixes it

Adds a more precise error message to the positions page when CGW returns an error.

## How to test it

* Open Safe eth:0xdAe0a6A3a1Ea96813a21B5A9814420da1cb72ebc
* Open Positions balance
* Observe error message

## Screenshots

<img width="1540" height="421" alt="grafik" src="https://github.com/user-attachments/assets/1481ed8d-babe-444f-a033-6f9a5db6c17c" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
