### PR TITLE
chore(mobile): bump version to v1.0.4

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -20,7 +20,7 @@ const config = {
   name: name,
   slug: 'safe-mobileapp',
   owner: 'safeglobal',
-  version: '1.0.3',
+  version: '1.0.4',
   extra: {
     storybookEnabled: process.env.STORYBOOK_ENABLED,
     eas: {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@safe-global/mobile",
   "main": "index.js",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "doctor": {
     "reactNativeDirectoryCheck": {
       "enabled": true


### PR DESCRIPTION
## What it solves
We need to bump, otherwise we can't distribute new builds as 1.0.3 is already approved & released. 

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
