### PR TITLE
fix(mobile): type-check

### DIFF
--- a/apps/mobile/src/app/signers/[address]/private-key.tsx
+++ b/apps/mobile/src/app/signers/[address]/private-key.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useLocalSearchParams } from 'expo-router'
-import { PrivateKeyContainer } from '@/src/features/PrivateKey/PrivateKey.container'
+import { PrivateKeyContainer } from '@/src/features/PrivateKey'
 import { type Address } from '@/src/types/address'
 import { useScreenProtection } from '@/src/hooks/useScreenProtection'
 

--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/AnalysisDisplay.test.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/AnalysisDisplay.test.tsx
@@ -51,7 +51,7 @@ describe('AnalysisDisplay', () => {
   })
 
   it('should render addresses when result has addresses', () => {
-    const addresses = [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()]
+    const addresses = [{ address: faker.finance.ethereumAddress() }, { address: faker.finance.ethereumAddress() }]
 
     const result = {
       ...ContractAnalysisResultBuilder.newContract().build(),
@@ -79,7 +79,7 @@ describe('AnalysisDisplay', () => {
       fireEvent.press(showAllText.parent?.parent || showAllText)
     }
 
-    addresses.forEach((address) => {
+    addresses.forEach(({ address }) => {
       expect(getByText(address)).toBeTruthy()
     })
   })
@@ -94,7 +94,7 @@ describe('AnalysisDisplay', () => {
   })
 
   it('should render all components together', () => {
-    const addresses = [faker.finance.ethereumAddress()]
+    const addresses = [{ address: faker.finance.ethereumAddress() }]
     const beforeAddress = faker.finance.ethereumAddress()
     const afterAddress = faker.finance.ethereumAddress()
 
@@ -130,6 +130,6 @@ describe('AnalysisDisplay', () => {
     } else {
       fireEvent.press(showAllText)
     }
-    expect(getByText(addresses[0])).toBeTruthy()
+    expect(getByText(addresses[0].address)).toBeTruthy()
   })
 })

--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/AnalysisDisplay.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/AnalysisDisplay.tsx
@@ -49,7 +49,7 @@ export function AnalysisDisplay({ result, description, severity }: AnalysisDispl
 
           {isAddressChange(result) && <AddressChanges result={result} />}
 
-          {result.addresses?.length && <ShowAllAddress addresses={result.addresses} />}
+          {result.addresses?.length && <ShowAllAddress addresses={result.addresses.map((a) => a.address)} />}
         </Stack>
       </View>
     </View>

--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/AnalysisDisplay.stories.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/AnalysisDisplay.stories.tsx
@@ -50,7 +50,11 @@ export const WithAddresses: Story = {
   args: {
     result: {
       ...ContractAnalysisResultBuilder.newContract().build(),
-      addresses: [faker.finance.ethereumAddress(), faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      addresses: [
+        { address: faker.finance.ethereumAddress() },
+        { address: faker.finance.ethereumAddress() },
+        { address: faker.finance.ethereumAddress() },
+      ],
     },
     severity: Severity.INFO,
   },
@@ -99,7 +103,7 @@ export const Complex: Story = {
           [Severity.INFO]: ['First interaction with this address'],
         })
         .build(),
-      addresses: [faker.finance.ethereumAddress(), faker.finance.ethereumAddress()],
+      addresses: [{ address: faker.finance.ethereumAddress() }, { address: faker.finance.ethereumAddress() }],
     },
     severity: Severity.CRITICAL,
   },


### PR DESCRIPTION
## What it solves
We added type-check script for the mobile files to the pre-commit hook. There was a PR merged before that had wrong ts in it. This PR fixes this.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates AnalysisDisplay to handle `addresses` as objects and maps them for display, with corresponding test and Storybook updates; minor import path cleanup.
> 
> - **SafeShield**:
>   - **AnalysisDisplay**: `result.addresses` now expected as `{ address }` objects; maps to strings when passing to `ShowAllAddress`.
> - **Tests**:
>   - Update AnalysisDisplay tests to provide `addresses` as objects and assert via mapped values.
> - **Storybook**:
>   - Update stories to use object-shaped `addresses` across variants.
> - **Misc**:
>   - Adjust import for `PrivateKeyContainer` in `apps/mobile/src/app/signers/[address]/private-key.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96ebe38194242493003fd94c3018d7da37652ba8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->