### PR TITLE
fix(mobile): switching active signer was deleting the signer type

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/utils.ts
+++ b/apps/mobile/src/features/ConfirmTx/utils.ts
@@ -11,6 +11,5 @@ export const extractAppSigners = (
 
   const { signers: signersList } = detailedExecutionInfo
 
-  // TODO: remove this casting once we fix the cgw type problem
-  return signersList.filter((signer) => signers[signer.value]) as unknown as SignerInfo[]
+  return signersList.filter((signer) => signers[signer.value]).map((signer) => signers[signer.value])
 }


### PR DESCRIPTION
## What it solves
If we had more then one signer in a safe and we would change the signer we were losing the signer type prop. This later caused an error when signing because a ledger device would be treated as a PK signer. 

partially resolves https://linear.app/safe-global/issue/COR-538/mobile-implement-ledger-support

## How this PR fixes it
We were casting to the expected type, but Typescript was right. The object didn't conform to the type

## How to test it
On a safe with multiple signers(one needs to be ledger). Switch the signers when trying to sign. Selecting the ledger device when signing should now work as expected and bring the - Connect to device screen.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
