### PR TITLE
fix: memoize logError callback in useGasPrice to prevent infinite re-renders

### DIFF
--- a/.github/workflows/web-unit-tests.yml
+++ b/.github/workflows/web-unit-tests.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - apps/web/**
+      - packages/**
 
   push:
     branches:

--- a/apps/web/src/hooks/useGasPrice.ts
+++ b/apps/web/src/hooks/useGasPrice.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { type AsyncResult } from '@safe-global/utils/hooks/useAsync'
 import { useCurrentChain } from './useChains'
 import { useWeb3ReadOnly } from './wallets/web3'
@@ -7,12 +8,14 @@ const useGasPrice = (isSpeedUp: boolean = false): AsyncResult<GasFeeParams> => {
   const chain = useCurrentChain()
   const provider = useWeb3ReadOnly()
 
+  const logError = useCallback((e: string) => {
+    console.error(e)
+  }, [])
+
   const [gasPrice, gasPriceError, gasPriceLoading] = useDefaultGasPrice(chain, provider, {
     isSpeedUp,
     withPooling: true,
-    logError: (e) => {
-      console.error(e)
-    },
+    logError,
   })
 
   return [gasPrice, gasPriceError, gasPriceLoading]


### PR DESCRIPTION
## Problem

PR #6734 added `logError` to the dependency array in `useDefaultGasPrice`, but `useGasPrice.ts` was passing an inline function that created a new reference on every render. This caused an infinite re-render loop, breaking 7 tests in `useGasPrice.test.ts`.

## Root Cause

The bug wasn't caught in PR #6734 because the web unit tests only run for `apps/web/**` changes in PRs, not `packages/**`.

## Solution

1. **Fix the bug**: Wrap `logError` in `useCallback` for referential stability
2. **Prevent future regressions**: Update CI to run web unit tests when `packages/**` changes in PRs

## Changes

| File | Change |
|------|--------|
| `apps/web/src/hooks/useGasPrice.ts` | Wrap `logError` in `useCallback` |
| `.github/workflows/web-unit-tests.yml` | Add `packages/**` to PR path triggers |

## Testing

- ✅ All 9 tests in `useGasPrice.test.ts` now pass
- ✅ Tested on Node v24.2.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Memoizes `logError` in `useGasPrice` to avoid re-render loops and updates CI to run web unit tests when `packages/**` changes.
> 
> - **Web hooks**:
>   - `apps/web/src/hooks/useGasPrice.ts`: Wrap `logError` in `useCallback` and pass it to `useDefaultGasPrice`.
> - **CI**:
>   - `.github/workflows/web-unit-tests.yml`: Add `packages/**` to `pull_request` path filters to trigger web unit tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f9b715c674945b1725e7ec3710b73be06db23da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->