### PR TITLE
fix(mobile): make private key / seed phrase input a little more user friendly

### DIFF
--- a/apps/mobile/src/features/ImportSigner/ImportSigner.container.tsx
+++ b/apps/mobile/src/features/ImportSigner/ImportSigner.container.tsx
@@ -43,6 +43,8 @@ export function ImportSigner() {
               success={!!wallet || inputType === 'seed-phrase'}
               textAlign="center"
               error={error}
+              numberOfLines={isMasked ? 1 : 3}
+              multiline={isMasked ? false : true}
               right={
                 <TouchableOpacity onPress={() => setIsMasked((prev) => !prev)} hitSlop={12}>
                   <SafeFontIcon name={isMasked ? 'eye-on' : 'eye-off'} size={16} color={'$color'} />


### PR DESCRIPTION
## What it solves
It was not easy to enter a private key or seed phrase because the TextInput was a single line. If the input is multiline we could not mask it. Now I opted for a hack - if the input is masked, we change it to a single line - this way RN's mask on the input works fine. If the user disables the mask, then it is 2 lines and it is a bit more comfortable to enter the text

Resolves https://linear.app/safe-global/issue/COR-668/mobile-display-a-seed-phrase-in-a-few-line-otherwise-its-hard-to

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
