### PR TITLE
fix(mobile): hide tx-checks if they are not enabled on the chain

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/TransactionChecks.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/TransactionChecks/TransactionChecks.tsx
@@ -7,6 +7,11 @@ import { useTransactionSecurity } from './hooks/useTransactionSecurity'
 import { getTransactionChecksLabel, shouldShowBottomContent } from './utils/transactionChecksUtils'
 import { TransactionChecksLeftNode } from './components/TransactionChecksLeftNode'
 import { TransactionChecksBottomContent } from './components/TransactionChecksBottomContent'
+import { useHasFeature } from '@/src/hooks/useHasFeature'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { isTxSimulationEnabled } from '@safe-global/utils/components/tx/security/tenderly/utils'
+import { selectActiveChain } from '@/src/store/chains'
+import { useAppSelector } from '@/src/store/hooks'
 
 interface TransactionChecksProps {
   txId: string
@@ -15,13 +20,20 @@ interface TransactionChecksProps {
 
 export function TransactionChecks({ txId, txDetails }: TransactionChecksProps) {
   const router = useRouter()
+  const chain = useAppSelector(selectActiveChain)
   const security = useTransactionSecurity(txDetails)
+  const blockaidEnabled = useHasFeature(FEATURES.RISK_MITIGATION) ?? false
+  const tenderlyEnabled = isTxSimulationEnabled(chain ?? undefined) ?? false
 
   const handleTransactionChecksPress = () => {
     router.push({
       pathname: '/transaction-checks',
       params: { txId },
     })
+  }
+
+  if (!tenderlyEnabled && !blockaidEnabled) {
+    return null
   }
 
   return (

--- a/apps/mobile/src/features/TransactionChecks/components/TransactionChecksView.tsx
+++ b/apps/mobile/src/features/TransactionChecks/components/TransactionChecksView.tsx
@@ -31,7 +31,8 @@ type Props = {
 }
 
 export const TransactionChecksView = ({ tenderly, blockaid }: Props) => {
-  const { enabled, fetchStatus } = tenderly
+  const { enabled: tenderlyEnabled, fetchStatus } = tenderly
+  const { enabled: blockaidEnabled } = blockaid
   const { handleScroll } = useScrollableHeader({
     children: <NavBarTitle>Transaction checks</NavBarTitle>,
   })
@@ -42,15 +43,13 @@ export const TransactionChecksView = ({ tenderly, blockaid }: Props) => {
         <LargeHeaderTitle marginBottom={'$5'}>Transaction checks</LargeHeaderTitle>
       </View>
       <YStack gap={'$4'}>
-        <Container gap={'$3'}>
-          {blockaid.enabled ? (
+        {blockaidEnabled && (
+          <Container gap={'$3'}>
             <BlockaidBalanceChanges blockaidResponse={blockaid.payload} fetchStatusLoading={blockaid.loading} />
-          ) : (
-            <Text>Security check is disabled</Text>
-          )}
-        </Container>
+          </Container>
+        )}
         <Container gap={'$3'}>
-          {enabled ? (
+          {tenderlyEnabled ? (
             <>
               <XStack justifyContent="space-between">
                 <XStack gap={'$2'}>


### PR DESCRIPTION
## What it solves
Hides the tx-checks screens if blockaid or tenderli are not enabled on the chian

Resolves https://linear.app/safe-global/issue/COR-670/mobile-when-blockaid-or-tenderly-are-not-available-on-the-network-we


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
