### PR TITLE
fix(mobile): wrong ledger live derivation path used

### DIFF
--- a/apps/mobile/src/features/Ledger/hooks/useLedgerAddresses.ts
+++ b/apps/mobile/src/features/Ledger/hooks/useLedgerAddresses.ts
@@ -5,11 +5,14 @@ import { ledgerEthereumService } from '@/src/services/ledger/ledger-ethereum.ser
 import logger from '@/src/utils/logger'
 import { useAddresses, type BaseAddress } from '@/src/hooks/useAddresses'
 
+export type DerivationPathType = 'ledger-live' | 'legacy-ledger'
+
 interface UseLedgerAddressesParams {
   sessionId?: string
+  derivationPathType?: DerivationPathType
 }
 
-export const useLedgerAddresses = ({ sessionId }: UseLedgerAddressesParams) => {
+export const useLedgerAddresses = ({ sessionId, derivationPathType = 'ledger-live' }: UseLedgerAddressesParams) => {
   const validateSession = useCallback((): { isValid: boolean; error?: { code: string; message: string } } => {
     if (!sessionId) {
       return {
@@ -29,25 +32,29 @@ export const useLedgerAddresses = ({ sessionId }: UseLedgerAddressesParams) => {
     return { isValid: true }
   }, [sessionId])
 
-  const fetchAddresses = useCallback(async (count: number, startIndex: number): Promise<BaseAddress[]> => {
-    const session = ledgerDMKService.getCurrentSession()
-    if (!session) {
-      throw new Error('No session available')
-    }
+  const fetchAddresses = useCallback(
+    async (count: number, startIndex: number, pathType?: DerivationPathType): Promise<BaseAddress[]> => {
+      const session = ledgerDMKService.getCurrentSession()
+      if (!session) {
+        throw new Error('No session available')
+      }
 
-    const addresses = await ledgerEthereumService.getEthereumAddresses(session, count, startIndex)
-    return addresses.map((a) => ({ address: a.address, path: a.path, index: a.index }))
-  }, [])
+      const typeToUse = pathType ?? derivationPathType
+      const addresses = await ledgerEthereumService.getEthereumAddresses(session, count, startIndex, typeToUse)
+      return addresses.map((a) => ({ address: a.address, path: a.path, index: a.index }))
+    },
+    [derivationPathType],
+  )
 
-  const { addresses, isLoading, error, clearError, loadAddresses } = useAddresses({
+  const { addresses, isLoading, error, clearError, loadAddresses, clearAddresses } = useAddresses({
     fetchAddresses,
     validateInput: validateSession,
   })
 
   const fetchAddressesWrapper = useCallback(
-    async (count: number) => {
+    async (count: number, startIndex?: number, pathType?: DerivationPathType) => {
       try {
-        await loadAddresses(count)
+        await loadAddresses(count, startIndex, pathType)
       } catch (error) {
         logger.error('Error loading addresses:', error)
       }
@@ -61,5 +68,6 @@ export const useLedgerAddresses = ({ sessionId }: UseLedgerAddressesParams) => {
     error,
     clearError,
     fetchAddresses: fetchAddressesWrapper,
+    clearAddresses,
   }
 }

--- a/apps/mobile/src/services/ledger/ledger-ethereum.service.ts
+++ b/apps/mobile/src/services/ledger/ledger-ethereum.service.ts
@@ -11,6 +11,8 @@ export interface EthereumAddress {
   index: number
 }
 
+export type DerivationPathType = 'ledger-live' | 'legacy-ledger'
+
 export class LedgerEthereumService {
   private static instance: LedgerEthereumService
 
@@ -78,15 +80,21 @@ export class LedgerEthereumService {
    * @param session The device session
    * @param count Number of addresses to retrieve (default: 10)
    * @param startIndex Starting index for address derivation (default: 0)
+   * @param derivationPathType Type of derivation path to use: 'ledger-live' uses account path, 'legacy-ledger' uses indexed path (default: 'ledger-live')
    * @returns Array of Ethereum addresses with their derivation paths
    */
-  public async getEthereumAddresses(session: DeviceSessionId, count = 10, startIndex = 0): Promise<EthereumAddress[]> {
+  public async getEthereumAddresses(
+    session: DeviceSessionId,
+    count = 10,
+    startIndex = 0,
+    derivationPathType: DerivationPathType = 'ledger-live',
+  ): Promise<EthereumAddress[]> {
     const signerEth = this.createSigner(session)
     const addresses: EthereumAddress[] = []
 
-    // Derive addresses using the standard Ethereum derivation path (BIP-44 account derivation)
+    // Derive addresses using the appropriate derivation path
     for (let i = startIndex; i < startIndex + count; i++) {
-      const fullPath = getAccountPath(i)
+      const fullPath = derivationPathType === 'ledger-live' ? getAccountPath(i) : `m/44'/60'/0'/${i}`
       const path = fullPath.substring(2) // Remove "m/" prefix for Ledger SDK
 
       try {


### PR DESCRIPTION
## What it solves
I made a mistake the first time I implemented the ledger support. The derived address was only correct for the first item that we load. Since I was passing an indexed account path (what is normally used in MM) we were ending up with addresses that are not the same as the one that Ledger Live generated as it only increased the account part in the path. 

Resolves: https://linear.app/safe-global/issue/COR-743/connecting-ledger-with-the-mobile

## How this PR fixes it
- increment the correct parth of the path
- ads a new "legacy ledger" option that uses a different path used by old wallets that integrated ledger in the past

## How to test it
- connect a ledger to the app and observe the shown paths

## Screenshots
<img width="150" alt="IMG_4044" src="https://github.com/user-attachments/assets/b45b4452-b8b8-40ce-a270-a442c4b269e6" />
<img width="150" alt="IMG_4043" src="https://github.com/user-attachments/assets/d8f61e49-c7ca-4a01-8fee-c3eac61e73aa" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
