### PR TITLE
fix(safe-creation): update address book only with successful networks

### DIFF
--- a/packages/utils/src/features/counterfactual/store/types.ts
+++ b/packages/utils/src/features/counterfactual/store/types.ts
@@ -1,6 +1,7 @@
 import type { SafeVersion } from '@safe-global/types-kit'
 import type { PredictedSafeProps } from '@safe-global/protocol-kit'
 import type { PayMethod } from '@safe-global/utils/features/counterfactual/types'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 
 export enum PendingSafeStatus {
   AWAITING_EXECUTION = 'AWAITING_EXECUTION',
@@ -41,3 +42,9 @@ export type UndeployedSafe = {
 }
 type UndeployedSafesSlice = { [address: string]: UndeployedSafe }
 export type UndeployedSafesState = { [chainId: string]: UndeployedSafesSlice }
+
+export type CreateSafeResult = {
+  chain: Chain
+  safeAddress: string
+  success: boolean
+}


### PR DESCRIPTION
## What it solves

Resolves: [#6605 ](`https://github.com/safe-global/safe-wallet-monorepo/issues/6605`)

## How this PR fixes it
- Add CreateSafeResult type to track results per network
- Modify createSafe to return explicit success/failure
- Filter successful results before updating address book
- Remove setIsCreating call in createSafe function to prevent re-enabling button during multichain loop

## How to test it
- Create a new account.
- Fill the info.
- Reject the transaction in the wallet.
- Retry

## Screenshots

https://github.com/user-attachments/assets/af7533f5-7d48-4fc5-9e4d-97cf2e0fc512


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track per-network Safe creation results, update the address book only for successful chains, and avoid resetting creating state inside the loop.
> 
> - **Frontend (`apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx`)**:
>   - `createSafe` returns `CreateSafeResult`; collect results across `data.networks`.
>   - Update `addressBook` using only successful results (`success === true`).
>   - Removed internal `setIsCreating(false)` from `createSafe`; handled in outer `finally` to prevent re-enabling during multichain loop.
>   - Minor: import `CreateSafeResult` and propagate success/failure returns in all paths.
> - **Utils/Types (`packages/utils/src/features/counterfactual/store/types.ts`)**:
>   - Add `CreateSafeResult` type with `chain`, `safeAddress`, and `success` fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9658e89d116b201031c4adfad75cc2476a5ffab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->