### PR TITLE
fix(mobile): failing build in testflight

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -43,6 +43,8 @@ const config = {
       AppGroup: IS_DEV ? 'group.global.safe.mobileapp.ios.dev' : 'group.global.safe.mobileapp.ios',
       // https://github.com/expo/expo/issues/39739
       UIDesignRequiresCompatibility: true,
+      // https://github.com/react-native-share/react-native-share/issues/1669
+      NSPhotoLibraryUsageDescription: 'Allow access to photo library to share images.',
     },
     supportsTablet: false,
     appleTeamId: appleDevTeamId,
@@ -138,8 +140,8 @@ const config = {
     [
       'react-native-share',
       {
-        ios: ['fb', 'instagram', 'twitter', 'tiktoksharesdk'],
-        android: ['com.facebook.katana', 'com.instagram.android', 'com.twitter.android', 'com.zhiliaoapp.musically'],
+        ios: ['fb', 'twitter', 'tiktoksharesdk'],
+        android: ['com.facebook.katana', 'com.twitter.android', 'com.zhiliaoapp.musically'],
         enableBase64ShareAndroid: true,
       },
     ],

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -44,7 +44,8 @@ const config = {
       // https://github.com/expo/expo/issues/39739
       UIDesignRequiresCompatibility: true,
       // https://github.com/react-native-share/react-native-share/issues/1669
-      NSPhotoLibraryUsageDescription: 'Allow access to photo library to share images.',
+      NSPhotoLibraryUsageDescription:
+        'This permission is required by third party libraries, but not used in the app. If you ever get prompted for it, deny it & contact support.',
     },
     supportsTablet: false,
     appleTeamId: appleDevTeamId,


### PR DESCRIPTION
## What it solves
Our testflight build was failng with:

> 0683: Missing purpose string in Info.plist. Your app’s code references one or more APIs that access sensitive user data, or the app has one or more entitlements that permit such access. The Info.plist file for the “DevSafeMobile.app” bundle should contain a NSPhotoLibraryUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. If you’re using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required.


Resolves https://linear.app/safe-global/issue/COR-635/fix-failing-ios-build

## How this PR fixes it

I think that this is a false positive as I'm not aware of us using the photo library anywhere. I thought that it is a problem with react-native-permissions, but in this issue the author of the library cliams that it is not: https://github.com/zoontek/react-native-permissions/issues/947

We do use react-native-share https://github.com/react-native-share/react-native-share/issues/1669 and apparently this permission is needed to share on instagram. I removed instagram from the plugin configs, but the error persisted. So I opted to "explain" why we use this permission, even though we don't. 

## How to test it
Auto test: Build distribution succeeds.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
