### PR TITLE
fix(method): empty call method

### DIFF
--- a/apps/mobile/src/features/HistoryTransactionDetails/components/history-views/HistoryContract.tsx
+++ b/apps/mobile/src/features/HistoryTransactionDetails/components/history-views/HistoryContract.tsx
@@ -46,17 +46,19 @@ export function HistoryContract({ txId, txInfo }: HistoryContractProps) {
 
       <Container padding="$4" gap="$4" borderRadius="$3">
         {/* Method Call Badge */}
-        <View alignItems="center" flexDirection="row" justifyContent="space-between">
-          <Text color="$textSecondaryLight">Call</Text>
-          <Badge
-            circleProps={methodBadgeProps}
-            themeName="badge_background"
-            fontSize={13}
-            textContentProps={{ fontFamily: 'DM Mono' }}
-            circular={false}
-            content={txInfo.methodName ?? ''}
-          />
-        </View>
+        {txInfo.methodName && (
+          <View alignItems="center" flexDirection="row" justifyContent="space-between">
+            <Text color="$textSecondaryLight">Call</Text>
+            <Badge
+              circleProps={methodBadgeProps}
+              themeName="badge_background"
+              fontSize={13}
+              textContentProps={{ fontFamily: 'DM Mono' }}
+              circular={false}
+              content={txInfo.methodName}
+            />
+          </View>
+        )}
 
         {/* Contract Information */}
         <View alignItems="center" flexDirection="row" justifyContent="space-between">


### PR DESCRIPTION
## What it solves
the methodName on txInfo could be null and we were erroneously outputing an empty string. Now we hide the "call" row completely. 

Resolves https://linear.app/safe-global/issue/COR-604/mobile-showing-empty-call-value

## How to test it
the call row should no longer be visible when viewing this tx on mobile:
https://safe-wallet-web.dev.5afe.dev/transactions/tx?safe=eth:0x8675B754342754A30A2AeF474D114d8460bca19b&id=multisig_0x8675B754342754A30A2AeF474D114d8460bca19b_0xaa885db5121623eadcce567f1f4969edc1f0c0fba992a644d288123c6bbbac6b

## Screenshots
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/b78b91b5-9ba2-4ea5-adb7-24c75c44272e" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
