### PR TITLE
fix(mobile): tx history list flicker when scrolling

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -69,7 +69,7 @@
     "@safe-global/protocol-kit": "^5.2.21",
     "@safe-global/store": "workspace:^",
     "@safe-global/utils": "workspace:^",
-    "@shopify/flash-list": "2.0.2",
+    "@shopify/flash-list": "^2.2.0",
     "@storybook/addon-react-native-web": "^0.0.26",
     "@storybook/addon-webpack5-compiler-babel": "^3.0.3",
     "@tamagui/animations-moti": "^1.126.3",

--- a/apps/mobile/src/components/transactions-list/Card/TxGroupedCard/TxGroupedCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxGroupedCard/TxGroupedCard.tsx
@@ -8,7 +8,6 @@ import { OrderTransactionInfo } from '@safe-global/store/gateway/types'
 import { TransactionQueuedItem, TransactionItem } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { Container } from '@/src/components/Container'
 import { TxCardPress } from '@/src/components/TxInfo/types'
-
 interface TxGroupedCard {
   transactions: (TransactionItem | TransactionQueuedItem)[]
   inQueue?: boolean

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
@@ -1,18 +1,19 @@
 import React, { useMemo, useCallback } from 'react'
-import { View, Text, getTokenValue } from 'tamagui'
+import { View, getTokenValue } from 'tamagui'
 import { Tabs } from 'react-native-collapsible-tab-view'
-import { getGroupHash, getTxHash } from '@/src/features/TxHistory/utils'
-import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
-import { TxGroupedCard } from '@/src/components/transactions-list/Card/TxGroupedCard'
-import { TxInfo } from '@/src/components/TxInfo'
-import { TransactionSkeleton, TransactionSkeletonItem } from '@/src/components/TransactionSkeleton'
-import { Platform, RefreshControl } from 'react-native'
-import { formatWithSchema } from '@/src/utils/date'
-import { isDateLabel, isCreationTxInfo } from '@/src/utils/transaction-guards'
-import { groupBulkTxs } from '@/src/utils/transactions'
+import { RefreshControl } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
+import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
+import { isDateLabel, isCreationTxInfo } from '@/src/utils/transaction-guards'
+import { groupBulkTxs } from '@/src/utils/transactions'
 import { TxCardPress } from '@/src/components/TxInfo/types'
+import { GroupedTransactionItem } from './components/GroupedTransactionItem'
+import { DateHeaderItem } from './components/DateHeaderItem'
+import { TransactionListItem } from './components/TransactionListItem'
+import { EmptyComponent, HeaderComponent, FooterComponent } from './components/LoadingComponents'
+import { keyExtractor, getItemType } from './utils'
+import { EMPTY_ARRAY } from './constants'
 
 interface TxHistoryList {
   transactions?: HistoryTransactionItems[]
@@ -21,130 +22,6 @@ interface TxHistoryList {
   isLoadingNext: boolean
   refreshing: boolean
   onRefresh: () => void
-}
-
-const TAB_BAR_HEIGHT = 34
-
-const createRenderItem = (onHistoryTransactionPress: (transaction: TxCardPress) => void) => {
-  const RenderItem = ({
-    item,
-    target,
-  }: {
-    item: HistoryTransactionItems | HistoryTransactionItems[]
-    target?: string
-  }) => {
-    if (Array.isArray(item)) {
-      // Render grouped transactions - filter to only TransactionItems for TxGroupedCard
-      const transactionItems = item.filter((tx) => tx.type === 'TRANSACTION')
-      if (transactionItems.length > 0) {
-        return (
-          <View marginTop="$4">
-            <TxGroupedCard transactions={transactionItems} onPress={onHistoryTransactionPress} />
-          </View>
-        )
-      }
-      return null
-    }
-
-    if (isDateLabel(item)) {
-      const dateTitle = formatWithSchema(item.timestamp, 'MMM d, yyyy')
-      const isSticky = target === 'StickyHeader'
-
-      return (
-        <View
-          marginTop={isSticky ? '$0' : '$2'}
-          backgroundColor={'$background'}
-          paddingTop={'$2'}
-          paddingBottom={isSticky ? '$2' : '0'}
-          paddingHorizontal={isSticky ? '$4' : '0'}
-          transform={Platform.OS === 'ios' ? [{ translateY: isSticky ? TAB_BAR_HEIGHT : 0 }] : undefined}
-        >
-          <Text fontWeight={500} color="$colorSecondary">
-            {dateTitle}
-          </Text>
-        </View>
-      )
-    }
-
-    if (item.type === 'TRANSACTION') {
-      return (
-        <View marginTop="$4">
-          <TxInfo tx={item.transaction} onPress={onHistoryTransactionPress} />
-        </View>
-      )
-    }
-
-    return null
-  }
-
-  return RenderItem
-}
-
-const keyExtractor = (item: HistoryTransactionItems | HistoryTransactionItems[]) => {
-  return Array.isArray(item) ? getGroupHash(item) : getTxHash(item)
-}
-
-const getItemType = (item: HistoryTransactionItems | HistoryTransactionItems[]) => {
-  if (Array.isArray(item)) {
-    return 'groupedTransaction'
-  }
-  if (isDateLabel(item)) {
-    return 'dateHeader'
-  }
-  if (item.type === 'TRANSACTION') {
-    return 'transaction'
-  }
-  return 'unknown'
-}
-
-const createEmptyComponent = (isInitialLoading: boolean) => {
-  if (isInitialLoading) {
-    return (
-      <View
-        flex={1}
-        alignItems="flex-start"
-        justifyContent="flex-start"
-        paddingTop="$4"
-        testID="tx-history-initial-loader"
-      >
-        <TransactionSkeleton count={6} sectionTitles={['Recent transactions']} />
-      </View>
-    )
-  }
-  return null
-}
-
-const createHeaderComponent = (isLoadingPrevious: boolean, hasTransactions: boolean) => {
-  if (isLoadingPrevious && hasTransactions) {
-    return (
-      <View testID="tx-history-previous-loader" marginBottom="$4">
-        <TransactionSkeletonItem />
-      </View>
-    )
-  }
-  return null
-}
-
-const createFooterComponent = (isLoadingNext: boolean, hasTransactions: boolean) => {
-  if (isLoadingNext && hasTransactions) {
-    return (
-      <View testID="tx-history-next-loader" marginTop="$4">
-        <TransactionSkeletonItem />
-      </View>
-    )
-  }
-  return null
-}
-
-const calculateStickyHeaderIndices = (flatList: (HistoryTransactionItems | HistoryTransactionItems[])[]) => {
-  return flatList
-    .map((item, index) => {
-      if (!Array.isArray(item) && isDateLabel(item)) {
-        return index
-      }
-      return null
-    })
-    .filter((item) => item !== null) as number[]
 }
 
 export function TxHistoryList({
@@ -176,54 +53,70 @@ export function TxHistoryList({
     [router],
   )
 
-  const renderItem = useMemo(() => createRenderItem(onHistoryTransactionPress), [onHistoryTransactionPress])
-
-  const flatList: (HistoryTransactionItems | HistoryTransactionItems[])[] = useMemo(() => {
-    return groupBulkTxs(transactions || [])
+  const groupedTransactions = useMemo(() => {
+    if (!transactions || transactions.length === 0) {
+      return EMPTY_ARRAY
+    }
+    return groupBulkTxs(transactions)
   }, [transactions])
 
-  const stickyHeaderIndices = useMemo(() => calculateStickyHeaderIndices(flatList), [flatList])
+  const renderItem = useCallback(
+    ({ item }: { item: HistoryTransactionItems | HistoryTransactionItems[] }) => {
+      if (Array.isArray(item)) {
+        return <GroupedTransactionItem item={item} onPress={onHistoryTransactionPress} />
+      }
+
+      if (isDateLabel(item)) {
+        return <DateHeaderItem timestamp={item.timestamp} />
+      }
+
+      if (item.type === 'TRANSACTION') {
+        return <TransactionListItem item={item} onPress={onHistoryTransactionPress} />
+      }
+
+      return null
+    },
+    [onHistoryTransactionPress],
+  )
 
   const hasTransactions = !!(transactions && transactions.length > 0)
   const isInitialLoading = !!(isLoading && !hasTransactions && !refreshing)
-
-  const renderEmptyComponent = useMemo(() => createEmptyComponent(isInitialLoading), [isInitialLoading])
-
-  const renderHeaderComponent = useMemo(
-    () => createHeaderComponent(isLoading, hasTransactions),
-    [isLoading, hasTransactions],
-  )
-
-  const renderFooterComponent = useMemo(
-    () => createFooterComponent(isLoadingNext, hasTransactions),
-    [isLoadingNext, hasTransactions],
-  )
 
   const handleEndReached = useCallback(() => {
     onEndReached({ distanceFromEnd: 0 })
   }, [onEndReached])
 
+  const contentContainerStyle = useMemo(
+    () => ({
+      paddingHorizontal: 16,
+      paddingTop: 0,
+      paddingBottom: bottom + getTokenValue('$4'),
+    }),
+    [bottom],
+  )
+
+  const listEmptyComponent = useMemo(() => {
+    if (isInitialLoading) {
+      return <EmptyComponent />
+    }
+    return null
+  }, [isInitialLoading])
+
   return (
     <View position="relative" flex={1}>
-      {Platform.OS === 'android' && <View style={{ height: TAB_BAR_HEIGHT }}></View>}
       <Tabs.FlashList
         testID="tx-history-list"
-        data={flatList}
+        data={groupedTransactions}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         getItemType={getItemType}
-        stickyHeaderIndices={stickyHeaderIndices}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         refreshControl={<RefreshControl refreshing={!!refreshing} onRefresh={onRefresh} />}
-        contentContainerStyle={{
-          paddingHorizontal: 16,
-          paddingTop: 0,
-          paddingBottom: bottom + getTokenValue('$4'),
-        }}
-        ListEmptyComponent={renderEmptyComponent}
-        ListHeaderComponent={renderHeaderComponent}
-        ListFooterComponent={renderFooterComponent}
+        contentContainerStyle={contentContainerStyle}
+        ListEmptyComponent={listEmptyComponent}
+        ListHeaderComponent={isLoading && hasTransactions ? HeaderComponent : null}
+        ListFooterComponent={isLoadingNext && hasTransactions ? FooterComponent : null}
         contentInsetAdjustmentBehavior="automatic"
       />
     </View>

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/DateHeaderItem.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/DateHeaderItem.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { View, Text } from 'tamagui'
+import { formatWithSchema } from '@/src/utils/date'
+
+interface DateHeaderItemProps {
+  timestamp: number
+}
+
+const DateHeaderItemComponent = ({ timestamp }: DateHeaderItemProps) => {
+  const dateTitle = formatWithSchema(timestamp, 'MMM d, yyyy')
+
+  return (
+    <View marginTop="$2" backgroundColor="$background" paddingTop="$2">
+      <Text fontWeight={500} color="$colorSecondary">
+        {dateTitle}
+      </Text>
+    </View>
+  )
+}
+
+export const DateHeaderItem = React.memo(DateHeaderItemComponent)
+DateHeaderItem.displayName = 'DateHeaderItem'

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/GroupedTransactionItem.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/GroupedTransactionItem.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { View } from 'tamagui'
+import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
+import { TxGroupedCard } from '@/src/components/transactions-list/Card/TxGroupedCard'
+import { TxCardPress } from '@/src/components/TxInfo/types'
+
+interface GroupedTransactionItemProps {
+  item: HistoryTransactionItems[]
+  onPress: (transaction: TxCardPress) => void
+}
+
+const GroupedTransactionItemComponent = ({ item, onPress }: GroupedTransactionItemProps) => {
+  const transactionItems = item.filter((tx) => tx.type === 'TRANSACTION')
+  if (transactionItems.length === 0) {
+    return null
+  }
+
+  return (
+    <View marginTop="$4">
+      <TxGroupedCard transactions={transactionItems} onPress={onPress} />
+    </View>
+  )
+}
+
+export const GroupedTransactionItem = React.memo(GroupedTransactionItemComponent)
+GroupedTransactionItem.displayName = 'GroupedTransactionItem'

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/LoadingComponents.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/LoadingComponents.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { View } from 'tamagui'
+import { TransactionSkeleton, TransactionSkeletonItem } from '@/src/components/TransactionSkeleton'
+
+const EmptyComponentBase = () => (
+  <View flex={1} alignItems="flex-start" justifyContent="flex-start" paddingTop="$4" testID="tx-history-initial-loader">
+    <TransactionSkeleton count={6} sectionTitles={['Recent transactions']} />
+  </View>
+)
+
+export const EmptyComponent = React.memo(EmptyComponentBase)
+EmptyComponent.displayName = 'EmptyComponent'
+
+const HeaderComponentBase = () => (
+  <View testID="tx-history-previous-loader" marginBottom="$4">
+    <TransactionSkeletonItem />
+  </View>
+)
+
+export const HeaderComponent = React.memo(HeaderComponentBase)
+HeaderComponent.displayName = 'HeaderComponent'
+
+const FooterComponentBase = () => (
+  <View testID="tx-history-next-loader" marginTop="$4">
+    <TransactionSkeletonItem />
+  </View>
+)
+
+export const FooterComponent = React.memo(FooterComponentBase)
+FooterComponent.displayName = 'FooterComponent'

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/TransactionListItem.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/TransactionListItem.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { View } from 'tamagui'
+import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
+import { TxInfo } from '@/src/components/TxInfo'
+import { TxCardPress } from '@/src/components/TxInfo/types'
+
+interface TransactionListItemProps {
+  item: HistoryTransactionItems
+  onPress: (transaction: TxCardPress) => void
+}
+
+const TransactionListItemComponent = ({ item, onPress }: TransactionListItemProps) => {
+  if (item.type !== 'TRANSACTION') {
+    return null
+  }
+
+  return (
+    <View marginTop="$4">
+      <TxInfo tx={item.transaction} onPress={onPress} />
+    </View>
+  )
+}
+
+export const TransactionListItem = React.memo(TransactionListItemComponent)
+TransactionListItem.displayName = 'TransactionListItem'

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/constants.ts
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/constants.ts
@@ -1,0 +1,4 @@
+import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
+
+// Stable empty array reference to avoid unnecessary re-renders
+export const EMPTY_ARRAY: HistoryTransactionItems[] = []

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/utils.ts
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/utils.ts
@@ -1,0 +1,20 @@
+import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
+import { getGroupHash, getTxHash } from '@/src/features/TxHistory/utils'
+import { isDateLabel } from '@/src/utils/transaction-guards'
+
+export const keyExtractor = (item: HistoryTransactionItems | HistoryTransactionItems[]) => {
+  return Array.isArray(item) ? getGroupHash(item) : getTxHash(item)
+}
+
+export const getItemType = (item: HistoryTransactionItems | HistoryTransactionItems[]) => {
+  if (Array.isArray(item)) {
+    return 'groupedTransaction'
+  }
+  if (isDateLabel(item)) {
+    return 'dateHeader'
+  }
+  if (item.type === 'TRANSACTION') {
+    return 'transaction'
+  }
+  return 'unknown'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10191,7 +10191,7 @@ __metadata:
     "@safe-global/test": "workspace:^"
     "@safe-global/types-kit": "npm:^1.0.5"
     "@safe-global/utils": "workspace:^"
-    "@shopify/flash-list": "npm:2.0.2"
+    "@shopify/flash-list": "npm:^2.2.0"
     "@storybook/addon-essentials": "npm:^8.4.6"
     "@storybook/addon-interactions": "npm:^8.4.6"
     "@storybook/addon-onboarding": "npm:^8.4.6"
@@ -10826,16 +10826,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shopify/flash-list@npm:2.0.2":
-  version: 2.0.2
-  resolution: "@shopify/flash-list@npm:2.0.2"
-  dependencies:
-    tslib: "npm:2.8.1"
+"@shopify/flash-list@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@shopify/flash-list@npm:2.2.0"
   peerDependencies:
     "@babel/runtime": "*"
     react: "*"
     react-native: "*"
-  checksum: 10/9e4dad24e886b6ff318a66a27500e1293fa28d7c466453893c45a73ca195e9fac5d6cd41142cb5ad7480f8a89475ecd5ba0dfbac61a20b7704eb85b690990540
+  checksum: 10/482e32e2e229d32a50312f8e83b02b99e323bb18dafca0fc547ac8faab712eec36d10560da4b01b4efba53271838deb8455d0831a2751218a6f1ca42e178131a
   languageName: node
   linkType: hard
 
@@ -34528,7 +34526,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2, tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
+"tslib@npm:2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.7.0, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7


### PR DESCRIPTION
## What it solves
When scrolling the list was re-rendering in an unexpected way which caused a noticeable jump. After some heavy use of memoization I no longer observe the jump 

Resolves https://linear.app/safe-global/issue/COR-738/scroll-is-jumping-on-transaction-history-list-on-android

## How this PR fixes it
- Memoize every component involved in rendering with the flashlist.
- Removes the sticky header - part of the jumping was caused by going from $0 marginTop to $4 marginTop. I spend a lot of time trying to get it to work, but gave up. Will revisit in the future. 

## How to test it
You need a safe with more than 20tx. Start scrolling slowly - in previous versions once we fetch a second page of data the list will jump briefly. With the new version - no jumping should be observed. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
