### PR TITLE
fix(mobile): listenerMiddleware/error [TypeError: Cannot read property 'pendingTxs' of undefined

### DIFF
--- a/apps/mobile/src/store/middleware/pendingTxs.ts
+++ b/apps/mobile/src/store/middleware/pendingTxs.ts
@@ -109,7 +109,7 @@ const startIndexingWatcher = (listenerApi: AppListenerEffectAPI, txId: string, c
 
 function isHydrateAction(action: Action): action is Action<typeof REHYDRATE> & {
   key: string
-  payload: RootState
+  payload: Partial<RootState> | undefined
   err: unknown
 } {
   return action.type === REHYDRATE
@@ -183,7 +183,10 @@ export const pendingTxsListeners = (startListening: AppStartListening) => {
   startListening({
     predicate: (action) => isHydrateAction(action),
     effect: (action, listenerApi) => {
-      runWatchers(listenerApi, action.payload.pendingTxs)
+      const pendingTxs = action.payload?.pendingTxs
+      if (pendingTxs) {
+        runWatchers(listenerApi, pendingTxs)
+      }
     },
   })
 


### PR DESCRIPTION
## What it solves
On completely new installs in dev mode we were seeing the following console error: "listenerMiddleware/error [TypeError: Cannot read property 'pendingTxs' of undefined"

This is due to the redux rehydrate action being called for the first time, but it doesn't have any data. So the action is undefined. Trying t oaccess the .pendingTxs caused the type error. 

## How to test it
On a new install in dev mode one should not see any error. This error didn't have any influence on the production builds - it's being silently swallowed
 

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
