### PR TITLE
fix(web): prevent inline simulation button from overlapping other elements

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/index.tsx
@@ -112,12 +112,6 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
         </div>
 
         <div className={css.detailsWrapper}>
-          {isQueue && (
-            <div className={css.inlineSimulation}>
-              <QueuedTxSimulation transaction={txDetails} />
-            </div>
-          )}
-
           <div className={css.txData}>
             <ErrorBoundary fallback={<div>Error parsing data</div>}>
               <TxData
@@ -137,6 +131,11 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
               </TxData>
             </ErrorBoundary>
           </div>
+          {isQueue && (
+            <div className={css.inlineSimulation}>
+              <QueuedTxSimulation transaction={txDetails} />
+            </div>
+          )}
         </div>
 
         {/* Module information*/}

--- a/apps/web/src/components/transactions/TxDetails/styles.module.css
+++ b/apps/web/src/components/transactions/TxDetails/styles.module.css
@@ -8,6 +8,9 @@
 
 .detailsWrapper {
   position: relative;
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .details {
@@ -25,10 +28,7 @@
 }
 
 .inlineSimulation {
-  display: flex;
-  justify-content: flex-end;
   margin: var(--space-2);
-  position: absolute;
   right: 0;
   top: 0;
   z-index: 1;
@@ -51,10 +51,6 @@
 .advancedDetails,
 .txModule {
   padding: var(--space-2);
-}
-
-.txData {
-  border-bottom: 1px solid var(--color-border-light);
 }
 
 .txData:empty {
@@ -119,6 +115,10 @@
 
 @media (max-width: 1350px) {
   .inlineSimulation {
-    position: relative;
+    margin-left: auto;
+  }
+
+  .detailsWrapper {
+    flex-direction: column-reverse;
   }
 }


### PR DESCRIPTION
## What it solves
This PR introduces a minor fix in the web frontend. It addresses a UI layout issue where the inline simulation button was overlapping other interface elements.

Resolves #
[COR-669](https://linear.app/safe-global/issue/COR-669/simulate-button-overlaps-adjacent-ui-elements-on-certain-screen-sizes)

## How to test it
Open the transaction queue, resize the browser window to make it narrower, and ensure that the simulation button does not overlap any other elements.

## Screenshots
<img width="671" height="150" alt="Screenshot 2025-10-14 at 13 30 34" src="https://github.com/user-attachments/assets/c5333b92-8241-46bc-84d4-760757c03581" />
