### PR TITLE
Fix Tenderly simulation links to respect custom configuration

### DIFF
--- a/apps/mobile/src/features/TransactionChecks/tenderly/useSimulation.ts
+++ b/apps/mobile/src/features/TransactionChecks/tenderly/useSimulation.ts
@@ -18,7 +18,10 @@ export const useSimulation = (): UseSimulationReturn => {
   const [requestError, setRequestError] = useState<string | undefined>(undefined)
   const tenderly = useAppSelector(selectTenderly)
 
-  const simulationLink = useMemo(() => getSimulationLink(simulation?.simulation.id || ''), [simulation])
+  const simulationLink = useMemo(
+    () => getSimulationLink(simulation?.simulation.id || '', tenderly),
+    [simulation, tenderly],
+  )
 
   const resetSimulation = useCallback(() => {
     setSimulationRequestStatus(FETCH_STATUS.NOT_ASKED)

--- a/apps/web/src/components/tx/security/tenderly/useSimulation.ts
+++ b/apps/web/src/components/tx/security/tenderly/useSimulation.ts
@@ -19,7 +19,10 @@ export const useSimulation = (): UseSimulationReturn => {
   const [requestError, setRequestError] = useState<string | undefined>(undefined)
   const tenderly = useAppSelector(selectTenderly)
 
-  const simulationLink = useMemo(() => getSimulationLink(simulation?.simulation.id || ''), [simulation])
+  const simulationLink = useMemo(
+    () => getSimulationLink(simulation?.simulation.id || '', tenderly),
+    [simulation, tenderly],
+  )
 
   const resetSimulation = useCallback(() => {
     setSimulationRequestStatus(FETCH_STATUS.NOT_ASKED)

--- a/packages/utils/src/components/tx/security/tenderly/__tests__/utils.test.ts
+++ b/packages/utils/src/components/tx/security/tenderly/__tests__/utils.test.ts
@@ -7,6 +7,7 @@ import {
   GUARD_STORAGE_POSITION,
   getCallTraceErrors,
   getSimulationStatus,
+  getSimulationLink,
 } from '../utils'
 import { ImplementationVersionState, type SafeInfo } from '@safe-global/safe-gateway-typescript-sdk'
 import type { SafeTransaction, SafeSignature } from '@safe-global/types-kit'
@@ -15,6 +16,7 @@ import { faker } from '@faker-js/faker'
 import { EthSafeSignature } from '@safe-global/protocol-kit'
 import { FETCH_STATUS, type TenderlySimulation } from '../types'
 import type { UseSimulationReturn } from '../useSimulation'
+import { TENDERLY_ORG_NAME, TENDERLY_PROJECT_NAME } from '@safe-global/utils/config/constants'
 
 describe('getStateOverwrites', () => {
   const mockOwners = [faker.finance.ethereumAddress(), faker.finance.ethereumAddress(), faker.finance.ethereumAddress()]
@@ -166,6 +168,47 @@ describe('getCallTraceErrors', () => {
     expect(errors).toHaveLength(2)
     expect(errors[0].error).toBe('Execution reverted')
     expect(errors[1].error).toBe('Out of gas')
+  })
+})
+
+describe('getSimulationLink', () => {
+  const simulationId = '123'
+
+  it('should fallback to the default dashboard URL when no custom Tenderly configuration is provided', () => {
+    const result = getSimulationLink(simulationId)
+
+    expect(result).toEqual(
+      `https://dashboard.tenderly.co/public/${TENDERLY_ORG_NAME}/${TENDERLY_PROJECT_NAME}/simulator/${simulationId}`,
+    )
+  })
+
+  it('should build a public dashboard URL when a custom Tenderly URL is provided without an access token', () => {
+    const result = getSimulationLink(simulationId, {
+      url: 'https://api.tenderly.co/api/v2/project/my-org/my-project/simulate',
+      accessToken: '',
+    })
+
+    expect(result).toEqual('https://dashboard.tenderly.co/public/my-org/my-project/simulator/123')
+  })
+
+  it('should build a private dashboard URL when a custom Tenderly URL and access token are provided', () => {
+    const result = getSimulationLink(simulationId, {
+      url: 'https://api.tenderly.co/api/v1/account/my-org/project/my-project/simulate',
+      accessToken: 'token',
+    })
+
+    expect(result).toEqual('https://dashboard.tenderly.co/my-org/my-project/simulator/123')
+  })
+
+  it('should fallback to defaults when the provided URL cannot be parsed', () => {
+    const result = getSimulationLink(simulationId, {
+      url: 'not-a-url',
+      accessToken: 'token',
+    })
+
+    expect(result).toEqual(
+      `https://dashboard.tenderly.co/public/${TENDERLY_ORG_NAME}/${TENDERLY_PROJECT_NAME}/simulator/${simulationId}`,
+    )
   })
 })
 

--- a/packages/utils/src/components/tx/security/tenderly/utils.ts
+++ b/packages/utils/src/components/tx/security/tenderly/utils.ts
@@ -17,8 +17,64 @@ import type { EnvState } from '@safe-global/store/settingsSlice'
 import { toBeHex, ZeroAddress } from 'ethers'
 import { UseSimulationReturn } from './useSimulation'
 
-export const getSimulationLink = (simulationId: string): string => {
-  return `https://dashboard.tenderly.co/public/${TENDERLY_ORG_NAME}/${TENDERLY_PROJECT_NAME}/simulator/${simulationId}`
+const TENDERLY_DASHBOARD_URL = 'https://dashboard.tenderly.co'
+
+const getTenderlyProjectFromUrl = (
+  tenderlyUrl?: string,
+): { org: string; project: string } | undefined => {
+  if (!tenderlyUrl) {
+    return
+  }
+
+  try {
+    const { pathname } = new URL(tenderlyUrl)
+    const segments = pathname.split('/').filter(Boolean)
+
+    if (!segments.length) {
+      return
+    }
+
+    const accountIndex = segments.findIndex((segment) => segment === 'account')
+
+    if (accountIndex !== -1) {
+      const org = segments[accountIndex + 1]
+      const projectIndex = segments.indexOf('project', accountIndex)
+      const project = projectIndex !== -1 ? segments[projectIndex + 1] : undefined
+
+      if (org && project) {
+        return { org, project }
+      }
+    }
+
+    const projectIndex = segments.findIndex((segment) => segment === 'project')
+
+    if (projectIndex !== -1) {
+      const org = segments[projectIndex + 1]
+      const project = segments[projectIndex + 2]
+
+      if (org && project) {
+        return { org, project }
+      }
+    }
+  } catch (error) {
+    // Ignore URL parsing errors and fall back to defaults
+  }
+}
+
+export const getSimulationLink = (
+  simulationId: string,
+  customTenderly?: EnvState['tenderly'],
+): string => {
+  const parsedTenderly = getTenderlyProjectFromUrl(customTenderly?.url)
+
+  if (parsedTenderly) {
+    const { org, project } = parsedTenderly
+    const baseUrl = customTenderly?.accessToken ? TENDERLY_DASHBOARD_URL : `${TENDERLY_DASHBOARD_URL}/public`
+
+    return `${baseUrl}/${org}/${project}/simulator/${simulationId}`
+  }
+
+  return `${TENDERLY_DASHBOARD_URL}/public/${TENDERLY_ORG_NAME}/${TENDERLY_PROJECT_NAME}/simulator/${simulationId}`
 }
 
 export type SingleTransactionSimulationParams = {


### PR DESCRIPTION
## Summary
- update Tenderly simulation link builder to derive organization and project from a custom API URL
- wire the custom Tenderly settings into the web and mobile simulation link usage
- add unit tests covering the new simulation link logic

## Testing
- yarn workspace @safe-global/web type-check
- yarn workspace @safe-global/web lint
- yarn workspace @safe-global/web prettier
- CI=1 yarn workspace @safe-global/web test > /tmp/web-test.log 2>&1
- yarn workspace @safe-global/mobile lint
- yarn workspace @safe-global/mobile prettier
- CI=1 yarn workspace @safe-global/mobile test > /tmp/mobile-test.log 2>&1

------
https://chatgpt.com/codex/tasks/task_b_68df7fa95e60832fa1520d234eaed147