### PR TITLE
chore(mobile): run e2e tests in expo

### DIFF
--- a/apps/mobile/.eas/build/build-and-maestro-test.yml
+++ b/apps/mobile/.eas/build/build-and-maestro-test.yml
@@ -32,8 +32,37 @@ build:
     - eas/run_fastlane
 
     - eas/find_and_upload_build_artifacts
-    - eas/maestro_test:
+
+    - eas/install_maestro
+    - eas/start_ios_simulator
+    - run:
+        command: |
+          # shopt -s nullglob is necessary not to try to install
+          # SEARCH_PATH literally if there are no matching files.
+          shopt -s nullglob
+
+          SEARCH_PATH="ios/build/Build/Products/*simulator/*.app"
+          FILES_FOUND=false
+
+          for APP_PATH in $SEARCH_PATH; do
+            FILES_FOUND=true
+            echo "Installing \\"$APP_PATH\\""
+            xcrun simctl install booted "$APP_PATH"
+            # Trigger biometric enrollment change to allow biometric authentication
+            xcrun simctl spawn booted notifyutil -s com.apple.BiometricKit.enrollmentChanged '1' && xcrun simctl spawn booted notifyutil -p com.apple.BiometricKit.enrollmentChanged
+          done
+
+          if ! $FILES_FOUND; then
+            echo "No files found matching \\"$SEARCH_PATH\\". Are you sure you've built a Simulator app?"
+            exit 1
+          fi
+    - run:
+        command: |
+          maestro test --env="IS_DEV_MODE=true" --env="APP_ID=global.safe.mobileapp.ios.dev" e2e
+    - eas/upload_artifact:
+        name: Upload test artifact
+        if: ${ always() }
         inputs:
-          flow_path: |
-            e2e/onboarding.yml
-            e2e/onboarded-user.yml
+          type: build-artifact
+          path: ${ eas.env.HOME }/.maestro/tests
+

--- a/apps/mobile/e2e/tests/onboarding/__suite__.yml
+++ b/apps/mobile/e2e/tests/onboarding/__suite__.yml
@@ -12,11 +12,25 @@ tags:
 
 # Run all onboarding tests with SKIP_CLEAN_START
 - runFlow:
-    file: ./new-user-onboarding.yml
+    file: ./add-existing-safe.yml
     env:
       SKIP_CLEAN_START: 'true'
 
 - runFlow:
-    file: ./add-existing-safe.yml
+    file: ./enhanced-onboarding-flow.yml
+
+- runFlow:
+    file: ./import-signer-private-key.yml
     env:
       SKIP_CLEAN_START: 'true'
+
+- runFlow:
+    file: ./import-signer-seed-phrase.yml
+    env:
+      SKIP_CLEAN_START: 'true'
+
+- runFlow:
+    file: ./import-signer.yml
+
+- runFlow:
+    file: ./new-user-onboarding.yml

--- a/apps/mobile/e2e/tests/settings/__suite__.yml
+++ b/apps/mobile/e2e/tests/settings/__suite__.yml
@@ -10,8 +10,23 @@ tags:
 - runFlow:
     file: ../../utils/setup/app-start.yml
 
+- runFlow:
+    file: ./address-book.yml
+    env:
+      SKIP_CLEAN_START: 'true'
+
 # Run all settings tests with SKIP_CLEAN_START
 - runFlow:
     file: ./change-theme.yml
+    env:
+      SKIP_CLEAN_START: 'true'
+
+- runFlow:
+    file: ./state-preservation.yml
+    env:
+      SKIP_CLEAN_START: 'true'
+
+- runFlow:
+    file: ./view-account-info.yml
     env:
       SKIP_CLEAN_START: 'true'

--- a/apps/mobile/e2e/tests/settings/address-book.yml
+++ b/apps/mobile/e2e/tests/settings/address-book.yml
@@ -239,6 +239,7 @@ tags:
 # Tap on Name field to focus it for editing
 - tapOn:
     text: '.*Test Safe.*'
+    index: 1
 
 # Clear existing text and enter new name
 - eraseText

--- a/apps/mobile/e2e/tests/transactions/history/__suite__.yml
+++ b/apps/mobile/e2e/tests/transactions/history/__suite__.yml
@@ -18,32 +18,7 @@ tags:
 
 # Subsequent tests: Preserve state from previous test
 - runFlow:
-    file: ./rejected-transaction.yml
-    env:
-      SKIP_CLEAN_START: 'true'
-
-- runFlow:
-    file: ./sent-transaction.yml
-    env:
-      SKIP_CLEAN_START: 'true'
-
-- runFlow:
     file: ./add-owner-threshold.yml
-    env:
-      SKIP_CLEAN_START: 'true'
-
-- runFlow:
-    file: ./received-transaction.yml
-    env:
-      SKIP_CLEAN_START: 'true'
-
-- runFlow:
-    file: ./change-threshold.yml
-    env:
-      SKIP_CLEAN_START: 'true'
-
-- runFlow:
-    file: ./bulk-transactions.yml
     env:
       SKIP_CLEAN_START: 'true'
 
@@ -53,17 +28,12 @@ tags:
       SKIP_CLEAN_START: 'true'
 
 - runFlow:
-    file: ./disable-module.yml
+    file: ./bulk-transactions.yml
     env:
       SKIP_CLEAN_START: 'true'
 
 - runFlow:
-    file: ./remove-owner.yml
-    env:
-      SKIP_CLEAN_START: 'true'
-
-- runFlow:
-    file: ./swap-owner.yml
+    file: ./change-threshold.yml
     env:
       SKIP_CLEAN_START: 'true'
 
@@ -72,12 +42,13 @@ tags:
     env:
       SKIP_CLEAN_START: 'true'
 
-# ============================================
-# Tests on Swap Test Safe
-# ============================================
+- runFlow:
+    file: ./contract-interaction-deposit.yml
+    env:
+      SKIP_CLEAN_START: 'true'
 
 - runFlow:
-    file: ./swap-order.yml
+    file: ./disable-module.yml
     env:
       SKIP_CLEAN_START: 'true'
 
@@ -87,13 +58,32 @@ tags:
       SKIP_CLEAN_START: 'true'
 
 - runFlow:
-    file: ./contract-interaction-deposit.yml
+    file: ./received-transaction.yml
     env:
       SKIP_CLEAN_START: 'true'
 
-# ============================================
-# Tests on Stake Deposit Safe
-# ============================================
+- runFlow:
+    file: ./rejected-transaction.yml
+    env:
+      SKIP_CLEAN_START: 'true'
+
+- runFlow:
+    file: ./remove-owner.yml
+    env:
+      SKIP_CLEAN_START: 'true'
+
+- runFlow:
+    file: ./sent-transaction.yml
+    env:
+      SKIP_CLEAN_START: 'true'
+
+- retry:
+    maxRetries: 3
+    commands:
+      - runFlow:
+          file: ./stake-claim.yml
+          env:
+            SKIP_CLEAN_START: 'true'
 
 - runFlow:
     file: ./stake-deposit.yml
@@ -101,6 +91,19 @@ tags:
       SKIP_CLEAN_START: 'true'
 
 - runFlow:
-    file: ./stake-claim.yml
+    file: ./swap-order.yml
     env:
       SKIP_CLEAN_START: 'true'
+
+- runFlow:
+    file: ./swap-owner.yml
+    env:
+      SKIP_CLEAN_START: 'true'
+# ============================================
+# Tests on Swap Test Safe
+# ============================================
+
+# ============================================
+# Tests on Stake Deposit Safe
+# ============================================
+

--- a/apps/mobile/e2e/utils/setup/app-start.yml
+++ b/apps/mobile/e2e/utils/setup/app-start.yml
@@ -4,6 +4,7 @@ tags:
 jsEngine: graaljs
 env:
   APP_ID: ${APP_ID || "unset"}
+  IS_DEV_MODE: ${IS_DEV_MODE || "false"}
 ---
 # Launches app with clearState based on SKIP_CLEAN_START environment variable
 # - If SKIP_CLEAN_START != "true": clears state (fresh start)
@@ -25,7 +26,7 @@ env:
       platform: Android
     commands:
       - evalScript: ${output.APP_ID = "global.safe.mobileapp"}
-- evalScript: ${console.log(output.APP_ID)}
+
 # Launch with clear state (individual test mode)
 - runFlow:
     when:
@@ -53,13 +54,17 @@ env:
 # Handle potential environment-specific dialogs (both modes)
 - runFlow:
     when:
-      visible:
-        text: 'http.*'
+      true: '${IS_DEV_MODE == "true"}'
     commands:
-      - tapOn: 'http.*'
+      - runFlow:
+          when:
+            visible:
+              text: 'http.*'
+          commands:
+            - tapOn: 'http.*'
 
-- runFlow:
-    when:
-      visible: 'Close'
-    commands:
-      - tapOn: 'Close'
+      - runFlow:
+          when:
+            visible: 'Close'
+          commands:
+            - tapOn: 'Close'

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -61,14 +61,17 @@
     },
     "build-and-maestro-test": {
       "withoutCredentials": true,
+      "environment": "development",
       "env": {
-        "RN_SRC_EXT": "e2e.ts,e2e.tsx"
+        "RN_SRC_EXT": "e2e.ts,e2e.tsx",
+        "EXPO_PUBLIC_SECURITY_RASP_ENABLED": "false"
       },
       "config": "build-and-maestro-test.yml",
       "android": {
         "buildType": "apk",
         "image": "latest"
       },
+
       "ios": {
         "simulator": true,
         "image": "latest",


### PR DESCRIPTION
## What it solves
With this PR our e2e will run on expo.

Resolves https://linear.app/safe-global/issue/COR-868/setup-e2e-tests-on-expo

## How this PR fixes it
I had to go change `eas/maestro_test:` to the individual commands hidden behind it as I need to launch maestro with env variables. 

I've made a modification to the `__suite__.yml`, but I think that I'm going to drop them completely in a different PR. Initially I added the `__suite__.yml` files as a way to execute on CI without having to constantly re-install the app. However after inspecting the logs it seems that the slowness is not in the app installation, but rather in the runFlow that waits to see the 'http' or 'close' buttons. Those buttons are only available when running the app in dev mode. Maestro waits 8s on every button adding a total of 16s to the start process. I switched to an .env variable and now we save 16s on every start and I think that because of this the `__suite__` is no longer needed. Will remove them in a separate PR. 

## How to test it
Nothing to test. I've tested it on expo and had a succesful run:
<img width="1173" height="183" alt="image" src="https://github.com/user-attachments/assets/ac37cd8f-c58f-4902-8101-c7f0bab8cd93" />

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
