### PR TITLE
fix(mobile): wrong default_tokenlist behavior

### DIFF
--- a/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
@@ -27,7 +27,7 @@ export function TokensContainer() {
   const tokenList = useAppSelector(selectTokenList)
   const hasDefaultTokenlist = useHasFeature(FEATURES.DEFAULT_TOKENLIST)
 
-  const trusted = hasDefaultTokenlist ? tokenList === TOKEN_LISTS.TRUSTED : true
+  const trusted = hasDefaultTokenlist ? tokenList === TOKEN_LISTS.TRUSTED : false
 
   const { data, isFetching, error, isLoading, refetch } = useBalancesGetBalancesV1Query(
     !activeSafe


### PR DESCRIPTION
## What it solves
On networks that don’t have default token lists we should return all tokens.

Resolves https://linear.app/safe-global/issue/COR-685/mobile-all-tokens-should-show-when-feature-flag-is-disabled

## How this PR fixes it
We were setting the wrong value for the network request.

## How to test it
Install the app - navigate to a network that doesn't have a token list - observe that all tokens are shown. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
