### PR TITLE
fix(mobile): continue button was behind the safe area on android

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/ExecuteForm/ExecuteForm.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ExecuteForm/ExecuteForm.tsx
@@ -1,15 +1,16 @@
 import { SafeButton } from '@/src/components/SafeButton'
 import React from 'react'
-import { View, Text, YStack } from 'tamagui'
+import { View, Text, YStack, getTokenValue } from 'tamagui'
 import { router } from 'expo-router'
-import { SafeAreaView } from 'react-native'
 import useIsNextTx from '@/src/hooks/useIsNextTx'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 interface ExecuteFormProps {
   txId: string
 }
 
 export function ExecuteForm({ txId }: ExecuteFormProps) {
+  const { bottom } = useSafeAreaInsets()
   const isNext = useIsNextTx(txId)
 
   const onExecutePress = () => {
@@ -20,7 +21,7 @@ export function ExecuteForm({ txId }: ExecuteFormProps) {
   }
 
   return (
-    <SafeAreaView style={{ gap: 24 }}>
+    <View gap="$4" paddingBottom={Math.max(bottom, getTokenValue('$4'))}>
       <View paddingHorizontal={'$3'} gap="$2" flexDirection="row">
         <YStack justifyContent="center" gap="$2" width="100%">
           {!isNext && (
@@ -40,6 +41,6 @@ export function ExecuteForm({ txId }: ExecuteFormProps) {
           </SafeButton>
         </YStack>
       </View>
-    </SafeAreaView>
+    </View>
   )
 }

--- a/apps/mobile/src/features/ConfirmTx/components/SignForm/SignForm.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/SignForm/SignForm.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
-import { SafeAreaView } from 'react-native'
-import { View } from 'tamagui'
+import { getTokenValue, View } from 'tamagui'
 import { SafeButton } from '@/src/components/SafeButton'
 import { router } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export interface SignFormProps {
   txId: string
 }
 
 export function SignForm({ txId }: SignFormProps) {
+  const { bottom } = useSafeAreaInsets()
   const onSignPress = () => {
     router.push({
       pathname: '/review-and-confirm',
@@ -17,12 +18,12 @@ export function SignForm({ txId }: SignFormProps) {
   }
 
   return (
-    <SafeAreaView style={{ gap: 24 }}>
+    <View gap="$4" paddingBottom={Math.max(bottom, getTokenValue('$4'))}>
       <View paddingHorizontal={'$3'} height={48} gap="$2" flexDirection="row">
         <SafeButton flex={1} height="100%" onPress={onSignPress}>
           Continue
         </SafeButton>
       </View>
-    </SafeAreaView>
+    </View>
   )
 }

--- a/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
+++ b/apps/mobile/src/features/TransactionActions/components/TxActionsList.tsx
@@ -64,7 +64,7 @@ const TxActionItem = ({ action, index, addressInfoIndex, txData }: TxActionItemP
                 Send {formatVisualAmount(transferTokenInfo.transferValue, transferTokenInfo?.tokenInfo?.decimals, 6)}{' '}
                 {transferTokenInfo.tokenInfo.symbol} to
               </Text>
-              <Identicon address={tx.to as `0x${string}`} size={20} />{' '}
+              <Identicon address={tx.to as `0x${string}`} size={20} />
               <Text fontSize="$4" numberOfLines={1} ellipsizeMode="tail" flexShrink={1}>
                 {shortenAddress(tx.to)}
               </Text>


### PR DESCRIPTION
## What it solves
On Android the continue button was behind the safe area and as such was not clickable

Resolves https://linear.app/safe-global/issue/COR-503/mobile-transaction-execution-on-mobile#comment-5551fd29

## How this PR fixes it
- correctly calculates the offset and ads it to the button

## How to test it
Try to sign or execute a tx on android.

## Screenshots
<img width="250" alt="grafik" src="https://github.com/user-attachments/assets/f3a69a9a-3663-4c81-b843-d759fbe2e0fe" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
