### PR TITLE
fix(Safe Shield): hide SafeShield widget on specific flows

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
@@ -78,6 +78,7 @@ type TxLayoutProps = {
   isBatch?: boolean
   isReplacement?: boolean
   isMessage?: boolean
+  hideSafeShield?: boolean
 }
 
 const TxLayout = ({
@@ -94,6 +95,7 @@ const TxLayout = ({
   isBatch = false,
   isReplacement = false,
   isMessage = false,
+  hideSafeShield = false,
 }: TxLayoutProps): ReactElement => {
   const smallScreenBreakpoint = 'md'
   const theme = useTheme()
@@ -175,7 +177,7 @@ const TxLayout = ({
                     </Grid>
 
                     {/* Sidebar */}
-                    {!isReplacement && (
+                    {!isReplacement && !hideSafeShield && (
                       <Grid
                         size={{ xs: 12, [smallScreenBreakpoint]: 4.5 }}
                         sx={{ width: { lg: 320 } }}

--- a/apps/web/src/components/tx-flow/flows/RecoveryAttempt/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/RecoveryAttempt/index.tsx
@@ -5,7 +5,7 @@ import type { RecoveryQueueItem } from '@/features/recovery/services/recovery-st
 
 const RecoveryAttemptFlow = ({ item }: { item: RecoveryQueueItem }) => {
   return (
-    <TxLayout title="Recovery" subtitle="Execute recovery" icon={SaveAddressIcon} step={0} hideNonce>
+    <TxLayout title="Recovery" subtitle="Execute recovery" icon={SaveAddressIcon} step={0} hideNonce hideSafeShield>
       <RecoveryAttemptReview item={item} />
     </TxLayout>
   )

--- a/apps/web/src/components/tx-flow/flows/SignMessage/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/SignMessage/index.tsx
@@ -55,6 +55,7 @@ const SignMessageFlow = ({ ...props }: SignMessageProps) => {
       step={0}
       hideNonce
       isMessage
+      hideSafeShield
     >
       <ErrorBoundary fallback={<div>Error signing message</div>}>
         <SignMessage {...props} />

--- a/apps/web/src/features/counterfactual/ActivateAccountFlow.tsx
+++ b/apps/web/src/features/counterfactual/ActivateAccountFlow.tsx
@@ -146,7 +146,7 @@ const ActivateAccountFlow = () => {
   const submitDisabled = !isSubmittable || isWrongChain
 
   return (
-    <TxLayout title="Activate account" hideNonce>
+    <TxLayout title="Activate account" hideNonce hideSafeShield>
       <TxCard>
         <Typography>
           You&apos;re about to deploy this Safe Account and will have to confirm the transaction with your connected


### PR DESCRIPTION
## What it solves

Hides SafeShield widget on the following flows because these are special cases where we don't have transaction data that can be analyszed:
- ActivateAccount
- RecoveryAttempt
- SignMessage

Resolves [COR-762](https://linear.app/safe-global/issue/COR-762/safe-shield-no-scanning-for-the-safe-activation)

## How this PR fixes it
- Introduced hideSafeShield prop in TxLayout to control the visibility of the Safe Shield sidebar.

## How to test it
Open any of the flows mentioned above and verify that the SafeShield widget does not appear.

## Screenshots
<img width="1669" height="804" alt="Screenshot 2025-10-29 at 17 51 38" src="https://github.com/user-attachments/assets/9c337840-6ac8-4b6a-97f6-04d39ad91fb0" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
