### PR TITLE
fix(mobile): UnhandledLinkingContext  when opening storybook on IOS 

### DIFF
--- a/apps/mobile/.storybook/preview.tsx
+++ b/apps/mobile/.storybook/preview.tsx
@@ -1,9 +1,66 @@
 import type { Preview } from '@storybook/react'
-import { NavigationIndependentTree } from '@react-navigation/native'
+import { NavigationContainer, NavigationIndependentTree } from '@react-navigation/native'
 import { StorybookThemeProvider } from '@/src/theme/provider/storybookTheme'
 import { SafeToastProvider } from '@/src/theme/provider/toastProvider'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { PortalProvider, View } from 'tamagui'
+import { createNavigationContainerRef } from '@react-navigation/native'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { rootReducer } from '@/src/store'
+import { FLUSH, PAUSE, PERSIST, PURGE, REGISTER, REHYDRATE } from 'redux-persist'
+import { cgwClient } from '@safe-global/store/gateway/cgwClient'
+import { web3API } from '@/src/store/signersBalance'
+import { TOKEN_LISTS } from '@/src/store/settingsSlice'
+
+const navigationRef = createNavigationContainerRef()
+
+// Create a mock Redux store for Storybook
+const createStorybookStore = () => {
+  return configureStore({
+    reducer: rootReducer,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: {
+          ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+        },
+      }).concat(cgwClient.middleware, web3API.middleware),
+    preloadedState: {
+      settings: {
+        onboardingVersionSeen: '',
+        themePreference: 'light',
+        currency: 'usd',
+        tokenList: TOKEN_LISTS.TRUSTED,
+        env: {
+          rpc: {},
+          tenderly: {
+            url: '',
+            accessToken: '',
+          },
+        },
+      },
+    } as any,
+  })
+}
+
+const storybookStore = createStorybookStore()
+
+// Navigation wrapper component for Storybook
+// Uses NavigationIndependentTree to isolate from any parent navigation
+const NavigationWrapper = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <NavigationIndependentTree>
+      <NavigationContainer
+        ref={navigationRef}
+        documentTitle={{
+          enabled: false,
+        }}
+      >
+        {children}
+      </NavigationContainer>
+    </NavigationIndependentTree>
+  )
+}
 
 const preview: Preview = {
   parameters: {
@@ -18,19 +75,21 @@ const preview: Preview = {
   decorators: [
     (Story) => {
       return (
-        <PortalProvider shouldAddRootHost>
-          <NavigationIndependentTree>
-            <SafeAreaProvider>
-              <StorybookThemeProvider>
-                <SafeToastProvider>
-                  <View style={{ padding: 16, flex: 1 }} backgroundColor={'$background'}>
-                    <Story />
-                  </View>
-                </SafeToastProvider>
-              </StorybookThemeProvider>
-            </SafeAreaProvider>
-          </NavigationIndependentTree>
-        </PortalProvider>
+        <Provider store={storybookStore}>
+          <PortalProvider shouldAddRootHost>
+            <NavigationWrapper>
+              <SafeAreaProvider>
+                <StorybookThemeProvider>
+                  <SafeToastProvider>
+                    <View style={{ padding: 16, flex: 1 }} backgroundColor={'$background'}>
+                      <Story />
+                    </View>
+                  </SafeToastProvider>
+                </StorybookThemeProvider>
+              </SafeAreaProvider>
+            </NavigationWrapper>
+          </PortalProvider>
+        </Provider>
       )
     },
   ],

--- a/apps/mobile/src/components/SafeAvatar/SafeAvatar.stories.tsx
+++ b/apps/mobile/src/components/SafeAvatar/SafeAvatar.stories.tsx
@@ -12,8 +12,11 @@ const meta: Meta<typeof SafeAvatar> = {
     label: { control: 'text' },
     delayMs: { control: 'number' },
     fallbackBackgroundColor: { control: 'color' },
-    // fallbackIcon is a ReactNode, so we disable controls
-    fallbackIcon: { control: false },
+    // fallbackIcon is a ReactNode, so we disable controls to avoid circular reference
+    fallbackIcon: {
+      control: false,
+      table: { disable: true },
+    },
   },
 }
 
@@ -30,11 +33,14 @@ export const Loaded: Story = {
 }
 
 export const Fallback: Story = {
+  // Don't include fallbackIcon in args to avoid circular reference warnings
   args: {
     src: '',
     size: '$10',
     label: 'Fallback Avatar',
     fallbackBackgroundColor: '$gray4',
-    fallbackIcon: <SafeFontIcon name="code-blocks" size={16} color="$color" />,
   },
+  render: (args) => (
+    <SafeAvatar {...args} fallbackIcon={<SafeFontIcon name="code-blocks" size={16} color="$color" />} />
+  ),
 }


### PR DESCRIPTION
## What it solves
We're not able to run the storybook in the mobile app when running `yarn storybook:ios`

## How this PR fixes it 
Fixed Issues ✅
1. ~~UnhandledLinkingContext Error~~
Fixed by: Wrapping NavigationContainer inside NavigationIndependentTree to provide proper navigation context without requiring linking setup.
2. ~~Nested NavigationContainer Warning~~
Fixed by: Using NavigationIndependentTree to explicitly isolate the Storybook navigation from any parent navigation.
3. ~~Redux Provider Missing Error~~
Fixed by: Adding Redux Provider with a properly configured store to the Storybook decorators.

## Screenshots
<img width="551" height="1037" alt="Screenshot 2025-11-13 at 15 28 39" src="https://github.com/user-attachments/assets/348bec1b-8007-4208-b6ac-17f3cfffbadc" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
