### PR TITLE
fix(mobile): change not_staked label

### DIFF
--- a/apps/mobile/src/components/ValidatorStatus/ValidatorStatus.tsx
+++ b/apps/mobile/src/components/ValidatorStatus/ValidatorStatus.tsx
@@ -16,7 +16,7 @@ const StatusConfigs: Record<NativeStakingStatus, ValidatorStatusConfig> = {
   NOT_STAKED: {
     themeName: 'badge_warning',
     icon: () => <SafeFontIcon name="signature" size={12} />,
-    text: 'Signature needed',
+    text: 'Inactive',
   },
   ACTIVATING: {
     themeName: 'badge_background',


### PR DESCRIPTION
## What it solves
We agreed that "Needs signature" although correct might be confusing to users, so we are changing the not_staked label to "inactive"

Resolves https://linear.app/safe-global/issue/COR-521/staking#comment-eb9d184f

## Screenshots
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/838079d4-26fe-4336-8bcd-0d2059e40fbb" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
