### PR TITLE
feat(mobile): add the last 24h change to assets

### DIFF
--- a/apps/mobile/src/components/FiatChange/FiatChange.tsx
+++ b/apps/mobile/src/components/FiatChange/FiatChange.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { Text, View } from 'tamagui'
+import { type Balance } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
+import { formatPercentage } from '@safe-global/utils/utils/formatters'
+
+interface FiatChangeProps {
+  balanceItem: Balance
+}
+
+export const FiatChange = ({ balanceItem }: FiatChangeProps) => {
+  if (!balanceItem.fiatBalance24hChange) {
+    return (
+      <Text fontSize="$3" color="$colorSecondary" opacity={0.7}>
+        0%
+      </Text>
+    )
+  }
+
+  const changeAsNumber = Number(balanceItem.fiatBalance24hChange) / 100
+  const changeLabel = formatPercentage(changeAsNumber)
+  const direction = changeAsNumber < 0 ? 'down' : changeAsNumber > 0 ? 'up' : 'none'
+
+  const getColor = () => {
+    switch (direction) {
+      case 'down':
+        return '$error'
+      case 'up':
+        return '$success'
+      default:
+        return '$colorSecondary'
+    }
+  }
+
+  const changeSign = () => {
+    switch (direction) {
+      case 'down':
+        return '-'
+      case 'up':
+        return '+'
+      default:
+        return ''
+    }
+  }
+
+  return (
+    <View flexDirection="row" alignItems="center" gap="$1">
+      <Text fontSize="$3" color={getColor()} fontWeight="500">
+        {changeSign()}
+        {changeLabel}
+      </Text>
+    </View>
+  )
+}

--- a/apps/mobile/src/components/FiatChange/__tests__/FiatChange.test.tsx
+++ b/apps/mobile/src/components/FiatChange/__tests__/FiatChange.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { render } from '@/src/tests/test-utils'
+import { FiatChange } from '../FiatChange'
+import { type Balance } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
+
+describe('FiatChange', () => {
+  it('renders "n/a" when fiatBalance24hChange is not present', () => {
+    const mockBalance: Balance = {
+      fiatBalance24hChange: undefined,
+    } as Balance
+
+    const { getByText } = render(<FiatChange balanceItem={mockBalance} />)
+    expect(getByText('0%')).toBeTruthy()
+  })
+
+  it('renders positive change with success color and plus sign', () => {
+    const mockBalance: Balance = {
+      fiatBalance24hChange: '5.00', // 5% increase
+    } as Balance
+
+    const { getByText } = render(<FiatChange balanceItem={mockBalance} />)
+
+    expect(getByText('+5.00%')).toBeTruthy()
+  })
+
+  it('renders negative change with error color and minus sign', () => {
+    const mockBalance: Balance = {
+      fiatBalance24hChange: '-3.00', // 3% decrease
+    } as Balance
+
+    const { getByText } = render(<FiatChange balanceItem={mockBalance} />)
+
+    expect(getByText('-3.00%')).toBeTruthy()
+  })
+
+  it('renders zero change with default styling', () => {
+    const mockBalance: Balance = {
+      fiatBalance24hChange: '0',
+    } as Balance
+
+    const { getByText } = render(<FiatChange balanceItem={mockBalance} />)
+
+    expect(getByText('0.00%')).toBeTruthy()
+  })
+
+  it('renders up to 2 decimal places', () => {
+    const mockBalance: Balance = {
+      fiatBalance24hChange: '1.23456789', // Should be formatted to 2 decimal places
+    } as Balance
+
+    const { getByText } = render(<FiatChange balanceItem={mockBalance} />)
+
+    expect(getByText('+1.23%')).toBeTruthy()
+  })
+})

--- a/apps/mobile/src/components/FiatChange/index.ts
+++ b/apps/mobile/src/components/FiatChange/index.ts
@@ -1,0 +1,1 @@
+export { FiatChange } from './FiatChange'

--- a/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { ListRenderItem } from 'react-native'
 import { useSelector } from 'react-redux'
-import { getTokenValue, Text } from 'tamagui'
+import { getTokenValue, Text, View } from 'tamagui'
 
 import { SafeTab } from '@/src/components/SafeTab'
 import { AssetsCard } from '@/src/components/transactions-list/Card/AssetsCard'
+import { FiatChange } from '@/src/components/FiatChange'
 import { POLLING_INTERVAL } from '@/src/config/constants'
 import { selectActiveSafe } from '@/src/store/activeSafeSlice'
 import { Balance, useBalancesGetBalancesV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
@@ -50,11 +51,16 @@ export function TokensContainer() {
             item.tokenInfo.symbol
           }`}
           rightNode={
-            <Text fontSize="$4" fontWeight={600} color="$color">
-              {shouldDisplayPreciseBalance(fiatBalance, 7)
-                ? formatCurrencyPrecise(fiatBalance, currency)
-                : formatCurrency(fiatBalance, currency)}
-            </Text>
+            <View alignItems="flex-end">
+              <Text fontSize="$4" fontWeight={600} color="$color">
+                {shouldDisplayPreciseBalance(fiatBalance, 7)
+                  ? formatCurrencyPrecise(fiatBalance, currency)
+                  : formatCurrency(fiatBalance, currency)}
+              </Text>
+              <View marginTop="$1">
+                <FiatChange balanceItem={item} />
+              </View>
+            </View>
           }
         />
       )


### PR DESCRIPTION
## What it solves
Display the 24h balance change

Resolves https://linear.app/safe-global/issue/COR-507/mobile-asset-page-design-update

## How this PR fixes it
Adds the necessary component to display the data.

## How to test it
Open any safe and observe that the assets now have a balance change indicator

## Screenshots
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/cdf43b16-c77c-4a21-b299-ef063e531114" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
