### PR TITLE
feat(web): add No Fee November card to token transfer create step

### DIFF
--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/CreateTokenTransfer.tsx
@@ -42,6 +42,8 @@ import Track from '@/components/common/Track'
 import { MODALS_EVENTS } from '@/services/analytics'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import { TxFlowContext, type TxFlowContextType } from '../../TxFlowProvider'
+import NoFeeNovemberTransactionCard from '@/features/no-fee-november/components/NoFeeNovemberTransactionCard'
+import useIsNoFeeNovemberEnabled from '@/features/no-fee-november/hooks/useIsNoFeeNovemberEnabled'
 
 export const AutocompleteItem = (item: { tokenInfo: Balance['tokenInfo']; balance: string }): ReactElement => (
   <Grid
@@ -87,6 +89,7 @@ export const CreateTokenTransfer = ({ txNonce }: CreateTokenTransferProps): Reac
   const [safeApps] = useRemoteSafeApps({ name: SafeAppsName.CSV })
   const isMassPayoutsEnabled = useHasFeature(FEATURES.MASS_PAYOUTS)
   const { onNext, data } = useContext(TxFlowContext) as TxFlowContextType<MultiTokenTransferParams>
+  const isNoFeeNovemberEnabled = useIsNoFeeNovemberEnabled()
 
   useEffect(() => {
     if (txNonce !== undefined) {
@@ -203,6 +206,8 @@ export const CreateTokenTransfer = ({ txNonce }: CreateTokenTransferProps): Reac
                     color={canAddMoreRecipients ? 'primary' : 'error.main'}
                   >{`${recipientFields.length}/${MAX_RECIPIENTS}`}</Typography>
                 </Stack>
+
+                {isNoFeeNovemberEnabled && <NoFeeNovemberTransactionCard />}
 
                 {hasInsufficientFunds && (
                   <Alert data-testid="insufficient-balance-error" severity="error">

--- a/apps/web/src/features/no-fee-november/components/NoFeeNovemberTransactionCard/index.tsx
+++ b/apps/web/src/features/no-fee-november/components/NoFeeNovemberTransactionCard/index.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { Box, Card, Stack, Typography } from '@mui/material'
+import SafeCoinsIllustration from '@/components/common/SafeCoinsIllustration'
+import css from './styles.module.css'
+import Link from 'next/link'
+import useNoFeeNovemberEligibility from '@/features/no-fee-november/hooks/useNoFeeNovemberEligibility'
+import InfoIcon from '@mui/icons-material/Info'
+
+const NoFeeNovemberTransactionCard = () => {
+  const { isEligible, isLoading, error } = useNoFeeNovemberEligibility()
+
+  // Loading state - show skeleton
+  if (isLoading) {
+    return (
+      <Card className={css.card}>
+        <Stack direction="row" alignItems="center" spacing={3}>
+          <Box className={css.skeletonIcon} />
+          <Box flex={1}>
+            <Box className={`${css.skeletonBox} ${css.skeletonTitle}`} />
+            <Box className={`${css.skeletonBox} ${css.skeletonSubtitle}`} />
+          </Box>
+        </Stack>
+      </Card>
+    )
+  }
+
+  // Error state - show eligible content (fail gracefully)
+  if (error) {
+    return (
+      <Card className={css.card}>
+        <Stack direction="row" alignItems="center" spacing={3}>
+          <Box className={css.iconContainer}>
+            <SafeCoinsIllustration />
+          </Box>
+          <Box flex={1}>
+            <Typography variant="subtitle2" fontWeight="bold" color="static.main" className={css.title}>
+              Enjoy No Fee November
+            </Typography>
+            <Typography variant="body2" color="static.light" className={css.description}>
+              SAFE holders enjoy gasless transactions on Mainnet this November.{' '}
+              <Link href="https://help.safe.global/en/" style={{ textDecoration: 'underline', fontWeight: 'bold' }}>
+                Learn more
+              </Link>
+            </Typography>
+          </Box>
+        </Stack>
+      </Card>
+    )
+  }
+
+  // Eligible state (from Figma design)
+  if (isEligible === true) {
+    return (
+      <Card className={css.card}>
+        <Stack direction="row" alignItems="center" spacing={3}>
+          <Box className={css.iconContainer}>
+            <SafeCoinsIllustration />
+          </Box>
+          <Box flex={1}>
+            <Typography variant="subtitle2" fontWeight="bold" color="static.main" className={css.title}>
+              Enjoy No Fee November
+            </Typography>
+            <Typography variant="body2" color="static.light" className={css.description}>
+              SAFE holders enjoy gasless transactions on Mainnet this November.{' '}
+              <Link href="https://help.safe.global/en/" style={{ textDecoration: 'underline', fontWeight: 'bold' }}>
+                Learn more
+              </Link>
+            </Typography>
+          </Box>
+        </Stack>
+      </Card>
+    )
+  }
+
+  // Not eligible state (from banner in assets/home, without Get SAFE button)
+  return (
+    <Card className={css.card}>
+      <Stack direction="row" alignItems="center" spacing={3}>
+        <Box className={css.iconContainer}>
+          <SafeCoinsIllustration />
+        </Box>
+        <Box flex={1}>
+          <Typography variant="subtitle2" fontWeight="bold" color="static.main" className={css.title}>
+            Enjoy No Fee November
+          </Typography>
+          <Typography variant="body2" color="static.light" className={css.description}>
+            SAFE holders enjoy gasless transactions on Mainnet this November.{' '}
+            <Link href="https://help.safe.global/en/" style={{ textDecoration: 'underline', fontWeight: 'bold' }}>
+              Learn more
+            </Link>
+          </Typography>
+
+          {/* Info message with icon */}
+          <Stack direction="row" alignItems="center" spacing={1} className={css.infoStack}>
+            <InfoIcon fontSize="small" className={css.infoIcon} />
+            <Typography variant="caption" color="static.light">
+              You don&apos;t hold any SAFE yet — get some to enjoy No Fee November.
+            </Typography>
+          </Stack>
+        </Box>
+      </Stack>
+    </Card>
+  )
+}
+
+export default NoFeeNovemberTransactionCard

--- a/apps/web/src/features/no-fee-november/components/NoFeeNovemberTransactionCard/styles.module.css
+++ b/apps/web/src/features/no-fee-november/components/NoFeeNovemberTransactionCard/styles.module.css
@@ -1,0 +1,58 @@
+.card {
+  padding: var(--space-4);
+  background: #ffffff;
+  border: 1px solid #5fddff;
+  border-radius: 6px;
+  height: 100%;
+}
+
+.iconContainer {
+  position: relative;
+  width: 58px;
+  height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.title {
+  pointer-events: none;
+  user-select: none;
+  margin-bottom: 4px;
+}
+
+.description {
+  pointer-events: auto;
+}
+
+.infoStack {
+  margin-top: var(--space-1);
+}
+
+.infoIcon {
+  color: var(--color-static-light);
+}
+
+/* Skeleton loading states */
+.skeletonIcon {
+  width: 58px;
+  height: 58px;
+  background-color: var(--color-grey-200);
+  border-radius: var(--space-1);
+  flex-shrink: 0;
+}
+
+.skeletonBox {
+  background-color: var(--color-grey-200);
+  border-radius: var(--space-1);
+}
+
+.skeletonTitle {
+  height: 20px;
+  margin-bottom: 4px;
+}
+
+.skeletonSubtitle {
+  height: 16px;
+}


### PR DESCRIPTION
## What it solves

Adds a “No Fee November” informational card to the first step of the token transfer flow (Create → Add recipient), so users see sponsorship eligibility before proceeding.
Linear: REVE-518 — Web app: Transaction Create: “No Fee November” card
Figma: https://www.figma.com/design/HL0FjJQtWGnGt15RlKOhus/No-fee-November?node-id=3061-5178&m=dev

## How this PR fixes it

- Introduces NoFeeNovemberTransactionCard with loading/eligible/not‑eligible states.
- Reuses existing eligibility hooks used by the banner.

## How to test it

Open New transaction → Send tokens (Create step).

## Screenshots
<img width="1647" height="1167" alt="Screenshot 2025-10-22 at 10 01 37" src="https://github.com/user-attachments/assets/f5a61d08-12c6-43c8-afc8-98abe9cc5e27" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
