### PR TITLE
Fix(Hypernative): stricter checks for HnTxReportBtn

### DIFF
--- a/apps/web/src/features/hypernative/hooks/__tests__/useBannerVisibility.test.ts
+++ b/apps/web/src/features/hypernative/hooks/__tests__/useBannerVisibility.test.ts
@@ -552,11 +552,11 @@ describe('useBannerVisibility', () => {
     })
 
     describe('when guard is installed', () => {
-      it('should show button when guard is installed (regardless of other conditions)', () => {
-        jest.spyOn(useIsHypernativeFeatureHook, 'useIsHypernativeFeature').mockReturnValue(false)
-        jest.spyOn(useBannerStorageHook, 'useBannerStorage').mockReturnValue(false)
-        jest.spyOn(useWalletHook, 'default').mockReturnValue(null)
-        jest.spyOn(useIsSafeOwnerHook, 'default').mockReturnValue(false)
+      it('should show button when guard is installed AND isEnabled AND isSafeOwner', () => {
+        jest.spyOn(useIsHypernativeFeatureHook, 'useIsHypernativeFeature').mockReturnValue(true)
+        jest.spyOn(useBannerStorageHook, 'useBannerStorage').mockReturnValue(true)
+        jest.spyOn(useWalletHook, 'default').mockReturnValue(mockWallet)
+        jest.spyOn(useIsSafeOwnerHook, 'default').mockReturnValue(true)
         jest.spyOn(useVisibleBalancesHook, 'useVisibleBalances').mockReturnValue({
           balances: { fiatTotal: '0', items: [] },
           loaded: true,
@@ -594,6 +594,52 @@ describe('useBannerVisibility', () => {
 
         expect(result.current).toEqual({
           showBanner: true,
+          loading: false,
+        })
+      })
+
+      it('should NOT show button when guard is installed but feature is disabled', () => {
+        jest.spyOn(useIsHypernativeFeatureHook, 'useIsHypernativeFeature').mockReturnValue(false)
+        jest.spyOn(useBannerStorageHook, 'useBannerStorage').mockReturnValue(true)
+        jest.spyOn(useWalletHook, 'default').mockReturnValue(mockWallet)
+        jest.spyOn(useIsSafeOwnerHook, 'default').mockReturnValue(true)
+        jest.spyOn(useVisibleBalancesHook, 'useVisibleBalances').mockReturnValue({
+          balances: { fiatTotal: '2000000', items: [] },
+          loaded: true,
+          loading: false,
+        })
+        jest.spyOn(useIsHypernativeGuardHook, 'useIsHypernativeGuard').mockReturnValue({
+          isHypernativeGuard: true,
+          loading: false,
+        })
+
+        const { result } = renderHook(() => useBannerVisibility(BannerType.TxReportButton))
+
+        expect(result.current).toEqual({
+          showBanner: false,
+          loading: false,
+        })
+      })
+
+      it('should NOT show button when guard is installed but user is not an owner', () => {
+        jest.spyOn(useIsHypernativeFeatureHook, 'useIsHypernativeFeature').mockReturnValue(true)
+        jest.spyOn(useBannerStorageHook, 'useBannerStorage').mockReturnValue(true)
+        jest.spyOn(useWalletHook, 'default').mockReturnValue(mockWallet)
+        jest.spyOn(useIsSafeOwnerHook, 'default').mockReturnValue(false)
+        jest.spyOn(useVisibleBalancesHook, 'useVisibleBalances').mockReturnValue({
+          balances: { fiatTotal: '2000000', items: [] },
+          loaded: true,
+          loading: false,
+        })
+        jest.spyOn(useIsHypernativeGuardHook, 'useIsHypernativeGuard').mockReturnValue({
+          isHypernativeGuard: true,
+          loading: false,
+        })
+
+        const { result } = renderHook(() => useBannerVisibility(BannerType.TxReportButton))
+
+        expect(result.current).toEqual({
+          showBanner: false,
           loading: false,
         })
       })

--- a/apps/web/src/features/hypernative/hooks/useBannerVisibility.ts
+++ b/apps/web/src/features/hypernative/hooks/useBannerVisibility.ts
@@ -40,7 +40,7 @@ const hasSufficientBalance = (fiatTotal: string): boolean => {
  * 3. Connected wallet must be an owner of the current Safe
  * 4. Safe must have balance > MIN_BALANCE_USD (production) or > 1 USD (non-production) - skipped for BannerType.NoBalanceCheck
  * 5. For Promo/Pending/NoBalanceCheck/Settings: Safe must not have HypernativeGuard installed
- *    For TxReportButton: Show if banner conditions are met OR if HypernativeGuard is installed
+ *    For TxReportButton: Requires isEnabled AND isSafeOwner, and either sufficient balance OR HypernativeGuard is installed
  *
  * If any condition fails, showBanner will be false.
  */
@@ -64,7 +64,7 @@ export const useBannerVisibility = (bannerType: BannerType): BannerVisibilityRes
     // For NoBalanceCheck, skip balance check (always pass)
     const hasSufficientBalanceCheck = skipBalanceCheck || hasSufficientBalance(balances.fiatTotal)
 
-    // For TxReportButton, show if banner conditions are met OR if guard is installed
+    // For TxReportButton, require isEnabled AND isSafeOwner, and either sufficient balance OR guard is installed
     if (bannerType === BannerType.TxReportButton) {
       const bannerConditionsMet = isEnabled && isSafeOwner
       const showBanner = bannerConditionsMet && (hasSufficientBalanceCheck || isHypernativeGuard)


### PR DESCRIPTION
## What it solves

This change makes the conditions to display HnTxReportBtn stricter.
It wasn't checking for connected wallet/ownership if HN guard is enabled.