### PR TITLE
Feat(Hypernative): Dashboard banner in UI

### DIFF
--- a/apps/web/src/components/dashboard/FirstSteps/index.tsx
+++ b/apps/web/src/components/dashboard/FirstSteps/index.tsx
@@ -26,8 +26,7 @@ import css from './styles.module.css'
 import ActivateAccountButton from '@/features/counterfactual/ActivateAccountButton'
 import { isReplayedSafeProps } from '@/features/counterfactual/utils'
 import { getExplorerLink } from '@safe-global/utils/utils/gateway'
-// import HnDashboardBanner from '@/features/hypernative/components/HnDashboardBanner'
-import { HnDashboardBanner } from '@/features/hypernative/components/HnDashboardBanner'
+import HnDashboardBanner from '@/features/hypernative/components/HnDashboardBanner'
 import { useBannerVisibility } from '@/features/hypernative/hooks/useBannerVisibility'
 import { BannerType } from '@/features/hypernative/hooks/useBannerStorage'
 
@@ -475,8 +474,7 @@ const FirstSteps = () => {
           </Grid>
 
           <Grid item xs={12} md={4}>
-            {/* {showHnDashboardBanner ? <HnDashboardBanner /> : <AccountReadyWidget />} */}
-            <HnDashboardBanner onHnSignupClick={() => { }} />
+            {showHnDashboardBanner ? <HnDashboardBanner /> : <AccountReadyWidget />}
           </Grid>
         </Grid>
       </WidgetBody>


### PR DESCRIPTION
## Summary

Embedding the `HnDashboardBanner` to the UI.

## What it solves
Conditionally render of `HnDashboardBanner` based on visibility conditions, with `AccountReadyWidget` as the default fallback.

## How this PR fixes it

- Added `useBannerVisibility(BannerType.Promo)` to check banner visibility conditions in the parent component
- Conditional rendering: `{showHnDashboardBanner ? <HnDashboardBanner /> : <AccountReadyWidget />}`
- `AccountReadyWidget` now shows by default; `HnDashboardBanner` only renders when all conditions are met (feature enabled, not dismissed, safe owner, sufficient balance, no guard installed)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
