### PR TITLE
feat(portfolio): use legacy balances when "All tokens" is selected

### DIFF
--- a/apps/web/src/hooks/loadables/useLoadBalances.ts
+++ b/apps/web/src/hooks/loadables/useLoadBalances.ts
@@ -88,9 +88,17 @@ export const useLegacyBalances = (skip = false): AsyncResult<PortfolioBalances> 
 /**
  * Hook to load token balances and positions data.
  * Uses portfolio endpoint when enabled, otherwise falls back to legacy endpoint.
+ * Falls back to legacy endpoint when "All tokens" is selected to show tokens that Zerion may not support.
+ * Returns `loading: true` when initialized, even if the query is skipped (e.g., no Safe selected).
  */
 const useLoadBalances = (): AsyncResult<PortfolioBalances> => {
-  const shouldUsePortfolioEndpoint = useHasFeature(FEATURES.PORTFOLIO_ENDPOINT) ?? false
+  const settings = useAppSelector(selectSettings)
+  const hasPortfolioFeature = useHasFeature(FEATURES.PORTFOLIO_ENDPOINT) ?? false
+  const isAllTokensSelected = settings.tokenList === TOKEN_LISTS.ALL
+
+  // Use legacy balances when portfolio feature is disabled OR when "All tokens" is selected
+  // This ensures users can see tokens that Zerion may not support via the legacy endpoint
+  const shouldUsePortfolioEndpoint = hasPortfolioFeature && !isAllTokensSelected
 
   const legacyResult = useLegacyBalances(shouldUsePortfolioEndpoint)
   const portfolioResult = usePortfolioBalances(!shouldUsePortfolioEndpoint)


### PR DESCRIPTION
## Summary

- When users select "All tokens" in the Token list selector on the Balances page and the portfolio feature is enabled, use the legacy balances endpoint instead of the portfolio endpoint
- This ensures users can see tokens that Zerion may not support via the legacy endpoint

## Changes

- Modified `useLoadBalances` hook to check for `isAllTokensSelected` and skip portfolio endpoint when "All tokens" is selected
- Added unit tests for the new behavior

## Test plan

- [ ] Verify that when "Default tokens" is selected and portfolio feature is enabled, the portfolio endpoint is used
- [ ] Verify that when "All tokens" is selected and portfolio feature is enabled, the legacy endpoint is used
- [ ] Verify that legacy tokens that Zerion doesn't support appear when "All tokens" is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)