### PR TITLE
fix(web): show delegate-call warning on history and queue views

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
@@ -15,10 +15,15 @@ interface Props {
   txData: TransactionDetails['txData']
   toInfo?: AddressInfo
   isTxExecuted?: boolean
-  isQueue?: boolean
+  isWarningEnabled?: boolean
 }
 
-export const DecodedData = ({ txData, toInfo, isTxExecuted = false, isQueue = false }: Props): ReactElement | null => {
+export const DecodedData = ({
+  txData,
+  toInfo,
+  isTxExecuted = false,
+  isWarningEnabled = false,
+}: Props): ReactElement | null => {
   const nativeTokenInfo = useNativeTokenInfo()
   const setsUntrustedFallbackHandler = useSetsUntrustedFallbackHandler(txData)
 
@@ -48,7 +53,7 @@ export const DecodedData = ({ txData, toInfo, isTxExecuted = false, isQueue = fa
   return (
     <Stack spacing={2}>
       {setsUntrustedFallbackHandler && <UntrustedFallbackHandlerWarning isTxExecuted={isTxExecuted} />}
-      {isDelegateCall && isQueue && <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget} />}
+      {isDelegateCall && isWarningEnabled && <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget} />}
 
       {method ? (
         <MethodCall contractAddress={toAddress} contractName={name} contractLogo={avatar} method={method} />

--- a/apps/web/src/components/transactions/TxDetails/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/index.tsx
@@ -117,7 +117,7 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
                   <DecodedData
                     txData={txDetails.txData}
                     toInfo={isCustomTxInfo(txDetails.txInfo) ? txDetails.txInfo.to : txDetails.txData?.to}
-                    isQueue={isQueue}
+                    isWarningEnabled
                   />
                 </Box>
               </TxData>


### PR DESCRIPTION
## What it solves

Resolves: [COR-812](https://linear.app/safe-global/issue/COR-812/safe-shield-trusteduntrusted-delegate-call-mark-is-missing-on-the-tx)

## How this PR fixes it

it seems that as part of [this](https://github.com/safe-global/safe-wallet-monorepo/pull/6524/commits/83f2703e2f69f953f2471e6cbbe0d0bc9516e113) commit the delegate call warning was removed not only from TxFlow but also from history view. This change brings it back

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
