### PR TITLE
tests(mobile): switch currency

### DIFF
--- a/apps/mobile/e2e/happypath/add-second-safe.yml
+++ b/apps/mobile/e2e/happypath/add-second-safe.yml
@@ -5,8 +5,6 @@ appId: global.safe.mobileapp.ios
 - tapOn:
     id: 'e2eOnboardedAccount'
 - tapOn:
-    id: 'opt-in-secondary-button'
-- tapOn:
     id: 'dropdown-label-view'
     index: 0
 - tapOn:

--- a/apps/mobile/e2e/happypath/assets.yml
+++ b/apps/mobile/e2e/happypath/assets.yml
@@ -5,7 +5,7 @@ appId: global.safe.mobileapp.ios
     file: ../shared/clean-app-start.yml
 
 - tapOn:
-    id: 'e2eOnboardedAccountNoNotifications'
+    id: 'e2eOnboardedAccountTestAssets'
 
 # Test Home tab / Assets default view
 - assertVisible:

--- a/apps/mobile/e2e/happypath/change-currency.yml
+++ b/apps/mobile/e2e/happypath/change-currency.yml
@@ -1,0 +1,253 @@
+appId: global.safe.mobileapp.ios
+---
+# Currency Change Happy Path Test
+# Tests changing the display currency and verifying fiat values update throughout the app
+
+- runFlow:
+    file: ../shared/clean-app-start.yml
+
+# Use e2eOnboardedAccount shortcut
+- tapOn:
+    id: 'e2eOnboardedAccount'
+
+# Wait for home screen to load
+- assertVisible:
+    id: 'home-tab'
+
+# ============================================
+# Note Initial Currency - Home Tab
+# ============================================
+
+# Verify fiat balance is displayed (e.g., "$1,234.56")
+- assertVisible:
+    id: 'fiat-balance-symbol'
+
+# Verify currency symbol is USD ($) - should contain dollar sign
+- assertVisible:
+    id: 'fiat-balance-symbol'
+    text: '.*\$.*'
+
+# Verify token fiat values in list - should contain dollar sign
+- assertVisible:
+    id: 'token-ETH-fiat-balance'
+    text: '.*\$.*'
+    optional: true
+
+# ============================================
+# Navigate to Settings tab
+# ============================================
+
+- tapOn:
+    id: 'account-tab'
+
+# Wait for settings screen
+- assertVisible:
+    text: '.*(Settings|Account).*'
+
+# ============================================
+# Navigate to App Settings
+# ============================================
+
+# Tap "App Settings" button (settings icon)
+- tapOn:
+    id: 'settings-screen-header-app-settings-button'
+
+# Verify navigation to app settings screen
+- assertVisible:
+    text: 'Settings'
+
+# Verify "Currency" row is visible
+- assertVisible:
+    text: '.*Currency.*'
+
+# ============================================
+# Navigate to Currency Settings
+# ============================================
+
+# Tap "Currency" row
+- tapOn:
+    text: '.*Currency.*'
+
+# Verify navigation to currency selection screen
+- assertVisible:
+    text: '.*(EUR|GBP).*'
+
+# ============================================
+# Currency List Verification
+# ============================================
+
+# Verify currencies show currency code (EUR, GBP, etc.)
+- assertVisible:
+    text: '.*EUR.*'
+
+- assertVisible:
+    text: '.*GBP.*'
+
+# Verify currency symbols ($, €, £, etc.)
+
+- assertVisible:
+    text: '.*€.*'
+
+- assertVisible:
+    text: '.*£.*'
+
+# Verify currency names (US Dollar, Euro, etc.)
+- assertVisible:
+    text: '.*Euro.*'
+
+- assertVisible:
+    text: '.*(British Pound|Pound).*'
+
+- scroll
+
+# Verify current currency (USD) is visible
+# Note: Selected currency shows a checkmark icon, but Maestro verifies via text matching
+- assertVisible:
+    text: 'USD.*'
+
+# ============================================
+# Change Currency to EUR
+# ============================================
+
+# Scroll if needed to find EUR
+- scrollUntilVisible:
+    element:
+      text: 'EUR.*'
+
+# Tap "EUR - Euro" option (currency selection navigates back automatically)
+- tapOn:
+    text: 'EUR.*'
+
+# Wait for automatic navigation back to app settings screen
+- assertVisible:
+    text: '.*Currency.*'
+
+# Verify we're back on app settings screen
+- assertVisible:
+    text: 'Settings'
+
+# ============================================
+# Verify Currency Change - Home Tab
+# ============================================
+
+- tapOn:
+    id: 'go-back'
+# Navigate back to Home tab
+- tapOn:
+    id: 'home-tab'
+
+# Wait for home tab to load
+- assertVisible:
+    id: 'home-tab'
+
+# Verify fiat balance now shows Euro symbol (€)
+- assertVisible:
+    id: 'fiat-balance-symbol'
+    text: '.*€.*'
+
+# Verify token fiat values show € symbol
+- assertVisible:
+    id: 'token-ETH-fiat-balance'
+    text: '.*€.*'
+    optional: true
+
+# ============================================
+# Change Currency Again - GBP
+# ============================================
+
+# Navigate back to Settings (if not already there)
+- tapOn:
+    id: 'account-tab'
+
+# Wait for settings screen
+- assertVisible:
+    text: '.*(Settings|Account).*'
+
+# Navigate to App Settings
+- tapOn:
+    id: 'settings-screen-header-app-settings-button'
+
+# Wait for app settings screen
+- assertVisible:
+    text: 'Settings'
+
+# Navigate to Currency
+- tapOn:
+    text: '.*Currency.*'
+
+# Select "GBP - British Pound"
+- scrollUntilVisible:
+    element:
+      text: 'GBP.*'
+
+- tapOn:
+    text: 'GBP.*'
+
+# Wait for automatic navigation back
+- assertVisible:
+    text: '.*Currency.*'
+
+- tapOn:
+    id: 'go-back'
+
+# Navigate to home
+- tapOn:
+    id: 'home-tab'
+
+# Wait for home tab to load
+- assertVisible:
+    id: 'home-tab'
+
+# Verify balance shows £ symbol
+- assertVisible:
+    id: 'fiat-balance-symbol'
+    text: '.*£.*'
+
+# ============================================
+# Reset to USD
+# ============================================
+
+# Return to currency settings
+- tapOn:
+    id: 'account-tab'
+
+- assertVisible:
+    text: '.*(Settings|Account).*'
+
+- tapOn:
+    id: 'settings-screen-header-app-settings-button'
+
+- assertVisible:
+    text: 'Settings'
+
+- tapOn:
+    text: '.*Currency.*'
+
+# Select "USD - US Dollar"
+- scrollUntilVisible:
+    element:
+      text: 'USD.*'
+
+- tapOn:
+    text: 'USD.*'
+
+# Wait for automatic navigation back
+- assertVisible:
+    text: '.*Currency.*'
+
+- tapOn:
+    id: 'go-back'
+
+# Navigate to home
+- tapOn:
+    id: 'home-tab'
+
+# Wait for home tab to load
+- assertVisible:
+    id: 'home-tab'
+
+# Verify returns to original state with $ symbol
+- assertVisible:
+    id: 'fiat-balance-symbol'
+    text: '.*\$.*'
+# Test completed successfully

--- a/apps/mobile/e2e/happypath/onboarded-user.yml
+++ b/apps/mobile/e2e/happypath/onboarded-user.yml
@@ -4,8 +4,6 @@ appId: global.safe.mobileapp.ios
     file: ../shared/clean-app-start.yml
 - tapOn:
     id: 'e2eOnboardedAccount'
-- tapOn:
-    id: 'opt-in-secondary-button'
 - assertVisible:
     id: 'home-tab'
 - tapOn:

--- a/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
+++ b/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
@@ -132,6 +132,7 @@ export function TestCtrls() {
       }),
     )
     dispatch(setActiveSafe(mockedActiveAccount))
+    dispatch(updatePromptAttempts(1))
     router.replace('/(tabs)')
   }
   const onPressTestOnboarding = async () => {
@@ -198,7 +199,7 @@ export function TestCtrls() {
         style={BTN}
       />
       <Pressable
-        testID="e2eOnboardedAccountNoNotifications"
+        testID="e2eOnboardedAccountTestAssets"
         onPress={() => {
           const keys = Object.keys(assetsTest.safes)
           Object.values(assetsTest.safes).forEach((safe: SafeOverview, index) => {


### PR DESCRIPTION
## What it solves
Ads a switch currency maestro test

Resolves: https://linear.app/safe-global/issue/COR-717/test-009-app-settings-currency-selection

## Screenshots

https://github.com/user-attachments/assets/dd003c93-b30f-473a-95d9-d6af0327185f


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
