### PR TITLE
fix(web): add font-size attribute to TotalAssetValue

### DIFF
--- a/apps/web/src/components/balances/TotalAssetValue/index.tsx
+++ b/apps/web/src/components/balances/TotalAssetValue/index.tsx
@@ -7,10 +7,13 @@ import { useVisibleBalances } from '@/hooks/useVisibleBalances'
 const TotalAssetValue = ({
   fiatTotal,
   title = 'Total asset value',
+  size = 'md',
 }: {
   fiatTotal: string | number | undefined
   title?: string
+  size?: 'md' | 'lg'
 }) => {
+  const fontSizeValue = size === 'lg' ? '44px' : '24px'
   const { safe } = useSafeInfo()
   const { balances } = useVisibleBalances()
 
@@ -19,7 +22,7 @@ const TotalAssetValue = ({
       <Typography fontWeight={700} mb={0.5} fontSize="14px" sx={{ color: 'var(--color-text-secondary)' }}>
         {title}
       </Typography>
-      <Typography component="div" variant="h1" fontSize="24px" lineHeight="1.2" letterSpacing="-0.5px">
+      <Typography component="div" variant="h1" fontSize={fontSizeValue} lineHeight="1.2" letterSpacing="-0.5px">
         {safe.deployed ? (
           fiatTotal !== undefined ? (
             <FiatValue value={fiatTotal} precise />

--- a/apps/web/src/components/dashboard/Overview/Overview.tsx
+++ b/apps/web/src/components/dashboard/Overview/Overview.tsx
@@ -50,7 +50,7 @@ const Overview = (): ReactElement => {
           alignItems={{ xs: 'flex-start', md: 'center' }}
           justifyContent="space-between"
         >
-          <TotalAssetValue fiatTotal={balances.fiatTotal} />
+          <TotalAssetValue fiatTotal={balances.fiatTotal} size="lg" />
 
           {safe.deployed && (
             <Stack


### PR DESCRIPTION
## What it solves

Set's the font-size of TotalAssetValue to 44px at the dashboard, while it stays at 24px on assets and positions pages.

## How this PR fixes it

## How to test it

Check the font size, as documented in the screenshots.

## Screenshots

<img width="1140" height="306" alt="grafik" src="https://github.com/user-attachments/assets/ac376ff0-d917-4243-ba20-fe62f3dfbb4c" />


<img width="505" height="229" alt="grafik" src="https://github.com/user-attachments/assets/952648c5-8df9-4fa2-94a9-a800d3fd2b0f" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
