### PR TITLE
chore(web): enable Storybook deployment in GitHub Actions workflow

### DIFF
--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -46,7 +46,9 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
           # if: startsWith(github.ref, 'refs/heads/main')
 
-      #- uses: ./.github/workflows/build-storybook
+      - uses: ./.github/actions/build-storybook
+        with:
+          secrets: ${{ toJSON(secrets) }}
 
       - name: Add SRI to scripts
         run: node ./scripts/integrity-hashes.cjs


### PR DESCRIPTION
## Summary
Re-enable the Storybook deployment in the GitHub Actions workflow that was previously disabled. The build step was commented out and had an incorrect path reference.

## Changes
- ✅ Uncommented the build-storybook action in `web-deploy-dev.yml`
- ✅ Fixed action path from `./.github/workflows/build-storybook` to `./.github/actions/build-storybook`
- ✅ Added required `secrets` parameter to the build-storybook action

## Testing
- ✅ Verified Storybook builds successfully locally
- ✅ Validated YAML syntax is correct
- ✅ Confirmed the build-storybook action exists and accepts the secrets parameter

## Result
Storybook will now be built and deployed alongside the main app for dev/staging branches and PRs. It will be accessible at:
`https://<branch>--walletweb.review.5afe.dev/storybook/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)