### PR TITLE
feat(web): increase safe accounts limit from 10 to 40 in AddAccounts …

### DIFF
--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -58,7 +58,7 @@ function getSelectedSafes(safes: AddAccountsFormValues['selectedSafes'], spaceSa
   )
 }
 
-const safeAccountsLimitRaw = Number.parseInt(process.env.SPACES_SAFE_ACCOUNTS_LIMIT ?? '', 10)
+const safeAccountsLimitRaw = Number.parseInt(process.env.NEXT_PUBLIC_SPACES_SAFE_ACCOUNTS_LIMIT ?? '', 10)
 const SAFE_ACCOUNTS_LIMIT = !Number.isNaN(safeAccountsLimitRaw) ? safeAccountsLimitRaw : 40
 
 const AddAccounts = () => {


### PR DESCRIPTION
## What it solves
This PR raises the default limit of safes that can be added to a space from 10 to 40. It also introduces configurability via an environment variable, allowing the limit to be adjusted as needed.

Resolves #COR-617

## How this PR fixes it
Increases the default value from 10 to 40 and makes it configurable by an env var.

## How to test it
Add more than 10 Safes to your Space.