### PR TITLE
feat(Swaps): add new fee calculation

### DIFF
--- a/apps/web/src/features/swap/helpers/__tests__/fee.test.ts
+++ b/apps/web/src/features/swap/helpers/__tests__/fee.test.ts
@@ -7,8 +7,8 @@ describe('calculateFeePercentageInBps', () => {
     let orderParams: OnTradeParamsPayload = {
       sellToken: { address: 'non-stablecoin-address' },
       buyToken: { address: 'non-stablecoin-address' },
-      buyTokenFiatAmount: '50000',
-      sellTokenFiatAmount: '50000',
+      buyTokenFiatAmount: '49999',
+      sellTokenFiatAmount: '49999',
       orderKind: 'sell',
     } as OnTradeParamsPayload
 
@@ -17,12 +17,21 @@ describe('calculateFeePercentageInBps', () => {
 
     orderParams = {
       ...orderParams,
-      buyTokenFiatAmount: '100000',
-      sellTokenFiatAmount: '100000',
+      buyTokenFiatAmount: '99999',
+      sellTokenFiatAmount: '99999',
     }
 
     const result2 = calculateFeePercentageInBps(orderParams)
-    expect(result2).toBe(20)
+    expect(result2).toBe(35)
+
+    orderParams = {
+      ...orderParams,
+      buyTokenFiatAmount: '999999',
+      sellTokenFiatAmount: '999999',
+    }
+
+    const result3 = calculateFeePercentageInBps(orderParams)
+    expect(result3).toBe(20)
 
     orderParams = {
       ...orderParams,
@@ -30,16 +39,16 @@ describe('calculateFeePercentageInBps', () => {
       sellTokenFiatAmount: '1000000',
     }
 
-    const result3 = calculateFeePercentageInBps(orderParams)
-    expect(result3).toBe(10)
+    const result4 = calculateFeePercentageInBps(orderParams)
+    expect(result4).toBe(10)
   })
 
   it('returns correct fee for non-stablecoin and buy order', () => {
     let orderParams: OnTradeParamsPayload = {
       sellToken: { address: 'non-stablecoin-address' },
       buyToken: { address: 'non-stablecoin-address' },
-      buyTokenFiatAmount: '50000',
-      sellTokenFiatAmount: '50000',
+      buyTokenFiatAmount: '49999',
+      sellTokenFiatAmount: '49999',
       orderKind: 'buy',
     } as OnTradeParamsPayload
 
@@ -48,12 +57,21 @@ describe('calculateFeePercentageInBps', () => {
 
     orderParams = {
       ...orderParams,
-      buyTokenFiatAmount: '100000',
-      sellTokenFiatAmount: '100000',
+      buyTokenFiatAmount: '99999',
+      sellTokenFiatAmount: '99999',
     }
 
     const result2 = calculateFeePercentageInBps(orderParams)
-    expect(result2).toBe(20)
+    expect(result2).toBe(35)
+
+    orderParams = {
+      ...orderParams,
+      buyTokenFiatAmount: '999999',
+      sellTokenFiatAmount: '999999',
+    }
+
+    const result3 = calculateFeePercentageInBps(orderParams)
+    expect(result3).toBe(20)
 
     orderParams = {
       ...orderParams,
@@ -61,8 +79,8 @@ describe('calculateFeePercentageInBps', () => {
       sellTokenFiatAmount: '1000000',
     }
 
-    const result3 = calculateFeePercentageInBps(orderParams)
-    expect(result3).toBe(10)
+    const result4 = calculateFeePercentageInBps(orderParams)
+    expect(result4).toBe(10)
   })
 
   it('returns correct fee for stablecoin and sell order', () => {
@@ -70,8 +88,8 @@ describe('calculateFeePercentageInBps', () => {
     let orderParams: OnTradeParamsPayload = {
       sellToken: { address: stableCoinAddressesKeys[0] },
       buyToken: { address: stableCoinAddressesKeys[1] },
-      buyTokenFiatAmount: '50000',
-      sellTokenFiatAmount: '50000',
+      buyTokenFiatAmount: '49999',
+      sellTokenFiatAmount: '49999',
       orderKind: 'sell',
     } as OnTradeParamsPayload
 
@@ -80,12 +98,21 @@ describe('calculateFeePercentageInBps', () => {
 
     orderParams = {
       ...orderParams,
-      buyTokenFiatAmount: '100000',
-      sellTokenFiatAmount: '100000',
+      buyTokenFiatAmount: '99999',
+      sellTokenFiatAmount: '99999',
     }
 
     const result2 = calculateFeePercentageInBps(orderParams)
-    expect(result2).toBe(7)
+    expect(result2).toBe(10)
+
+    orderParams = {
+      ...orderParams,
+      buyTokenFiatAmount: '999999',
+      sellTokenFiatAmount: '999999',
+    }
+
+    const result3 = calculateFeePercentageInBps(orderParams)
+    expect(result3).toBe(7)
 
     orderParams = {
       ...orderParams,
@@ -93,8 +120,8 @@ describe('calculateFeePercentageInBps', () => {
       sellTokenFiatAmount: '1000000',
     }
 
-    const result3 = calculateFeePercentageInBps(orderParams)
-    expect(result3).toBe(5)
+    const result4 = calculateFeePercentageInBps(orderParams)
+    expect(result4).toBe(5)
   })
 
   it('returns correct fee for stablecoin and buy order', () => {
@@ -102,8 +129,8 @@ describe('calculateFeePercentageInBps', () => {
     let orderParams: OnTradeParamsPayload = {
       sellToken: { address: stableCoinAddressesKeys[0] },
       buyToken: { address: stableCoinAddressesKeys[1] },
-      buyTokenFiatAmount: '50000',
-      sellTokenFiatAmount: '50000',
+      buyTokenFiatAmount: '49999',
+      sellTokenFiatAmount: '49999',
       orderKind: 'buy',
     } as OnTradeParamsPayload
 
@@ -112,12 +139,21 @@ describe('calculateFeePercentageInBps', () => {
 
     orderParams = {
       ...orderParams,
-      buyTokenFiatAmount: '100000',
-      sellTokenFiatAmount: '100000',
+      buyTokenFiatAmount: '99999',
+      sellTokenFiatAmount: '99999',
     }
 
     const result2 = calculateFeePercentageInBps(orderParams)
-    expect(result2).toBe(7)
+    expect(result2).toBe(10)
+
+    orderParams = {
+      ...orderParams,
+      buyTokenFiatAmount: '999999',
+      sellTokenFiatAmount: '999999',
+    }
+
+    const result3 = calculateFeePercentageInBps(orderParams)
+    expect(result3).toBe(7)
 
     orderParams = {
       ...orderParams,
@@ -125,17 +161,17 @@ describe('calculateFeePercentageInBps', () => {
       sellTokenFiatAmount: '1000000',
     }
 
-    const result3 = calculateFeePercentageInBps(orderParams)
-    expect(result3).toBe(5)
+    const result4 = calculateFeePercentageInBps(orderParams)
+    expect(result4).toBe(5)
   })
 
   describe('V2 fees when nativeCowSwapFeeV2Enabled is true', () => {
-    it('returns 70 bps for regular tokens (0-100k)', () => {
+    it('returns 70 bps for regular tokens (0-50k)', () => {
       const orderParams: OnTradeParamsPayload = {
         sellToken: { address: 'non-stablecoin-address' },
         buyToken: { address: 'non-stablecoin-address' },
-        buyTokenFiatAmount: '50000',
-        sellTokenFiatAmount: '50000',
+        buyTokenFiatAmount: '49999',
+        sellTokenFiatAmount: '49999',
         orderKind: 'sell',
       } as OnTradeParamsPayload
 
@@ -143,13 +179,25 @@ describe('calculateFeePercentageInBps', () => {
       expect(result).toBe(70)
     })
 
-    it('returns 20 bps for stablecoin pairs (0-100k)', () => {
-      const stableCoinAddressesKeys = Object.keys(stableCoinAddresses)
+    it('returns 35 bps for regular tokens (50k-100k)', () => {
       const orderParams: OnTradeParamsPayload = {
-        sellToken: { address: stableCoinAddressesKeys[0] },
-        buyToken: { address: stableCoinAddressesKeys[1] },
-        buyTokenFiatAmount: '50000',
-        sellTokenFiatAmount: '50000',
+        sellToken: { address: 'non-stablecoin-address' },
+        buyToken: { address: 'non-stablecoin-address' },
+        buyTokenFiatAmount: '99999',
+        sellTokenFiatAmount: '99999',
+        orderKind: 'sell',
+      } as OnTradeParamsPayload
+
+      const result = calculateFeePercentageInBps(orderParams, true)
+      expect(result).toBe(35)
+    })
+
+    it('returns 20 bps for regular tokens (100k-1M)', () => {
+      const orderParams: OnTradeParamsPayload = {
+        sellToken: { address: 'non-stablecoin-address' },
+        buyToken: { address: 'non-stablecoin-address' },
+        buyTokenFiatAmount: '999999',
+        sellTokenFiatAmount: '999999',
         orderKind: 'sell',
       } as OnTradeParamsPayload
 
@@ -157,17 +205,73 @@ describe('calculateFeePercentageInBps', () => {
       expect(result).toBe(20)
     })
 
-    it('returns standard fees for V2 above 100k', () => {
+    it('returns 10 bps for regular tokens (>1M)', () => {
       const orderParams: OnTradeParamsPayload = {
         sellToken: { address: 'non-stablecoin-address' },
         buyToken: { address: 'non-stablecoin-address' },
-        buyTokenFiatAmount: '150000',
-        sellTokenFiatAmount: '150000',
+        buyTokenFiatAmount: '1000000',
+        sellTokenFiatAmount: '1000000',
         orderKind: 'sell',
       } as OnTradeParamsPayload
 
       const result = calculateFeePercentageInBps(orderParams, true)
-      expect(result).toBe(20) // V2 tier 2 fee
+      expect(result).toBe(10)
+    })
+
+    it('returns 15 bps for stablecoin pairs (0-50k)', () => {
+      const stableCoinAddressesKeys = Object.keys(stableCoinAddresses)
+      const orderParams: OnTradeParamsPayload = {
+        sellToken: { address: stableCoinAddressesKeys[0] },
+        buyToken: { address: stableCoinAddressesKeys[1] },
+        buyTokenFiatAmount: '49999',
+        sellTokenFiatAmount: '49999',
+        orderKind: 'sell',
+      } as OnTradeParamsPayload
+
+      const result = calculateFeePercentageInBps(orderParams, true)
+      expect(result).toBe(15)
+    })
+
+    it('returns 10 bps for stablecoin pairs (50k-100k)', () => {
+      const stableCoinAddressesKeys = Object.keys(stableCoinAddresses)
+      const orderParams: OnTradeParamsPayload = {
+        sellToken: { address: stableCoinAddressesKeys[0] },
+        buyToken: { address: stableCoinAddressesKeys[1] },
+        buyTokenFiatAmount: '99999',
+        sellTokenFiatAmount: '99999',
+        orderKind: 'sell',
+      } as OnTradeParamsPayload
+
+      const result = calculateFeePercentageInBps(orderParams, true)
+      expect(result).toBe(10)
+    })
+
+    it('returns 7 bps for stablecoin pairs (100k-1M)', () => {
+      const stableCoinAddressesKeys = Object.keys(stableCoinAddresses)
+      const orderParams: OnTradeParamsPayload = {
+        sellToken: { address: stableCoinAddressesKeys[0] },
+        buyToken: { address: stableCoinAddressesKeys[1] },
+        buyTokenFiatAmount: '999999',
+        sellTokenFiatAmount: '999999',
+        orderKind: 'sell',
+      } as OnTradeParamsPayload
+
+      const result = calculateFeePercentageInBps(orderParams, true)
+      expect(result).toBe(7)
+    })
+
+    it('returns 5 bps for stablecoin pairs (>1M)', () => {
+      const stableCoinAddressesKeys = Object.keys(stableCoinAddresses)
+      const orderParams: OnTradeParamsPayload = {
+        sellToken: { address: stableCoinAddressesKeys[0] },
+        buyToken: { address: stableCoinAddressesKeys[1] },
+        buyTokenFiatAmount: '1000000',
+        sellTokenFiatAmount: '1000000',
+        orderKind: 'sell',
+      } as OnTradeParamsPayload
+
+      const result = calculateFeePercentageInBps(orderParams, true)
+      expect(result).toBe(5)
     })
   })
 
@@ -176,8 +280,8 @@ describe('calculateFeePercentageInBps', () => {
       const orderParams: OnTradeParamsPayload = {
         sellToken: { address: 'non-stablecoin-address' },
         buyToken: { address: 'non-stablecoin-address' },
-        buyTokenFiatAmount: '50000',
-        sellTokenFiatAmount: '50000',
+        buyTokenFiatAmount: '49999',
+        sellTokenFiatAmount: '49999',
         orderKind: 'sell',
       } as OnTradeParamsPayload
 
@@ -190,8 +294,8 @@ describe('calculateFeePercentageInBps', () => {
       const orderParams: OnTradeParamsPayload = {
         sellToken: { address: stableCoinAddressesKeys[0] },
         buyToken: { address: stableCoinAddressesKeys[1] },
-        buyTokenFiatAmount: '50000',
-        sellTokenFiatAmount: '50000',
+        buyTokenFiatAmount: '49999',
+        sellTokenFiatAmount: '49999',
         orderKind: 'sell',
       } as OnTradeParamsPayload
 
@@ -203,8 +307,8 @@ describe('calculateFeePercentageInBps', () => {
       const orderParams: OnTradeParamsPayload = {
         sellToken: { address: 'non-stablecoin-address' },
         buyToken: { address: 'non-stablecoin-address' },
-        buyTokenFiatAmount: '50000',
-        sellTokenFiatAmount: '50000',
+        buyTokenFiatAmount: '49999',
+        sellTokenFiatAmount: '49999',
         orderKind: 'sell',
       } as OnTradeParamsPayload
 

--- a/apps/web/src/features/swap/helpers/fee.ts
+++ b/apps/web/src/features/swap/helpers/fee.ts
@@ -4,29 +4,34 @@ import { stableCoinAddresses } from '@/features/swap/helpers/data/stablecoins'
 const FEE_PERCENTAGE_BPS = {
   REGULAR: {
     TIER_1: 35,
-    TIER_2: 20,
-    TIER_3: 10,
+    TIER_2: 35,
+    TIER_3: 20,
+    TIER_4: 10,
   },
   STABLE: {
     TIER_1: 10,
-    TIER_2: 7,
-    TIER_3: 5,
+    TIER_2: 10,
+    TIER_3: 7,
+    TIER_4: 5,
   },
   V2_REGULAR: {
     TIER_1: 70,
-    TIER_2: 20,
-    TIER_3: 10,
+    TIER_2: 35,
+    TIER_3: 20,
+    TIER_4: 10,
   },
   V2_STABLE: {
-    TIER_1: 20,
-    TIER_2: 7,
-    TIER_3: 5,
+    TIER_1: 15,
+    TIER_2: 10,
+    TIER_3: 7,
+    TIER_4: 5,
   },
 }
 
 const FEE_TIERS = {
-  TIER_1: 100_000, // 0 - 100k
-  TIER_2: 1_000_000, // 100k - 1m
+  TIER_1: 50_000, // 0 - 50k
+  TIER_2: 100_000, // 50k - 100k
+  TIER_3: 1_000_000, // 100k - 1m
 }
 
 const getLowerCaseStableCoinAddresses = () => {
@@ -68,5 +73,9 @@ export const calculateFeePercentageInBps = (
     return isStableCoin ? stableFees.TIER_2 : regularFees.TIER_2
   }
 
-  return isStableCoin ? stableFees.TIER_3 : regularFees.TIER_3
+  if (fiatAmount < FEE_TIERS.TIER_3) {
+    return isStableCoin ? stableFees.TIER_3 : regularFees.TIER_3
+  }
+
+  return isStableCoin ? stableFees.TIER_4 : regularFees.TIER_4
 }


### PR DESCRIPTION
## What it solves

Resolves https://linear.app/safe-global/issue/GRO-96/adjust-fees-to-07percent-on-more-network

## How this PR fixes it

Adds new fee logic.

## How to test it

Test the 4 fee tiers for "regular" and "stable" swaps. Check chains with new fee logic (Base) and chains with old fee logic (Ethereum Mainnet).

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
