### PR TITLE
fix(mobile): display can not estimate info if total fee is 0

### DIFF
--- a/apps/mobile/src/features/ExecuteTx/components/EstimatedNetworkFee/EstimatedNetworkFee.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/EstimatedNetworkFee/EstimatedNetworkFee.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Text, View } from 'tamagui'
 import { router } from 'expo-router'
+import { Skeleton } from 'moti/skeleton'
+import { useTheme } from '@/src/theme/hooks/useTheme'
 
 import { useAppSelector } from '@/src/store/hooks'
 import { selectActiveChain } from '@/src/store/chains'
@@ -9,10 +11,12 @@ interface EstimatedNetworkFeeProps {
   totalFee: string
   txId: string
   totalFeeRaw: bigint
+  isLoadingFees: boolean
 }
 
-export const EstimatedNetworkFee = ({ totalFee, txId, totalFeeRaw }: EstimatedNetworkFeeProps) => {
+export const EstimatedNetworkFee = ({ totalFee, txId, totalFeeRaw, isLoadingFees }: EstimatedNetworkFeeProps) => {
   const chain = useAppSelector(selectActiveChain)
+  const { colorScheme } = useTheme()
 
   const onPress = () => {
     router.push({
@@ -25,19 +29,23 @@ export const EstimatedNetworkFee = ({ totalFee, txId, totalFeeRaw }: EstimatedNe
     <View flexDirection="row" justifyContent="space-between" gap="$2" alignItems="center">
       <Text color="$textSecondaryLight">Est. network fee</Text>
 
-      <View flexDirection="row" alignItems="center" onPress={onPress}>
-        <View borderStyle="dashed" borderBottomWidth={totalFeeRaw ? 1 : 0} borderColor="$color">
-          {totalFeeRaw ? (
-            <Text fontWeight={700}>
-              {totalFeeRaw ? `${totalFee} ${chain?.nativeCurrency.symbol}` : 'Can not estimate'}
-            </Text>
-          ) : (
-            <Text color="$error" fontWeight={700}>
-              Can not estimate
-            </Text>
-          )}
+      {isLoadingFees ? (
+        <Skeleton colorMode={colorScheme} height={16} width={100} />
+      ) : (
+        <View flexDirection="row" alignItems="center" onPress={onPress}>
+          <View borderStyle="dashed" borderBottomWidth={totalFeeRaw ? 1 : 0} borderColor="$color">
+            {totalFeeRaw ? (
+              <Text fontWeight={700}>
+                {totalFee} {chain?.nativeCurrency.symbol}
+              </Text>
+            ) : (
+              <Text color="$error" fontWeight={700}>
+                Can not estimate
+              </Text>
+            )}
+          </View>
         </View>
-      </View>
+      )}
     </View>
   )
 }

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.tsx
@@ -28,6 +28,7 @@ export function ReviewExecuteFooter({ txId, txDetails }: ReviewFooterProps) {
   const { setGuard } = useGuard()
   const insets = useSafeAreaInsets()
   const { totalFee, estimatedFeeParams, totalFeeRaw } = useGasFee(txDetails, manualParams)
+  const isLoadingFees = estimatedFeeParams.isLoadingGasPrice || estimatedFeeParams.gasLimitLoading
 
   const handleConfirmPress = async () => {
     try {
@@ -77,7 +78,7 @@ export function ReviewExecuteFooter({ txId, txDetails }: ReviewFooterProps) {
       >
         <SelectExecutor address={activeSigner?.value as Address} txId={txId} />
 
-        <EstimatedNetworkFee txId={txId} totalFee={totalFee} totalFeeRaw={totalFeeRaw} />
+        <EstimatedNetworkFee isLoadingFees={isLoadingFees} txId={txId} totalFee={totalFee} totalFeeRaw={totalFeeRaw} />
       </Container>
 
       <SafeButton onPress={handleConfirmPress} width="100%">


### PR DESCRIPTION
## What it solves
Currently we show 0 eth in case we could not estimate the transaction fee.

Resolves #https://linear.app/safe-global/issue/COR-579/add-gas-estimation-and-manual-gas-adjustment-possibility

## How this PR solves it
We check the totalFee, if it is 0 we show the "can not estimate" information in red.

## How to test it

To test this try to execute a tx that cannot be executed, for example queue adding the same owner in 2 different tx, execute the first one and try to execute the 2nd one

## Screenshots
<img width="434" height="810" alt="Screenshot 2025-10-09 at 15 15 37" src="https://github.com/user-attachments/assets/66b8cd75-82cc-41a1-8aae-1c3c43457c00" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
