### PR TITLE
feat(mobile): add claim stake view in transaction history

### DIFF
--- a/apps/mobile/src/features/HistoryTransactionDetails/components/HistoryTransactionView/HistoryTransactionView.tsx
+++ b/apps/mobile/src/features/HistoryTransactionDetails/components/HistoryTransactionView/HistoryTransactionView.tsx
@@ -8,6 +8,7 @@ import {
   VaultRedeemTransactionInfo,
   NativeStakingDepositTransactionInfo,
   NativeStakingValidatorsExitTransactionInfo,
+  NativeStakingWithdrawTransactionInfo,
 } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { OrderTransactionInfo } from '@safe-global/store/gateway/types'
 import { HistoryTokenTransfer } from '../history-views/HistoryTokenTransfer'
@@ -26,6 +27,7 @@ import { HistoryContract } from '@/src/features/HistoryTransactionDetails/compon
 import { NormalizedSettingsChangeTransaction } from '@/src/features/ConfirmTx/components/ConfirmationView/types'
 import { CancelTx } from '@/src/features/HistoryTransactionDetails/components/history-views/CancelTx'
 import { CustomTransactionInfo, MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { HistoryStakeWithdraw } from '../history-views/HistoryStakeWithdraw'
 
 interface HistoryTransactionViewProps {
   txDetails: TransactionDetails
@@ -111,6 +113,15 @@ export function HistoryTransactionView({ txDetails }: HistoryTransactionViewProp
           txData={txDetails.txData as TransactionData}
         />
       )
+    case ETxType.STAKE_EXIT: {
+      return (
+        <HistoryStakeWithdraw
+          txId={txDetails.txId}
+          txInfo={txDetails.txInfo as NativeStakingWithdrawTransactionInfo}
+          txData={txDetails.txData as TransactionData}
+        />
+      )
+    }
 
     case ETxType.VAULT_DEPOSIT:
       return <HistoryVaultDeposit txId={txDetails.txId} txInfo={txDetails.txInfo as VaultDepositTransactionInfo} />

--- a/apps/mobile/src/features/HistoryTransactionDetails/components/history-views/HistoryStakeWithdraw.tsx
+++ b/apps/mobile/src/features/HistoryTransactionDetails/components/history-views/HistoryStakeWithdraw.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { YStack, Text, View } from 'tamagui'
+import {
+  NativeStakingWithdrawTransactionInfo,
+  TransactionData,
+} from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { HistoryTransactionHeader } from '../HistoryTransactionHeader'
+import { Container } from '@/src/components/Container'
+import { TokenAmount } from '@/src/components/TokenAmount'
+import { stakingTypeToLabel } from '@/src/features/ConfirmTx/components/confirmation-views/Stake/utils'
+import { HistoryAdvancedDetailsButton } from '@/src/features/HistoryTransactionDetails/components/HistoryAdvancedDetailsButton'
+import { NetworkDisplay } from '../shared/NetworkDisplay'
+import { HashDisplay } from '@/src/components/HashDisplay'
+
+interface HistoryStakeWithdrawProps {
+  txId: string
+  txInfo: NativeStakingWithdrawTransactionInfo
+  txData: TransactionData
+}
+
+export function HistoryStakeWithdraw({ txId, txInfo, txData }: HistoryStakeWithdrawProps) {
+  return (
+    <YStack gap="$4">
+      <HistoryTransactionHeader
+        logo={txInfo.tokenInfo.logoUri ?? undefined}
+        badgeIcon="transaction-stake"
+        badgeColor="$textSecondaryLight"
+        transactionType={stakingTypeToLabel[txInfo.type]}
+      >
+        <View alignItems="center">
+          <TokenAmount
+            value={txInfo.value}
+            tokenSymbol={txInfo.tokenInfo.symbol}
+            decimals={txInfo.tokenInfo.decimals}
+            textProps={{ fontSize: '$6', fontWeight: '600' }}
+          />
+        </View>
+      </HistoryTransactionHeader>
+      <Container padding="$4" gap="$4" borderRadius="$3">
+        <View alignItems="center" flexDirection="row" justifyContent="space-between">
+          <Text color="$textSecondaryLight">Contract</Text>
+          <HashDisplay value={txData.to.value} />
+        </View>
+
+        <NetworkDisplay />
+
+        <HistoryAdvancedDetailsButton txId={txId} />
+      </Container>
+    </YStack>
+  )
+}


### PR DESCRIPTION
## What it solves
When viewing an executed claim stake transaction we were nto showing the decoded info of the tx. 

Resolves https://linear.app/safe-global/issue/COR-523/stake-withdraw-request#comment-8afb2813

## How this PR fixes it
- ads custom decoding when we have a stake_exit transaction

## How to test it
Open a claim stake tx and it should be styled like in the screenshot

## Screenshots
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/d1afd1d2-f308-401d-9300-cb7b0f6fd52e" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
