### PR TITLE
fix(mobile): sorting for my accounts not working

### DIFF
--- a/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
+++ b/apps/mobile/src/components/SafeBottomSheet/SafeBottomSheet.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useEffect, useRef } from 'react'
 import BottomSheet, {
   BottomSheetFooterProps,
   BottomSheetModalProps,
-  BottomSheetView,
   BottomSheetScrollView,
   BottomSheetFooter,
 } from '@gorhom/bottom-sheet'
@@ -129,22 +128,18 @@ export function SafeBottomSheet<T>({
       backdropComponent={() => <BackdropComponent />}
       footerComponent={isSortable ? undefined : renderFooter}
       topInset={insets.top}
-      // bottomInset={Platform.OS === 'android' ? insets.bottom : 0}
       handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
     >
       {isSortable ? (
-        <BottomSheetView style={[styles.contentContainer]}>
-          {title && <TitleHeader />}
-          <DraggableFlatList<T>
-            data={items}
-            style={{ marginBottom: insets.bottom }}
-            containerStyle={{ height: '100%' }}
-            contentContainerStyle={{ paddingBottom: 50 }}
-            onDragEnd={onDragEnd}
-            keyExtractor={(item, index) => (keyExtractor ? keyExtractor({ item, index }) : index.toString())}
-            renderItem={renderItem}
-          />
-        </BottomSheetView>
+        <DraggableFlatList<T>
+          data={items}
+          contentContainerStyle={{ paddingBottom: insets.bottom }}
+          ListHeaderComponent={title ? <TitleHeader /> : undefined}
+          stickyHeaderIndices={title ? [0] : undefined}
+          onDragEnd={onDragEnd}
+          keyExtractor={(item, index) => (keyExtractor ? keyExtractor({ item, index }) : index.toString())}
+          renderItem={renderItem}
+        />
       ) : (
         <BottomSheetScrollView
           contentContainerStyle={[


### PR DESCRIPTION
## What it solves
If we had more accounts visible on the screen, than the available screen height we weren’t able to scroll. 
Resolves https://linear.app/safe-global/issue/COR-653/mobile-can-not-edit-safes-list-if-there-are-10-safes-scroll-doesnt

## How this PR fixes it
I’m not 100% sure how the individual views are stacking and who is strealing the drag event, but if we switch to just having a DraggableFlatList without wrapping it in a view it works fine.

## How to test it
Add more safes than can fit on the screen. Try to sort them - it you should be able to scroll the list and then drag them around. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
