### PR TITLE
fix(Safe Shield): restore green delegate call badge on confirmation view

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/TxData/DecodedData/index.tsx
@@ -1,7 +1,6 @@
 import type { AddressInfo, TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import type { ReactElement } from 'react'
 import { Stack, Typography } from '@mui/material'
-import { Operation } from '@safe-global/store/gateway/types'
 import { HexEncodedData } from '@/components/transactions/HexEncodedData'
 import { MethodDetails } from '@/components/transactions/TxDetails/TxData/DecodedData/MethodDetails'
 import SendAmountBlock from '@/components/tx-flow/flows/TokenTransfer/SendAmountBlock'
@@ -43,7 +42,6 @@ export const DecodedData = ({
   }
 
   const amountInWei = txData.value ?? '0'
-  const isDelegateCall = txData.operation === Operation.DELEGATE
   const toAddress = toInfo?.value || txData.to?.value
   const method = txData.dataDecoded?.method || ''
   const addressInfo = txData.addressInfoIndex?.[toAddress]
@@ -53,7 +51,7 @@ export const DecodedData = ({
   return (
     <Stack spacing={2}>
       {setsUntrustedFallbackHandler && <UntrustedFallbackHandlerWarning isTxExecuted={isTxExecuted} />}
-      {isDelegateCall && isWarningEnabled && <DelegateCallWarning showWarning={!txData.trustedDelegateCallTarget} />}
+      <DelegateCallWarning txData={txData} showWarning={isWarningEnabled} />
 
       {method ? (
         <MethodCall contractAddress={toAddress} contractName={name} contractLogo={avatar} method={method} />

--- a/apps/web/src/components/transactions/Warning/index.tsx
+++ b/apps/web/src/components/transactions/Warning/index.tsx
@@ -8,6 +8,8 @@ import ExternalLink from '@/components/common/ExternalLink'
 import { maybePlural } from '@safe-global/utils/utils/formatters'
 import { UntrustedFallbackHandlerTxText } from '@/components/tx/confirmation-views/SettingsChange/UntrustedFallbackHandlerTxAlert'
 import { HelpCenterArticle } from '@safe-global/utils/config/constants'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { Operation } from '@safe-global/store/gateway/types'
 
 const Warning = ({
   datatestid,
@@ -34,15 +36,25 @@ const Warning = ({
   )
 }
 
-export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): ReactElement => {
-  const severity = showWarning ? 'warning' : 'success'
+export const DelegateCallWarning = ({
+  txData,
+  showWarning,
+}: {
+  txData: TransactionDetails['txData']
+  showWarning: boolean
+}): ReactElement => {
+  const isDelegateCall = txData?.operation === Operation.DELEGATE
+  const trustedDelegateCall = isDelegateCall && !!txData?.trustedDelegateCallTarget
+
+  if (!isDelegateCall || (!trustedDelegateCall && !showWarning)) return <></>
+
   return (
     <Warning
       datatestid="delegate-call-warning"
       title={
         <>
           This transaction calls a smart contract that will be able to modify your Safe Account.
-          {showWarning && (
+          {!trustedDelegateCall && (
             <>
               <br />
               <ExternalLink href={HelpCenterArticle.UNEXPECTED_DELEGATE_CALL}>Learn more</ExternalLink>
@@ -50,8 +62,8 @@ export const DelegateCallWarning = ({ showWarning }: { showWarning: boolean }): 
           )}
         </>
       }
-      severity={severity}
-      text={showWarning ? 'Unexpected delegate call' : 'Delegate call'}
+      severity={trustedDelegateCall ? 'success' : 'warning'}
+      text={trustedDelegateCall ? 'Delegate call' : 'Unexpected delegate call'}
     />
   )
 }


### PR DESCRIPTION
## What it solves

Linear: [COR-823](https://linear.app/safe-global/issue/COR-823/safe-shield-restore-trusted-delegate-call-badge-in-the-tx-details)

## How this PR fixes it
Refactored `DelegateCallWarning` component to:
- Accept full `txData` object instead of just a boolean flag
- Determine delegate call status internally using `Operation.DELEGATE`
- Show green "Delegate call" badge for trusted delegate calls (`trustedDelegateCallTarget`)
- Hides the badge in case of an untrusted delegate call in the tx flow

## How to test it
1. First open a transaction that does a trusted delegate call in the TX flow.
2. In the transaction details observe that the green delegate call badge is displayed.
3. Open another transaction that is performing an untrusted delegate call.
4. Observe that the delegate call warning badge is not being displayed in the transaction details but only in the SafeShield widget.

## Screenshots
<img width="1189" height="888" alt="Screenshot 2025-11-10 at 11 11 23" src="https://github.com/user-attachments/assets/d2097b78-0d84-42b2-bcb0-80d6409b4a79" />
<img width="1232" height="915" alt="Screenshot 2025-11-10 at 11 11 55" src="https://github.com/user-attachments/assets/e450b367-b11f-450b-84d7-26440f994eed" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
