### PR TITLE
fix(mobile): notification badge was not cleared

### DIFF
--- a/apps/mobile/src/features/PendingTx/PendingTx.container.tsx
+++ b/apps/mobile/src/features/PendingTx/PendingTx.container.tsx
@@ -2,10 +2,18 @@ import React from 'react'
 import { PendingTxListContainer } from '@/src/features/PendingTx/components/PendingTxList'
 import usePendingTxs from '@/src/hooks/usePendingTxs'
 import Logger from '@/src/utils/logger'
+import BadgeManager from '@/src/services/notifications/BadgeManager'
 
 export function PendingTxContainer() {
   const { data, isLoading, isFetching, fetchMoreTx, hasMore, amount, refetch } = usePendingTxs()
   const [isRefreshing, setIsRefreshing] = React.useState(false)
+
+  // Clear badge when user views pending transactions (whether from notification tap or normal navigation)
+  React.useEffect(() => {
+    BadgeManager.clearAllBadges().catch((error) => {
+      Logger.error('PendingTxContainer: Failed to clear badges', error)
+    })
+  }, [])
 
   // Handle pull-to-refresh - reset the data and fetch from the beginning
   const onRefresh = React.useCallback(async () => {

--- a/apps/mobile/src/features/TxHistory/TxHistory.container.tsx
+++ b/apps/mobile/src/features/TxHistory/TxHistory.container.tsx
@@ -9,6 +9,7 @@ import { useAppDispatch } from '@/src/store/hooks'
 import { useLocalSearchParams } from 'expo-router'
 import Logger from '@/src/utils/logger'
 import useSafeInfo from '@/src/hooks/useSafeInfo'
+import BadgeManager from '@/src/services/notifications/BadgeManager'
 
 export function TxHistoryContainer() {
   const activeSafe = useDefinedActiveSafe()
@@ -33,6 +34,13 @@ export function TxHistoryContainer() {
     isUninitialized,
     refetch,
   } = useGetTxsHistoryInfiniteQuery(queryArgs)
+
+  // Clear badge when user views transaction history (whether from notification tap or normal navigation)
+  React.useEffect(() => {
+    BadgeManager.clearAllBadges().catch((error) => {
+      Logger.error('TxHistoryContainer: Failed to clear badges', error)
+    })
+  }, [])
 
   // Force refetch when coming from push notification
   React.useEffect(() => {

--- a/apps/mobile/src/hooks/__tests__/useNotificationHandler.test.ts
+++ b/apps/mobile/src/hooks/__tests__/useNotificationHandler.test.ts
@@ -5,6 +5,7 @@ import { renderHook } from '@testing-library/react-native'
 import { EventType, EventDetail } from '@notifee/react-native'
 import { useNotificationHandler } from '../useNotificationHandler'
 import NotificationsService from '@/src/services/notifications/NotificationService'
+import BadgeManager from '@/src/services/notifications/BadgeManager'
 import Logger from '@/src/utils/logger'
 
 // Define types for test events
@@ -17,6 +18,9 @@ interface TestNotificationEvent {
 jest.mock('@/src/services/notifications/NotificationService', () => ({
   onForegroundEvent: jest.fn(),
   handleNotificationPress: jest.fn(),
+}))
+
+jest.mock('@/src/services/notifications/BadgeManager', () => ({
   incrementBadgeCount: jest.fn(),
 }))
 
@@ -35,6 +39,7 @@ jest.mock('@notifee/react-native', () => ({
 }))
 
 const mockNotificationsService = jest.mocked(NotificationsService)
+const mockBadgeManager = jest.mocked(BadgeManager)
 const mockLogger = jest.mocked(Logger)
 
 describe('useNotificationHandler', () => {
@@ -51,7 +56,7 @@ describe('useNotificationHandler', () => {
     })
 
     mockNotificationsService.handleNotificationPress.mockResolvedValue()
-    mockNotificationsService.incrementBadgeCount.mockResolvedValue()
+    mockBadgeManager.incrementBadgeCount.mockResolvedValue()
   })
 
   describe('hook initialization', () => {
@@ -107,8 +112,8 @@ describe('useNotificationHandler', () => {
 
       await mockEventHandler?.(mockEvent)
 
-      expect(mockNotificationsService.incrementBadgeCount).toHaveBeenCalledWith(1)
-      expect(mockNotificationsService.incrementBadgeCount).toHaveBeenCalledTimes(1)
+      expect(mockBadgeManager.incrementBadgeCount).toHaveBeenCalledWith(1)
+      expect(mockBadgeManager.incrementBadgeCount).toHaveBeenCalledTimes(1)
     })
 
     it('should handle DISMISSED event correctly', async () => {
@@ -161,7 +166,7 @@ describe('useNotificationHandler', () => {
 
       // Should not call any notification service methods for unknown events
       expect(mockNotificationsService.handleNotificationPress).not.toHaveBeenCalled()
-      expect(mockNotificationsService.incrementBadgeCount).not.toHaveBeenCalled()
+      expect(mockBadgeManager.incrementBadgeCount).not.toHaveBeenCalled()
       expect(mockLogger.info).not.toHaveBeenCalled()
     })
   })
@@ -195,7 +200,7 @@ describe('useNotificationHandler', () => {
       renderHook(() => useNotificationHandler())
 
       const mockError = new Error('Badge increment failed')
-      mockNotificationsService.incrementBadgeCount.mockRejectedValue(mockError)
+      mockBadgeManager.incrementBadgeCount.mockRejectedValue(mockError)
 
       const mockEvent: TestNotificationEvent = {
         type: EventType.DELIVERED,
@@ -320,7 +325,7 @@ describe('useNotificationHandler', () => {
         await mockEventHandler?.(event)
       }
 
-      expect(mockNotificationsService.incrementBadgeCount).toHaveBeenCalledTimes(1)
+      expect(mockBadgeManager.incrementBadgeCount).toHaveBeenCalledTimes(1)
       expect(mockNotificationsService.handleNotificationPress).toHaveBeenCalledTimes(1)
       expect(mockLogger.info).toHaveBeenCalledTimes(1)
     })

--- a/apps/mobile/src/hooks/useNotificationHandler.ts
+++ b/apps/mobile/src/hooks/useNotificationHandler.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { EventType } from '@notifee/react-native'
 import NotificationsService from '@/src/services/notifications/NotificationService'
+import BadgeManager from '@/src/services/notifications/BadgeManager'
 import Logger from '@/src/utils/logger'
 
 /**
@@ -14,7 +15,7 @@ export const useNotificationHandler = () => {
         if (type === EventType.PRESS) {
           await NotificationsService.handleNotificationPress({ detail })
         } else if (type === EventType.DELIVERED) {
-          await NotificationsService.incrementBadgeCount(1)
+          await BadgeManager.incrementBadgeCount(1)
         } else if (type === EventType.DISMISSED) {
           Logger.info('User dismissed notification:', detail.notification?.id)
         }

--- a/apps/mobile/src/services/notifications/BadgeManager.ts
+++ b/apps/mobile/src/services/notifications/BadgeManager.ts
@@ -1,0 +1,38 @@
+import notifee from '@notifee/react-native'
+import Logger from '@/src/utils/logger'
+
+class BadgeManager {
+  async incrementBadgeCount(incrementBy?: number): Promise<void> {
+    await notifee.incrementBadgeCount(incrementBy)
+    const newCount = await notifee.getBadgeCount()
+    Logger.info(`Badge incremented by ${incrementBy || 1}, new count: ${newCount}`)
+  }
+
+  async decrementBadgeCount(decrementBy?: number): Promise<void> {
+    await notifee.decrementBadgeCount(decrementBy)
+    const newCount = await notifee.getBadgeCount()
+    Logger.info(`Badge decremented by ${decrementBy || 1}, new count: ${newCount}`)
+  }
+
+  async setBadgeCount(count: number): Promise<void> {
+    await notifee.setBadgeCount(count)
+    Logger.info(`Badge count set to: ${count}`)
+  }
+
+  async getBadgeCount(): Promise<number> {
+    const count = await notifee.getBadgeCount()
+    Logger.info(`Current badge count: ${count}`)
+    return count
+  }
+
+  async clearAllBadges(): Promise<void> {
+    try {
+      await this.setBadgeCount(0)
+      Logger.info('All badges cleared')
+    } catch (error) {
+      Logger.error('Failed to clear badges', error)
+    }
+  }
+}
+
+export default new BadgeManager()

--- a/apps/mobile/src/services/notifications/notificationNavigationHandler.ts
+++ b/apps/mobile/src/services/notifications/notificationNavigationHandler.ts
@@ -6,6 +6,7 @@ import { NotificationTypeEnum } from '@safe-global/store/gateway/AUTO_GENERATED/
 import { FirebaseMessagingTypes } from '@react-native-firebase/messaging'
 import { Address } from '@/src/types/address'
 import Logger from '@/src/utils/logger'
+import BadgeManager from './BadgeManager'
 
 // Helper function to wait for router to be ready
 const waitForRouter = async (maxAttempts = 50, delayMs = 100): Promise<boolean> => {
@@ -45,6 +46,9 @@ export const NotificationNavigationHandler = {
       Logger.warn('NotificationNavigationHandler: No data provided')
       return
     }
+
+    // Clear badge when user taps the notification
+    await BadgeManager.clearAllBadges()
 
     try {
       // Wait for router to be ready before attempting navigation


### PR DESCRIPTION
## What it solves
The notification badge was only cleared when the user would click on the push notification. If the user would open the app, by pressing the icon the badge won’t be cleared.

Resolves https://linear.app/safe-global/issue/COR-797/notification-badge-not-cleared

## How this PR fixes it
It clears the badge when the user navigatese to the pending tx or history screen.

## How to test it
Receive a push notification. Note the badge on the icon increasing. Dismiss the push notification. Open the app by pressing the app icon and navigate to the history or pendingtx screen. Close the app. Now the badge should be gone. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
