### PR TITLE
fix(web): improve TxNonce layout and styling

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxLayout/styles.module.css
+++ b/apps/web/src/components/tx-flow/common/TxLayout/styles.module.css
@@ -10,6 +10,7 @@
 .headerInner {
   display: flex;
   justify-content: space-between;
+  word-break: break-all;
   align-items: center;
   padding: var(--space-3);
   border-bottom: 1px solid var(--color-border-light);

--- a/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
@@ -299,7 +299,7 @@ const TxNonce = ({ canEdit = true }: { canEdit?: boolean } = {}) => {
   const { nonce, recommendedNonce, isReadOnly } = useContext(SafeTxContext)
 
   return (
-    <Box data-testid="nonce-fld" display="flex" alignItems="center" gap={1}>
+    <Box data-testid="nonce-fld" display="flex" alignItems="center" gap={1} className={css.nonce}>
       Nonce{' '}
       <Typography component="span" fontWeight={700}>
         #

--- a/apps/web/src/components/tx-flow/common/TxNonce/styles.module.css
+++ b/apps/web/src/components/tx-flow/common/TxNonce/styles.module.css
@@ -39,3 +39,8 @@
   position: absolute;
   right: 0;
 }
+
+.nonce {
+  min-width: 170px;
+  justify-content: flex-end;
+}


### PR DESCRIPTION
Resolves [COR-629](https://linear.app/safe-global/issue/COR-629/tx-flow-nonce-display-is-broken)
This PR fixes an issue where the nonce became misaligned when the text preceding it was too long.