### PR TITLE
fix(mobile): display threshold change or confirmations

### DIFF
--- a/apps/mobile/src/features/HistoryTransactionDetails/components/history-views/HistoryAddSigner.tsx
+++ b/apps/mobile/src/features/HistoryTransactionDetails/components/history-views/HistoryAddSigner.tsx
@@ -7,8 +7,6 @@ import { NormalizedSettingsChangeTransaction } from '@/src/features/ConfirmTx/co
 import { HistoryAdvancedDetailsButton } from '@/src/features/HistoryTransactionDetails/components/HistoryAdvancedDetailsButton'
 import { HashDisplay } from '@/src/components/HashDisplay'
 import { ThresholdChangeDisplay, NetworkDisplay } from '../shared'
-import { InfoSheet } from '@/src/components/InfoSheet'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 
 interface HistoryAddSignerProps {
   txId: string
@@ -33,17 +31,6 @@ export function HistoryAddSigner({ txId, txInfo, executionInfo }: HistoryAddSign
             <Text color="$textSecondaryLight">New signer</Text>
             <XStack alignItems="center" gap="$2">
               <HashDisplay value={txInfo.settingsInfo?.owner?.value} />
-            </XStack>
-          </XStack>
-          <XStack alignItems="center" justifyContent="space-between">
-            <InfoSheet info="Confirmations required for new transactions">
-              <XStack alignItems="center" gap="$1">
-                <Text color="$textSecondaryLight">Confirmations</Text>
-                <SafeFontIcon name="info" size={16} color="$textSecondaryLight" />
-              </XStack>
-            </InfoSheet>
-            <XStack alignItems="center" gap="$2">
-              <Text fontSize="$4">{txInfo.settingsInfo?.threshold}</Text>
             </XStack>
           </XStack>
 

--- a/apps/mobile/src/features/HistoryTransactionDetails/components/shared/ThresholdChangeDisplay.tsx
+++ b/apps/mobile/src/features/HistoryTransactionDetails/components/shared/ThresholdChangeDisplay.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
-import { View, Text } from 'tamagui'
+import { Text, XStack } from 'tamagui'
 import { MultisigExecutionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { NormalizedSettingsChangeTransaction } from '@/src/features/ConfirmTx/components/ConfirmationView/types'
+import { InfoSheet } from '@/src/components/InfoSheet'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 
 interface ThresholdChangeDisplayProps {
   txInfo: NormalizedSettingsChangeTransaction
@@ -12,20 +14,32 @@ export function ThresholdChangeDisplay({ txInfo, executionInfo }: ThresholdChang
   const hasThresholdChanged = txInfo.settingsInfo?.threshold !== executionInfo.confirmationsRequired
 
   if (!hasThresholdChanged) {
-    return null
+    return (
+      <XStack alignItems="center" justifyContent="space-between">
+        <InfoSheet info="Confirmations required for new transactions">
+          <XStack alignItems="center" gap="$1">
+            <Text color="$textSecondaryLight">Confirmations</Text>
+            <SafeFontIcon name="info" size={16} color="$textSecondaryLight" />
+          </XStack>
+        </InfoSheet>
+        <XStack alignItems="center" gap="$2">
+          <Text fontSize="$4">{txInfo.settingsInfo?.threshold}</Text>
+        </XStack>
+      </XStack>
+    )
   }
 
   return (
-    <View alignItems="center" flexDirection="row" justifyContent="space-between">
+    <XStack alignItems="center" justifyContent="space-between">
       <Text color="$textSecondaryLight">Threshold change</Text>
-      <View flexDirection="row" alignItems="center" gap="$2">
+      <XStack alignItems="center" gap="$2">
         <Text fontSize="$4">
           {txInfo.settingsInfo?.threshold}/{executionInfo.signers.length}
         </Text>
         <Text textDecorationLine="line-through" color="$textSecondaryLight" fontSize="$4">
           {executionInfo.confirmationsRequired}/{executionInfo.signers.length}
         </Text>
-      </View>
-    </View>
+      </XStack>
+    </XStack>
   )
 }


### PR DESCRIPTION
## What it solves
If the threshold changes, display that. If it doesn’t change display the confirmation necessary after that tx.

Resolves https://linear.app/safe-global/issue/COR-603/mobile-add-signer-is-missing-the-new-threshold-in-the-first-tx-detail#comment-d23c814e

## How this PR fixes it
When there was no threshold change we were not showing anything. Now that we opted for showing confirmations we ended up in situatioons where we would show the confirmations next to the threshold and for others we would show nothing. With this change we either show confirmations or threshold

## How to test it

## Screenshots
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/a32e32e5-e406-48b0-98e5-34407c85a858" />
<img width="150" alt="grafik" src="https://github.com/user-attachments/assets/a1a97050-13fe-4fbf-a5f1-35e0bd7c90ac" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
