### PR TITLE
fix(mobile): importing safe was not showing network errors

### DIFF
--- a/apps/mobile/src/components/SafeAccountInput/hooks/useImportSafe.ts
+++ b/apps/mobile/src/components/SafeAccountInput/hooks/useImportSafe.ts
@@ -9,6 +9,7 @@ import { useLazySafesGetOverviewForManyQuery } from '@safe-global/store/gateway/
 import { FormValues } from '@/src/features/ImportReadOnly/types'
 import debounce from 'lodash/debounce'
 import { selectCurrency } from '@/src/store/settingsSlice'
+import { asError } from '@safe-global/utils/services/exceptions/utils'
 
 const NO_SAFE_DEPLOYMENT_ERROR = 'No Safe deployment found for this address'
 
@@ -35,12 +36,15 @@ export const useImportSafe = () => {
       const isValid = isValidAddress(address)
 
       if (isValid) {
-        trigger({
-          safes: chainIds.map((chainId: string) => makeSafeId(chainId, address)),
-          currency,
-          trusted: true,
-          excludeSpam: true,
-        })
+        trigger(
+          {
+            safes: chainIds.map((chainId: string) => makeSafeId(chainId, address)),
+            currency,
+            trusted: true,
+            excludeSpam: true,
+          },
+          false,
+        )
       } else {
         setValue('importedSafeResult', undefined)
       }
@@ -71,6 +75,9 @@ export const useImportSafe = () => {
 
       if (result?.data?.length === 0 && !result?.isLoading) {
         setError('safeAddress', { message: NO_SAFE_DEPLOYMENT_ERROR })
+      } else if (result?.error) {
+        const error = asError(result.error)
+        setError('safeAddress', { message: error.message })
       } else if (addressState.invalid) {
         triggerInput('name')
         clearErrors('safeAddress')


### PR DESCRIPTION
## What it solves
The import safe function was caching the network request and was not redoing it. So if the user had bad internet connection at the time of import he would get a network request error - this request would be cached and we would always return empty data. We would not display any error - so the user wouldn’t know what was going on. Now on error we display a “network error” message. In addition to that we dispatch the network request again if the user modifies the input.

Resolves https://linear.app/safe-global/issue/COR-893/import-safe-error

## How to test it
Try to import safe (use manual import). type a name before pasting an address -> disable your internet connection. Then past safe - you should see an error message. Now enable your internet connection, remove one letter of the safe, then add it back - this time you should see a success

## Screenshots

<img width="150" height="2736" alt="image" src="https://github.com/user-attachments/assets/af4cdc35-247d-4a2d-9bcc-679e9b05360c" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
