### PR TITLE
fix: reset RiskConfirmation state

### DIFF
--- a/apps/web/src/features/safe-shield/SafeShieldContext.tsx
+++ b/apps/web/src/features/safe-shield/SafeShieldContext.tsx
@@ -45,23 +45,32 @@ export const SafeShieldProvider = ({ children }: { children: ReactNode }) => {
 
   const recipient = recipientOnlyAnalysis || counterpartyAnalysis.recipient
   const contract = counterpartyAnalysis.contract
+  const safeShieldTx = safeTx || safeTxContext.safeTx
 
   const [isRiskConfirmed, setIsRiskConfirmed] = useState(false)
 
-  const needsRiskConfirmation = useMemo(() => {
+  const { needsRiskConfirmation, primaryThreatSeverity } = useMemo(() => {
     const [threatAnalysisResult] = threat || []
     const primaryThreatResult = getPrimaryResult(threatAnalysisResult?.THREAT || [])
-    return (
-      !!primaryThreatResult && SEVERITY_PRIORITY[primaryThreatResult.severity] <= SEVERITY_PRIORITY[Severity.CRITICAL]
-    )
+    const severity = primaryThreatResult?.severity
+    const needsRiskConfirmation = !!severity && SEVERITY_PRIORITY[severity] <= SEVERITY_PRIORITY[Severity.CRITICAL]
+
+    return {
+      needsRiskConfirmation,
+      primaryThreatSeverity: severity,
+    }
   }, [threat])
+
+  useEffect(() => {
+    setIsRiskConfirmed(false)
+  }, [primaryThreatSeverity, safeShieldTx])
 
   return (
     <SafeShieldContext.Provider
       value={{
         setRecipientAddresses,
         setSafeTx,
-        safeTx: safeTx || safeTxContext.safeTx,
+        safeTx: safeShieldTx,
         recipient,
         contract,
         threat,


### PR DESCRIPTION
## What it solves

Resolves: 

riskConfirmation was not properly reset

## How this PR fixes it
- Created `safeShieldTx` that combines both `safeTx` and `safeTxContext.safeTx`,
- Refactored the memoization to compute needsRiskConfirmation and primaryThreatSeverity
- Added the useEffect that resets isRiskConfirmed to false whenever primaryThreatSeverity or safeShieldTx changes.

The confirmation is reset whenever either the transaction or its threat severity changes, forcing fresh confirmation for each risky transaction

## How to test it
- Open a transaction that triggers Safe Shield threat analysis with CRITICAL severity
- Accept the risk (click through the confirmation)
- Change the transaction (e.g., modify amount, recipient, or data)
Expected: Risk confirmation dialog should appear again

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
