### PR TITLE
feat(web): add useAddressBookCheck hook

### DIFF
--- a/apps/web/src/features/address-analysis/__tests__/addressActivityService.test.ts
+++ b/apps/web/src/features/address-analysis/__tests__/addressActivityService.test.ts
@@ -1,0 +1,151 @@
+import { faker } from '@faker-js/faker'
+import type { JsonRpcProvider } from 'ethers'
+import { analyzeAddressActivity, isLowActivityAddress } from '../addressActivityService'
+
+describe('addressActivityService', () => {
+  describe('analyzeAddressActivity', () => {
+    it('should return NO_ACTIVITY for address with 0 transactions', async () => {
+      const address = faker.finance.ethereumAddress()
+      const provider = {
+        getTransactionCount: jest.fn().mockResolvedValue(0),
+      } as unknown as JsonRpcProvider
+
+      const result = await analyzeAddressActivity(address, provider)
+
+      expect(result).toEqual({
+        txCount: 0,
+        activityLevel: 'NO_ACTIVITY',
+      })
+      expect(provider.getTransactionCount).toHaveBeenCalledWith(address, 'latest')
+    })
+
+    it('should return VERY_LOW_ACTIVITY for address with 1-4 transactions', async () => {
+      const address = faker.finance.ethereumAddress()
+      const provider = {
+        getTransactionCount: jest.fn().mockResolvedValue(3),
+      } as unknown as JsonRpcProvider
+
+      const result = await analyzeAddressActivity(address, provider)
+
+      expect(result).toEqual({
+        txCount: 3,
+        activityLevel: 'VERY_LOW_ACTIVITY',
+      })
+    })
+
+    it('should return LOW_ACTIVITY for address with 5-19 transactions', async () => {
+      const address = faker.finance.ethereumAddress()
+      const provider = {
+        getTransactionCount: jest.fn().mockResolvedValue(10),
+      } as unknown as JsonRpcProvider
+
+      const result = await analyzeAddressActivity(address, provider)
+
+      expect(result).toEqual({
+        txCount: 10,
+        activityLevel: 'LOW_ACTIVITY',
+      })
+    })
+
+    it('should return MODERATE_ACTIVITY for address with 20-99 transactions', async () => {
+      const address = faker.finance.ethereumAddress()
+      const provider = {
+        getTransactionCount: jest.fn().mockResolvedValue(50),
+      } as unknown as JsonRpcProvider
+
+      const result = await analyzeAddressActivity(address, provider)
+
+      expect(result).toEqual({
+        txCount: 50,
+        activityLevel: 'MODERATE_ACTIVITY',
+      })
+    })
+
+    it('should return HIGH_ACTIVITY for address with 100+ transactions', async () => {
+      const address = faker.finance.ethereumAddress()
+      const provider = {
+        getTransactionCount: jest.fn().mockResolvedValue(250),
+      } as unknown as JsonRpcProvider
+
+      const result = await analyzeAddressActivity(address, provider)
+
+      expect(result).toEqual({
+        txCount: 250,
+        activityLevel: 'HIGH_ACTIVITY',
+      })
+    })
+
+    it('should throw error for invalid address', async () => {
+      const invalidAddress = 'invalid-address'
+      const provider = {} as JsonRpcProvider
+
+      await expect(analyzeAddressActivity(invalidAddress, provider)).rejects.toThrow('Invalid Ethereum address')
+    })
+
+    it('should throw error if provider is not available', async () => {
+      const address = faker.finance.ethereumAddress()
+      const provider = undefined as unknown as JsonRpcProvider
+
+      await expect(analyzeAddressActivity(address, provider)).rejects.toThrow('Web3 provider not available')
+    })
+
+    it('should throw error if getTransactionCount fails', async () => {
+      const address = faker.finance.ethereumAddress()
+      const errorMessage = 'RPC error'
+      const provider = {
+        getTransactionCount: jest.fn().mockRejectedValue(new Error(errorMessage)),
+      } as unknown as JsonRpcProvider
+
+      await expect(analyzeAddressActivity(address, provider)).rejects.toThrow(
+        `Failed to analyze address activity: ${errorMessage}`,
+      )
+    })
+  })
+
+  describe('isLowActivityAddress', () => {
+    it('should return true for NO_ACTIVITY', () => {
+      const assessment = {
+        txCount: 0,
+        activityLevel: 'NO_ACTIVITY' as const,
+      }
+
+      expect(isLowActivityAddress(assessment)).toBe(true)
+    })
+
+    it('should return true for VERY_LOW_ACTIVITY', () => {
+      const assessment = {
+        txCount: 2,
+        activityLevel: 'VERY_LOW_ACTIVITY' as const,
+      }
+
+      expect(isLowActivityAddress(assessment)).toBe(true)
+    })
+
+    it('should return true for LOW_ACTIVITY', () => {
+      const assessment = {
+        txCount: 10,
+        activityLevel: 'LOW_ACTIVITY' as const,
+      }
+
+      expect(isLowActivityAddress(assessment)).toBe(true)
+    })
+
+    it('should return false for MODERATE_ACTIVITY', () => {
+      const assessment = {
+        txCount: 50,
+        activityLevel: 'MODERATE_ACTIVITY' as const,
+      }
+
+      expect(isLowActivityAddress(assessment)).toBe(false)
+    })
+
+    it('should return false for HIGH_ACTIVITY', () => {
+      const assessment = {
+        txCount: 250,
+        activityLevel: 'HIGH_ACTIVITY' as const,
+      }
+
+      expect(isLowActivityAddress(assessment)).toBe(false)
+    })
+  })
+})

--- a/apps/web/src/features/address-analysis/__tests__/useAddressActivity.test.ts
+++ b/apps/web/src/features/address-analysis/__tests__/useAddressActivity.test.ts
@@ -3,7 +3,6 @@ import { renderHook, waitFor } from '@testing-library/react'
 import type { JsonRpcProvider } from 'ethers'
 import { useAddressActivity } from '../useAddressActivity'
 import * as web3 from '@/hooks/wallets/web3'
-import * as useChainIdHook from '@/hooks/useChainId'
 import { ActivityMessages } from '../config'
 
 describe('useAddressActivity', () => {
@@ -14,7 +13,6 @@ describe('useAddressActivity', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    jest.spyOn(useChainIdHook, 'default').mockReturnValue('1')
   })
 
   it('should return undefined when address is not provided', async () => {
@@ -190,15 +188,12 @@ describe('useAddressActivity', () => {
     expect(mockGetTransactionCount).toHaveBeenCalledTimes(2)
   })
 
-  it('should re-fetch when chainId changes', async () => {
+  it('should re-fetch when web3ReadOnly changes', async () => {
     const address = faker.finance.ethereumAddress()
-    const mockGetTransactionCount = jest.fn().mockResolvedValueOnce(10).mockResolvedValueOnce(50)
-    const provider = {
-      getTransactionCount: mockGetTransactionCount,
-    } as unknown as JsonRpcProvider
+    const provider1 = mockProvider(10)
+    const provider2 = mockProvider(50)
 
-    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(provider)
-    const useChainIdSpy = jest.spyOn(useChainIdHook, 'default').mockReturnValue('1')
+    const useWeb3ReadOnlySpy = jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(provider1)
 
     const { result, rerender } = renderHook(() => useAddressActivity(address))
 
@@ -208,13 +203,11 @@ describe('useAddressActivity', () => {
 
     expect(result.current.assessment?.txCount).toBe(10)
 
-    useChainIdSpy.mockReturnValue('137')
+    useWeb3ReadOnlySpy.mockReturnValue(provider2)
     rerender()
 
     await waitFor(() => {
       expect(result.current.assessment?.txCount).toBe(50)
     })
-
-    expect(mockGetTransactionCount).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/web/src/features/address-analysis/__tests__/useAddressActivity.test.ts
+++ b/apps/web/src/features/address-analysis/__tests__/useAddressActivity.test.ts
@@ -1,0 +1,220 @@
+import { faker } from '@faker-js/faker'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { JsonRpcProvider } from 'ethers'
+import { useAddressActivity } from '../useAddressActivity'
+import * as web3 from '@/hooks/wallets/web3'
+import * as useChainIdHook from '@/hooks/useChainId'
+import { ActivityMessages } from '../config'
+
+describe('useAddressActivity', () => {
+  const mockProvider = (txCount: number) =>
+    ({
+      getTransactionCount: jest.fn().mockResolvedValue(txCount),
+    }) as unknown as JsonRpcProvider
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(useChainIdHook, 'default').mockReturnValue('1')
+  })
+
+  it('should return undefined when address is not provided', async () => {
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(mockProvider(0))
+
+    const { result } = renderHook(() => useAddressActivity(undefined))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment).toBeUndefined()
+    expect(result.current.title).toBeUndefined()
+    expect(result.current.description).toBeUndefined()
+  })
+
+  it('should return undefined when provider is not available', async () => {
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(undefined as unknown as JsonRpcProvider)
+
+    const address = faker.finance.ethereumAddress()
+    const { result } = renderHook(() => useAddressActivity(address))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment).toBeUndefined()
+  })
+
+  it('should return NO_ACTIVITY assessment with corresponding title and description', async () => {
+    const address = faker.finance.ethereumAddress()
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(mockProvider(0))
+
+    const { result } = renderHook(() => useAddressActivity(address))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment).toEqual({
+      txCount: 0,
+      activityLevel: 'NO_ACTIVITY',
+    })
+    expect(result.current.title).toBe(ActivityMessages.NO_ACTIVITY.title)
+    expect(result.current.description).toBe(ActivityMessages.NO_ACTIVITY.description)
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('should return VERY_LOW_ACTIVITY assessment with corresponding title and description', async () => {
+    const address = faker.finance.ethereumAddress()
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(mockProvider(3))
+
+    const { result } = renderHook(() => useAddressActivity(address))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment).toEqual({
+      txCount: 3,
+      activityLevel: 'VERY_LOW_ACTIVITY',
+    })
+    expect(result.current.title).toBe(ActivityMessages.VERY_LOW_ACTIVITY.title)
+    expect(result.current.description).toBe(ActivityMessages.VERY_LOW_ACTIVITY.description)
+  })
+
+  it('should return LOW_ACTIVITY assessment with corresponding title and description', async () => {
+    const address = faker.finance.ethereumAddress()
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(mockProvider(10))
+
+    const { result } = renderHook(() => useAddressActivity(address))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment).toEqual({
+      txCount: 10,
+      activityLevel: 'LOW_ACTIVITY',
+    })
+    expect(result.current.title).toBe(ActivityMessages.LOW_ACTIVITY.title)
+    expect(result.current.description).toBe(ActivityMessages.LOW_ACTIVITY.description)
+  })
+
+  it('should return MODERATE_ACTIVITY assessment with corresponding title and description', async () => {
+    const address = faker.finance.ethereumAddress()
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(mockProvider(50))
+
+    const { result } = renderHook(() => useAddressActivity(address))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment).toEqual({
+      txCount: 50,
+      activityLevel: 'MODERATE_ACTIVITY',
+    })
+    expect(result.current.title).toBe(ActivityMessages.MODERATE_ACTIVITY.title)
+    expect(result.current.description).toBe(ActivityMessages.MODERATE_ACTIVITY.description)
+  })
+
+  it('should return HIGH_ACTIVITY assessment with corresponding title and description', async () => {
+    const address = faker.finance.ethereumAddress()
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(mockProvider(250))
+
+    const { result } = renderHook(() => useAddressActivity(address))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment).toEqual({
+      txCount: 250,
+      activityLevel: 'HIGH_ACTIVITY',
+    })
+    expect(result.current.title).toBe(ActivityMessages.HIGH_ACTIVITY.title)
+    expect(result.current.description).toBe(ActivityMessages.HIGH_ACTIVITY.description)
+  })
+
+  it('should handle errors gracefully', async () => {
+    const address = faker.finance.ethereumAddress()
+    const errorMessage = 'RPC error'
+    const provider = {
+      getTransactionCount: jest.fn().mockRejectedValue(new Error(errorMessage)),
+    } as unknown as JsonRpcProvider
+
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(provider)
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+
+    const { result } = renderHook(() => useAddressActivity(address))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment).toBeUndefined()
+    expect(result.current.error).toBeDefined()
+    expect(result.current.error?.message).toContain('Failed to analyze address activity')
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Address activity analysis error:', expect.any(Error))
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('should re-fetch when address changes', async () => {
+    const address1 = faker.finance.ethereumAddress()
+    const address2 = faker.finance.ethereumAddress()
+    const mockGetTransactionCount = jest.fn().mockResolvedValueOnce(5).mockResolvedValueOnce(100)
+    const provider = {
+      getTransactionCount: mockGetTransactionCount,
+    } as unknown as JsonRpcProvider
+
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(provider)
+
+    const { result, rerender } = renderHook(({ addr }) => useAddressActivity(addr), {
+      initialProps: { addr: address1 },
+    })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment?.txCount).toBe(5)
+    expect(result.current.assessment?.activityLevel).toBe('LOW_ACTIVITY')
+
+    rerender({ addr: address2 })
+
+    await waitFor(() => {
+      expect(result.current.assessment?.txCount).toBe(100)
+    })
+
+    expect(result.current.assessment?.activityLevel).toBe('HIGH_ACTIVITY')
+    expect(mockGetTransactionCount).toHaveBeenCalledTimes(2)
+  })
+
+  it('should re-fetch when chainId changes', async () => {
+    const address = faker.finance.ethereumAddress()
+    const mockGetTransactionCount = jest.fn().mockResolvedValueOnce(10).mockResolvedValueOnce(50)
+    const provider = {
+      getTransactionCount: mockGetTransactionCount,
+    } as unknown as JsonRpcProvider
+
+    jest.spyOn(web3, 'useWeb3ReadOnly').mockReturnValue(provider)
+    const useChainIdSpy = jest.spyOn(useChainIdHook, 'default').mockReturnValue('1')
+
+    const { result, rerender } = renderHook(() => useAddressActivity(address))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.assessment?.txCount).toBe(10)
+
+    useChainIdSpy.mockReturnValue('137')
+    rerender()
+
+    await waitFor(() => {
+      expect(result.current.assessment?.txCount).toBe(50)
+    })
+
+    expect(mockGetTransactionCount).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/src/features/address-analysis/__tests__/useAddressBookCheck.test.ts
+++ b/apps/web/src/features/address-analysis/__tests__/useAddressBookCheck.test.ts
@@ -1,0 +1,176 @@
+import { faker } from '@faker-js/faker'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useAddressBookCheck, AddressCheckDescription, AddressCheckSeverity } from '../useAddressBookCheck'
+import * as useChainIdHook from '@/hooks/useChainId'
+import * as useAllAddressBooksHook from '@/hooks/useAllAddressBooks'
+import * as useOwnedSafesHook from '@/hooks/useOwnedSafes'
+import type { MergedAddressBook } from '@/hooks/useAllAddressBooks'
+
+jest.mock('@/hooks/useChainId')
+jest.mock('@/hooks/useAllAddressBooks')
+jest.mock('@/hooks/useOwnedSafes')
+
+describe('useAddressBookCheck', () => {
+  const mockChainId = '1'
+  const mockAddress = faker.finance.ethereumAddress()
+
+  const mockMergedAddressBooks = (hasContact: boolean): MergedAddressBook => ({
+    list: [],
+    get: jest.fn(),
+    has: jest.fn().mockReturnValue(hasContact),
+    getFromLocal: jest.fn(),
+    getFromSpace: jest.fn(),
+  })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(useChainIdHook, 'default').mockReturnValue(mockChainId)
+  })
+
+  it('should return all false when address is not provided', async () => {
+    jest.spyOn(useAllAddressBooksHook, 'useMergedAddressBooks').mockReturnValue(mockMergedAddressBooks(false))
+    jest.spyOn(useOwnedSafesHook, 'default').mockReturnValue({ [mockChainId]: [] })
+
+    const { result } = renderHook(() => useAddressBookCheck(undefined))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.isKnownAddress).toBe(false)
+    expect(result.current.isAddressBookContact).toBe(false)
+    expect(result.current.isOwnedSafe).toBe(false)
+    expect(result.current.description).toBe(AddressCheckDescription.UNKNOWN)
+    expect(result.current.severity).toBe(AddressCheckSeverity.INFO)
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('should return true for isAddressBookContact when address is in address book', async () => {
+    jest.spyOn(useAllAddressBooksHook, 'useMergedAddressBooks').mockReturnValue(mockMergedAddressBooks(true))
+    jest.spyOn(useOwnedSafesHook, 'default').mockReturnValue({ [mockChainId]: [] })
+
+    const { result } = renderHook(() => useAddressBookCheck(mockAddress))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.isKnownAddress).toBe(true)
+    expect(result.current.isAddressBookContact).toBe(true)
+    expect(result.current.isOwnedSafe).toBe(false)
+    expect(result.current.description).toBe(AddressCheckDescription.ADDRESS_BOOK)
+    expect(result.current.severity).toBe(AddressCheckSeverity.OK)
+  })
+
+  it('should return true for isOwnedSafe when address is in owned safes', async () => {
+    jest.spyOn(useAllAddressBooksHook, 'useMergedAddressBooks').mockReturnValue(mockMergedAddressBooks(false))
+    jest.spyOn(useOwnedSafesHook, 'default').mockReturnValue({ [mockChainId]: [mockAddress] })
+
+    const { result } = renderHook(() => useAddressBookCheck(mockAddress))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.isKnownAddress).toBe(true)
+    expect(result.current.isAddressBookContact).toBe(false)
+    expect(result.current.isOwnedSafe).toBe(true)
+    expect(result.current.description).toBe(AddressCheckDescription.OWNED_SAFE)
+    expect(result.current.severity).toBe(AddressCheckSeverity.OK)
+  })
+
+  it('should handle case-insensitive address matching for owned safes', async () => {
+    const upperCaseAddress = mockAddress.toUpperCase()
+    jest.spyOn(useAllAddressBooksHook, 'useMergedAddressBooks').mockReturnValue(mockMergedAddressBooks(false))
+    jest.spyOn(useOwnedSafesHook, 'default').mockReturnValue({ [mockChainId]: [upperCaseAddress] })
+
+    const { result } = renderHook(() => useAddressBookCheck(mockAddress.toLowerCase()))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.isOwnedSafe).toBe(true)
+    expect(result.current.isKnownAddress).toBe(true)
+  })
+
+  it('should return true for all checks when address is in all sources', async () => {
+    jest.spyOn(useAllAddressBooksHook, 'useMergedAddressBooks').mockReturnValue(mockMergedAddressBooks(true))
+    jest.spyOn(useOwnedSafesHook, 'default').mockReturnValue({ [mockChainId]: [mockAddress] })
+
+    const { result } = renderHook(() => useAddressBookCheck(mockAddress))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.isKnownAddress).toBe(true)
+    expect(result.current.isAddressBookContact).toBe(true)
+    expect(result.current.isOwnedSafe).toBe(true)
+    expect(result.current.description).toBe(AddressCheckDescription.ADDRESS_BOOK)
+    expect(result.current.severity).toBe(AddressCheckSeverity.OK)
+  })
+
+  it('should return false for all checks when address is not in any source', async () => {
+    jest.spyOn(useAllAddressBooksHook, 'useMergedAddressBooks').mockReturnValue(mockMergedAddressBooks(false))
+    jest.spyOn(useOwnedSafesHook, 'default').mockReturnValue({ [mockChainId]: [] })
+
+    const { result } = renderHook(() => useAddressBookCheck(mockAddress))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.isKnownAddress).toBe(false)
+    expect(result.current.isAddressBookContact).toBe(false)
+    expect(result.current.isOwnedSafe).toBe(false)
+    expect(result.current.description).toBe(AddressCheckDescription.UNKNOWN)
+    expect(result.current.severity).toBe(AddressCheckSeverity.INFO)
+  })
+
+  it('should handle empty owned safes array for the chain', async () => {
+    jest.spyOn(useAllAddressBooksHook, 'useMergedAddressBooks').mockReturnValue(mockMergedAddressBooks(false))
+    jest.spyOn(useOwnedSafesHook, 'default').mockReturnValue({})
+
+    const { result } = renderHook(() => useAddressBookCheck(mockAddress))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.isOwnedSafe).toBe(false)
+    expect(result.current.isKnownAddress).toBe(false)
+  })
+
+  it('should re-check when address changes', async () => {
+    const address1 = faker.finance.ethereumAddress()
+    const address2 = faker.finance.ethereumAddress()
+
+    const mergedAddressBooks = mockMergedAddressBooks(false)
+    ;(mergedAddressBooks.has as jest.Mock).mockImplementation((addr: string) => {
+      return addr === address1
+    })
+
+    jest.spyOn(useAllAddressBooksHook, 'useMergedAddressBooks').mockReturnValue(mergedAddressBooks)
+    jest.spyOn(useOwnedSafesHook, 'default').mockReturnValue({ [mockChainId]: [] })
+
+    const { result, rerender } = renderHook(({ addr }) => useAddressBookCheck(addr), {
+      initialProps: { addr: address1 },
+    })
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.isAddressBookContact).toBe(true)
+    expect(result.current.isKnownAddress).toBe(true)
+
+    rerender({ addr: address2 })
+
+    await waitFor(() => {
+      expect(result.current.isAddressBookContact).toBe(false)
+    })
+
+    expect(result.current.isKnownAddress).toBe(false)
+  })
+})

--- a/apps/web/src/features/address-analysis/addressActivityService.ts
+++ b/apps/web/src/features/address-analysis/addressActivityService.ts
@@ -62,7 +62,9 @@ export const analyzeAddressActivity = async (
  * @returns True if the address has suspiciously low activity
  */
 export const isLowActivityAddress = (assessment: AddressActivityAssessment): boolean => {
-  return assessment.activityLevel === 'NO_ACTIVITY' ||
-         assessment.activityLevel === 'VERY_LOW_ACTIVITY' ||
-         assessment.activityLevel === 'LOW_ACTIVITY'
+  return (
+    assessment.activityLevel === 'NO_ACTIVITY' ||
+    assessment.activityLevel === 'VERY_LOW_ACTIVITY' ||
+    assessment.activityLevel === 'LOW_ACTIVITY'
+  )
 }

--- a/apps/web/src/features/address-analysis/addressActivityService.ts
+++ b/apps/web/src/features/address-analysis/addressActivityService.ts
@@ -1,0 +1,75 @@
+import type { JsonRpcProvider } from 'ethers'
+import { isAddress } from 'ethers'
+
+// Activity thresholds for scoring
+export const ACTIVITY_THRESHOLDS = {
+  VERY_LOW: 1,
+  LOW: 5,
+  MODERATE: 20,
+  HIGH: 100,
+} as const
+
+export type AddressActivityAssessment = {
+  txCount: number
+  activityScore: number
+}
+
+/**
+ * Calculate activity score based on transaction count
+ * Returns a score from 0 to 1:
+ * - 0: No activity (0 transactions)
+ * - 0.1-0.3: Very low activity (1-4 transactions)
+ * - 0.3-0.5: Low activity (5-19 transactions)
+ * - 0.5-0.8: Moderate activity (20-99 transactions)
+ * - 0.8-1.0: High activity (100+ transactions)
+ */
+const calculateActivityScore = (txCount: number): number => {
+  if (txCount === 0) return 0
+  if (txCount < ACTIVITY_THRESHOLDS.LOW) return 0.1 + (txCount / ACTIVITY_THRESHOLDS.LOW) * 0.2
+  if (txCount < ACTIVITY_THRESHOLDS.MODERATE) return 0.3 + ((txCount - ACTIVITY_THRESHOLDS.LOW) / (ACTIVITY_THRESHOLDS.MODERATE - ACTIVITY_THRESHOLDS.LOW)) * 0.2
+  if (txCount < ACTIVITY_THRESHOLDS.HIGH) return 0.5 + ((txCount - ACTIVITY_THRESHOLDS.MODERATE) / (ACTIVITY_THRESHOLDS.HIGH - ACTIVITY_THRESHOLDS.MODERATE)) * 0.3
+  return Math.min(1.0, 0.8 + (txCount - ACTIVITY_THRESHOLDS.HIGH) / 1000 * 0.2)
+}
+
+/**
+ * Analyzes address activity by checking transaction count
+ * @param address - Ethereum address to analyze
+ * @param web3ReadOnly - Web3 readonly provider instance
+ * @returns Assessment of address activity
+ */
+export const analyzeAddressActivity = async (
+  address: string,
+  web3ReadOnly: JsonRpcProvider,
+): Promise<AddressActivityAssessment> => {
+  if (!isAddress(address)) {
+    throw new Error('Invalid Ethereum address')
+  }
+
+  if (!web3ReadOnly) {
+    throw new Error('Web3 provider not available')
+  }
+
+  try {
+    // Get transaction count using eth_getTransactionCount
+    const txCount = await web3ReadOnly.getTransactionCount(address, 'latest')
+
+    // Calculate activity score
+    const activityScore = calculateActivityScore(txCount)
+
+    return {
+      txCount,
+      activityScore,
+    }
+  } catch (error) {
+    throw new Error(`Failed to analyze address activity: ${error instanceof Error ? error.message : 'Unknown error'}`)
+  }
+}
+
+/**
+ * Determines if an address has low activity and might be lost/abandoned
+ * @param assessment - Address activity assessment
+ * @returns True if the address has suspiciously low activity
+ */
+export const isLowActivityAddress = (assessment: AddressActivityAssessment): boolean => {
+  return assessment.activityScore < 0.3 || assessment.txCount < ACTIVITY_THRESHOLDS.LOW
+}

--- a/apps/web/src/features/address-analysis/addressActivityService.ts
+++ b/apps/web/src/features/address-analysis/addressActivityService.ts
@@ -1,34 +1,25 @@
 import type { JsonRpcProvider } from 'ethers'
 import { isAddress } from 'ethers'
+import { ACTIVITY_THRESHOLDS } from './config'
 
-// Activity thresholds for scoring
-export const ACTIVITY_THRESHOLDS = {
-  VERY_LOW: 1,
-  LOW: 5,
-  MODERATE: 20,
-  HIGH: 100,
-} as const
+export type ActivityLevel = 'NO_ACTIVITY' | 'VERY_LOW_ACTIVITY' | 'LOW_ACTIVITY' | 'MODERATE_ACTIVITY' | 'HIGH_ACTIVITY'
 
 export type AddressActivityAssessment = {
   txCount: number
-  activityScore: number
+  activityLevel: ActivityLevel
 }
 
 /**
- * Calculate activity score based on transaction count
- * Returns a score from 0 to 1:
- * - 0: No activity (0 transactions)
- * - 0.1-0.3: Very low activity (1-4 transactions)
- * - 0.3-0.5: Low activity (5-19 transactions)
- * - 0.5-0.8: Moderate activity (20-99 transactions)
- * - 0.8-1.0: High activity (100+ transactions)
+ * Determine activity level based on transaction count
+ * @param txCount - Number of transactions
+ * @returns Activity level category
  */
-const calculateActivityScore = (txCount: number): number => {
-  if (txCount === 0) return 0
-  if (txCount < ACTIVITY_THRESHOLDS.LOW) return 0.1 + (txCount / ACTIVITY_THRESHOLDS.LOW) * 0.2
-  if (txCount < ACTIVITY_THRESHOLDS.MODERATE) return 0.3 + ((txCount - ACTIVITY_THRESHOLDS.LOW) / (ACTIVITY_THRESHOLDS.MODERATE - ACTIVITY_THRESHOLDS.LOW)) * 0.2
-  if (txCount < ACTIVITY_THRESHOLDS.HIGH) return 0.5 + ((txCount - ACTIVITY_THRESHOLDS.MODERATE) / (ACTIVITY_THRESHOLDS.HIGH - ACTIVITY_THRESHOLDS.MODERATE)) * 0.3
-  return Math.min(1.0, 0.8 + (txCount - ACTIVITY_THRESHOLDS.HIGH) / 1000 * 0.2)
+const getActivityLevel = (txCount: number): ActivityLevel => {
+  if (txCount === 0) return 'NO_ACTIVITY'
+  if (txCount < ACTIVITY_THRESHOLDS.LOW) return 'VERY_LOW_ACTIVITY'
+  if (txCount < ACTIVITY_THRESHOLDS.MODERATE) return 'LOW_ACTIVITY'
+  if (txCount < ACTIVITY_THRESHOLDS.HIGH) return 'MODERATE_ACTIVITY'
+  return 'HIGH_ACTIVITY'
 }
 
 /**
@@ -53,12 +44,12 @@ export const analyzeAddressActivity = async (
     // Get transaction count using eth_getTransactionCount
     const txCount = await web3ReadOnly.getTransactionCount(address, 'latest')
 
-    // Calculate activity score
-    const activityScore = calculateActivityScore(txCount)
+    // Determine activity level
+    const activityLevel = getActivityLevel(txCount)
 
     return {
       txCount,
-      activityScore,
+      activityLevel,
     }
   } catch (error) {
     throw new Error(`Failed to analyze address activity: ${error instanceof Error ? error.message : 'Unknown error'}`)
@@ -71,5 +62,7 @@ export const analyzeAddressActivity = async (
  * @returns True if the address has suspiciously low activity
  */
 export const isLowActivityAddress = (assessment: AddressActivityAssessment): boolean => {
-  return assessment.activityScore < 0.3 || assessment.txCount < ACTIVITY_THRESHOLDS.LOW
+  return assessment.activityLevel === 'NO_ACTIVITY' ||
+         assessment.activityLevel === 'VERY_LOW_ACTIVITY' ||
+         assessment.activityLevel === 'LOW_ACTIVITY'
 }

--- a/apps/web/src/features/address-analysis/config.ts
+++ b/apps/web/src/features/address-analysis/config.ts
@@ -1,0 +1,31 @@
+// Activity thresholds for scoring
+export const ACTIVITY_THRESHOLDS = {
+  VERY_LOW: 1,
+  LOW: 5,
+  MODERATE: 20,
+  HIGH: 100,
+} as const
+
+// Activity messages for user-facing text
+export const ActivityMessages = {
+  NO_ACTIVITY: {
+    title: 'No activity detected',
+    description: 'This address has never made any transactions. Please verify the recipient address carefully.',
+  },
+  VERY_LOW_ACTIVITY: {
+    title: 'Very low activity recipient',
+    description: 'This address has very few transactions. Please verify the recipient address carefully.',
+  },
+  LOW_ACTIVITY: {
+    title: 'Low activity recipient',
+    description: 'This address has low transaction activity. Please verify the recipient address carefully.',
+  },
+  MODERATE_ACTIVITY: {
+    title: 'Moderate activity recipient',
+    description: 'This address has moderate transaction activity.',
+  },
+  HIGH_ACTIVITY: {
+    title: 'Active recipient',
+    description: 'This address has high transaction activity.',
+  },
+} as const

--- a/apps/web/src/features/address-analysis/index.ts
+++ b/apps/web/src/features/address-analysis/index.ts
@@ -1,4 +1,5 @@
 export { useAddressActivity } from './useAddressActivity'
+export { useAddressBookCheck, AddressCheckDescription, AddressCheckSeverity } from './useAddressBookCheck'
 export {
   analyzeAddressActivity,
   isLowActivityAddress,

--- a/apps/web/src/features/address-analysis/index.ts
+++ b/apps/web/src/features/address-analysis/index.ts
@@ -1,0 +1,7 @@
+export { useAddressActivity } from './useAddressActivity'
+export {
+  analyzeAddressActivity,
+  isLowActivityAddress,
+  ACTIVITY_THRESHOLDS,
+  type AddressActivityAssessment,
+} from './addressActivityService'

--- a/apps/web/src/features/address-analysis/index.ts
+++ b/apps/web/src/features/address-analysis/index.ts
@@ -2,6 +2,7 @@ export { useAddressActivity } from './useAddressActivity'
 export {
   analyzeAddressActivity,
   isLowActivityAddress,
-  ACTIVITY_THRESHOLDS,
   type AddressActivityAssessment,
+  type ActivityLevel,
 } from './addressActivityService'
+export { ACTIVITY_THRESHOLDS, ActivityMessages } from './config'

--- a/apps/web/src/features/address-analysis/useAddressActivity.ts
+++ b/apps/web/src/features/address-analysis/useAddressActivity.ts
@@ -1,7 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
-import useChainId from '@/hooks/useChainId'
 import { analyzeAddressActivity, type AddressActivityAssessment, type ActivityLevel } from './addressActivityService'
 import { ActivityMessages } from './config'
 
@@ -29,7 +28,6 @@ export const useAddressActivity = (
   description?: string
 } => {
   const web3ReadOnly = useWeb3ReadOnly()
-  const chainId = useChainId()
 
   const [assessment, error, loading] = useAsync<AddressActivityAssessment | undefined>(async () => {
     if (!address || !web3ReadOnly) {
@@ -37,7 +35,7 @@ export const useAddressActivity = (
     }
 
     return analyzeAddressActivity(address, web3ReadOnly)
-  }, [address, web3ReadOnly, chainId])
+  }, [address, web3ReadOnly])
 
   const message = useMemo(() => {
     if (!assessment) return undefined

--- a/apps/web/src/features/address-analysis/useAddressActivity.ts
+++ b/apps/web/src/features/address-analysis/useAddressActivity.ts
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import useAsync from '@safe-global/utils/hooks/useAsync'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { analyzeAddressActivity, type AddressActivityAssessment } from './addressActivityService'
+
+/**
+ * React hook to analyze address activity
+ * @param address - Ethereum address to analyze
+ * @param chainId - Chain ID to analyze on (optional, for future multi-chain support)
+ * @returns Object containing activity assessment, loading state, and error
+ */
+export const useAddressActivity = (
+  address: string | undefined,
+  chainId?: string,
+): {
+  assessment?: AddressActivityAssessment
+  loading: boolean
+  error?: Error
+} => {
+  const web3ReadOnly = useWeb3ReadOnly()
+
+  const [assessment, error, loading] = useAsync<AddressActivityAssessment | undefined>(async () => {
+    if (!address || !web3ReadOnly) {
+      return undefined
+    }
+
+    return analyzeAddressActivity(address, web3ReadOnly)
+  }, [address, web3ReadOnly, chainId])
+
+  useEffect(() => {
+    if (error) {
+      console.error('Address activity analysis error:', error)
+    }
+  }, [error])
+
+  return {
+    assessment,
+    loading,
+    error,
+  }
+}

--- a/apps/web/src/features/address-analysis/useAddressActivity.ts
+++ b/apps/web/src/features/address-analysis/useAddressActivity.ts
@@ -1,23 +1,23 @@
 import { useEffect } from 'react'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import useChainId from '@/hooks/useChainId'
 import { analyzeAddressActivity, type AddressActivityAssessment } from './addressActivityService'
 
 /**
  * React hook to analyze address activity
  * @param address - Ethereum address to analyze
- * @param chainId - Chain ID to analyze on (optional, for future multi-chain support)
  * @returns Object containing activity assessment, loading state, and error
  */
 export const useAddressActivity = (
   address: string | undefined,
-  chainId?: string,
 ): {
   assessment?: AddressActivityAssessment
   loading: boolean
   error?: Error
 } => {
   const web3ReadOnly = useWeb3ReadOnly()
+  const chainId = useChainId()
 
   const [assessment, error, loading] = useAsync<AddressActivityAssessment | undefined>(async () => {
     if (!address || !web3ReadOnly) {

--- a/apps/web/src/features/address-analysis/useAddressActivity.ts
+++ b/apps/web/src/features/address-analysis/useAddressActivity.ts
@@ -1,13 +1,23 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
 import useChainId from '@/hooks/useChainId'
-import { analyzeAddressActivity, type AddressActivityAssessment } from './addressActivityService'
+import { analyzeAddressActivity, type AddressActivityAssessment, type ActivityLevel } from './addressActivityService'
+import { ActivityMessages } from './config'
+
+type ActivityMessage = {
+  title: string
+  description: string
+}
+
+const getActivityMessage = (activityLevel: ActivityLevel): ActivityMessage => {
+  return ActivityMessages[activityLevel]
+}
 
 /**
  * React hook to analyze address activity
  * @param address - Ethereum address to analyze
- * @returns Object containing activity assessment, loading state, and error
+ * @returns Object containing activity assessment, loading state, error, title and description
  */
 export const useAddressActivity = (
   address: string | undefined,
@@ -15,6 +25,8 @@ export const useAddressActivity = (
   assessment?: AddressActivityAssessment
   loading: boolean
   error?: Error
+  title?: string
+  description?: string
 } => {
   const web3ReadOnly = useWeb3ReadOnly()
   const chainId = useChainId()
@@ -27,6 +39,11 @@ export const useAddressActivity = (
     return analyzeAddressActivity(address, web3ReadOnly)
   }, [address, web3ReadOnly, chainId])
 
+  const message = useMemo(() => {
+    if (!assessment) return undefined
+    return getActivityMessage(assessment.activityLevel)
+  }, [assessment])
+
   useEffect(() => {
     if (error) {
       console.error('Address activity analysis error:', error)
@@ -37,5 +54,7 @@ export const useAddressActivity = (
     assessment,
     loading,
     error,
+    title: message?.title,
+    description: message?.description,
   }
 }

--- a/apps/web/src/features/address-analysis/useAddressBookCheck.ts
+++ b/apps/web/src/features/address-analysis/useAddressBookCheck.ts
@@ -1,0 +1,87 @@
+import { useMemo } from 'react'
+import useAsync from '@safe-global/utils/hooks/useAsync'
+import useChainId from '@/hooks/useChainId'
+import { useMergedAddressBooks } from '@/hooks/useAllAddressBooks'
+import useOwnedSafes from '@/hooks/useOwnedSafes'
+
+export enum AddressCheckDescription {
+  ADDRESS_BOOK = 'Recipient is in the address book',
+  OWNED_SAFE = 'Recipient is an owned Safe',
+  UNKNOWN = 'Recipient is not in the address book and not an owned Safe',
+}
+
+export enum AddressCheckSeverity {
+  OK = 'OK',
+  INFO = 'INFO',
+}
+
+type UseAddressBookCheckReturn = {
+  isKnownAddress: boolean
+  isAddressBookContact: boolean
+  isOwnedSafe: boolean
+  description: AddressCheckDescription
+  severity: AddressCheckSeverity
+  loading: boolean
+  error?: Error
+}
+
+/**
+ * React hook to check if an address is known from various sources
+ * @param address - Ethereum address to check
+ * @returns Object containing check results, loading state, and error
+ */
+export const useAddressBookCheck = (address: string | undefined): UseAddressBookCheckReturn => {
+  const chainId = useChainId()
+  const mergedAddressBooks = useMergedAddressBooks(chainId)
+  const ownedSafes = useOwnedSafes(chainId)
+
+  const [result, error, loading] = useAsync<Omit<UseAddressBookCheckReturn, 'loading' | 'error'> | undefined>(
+    async () => {
+      if (!address) {
+        return undefined
+      }
+
+      // Check if address is in merged address book (local or spaces)
+      const isAddressBookContact = mergedAddressBooks.has(address, chainId)
+
+      // Check if address is a Safe owned by the currently connected wallet
+      const currentChainSafes = ownedSafes[chainId] || []
+      const isOwnedSafe = currentChainSafes.some((safe) => safe.toLowerCase() === address.toLowerCase())
+
+      // Determine if address is known from any source
+      const isKnownAddress = isAddressBookContact || isOwnedSafe
+
+      // Determine description based on checks (priority: address book > owned safe > unknown)
+      let description: AddressCheckDescription
+      if (isAddressBookContact) {
+        description = AddressCheckDescription.ADDRESS_BOOK
+      } else if (isOwnedSafe) {
+        description = AddressCheckDescription.OWNED_SAFE
+      } else {
+        description = AddressCheckDescription.UNKNOWN
+      }
+
+      // Determine severity
+      const severity = isKnownAddress ? AddressCheckSeverity.OK : AddressCheckSeverity.INFO
+
+      return {
+        isKnownAddress,
+        isAddressBookContact,
+        isOwnedSafe,
+        description,
+        severity,
+      }
+    },
+    [address, chainId, mergedAddressBooks, ownedSafes],
+  )
+
+  return {
+    isKnownAddress: result?.isKnownAddress ?? false,
+    isAddressBookContact: result?.isAddressBookContact ?? false,
+    isOwnedSafe: result?.isOwnedSafe ?? false,
+    description: result?.description ?? AddressCheckDescription.UNKNOWN,
+    severity: result?.severity ?? AddressCheckSeverity.INFO,
+    loading,
+    error,
+  }
+}


### PR DESCRIPTION
## Summary

- Add new `useAddressBookCheck` hook in `src/features/address-analysis`
- The hook checks if an Ethereum address is known from multiple sources:
  - Address book contacts (merged local and Spaces address books)
  - Owned Safes by the currently connected wallet
- Returns comprehensive status information including boolean flags, description, and severity level

## Implementation Details

**Hook signature:**
```typescript
useAddressBookCheck(address: string | undefined): {
  isKnownAddress: boolean
  isAddressBookContact: boolean
  isOwnedSafe: boolean
  description: AddressCheckDescription
  severity: AddressCheckSeverity
  loading: boolean
  error?: Error
}
```

**Enums:**
- `AddressCheckDescription`: "Recipient is in the address book" | "Recipient is an owned Safe" | "Recipient is not in the address book and not an owned Safe"
- `AddressCheckSeverity`: "OK" (known address) | "INFO" (unknown address)

**Features:**
- Uses `useMergedAddressBooks` to check both local and Spaces address books automatically
- Checks owned Safes via `useOwnedSafes` hook
- Case-insensitive address matching for owned Safes
- Proper loading and error states
- Priority for description: address book > owned safe > unknown

## Test Plan

- [x] All 8 unit tests pass
- [x] Tests cover undefined address handling
- [x] Tests verify address book detection
- [x] Tests verify owned Safe detection
- [x] Tests verify case-insensitive matching
- [x] Tests verify correct description and severity values
- [x] Tests verify behavior when address changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)