### PR TITLE
fix(mobile): missing data row in data tab

### DIFF
--- a/apps/mobile/e2e/utils/components/advanced-details/data.yml
+++ b/apps/mobile/e2e/utils/components/advanced-details/data.yml
@@ -34,6 +34,20 @@ tags:
 # Value (always present if txData.value exists)
 - assertVisible: 'Value'
 
+# Hex Data (optional - only if txData?.hexData exists)
+- extendedWaitUntil:
+    visible:
+      text: 'Data'
+      optional: true
+    timeout: ${output.defaults.extendedWaitUntilTimeout}
+
+# Hex Data value (shortened format like "0x1234...abcd")
+- extendedWaitUntil:
+    visible:
+      text: '0x[0-9a-fA-F]{4}.*[0-9a-fA-F]{4}'
+      optional: true
+    timeout: ${output.defaults.extendedWaitUntilTimeout}
+
 # Value amount (can be "0" or any number)
 - assertVisible:
     text: '^\d+$'

--- a/apps/mobile/e2e/utils/components/advanced-details/parameters.yml
+++ b/apps/mobile/e2e/utils/components/advanced-details/parameters.yml
@@ -54,20 +54,6 @@ tags:
       optional: true
     timeout: ${output.defaults.extendedWaitUntilTimeout}
 
-# Hex Data (optional - only if txData?.hexData exists)
-- extendedWaitUntil:
-    visible:
-      text: 'Hex Data'
-      optional: true
-    timeout: ${output.defaults.extendedWaitUntilTimeout}
-
-# Hex Data value (shortened format like "0x1234...abcd")
-- extendedWaitUntil:
-    visible:
-      text: '0x[0-9a-fA-F]{4}.*[0-9a-fA-F]{4}'
-      optional: true
-    timeout: ${output.defaults.extendedWaitUntilTimeout}
-
 # Hex Data copy button (optional - if hex data exists)
 - extendedWaitUntil:
     visible:

--- a/apps/mobile/src/components/HexDataDisplay/HexDataDisplay.tsx
+++ b/apps/mobile/src/components/HexDataDisplay/HexDataDisplay.tsx
@@ -49,7 +49,7 @@ export const HexDataDisplay = ({
   return (
     <InfoSheet title={title} info={data}>
       <View flexDirection="row" alignItems="center" gap={gap}>
-        <Text>{shortenText(data, characterLimit)}</Text>
+        <Text>{data.length > characterLimit ? shortenText(data, characterLimit) : data}</Text>
         <CopyButton value={data} color={copyButtonColor} text={copyMessage} />
       </View>
     </InfoSheet>

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatParameters.test.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatParameters.test.tsx
@@ -108,23 +108,6 @@ describe('formatParameters', () => {
     expect(formatArrayValue).toHaveBeenCalledTimes(1)
   })
 
-  it('should include hex data when present', () => {
-    const txData = {
-      to: { value: '0x123...' },
-      dataDecoded: {
-        method: 'transfer',
-        parameters: [],
-      },
-      hexData: '0x1234567890abcdef1234567890abcdef',
-      value: null,
-      operation: 0 as Operation,
-    }
-
-    const result = formatParameters({ txData })
-
-    expect(result).toHaveLength(2) // 1 basic + 1 hex data
-  })
-
   it('should handle missing dataDecoded', () => {
     const txData = {
       to: { value: '0x123...' },
@@ -136,7 +119,7 @@ describe('formatParameters', () => {
 
     const result = formatParameters({ txData })
 
-    expect(result).toHaveLength(2) // 1 basic + 1 hex data
+    expect(result).toHaveLength(1) // Only basic item, hexData is ignored
   })
 
   it('should handle mixed parameter types', () => {
@@ -160,7 +143,7 @@ describe('formatParameters', () => {
 
     const result = formatParameters({ txData })
 
-    expect(result).toHaveLength(6) // 1 basic + 4 parameters + 1 hex data
+    expect(result).toHaveLength(5) // 1 basic + 4 parameters
     expect(formatValueTemplate).toHaveBeenCalledTimes(2) // address and flag
     expect(formatArrayValue).toHaveBeenCalledTimes(2) // amounts array and data with array value
   })

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatParameters.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatParameters.tsx
@@ -5,7 +5,6 @@ import { CircleProps } from 'tamagui'
 import { formatValueTemplate } from '../formatters/singleValue'
 import { formatArrayValue } from '../formatters/arrayValue'
 import { Badge } from '@/src/components/Badge'
-import { HexDataDisplay } from '@/src/components/HexDataDisplay'
 import React from 'react'
 
 interface formatParametersProps {
@@ -51,13 +50,6 @@ const formatParameters = ({ txData }: formatParametersProps): ListTableItem[] =>
     }, [])
 
     items.push(...formatedParameters)
-  }
-
-  if (txData?.hexData) {
-    items.push({
-      label: 'Hex Data',
-      render: () => <HexDataDisplay data={txData?.hexData} title="Hex Data" copyMessage="Data copied." />,
-    })
   }
 
   return items

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.test.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.test.tsx
@@ -100,9 +100,11 @@ describe('formatTxDetails', () => {
 
     const result = formatTxDetails({ txDetails, viewOnExplorer })
 
-    expect(result.length).toBeGreaterThanOrEqual(1)
+    expect(result.length).toBeGreaterThanOrEqual(2)
     // Check that we have a 'To' field
     expect(result.some((item) => 'label' in item && item.label === 'To')).toBe(true)
+    // Check that we have a 'Data' field (always shown when txData exists)
+    expect(result.some((item) => 'label' in item && item.label === 'Data')).toBe(true)
   })
 
   it('should include Value field when transaction has value', () => {
@@ -137,6 +139,23 @@ describe('formatTxDetails', () => {
 
     // Check that we have an 'Operation' field
     expect(result.some((item) => 'label' in item && item.label === 'Operation')).toBe(true)
+  })
+
+  it('should include Data field when txData exists', () => {
+    const txDetails = createMockTxDetails({
+      txData: {
+        to: { value: faker.finance.ethereumAddress() },
+        value: null,
+        operation: Operation.CALL,
+        hexData: '0x1234',
+        dataDecoded: null,
+      },
+    })
+
+    const result = formatTxDetails({ txDetails, viewOnExplorer })
+
+    // Check that we have a 'Data' field
+    expect(result.some((item) => 'label' in item && item.label === 'Data')).toBe(true)
   })
 
   it('should include multisig execution details when available', () => {
@@ -204,8 +223,10 @@ describe('formatTxDetails', () => {
 
     const result = formatTxDetails({ txDetails, viewOnExplorer })
 
-    // Should only have the 'To' field
-    expect(result).toHaveLength(1)
+    // Should have the 'To' and 'Data' fields (Data is always shown when txData exists)
+    expect(result).toHaveLength(2)
+    expect(result.some((item) => 'label' in item && item.label === 'To')).toBe(true)
+    expect(result.some((item) => 'label' in item && item.label === 'Data')).toBe(true)
     expect(result.some((item) => 'label' in item && item.label === 'Value')).toBe(false)
     expect(result.some((item) => 'label' in item && item.label === 'Operation')).toBe(false)
     expect(result.some((item) => 'label' in item && item.label === 'Transaction Hash')).toBe(false)
@@ -277,6 +298,7 @@ describe('formatTxDetails', () => {
     // Should have all possible fields
     expect(result.some((item) => 'label' in item && item.label === 'To')).toBe(true)
     expect(result.some((item) => 'label' in item && item.label === 'Value')).toBe(true)
+    expect(result.some((item) => 'label' in item && item.label === 'Data')).toBe(true)
     expect(result.some((item) => 'label' in item && item.label === 'Operation')).toBe(true)
     expect(result.some((item) => 'label' in item && item.label === 'SafeTxGas')).toBe(true)
     expect(result.some((item) => 'label' in item && item.label === 'Transaction Hash')).toBe(true)

--- a/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/utils/formatTxDetails.tsx
@@ -14,6 +14,7 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { TouchableOpacity } from 'react-native'
 import { Receiver } from '../components/Receiver'
 import { InfoSheet } from '@/src/components/InfoSheet'
+import { HexDataDisplay } from '@/src/components/HexDataDisplay'
 
 interface formatTxDetailsProps {
   txDetails?: TransactionDetails
@@ -66,6 +67,14 @@ const formatTxDetails = ({ txDetails, viewOnExplorer }: formatTxDetailsProps): L
     items.push({
       label: 'Value',
       render: () => <Text>{txDetails.txData?.value || '0'}</Text>,
+    })
+  }
+
+  // Data field - always show when txData exists
+  if (txDetails.txData) {
+    items.push({
+      label: 'Data',
+      render: () => <HexDataDisplay data={txDetails.txData?.hexData || '0x'} title="Data" copyMessage="Data copied." />,
     })
   }
 


### PR DESCRIPTION
## What it solves
The actual tx data was missing from the "data" tab. It was present under parameters, but since we are not showing any parameters on the review-and-execute it looked weird.

Resolves https://linear.app/safe-global/issue/COR-866/tx-data-missing-on-confirm-view

## How this PR fixes it
I've moved the data form the parameters tab to the data tab. This way it's available everywhere where we display "data" related to the tx

## How to test it
Open a pending tx and try to execute it. Observe that on the review and execute screen the data or '0x' is visible.

## Screenshots
<img width="150" alt="image" src="https://github.com/user-attachments/assets/b6ad1049-ec3a-4e8d-aed9-fb48ce576604" />

<img width="150" alt="image" src="https://github.com/user-attachments/assets/cafc411d-0207-4a9c-b751-b055a51072e0" />



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
