### PR TITLE
feat(analytics): limit requests to mixpanel for new user properties

### DIFF
--- a/apps/web/src/services/analytics/useMixpanel.ts
+++ b/apps/web/src/services/analytics/useMixpanel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useTheme } from '@mui/material/styles'
 import mixpanel from 'mixpanel-browser'
 import {
@@ -43,6 +43,7 @@ const useMixpanel = () => {
   const { safe } = useSafeInfo()
   const currentChain = useChain(safe?.chainId || '')
   const walletChain = useChain(wallet?.chainId || '')
+  const lastUserPropertiesRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (isMixpanelEnabled) {
@@ -122,7 +123,13 @@ const useMixpanel = () => {
   useEffect(() => {
     if (!userProperties) return
 
-    mixpanelSetUserProperties(userProperties.properties)
+    // Deep comparison to prevent infinite loop from object reference changes
+    const currentPropertiesStr = JSON.stringify(userProperties.properties)
+
+    if (lastUserPropertiesRef.current !== currentPropertiesStr) {
+      lastUserPropertiesRef.current = currentPropertiesStr
+      mixpanelSetUserProperties(userProperties.properties)
+    }
   }, [userProperties])
 }
 


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/GRO-115/solve-bug-at-mixpanel

## How this PR fixes it

## How to test it

Open the app, make sure user properties are sent to Mixpanel, but only at every change of user properties, and not repeatatly (check the console of another staging to see how repeated calls look like, it's very obvious).

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
