### PR TITLE
fix(mobile): ui text was going out of bounds

### DIFF
--- a/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Text, Theme } from 'tamagui'
+import { Text, Theme, View } from 'tamagui'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { MultiSend } from '@safe-global/store/gateway/types'
 import { CustomTransactionInfo, SafeAppInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
@@ -31,7 +31,13 @@ export function TxContractInteractionCard({ txInfo, safeAppInfo, ...rest }: TxCo
           />
         </Theme>
       }
-      rightNode={<Text>{txInfo.methodName}</Text>}
+      rightNode={
+        <View flex={1}>
+          <Text numberOfLines={1} ellipsizeMode="tail">
+            {txInfo.methodName}
+          </Text>
+        </View>
+      }
       {...rest}
     />
   )


### PR DESCRIPTION
## What it solves
Check the screenshots. Some contract names are pretty long and were spanning outside the card. Still this doesn't look good, but it is better then before.

Resolves: 

## How this PR fixes it
Ads a View with flex=1 and restricts the text to  numberOfLines={1} ellipsizeMode="tail"

## How to test it
1. Check the history of safe 0x2f3e600a3F38b66aDcbe6530B191F2BE55c2Fbb6 - the contract name should be fine

## Screenshots

before:
<img width="150" alt="image" src="https://github.com/user-attachments/assets/e62c4123-ba01-41e3-8287-8d1878e1e820" />

after:
<img width="150"  alt="image" src="https://github.com/user-attachments/assets/50e5a5f2-5fcd-459d-8d56-9c4c86c2d6e1" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
