### PR TITLE
Fix(Hypernative): Settings banner is visible after form completion

### DIFF
--- a/apps/web/src/features/hypernative/hooks/useBannerStorage.ts
+++ b/apps/web/src/features/hypernative/hooks/useBannerStorage.ts
@@ -23,7 +23,7 @@ export enum BannerType {
  * - For BannerType.Pending: Returns true if formCompleted is true AND pendingBannerDismissed is false, otherwise false
  * - For BannerType.TxReportButton: Always returns true (ignores bannerDismissed and formCompleted)
  * - For BannerType.NoBalanceCheck: Same as BannerType.Promo, but used when balance cannot be checked (e.g., for undeployed safes)
- * - For BannerType.Settings: Ignores bannerDismissed but respects formCompleted (used for Settings page)
+ * - For BannerType.Settings: Always true, visibility depends on the guard status in useBannerVisibility
  */
 export const useBannerStorage = (bannerType: BannerType): boolean => {
   const chainId = useChainId()
@@ -37,19 +37,14 @@ export const useBannerStorage = (bannerType: BannerType): boolean => {
       return true
     }
 
-    if (!safeHnState) {
-      // If no state exists, show promo banner by default, hide pending banner
-      // For Settings, show if no state exists (no form completed yet)
-      return (
-        bannerType === BannerType.Settings ||
-        bannerType === BannerType.Promo ||
-        bannerType === BannerType.NoBalanceCheck
-      )
+    // Settings banner always shows (visibility controlled by guard status in useBannerVisibility)
+    if (bannerType === BannerType.Settings) {
+      return true
     }
 
-    // Settings banner ignores dismissal state but respects formCompleted
-    if (bannerType === BannerType.Settings) {
-      return !safeHnState.formCompleted
+    if (!safeHnState) {
+      // If no state exists, show promo banner by default, hide pending banner
+      return bannerType === BannerType.Promo || bannerType === BannerType.NoBalanceCheck
     }
 
     if (bannerType === BannerType.Promo || bannerType === BannerType.NoBalanceCheck) {


### PR DESCRIPTION
## What it solves

The Hypernative promo banner in Settings was hidden after form completion. With this change target users who completed the form but hadn't activated the guard would see the banner regardless.

Resolves: [COR-849](https://linear.app/safe-global/issue/COR-849/safe-shield-hn-hn-banner-disappears-from-the-settings-if-its-closed-on)

## How this PR fixes it

Modified `useBannerStorage` hook to always return `true` for `BannerType.Settings`, removing the dependency on `formCompleted` status. The banner visibility is now solely controlled by the Guard status check in `useBannerVisibility`, which correctly hides the banner only when `isHypernativeGuard` is `true`. This ensures the banner remains visible after form completion until the guard is actually activated.

## How to test it

1. Complete the Hypernative form
2. Go to Settings -> Security
3. **Expected result**: The promo banner is visible on the top of the page

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).