### PR TITLE
Fix (WalletConnect): Namespace fix

### DIFF
--- a/apps/web/src/features/walletconnect/services/WalletConnectWallet.ts
+++ b/apps/web/src/features/walletconnect/services/WalletConnectWallet.ts
@@ -37,7 +37,7 @@ class WalletConnectWallet {
       logger: IS_PRODUCTION ? undefined : 'debug',
       // This isolation ensures wallet connections work independently from dApp connections.
       customStoragePrefix: LS_NAMESPACE + 'wc_dapp_',
-    }) as unknown as WalletKitTypes.Options['core']
+    })
 
     const web3wallet = await WalletKit.init({
       core,


### PR DESCRIPTION
## What it solves

https://linear.app/safe-global/issue/COR-786/walletconnect

## How this PR fixes it

Prevents concurrent initialization of WalletConnect Core by implementing:
- Unique storage prefix (wc_dapp_) to isolate Safe-to-dApp from Wallet-to-Safe
- Promise-based initialization guard to prevent race conditions
- Proper error handling and cleanup on initialization failure

This fixes session corruption and hanging connections caused by two WalletConnect
implementations sharing the same global Core singleton instance.

## How to test it


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set a unique WalletConnect Core storage prefix (`LS_NAMESPACE + 'wc_dapp_'`) to isolate wallet connections from dApp connections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9a112de2986dbe652895488c154eed98dffbadd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->