### PR TITLE
fix(mobile): wrong methodName alignment

### DIFF
--- a/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxContractInteractionCard/TxContractInteractionCard.tsx
@@ -32,7 +32,7 @@ export function TxContractInteractionCard({ txInfo, safeAppInfo, ...rest }: TxCo
         </Theme>
       }
       rightNode={
-        <View flex={1}>
+        <View flex={1} alignItems="flex-end">
           <Text numberOfLines={1} ellipsizeMode="tail">
             {txInfo.methodName}
           </Text>


### PR DESCRIPTION
## What it solves
In https://github.com/safe-global/safe-wallet-monorepo/pull/6663 I tried to solve to long methodNames overflowing the card body, but didn't notice that they now are left aligned. 

Resolves:

## How this PR fixes it
Align the method name to the right

## How to test it

## Screenshots
before:
<img width="150" alt="image" src="https://github.com/user-attachments/assets/2106f87d-6502-4f7a-90d9-dcc8ae1948e8" />

after:
<img width="150" alt="image" src="https://github.com/user-attachments/assets/8960fb11-3a47-4c47-9cb2-f481ae7b90a7" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
