### PR TITLE
fix(blockaid): parse Safe App origin JSON before sending to Blockaid

### DIFF
--- a/packages/utils/src/services/security/modules/BlockaidModule/index.ts
+++ b/packages/utils/src/services/security/modules/BlockaidModule/index.ts
@@ -97,8 +97,13 @@ export class BlockaidModule implements SecurityModule<BlockaidModuleRequest, Blo
     if (request.origin) {
       try {
         const parsed = JSON.parse(request.origin)
-        domain = parsed.url || request.origin
+        // Only use parsed.url if it's a non-empty string
+        if (typeof parsed.url === 'string' && parsed.url.length > 0) {
+          domain = parsed.url
+        }
+        // Otherwise leave domain undefined to fall back to non_dapp
       } catch {
+        // Not JSON - use the original string as-is
         domain = request.origin
       }
     }


### PR DESCRIPTION
Resolves https://linear.app/safe-global/issue/EPD-337/malformed-safe-app-url-in-blockaid-request

## Summary

Fixes malformed Safe App URL being sent to Blockaid for security scanning.

**Problem**: The origin parameter from Safe Apps is a JSON string like `'{"url":"https://app.request.finance","name":"..."}'` but was being sent directly to Blockaid as the `domain` field. This resulted in malformed URLs like `http://{"url":"https://app.request.finance"` in Blockaid requests.

**Solution**: Parse the origin JSON string and extract just the URL before passing it to Blockaid. Falls back to the original string if parsing fails (for non-JSON origins).

## Changes

- Added JSON parsing logic in `BlockaidModule.scanTransaction()` to extract the URL from the origin JSON
- Maintains backward compatibility by falling back to the original string if parsing fails

## Test plan

- [ ] Test Safe App transactions are scanned correctly with Blockaid
- [ ] Verify the domain field in Blockaid requests contains only the URL (e.g., `https://app.request.finance`) instead of the full JSON string
- [ ] Verify non-JSON origin strings still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)