### PR TITLE
fix(mobile): add the review data table on ledger review screen

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewAndConfirmView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewAndConfirmView.tsx
@@ -11,9 +11,10 @@ import { useTheme as useCurrentTheme } from '@/src/theme/hooks/useTheme'
 interface ReviewAndConfirmViewProps {
   txDetails: TransactionDetails
   children: ReactNode
+  header?: ReactNode
 }
 
-export function ReviewAndConfirmView({ txDetails, children }: ReviewAndConfirmViewProps) {
+export function ReviewAndConfirmView({ txDetails, children, header }: ReviewAndConfirmViewProps) {
   const { isDark } = useCurrentTheme()
   const theme = useTheme()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,7 +43,7 @@ export function ReviewAndConfirmView({ txDetails, children }: ReviewAndConfirmVi
           shadowColor: 'transparent',
           shadowOffset: { width: 0, height: 0 },
         }}
-        renderHeader={() => <ReviewHeader />}
+        renderHeader={() => (header ? <>{header}</> : <ReviewHeader />)}
       >
         <Tabs.Tab name="Data" label="Data">
           <DataTab />

--- a/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/tabs/HashesTab.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/tabs/HashesTab.tsx
@@ -7,6 +7,7 @@ import { calculateSafeTransactionHash } from '@safe-global/protocol-kit/dist/src
 import useSafeInfo from '@/src/hooks/useSafeInfo'
 import extractTxInfo from '@/src/services/tx/extractTx'
 import { getDomainHash, getSafeTxMessageHash } from '@safe-global/utils/utils/safe-hashes'
+import { Container } from '@/src/components/Container'
 
 interface HashesTabProps {
   txDetails: TransactionDetails
@@ -39,33 +40,35 @@ export const HashesTab = ({ txDetails }: HashesTabProps) => {
   }, [safe.version, safe.chainId, safeAddress, txDetails])
 
   return (
-    <Tabs.ScrollView contentContainerStyle={{ padding: 16 }}>
-      <View gap="$3">
-        <View>
-          <Text fontSize="$3" color="$colorSecondary">
-            Domain hash
-          </Text>
-          <Text fontSize="$5" color="$color">
-            {domainHash ?? '—'}
-          </Text>
+    <Tabs.ScrollView contentContainerStyle={{ padding: 16, marginTop: 8 }}>
+      <Container>
+        <View gap="$3">
+          <View>
+            <Text fontSize="$3" color="$colorSecondary">
+              Domain hash
+            </Text>
+            <Text fontSize="$5" color="$color">
+              {domainHash ?? '—'}
+            </Text>
+          </View>
+          <View>
+            <Text fontSize="$3" color="$colorSecondary">
+              Message hash
+            </Text>
+            <Text fontSize="$5" color="$color">
+              {messageHash ?? '—'}
+            </Text>
+          </View>
+          <View>
+            <Text fontSize="$3" color="$colorSecondary">
+              safeTxHash
+            </Text>
+            <Text fontSize="$5" color="$color">
+              {safeTxHash ?? '—'}
+            </Text>
+          </View>
         </View>
-        <View>
-          <Text fontSize="$3" color="$colorSecondary">
-            Message hash
-          </Text>
-          <Text fontSize="$5" color="$color">
-            {messageHash ?? '—'}
-          </Text>
-        </View>
-        <View>
-          <Text fontSize="$3" color="$colorSecondary">
-            safeTxHash
-          </Text>
-          <Text fontSize="$5" color="$color">
-            {safeTxHash ?? '—'}
-          </Text>
-        </View>
-      </View>
+      </Container>
     </Tabs.ScrollView>
   )
 }

--- a/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/tabs/JSONTab.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/tabs/JSONTab.tsx
@@ -18,7 +18,7 @@ export function JSONTab({ txDetails }: JSONTabProps) {
   }
 
   return (
-    <Tabs.ScrollView contentContainerStyle={{ padding: 16, marginTop: 16 }}>
+    <Tabs.ScrollView contentContainerStyle={{ padding: 16, marginTop: 8 }}>
       <Container>
         <View position="absolute" right={10} top={10} zIndex={1000}>
           <CopyButton value={jsonData} color="$colorSecondary" size={16} text="JSON value copied to clipboard" />

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.tsx
@@ -86,6 +86,14 @@ export function ReviewExecuteFooter({ txId, txDetails, relaysRemaining }: Review
         nonce: estimatedFeeParams.nonce?.toString(),
       }
 
+      if (executionMethod === ExecutionMethod.WITH_RELAY) {
+        router.push({
+          pathname: '/execute-transaction',
+          params,
+        })
+        return
+      }
+
       // If active signer is a Ledger device, start the Ledger-specific execution flow
       if (activeSigner?.type === 'ledger') {
         router.push({


### PR DESCRIPTION
## What it solves
Newer ledger devices were showing more data than what one sees on Nano X for example. We decided to display our standard Data | Hashes | Json table on the ledger review step.

Resolves https://linear.app/safe-global/issue/COR-663/mobile-the-user-can-not-check-the-data-from-the-mobile-app-in-the-new

## How this PR fixes it
- ads the Data | Hashes | Json component to the review ledger step
- modified the component to accept a custom header
- fixed a bug when a ledger signer was selected we were not able to use the relayer for txs

## Screenshots
<img width="150" alt="Screenshot 2025-10-14 at 14 15 32" src="https://github.com/user-attachments/assets/fae8725b-1296-4329-8d03-f91fd7100d26" />
<img width="150" alt="Screenshot 2025-10-14 at 14 14 47" src="https://github.com/user-attachments/assets/f2f236df-e189-4c33-af84-bdd93505a4ea" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
