### PR TITLE
Feat(web): show tx notes in summary

### DIFF
--- a/apps/web/src/components/transactions/TxSummary/index.tsx
+++ b/apps/web/src/components/transactions/TxSummary/index.tsx
@@ -38,7 +38,6 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
   const isPending = useIsPending(tx.id)
   const executionInfo = isMultisigExecutionInfo(tx.executionInfo) ? tx.executionInfo : undefined
   const expiredSwap = useIsExpiredSwap(tx.txInfo)
-  const note = isMultisigExecutionInfo(tx.executionInfo) ? tx.note : undefined
 
   return (
     <Box
@@ -66,9 +65,9 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
       <Box data-testid="tx-type" gridArea="type">
         <TxType tx={tx} />
 
-        {note && (
-          <Typography variant="body2" component="span" color="text.secondary" title={note}>
-            {ellipsis(note, 25)}
+        {tx.note && (
+          <Typography variant="body2" component="span" color="text.secondary" title={tx.note}>
+            {ellipsis(tx.note, 25)}
           </Typography>
         )}
       </Box>


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/EPD-383/transaction-notes-show-in-tx-summary

<img width="1143" height="561" alt="Screenshot 2025-10-27 at 15 10 41" src="https://github.com/user-attachments/assets/26c39aea-c248-4461-99b3-5fde54cbdb2b" />

Notes are now displayed in the tx summary under the tx type. They are trimmed to 25 characters.