### PR TITLE
feat(safe-schield): Add custom AnalysisCard for delegate call

### DIFF
--- a/apps/web/src/features/safe-shield/components/AnalysisGroupCard/AnalysisGroupCard.tsx
+++ b/apps/web/src/features/safe-shield/components/AnalysisGroupCard/AnalysisGroupCard.tsx
@@ -2,13 +2,10 @@ import { type ReactElement, useMemo, useState } from 'react'
 import { Box, Typography, Stack, IconButton, Collapse } from '@mui/material'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import { ContractStatus, type GroupedAnalysisResults } from '@safe-global/utils/features/safe-shield/types'
-import { isAddressChange, mapVisibleAnalysisResults } from '@safe-global/utils/features/safe-shield/utils'
+import { mapVisibleAnalysisResults } from '@safe-global/utils/features/safe-shield/utils'
 import { SeverityIcon } from '../SeverityIcon'
-import { AnalysisIssuesDisplay } from '../AnalysisIssuesDisplay'
-import { AddressChanges } from '../AddressChanges'
 import { AnalysisGroupCardItem } from './AnalysisGroupCardItem'
 import { DelegateCallCardItem } from './DelegateCallCardItem'
-import { ShowAllAddress } from './ShowAllAddress'
 
 export const AnalysisGroupCard = ({
   data,
@@ -59,29 +56,13 @@ export const AnalysisGroupCard = ({
         <Box sx={{ padding: '4px 12px 16px' }}>
           <Stack gap={2}>
             {visibleResults.map((result, index) => {
-              const severity = !index ? result.severity : undefined
+              const isPrimary = index === 0
 
               if (result.type === ContractStatus.UNEXPECTED_DELEGATECALL) {
-                return (
-                  <DelegateCallCardItem key={index} severity={severity}>
-                    <AnalysisIssuesDisplay result={result} />
-
-                    {isAddressChange(result) && <AddressChanges result={result} />}
-
-                    {result.addresses?.length && <ShowAllAddress addresses={result.addresses} />}
-                  </DelegateCallCardItem>
-                )
+                return <DelegateCallCardItem key={index} result={result} isPrimary={isPrimary} />
               }
 
-              return (
-                <AnalysisGroupCardItem key={index} severity={severity} description={result.description}>
-                  <AnalysisIssuesDisplay result={result} />
-
-                  {isAddressChange(result) && <AddressChanges result={result} />}
-
-                  {result.addresses?.length && <ShowAllAddress addresses={result.addresses} />}
-                </AnalysisGroupCardItem>
-              )
+              return <AnalysisGroupCardItem key={index} result={result} isPrimary={isPrimary} />
             })}
           </Stack>
         </Box>

--- a/apps/web/src/features/safe-shield/components/AnalysisGroupCard/AnalysisGroupCardItem.tsx
+++ b/apps/web/src/features/safe-shield/components/AnalysisGroupCard/AnalysisGroupCardItem.tsx
@@ -1,26 +1,35 @@
 import { Stack, Typography } from '@mui/material'
 import { Box } from '@mui/material'
-import { type Severity } from '@safe-global/utils/features/safe-shield/types'
+import { type AnalysisResult } from '@safe-global/utils/features/safe-shield/types'
+import { isAddressChange } from '@safe-global/utils/features/safe-shield/utils'
 import { SEVERITY_COLORS } from '../../constants'
+import { AnalysisIssuesDisplay } from '../AnalysisIssuesDisplay'
+import { AddressChanges } from '../AddressChanges'
+import { ShowAllAddress } from './ShowAllAddress'
 
 interface AnalysisGroupCardItemProps {
-  children?: React.ReactNode
-  severity?: Severity
-  description: React.ReactNode
+  result: AnalysisResult
+  isPrimary?: boolean
+  description?: React.ReactNode
 }
 
-export const AnalysisGroupCardItem = ({ children, severity, description }: AnalysisGroupCardItemProps) => {
-  const borderColor = severity ? SEVERITY_COLORS[severity].main : 'var(--color-border-main)'
+export const AnalysisGroupCardItem = ({ result, isPrimary = false, description }: AnalysisGroupCardItemProps) => {
+  const borderColor = isPrimary && result.severity ? SEVERITY_COLORS[result.severity].main : 'var(--color-border-main)'
+  const displayDescription = description ?? result.description
 
   return (
     <Box bgcolor="background.main" borderRadius="4px" overflow="hidden">
       <Box sx={{ borderLeft: `4px solid ${borderColor}`, padding: '12px' }}>
         <Stack gap={2}>
           <Typography variant="body2" color="primary.light">
-            {description}
+            {displayDescription}
           </Typography>
 
-          {children}
+          <AnalysisIssuesDisplay result={result} />
+
+          {isAddressChange(result) && <AddressChanges result={result} />}
+
+          {result.addresses?.length && <ShowAllAddress addresses={result.addresses} />}
         </Stack>
       </Box>
     </Box>

--- a/apps/web/src/features/safe-shield/components/AnalysisGroupCard/DelegateCallCardItem.tsx
+++ b/apps/web/src/features/safe-shield/components/AnalysisGroupCard/DelegateCallCardItem.tsx
@@ -1,30 +1,23 @@
-import { Link } from '@mui/material'
-import { type Severity } from '@safe-global/utils/features/safe-shield/types'
+import { type AnalysisResult } from '@safe-global/utils/features/safe-shield/types'
 import { AnalysisGroupCardItem } from './AnalysisGroupCardItem'
 import { type ReactElement } from 'react'
+import ExternalLink from '@/components/common/ExternalLink'
+import { HelpCenterArticle } from '@safe-global/utils/config/constants'
 
 interface DelegateCallCardItemProps {
-  children?: React.ReactNode
-  severity?: Severity
+  result: AnalysisResult
+  isPrimary?: boolean
 }
 
-export const DelegateCallCardItem = ({ children, severity }: DelegateCallCardItemProps): ReactElement => {
+export const DelegateCallCardItem = ({ result, isPrimary = false }: DelegateCallCardItemProps): ReactElement => {
   const description = (
     <>
       This transaction calls a smart contract that will be able to modify your Safe account.{' '}
-      <Link
-        href="https://help.safe.global/en/articles/40794-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
+      <ExternalLink noIcon href={HelpCenterArticle.UNEXPECTED_DELEGATE_CALL}>
         Learn more
-      </Link>
+      </ExternalLink>
     </>
   )
 
-  return (
-    <AnalysisGroupCardItem severity={severity} description={description}>
-      {children}
-    </AnalysisGroupCardItem>
-  )
+  return <AnalysisGroupCardItem description={description} result={result} isPrimary={isPrimary} />
 }


### PR DESCRIPTION
## What it solves 

Resolves: [COR-780](https://linear.app/safe-global/issue/COR-780/use-standard-delegatecall-message-in-risk-panel)

## How this PR fixes it

- Introduces a custom `AnalysisCardItem` for `UNEXPECTED_DELEGATE_CALL` to be able to show a link to help center

## How to test it

- create a transaction with unexpected delegate call
- observe the Safe Shield analysis, there should be a link `Learn more`

## Screenshots
<img width="2928" height="1398" alt="Screenshot 2025-10-30 at 5 20 31 PM" src="https://github.com/user-attachments/assets/7f1243c6-8190-4365-a724-d403ca088307" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a dedicated delegatecall analysis card with a Help Center link and refactors AnalysisGroupCardItem to take a result/isPrimary while updating routing in AnalysisGroupCard.
> 
> - **Safe Shield UI**
>   - **`AnalysisGroupCard`**:
>     - Routes `ContractStatus.UNEXPECTED_DELEGATECALL` to new `DelegateCallCardItem`.
>     - Uses `isPrimary` (first item) to pass prominence; simplifies item rendering.
>   - **`AnalysisGroupCardItem`**:
>     - Refactors props to accept `result` and optional `isPrimary`/`description`.
>     - Derives border color from primary item severity; renders issues, address changes, and `ShowAllAddress` internally.
>   - **New `DelegateCallCardItem`**:
>     - Provides custom description for unexpected delegate call with "Learn more" link to `HelpCenterArticle.UNEXPECTED_DELEGATE_CALL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 586a90234ff1bd9e67fe16c6290c5406c394407a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->