### PR TITLE
fix(mobile): safes were hidden behind bottom footer

### DIFF
--- a/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
+++ b/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
@@ -147,11 +147,14 @@ export function SafeBottomSheet<T>({
         </BottomSheetView>
       ) : (
         <BottomSheetScrollView
-          style={{
-            marginBottom:
-              (!sortable && FooterComponent ? footerHeight : 0) + getTokenValue(Platform.OS === 'ios' ? '$4' : '$8'),
-          }}
-          contentContainerStyle={[styles.scrollInnerContainer]}
+          contentContainerStyle={[
+            styles.scrollInnerContainer,
+            {
+              paddingBottom:
+                (!sortable && FooterComponent ? footerHeight : insets.bottom) +
+                getTokenValue(Platform.OS === 'ios' ? '$4' : '$8'),
+            },
+          ]}
           stickyHeaderIndices={[0]}
         >
           {title && <TitleHeader />}


### PR DESCRIPTION
## What it solves
Safes in the "My accounts" list were behind the footer. Now the size of the bottom-sheet grows correctly

Resolves https://linear.app/safe-global/issue/COR-504/mobile-my-accounts-showing-all-safes-directly

## How this PR fixes it
We were erroniously using marginBottom on the Scrollview instead of paddingBottom.

## How to test it
No accounts shoudl go behind the footer.

## Screenshots
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/0024f0d0-2d06-4e63-87b0-b7d3c21aa076" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
