### PR TITLE
Tests(e2e): update Swap Token tests

### DIFF
--- a/apps/web/cypress/e2e/pages/assets.pages.js
+++ b/apps/web/cypress/e2e/pages/assets.pages.js
@@ -18,6 +18,7 @@ const currencyDropDown = 'div[id="currency"]'
 export const tokenListTable = 'table[aria-labelledby="tableTitle"]'
 const tokenListDropdown = 'div[id="tokenlist-select"]'
 export const tablePaginationContainer = '[data-testid="table-pagination"]'
+export const tableContainer = '[data-testid="table-container"]'
 
 const hiddenTokenSaveBtn = 'span[data-track="assets: Save hide dialog"]'
 const hiddenTokenCancelBtn = 'span[data-track="assets: Cancel hide dialog"]'
@@ -52,7 +53,8 @@ const PRICE_COLUMN = 1
 const TOKEN_AMOUNT_COLUMN = 2
 const FIAT_AMOUNT_COLUMN = 3
 // column with the send button and swap in the assets table
-const ACTION_COLUMN = 5
+export const ACTION_COLUMN = 5
+export const actionColumnCell = '[data-testid="table-cell-actions"]'
 
 export const fiatRegex = new RegExp(`\\$?(([0-9]{1,3},)*[0-9]{1,3}(\\.[0-9]{2})?|0)`)
 

--- a/apps/web/cypress/e2e/pages/dashboard.pages.js
+++ b/apps/web/cypress/e2e/pages/dashboard.pages.js
@@ -20,6 +20,7 @@ const viewAllLink = '[data-testid="view-all-link"][href^="/transactions/queue"]'
 const noTxText = '[data-testid="no-tx-text"]'
 export const pendingTxWidget = '[data-testid="pending-tx-widget"]'
 export const pendingTxItem = '[data-testid="tx-pending-item"]'
+export const assetsWidget = '[data-testid="assets-widget"]'
 const singleTxDetailsHeader = '[data-testid="tx-details"]'
 
 export function clickOnTxByIndex(index) {

--- a/apps/web/cypress/e2e/pages/swaps.pages.js
+++ b/apps/web/cypress/e2e/pages/swaps.pages.js
@@ -4,6 +4,9 @@ import * as create_tx from '../pages/create_tx.pages.js'
 import * as table from '../pages/tables.page.js'
 import * as modals from '../pages/modals.page.js'
 import * as swaps_data from '../../fixtures/swaps_data.json'
+import * as assets from './assets.pages.js'
+import * as addressbook from './address_book.page.js'
+import * as dashboard from './dashboard.pages.js'
 
 export const inputCurrencyInput = '[id="input-currency-input"]'
 export const outputCurrencyInput = '[id="output-currency-input"]'
@@ -154,6 +157,18 @@ export const tokenBlockLabels = {
 
 export function verifySwapBtnIsVisible() {
   cy.get(assetsSwapBtn).should('be.visible')
+}
+
+export function verifyAssetsPageSwapButtonsCount(count) {
+  cy.get(assets.tableContainer)
+    .find(addressbook.tableRow)
+    .find(assets.actionColumnCell)
+    .find(assetsSwapBtn)
+    .should('have.length', count)
+}
+
+export function verifyDashboardPageSwapButtonsCount(count) {
+  cy.get(dashboard.assetsWidget).find(assetsSwapBtn).should('have.length', count)
 }
 
 export function checkInputCurrencyPreviewValue(value) {

--- a/apps/web/cypress/e2e/regression/swaps_tokens.cy.js
+++ b/apps/web/cypress/e2e/regression/swaps_tokens.cy.js
@@ -40,15 +40,17 @@ describe('Swaps token tests', () => {
 
   it('Verify swap button are displayed in assets table and dashboard', () => {
     assets.selectTokenList(assets.tokenListOptions.allTokens)
-    main.verifyElementsCount(swaps.assetsSwapBtn, 4)
+    swaps.verifyAssetsPageSwapButtonsCount(4)
+
     cy.window().then((window) => {
       window.localStorage.setItem(
         constants.localStorageKeys.SAFE_v2__settings,
         JSON.stringify(ls.safeSettings.slimitSettings),
       )
     })
+
     cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_1)
-    main.verifyElementsCount(swaps.assetsSwapBtn, 4)
+    swaps.verifyDashboardPageSwapButtonsCount(4)
     main.verifyElementsCount(swaps.dashboardSwapBtn, 1)
   })
 })

--- a/apps/web/src/components/common/EnhancedTable/index.tsx
+++ b/apps/web/src/components/common/EnhancedTable/index.tsx
@@ -186,6 +186,7 @@ function EnhancedTable({ rows, headCells, mobileVariant, compact }: EnhancedTabl
                     {Object.entries(row.cells).map(([key, cell]) => (
                       <TableCell
                         key={key}
+                        data-testid={`table-cell-${key}`}
                         className={classNames({
                           [css.collapsedCell]: row.collapsed,
                         })}


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/QA-42/swap-tokens-e2e-tests

## How this PR fixes it
1. Update Swap tokem suite to find swap buttons on the dashboard and assets page after the latest button re-design 

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update swaps E2E tests to use new selectors and helpers for locating swap buttons on assets table and dashboard; add TableCell test id to support.
> 
> - **E2E tests (Cypress)**:
>   - **Pages**:
>     - `pages/assets.pages.js`: export `table-container`, `ACTION_COLUMN`, and `table-cell-actions` selectors.
>     - `pages/dashboard.pages.js`: export `assets-widget` selector.
>     - `pages/swaps.pages.js`: add helpers `verifyAssetsPageSwapButtonsCount` and `verifyDashboardPageSwapButtonsCount`; import new page selectors; minor refactors.
>   - **Specs**:
>     - `regression/swaps_tokens.cy.js`: update assertions to use new helpers to count swap buttons on assets table and dashboard.
> - **UI component**:
>   - `EnhancedTable`: add `data-testid="table-cell-{key}"` to each `TableCell` to support selector-based tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24235a1265a0bd48f0496e629b247efebe17b506. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->