### PR TITLE
fix(mobile): disable android backup

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -75,6 +75,7 @@ const config: ExpoConfig = {
       'android.permission.WAKE_LOCK',
     ],
     edgeToEdgeEnabled: true,
+    allowBackup: false,
   },
   web: {
     bundler: 'metro',


### PR DESCRIPTION
## What it solves
- switched our config to typescript - this way we get auto-complete and know whether we are using a feature correctly or not
- disabled automatic backups on Android - Android is automatically backing up the app database. The app restoration worked, but it looked weird as the local database would indicate that a PK was imported, but the app can't actually access it (as it is not there). That's why I'm disabling this for now. 

Resolves https://linear.app/safe-global/issue/COR-869/android-app-data-is-backed-up

## How this PR fixes it
- set the corresponding expo conf variable

## How to test it
Make sure that backup on your phone is on. Delete any previous backup of the app if any. Install the new version. Observe that android is no longer going to backup app files.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
