### PR TITLE
feat(mobile): automatically set the name of imported ledger address

### DIFF
--- a/apps/mobile/src/features/Ledger/LedgerAddresses.container.tsx
+++ b/apps/mobile/src/features/Ledger/LedgerAddresses.container.tsx
@@ -22,7 +22,7 @@ export const LedgerAddressesContainer = () => {
   const { bottom } = useSafeAreaInsets()
 
   const [selectedIndex, setSelectedIndex] = useState<number>(0)
-
+  const deviceLabel = params.deviceName || 'Ledger device'
   const {
     addresses,
     isLoading,
@@ -52,7 +52,6 @@ export const LedgerAddressesContainer = () => {
       return
     }
 
-    const deviceLabel = params.deviceName || 'Ledger device'
     const reset = () => clearError()
 
     switch (error.code) {
@@ -97,7 +96,7 @@ export const LedgerAddressesContainer = () => {
         })
         break
     }
-  }, [error, clearError, fetchAddresses, params.deviceName, router, selectedIndex, addresses])
+  }, [error, clearError, fetchAddresses, deviceLabel, addresses, router, selectedIndex])
 
   const { handleScroll } = useScrollableHeader({
     children: <NavBarTitle paddingRight={5}>{TITLE}</NavBarTitle>,
@@ -108,10 +107,7 @@ export const LedgerAddressesContainer = () => {
   if (isInitialLoading) {
     return (
       <View flex={1} justifyContent="center" alignItems="center" marginBottom={'$10'}>
-        <LedgerProgress
-          title="Loading addresses..."
-          description={`Retrieving addresses from your ${params.deviceName || 'Ledger device'}`}
-        />
+        <LedgerProgress title="Loading addresses..." description={`Retrieving addresses from your ${deviceLabel}`} />
       </View>
     )
   }
@@ -122,15 +118,14 @@ export const LedgerAddressesContainer = () => {
     }
 
     const selected = addresses[selectedIndex]
-    const res = await importAddress(selected.address, selected.path, selected.index)
+    const res = await importAddress(selected.address, selected.path, selected.index, deviceLabel)
 
     if (res && 'success' in res && res.success && 'selected' in res && res.selected) {
-      const name = `Ledger ${params.deviceName || 'Device'}`
       router.push({
         pathname: '/import-signers/ledger-success',
         params: {
           address: res.selected.address,
-          name,
+          name: deviceLabel,
           path: res.selected.path,
         },
       })
@@ -151,9 +146,7 @@ export const LedgerAddressesContainer = () => {
       <SectionTitle
         title={TITLE}
         paddingHorizontal={'$0'}
-        description={`Select one or more addresses derived from your ${
-          params.deviceName || 'Ledger device'
-        }. Make sure they are signers of the selected Safe Account.`}
+        description={`Select one or more addresses derived from your ${deviceLabel}. Make sure they are signers of the selected Safe Account.`}
       />
 
       {addresses[0] && (

--- a/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.test.ts
+++ b/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.test.ts
@@ -114,7 +114,7 @@ describe('useImportLedgerAddress', () => {
 
       let importResult
       await act(async () => {
-        importResult = await result.current.importAddress('', createMockPath(), createMockIndex())
+        importResult = await result.current.importAddress('', createMockPath(), createMockIndex(), 'Ledger Device')
       })
 
       expect(importResult).toEqual({ success: false })
@@ -130,7 +130,7 @@ describe('useImportLedgerAddress', () => {
 
       let importResult
       await act(async () => {
-        importResult = await result.current.importAddress(createMockAddress(), '', createMockIndex())
+        importResult = await result.current.importAddress(createMockAddress(), '', createMockIndex(), 'Ledger Device')
       })
 
       expect(importResult).toEqual({ success: false })
@@ -146,7 +146,7 @@ describe('useImportLedgerAddress', () => {
 
       let importResult
       await act(async () => {
-        importResult = await result.current.importAddress('', '', createMockIndex())
+        importResult = await result.current.importAddress('', '', createMockIndex(), 'Ledger Device')
       })
 
       expect(importResult).toEqual({ success: false })
@@ -164,7 +164,12 @@ describe('useImportLedgerAddress', () => {
 
       let importResult
       await act(async () => {
-        importResult = await result.current.importAddress(createMockAddress(), createMockPath(), createMockIndex())
+        importResult = await result.current.importAddress(
+          createMockAddress(),
+          createMockPath(),
+          createMockIndex(),
+          'Ledger Device',
+        )
       })
 
       expect(importResult).toEqual({ success: false })
@@ -198,7 +203,7 @@ describe('useImportLedgerAddress', () => {
 
       let importResult
       await act(async () => {
-        importResult = await result.current.importAddress(mockAddress, mockPath, mockIndex)
+        importResult = await result.current.importAddress(mockAddress, mockPath, mockIndex, 'Ledger Device')
       })
 
       // Check import result
@@ -222,7 +227,7 @@ describe('useImportLedgerAddress', () => {
       const signers = selectSigners(state)
       expect(signers[mockAddress]).toEqual({
         value: mockAddress,
-        name: null,
+        name: `Ledger Device-${mockAddress.slice(-4)}`,
         logoUri: null,
         type: 'ledger',
         derivationPath: mockPath,
@@ -232,7 +237,7 @@ describe('useImportLedgerAddress', () => {
       const contact = selectContactByAddress(mockAddress)(state)
       expect(contact).toEqual({
         value: mockAddress,
-        name: `Signer-${mockAddress.slice(-4)}`,
+        name: `Ledger Device-${mockAddress.slice(-4)}`,
         chainIds: [],
       })
 
@@ -257,7 +262,7 @@ describe('useImportLedgerAddress', () => {
       const { result } = renderHook(() => useImportLedgerAddress())
 
       // Start the import process
-      const importPromise = result.current.importAddress(mockAddress, mockPath, mockIndex)
+      const importPromise = result.current.importAddress(mockAddress, mockPath, mockIndex, 'Ledger Device')
 
       // Check that isImporting is true during the process
       await waitFor(() => {
@@ -290,7 +295,7 @@ describe('useImportLedgerAddress', () => {
 
       let importResult
       await act(async () => {
-        importResult = await result.current.importAddress(mockAddress, mockPath, mockIndex)
+        importResult = await result.current.importAddress(mockAddress, mockPath, mockIndex, 'Ledger Device')
       })
 
       // Should fail when disconnect fails since it's in the try-catch
@@ -310,7 +315,7 @@ describe('useImportLedgerAddress', () => {
 
       // First, create an error
       await act(async () => {
-        await result.current.importAddress('', '', createMockIndex())
+        await result.current.importAddress('', '', createMockIndex(), 'Ledger Device')
       })
 
       expect(result.current.error).not.toBeNull()
@@ -331,7 +336,7 @@ describe('useImportLedgerAddress', () => {
 
       // First, create a validation error
       await act(async () => {
-        await result.current.importAddress('', '', createMockIndex())
+        await result.current.importAddress('', '', createMockIndex(), 'Ledger Device')
       })
 
       expect(result.current.error).toEqual({
@@ -347,7 +352,7 @@ describe('useImportLedgerAddress', () => {
       setupSuccessfulOwnershipValidation(mockAddress, mockSafeAddress, mockChainId)
 
       await act(async () => {
-        await result.current.importAddress(mockAddress, mockPath, mockIndex)
+        await result.current.importAddress(mockAddress, mockPath, mockIndex, 'Ledger Device')
       })
 
       expect(result.current.error).toBeNull()
@@ -397,7 +402,7 @@ describe('useImportLedgerAddress', () => {
       const store = hookResult.store as { getState: () => RootState }
 
       await act(async () => {
-        await result.current.importAddress(newAddress, newPath, newIndex)
+        await result.current.importAddress(newAddress, newPath, newIndex, 'Ledger Device')
       })
 
       // Check the Redux state through the returned store
@@ -408,7 +413,7 @@ describe('useImportLedgerAddress', () => {
       expect(signers[existingAddress]).toEqual(existingSigner)
       expect(signers[newAddress]).toEqual({
         value: newAddress,
-        name: null,
+        name: `Ledger Device-${newAddress.slice(-4)}`,
         logoUri: null,
         type: 'ledger',
         derivationPath: newPath,
@@ -440,7 +445,7 @@ describe('useImportLedgerAddress', () => {
       const store = hookResult.store as { getState: () => RootState }
 
       await act(async () => {
-        await result.current.importAddress(mockAddress, mockPath, mockIndex)
+        await result.current.importAddress(mockAddress, mockPath, mockIndex, 'Ledger Device')
       })
 
       // Check the Redux state through the returned store
@@ -450,7 +455,7 @@ describe('useImportLedgerAddress', () => {
       const activeSigner = selectActiveSigner(state, safeAddress)
       expect(activeSigner).toEqual({
         value: mockAddress,
-        name: null,
+        name: `Ledger Device-${mockAddress.slice(-4)}`,
         logoUri: null,
         type: 'ledger',
         derivationPath: mockPath,

--- a/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.ts
+++ b/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.ts
@@ -34,7 +34,7 @@ export const useImportLedgerAddress = () => {
   }, [])
 
   const importAddress = useCallback(
-    async (address: string, path: string, index: number): Promise<ImportResult | ImportFailure> => {
+    async (address: string, path: string, index: number, name: string): Promise<ImportResult | ImportFailure> => {
       if (!address || !path) {
         setError({
           code: 'VALIDATION',
@@ -58,10 +58,14 @@ export const useImportLedgerAddress = () => {
           return { success: false }
         }
 
+        let ownerName = validationResult.ownerInfo?.name || null
+        if (!ownerName) {
+          ownerName = `${name}-${address.slice(-4)}`
+        }
         await dispatch(
           addSignerWithEffects({
             value: address,
-            name: validationResult.ownerInfo?.name || null,
+            name: ownerName,
             logoUri: validationResult.ownerInfo?.logoUri || null,
             type: 'ledger',
             derivationPath: path,

--- a/apps/mobile/src/store/signersSlice.ts
+++ b/apps/mobile/src/store/signersSlice.ts
@@ -40,7 +40,7 @@ const signersSlice = createSlice({
 export const addSignerWithEffects =
   (signerInfo: Signer) => async (dispatch: AppDispatch, getState: () => RootState) => {
     const { activeSafe, activeSigner } = getState()
-    const signerNamePrefix = 'Signer-'
+    const signerName = signerInfo.name || `Signer-${signerInfo.value.slice(-4)}`
 
     dispatch(addSigner(signerInfo))
 
@@ -51,7 +51,7 @@ export const addSignerWithEffects =
     dispatch(
       addContact({
         value: signerInfo.value,
-        name: signerNamePrefix + signerInfo.value.slice(-4),
+        name: signerName,
         chainIds: [],
       }),
     )


### PR DESCRIPTION
## What it solves
Currently the imported ledger address would end up being "Singer-{last 4 digits of address}". With this PR the imported address would be stored as "{LEDGER device name} + {last 4 digits of address}"

Resolves https://linear.app/safe-global/issue/COR-538/mobile-implement-ledger-support#comment-34c3abb8

## How this PR fixes it
I had to refactor the addSignerWithEffects hook to accept the passed name instead of always setting one itself.  

## How to test it
Add a ledger signer and observe that the signer has a name that contains the Ledger device name. (note: if you've already imported this signer the name won't change as the contact exists in the address book)

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
