### PR TITLE
fix(mobile): android textinput height was wrong

### DIFF
--- a/apps/mobile/src/components/SafeInput/styled.ts
+++ b/apps/mobile/src/components/SafeInput/styled.ts
@@ -27,7 +27,8 @@ export const StyledInput = styled(Input, {
   borderWidth: 0,
 
   style: {
-    padding: 0,
     lineHeight: 20.5,
+    paddingTop: 0,
+    paddingBottom: 0,
   },
 })


### PR DESCRIPTION
## What it solves
On android the paddingTop and paddingBottom were making it impossible to have 2 lines of text visible in a TextInput

Resolves https://linear.app/safe-global/issue/COR-668/mobile-display-a-seed-phrase-in-a-few-line-otherwise-its-hard-to#comment-cabdf344

## How this PR fixes it
- removes the padding on TextInput

## How to test it
Naviagate to singer -> import signer. Now when displaying the pk or seedphrase the user should be able to type 2 lines of text and they shouldn't be cut off.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
