### PR TITLE
feature(portfolio): improve design of hide tokens menu

### DIFF
--- a/apps/web/src/components/common/Sticky/index.tsx
+++ b/apps/web/src/components/common/Sticky/index.tsx
@@ -1,12 +1,12 @@
 import { Box } from '@mui/material'
 import type { ReactElement } from 'react'
 
-const stickyTop = { xs: '103px', md: '111px' }
+const stickyTop = { xs: '103px', sm: '111px' }
 export const Sticky = ({ children }: { children: ReactElement }): ReactElement => (
   <Box
     sx={{
       position: 'sticky',
-      zIndex: '1',
+      zIndex: 2,
       top: stickyTop,
       py: 1,
       bgcolor: 'background.main',

--- a/apps/web/src/pages/balances/index.tsx
+++ b/apps/web/src/pages/balances/index.tsx
@@ -57,7 +57,7 @@ const Balances: NextPage = () => {
         ) : (
           <>
             {isNoFeeNovemberEnabled && !hideNoFeeNovemberBanner && (
-              <Box mb={2} sx={{ position: 'sticky', top: 0, zIndex: 1 }}>
+              <Box mb={2}>
                 <NoFeeNovemberBanner onDismiss={handleNoFeeNovemberDismiss} />
               </Box>
             )}


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/GRO-138/hide-tokens-menu-overlaps-tokens-when-scrolling

## How this PR fixes it

* Fixes top position of `Sticky` component.
* Additionally removes sticky behaviour from NoFeeNovember banner, as it broke design.

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
