### PR TITLE
fix(mobile): enable token list only when the list exist on the chain

### DIFF
--- a/apps/mobile/src/features/Assets/Assets.container.tsx
+++ b/apps/mobile/src/features/Assets/Assets.container.tsx
@@ -8,6 +8,8 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { TokensContainer } from '@/src/features/Assets/components/Tokens'
 import { NFTsContainer } from '@/src/features/Assets/components/NFTs'
 import { AssetsHeaderContainer } from '@/src/features/Assets/components/AssetsHeader'
+import { useHasFeature } from '@/src/hooks/useHasFeature'
+import { FEATURES } from '@safe-global/utils/utils/chains'
 
 const tabItems = [
   {
@@ -22,13 +24,14 @@ const tabItems = [
 
 export function AssetsContainer() {
   const router = useRouter()
+  const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
 
   const handleOpenManageTokens = () => {
     router.push('/manage-tokens-sheet')
   }
 
   const renderRightNode = (activeTabLabel: string) => {
-    if (activeTabLabel !== 'Tokens') {
+    if (activeTabLabel !== 'Tokens' || !hasDefaultTokenlist) {
       return null
     }
 

--- a/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
@@ -18,13 +18,16 @@ import { NoFunds } from '@/src/features/Assets/components/NoFunds'
 import { AssetError } from '@/src/features/Assets/Assets.error'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectCurrency, selectTokenList, TOKEN_LISTS } from '@/src/store/settingsSlice'
+import { useHasFeature } from '@/src/hooks/useHasFeature'
+import { FEATURES } from '@safe-global/utils/utils/chains'
 
 export function TokensContainer() {
   const activeSafe = useSelector(selectActiveSafe)
   const currency = useAppSelector(selectCurrency)
   const tokenList = useAppSelector(selectTokenList)
+  const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
 
-  const trusted = tokenList === TOKEN_LISTS.TRUSTED
+  const trusted = hasDefaultTokenlist ? tokenList === TOKEN_LISTS.TRUSTED : true
 
   const { data, isFetching, error, isLoading, refetch } = useBalancesGetBalancesV1Query(
     !activeSafe


### PR DESCRIPTION
## What it solves
The "token list" was not respecting the on/off setting per chain.

Resolves https://linear.app/safe-global/issue/COR-507/mobile-asset-page-design-update#comment-881fa50d

## How this PR fixes it
- hide the token list selection option when it is not available on the chain
- if the feature is not available on the chain only fetch with hideSuspicious tokens


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
