### PR TITLE
feat(web): Add Unstoppable Domains Resolution Support

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -65,6 +65,7 @@
     "@safe-global/safe-modules-deployments": "^2.2.16",
     "@safe-global/store": "workspace:^",
     "@sentry/react": "^7.91.0",
+    "@unstoppabledomains/resolution": "^9.3.3",
     "@walletconnect/core": "^2.21.9",
     "@walletconnect/utils": "^2.21.9",
     "@web3-onboard/coinbase": "^2.4.2",

--- a/apps/web/src/components/common/AddressInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressInput/index.test.tsx
@@ -92,7 +92,7 @@ describe('AddressInput tests', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-      ; (useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
     jest.spyOn(addressBook, 'default').mockReturnValue({})
   })
 
@@ -221,7 +221,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should not resolve UD names if this feature is disabled', async () => {
-    ; (useCurrentChain as jest.Mock).mockImplementation(() => ({
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
       shortName: 'gor',
       chainId: '5',
       chainName: 'Goerli',
@@ -241,7 +241,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should show a spinner when UD resolution is in progress', async () => {
-    ; (useNameResolver as jest.Mock).mockImplementation((val: string) => ({
+    ;(useNameResolver as jest.Mock).mockImplementation((val: string) => ({
       address: undefined,
       resolverError: undefined,
       resolving: val === 'loading.crypto',
@@ -271,7 +271,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should not resolve ENS names if this feature is disabled', async () => {
-    ; (useCurrentChain as jest.Mock).mockImplementation(() => ({
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
       shortName: 'gor',
       chainId: '5',
       chainName: 'Goerli',
@@ -301,7 +301,7 @@ describe('AddressInput tests', () => {
   // TODO: Fix this test
   it.skip('should not show the adornment prefix when the value contains correct prefix', async () => {
     const mockChain = chainBuilder().with({ features: [] }).build()
-      ; (useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
 
     const { input } = setup(`${mockChain.shortName}:${TEST_ADDRESS_A}`)
 
@@ -344,7 +344,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should clean up the input value if it contains a valid address', async () => {
-    ; (useCurrentChain as jest.Mock).mockImplementation(() => ({
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
       shortName: 'gor',
       chainId: '5',
       chainName: 'Goerli',

--- a/apps/web/src/components/common/AddressInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressInput/index.test.tsx
@@ -93,7 +93,7 @@ describe('AddressInput tests', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-      ; (useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
     jest.spyOn(addressBook, 'default').mockReturnValue({})
     // Reset UD singleton between tests to prevent state leakage
     __resetResolutionForTesting()
@@ -224,7 +224,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should not resolve UD names if this feature is disabled', async () => {
-    ; (useCurrentChain as jest.Mock).mockImplementation(() => ({
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
       shortName: 'gor',
       chainId: '5',
       chainName: 'Goerli',
@@ -256,7 +256,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should not resolve ENS names if this feature is disabled', async () => {
-    ; (useCurrentChain as jest.Mock).mockImplementation(() => ({
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
       shortName: 'gor',
       chainId: '5',
       chainName: 'Goerli',
@@ -286,7 +286,7 @@ describe('AddressInput tests', () => {
   // TODO: Fix this test
   it.skip('should not show the adornment prefix when the value contains correct prefix', async () => {
     const mockChain = chainBuilder().with({ features: [] }).build()
-      ; (useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
 
     const { input } = setup(`${mockChain.shortName}:${TEST_ADDRESS_A}`)
 
@@ -329,7 +329,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should clean up the input value if it contains a valid address', async () => {
-    ; (useCurrentChain as jest.Mock).mockImplementation(() => ({
+    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
       shortName: 'gor',
       chainId: '5',
       chainName: 'Goerli',

--- a/apps/web/src/components/common/AddressInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressInput/index.test.tsx
@@ -11,6 +11,7 @@ import { chainBuilder } from '@/tests/builders/chains'
 import { FEATURES } from '@safe-global/safe-gateway-typescript-sdk'
 import userEvent from '@testing-library/user-event'
 import { ContactSource } from '@/hooks/useAllAddressBooks'
+import { __resetResolutionForTesting } from '@/services/ud'
 
 const mockChain = chainBuilder()
   .with({ features: [FEATURES.DOMAIN_LOOKUP] })
@@ -92,8 +93,10 @@ describe('AddressInput tests', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    ;(useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
+      ; (useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
     jest.spyOn(addressBook, 'default').mockReturnValue({})
+    // Reset UD singleton between tests to prevent state leakage
+    __resetResolutionForTesting()
   })
 
   it('should render with a default address value', () => {
@@ -221,7 +224,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should not resolve UD names if this feature is disabled', async () => {
-    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
+    ; (useCurrentChain as jest.Mock).mockImplementation(() => ({
       shortName: 'gor',
       chainId: '5',
       chainName: 'Goerli',
@@ -240,24 +243,6 @@ describe('AddressInput tests', () => {
     await waitFor(() => expect(utils.getByLabelText('Invalid address format', { exact: false })).toBeDefined())
   })
 
-  it('should show a spinner when UD resolution is in progress', async () => {
-    ;(useNameResolver as jest.Mock).mockImplementation((val: string) => ({
-      address: undefined,
-      resolverError: undefined,
-      resolving: val === 'loading.crypto',
-    }))
-
-    const { input, utils } = setup('')
-
-    act(() => {
-      fireEvent.change(input, { target: { value: 'loading.crypto' } })
-    })
-
-    await waitFor(() => {
-      expect(utils.getByRole('progressbar')).toBeDefined()
-    })
-  })
-
   it('should show an error if ENS resolution has failed', async () => {
     const { input, utils } = setup('')
 
@@ -271,7 +256,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should not resolve ENS names if this feature is disabled', async () => {
-    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
+    ; (useCurrentChain as jest.Mock).mockImplementation(() => ({
       shortName: 'gor',
       chainId: '5',
       chainName: 'Goerli',
@@ -301,7 +286,7 @@ describe('AddressInput tests', () => {
   // TODO: Fix this test
   it.skip('should not show the adornment prefix when the value contains correct prefix', async () => {
     const mockChain = chainBuilder().with({ features: [] }).build()
-    ;(useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
+      ; (useCurrentChain as jest.Mock).mockImplementation(() => mockChain)
 
     const { input } = setup(`${mockChain.shortName}:${TEST_ADDRESS_A}`)
 
@@ -344,7 +329,7 @@ describe('AddressInput tests', () => {
   })
 
   it('should clean up the input value if it contains a valid address', async () => {
-    ;(useCurrentChain as jest.Mock).mockImplementation(() => ({
+    ; (useCurrentChain as jest.Mock).mockImplementation(() => ({
       shortName: 'gor',
       chainId: '5',
       chainName: 'Goerli',

--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -163,7 +163,9 @@ const AddressInput = ({
         className={inputCss.input}
         autoComplete="off"
         autoFocus={props.focused}
-        label={<>{error?.message || props.label || `Recipient address${isDomainLookupEnabled ? ' or domain name' : ''}`}</>}
+        label={
+          <>{error?.message || props.label || `Recipient address${isDomainLookupEnabled ? ' or domain name' : ''}`}</>
+        }
         error={!!error}
         fullWidth
         onClick={resetName}

--- a/apps/web/src/components/common/AddressInput/index.tsx
+++ b/apps/web/src/components/common/AddressInput/index.tsx
@@ -68,14 +68,14 @@ const AddressInput = ({
 
   const addressBook = useAddressBook()
 
-  // Fetch an ENS resolution for the current address
+  // Fetch domain resolution for the current address
   const isDomainLookupEnabled = !!currentChain && hasFeature(currentChain, FEATURES.DOMAIN_LOOKUP)
   const { address, resolverError, resolving } = useNameResolver(isDomainLookupEnabled ? watchedValue : '')
 
   // errors[name] doesn't work with nested field names like 'safe.address', need to use the lodash get
   const fieldError = resolverError || get(errors, name)
 
-  // Debounce the field error unless there's no error or it's resolving a domain
+  // Debounce the field error unless there's no error or it's resolving a domain name
   let error = useDebounce(fieldError, 500)
   if (resolverError) error = resolverError
   if (!fieldError || resolving) error = undefined
@@ -106,7 +106,7 @@ const AddressInput = ({
     [setValue, name],
   )
 
-  // On ENS resolution, update the input value
+  // On domain name resolution, update the input value
   useEffect(() => {
     if (address) {
       setAddressValue(`${currentShortName}:${address}`)
@@ -163,7 +163,7 @@ const AddressInput = ({
         className={inputCss.input}
         autoComplete="off"
         autoFocus={props.focused}
-        label={<>{error?.message || props.label || `Recipient address${isDomainLookupEnabled ? ' or ENS' : ''}`}</>}
+        label={<>{error?.message || props.label || `Recipient address${isDomainLookupEnabled ? ' or domain name' : ''}`}</>}
         error={!!error}
         fullWidth
         onClick={resetName}

--- a/apps/web/src/components/common/AddressInput/useNameResolver.ts
+++ b/apps/web/src/components/common/AddressInput/useNameResolver.ts
@@ -2,26 +2,43 @@ import { useMemo } from 'react'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 import { isDomain, resolveName } from '@/services/ens'
+import { resolveUnstoppableAddress } from '@/services/ud'
+import { useCurrentChain } from '@/hooks/useChains'
 import useDebounce from '@/hooks/useDebounce'
 
 const useNameResolver = (
   value?: string,
 ): { address: string | undefined; resolverError?: Error; resolving: boolean } => {
   const ethersProvider = useWeb3ReadOnly()
+  const currentChain = useCurrentChain()
   const debouncedValue = useDebounce((value || '').trim(), 200)
 
-  // Fetch an ENS resolution for the current address
-  const [ens, resolverError, isResolving] = useAsync<{ name: string; address: string } | undefined>(() => {
-    if (!ethersProvider || !debouncedValue || !isDomain(debouncedValue)) return
+  // Fetch an ENS resolution for the current address; fallback to UD
+  const [resolved, resolverError, isResolving] = useAsync<{ name: string; address: string } | undefined>(async () => {
+    if (!debouncedValue || !isDomain(debouncedValue)) return
 
-    return resolveName(ethersProvider, debouncedValue).then((address) => {
-      if (!address) throw Error('Failed to resolve the address')
-      return { name: debouncedValue, address }
-    })
-  }, [debouncedValue, ethersProvider])
+    // Try ENS first if provider available
+    if (ethersProvider) {
+      try {
+        const ensAddress = await resolveName(ethersProvider, debouncedValue)
+        if (ensAddress) {
+          return { name: debouncedValue, address: ensAddress }
+        }
+      } catch (_) {
+        // continue to UD fallback
+      }
+    }
 
-  const resolving = isResolving && !!ethersProvider && !!debouncedValue
-  const address = ens && ens.name === value ? ens.address : undefined
+    // Try UD resolution (handles all UD TLDs and gracefully returns undefined for unsupported domains)
+    const token = currentChain?.nativeCurrency?.symbol || 'ETH'
+    const network = currentChain?.shortName?.toUpperCase()
+    const udAddress = await resolveUnstoppableAddress(debouncedValue, { token, network })
+    if (!udAddress) throw Error('Failed to resolve the address')
+    return { name: debouncedValue, address: udAddress }
+  }, [debouncedValue, ethersProvider, currentChain?.nativeCurrency?.symbol, currentChain?.shortName])
+
+  const resolving = isResolving && !!debouncedValue
+  const address = resolved && resolved.name === value ? resolved.address : undefined
 
   return useMemo(
     () => ({

--- a/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
@@ -23,7 +23,7 @@ const AccountListFilters = ({ setSearchQuery }: { setSearchQuery: Dispatch<SetSt
       <Box display="flex" justifyContent="space-between" width="100%" gap={1}>
         <TextField
           id="search-by-name"
-          placeholder="Search by name, ENS, address, or chain"
+          placeholder="Search by name, ENS, UD, address, or chain"
           aria-label="Search Safe list by name"
           variant="filled"
           hiddenLabel

--- a/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
@@ -23,7 +23,7 @@ const AccountListFilters = ({ setSearchQuery }: { setSearchQuery: Dispatch<SetSt
       <Box display="flex" justifyContent="space-between" width="100%" gap={1}>
         <TextField
           id="search-by-name"
-          placeholder="Search by name, ENS, UD, address, or chain"
+          placeholder="Search by name, domain, address, or chain"
           aria-label="Search Safe list by name"
           variant="filled"
           hiddenLabel

--- a/apps/web/src/features/myAccounts/hooks/useSafesSearch.ts
+++ b/apps/web/src/features/myAccounts/hooks/useSafesSearch.ts
@@ -4,9 +4,39 @@ import type { AllSafeItems } from './useAllSafesGrouped'
 import { selectChains } from '@/store/chainsSlice'
 import { useAppSelector } from '@/store'
 import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
+import { isDomain } from '@/services/ens'
+import useAsync from '@safe-global/utils/hooks/useAsync'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { resolveName } from '@/services/ens'
+import { resolveUnstoppableAddress } from '@/services/ud'
+import { useCurrentChain } from '@/hooks/useChains'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
 
 const useSafesSearch = (safes: AllSafeItems, query: string): AllSafeItems => {
   const chains = useAppSelector(selectChains)
+  const ethersProvider = useWeb3ReadOnly()
+  const currentChain = useCurrentChain()
+
+  // Resolve ENS/UD domain if query looks like a domain
+  const [resolvedAddress] = useAsync<string | undefined>(async () => {
+    if (!query || !isDomain(query)) return undefined
+
+    // Try ENS first
+    if (ethersProvider) {
+      try {
+        const ensAddress = await resolveName(ethersProvider, query)
+        if (ensAddress) return ensAddress
+      } catch (_) {
+        // Continue to UD
+      }
+    }
+
+    // Try UD
+    const token = currentChain?.nativeCurrency?.symbol || 'ETH'
+    const network = currentChain?.shortName?.toUpperCase()
+    const udAddress = await resolveUnstoppableAddress(query, { token, network })
+    return udAddress
+  }, [query, ethersProvider, currentChain?.nativeCurrency?.symbol, currentChain?.shortName])
 
   // Include chain names in the search
   const safesWithChainNames = useMemo(
@@ -37,16 +67,20 @@ const useSafesSearch = (safes: AllSafeItems, query: string): AllSafeItems => {
   )
 
   // Return results in the original format
-  return useMemo(
-    () =>
-      query
-        ? fuse.search(query).map((result) => {
-            const { chainNames: _chainNames, names: _names, ...safe } = result.item
-            return safe
-          })
-        : [],
-    [fuse, query],
-  )
+  return useMemo(() => {
+    if (!query) return []
+
+    // If we have a resolved address from ENS/UD, filter by that address
+    if (resolvedAddress) {
+      return safesWithChainNames.filter((safe) => sameAddress(safe.address, resolvedAddress))
+    }
+
+    // Otherwise use fuzzy search
+    return fuse.search(query).map((result) => {
+      const { chainNames: _chainNames, names: _names, ...safe } = result.item
+      return safe
+    })
+  }, [fuse, query, resolvedAddress, safesWithChainNames])
 }
 
 export { useSafesSearch }

--- a/apps/web/src/features/myAccounts/hooks/useSafesSearch.ts
+++ b/apps/web/src/features/myAccounts/hooks/useSafesSearch.ts
@@ -41,9 +41,9 @@ const useSafesSearch = (safes: AllSafeItems, query: string): AllSafeItems => {
     () =>
       query
         ? fuse.search(query).map((result) => {
-          const { chainNames: _chainNames, names: _names, ...safe } = result.item
-          return safe
-        })
+            const { chainNames: _chainNames, names: _names, ...safe } = result.item
+            return safe
+          })
         : [],
     [fuse, query],
   )

--- a/apps/web/src/features/myAccounts/hooks/useSafesSearch.ts
+++ b/apps/web/src/features/myAccounts/hooks/useSafesSearch.ts
@@ -4,39 +4,9 @@ import type { AllSafeItems } from './useAllSafesGrouped'
 import { selectChains } from '@/store/chainsSlice'
 import { useAppSelector } from '@/store'
 import { isMultiChainSafeItem } from '@/features/multichain/utils/utils'
-import { isDomain } from '@/services/ens'
-import useAsync from '@safe-global/utils/hooks/useAsync'
-import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
-import { resolveName } from '@/services/ens'
-import { resolveUnstoppableAddress } from '@/services/ud'
-import { useCurrentChain } from '@/hooks/useChains'
-import { sameAddress } from '@safe-global/utils/utils/addresses'
 
 const useSafesSearch = (safes: AllSafeItems, query: string): AllSafeItems => {
   const chains = useAppSelector(selectChains)
-  const ethersProvider = useWeb3ReadOnly()
-  const currentChain = useCurrentChain()
-
-  // Resolve ENS/UD domain if query looks like a domain
-  const [resolvedAddress] = useAsync<string | undefined>(async () => {
-    if (!query || !isDomain(query)) return undefined
-
-    // Try ENS first
-    if (ethersProvider) {
-      try {
-        const ensAddress = await resolveName(ethersProvider, query)
-        if (ensAddress) return ensAddress
-      } catch (_) {
-        // Continue to UD
-      }
-    }
-
-    // Try UD
-    const token = currentChain?.nativeCurrency?.symbol || 'ETH'
-    const network = currentChain?.shortName?.toUpperCase()
-    const udAddress = await resolveUnstoppableAddress(query, { token, network })
-    return udAddress
-  }, [query, ethersProvider, currentChain?.nativeCurrency?.symbol, currentChain?.shortName])
 
   // Include chain names in the search
   const safesWithChainNames = useMemo(
@@ -67,20 +37,16 @@ const useSafesSearch = (safes: AllSafeItems, query: string): AllSafeItems => {
   )
 
   // Return results in the original format
-  return useMemo(() => {
-    if (!query) return []
-
-    // If we have a resolved address from ENS/UD, filter by that address
-    if (resolvedAddress) {
-      return safesWithChainNames.filter((safe) => sameAddress(safe.address, resolvedAddress))
-    }
-
-    // Otherwise use fuzzy search
-    return fuse.search(query).map((result) => {
-      const { chainNames: _chainNames, names: _names, ...safe } = result.item
-      return safe
-    })
-  }, [fuse, query, resolvedAddress, safesWithChainNames])
+  return useMemo(
+    () =>
+      query
+        ? fuse.search(query).map((result) => {
+          const { chainNames: _chainNames, names: _names, ...safe } = result.item
+          return safe
+        })
+        : [],
+    [fuse, query],
+  )
 }
 
 export { useSafesSearch }

--- a/apps/web/src/hooks/__tests__/useAddressResolver.test.ts
+++ b/apps/web/src/hooks/__tests__/useAddressResolver.test.ts
@@ -2,12 +2,14 @@ import { useAddressResolver } from '@/hooks/useAddressResolver'
 import * as addressBook from '@/hooks/useAddressBook'
 import { zeroPadValue } from 'ethers'
 import * as domains from '@/services/ens'
+import * as ud from '@/services/ud'
 import * as web3 from '@/hooks/wallets/web3'
 import * as useChains from '@/hooks/useChains'
 import { renderHook, waitFor } from '@/tests/test-utils'
 import { JsonRpcProvider } from 'ethers'
 
 const ADDRESS1 = zeroPadValue('0x01', 20)
+const ADDRESS2 = zeroPadValue('0x02', 20)
 const mockProvider = new JsonRpcProvider()
 
 describe('useAddressResolver', () => {
@@ -16,12 +18,15 @@ describe('useAddressResolver', () => {
     jest.spyOn(web3, 'useWeb3ReadOnly').mockImplementation(() => mockProvider)
   })
 
-  it('returns address book name if found, not resolving ENS domain', async () => {
+  it('returns address book name if found, not resolving domain', async () => {
     jest.spyOn(addressBook, 'default').mockReturnValue({
       [ADDRESS1]: 'Testname',
     })
-    const domainsMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
+    const ensMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
       return Promise.resolve('test.eth')
+    })
+    const udMock = jest.spyOn(ud, 'reverseResolveUnstoppable').mockImplementation(() => {
+      return Promise.resolve('test.crypto')
     })
 
     const { result } = renderHook(() => useAddressResolver(ADDRESS1))
@@ -30,14 +35,18 @@ describe('useAddressResolver', () => {
       expect(result.current.ens).toBeUndefined()
       expect(result.current.name).toBe('Testname')
       expect(result.current.resolving).toBe(false)
-      expect(domainsMock).toHaveBeenCalledTimes(0)
+      expect(ensMock).toHaveBeenCalledTimes(0)
+      expect(udMock).toHaveBeenCalledTimes(0)
     })
   })
 
   it('resolves ENS domain if no address book name is found', async () => {
     jest.spyOn(addressBook, 'default').mockReturnValue({})
-    const domainsMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
+    const ensMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
       return Promise.resolve('test.eth')
+    })
+    const udMock = jest.spyOn(ud, 'reverseResolveUnstoppable').mockImplementation(() => {
+      return Promise.resolve(undefined)
     })
 
     jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
@@ -48,14 +57,40 @@ describe('useAddressResolver', () => {
       expect(result.current.ens).toBe('test.eth')
       expect(result.current.name).toBeUndefined()
       expect(result.current.resolving).toBe(false)
-      expect(domainsMock).toHaveBeenCalledTimes(1)
+      expect(ensMock).toHaveBeenCalledTimes(1)
+      expect(udMock).toHaveBeenCalledTimes(0) // Should not call UD if ENS found
     })
   })
 
-  it('does not resolve ENS domain if feature is disabled', async () => {
+  it('falls back to UD if ENS returns nothing', async () => {
     jest.spyOn(addressBook, 'default').mockReturnValue({})
-    const domainsMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
+    const ensMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
+      return Promise.resolve(undefined)
+    })
+    const udMock = jest.spyOn(ud, 'reverseResolveUnstoppable').mockImplementation(() => {
+      return Promise.resolve('test.crypto')
+    })
+
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+
+    const { result } = renderHook(() => useAddressResolver(ADDRESS2))
+
+    await waitFor(() => {
+      expect(result.current.ens).toBe('test.crypto')
+      expect(result.current.name).toBeUndefined()
+      expect(result.current.resolving).toBe(false)
+      expect(ensMock).toHaveBeenCalledTimes(1)
+      expect(udMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not resolve domain if feature is disabled', async () => {
+    jest.spyOn(addressBook, 'default').mockReturnValue({})
+    const ensMock = jest.spyOn(domains, 'lookupAddress').mockImplementation(() => {
       return Promise.resolve('test.eth')
+    })
+    const udMock = jest.spyOn(ud, 'reverseResolveUnstoppable').mockImplementation(() => {
+      return Promise.resolve('test.crypto')
     })
     jest.spyOn(useChains, 'useHasFeature').mockReturnValue(false)
 
@@ -65,7 +100,8 @@ describe('useAddressResolver', () => {
       expect(result.current.ens).toBeUndefined()
       expect(result.current.name).toBeUndefined()
       expect(result.current.resolving).toBe(false)
-      expect(domainsMock).toHaveBeenCalledTimes(0)
+      expect(ensMock).toHaveBeenCalledTimes(0)
+      expect(udMock).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/apps/web/src/services/ud/index.test.ts
+++ b/apps/web/src/services/ud/index.test.ts
@@ -7,189 +7,228 @@ jest.mock('@unstoppabledomains/resolution')
 
 // Mock logError
 jest.mock('../exceptions', () => ({
-    logError: jest.fn(),
+  logError: jest.fn(),
 }))
 
 describe('Unstoppable Domains', () => {
-    const mockApiKey = 'test-api-key'
-    const originalEnv = process.env
+  const mockApiKey = 'test-api-key'
+  const originalEnv = process.env
 
-    beforeEach(() => {
-        jest.clearAllMocks()
-        process.env = { ...originalEnv, NEXT_PUBLIC_UNSTOPPABLE_API_KEY: mockApiKey }
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv, NEXT_PUBLIC_UNSTOPPABLE_API_KEY: mockApiKey }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  describe('resolveUnstoppableAddress', () => {
+    it('should resolve UD names using the SDK', async () => {
+      const mockGetAddress = jest.fn().mockResolvedValue('0x1111111111111111111111111111111111111111')
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            getAddress: mockGetAddress,
+          }) as any,
+      )
+
+      const address = await resolveUnstoppableAddress('brad.crypto', { token: 'ETH', network: 'ETH' })
+
+      expect(address).toBe('0x1111111111111111111111111111111111111111')
+      expect(mockGetAddress).toHaveBeenCalledWith('brad.crypto', 'ETH', 'ETH')
     })
 
-    afterEach(() => {
-        process.env = originalEnv
+    it('should handle different currencies and networks', async () => {
+      const mockGetAddress = jest.fn().mockResolvedValue('0x3333333333333333333333333333333333333333')
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            getAddress: mockGetAddress,
+          }) as any,
+      )
+
+      const address = await resolveUnstoppableAddress('brad.crypto', { token: 'MATIC', network: 'MATIC' })
+
+      expect(address).toBe('0x3333333333333333333333333333333333333333')
+      expect(mockGetAddress).toHaveBeenCalledWith('brad.crypto', 'MATIC', 'MATIC')
     })
 
-    describe('resolveUnstoppableAddress', () => {
-        it('should resolve UD names using the SDK', async () => {
-            const mockGetAddress = jest.fn().mockResolvedValue('0x1111111111111111111111111111111111111111')
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    getAddress: mockGetAddress,
-                }) as any)
+    it('should return undefined if domain not found', async () => {
+      const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnregisteredDomain'))
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            getAddress: mockGetAddress,
+          }) as any,
+      )
 
-            const address = await resolveUnstoppableAddress('brad.crypto', { token: 'ETH', network: 'ETH' })
+      const address = await resolveUnstoppableAddress('nonexistent.crypto')
 
-            expect(address).toBe('0x1111111111111111111111111111111111111111')
-            expect(mockGetAddress).toHaveBeenCalledWith('brad.crypto', 'ETH', 'ETH')
-        })
-
-        it('should handle different currencies and networks', async () => {
-            const mockGetAddress = jest.fn().mockResolvedValue('0x3333333333333333333333333333333333333333')
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    getAddress: mockGetAddress,
-                }) as any)
-
-            const address = await resolveUnstoppableAddress('brad.crypto', { token: 'MATIC', network: 'MATIC' })
-
-            expect(address).toBe('0x3333333333333333333333333333333333333333')
-            expect(mockGetAddress).toHaveBeenCalledWith('brad.crypto', 'MATIC', 'MATIC')
-        })
-
-        it('should return undefined if domain not found', async () => {
-            const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnregisteredDomain'))
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    getAddress: mockGetAddress,
-                }) as any)
-
-            const address = await resolveUnstoppableAddress('nonexistent.crypto')
-
-            expect(address).toBe(undefined)
-            expect(logError).not.toHaveBeenCalled()
-        })
-
-        it('should return undefined if record not found', async () => {
-            const mockGetAddress = jest.fn().mockRejectedValue(new Error('RecordNotFound'))
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    getAddress: mockGetAddress,
-                }) as any)
-
-            const address = await resolveUnstoppableAddress('brad.crypto', { token: 'BTC' })
-
-            expect(address).toBe(undefined)
-            expect(logError).not.toHaveBeenCalled()
-        })
-
-        it('should return undefined for unsupported domains', async () => {
-            const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnsupportedDomain'))
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    getAddress: mockGetAddress,
-                }) as any)
-
-            const address = await resolveUnstoppableAddress('test.nonexistent')
-
-            expect(address).toBe(undefined)
-            expect(logError).not.toHaveBeenCalled()
-        })
-
-        it('should return undefined for unspecified resolver', async () => {
-            const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnspecifiedResolver'))
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    getAddress: mockGetAddress,
-                }) as any)
-
-            const address = await resolveUnstoppableAddress('test.crypto')
-
-            expect(address).toBe(undefined)
-            expect(logError).not.toHaveBeenCalled()
-        })
-
-        it('should log error for unexpected SDK errors', async () => {
-            const mockGetAddress = jest.fn().mockRejectedValue(new Error('Network error'))
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    getAddress: mockGetAddress,
-                }) as any)
-
-            const address = await resolveUnstoppableAddress('brad.crypto')
-
-            expect(address).toBe(undefined)
-            expect(logError).toHaveBeenCalledWith('101: Failed to resolve the address', 'UD resolution error: Network error')
-        })
-
-        it('should return undefined if API key is not configured', async () => {
-            process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY = ''
-
-            const address = await resolveUnstoppableAddress('brad.crypto')
-
-            expect(address).toBe(undefined)
-            expect(logError).toHaveBeenCalledWith(
-                '101: Failed to resolve the address',
-                'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution',
-            )
-        })
-
-        it('should initialize Resolution with API key', async () => {
-            const mockGetAddress = jest.fn().mockResolvedValue('0x4444444444444444444444444444444444444444')
-            const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
-            MockedResolution.mockImplementation(() => ({
-                getAddress: mockGetAddress,
-            }) as any)
-
-            await resolveUnstoppableAddress('brad.crypto')
-
-            expect(MockedResolution).toHaveBeenCalledWith({
-                apiKey: mockApiKey,
-            })
-        })
+      expect(address).toBe(undefined)
+      expect(logError).not.toHaveBeenCalled()
     })
 
-    describe('reverseResolveUnstoppable', () => {
-        it('should reverse resolve address to UD domain', async () => {
-            const mockReverse = jest.fn().mockResolvedValue('brad.crypto')
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    reverse: mockReverse,
-                }) as any)
+    it('should return undefined if record not found', async () => {
+      const mockGetAddress = jest.fn().mockRejectedValue(new Error('RecordNotFound'))
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            getAddress: mockGetAddress,
+          }) as any,
+      )
 
-            const { reverseResolveUnstoppable } = await import('.')
+      const address = await resolveUnstoppableAddress('brad.crypto', { token: 'BTC' })
 
-            const domain = await reverseResolveUnstoppable('0x1111111111111111111111111111111111111111')
-
-            expect(domain).toBe('brad.crypto')
-            expect(mockReverse).toHaveBeenCalledWith('0x1111111111111111111111111111111111111111')
-        })
-
-        it('should return undefined if no reverse record found', async () => {
-            const mockReverse = jest.fn().mockRejectedValue(new Error('ReverseResolutionNotSpecified'))
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    reverse: mockReverse,
-                }) as any)
-
-            const { reverseResolveUnstoppable } = await import('.')
-
-            const domain = await reverseResolveUnstoppable('0x2222222222222222222222222222222222222222')
-
-            expect(domain).toBe(undefined)
-            expect(logError).not.toHaveBeenCalled()
-        })
-
-        it('should return undefined if domain not registered', async () => {
-            const mockReverse = jest.fn().mockRejectedValue(new Error('UnregisteredDomain'))
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    reverse: mockReverse,
-                }) as any)
-
-            const { reverseResolveUnstoppable } = await import('.')
-
-            const domain = await reverseResolveUnstoppable('0x3333333333333333333333333333333333333333')
-
-            expect(domain).toBe(undefined)
-            expect(logError).not.toHaveBeenCalled()
-        })
-
-        it('should log error for unexpected SDK errors', async () => {
-            const mockReverse = jest.fn().mockRejectedValue(new Error('Network error'))
-                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
-                    reverse: mockReverse,
-                }) as any)
-
-            const { reverseResolveUnstoppable } = await import('.')
-
-            const domain = await reverseResolveUnstoppable('0x4444444444444444444444444444444444444444')
-
-            expect(domain).toBe(undefined)
-            expect(logError).toHaveBeenCalledWith('101: Failed to resolve the address', 'UD reverse resolution error: Network error')
-        })
+      expect(address).toBe(undefined)
+      expect(logError).not.toHaveBeenCalled()
     })
+
+    it('should return undefined for unsupported domains', async () => {
+      const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnsupportedDomain'))
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            getAddress: mockGetAddress,
+          }) as any,
+      )
+
+      const address = await resolveUnstoppableAddress('test.nonexistent')
+
+      expect(address).toBe(undefined)
+      expect(logError).not.toHaveBeenCalled()
+    })
+
+    it('should return undefined for unspecified resolver', async () => {
+      const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnspecifiedResolver'))
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            getAddress: mockGetAddress,
+          }) as any,
+      )
+
+      const address = await resolveUnstoppableAddress('test.crypto')
+
+      expect(address).toBe(undefined)
+      expect(logError).not.toHaveBeenCalled()
+    })
+
+    it('should log error for unexpected SDK errors', async () => {
+      const mockGetAddress = jest.fn().mockRejectedValue(new Error('Network error'))
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            getAddress: mockGetAddress,
+          }) as any,
+      )
+
+      const address = await resolveUnstoppableAddress('brad.crypto')
+
+      expect(address).toBe(undefined)
+      expect(logError).toHaveBeenCalledWith('101: Failed to resolve the address', 'UD resolution error: Network error')
+    })
+
+    it('should return undefined if API key is not configured', async () => {
+      process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY = ''
+
+      const address = await resolveUnstoppableAddress('brad.crypto')
+
+      expect(address).toBe(undefined)
+      expect(logError).toHaveBeenCalledWith(
+        '101: Failed to resolve the address',
+        'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution',
+      )
+    })
+
+    it('should initialize Resolution with API key', async () => {
+      const mockGetAddress = jest.fn().mockResolvedValue('0x4444444444444444444444444444444444444444')
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
+        () =>
+          ({
+            getAddress: mockGetAddress,
+          }) as any,
+      )
+
+      await resolveUnstoppableAddress('brad.crypto')
+
+      expect(MockedResolution).toHaveBeenCalledWith({
+        apiKey: mockApiKey,
+      })
+    })
+  })
+
+  describe('reverseResolveUnstoppable', () => {
+    it('should reverse resolve address to UD domain', async () => {
+      const mockReverse = jest.fn().mockResolvedValue('brad.crypto')
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            reverse: mockReverse,
+          }) as any,
+      )
+
+      const { reverseResolveUnstoppable } = await import('.')
+
+      const domain = await reverseResolveUnstoppable('0x1111111111111111111111111111111111111111')
+
+      expect(domain).toBe('brad.crypto')
+      expect(mockReverse).toHaveBeenCalledWith('0x1111111111111111111111111111111111111111')
+    })
+
+    it('should return undefined if no reverse record found', async () => {
+      const mockReverse = jest.fn().mockRejectedValue(new Error('ReverseResolutionNotSpecified'))
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            reverse: mockReverse,
+          }) as any,
+      )
+
+      const { reverseResolveUnstoppable } = await import('.')
+
+      const domain = await reverseResolveUnstoppable('0x2222222222222222222222222222222222222222')
+
+      expect(domain).toBe(undefined)
+      expect(logError).not.toHaveBeenCalled()
+    })
+
+    it('should return undefined if domain not registered', async () => {
+      const mockReverse = jest.fn().mockRejectedValue(new Error('UnregisteredDomain'))
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            reverse: mockReverse,
+          }) as any,
+      )
+
+      const { reverseResolveUnstoppable } = await import('.')
+
+      const domain = await reverseResolveUnstoppable('0x3333333333333333333333333333333333333333')
+
+      expect(domain).toBe(undefined)
+      expect(logError).not.toHaveBeenCalled()
+    })
+
+    it('should log error for unexpected SDK errors', async () => {
+      const mockReverse = jest.fn().mockRejectedValue(new Error('Network error'))
+      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+        () =>
+          ({
+            reverse: mockReverse,
+          }) as any,
+      )
+
+      const { reverseResolveUnstoppable } = await import('.')
+
+      const domain = await reverseResolveUnstoppable('0x4444444444444444444444444444444444444444')
+
+      expect(domain).toBe(undefined)
+      expect(logError).toHaveBeenCalledWith(
+        '101: Failed to resolve the address',
+        'UD reverse resolution error: Network error',
+      )
+    })
+  })
 })

--- a/apps/web/src/services/ud/index.test.ts
+++ b/apps/web/src/services/ud/index.test.ts
@@ -1,0 +1,137 @@
+import { resolveUnstoppableAddress } from '.'
+import { logError } from '../exceptions'
+import Resolution from '@unstoppabledomains/resolution'
+
+// Mock Resolution SDK
+jest.mock('@unstoppabledomains/resolution')
+
+// Mock logError
+jest.mock('../exceptions', () => ({
+    logError: jest.fn(),
+}))
+
+describe('Unstoppable Domains', () => {
+    const mockApiKey = 'test-api-key'
+    const originalEnv = process.env
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        process.env = { ...originalEnv, NEXT_PUBLIC_UNSTOPPABLE_API_KEY: mockApiKey }
+    })
+
+    afterEach(() => {
+        process.env = originalEnv
+    })
+
+    describe('resolveUnstoppableAddress', () => {
+        it('should resolve UD names using the SDK', async () => {
+            const mockGetAddress = jest.fn().mockResolvedValue('0x1111111111111111111111111111111111111111')
+                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
+                    getAddress: mockGetAddress,
+                }) as any)
+
+            const address = await resolveUnstoppableAddress('brad.crypto', { token: 'ETH', network: 'ETH' })
+
+            expect(address).toBe('0x1111111111111111111111111111111111111111')
+            expect(mockGetAddress).toHaveBeenCalledWith('brad.crypto', 'ETH', 'ETH')
+        })
+
+        it('should handle different currencies and networks', async () => {
+            const mockGetAddress = jest.fn().mockResolvedValue('0x3333333333333333333333333333333333333333')
+                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
+                    getAddress: mockGetAddress,
+                }) as any)
+
+            const address = await resolveUnstoppableAddress('brad.crypto', { token: 'MATIC', network: 'MATIC' })
+
+            expect(address).toBe('0x3333333333333333333333333333333333333333')
+            expect(mockGetAddress).toHaveBeenCalledWith('brad.crypto', 'MATIC', 'MATIC')
+        })
+
+        it('should return undefined if domain not found', async () => {
+            const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnregisteredDomain'))
+                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
+                    getAddress: mockGetAddress,
+                }) as any)
+
+            const address = await resolveUnstoppableAddress('nonexistent.crypto')
+
+            expect(address).toBe(undefined)
+            expect(logError).not.toHaveBeenCalled()
+        })
+
+        it('should return undefined if record not found', async () => {
+            const mockGetAddress = jest.fn().mockRejectedValue(new Error('RecordNotFound'))
+                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
+                    getAddress: mockGetAddress,
+                }) as any)
+
+            const address = await resolveUnstoppableAddress('brad.crypto', { token: 'BTC' })
+
+            expect(address).toBe(undefined)
+            expect(logError).not.toHaveBeenCalled()
+        })
+
+        it('should return undefined for unsupported domains', async () => {
+            const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnsupportedDomain'))
+                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
+                    getAddress: mockGetAddress,
+                }) as any)
+
+            const address = await resolveUnstoppableAddress('test.nonexistent')
+
+            expect(address).toBe(undefined)
+            expect(logError).not.toHaveBeenCalled()
+        })
+
+        it('should return undefined for unspecified resolver', async () => {
+            const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnspecifiedResolver'))
+                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
+                    getAddress: mockGetAddress,
+                }) as any)
+
+            const address = await resolveUnstoppableAddress('test.crypto')
+
+            expect(address).toBe(undefined)
+            expect(logError).not.toHaveBeenCalled()
+        })
+
+        it('should log error for unexpected SDK errors', async () => {
+            const mockGetAddress = jest.fn().mockRejectedValue(new Error('Network error'))
+                ; (Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(() => ({
+                    getAddress: mockGetAddress,
+                }) as any)
+
+            const address = await resolveUnstoppableAddress('brad.crypto')
+
+            expect(address).toBe(undefined)
+            expect(logError).toHaveBeenCalledWith('101: Failed to resolve the address', 'UD resolution error: Network error')
+        })
+
+        it('should return undefined if API key is not configured', async () => {
+            process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY = ''
+
+            const address = await resolveUnstoppableAddress('brad.crypto')
+
+            expect(address).toBe(undefined)
+            expect(logError).toHaveBeenCalledWith(
+                '101: Failed to resolve the address',
+                'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution',
+            )
+        })
+
+        it('should initialize Resolution with API key', async () => {
+            const mockGetAddress = jest.fn().mockResolvedValue('0x4444444444444444444444444444444444444444')
+            const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+            MockedResolution.mockImplementation(() => ({
+                getAddress: mockGetAddress,
+            }) as any)
+
+            await resolveUnstoppableAddress('brad.crypto')
+
+            expect(MockedResolution).toHaveBeenCalledWith({
+                apiKey: mockApiKey,
+            })
+        })
+    })
+})

--- a/apps/web/src/services/ud/index.test.ts
+++ b/apps/web/src/services/ud/index.test.ts
@@ -1,4 +1,4 @@
-import { resolveUnstoppableAddress } from '.'
+import { resolveUnstoppableAddress, reverseResolveUnstoppable, __resetResolutionForTesting } from '.'
 import { logError } from '../exceptions'
 import Resolution from '@unstoppabledomains/resolution'
 
@@ -16,7 +16,11 @@ describe('Unstoppable Domains', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    // Reset environment
     process.env = { ...originalEnv, NEXT_PUBLIC_UNSTOPPABLE_API_KEY: mockApiKey }
+
+    // Reset the singleton instance
+    __resetResolutionForTesting()
   })
 
   afterEach(() => {
@@ -26,7 +30,8 @@ describe('Unstoppable Domains', () => {
   describe('resolveUnstoppableAddress', () => {
     it('should resolve UD names using the SDK', async () => {
       const mockGetAddress = jest.fn().mockResolvedValue('0x1111111111111111111111111111111111111111')
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             getAddress: mockGetAddress,
@@ -41,7 +46,8 @@ describe('Unstoppable Domains', () => {
 
     it('should handle different currencies and networks', async () => {
       const mockGetAddress = jest.fn().mockResolvedValue('0x3333333333333333333333333333333333333333')
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             getAddress: mockGetAddress,
@@ -56,7 +62,8 @@ describe('Unstoppable Domains', () => {
 
     it('should return undefined if domain not found', async () => {
       const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnregisteredDomain'))
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             getAddress: mockGetAddress,
@@ -71,7 +78,8 @@ describe('Unstoppable Domains', () => {
 
     it('should return undefined if record not found', async () => {
       const mockGetAddress = jest.fn().mockRejectedValue(new Error('RecordNotFound'))
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             getAddress: mockGetAddress,
@@ -86,7 +94,8 @@ describe('Unstoppable Domains', () => {
 
     it('should return undefined for unsupported domains', async () => {
       const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnsupportedDomain'))
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             getAddress: mockGetAddress,
@@ -101,7 +110,8 @@ describe('Unstoppable Domains', () => {
 
     it('should return undefined for unspecified resolver', async () => {
       const mockGetAddress = jest.fn().mockRejectedValue(new Error('UnspecifiedResolver'))
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             getAddress: mockGetAddress,
@@ -116,7 +126,8 @@ describe('Unstoppable Domains', () => {
 
     it('should log error for unexpected SDK errors', async () => {
       const mockGetAddress = jest.fn().mockRejectedValue(new Error('Network error'))
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             getAddress: mockGetAddress,
@@ -131,6 +142,7 @@ describe('Unstoppable Domains', () => {
 
     it('should return undefined if API key is not configured', async () => {
       process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY = ''
+      __resetResolutionForTesting() // Reset after changing env
 
       const address = await resolveUnstoppableAddress('brad.crypto')
 
@@ -162,14 +174,13 @@ describe('Unstoppable Domains', () => {
   describe('reverseResolveUnstoppable', () => {
     it('should reverse resolve address to UD domain', async () => {
       const mockReverse = jest.fn().mockResolvedValue('brad.crypto')
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             reverse: mockReverse,
           }) as any,
       )
-
-      const { reverseResolveUnstoppable } = await import('.')
 
       const domain = await reverseResolveUnstoppable('0x1111111111111111111111111111111111111111')
 
@@ -179,14 +190,13 @@ describe('Unstoppable Domains', () => {
 
     it('should return undefined if no reverse record found', async () => {
       const mockReverse = jest.fn().mockRejectedValue(new Error('ReverseResolutionNotSpecified'))
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             reverse: mockReverse,
           }) as any,
       )
-
-      const { reverseResolveUnstoppable } = await import('.')
 
       const domain = await reverseResolveUnstoppable('0x2222222222222222222222222222222222222222')
 
@@ -196,14 +206,13 @@ describe('Unstoppable Domains', () => {
 
     it('should return undefined if domain not registered', async () => {
       const mockReverse = jest.fn().mockRejectedValue(new Error('UnregisteredDomain'))
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             reverse: mockReverse,
           }) as any,
       )
-
-      const { reverseResolveUnstoppable } = await import('.')
 
       const domain = await reverseResolveUnstoppable('0x3333333333333333333333333333333333333333')
 
@@ -213,14 +222,13 @@ describe('Unstoppable Domains', () => {
 
     it('should log error for unexpected SDK errors', async () => {
       const mockReverse = jest.fn().mockRejectedValue(new Error('Network error'))
-      ;(Resolution as jest.MockedClass<typeof Resolution>).mockImplementation(
+      const MockedResolution = Resolution as jest.MockedClass<typeof Resolution>
+      MockedResolution.mockImplementation(
         () =>
           ({
             reverse: mockReverse,
           }) as any,
       )
-
-      const { reverseResolveUnstoppable } = await import('.')
 
       const domain = await reverseResolveUnstoppable('0x4444444444444444444444444444444444444444')
 

--- a/apps/web/src/services/ud/index.ts
+++ b/apps/web/src/services/ud/index.ts
@@ -31,6 +31,11 @@ const getResolution = (): Resolution | null => {
   }
 }
 
+// Export for testing only - allows resetting the singleton instance
+export const __resetResolutionForTesting = () => {
+  resolutionInstance = null
+}
+
 /**
  * Resolve an Unstoppable Domain to an address (forward resolution)
  */

--- a/apps/web/src/services/ud/index.ts
+++ b/apps/web/src/services/ud/index.ts
@@ -3,94 +3,94 @@ import { logError } from '@/services/exceptions'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
 
 export interface UdResolveOptions {
-    token?: string
-    network?: string
+  token?: string
+  network?: string
 }
 
 // Lazy-initialize Resolution instance
 let resolutionInstance: Resolution | null = null
 
 const getResolution = (): Resolution | null => {
-    if (resolutionInstance) return resolutionInstance
+  if (resolutionInstance) return resolutionInstance
 
-    const apiKey = process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY
-    if (!apiKey) {
-        logError(ErrorCodes._101, 'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution')
-        return null
-    }
+  const apiKey = process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY
+  if (!apiKey) {
+    logError(ErrorCodes._101, 'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution')
+    return null
+  }
 
-    try {
-        resolutionInstance = new Resolution({
-            apiKey,
-        })
-        return resolutionInstance
-    } catch (e) {
-        const err = e as Error
-        logError(ErrorCodes._101, `Failed to initialize UD Resolution: ${err.message}`)
-        return null
-    }
+  try {
+    resolutionInstance = new Resolution({
+      apiKey,
+    })
+    return resolutionInstance
+  } catch (e) {
+    const err = e as Error
+    logError(ErrorCodes._101, `Failed to initialize UD Resolution: ${err.message}`)
+    return null
+  }
 }
 
 // Export for testing only - allows resetting the singleton instance
 export const __resetResolutionForTesting = () => {
-    resolutionInstance = null
+  resolutionInstance = null
 }
 
 /**
  * Resolve an Unstoppable Domain to an address (forward resolution)
  */
 export const resolveUnstoppableAddress = async (
-    domain: string,
-    options?: UdResolveOptions,
+  domain: string,
+  options?: UdResolveOptions,
 ): Promise<string | undefined> => {
-    const resolution = getResolution()
-    if (!resolution) return undefined
+  const resolution = getResolution()
+  if (!resolution) return undefined
 
-    try {
-        // Use the token/network if provided, otherwise default to empty string
-        const token = options?.token?.toUpperCase() || ''
-        const network = options?.network?.toUpperCase() || ''
+  try {
+    // Use the token/network if provided, otherwise default to empty string
+    const token = options?.token?.toUpperCase() || ''
+    const network = options?.network?.toUpperCase() || ''
 
-        const address = await resolution.getAddress(domain, network, token)
-        return address || undefined
-    } catch (e) {
-        const err = e as Error
-        // Resolution SDK throws for unregistered domains or unsupported TLDs, which is expected
-        if (
-            err.message?.includes('UnregisteredDomain') ||
-            err.message?.includes('RecordNotFound') ||
-            err.message?.includes('UnspecifiedResolver') ||
-            err.message?.includes('UnsupportedDomain')
-        ) {
-            return undefined
-        }
-        logError(ErrorCodes._101, `UD resolution error: ${err.message}`)
-        return undefined
+    const address = await resolution.getAddress(domain, network, token)
+    return address || undefined
+  } catch (e) {
+    const err = e as Error
+    // Resolution SDK throws for unregistered domains or unsupported TLDs, which is expected
+    if (
+      err.message?.includes('UnregisteredDomain') ||
+      err.message?.includes('RecordNotFound') ||
+      err.message?.includes('UnspecifiedResolver') ||
+      err.message?.includes('UnsupportedDomain')
+    ) {
+      return undefined
     }
+    logError(ErrorCodes._101, `UD resolution error: ${err.message}`)
+    return undefined
+  }
 }
 
 /**
  * Reverse resolve an address to an Unstoppable Domain name
  */
 export const reverseResolveUnstoppable = async (address: string): Promise<string | undefined> => {
-    const resolution = getResolution()
-    if (!resolution) return undefined
+  const resolution = getResolution()
+  if (!resolution) return undefined
 
-    try {
-        const domain = await resolution.reverse(address)
-        return domain || undefined
-    } catch (e) {
-        const err = e as Error
-        // Resolution SDK throws for addresses without reverse records, which is expected
-        if (
-            err.message?.includes('UnregisteredDomain') ||
-            err.message?.includes('RecordNotFound') ||
-            err.message?.includes('UnspecifiedResolver') ||
-            err.message?.includes('ReverseResolutionNotSpecified')
-        ) {
-            return undefined
-        }
-        logError(ErrorCodes._101, `UD reverse resolution error: ${err.message}`)
-        return undefined
+  try {
+    const domain = await resolution.reverse(address)
+    return domain || undefined
+  } catch (e) {
+    const err = e as Error
+    // Resolution SDK throws for addresses without reverse records, which is expected
+    if (
+      err.message?.includes('UnregisteredDomain') ||
+      err.message?.includes('RecordNotFound') ||
+      err.message?.includes('UnspecifiedResolver') ||
+      err.message?.includes('ReverseResolutionNotSpecified')
+    ) {
+      return undefined
     }
+    logError(ErrorCodes._101, `UD reverse resolution error: ${err.message}`)
+    return undefined
+  }
 }

--- a/apps/web/src/services/ud/index.ts
+++ b/apps/web/src/services/ud/index.ts
@@ -3,92 +3,89 @@ import { logError } from '@/services/exceptions'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
 
 export interface UdResolveOptions {
-    token?: string
-    network?: string
+  token?: string
+  network?: string
 }
 
 // Lazy-initialize Resolution instance
 let resolutionInstance: Resolution | null = null
 
 const getResolution = (): Resolution | null => {
-    if (resolutionInstance) return resolutionInstance
+  if (resolutionInstance) return resolutionInstance
 
-    const apiKey = process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY
-    if (!apiKey) {
-        logError(ErrorCodes._101, 'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution')
-        return null
-    }
+  const apiKey = process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY
+  if (!apiKey) {
+    logError(ErrorCodes._101, 'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution')
+    return null
+  }
 
-    try {
-        resolutionInstance = new Resolution({
-            apiKey,
-        })
-        return resolutionInstance
-    } catch (e) {
-        const err = e as Error
-        logError(ErrorCodes._101, `Failed to initialize UD Resolution: ${err.message}`)
-        return null
-    }
+  try {
+    resolutionInstance = new Resolution({
+      apiKey,
+    })
+    return resolutionInstance
+  } catch (e) {
+    const err = e as Error
+    logError(ErrorCodes._101, `Failed to initialize UD Resolution: ${err.message}`)
+    return null
+  }
 }
 
 /**
  * Resolve an Unstoppable Domain to an address (forward resolution)
  */
 export const resolveUnstoppableAddress = async (
-    domain: string,
-    options?: UdResolveOptions,
+  domain: string,
+  options?: UdResolveOptions,
 ): Promise<string | undefined> => {
-    const resolution = getResolution()
-    if (!resolution) return undefined
+  const resolution = getResolution()
+  if (!resolution) return undefined
 
-    try {
-        // Use the token/network if provided, otherwise default to empty string
-        const token = options?.token?.toUpperCase() || ''
-        const network = options?.network?.toUpperCase() || ''
+  try {
+    // Use the token/network if provided, otherwise default to empty string
+    const token = options?.token?.toUpperCase() || ''
+    const network = options?.network?.toUpperCase() || ''
 
-        const address = await resolution.getAddress(domain, network, token)
-        return address || undefined
-    } catch (e) {
-        const err = e as Error
-        // Resolution SDK throws for unregistered domains or unsupported TLDs, which is expected
-        if (
-            err.message?.includes('UnregisteredDomain') ||
-            err.message?.includes('RecordNotFound') ||
-            err.message?.includes('UnspecifiedResolver') ||
-            err.message?.includes('UnsupportedDomain')
-        ) {
-            return undefined
-        }
-        logError(ErrorCodes._101, `UD resolution error: ${err.message}`)
-        return undefined
+    const address = await resolution.getAddress(domain, network, token)
+    return address || undefined
+  } catch (e) {
+    const err = e as Error
+    // Resolution SDK throws for unregistered domains or unsupported TLDs, which is expected
+    if (
+      err.message?.includes('UnregisteredDomain') ||
+      err.message?.includes('RecordNotFound') ||
+      err.message?.includes('UnspecifiedResolver') ||
+      err.message?.includes('UnsupportedDomain')
+    ) {
+      return undefined
     }
+    logError(ErrorCodes._101, `UD resolution error: ${err.message}`)
+    return undefined
+  }
 }
 
 /**
  * Reverse resolve an address to an Unstoppable Domain name
  */
 export const reverseResolveUnstoppable = async (address: string): Promise<string | undefined> => {
-    const resolution = getResolution()
-    if (!resolution) return undefined
+  const resolution = getResolution()
+  if (!resolution) return undefined
 
-    try {
-        const domain = await resolution.reverse(address)
-        return domain || undefined
-    } catch (e) {
-        const err = e as Error
-        // Resolution SDK throws for addresses without reverse records, which is expected
-        if (
-            err.message?.includes('UnregisteredDomain') ||
-            err.message?.includes('RecordNotFound') ||
-            err.message?.includes('UnspecifiedResolver') ||
-            err.message?.includes('ReverseResolutionNotSpecified')
-        ) {
-            return undefined
-        }
-        logError(ErrorCodes._101, `UD reverse resolution error: ${err.message}`)
-        return undefined
+  try {
+    const domain = await resolution.reverse(address)
+    return domain || undefined
+  } catch (e) {
+    const err = e as Error
+    // Resolution SDK throws for addresses without reverse records, which is expected
+    if (
+      err.message?.includes('UnregisteredDomain') ||
+      err.message?.includes('RecordNotFound') ||
+      err.message?.includes('UnspecifiedResolver') ||
+      err.message?.includes('ReverseResolutionNotSpecified')
+    ) {
+      return undefined
     }
+    logError(ErrorCodes._101, `UD reverse resolution error: ${err.message}`)
+    return undefined
+  }
 }
-
-
-

--- a/apps/web/src/services/ud/index.ts
+++ b/apps/web/src/services/ud/index.ts
@@ -3,94 +3,94 @@ import { logError } from '@/services/exceptions'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
 
 export interface UdResolveOptions {
-  token?: string
-  network?: string
+    token?: string
+    network?: string
 }
 
 // Lazy-initialize Resolution instance
 let resolutionInstance: Resolution | null = null
 
 const getResolution = (): Resolution | null => {
-  if (resolutionInstance) return resolutionInstance
+    if (resolutionInstance) return resolutionInstance
 
-  const apiKey = process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY
-  if (!apiKey) {
-    logError(ErrorCodes._101, 'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution')
-    return null
-  }
+    const apiKey = process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY
+    if (!apiKey) {
+        logError(ErrorCodes._101, 'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution')
+        return null
+    }
 
-  try {
-    resolutionInstance = new Resolution({
-      apiKey,
-    })
-    return resolutionInstance
-  } catch (e) {
-    const err = e as Error
-    logError(ErrorCodes._101, `Failed to initialize UD Resolution: ${err.message}`)
-    return null
-  }
+    try {
+        resolutionInstance = new Resolution({
+            apiKey,
+        })
+        return resolutionInstance
+    } catch (e) {
+        const err = e as Error
+        logError(ErrorCodes._101, `Failed to initialize UD Resolution: ${err.message}`)
+        return null
+    }
 }
 
 // Export for testing only - allows resetting the singleton instance
 export const __resetResolutionForTesting = () => {
-  resolutionInstance = null
+    resolutionInstance = null
 }
 
 /**
  * Resolve an Unstoppable Domain to an address (forward resolution)
  */
 export const resolveUnstoppableAddress = async (
-  domain: string,
-  options?: UdResolveOptions,
+    domain: string,
+    options?: UdResolveOptions,
 ): Promise<string | undefined> => {
-  const resolution = getResolution()
-  if (!resolution) return undefined
+    const resolution = getResolution()
+    if (!resolution) return undefined
 
-  try {
-    // Use the token/network if provided, otherwise default to empty string
-    const token = options?.token?.toUpperCase() || ''
-    const network = options?.network?.toUpperCase() || ''
+    try {
+        // Use the token/network if provided, otherwise default to empty string
+        const token = options?.token?.toUpperCase() || ''
+        const network = options?.network?.toUpperCase() || ''
 
-    const address = await resolution.getAddress(domain, network, token)
-    return address || undefined
-  } catch (e) {
-    const err = e as Error
-    // Resolution SDK throws for unregistered domains or unsupported TLDs, which is expected
-    if (
-      err.message?.includes('UnregisteredDomain') ||
-      err.message?.includes('RecordNotFound') ||
-      err.message?.includes('UnspecifiedResolver') ||
-      err.message?.includes('UnsupportedDomain')
-    ) {
-      return undefined
+        const address = await resolution.getAddress(domain, network, token)
+        return address || undefined
+    } catch (e) {
+        const err = e as Error
+        // Resolution SDK throws for unregistered domains or unsupported TLDs, which is expected
+        if (
+            err.message?.includes('UnregisteredDomain') ||
+            err.message?.includes('RecordNotFound') ||
+            err.message?.includes('UnspecifiedResolver') ||
+            err.message?.includes('UnsupportedDomain')
+        ) {
+            return undefined
+        }
+        logError(ErrorCodes._101, `UD resolution error: ${err.message}`)
+        return undefined
     }
-    logError(ErrorCodes._101, `UD resolution error: ${err.message}`)
-    return undefined
-  }
 }
 
 /**
  * Reverse resolve an address to an Unstoppable Domain name
  */
 export const reverseResolveUnstoppable = async (address: string): Promise<string | undefined> => {
-  const resolution = getResolution()
-  if (!resolution) return undefined
+    const resolution = getResolution()
+    if (!resolution) return undefined
 
-  try {
-    const domain = await resolution.reverse(address)
-    return domain || undefined
-  } catch (e) {
-    const err = e as Error
-    // Resolution SDK throws for addresses without reverse records, which is expected
-    if (
-      err.message?.includes('UnregisteredDomain') ||
-      err.message?.includes('RecordNotFound') ||
-      err.message?.includes('UnspecifiedResolver') ||
-      err.message?.includes('ReverseResolutionNotSpecified')
-    ) {
-      return undefined
+    try {
+        const domain = await resolution.reverse(address)
+        return domain || undefined
+    } catch (e) {
+        const err = e as Error
+        // Resolution SDK throws for addresses without reverse records, which is expected
+        if (
+            err.message?.includes('UnregisteredDomain') ||
+            err.message?.includes('RecordNotFound') ||
+            err.message?.includes('UnspecifiedResolver') ||
+            err.message?.includes('ReverseResolutionNotSpecified')
+        ) {
+            return undefined
+        }
+        logError(ErrorCodes._101, `UD reverse resolution error: ${err.message}`)
+        return undefined
     }
-    logError(ErrorCodes._101, `UD reverse resolution error: ${err.message}`)
-    return undefined
-  }
 }

--- a/apps/web/src/services/ud/index.ts
+++ b/apps/web/src/services/ud/index.ts
@@ -1,0 +1,68 @@
+import Resolution from '@unstoppabledomains/resolution'
+import { logError } from '@/services/exceptions'
+import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
+
+export interface UdResolveOptions {
+    token?: string
+    network?: string
+}
+
+// Lazy-initialize Resolution instance
+let resolutionInstance: Resolution | null = null
+
+const getResolution = (): Resolution | null => {
+    if (resolutionInstance) return resolutionInstance
+
+    const apiKey = process.env.NEXT_PUBLIC_UNSTOPPABLE_API_KEY
+    if (!apiKey) {
+        logError(ErrorCodes._101, 'NEXT_PUBLIC_UNSTOPPABLE_API_KEY not configured for UD resolution')
+        return null
+    }
+
+    try {
+        resolutionInstance = new Resolution({
+            apiKey,
+        })
+        return resolutionInstance
+    } catch (e) {
+        const err = e as Error
+        logError(ErrorCodes._101, `Failed to initialize UD Resolution: ${err.message}`)
+        return null
+    }
+}
+
+/**
+ * Resolve an Unstoppable Domain to an address
+ */
+export const resolveUnstoppableAddress = async (
+    domain: string,
+    options?: UdResolveOptions,
+): Promise<string | undefined> => {
+    const resolution = getResolution()
+    if (!resolution) return undefined
+
+    try {
+        // Use the token/network if provided, otherwise default to empty string
+        const token = options?.token?.toUpperCase() || ''
+        const network = options?.network?.toUpperCase() || ''
+
+        const address = await resolution.getAddress(domain, network, token)
+        return address || undefined
+    } catch (e) {
+        const err = e as Error
+        // Resolution SDK throws for unregistered domains or unsupported TLDs, which is expected
+        if (
+            err.message?.includes('UnregisteredDomain') ||
+            err.message?.includes('RecordNotFound') ||
+            err.message?.includes('UnspecifiedResolver') ||
+            err.message?.includes('UnsupportedDomain')
+        ) {
+            return undefined
+        }
+        logError(ErrorCodes._101, `UD resolution error: ${err.message}`)
+        return undefined
+    }
+}
+
+
+

--- a/apps/web/src/services/ud/index.ts
+++ b/apps/web/src/services/ud/index.ts
@@ -32,7 +32,7 @@ const getResolution = (): Resolution | null => {
 }
 
 /**
- * Resolve an Unstoppable Domain to an address
+ * Resolve an Unstoppable Domain to an address (forward resolution)
  */
 export const resolveUnstoppableAddress = async (
     domain: string,
@@ -60,6 +60,32 @@ export const resolveUnstoppableAddress = async (
             return undefined
         }
         logError(ErrorCodes._101, `UD resolution error: ${err.message}`)
+        return undefined
+    }
+}
+
+/**
+ * Reverse resolve an address to an Unstoppable Domain name
+ */
+export const reverseResolveUnstoppable = async (address: string): Promise<string | undefined> => {
+    const resolution = getResolution()
+    if (!resolution) return undefined
+
+    try {
+        const domain = await resolution.reverse(address)
+        return domain || undefined
+    } catch (e) {
+        const err = e as Error
+        // Resolution SDK throws for addresses without reverse records, which is expected
+        if (
+            err.message?.includes('UnregisteredDomain') ||
+            err.message?.includes('RecordNotFound') ||
+            err.message?.includes('UnspecifiedResolver') ||
+            err.message?.includes('ReverseResolutionNotSpecified')
+        ) {
+            return undefined
+        }
+        logError(ErrorCodes._101, `UD reverse resolution error: ${err.message}`)
         return undefined
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,6 +3225,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ensdomains/address-encoder@npm:^0.2.22":
+  version: 0.2.22
+  resolution: "@ensdomains/address-encoder@npm:0.2.22"
+  dependencies:
+    bech32: "npm:^2.0.0"
+    blakejs: "npm:^1.1.0"
+    bn.js: "npm:^4.11.8"
+    bs58: "npm:^4.0.1"
+    crypto-addr-codec: "npm:^0.1.8"
+    js-crc: "npm:^0.2.0"
+    js-sha256: "npm:^0.9.0"
+    js-sha512: "npm:^0.8.0"
+    nano-base32: "npm:^1.0.1"
+    ripemd160: "npm:^2.0.2"
+    sha3: "npm:^2.1.3"
+  checksum: 10/5bf2390ad8291b7a10a266044dee108fa957d599dcdf7d59c975b2507fef53cab3e3413567f7023d3c162fa5184af5bef86cf60047026d247076f8e74261e054
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.19.12":
   version: 0.19.12
   resolution: "@esbuild/aix-ppc64@npm:0.19.12"
@@ -3869,7 +3888,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/abi@npm:^5.5.0":
+"@ethersproject/abi@npm:^5.0.1, @ethersproject/abi@npm:^5.5.0":
   version: 5.8.0
   resolution: "@ethersproject/abi@npm:5.8.0"
   dependencies:
@@ -10352,6 +10371,7 @@ __metadata:
     "@types/semver": "npm:^7.3.10"
     "@typescript-eslint/eslint-plugin": "npm:^7.6.0"
     "@typescript-eslint/parser": "npm:^8.18.1"
+    "@unstoppabledomains/resolution": "npm:^9.3.3"
     "@walletconnect/core": "npm:^2.21.9"
     "@walletconnect/utils": "npm:^2.21.9"
     "@web3-onboard/coinbase": "npm:^2.4.2"
@@ -14534,6 +14554,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@unstoppabledomains/resolution@npm:^9.3.3":
+  version: 9.3.3
+  resolution: "@unstoppabledomains/resolution@npm:9.3.3"
+  dependencies:
+    "@ensdomains/address-encoder": "npm:^0.2.22"
+    "@ethersproject/abi": "npm:^5.0.1"
+    bip44-constants: "npm:^8.0.103"
+    bn.js: "npm:^4.4.0"
+    content-hash: "npm:^2.5.2"
+    cross-fetch: "npm:4.0.0"
+    crypto-js: "npm:^4.1.1"
+    elliptic: "npm:^6.5.4"
+    js-sha256: "npm:^0.9.0"
+    js-sha3: "npm:^0.8.0"
+  checksum: 10/7b68eb29a3efe133ac0384363b0e09fa28c86ceb7bddd076159ef50213a9c05e0edab4b9f50531b81858abd9b59447c51acd6b20e470d48ea9a21cce57a637e5
+  languageName: node
+  linkType: hard
+
 "@urql/core@npm:^5.0.0, @urql/core@npm:^5.0.6":
   version: 5.0.8
   resolution: "@urql/core@npm:5.0.8"
@@ -16486,7 +16524,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^3.0.2":
+"base-x@npm:^3.0.2, base-x@npm:^3.0.8":
   version: 3.0.11
   resolution: "base-x@npm:3.0.11"
   dependencies:
@@ -16548,12 +16586,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bech32@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "bech32@npm:2.0.0"
+  checksum: 10/fa15acb270b59aa496734a01f9155677b478987b773bf701f465858bf1606c6a970085babd43d71ce61895f1baa594cb41a2cd1394bd2c6698f03cc2d811300e
+  languageName: node
+  linkType: hard
+
 "better-opn@npm:^3.0.2, better-opn@npm:~3.0.2":
   version: 3.0.2
   resolution: "better-opn@npm:3.0.2"
   dependencies:
     open: "npm:^8.0.4"
   checksum: 10/24668e5a837d0d2c0edf17ad5ebcfeb00a8a5578a5eb09f7a409e1a60617cdfea40b8ebfc95e5f12d9568157930d033e6805788fcf0780413ac982c95d3745d1
+  languageName: node
+  linkType: hard
+
+"big-integer@npm:1.6.36":
+  version: 1.6.36
+  resolution: "big-integer@npm:1.6.36"
+  checksum: 10/961fdd96c847765907e38759053ef4f9e66646739f2e6561087639dce7d1707db180dcb878761bb812a265af600f2d57cc31f5a57645dd790e4bd52c5d28382a
   languageName: node
   linkType: hard
 
@@ -16582,6 +16634,13 @@ __metadata:
   version: 2.3.0
   resolution: "binary-extensions@npm:2.3.0"
   checksum: 10/bcad01494e8a9283abf18c1b967af65ee79b0c6a9e6fcfafebfe91dbe6e0fc7272bafb73389e198b310516ae04f7ad17d79aacf6cb4c0d5d5202a7e2e52c7d98
+  languageName: node
+  linkType: hard
+
+"bip44-constants@npm:^8.0.103":
+  version: 8.0.103
+  resolution: "bip44-constants@npm:8.0.103"
+  checksum: 10/8452b848f83167d12b8cb1e2acd5a286eeae1dfcb340cbe3ae79e503f4dc40ff645a398ec6dca086c1a5a73d5f0943c2c055f377287f032e1741a96a0b72b879
   languageName: node
   linkType: hard
 
@@ -16628,6 +16687,13 @@ __metadata:
   version: 4.12.1
   resolution: "bn.js@npm:4.12.1"
   checksum: 10/07f22df8880b423c4890648e95791319898b96712b6ebc5d6b1082b34074f09dedb8601e717d67f905ce29bb1a5313f9a2b1a2015a679e42c9eed94392c0d379
+  languageName: node
+  linkType: hard
+
+"bn.js@npm:^4.11.8, bn.js@npm:^4.4.0":
+  version: 4.12.2
+  resolution: "bn.js@npm:4.12.2"
+  checksum: 10/5803983405c087443e0e6c9bb5d0bc863d9f987d77e710f81b14c55616494f5a274e1650ee892531acb3529d52c0e0ea48aa12d2873dd80a75dde9d73a2ec518
   languageName: node
   linkType: hard
 
@@ -16883,7 +16949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs58@npm:^4.0.0":
+"bs58@npm:^4.0.0, bs58@npm:^4.0.1":
   version: 4.0.1
   resolution: "bs58@npm:4.0.1"
   dependencies:
@@ -16940,23 +17006,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer@npm:^5.4.3, buffer@npm:^5.7.1":
-  version: 5.7.1
-  resolution: "buffer@npm:5.7.1"
-  dependencies:
-    base64-js: "npm:^1.3.1"
-    ieee754: "npm:^1.1.13"
-  checksum: 10/997434d3c6e3b39e0be479a80288875f71cd1c07d75a3855e6f08ef848a3c966023f79534e22e415ff3a5112708ce06127277ab20e527146d55c84566405c7c6
-  languageName: node
-  linkType: hard
-
-"buffer@npm:^6.0.3":
+"buffer@npm:6.0.3, buffer@npm:^6.0.3":
   version: 6.0.3
   resolution: "buffer@npm:6.0.3"
   dependencies:
     base64-js: "npm:^1.3.1"
     ieee754: "npm:^1.2.1"
   checksum: 10/b6bc68237ebf29bdacae48ce60e5e28fc53ae886301f2ad9496618efac49427ed79096750033e7eab1897a4f26ae374ace49106a5758f38fb70c78c9fda2c3b1
+  languageName: node
+  linkType: hard
+
+"buffer@npm:^5.4.3, buffer@npm:^5.5.0, buffer@npm:^5.6.0, buffer@npm:^5.7.1":
+  version: 5.7.1
+  resolution: "buffer@npm:5.7.1"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.1.13"
+  checksum: 10/997434d3c6e3b39e0be479a80288875f71cd1c07d75a3855e6f08ef848a3c966023f79534e22e415ff3a5112708ce06127277ab20e527146d55c84566405c7c6
   languageName: node
   linkType: hard
 
@@ -17481,6 +17547,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cids@npm:^0.7.1":
+  version: 0.7.5
+  resolution: "cids@npm:0.7.5"
+  dependencies:
+    buffer: "npm:^5.5.0"
+    class-is: "npm:^1.1.0"
+    multibase: "npm:~0.6.0"
+    multicodec: "npm:^1.0.0"
+    multihashes: "npm:~0.4.15"
+  checksum: 10/b916b0787e238dd9f84fb5e155333cadf07fd7ad34ea8dbd47f98bb618eecc9c70760767c0966d0eae73050c4fa6080fdc387e515565b009d2126253c7775fac
+  languageName: node
+  linkType: hard
+
 "cids@npm:^1.0.0, cids@npm:^1.1.5, cids@npm:^1.1.6":
   version: 1.1.9
   resolution: "cids@npm:1.1.9"
@@ -17516,6 +17595,13 @@ __metadata:
   version: 1.4.1
   resolution: "cjs-module-lexer@npm:1.4.1"
   checksum: 10/6e830a1e00a34d416949bbc1924f3e8da65cef4a6a09e2b7fa35722e2d1c34bf378d3baca987b698d1cbc3eb83e44b044039b4e82755c96f30e0f03d1d227637
+  languageName: node
+  linkType: hard
+
+"class-is@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "class-is@npm:1.1.0"
+  checksum: 10/8147a3e4ce86eb103d78621d665b87e8e33fcb3f54932fdca894b8222820903b43b2f6b4335d8822104702a5dc904c8f187127fdea4e7d48d905488b35c9e6a7
   languageName: node
   linkType: hard
 
@@ -17972,6 +18058,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"content-hash@npm:^2.5.2":
+  version: 2.5.2
+  resolution: "content-hash@npm:2.5.2"
+  dependencies:
+    cids: "npm:^0.7.1"
+    multicodec: "npm:^0.5.5"
+    multihashes: "npm:^0.4.15"
+  checksum: 10/7c5d05052aecead40a1bbdd251468a6cc9bf4c48b361b4f138d60e6d876dc3028da6142031578ddc42e44e0024f91cc01b7a539bdb0bf7187e36bec15052e02d
+  languageName: node
+  linkType: hard
+
 "convert-source-map@npm:^1.5.0, convert-source-map@npm:^1.7.0":
   version: 1.9.0
   resolution: "convert-source-map@npm:1.9.0"
@@ -18201,6 +18298,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-fetch@npm:4.0.0":
+  version: 4.0.0
+  resolution: "cross-fetch@npm:4.0.0"
+  dependencies:
+    node-fetch: "npm:^2.6.12"
+  checksum: 10/e231a71926644ef122d334a3a4e73d9ba3ba4b480a8a277fb9badc434c1ba905b3d60c8034e18b348361a09afbec40ba9371036801ba2b675a7b84588f9f55d8
+  languageName: node
+  linkType: hard
+
 "cross-fetch@npm:^3.1.4, cross-fetch@npm:^3.1.5":
   version: 3.1.8
   resolution: "cross-fetch@npm:3.1.8"
@@ -18227,6 +18333,21 @@ __metadata:
   dependencies:
     uncrypto: "npm:^0.1.3"
   checksum: 10/d358a58b364b3314a0e42ee66b1432c01d416128e53eda983eb121abdad5ff39831a1f1ea3e90e80157ceaa0fc925f5193c151b156aa62af9e0c9bcb2fb2a15a
+  languageName: node
+  linkType: hard
+
+"crypto-addr-codec@npm:^0.1.8":
+  version: 0.1.8
+  resolution: "crypto-addr-codec@npm:0.1.8"
+  dependencies:
+    base-x: "npm:^3.0.8"
+    big-integer: "npm:1.6.36"
+    blakejs: "npm:^1.1.0"
+    bs58: "npm:^4.0.1"
+    ripemd160-min: "npm:0.0.6"
+    safe-buffer: "npm:^5.2.0"
+    sha3: "npm:^2.1.1"
+  checksum: 10/cb086919331ae0acb2f1ace78ea81c1f400ecea8b9f2fc680f8e2be1475b62a90ec09643ca07c90a37097c1c9eaf0705c5cadfb5010ec96dc7d6bb1b2b80188a
   languageName: node
   linkType: hard
 
@@ -18257,7 +18378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-js@npm:^4.2.0":
+"crypto-js@npm:^4.1.1, crypto-js@npm:^4.2.0":
   version: 4.2.0
   resolution: "crypto-js@npm:4.2.0"
   checksum: 10/c7bcc56a6e01c3c397e95aa4a74e4241321f04677f9a618a8f48a63b5781617248afb9adb0629824792e7ec20ca0d4241a49b6b2938ae6f973ec4efc5c53c924
@@ -19262,7 +19383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.6.1, elliptic@npm:^6.5.3, elliptic@npm:^6.5.5, elliptic@npm:^6.5.7, elliptic@npm:^6.6.1":
+"elliptic@npm:6.6.1, elliptic@npm:^6.5.3, elliptic@npm:^6.5.4, elliptic@npm:^6.5.5, elliptic@npm:^6.5.7, elliptic@npm:^6.6.1":
   version: 6.6.1
   resolution: "elliptic@npm:6.6.1"
   dependencies:
@@ -22797,6 +22918,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hash-base@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "hash-base@npm:3.1.2"
+  dependencies:
+    inherits: "npm:^2.0.4"
+    readable-stream: "npm:^2.3.8"
+    safe-buffer: "npm:^5.2.1"
+    to-buffer: "npm:^1.2.1"
+  checksum: 10/f2100420521ec77736ebd9279f2c0b3ab2820136a2fa408ea36f3201d3f6984cda166806e6a0287f92adf179430bedfbdd74348ac351e24a3eff9f01a8c406b0
+  languageName: node
+  linkType: hard
+
 "hash-base@npm:~3.0, hash-base@npm:~3.0.4":
   version: 3.0.5
   resolution: "hash-base@npm:3.0.5"
@@ -25048,10 +25181,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-crc@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "js-crc@npm:0.2.0"
+  checksum: 10/682736488260d34da80e4b64d4b9223972edbb23b8689323c80536caaf1dcd254ff3e04eb0673dd9086fcaa2d8a3735ae8bd78f32f141244137942587cafde87
+  languageName: node
+  linkType: hard
+
+"js-sha256@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "js-sha256@npm:0.9.0"
+  checksum: 10/4dc16be74bf4e60d8ee2a482cc822c4d4f5cd060d9f92a060fe3ab1f143cd0946edda552cd274459251c279073df15872a5df47fc4bff054bbc3812e396e990b
+  languageName: node
+  linkType: hard
+
 "js-sha3@npm:0.8.0, js-sha3@npm:^0.8.0":
   version: 0.8.0
   resolution: "js-sha3@npm:0.8.0"
   checksum: 10/a49ac6d3a6bfd7091472a28ab82a94c7fb8544cc584ee1906486536ba1cb4073a166f8c7bb2b0565eade23c5b3a7b8f7816231e0309ab5c549b737632377a20c
+  languageName: node
+  linkType: hard
+
+"js-sha512@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "js-sha512@npm:0.8.0"
+  checksum: 10/2e8f98a6c0c35ff039dc74d4ea7a00f7cd3f4712d1cb74007713e0338bffc44c53a44729c60e97afbd7430eeefb1f435eca30b355f17fc11ec0c35351e3e9bdd
   languageName: node
   linkType: hard
 
@@ -27783,12 +27937,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"multibase@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "multibase@npm:0.7.0"
+  dependencies:
+    base-x: "npm:^3.0.8"
+    buffer: "npm:^5.5.0"
+  checksum: 10/a5cbbf00b8aa61bcb92a706e210d8f258e8413cff2893584fedbc316c98bf2a44b8f648b57c124ddfaa29750c3b686ee5ba973cb8da84a896c19d63101b09445
+  languageName: node
+  linkType: hard
+
 "multibase@npm:^4.0.1":
   version: 4.0.6
   resolution: "multibase@npm:4.0.6"
   dependencies:
     "@multiformats/base-x": "npm:^4.0.1"
   checksum: 10/4c008da32f6f0f7c790bb9749e0811cfce0cbae31920a005419c8674706878bfd79ac8939d38042fcb66a02605c712b57db7a1e95b1c163d4de8586c54752bcb
+  languageName: node
+  linkType: hard
+
+"multibase@npm:~0.6.0":
+  version: 0.6.1
+  resolution: "multibase@npm:0.6.1"
+  dependencies:
+    base-x: "npm:^3.0.8"
+    buffer: "npm:^5.5.0"
+  checksum: 10/c9e3bf20dc1b109019b94b14a76731ea0a6b0e654a4ef627ba154bfc2b8602ac43b160c44d8245d18cd6a9ed971826efb204230f22b929c8b3e72da13dbc1859
+  languageName: node
+  linkType: hard
+
+"multicodec@npm:^0.5.5":
+  version: 0.5.7
+  resolution: "multicodec@npm:0.5.7"
+  dependencies:
+    varint: "npm:^5.0.0"
+  checksum: 10/b61bbf04e1bfff180f77693661b8111bf94f65580abc455e6d83d2240c227d8c2e8af99ca93b6c02500c5da43d16e2b028dbbec1b376a85145a774f542d9ca2c
+  languageName: node
+  linkType: hard
+
+"multicodec@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "multicodec@npm:1.0.4"
+  dependencies:
+    buffer: "npm:^5.6.0"
+    varint: "npm:^5.0.0"
+  checksum: 10/3a78ac54d3715e6b095a1805f63b4c4e7d5bb4642445691c0c4e6442cad9f97823469634e73ee362ba748596570db1050d69d5cc74a88928b1e9658916cdfbcd
   languageName: node
   linkType: hard
 
@@ -27806,6 +27999,17 @@ __metadata:
   version: 9.9.0
   resolution: "multiformats@npm:9.9.0"
   checksum: 10/ad55c7d480d22f4258a68fd88aa2aab744fe0cb1e68d732fc886f67d858b37e3aa6c2cec12b2960ead7730d43be690931485238569952d8a3d7f90fdc726c652
+  languageName: node
+  linkType: hard
+
+"multihashes@npm:^0.4.15, multihashes@npm:~0.4.15":
+  version: 0.4.21
+  resolution: "multihashes@npm:0.4.21"
+  dependencies:
+    buffer: "npm:^5.5.0"
+    multibase: "npm:^0.7.0"
+    varint: "npm:^5.0.0"
+  checksum: 10/a482d9ba7ed0ad41db22ca589f228e4b7a30207a229a64dfc9888796752314fca00a8d03025fe40d6d73965bbb246f54b73626c5a235463e30c06c7bf7a8785f
   languageName: node
   linkType: hard
 
@@ -27866,6 +28070,13 @@ __metadata:
     object-assign: "npm:^4.0.1"
     thenify-all: "npm:^1.0.0"
   checksum: 10/8427de0ece99a07e9faed3c0c6778820d7543e3776f9a84d22cf0ec0a8eb65f6e9aee9c9d353ff9a105ff62d33a9463c6ca638974cc652ee8140cd1e35951c87
+  languageName: node
+  linkType: hard
+
+"nano-base32@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "nano-base32@npm:1.0.1"
+  checksum: 10/91acac2bc7883c2e6abe7e190d1253a9441ca89a05d839b46a737e3cf76ae0c5d160590b584f20c963198691b60d89fd6bb255ab5ec1b6c259759966c907a382
   languageName: node
   linkType: hard
 
@@ -31844,6 +32055,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ripemd160-min@npm:0.0.6":
+  version: 0.0.6
+  resolution: "ripemd160-min@npm:0.0.6"
+  checksum: 10/f2b641d42bffe0301f1c4e7c853a6fdd18a2639346f528c727b28078ccaaf7b764e074faac3ca8595b68213bf08ca11f4990d21b75d63b39ab1d48ccd861bf77
+  languageName: node
+  linkType: hard
+
 "ripemd160@npm:=2.0.1":
   version: 2.0.1
   resolution: "ripemd160@npm:2.0.1"
@@ -31861,6 +32079,16 @@ __metadata:
     hash-base: "npm:^3.0.0"
     inherits: "npm:^2.0.1"
   checksum: 10/006accc40578ee2beae382757c4ce2908a826b27e2b079efdcd2959ee544ddf210b7b5d7d5e80467807604244e7388427330f5c6d4cd61e6edaddc5773ccc393
+  languageName: node
+  linkType: hard
+
+"ripemd160@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "ripemd160@npm:2.0.3"
+  dependencies:
+    hash-base: "npm:^3.1.2"
+    inherits: "npm:^2.0.4"
+  checksum: 10/d15d42ea0460426675e5320f86d3468ab408af95b1761cf35f8d32c0c97b4d3bb72b7226e990e643b96e1637a8ad26b343a6c7666e1a297bcab4f305a1d9d3e3
   languageName: node
   linkType: hard
 
@@ -32366,6 +32594,15 @@ __metadata:
   bin:
     sha.js: bin.js
   checksum: 10/39c0993592c2ab34eb2daae2199a2a1d502713765aecb611fd97c0c4ab7cd53e902d628e1962aaf384bafd28f55951fef46dcc78799069ce41d74b03aa13b5a7
+  languageName: node
+  linkType: hard
+
+"sha3@npm:^2.1.1, sha3@npm:^2.1.3":
+  version: 2.1.4
+  resolution: "sha3@npm:2.1.4"
+  dependencies:
+    buffer: "npm:6.0.3"
+  checksum: 10/55f8b2608559987219203056c800c64afd3b4ffd5c9ebf281f6adb9d6a7eb5093754987b7c81d83f693f18ef5fb7e62e46bd78b67fc82a6852feda9ef1ba71a7
   languageName: node
   linkType: hard
 
@@ -34183,6 +34420,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"to-buffer@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "to-buffer@npm:1.2.2"
+  dependencies:
+    isarray: "npm:^2.0.5"
+    safe-buffer: "npm:^5.2.1"
+    typed-array-buffer: "npm:^1.0.3"
+  checksum: 10/69d806c20524ff1e4c44d49276bc96ff282dcae484780a3974e275dabeb75651ea430b074a2a4023701e63b3e1d87811cd82c0972f35280fe5461710e4872aba
+  languageName: node
+  linkType: hard
+
 "to-regex-range@npm:^5.0.1":
   version: 5.0.1
   resolution: "to-regex-range@npm:5.0.1"
@@ -35656,7 +35904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"varint@npm:^5.0.2":
+"varint@npm:^5.0.0, varint@npm:^5.0.2":
   version: 5.0.2
   resolution: "varint@npm:5.0.2"
   checksum: 10/e1a66bf9a6cea96d1f13259170d4d41b845833acf3a9df990ea1e760d279bd70d5b1f4c002a50197efd2168a2fd43eb0b808444600fd4d23651e8d42fe90eb05


### PR DESCRIPTION
## What it solves

Safe Wallet currently only supports ENS for domain name resolution and reverse resolution

## How this PR fixes it

Adds Unstoppable Domains Resolution and Reverse Resolution SDK alongside ENS with the goal of feature parity. Defaults to ENS and then fallsback to UD resolution to keep the existing UI flow as-is. Also changes ENS copy in the UI to be domain-name agnostic.

## How to test it

- Use an Unstoppable Domain (partner-engineering.crypto) in any Address Input field. 
- See wallet names resolve to ENS or UNS (example UNS address: 0x64F23b8c6261f8717E486955383679b9aEC67A56)

## Screenshots

<img width="725" height="226" alt="Screenshot 2025-10-03 at 11 20 50 AM" src="https://github.com/user-attachments/assets/c360fec0-4bdb-4035-b985-02cf099cd18c" />

![safe wallet ud resolution](https://github.com/user-attachments/assets/bd4e9f83-9d13-4f38-b748-8283c29931d1)

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
