### PR TITLE
Fix(Hypernative): Copy link button positioning in TxDetails

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/index.tsx
+++ b/apps/web/src/components/transactions/TxDetails/index.tsx
@@ -169,7 +169,10 @@ const TxDetailsBlock = ({ txSummary, txDetails }: TxDetailsProps): ReactElement 
       {/* Signers */}
       {(!isUnsigned || proposedByDelegate) && (
         <div className={css.txSigners}>
-          <TxShareBlock txId={txDetails.txId} />
+          <TxShareBlock
+            txId={txDetails.txId}
+            hasSigners={isMultisigDetailedExecutionInfo(txDetails.detailedExecutionInfo)}
+          />
 
           <TxSigners
             txDetails={txDetails}

--- a/apps/web/src/components/transactions/TxDetails/styles.module.css
+++ b/apps/web/src/components/transactions/TxDetails/styles.module.css
@@ -73,6 +73,7 @@
   padding: var(--space-3);
   border-left: 1px solid var(--color-border-light);
   gap: var(--space-2);
+  position: relative;
 }
 
 .delegateCall .alert {

--- a/apps/web/src/components/transactions/TxShareLink/index.tsx
+++ b/apps/web/src/components/transactions/TxShareLink/index.tsx
@@ -20,13 +20,19 @@ export function TxExplorerLink({ txHash }: { txHash: string }) {
   )
 }
 
-export function TxShareBlock({ txId }: { txId: string }) {
+export function TxShareBlock({ txId, hasSigners = true }: { txId: string; hasSigners?: boolean }) {
   return (
-    <Box data-testid="share-block" display="flex" justifyContent="flex-end" className={css.shareBlock}>
+    <Box
+      data-testid="share-block"
+      display="flex"
+      justifyContent={hasSigners ? 'flex-end' : 'stretch'}
+      className={hasSigners ? css.shareBlock : css.shareBlockStatic}
+    >
       <TxShareLink id={txId} eventLabel={CopyDeeplinkLabels.shareBlock}>
         <Button
           data-testid="copy-link-btn"
           variant="neutral"
+          fullWidth={!hasSigners}
           startIcon={<SvgIcon component={ShareIcon} inheritViewBox fontSize="small" className={css.shareIcon} />}
         >
           Copy link

--- a/apps/web/src/components/transactions/TxShareLink/styles.module.css
+++ b/apps/web/src/components/transactions/TxShareLink/styles.module.css
@@ -1,7 +1,15 @@
 .shareBlock {
-  margin-bottom: -42px;
+  margin-bottom: -53px;
   position: relative;
   z-index: 10;
+}
+
+.shareBlockStatic {
+  width: 100%;
+}
+
+.shareBlockStatic > * {
+  width: 100%;
 }
 
 .shareIcon {


### PR DESCRIPTION
## Summary

Resolves https://linear.app/safe-global/issue/COR-843/safe-shieldhn-copy-button-from-the-tx-details-is-displayed-in-tx

- Add `position: relative` to `.txSigners` container for proper absolute positioning context
- Fix Copy link button positioning for incoming transactions without signers
- Update negative margin to -53px for better overlap positioning

## Changes
1. **TxDetails/styles.module.css**: Added `position: relative` to `.txSigners` container
2. **TxShareLink/styles.module.css**: 
   - Updated negative margin from -42px to -53px
   - Added `.shareBlockStatic` class for full-width layout
3. **TxShareLink/index.tsx**: Added `hasSigners` prop to conditionally apply positioning
4. **TxDetails/index.tsx**: Pass `hasSigners` based on whether the transaction is multisig

## Behavior
- **For transactions with signers (multisig)**: Copy link button uses -53px negative margin to overlap with signers section
- **For incoming transactions without signers**: Copy link button displays full-width without overlap to prevent collision with "View on explorer" link

## Test plan
- [ ] Test Copy link button on outgoing transactions (with signers) - should overlap as before
- [ ] Test Copy link button on incoming transactions (without signers) - should be full width and not overlap with View on explorer link
- [ ] Verify button functionality works correctly in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)