### PR TITLE
tests(mobile): add unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,12 @@ Specifically for the web app:
 ## Workflow
 
 1. **Install dependencies**: `yarn install` (from the repository root).
+
    - Uses Yarn 4 (managed via `corepack`)
    - Automatically runs `yarn after-install` for the web workspace, which generates TypeScript types from contract ABIs
 
 2. **Pre-commit hooks**: The repository uses Husky for git hooks:
+
    - **pre-commit**: Automatically runs `lint-staged` (prettier) and type-check on staged TypeScript files
    - **pre-push**: Runs linting before pushing
    - These hooks ensure code quality before commits reach the repository
@@ -78,15 +80,18 @@ Specifically for the web app:
    For mobile:
 
    ```bash
+   yarn workspace @safe-global/mobile type-check
    yarn workspace @safe-global/mobile lint
    yarn workspace @safe-global/mobile prettier
    yarn workspace @safe-global/mobile test
    ```
 
 5. **Commit messages**: use [semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/) as described in `CONTRIBUTING.md`.
+
    - Examples: `feat: add transaction history`, `fix: resolve wallet connection bug`, `refactor: simplify address validation`
 
 6. **Code style**: follow the guidelines in:
+
    - `apps/web/docs/code-style.md` for the web app.
    - `apps/mobile/docs/code-style.md` for the mobile app.
 

--- a/apps/mobile/src/components/SafeAccountInput/hooks/useImportSafe.test.tsx
+++ b/apps/mobile/src/components/SafeAccountInput/hooks/useImportSafe.test.tsx
@@ -1,0 +1,247 @@
+import * as React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react-native'
+import { useImportSafe } from './useImportSafe'
+import { createTestStore, type TestStore } from '@/src/tests/test-utils'
+import { apiSliceWithChainsConfig } from '@safe-global/store/gateway/chains'
+import { FormProvider, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { formSchema } from '@/src/features/ImportReadOnly/schema'
+import type { FormValues } from '@/src/features/ImportReadOnly/types'
+import { Provider } from 'react-redux'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/src/tests/server'
+import { GATEWAY_URL } from '@/src/config/constants'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+
+jest.mock('lodash/debounce', () => (fn: (...args: unknown[]) => unknown) => {
+  const debounced = fn as ((...args: unknown[]) => unknown) & { cancel: () => void }
+  debounced.cancel = jest.fn()
+  return debounced
+})
+
+const VALID_ADDRESS = '0x1234567890123456789012345678901234567890'
+
+const createMockSafeOverview = (chainId: string, address: string): SafeOverview => ({
+  address: { value: address, name: null, logoUri: null },
+  chainId,
+  threshold: 2,
+  owners: [{ value: '0xowner1' }, { value: '0xowner2' }],
+  fiatTotal: '1000',
+  queued: 0,
+  awaitingConfirmation: null,
+})
+
+const createStoreWithChains = async (): Promise<TestStore> => {
+  const store = createTestStore({
+    settings: { currency: 'usd' },
+  })
+  await store.dispatch(apiSliceWithChainsConfig.endpoints.getChainsConfig.initiate())
+  return store
+}
+
+const createWrapper = (store: TestStore, defaultValues?: Partial<FormValues>) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    const methods = useForm<FormValues>({
+      resolver: zodResolver(formSchema),
+      mode: 'onChange',
+      defaultValues: { name: '', safeAddress: '', ...defaultValues },
+    })
+    return (
+      <Provider store={store}>
+        <FormProvider {...methods}>{children}</FormProvider>
+      </Provider>
+    )
+  }
+
+describe('useImportSafe', () => {
+  describe('address input handling', () => {
+    it('should trigger query for valid address', async () => {
+      const mockSafeOverviews = [
+        createMockSafeOverview('1', VALID_ADDRESS),
+        createMockSafeOverview('137', VALID_ADDRESS),
+      ]
+
+      server.use(
+        http.get(`${GATEWAY_URL}/v1/safes`, () => {
+          return HttpResponse.json(mockSafeOverviews)
+        }),
+      )
+
+      const store = await createStoreWithChains()
+      renderHook(() => useImportSafe(), { wrapper: createWrapper(store, { safeAddress: VALID_ADDRESS }) })
+
+      await act(async () => {
+        jest.runAllTimers()
+      })
+
+      await waitFor(() => {
+        const state = store.getState()
+        const queries = state.api.queries
+        const safeQuery = Object.keys(queries).find((key) => key.startsWith('safesGetOverviewForMany'))
+        expect(safeQuery).toBeDefined()
+      })
+    })
+
+    it('should not trigger query for invalid address', async () => {
+      const store = await createStoreWithChains()
+      renderHook(() => useImportSafe(), { wrapper: createWrapper(store, { safeAddress: 'invalid-address' }) })
+
+      await act(async () => {
+        jest.runAllTimers()
+      })
+
+      const state = store.getState()
+      const queries = state.api.queries
+      const safeQuery = Object.keys(queries).find((key) => key.startsWith('safesGetOverviewForMany'))
+      expect(safeQuery).toBeUndefined()
+    })
+
+    it('should not trigger query for short address', async () => {
+      const store = await createStoreWithChains()
+      renderHook(() => useImportSafe(), { wrapper: createWrapper(store, { safeAddress: '0x123' }) })
+
+      await act(async () => {
+        jest.runAllTimers()
+      })
+
+      const state = store.getState()
+      const queries = state.api.queries
+      const safeQuery = Object.keys(queries).find((key) => key.startsWith('safesGetOverviewForMany'))
+      expect(safeQuery).toBeUndefined()
+    })
+  })
+
+  describe('query result handling', () => {
+    it('should handle successful query with Safe deployments', async () => {
+      const mockSafeOverviews = [createMockSafeOverview('1', VALID_ADDRESS)]
+
+      server.use(
+        http.get(`${GATEWAY_URL}/v1/safes`, () => {
+          return HttpResponse.json(mockSafeOverviews)
+        }),
+      )
+
+      const store = await createStoreWithChains()
+      renderHook(() => useImportSafe(), { wrapper: createWrapper(store, { safeAddress: VALID_ADDRESS }) })
+
+      await act(async () => {
+        jest.runAllTimers()
+      })
+
+      await waitFor(() => {
+        const state = store.getState()
+        const queries = state.api.queries
+        const safeQueryKey = Object.keys(queries).find((key) => key.startsWith('safesGetOverviewForMany'))
+        if (safeQueryKey) {
+          const query = queries[safeQueryKey]
+          expect(query?.status).toBe('fulfilled')
+          expect(query?.data).toEqual(mockSafeOverviews)
+        }
+      })
+    })
+
+    it('should handle empty response when no Safe deployment found', async () => {
+      server.use(
+        http.get(`${GATEWAY_URL}/v1/safes`, () => {
+          return HttpResponse.json([])
+        }),
+      )
+
+      const store = await createStoreWithChains()
+      renderHook(() => useImportSafe(), { wrapper: createWrapper(store, { safeAddress: VALID_ADDRESS }) })
+
+      await act(async () => {
+        jest.runAllTimers()
+      })
+
+      await waitFor(() => {
+        const state = store.getState()
+        const queries = state.api.queries
+        const safeQueryKey = Object.keys(queries).find((key) => key.startsWith('safesGetOverviewForMany'))
+        if (safeQueryKey) {
+          const query = queries[safeQueryKey]
+          expect(query?.status).toBe('fulfilled')
+          expect(query?.data).toEqual([])
+        }
+      })
+    })
+
+    it('should handle API error', async () => {
+      server.use(
+        http.get(`${GATEWAY_URL}/v1/safes`, () => {
+          return HttpResponse.json({ message: 'Internal server error' }, { status: 500 })
+        }),
+      )
+
+      const store = await createStoreWithChains()
+      renderHook(() => useImportSafe(), { wrapper: createWrapper(store, { safeAddress: VALID_ADDRESS }) })
+
+      await act(async () => {
+        jest.runAllTimers()
+      })
+
+      await waitFor(() => {
+        const state = store.getState()
+        const queries = state.api.queries
+        const safeQueryKey = Object.keys(queries).find((key) => key.startsWith('safesGetOverviewForMany'))
+        if (safeQueryKey) {
+          const query = queries[safeQueryKey]
+          expect(query?.status).toBe('rejected')
+        }
+      })
+    })
+  })
+
+  describe('multi-chain queries', () => {
+    it('should query all available chains', async () => {
+      let requestedSafes: string[] = []
+
+      server.use(
+        http.get(`${GATEWAY_URL}/v1/safes`, ({ request }) => {
+          const url = new URL(request.url)
+          const safes = url.searchParams.get('safes')
+          if (safes) {
+            requestedSafes = safes.split(',')
+          }
+          return HttpResponse.json([createMockSafeOverview('1', VALID_ADDRESS)])
+        }),
+      )
+
+      const store = await createStoreWithChains()
+      renderHook(() => useImportSafe(), { wrapper: createWrapper(store, { safeAddress: VALID_ADDRESS }) })
+
+      await act(async () => {
+        jest.runAllTimers()
+      })
+
+      await waitFor(() => {
+        expect(requestedSafes.length).toBeGreaterThan(0)
+        expect(requestedSafes.some((s) => s.includes('1:'))).toBe(true)
+        expect(requestedSafes.some((s) => s.includes('137:'))).toBe(true)
+      })
+    })
+
+    it('should use configured currency from store', async () => {
+      let requestedCurrency: string | null = null
+
+      server.use(
+        http.get(`${GATEWAY_URL}/v1/safes`, ({ request }) => {
+          const url = new URL(request.url)
+          requestedCurrency = url.searchParams.get('currency')
+          return HttpResponse.json([])
+        }),
+      )
+
+      const store = await createStoreWithChains()
+      renderHook(() => useImportSafe(), { wrapper: createWrapper(store, { safeAddress: VALID_ADDRESS }) })
+
+      await act(async () => {
+        jest.runAllTimers()
+      })
+
+      await waitFor(() => {
+        expect(requestedCurrency).toBe('usd')
+      })
+    })
+  })
+})

--- a/apps/mobile/src/features/AddressBook/Contact/schemas/contactSchema.test.ts
+++ b/apps/mobile/src/features/AddressBook/Contact/schemas/contactSchema.test.ts
@@ -1,0 +1,161 @@
+import { faker } from '@faker-js/faker'
+import { contactSchema, ContactFormData } from './contactSchema'
+import { getAddress } from 'ethers'
+
+const validChecksummedAddress = getAddress(faker.finance.ethereumAddress())
+
+describe('contactSchema', () => {
+  describe('name validation', () => {
+    it('accepts valid name', () => {
+      const data: ContactFormData = {
+        name: 'Alice',
+        address: validChecksummedAddress,
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty name', () => {
+      const data = {
+        name: '',
+        address: validChecksummedAddress,
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe('Name is required')
+    })
+
+    it('rejects whitespace-only name', () => {
+      const data = {
+        name: '   ',
+        address: validChecksummedAddress,
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe('Name cannot be empty or only whitespace')
+    })
+
+    it('rejects name exceeding 50 characters', () => {
+      const data = {
+        name: 'a'.repeat(51),
+        address: validChecksummedAddress,
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe('Name is too long')
+    })
+
+    it('accepts name with exactly 50 characters', () => {
+      const data: ContactFormData = {
+        name: 'a'.repeat(50),
+        address: validChecksummedAddress,
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts name with leading/trailing spaces when content exists', () => {
+      const data: ContactFormData = {
+        name: '  Bob  ',
+        address: validChecksummedAddress,
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('address validation', () => {
+    it('accepts valid checksummed address', () => {
+      const data: ContactFormData = {
+        name: 'Alice',
+        address: validChecksummedAddress,
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts prefixed address', () => {
+      const data: ContactFormData = {
+        name: 'Alice',
+        address: `eth:${validChecksummedAddress}`,
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects empty address', () => {
+      const data = {
+        name: 'Alice',
+        address: '',
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe('Address is required')
+    })
+
+    it('rejects invalid address format', () => {
+      const data = {
+        name: 'Alice',
+        address: 'not-an-address',
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe('Invalid Ethereum address format')
+    })
+
+    it('rejects address with wrong length', () => {
+      const data = {
+        name: 'Alice',
+        address: '0x123',
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe('Invalid Ethereum address format')
+    })
+
+    it('accepts lowercase address (gets checksummed by parsePrefixedAddress)', () => {
+      const data: ContactFormData = {
+        name: 'Alice',
+        address: validChecksummedAddress.toLowerCase(),
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects address with invalid hex characters', () => {
+      const data = {
+        name: 'Alice',
+        address: '0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG',
+      }
+
+      const result = contactSchema.safeParse(data)
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe('Invalid Ethereum address format')
+    })
+  })
+})

--- a/apps/mobile/src/features/AddressBook/List/hooks/useContactActions.test.ts
+++ b/apps/mobile/src/features/AddressBook/List/hooks/useContactActions.test.ts
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react-native'
+import { Platform } from 'react-native'
+import { useContactActions } from './useContactActions'
+
+jest.mock('tamagui', () => ({
+  useTheme: () => ({
+    color: {
+      get: () => '#000000',
+    },
+  }),
+}))
+
+describe('useContactActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('common behavior', () => {
+    it('should return two actions', () => {
+      const { result } = renderHook(() => useContactActions())
+
+      expect(result.current).toHaveLength(2)
+    })
+
+    it('should have copy action as first item', () => {
+      const { result } = renderHook(() => useContactActions())
+
+      expect(result.current[0].id).toBe('copy')
+      expect(result.current[0].title).toBe('Copy address')
+    })
+
+    it('should have delete action as second item', () => {
+      const { result } = renderHook(() => useContactActions())
+
+      expect(result.current[1].id).toBe('delete')
+      expect(result.current[1].title).toBe('Delete contact')
+    })
+
+    it('should mark delete action as destructive', () => {
+      const { result } = renderHook(() => useContactActions())
+
+      expect(result.current[1].attributes).toEqual({ destructive: true })
+    })
+
+    it('should set delete image color to red', () => {
+      const { result } = renderHook(() => useContactActions())
+
+      expect(result.current[1].imageColor).toBe('red')
+    })
+  })
+
+  describe('platform-specific icons', () => {
+    it('should have platform-specific copy icon', () => {
+      const { result } = renderHook(() => useContactActions())
+
+      const expectedIcon = Platform.select({
+        ios: 'doc.on.doc',
+        android: 'baseline_content_copy_24',
+      })
+      expect(result.current[0].image).toBe(expectedIcon)
+    })
+
+    it('should have platform-specific delete icon', () => {
+      const { result } = renderHook(() => useContactActions())
+
+      const expectedIcon = Platform.select({
+        ios: 'trash',
+        android: 'baseline_delete_24',
+      })
+      expect(result.current[1].image).toBe(expectedIcon)
+    })
+
+    it('should have platform-specific copy icon color', () => {
+      const { result } = renderHook(() => useContactActions())
+
+      const expectedColor = Platform.select({ ios: '#000000', android: '#000' })
+      expect(result.current[0].imageColor).toBe(expectedColor)
+    })
+  })
+
+  describe('memoization', () => {
+    it('should return same reference when theme color does not change', () => {
+      const { result, rerender } = renderHook(() => useContactActions())
+
+      const firstResult = result.current
+
+      rerender({})
+
+      expect(result.current).toBe(firstResult)
+    })
+  })
+})

--- a/apps/mobile/src/features/AdvancedDetails/formatters/arrayValue.test.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/formatters/arrayValue.test.tsx
@@ -1,0 +1,123 @@
+import { render } from '@/src/tests/test-utils'
+import { formatArrayValue } from './arrayValue'
+import { DataDecodedParameter } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+type LabelValueItem = {
+  label: string | React.ReactNode
+  value?: string
+  render?: () => React.ReactNode
+  direction?: string
+  alignItems?: string
+}
+
+describe('formatArrayValue', () => {
+  describe('with string array values', () => {
+    it('returns ListTableItem with label containing name and type', () => {
+      const param: DataDecodedParameter = {
+        name: 'recipients',
+        type: 'address[]',
+        value: ['0x1234567890123456789012345678901234567890'],
+      }
+
+      const result = formatArrayValue(param) as LabelValueItem
+
+      expect(result.label).toBeDefined()
+      expect(result.direction).toBe('column')
+      expect(result.alignItems).toBe('flex-start')
+    })
+
+    it('renders the label with parameter name and type', () => {
+      const param: DataDecodedParameter = {
+        name: 'amounts',
+        type: 'uint256[]',
+        value: ['100', '200'],
+      }
+
+      const result = formatArrayValue(param) as LabelValueItem
+      const { getByText } = render(result.label as React.ReactElement)
+
+      expect(getByText('amounts')).toBeTruthy()
+      expect(getByText('uint256[]')).toBeTruthy()
+    })
+
+    it('renders simple string array values', () => {
+      const param: DataDecodedParameter = {
+        name: 'values',
+        type: 'uint256[]',
+        value: ['100', '200', '300'],
+      }
+
+      const result = formatArrayValue(param) as LabelValueItem
+      const { getByText, getAllByTestId } = render(result.render?.() as React.ReactElement)
+
+      expect(getByText('[')).toBeTruthy()
+      expect(getByText(']')).toBeTruthy()
+      expect(getAllByTestId('copy-button').length).toBe(3)
+    })
+
+    it('shortens long string values', () => {
+      const longValue = '0x1234567890abcdef1234567890abcdef1234567890abcdef'
+      const param: DataDecodedParameter = {
+        name: 'data',
+        type: 'bytes[]',
+        value: [longValue],
+      }
+
+      const result = formatArrayValue(param) as LabelValueItem
+      const { queryByText } = render(result.render?.() as React.ReactElement)
+
+      expect(queryByText(longValue)).toBeNull()
+    })
+  })
+
+  describe('with nested array values', () => {
+    it('renders nested arrays recursively', () => {
+      const param: DataDecodedParameter = {
+        name: 'matrix',
+        type: 'uint256[][]',
+        value: [
+          ['1', '2'],
+          ['3', '4'],
+        ] as unknown as string[],
+      }
+
+      const result = formatArrayValue(param) as LabelValueItem
+      const { getAllByText } = render(result.render?.() as React.ReactElement)
+
+      const brackets = getAllByText('[')
+      expect(brackets.length).toBeGreaterThan(1)
+    })
+  })
+
+  describe('with single string value', () => {
+    it('renders a single string value with copy button', () => {
+      const param: DataDecodedParameter = {
+        name: 'singleItem',
+        type: 'string[]',
+        value: ['hello'],
+      }
+
+      const result = formatArrayValue(param) as LabelValueItem
+      const { getByTestId, getByText } = render(result.render?.() as React.ReactElement)
+
+      expect(getByText('[')).toBeTruthy()
+      expect(getByTestId('copy-button')).toBeTruthy()
+    })
+  })
+
+  describe('with empty array', () => {
+    it('renders empty brackets for empty array', () => {
+      const param: DataDecodedParameter = {
+        name: 'empty',
+        type: 'address[]',
+        value: [],
+      }
+
+      const result = formatArrayValue(param) as LabelValueItem
+      const { getByText } = render(result.render?.() as React.ReactElement)
+
+      expect(getByText('[')).toBeTruthy()
+      expect(getByText(']')).toBeTruthy()
+    })
+  })
+})

--- a/apps/mobile/src/features/AdvancedDetails/formatters/singleValue.test.tsx
+++ b/apps/mobile/src/features/AdvancedDetails/formatters/singleValue.test.tsx
@@ -1,0 +1,204 @@
+import { render } from '@/src/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import { DisplayValue, formatValueTemplate, characterDisplayLimit } from './singleValue'
+import { DataDecodedParameter } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+
+type LabelValueItem = {
+  label: string | React.ReactNode
+  value?: string
+  render?: () => React.ReactNode
+}
+
+describe('characterDisplayLimit', () => {
+  it('is set to 15', () => {
+    expect(characterDisplayLimit).toBe(15)
+  })
+})
+
+describe('DisplayValue', () => {
+  describe('with address type', () => {
+    it('renders address with identicon', () => {
+      const address = faker.finance.ethereumAddress()
+      const { getByTestId } = render(<DisplayValue type="address" value={address} />)
+
+      expect(getByTestId('identicon-image-container')).toBeTruthy()
+    })
+
+    it('renders EthAddress component for address', () => {
+      const address = faker.finance.ethereumAddress()
+      const { getByText } = render(<DisplayValue type="address" value={address} />)
+
+      const shortAddress = `${address.slice(0, 6)}...${address.slice(-4)}`
+      expect(getByText(shortAddress)).toBeTruthy()
+    })
+  })
+
+  describe('with hash type', () => {
+    it('renders hash with identicon', () => {
+      const hash = faker.string.hexadecimal({ length: 64, prefix: '0x' })
+      const { getByTestId } = render(<DisplayValue type="hash" value={hash} />)
+
+      expect(getByTestId('identicon-image-container')).toBeTruthy()
+    })
+  })
+
+  describe('with bytes type', () => {
+    it('renders shortened bytes value', () => {
+      const bytes = faker.string.hexadecimal({ length: 100, prefix: '0x' })
+      const { queryByText } = render(<DisplayValue type="bytes" value={bytes} />)
+
+      expect(queryByText(bytes)).toBeNull()
+    })
+
+    it('includes copy button for bytes', () => {
+      const bytes = faker.string.hexadecimal({ length: 100, prefix: '0x' })
+      const { getByTestId } = render(<DisplayValue type="bytes" value={bytes} />)
+
+      expect(getByTestId('copy-button')).toBeTruthy()
+    })
+  })
+
+  describe('with rawData type', () => {
+    it('renders shortened rawData value', () => {
+      const rawData = faker.string.hexadecimal({ length: 100, prefix: '0x' })
+      const { queryByText } = render(<DisplayValue type="rawData" value={rawData} />)
+
+      expect(queryByText(rawData)).toBeNull()
+    })
+  })
+
+  describe('with default type', () => {
+    it('renders short values directly without copy button', () => {
+      const shortValue = '12345'
+      const { getByText, queryByTestId } = render(<DisplayValue type="uint256" value={shortValue} />)
+
+      expect(getByText(shortValue)).toBeTruthy()
+      expect(queryByTestId('copy-button')).toBeNull()
+    })
+
+    it('shortens long values and shows copy button', () => {
+      const longValue = '123456789012345678901234567890'
+      const { queryByText, getByTestId } = render(<DisplayValue type="uint256" value={longValue} />)
+
+      expect(queryByText(longValue)).toBeNull()
+      expect(getByTestId('copy-button')).toBeTruthy()
+    })
+
+    it('renders value at exactly characterDisplayLimit without copy button', () => {
+      const exactLengthValue = 'a'.repeat(characterDisplayLimit)
+      const { getByText, queryByTestId } = render(<DisplayValue type="string" value={exactLengthValue} />)
+
+      expect(getByText(exactLengthValue)).toBeTruthy()
+      expect(queryByTestId('copy-button')).toBeNull()
+    })
+
+    it('renders value one character over limit with copy button', () => {
+      const overLimitValue = 'a'.repeat(characterDisplayLimit + 1)
+      const { queryByText, getByTestId } = render(<DisplayValue type="string" value={overLimitValue} />)
+
+      expect(queryByText(overLimitValue)).toBeNull()
+      expect(getByTestId('copy-button')).toBeTruthy()
+    })
+  })
+})
+
+describe('formatValueTemplate', () => {
+  describe('with valid string value', () => {
+    it('returns ListTableItem with rendered label', () => {
+      const param: DataDecodedParameter = {
+        name: 'amount',
+        type: 'uint256',
+        value: '1000000000000000000',
+      }
+
+      const result = formatValueTemplate(param) as LabelValueItem
+
+      expect(result.label).toBeDefined()
+      expect(result.render).toBeDefined()
+    })
+
+    it('renders label with parameter name and type', () => {
+      const param: DataDecodedParameter = {
+        name: 'recipient',
+        type: 'address',
+        value: faker.finance.ethereumAddress(),
+      }
+
+      const result = formatValueTemplate(param) as LabelValueItem
+      const { getByText } = render(result.label as React.ReactElement)
+
+      expect(getByText('recipient')).toBeTruthy()
+      expect(getByText('address')).toBeTruthy()
+    })
+
+    it('wraps value in InfoSheet component', () => {
+      const param: DataDecodedParameter = {
+        name: 'data',
+        type: 'bytes',
+        value: '0x1234',
+      }
+
+      const result = formatValueTemplate(param) as LabelValueItem
+      const rendered = result.render?.()
+
+      expect(rendered).toBeDefined()
+    })
+  })
+
+  describe('with undefined value', () => {
+    it('returns ListTableItem with only label', () => {
+      const param: DataDecodedParameter = {
+        name: 'optionalParam',
+        type: 'bytes',
+        value: undefined as unknown as string,
+      }
+
+      const result = formatValueTemplate(param) as LabelValueItem
+
+      expect(result.label).toBe('optionalParam')
+      expect(result.render).toBeUndefined()
+    })
+  })
+
+  describe('with non-string value', () => {
+    it('returns ListTableItem with only label for array value', () => {
+      const param: DataDecodedParameter = {
+        name: 'arrayParam',
+        type: 'uint256[]',
+        value: ['1', '2', '3'],
+      }
+
+      const result = formatValueTemplate(param) as LabelValueItem
+
+      expect(result.label).toBe('arrayParam')
+      expect(result.render).toBeUndefined()
+    })
+
+    it('returns ListTableItem with only label for object value', () => {
+      const param: DataDecodedParameter = {
+        name: 'tupleParam',
+        type: 'tuple',
+        value: { a: '1', b: '2' } as unknown as string,
+      }
+
+      const result = formatValueTemplate(param) as LabelValueItem
+
+      expect(result.label).toBe('tupleParam')
+      expect(result.render).toBeUndefined()
+    })
+  })
+
+  describe('with numeric value converted to string', () => {
+    it('handles number value by converting to string', () => {
+      const param: DataDecodedParameter = {
+        name: 'count',
+        type: 'uint8',
+        value: '42',
+      }
+
+      const result = formatValueTemplate(param) as LabelValueItem
+
+      expect(result.render).toBeDefined()
+    })
+  })
+})

--- a/apps/mobile/src/features/ExecuteTx/hooks/useGasFee.test.ts
+++ b/apps/mobile/src/features/ExecuteTx/hooks/useGasFee.test.ts
@@ -1,0 +1,320 @@
+import { renderHook } from '@/src/tests/test-utils'
+import useGasFee from './useGasFee'
+import { useFeeParams } from '@/src/hooks/useFeeParams/useFeeParams'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { faker } from '@faker-js/faker'
+import * as chainsSelectors from '@/src/store/chains'
+import { generateChecksummedAddress, createMockChain } from '@safe-global/test'
+
+jest.mock('@/src/hooks/useFeeParams/useFeeParams', () => ({
+  useFeeParams: jest.fn(),
+}))
+
+jest.mock('@/src/store/chains', () => ({
+  ...jest.requireActual('@/src/store/chains'),
+  selectActiveChain: jest.fn(),
+}))
+
+const mockUseFeeParams = useFeeParams as jest.MockedFunction<typeof useFeeParams>
+const mockSelectActiveChain = chainsSelectors.selectActiveChain as unknown as jest.Mock
+
+const createMockTxDetails = (): TransactionDetails =>
+  ({
+    safeAddress: generateChecksummedAddress(),
+    txId: faker.string.uuid(),
+    executedAt: null,
+    txStatus: 'AWAITING_CONFIRMATIONS',
+    txInfo: {
+      type: 'Custom',
+      to: { value: generateChecksummedAddress() },
+      value: '0',
+      dataSize: '0',
+      methodName: null,
+      isCancellation: false,
+    },
+  }) as TransactionDetails
+
+describe('useGasFee', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSelectActiveChain.mockReturnValue(createMockChain())
+  })
+
+  describe('when loading', () => {
+    it('returns "loading..." for totalFee when gas price is loading', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: 10000000000n,
+        gasLimit: 21000n,
+        isLoadingGasPrice: true,
+        gasLimitLoading: false,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFee).toBe('loading...')
+    })
+
+    it('returns "loading..." for totalFee when gas limit is loading', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: 10000000000n,
+        gasLimit: 21000n,
+        isLoadingGasPrice: false,
+        gasLimitLoading: true,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFee).toBe('loading...')
+    })
+
+    it('returns "loading..." when both gas price and limit are loading', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: undefined,
+        gasLimit: undefined,
+        isLoadingGasPrice: true,
+        gasLimitLoading: true,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFee).toBe('loading...')
+    })
+  })
+
+  describe('when loaded', () => {
+    it('calculates and formats totalFee correctly', () => {
+      const maxFeePerGas = 10000000000n // 10 gwei
+      const gasLimit = 21000n
+
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas,
+        gasLimit,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFee).not.toBe('loading...')
+      expect(result.current.totalFeeRaw).toBe(maxFeePerGas * gasLimit)
+    })
+
+    it('returns totalFeeRaw as bigint', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: 20000000000n,
+        gasLimit: 50000n,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(typeof result.current.totalFeeRaw).toBe('bigint')
+      expect(result.current.totalFeeRaw).toBe(20000000000n * 50000n)
+    })
+
+    it('returns formatted totalFeeEth', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: 10000000000n,
+        gasLimit: 21000n,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFeeEth).toBeDefined()
+      expect(typeof result.current.totalFeeEth).toBe('string')
+    })
+
+    it('returns estimatedFeeParams from useFeeParams', () => {
+      const feeParams = {
+        maxFeePerGas: 15000000000n,
+        maxPriorityFeePerGas: 1000000000n,
+        gasLimit: 100000n,
+        nonce: 5,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      }
+
+      mockUseFeeParams.mockReturnValue(feeParams)
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.estimatedFeeParams).toEqual(feeParams)
+    })
+  })
+
+  describe('with undefined values', () => {
+    it('handles undefined maxFeePerGas by using 0n', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: undefined,
+        gasLimit: 21000n,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFeeRaw).toBe(0n)
+    })
+
+    it('handles undefined gasLimit by using 0n', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: 10000000000n,
+        gasLimit: undefined,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFeeRaw).toBe(0n)
+    })
+
+    it('handles both undefined maxFeePerGas and gasLimit', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: undefined,
+        gasLimit: undefined,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFeeRaw).toBe(0n)
+      expect(result.current.totalFee).not.toBe('loading...')
+    })
+  })
+
+  describe('with manual params', () => {
+    it('passes manual params to useFeeParams', () => {
+      const manualParams = {
+        maxFeePerGas: 25000000000n,
+        maxPriorityFeePerGas: 2000000000n,
+        gasLimit: 150000n,
+        nonce: 10,
+      }
+
+      mockUseFeeParams.mockReturnValue({
+        ...manualParams,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const txDetails = createMockTxDetails()
+      renderHook(() => useGasFee(txDetails, manualParams), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(mockUseFeeParams).toHaveBeenCalledWith(txDetails, manualParams, undefined)
+    })
+
+    it('calculates fee based on manual params', () => {
+      const manualParams = {
+        maxFeePerGas: 30000000000n,
+        maxPriorityFeePerGas: 2000000000n,
+        gasLimit: 200000n,
+        nonce: 15,
+      }
+
+      mockUseFeeParams.mockReturnValue({
+        ...manualParams,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), manualParams), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFeeRaw).toBe(30000000000n * 200000n)
+    })
+  })
+
+  describe('with settings', () => {
+    it('passes settings to useFeeParams', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: 10000000000n,
+        gasLimit: 21000n,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const txDetails = createMockTxDetails()
+      const settings = { pooling: false, logError: jest.fn() }
+
+      renderHook(() => useGasFee(txDetails, null, settings), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(mockUseFeeParams).toHaveBeenCalledWith(txDetails, null, settings)
+    })
+  })
+
+  describe('with undefined txDetails', () => {
+    it('handles undefined txDetails', () => {
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: undefined,
+        gasLimit: undefined,
+        isLoadingGasPrice: true,
+        gasLimitLoading: true,
+      })
+
+      const { result } = renderHook(() => useGasFee(undefined, null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFee).toBe('loading...')
+      expect(mockUseFeeParams).toHaveBeenCalledWith(undefined, null, undefined)
+    })
+  })
+
+  describe('with different chain decimals', () => {
+    it('formats fee correctly for chain with different decimals', () => {
+      mockSelectActiveChain.mockReturnValue(
+        createMockChain({
+          nativeCurrency: {
+            name: 'Test Token',
+            symbol: 'TST',
+            decimals: 8,
+          },
+        }),
+      )
+
+      mockUseFeeParams.mockReturnValue({
+        maxFeePerGas: 1000000n,
+        gasLimit: 21000n,
+        isLoadingGasPrice: false,
+        gasLimitLoading: false,
+      })
+
+      const { result } = renderHook(() => useGasFee(createMockTxDetails(), null), {
+        activeSafe: { chainId: '1', address: generateChecksummedAddress() },
+      })
+
+      expect(result.current.totalFee).not.toBe('loading...')
+      expect(result.current.totalFeeRaw).toBe(1000000n * 21000n)
+    })
+  })
+})

--- a/apps/mobile/src/features/HistoryTransactionDetails/utils/header.test.ts
+++ b/apps/mobile/src/features/HistoryTransactionDetails/utils/header.test.ts
@@ -1,0 +1,310 @@
+import { faker } from '@faker-js/faker'
+import { getHeaderTitle } from './header'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { generateAddress } from '@safe-global/test'
+
+const createBaseTxDetails = (txInfo: TransactionDetails['txInfo']): TransactionDetails =>
+  ({
+    safeAddress: generateAddress(),
+    txId: faker.string.uuid(),
+    executedAt: Date.now(),
+    txStatus: 'SUCCESS',
+    txInfo,
+    txData: null,
+    detailedExecutionInfo: null,
+    txHash: faker.string.hexadecimal({ length: 64, prefix: '0x' }),
+    safeAppInfo: null,
+  }) as TransactionDetails
+
+describe('getHeaderTitle', () => {
+  describe('Transfer transactions', () => {
+    it('returns "Sent" for outgoing transfers', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'Transfer',
+        sender: { value: generateAddress() },
+        recipient: { value: generateAddress() },
+        direction: 'OUTGOING',
+        transferInfo: {
+          type: 'NATIVE_COIN',
+          value: '1000000000000000000',
+        },
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Sent')
+    })
+
+    it('returns "Received" for incoming transfers', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'Transfer',
+        sender: { value: generateAddress() },
+        recipient: { value: generateAddress() },
+        direction: 'INCOMING',
+        transferInfo: {
+          type: 'NATIVE_COIN',
+          value: '1000000000000000000',
+        },
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Received')
+    })
+
+    it('returns "Received" for unknown direction transfers', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'Transfer',
+        sender: { value: generateAddress() },
+        recipient: { value: generateAddress() },
+        direction: 'UNKNOWN',
+        transferInfo: {
+          type: 'NATIVE_COIN',
+          value: '1000000000000000000',
+        },
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Received')
+    })
+
+    it('handles ERC20 transfers', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'Transfer',
+        sender: { value: generateAddress() },
+        recipient: { value: generateAddress() },
+        direction: 'OUTGOING',
+        transferInfo: {
+          type: 'ERC20',
+          tokenAddress: generateAddress(),
+          tokenName: 'Test Token',
+          tokenSymbol: 'TST',
+          logoUri: null,
+          decimals: 18,
+          value: '1000000000000000000',
+          trusted: true,
+          imitation: false,
+        },
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Sent')
+    })
+  })
+
+  describe('Swap order transactions', () => {
+    it('returns "Swap order" for swap orders', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'SwapOrder',
+        uid: faker.string.uuid(),
+        status: 'fulfilled',
+        kind: 'sell',
+        validUntil: Math.floor(Date.now() / 1000) + 3600,
+        sellToken: {
+          address: generateAddress(),
+          decimals: 18,
+          logoUri: null,
+          name: 'Ether',
+          symbol: 'ETH',
+          trusted: true,
+        },
+        buyToken: {
+          address: generateAddress(),
+          decimals: 6,
+          logoUri: null,
+          name: 'USD Coin',
+          symbol: 'USDC',
+          trusted: true,
+        },
+        sellAmount: '1000000000000000000',
+        buyAmount: '2000000000',
+        executedSellAmount: '1000000000000000000',
+        executedBuyAmount: '2000000000',
+        explorerUrl: 'https://explorer.cow.fi',
+        orderClass: 'market',
+        executedFee: '0',
+        executedFeeToken: {
+          address: generateAddress(),
+          decimals: 18,
+          logoUri: null,
+          name: 'Ether',
+          symbol: 'ETH',
+          trusted: true,
+        },
+        humanDescription: null,
+        receiver: generateAddress(),
+        owner: generateAddress(),
+        fullAppData: null,
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Swap order')
+    })
+  })
+
+  describe('TWAP order transactions', () => {
+    it('returns "Twap order" for TWAP orders', () => {
+      const txInfo = {
+        type: 'TwapOrder' as const,
+        status: 'fulfilled' as const,
+        kind: 'sell' as const,
+        validUntil: Math.floor(Date.now() / 1000) + 3600,
+        sellToken: {
+          address: generateAddress(),
+          decimals: 18,
+          logoUri: null,
+          name: 'Ether',
+          symbol: 'ETH',
+          trusted: true,
+        },
+        buyToken: {
+          address: generateAddress(),
+          decimals: 6,
+          logoUri: null,
+          name: 'USD Coin',
+          symbol: 'USDC',
+          trusted: true,
+        },
+        sellAmount: '1000000000000000000',
+        buyAmount: '2000000000',
+        executedSellAmount: '1000000000000000000',
+        executedBuyAmount: '2000000000',
+        numberOfParts: '4',
+        partSellAmount: '250000000000000000',
+        minPartLimit: '500000000',
+        timeBetweenParts: 3600,
+        startTime: { startType: 'AT_MINING_TIME' },
+        executedFee: '0',
+        executedFeeToken: {
+          address: generateAddress(),
+          decimals: 18,
+          logoUri: null,
+          name: 'Ether',
+          symbol: 'ETH',
+          trusted: true,
+        },
+        humanDescription: null,
+        receiver: generateAddress(),
+        owner: generateAddress(),
+        fullAppData: null,
+      } as TransactionDetails['txInfo']
+
+      const txDetails = createBaseTxDetails(txInfo)
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Twap order')
+    })
+  })
+
+  describe('Settings change transactions', () => {
+    it('returns "Add signer" for add owner settings change', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'SettingsChange',
+        dataDecoded: {
+          method: 'addOwnerWithThreshold',
+          parameters: [],
+        },
+        settingsInfo: {
+          type: 'ADD_OWNER',
+          owner: { value: generateAddress() },
+          threshold: 2,
+        },
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Add signer')
+    })
+
+    it('returns "Remove signer" for remove owner settings change', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'SettingsChange',
+        dataDecoded: {
+          method: 'removeOwner',
+          parameters: [],
+        },
+        settingsInfo: {
+          type: 'REMOVE_OWNER',
+          owner: { value: generateAddress() },
+          threshold: 1,
+        },
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Remove signer')
+    })
+
+    it('returns "Change threshold" for change threshold settings change', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'SettingsChange',
+        dataDecoded: {
+          method: 'changeThreshold',
+          parameters: [],
+        },
+        settingsInfo: {
+          type: 'CHANGE_THRESHOLD',
+          threshold: 3,
+        },
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Change threshold')
+    })
+
+    it('returns "Transaction details" for other settings changes', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'SettingsChange',
+        dataDecoded: {
+          method: 'setGuard',
+          parameters: [],
+        },
+        settingsInfo: {
+          type: 'SET_GUARD',
+          guard: { value: generateAddress() },
+        },
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Transaction details')
+    })
+  })
+
+  describe('Custom transactions', () => {
+    it('returns "Transaction details" for custom transactions', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'Custom',
+        to: { value: generateAddress() },
+        value: '0',
+        dataSize: '68',
+        methodName: 'transfer',
+        isCancellation: false,
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Transaction details')
+    })
+  })
+
+  describe('Creation transactions', () => {
+    it('returns "Transaction details" for creation transactions', () => {
+      const txDetails = createBaseTxDetails({
+        type: 'Creation',
+        creator: { value: generateAddress() },
+        transactionHash: faker.string.hexadecimal({ length: 64, prefix: '0x' }),
+        implementation: { value: generateAddress() },
+        factory: { value: generateAddress() },
+      })
+
+      const result = getHeaderTitle(txDetails)
+
+      expect(result).toBe('Transaction details')
+    })
+  })
+})

--- a/apps/mobile/src/features/Signers/hooks/useSignersGroupService.test.ts
+++ b/apps/mobile/src/features/Signers/hooks/useSignersGroupService.test.ts
@@ -1,0 +1,205 @@
+import { renderHook, waitFor } from '@/src/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import { http, HttpResponse } from 'msw'
+import { server } from '@/src/tests/server'
+import { GATEWAY_URL } from '@/src/config/constants'
+import { useSignersGroupService, groupSigners } from './useSignersGroupService'
+import type { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { generateChecksummedAddress } from '@safe-global/test'
+
+const createMockAddressInfo = (overrides: Partial<AddressInfo> = {}): AddressInfo => ({
+  value: generateChecksummedAddress(),
+  name: faker.person.fullName(),
+  logoUri: faker.image.url(),
+  ...overrides,
+})
+
+describe('groupSigners', () => {
+  it('returns empty object when owners is undefined', () => {
+    const result = groupSigners(undefined, {})
+    expect(result).toEqual({})
+  })
+
+  it('groups imported signers correctly', () => {
+    const owner1 = createMockAddressInfo()
+    const owner2 = createMockAddressInfo()
+    const appSigners = {
+      [owner1.value]: owner1,
+    }
+
+    const result = groupSigners([owner1, owner2], appSigners)
+
+    expect(result.imported.data).toHaveLength(1)
+    expect(result.imported.data[0]).toEqual(owner1)
+    expect(result.notImported.data).toHaveLength(1)
+    expect(result.notImported.data[0]).toEqual(owner2)
+  })
+
+  it('puts all owners in notImported when no app signers match', () => {
+    const owner1 = createMockAddressInfo()
+    const owner2 = createMockAddressInfo()
+
+    const result = groupSigners([owner1, owner2], {})
+
+    expect(result.imported.data).toHaveLength(0)
+    expect(result.notImported.data).toHaveLength(2)
+  })
+
+  it('puts all owners in imported when all match app signers', () => {
+    const owner1 = createMockAddressInfo()
+    const owner2 = createMockAddressInfo()
+    const appSigners = {
+      [owner1.value]: owner1,
+      [owner2.value]: owner2,
+    }
+
+    const result = groupSigners([owner1, owner2], appSigners)
+
+    expect(result.imported.data).toHaveLength(2)
+    expect(result.notImported.data).toHaveLength(0)
+  })
+
+  it('returns empty arrays for both groups when owners array is empty', () => {
+    const result = groupSigners([], {})
+
+    expect(result.imported.data).toHaveLength(0)
+    expect(result.notImported.data).toHaveLength(0)
+  })
+
+  it('preserves group metadata', () => {
+    const owner = createMockAddressInfo()
+
+    const result = groupSigners([owner], {})
+
+    expect(result.imported.id).toBe('imported_signers')
+    expect(result.imported.title).toBe('My signers')
+    expect(result.notImported.id).toBe('not_imported_signers')
+    expect(result.notImported.title).toBe('Not imported signers')
+  })
+
+  it('does not mutate the original groupedSigners constant', () => {
+    const owner = createMockAddressInfo()
+
+    groupSigners([owner], {})
+    const result2 = groupSigners([], {})
+
+    expect(result2.imported.data).toHaveLength(0)
+    expect(result2.notImported.data).toHaveLength(0)
+  })
+})
+
+describe('useSignersGroupService', () => {
+  const mockSafeAddress = generateChecksummedAddress()
+  const mockChainId = '1'
+
+  beforeEach(() => {
+    server.resetHandlers()
+  })
+
+  it('returns empty group when safe has no owners', async () => {
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/chains/${mockChainId}/safes/${mockSafeAddress}`, () => {
+        return HttpResponse.json({ owners: [] })
+      }),
+    )
+
+    const { result } = renderHook(() => useSignersGroupService(), {
+      activeSafe: { address: mockSafeAddress, chainId: mockChainId },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false)
+    })
+
+    expect(result.current.group.imported?.data).toHaveLength(0)
+    expect(result.current.group.notImported?.data).toHaveLength(0)
+  })
+
+  it('groups owners as not imported when no signers in store', async () => {
+    const owner1 = createMockAddressInfo()
+    const owner2 = createMockAddressInfo()
+
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/chains/${mockChainId}/safes/${mockSafeAddress}`, () => {
+        return HttpResponse.json({ owners: [owner1, owner2] })
+      }),
+    )
+
+    const { result } = renderHook(() => useSignersGroupService(), {
+      activeSafe: { address: mockSafeAddress, chainId: mockChainId },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false)
+    })
+
+    expect(result.current.group.notImported?.data).toHaveLength(2)
+    expect(result.current.group.imported?.data).toHaveLength(0)
+  })
+
+  it('groups owners as imported when signers exist in store', async () => {
+    const owner1 = createMockAddressInfo()
+    const owner2 = createMockAddressInfo()
+
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/chains/${mockChainId}/safes/${mockSafeAddress}`, () => {
+        return HttpResponse.json({ owners: [owner1, owner2] })
+      }),
+    )
+
+    const { result } = renderHook(() => useSignersGroupService(), {
+      activeSafe: { address: mockSafeAddress, chainId: mockChainId },
+      signers: { [owner1.value]: { ...owner1, type: 'private-key' as const } },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false)
+    })
+
+    expect(result.current.group.imported?.data).toHaveLength(1)
+    expect(result.current.group.imported?.data[0].value).toBe(owner1.value)
+    expect(result.current.group.notImported?.data).toHaveLength(1)
+    expect(result.current.group.notImported?.data[0].value).toBe(owner2.value)
+  })
+
+  it('indicates fetching state while loading', async () => {
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/chains/${mockChainId}/safes/${mockSafeAddress}`, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        return HttpResponse.json({ owners: [] })
+      }),
+    )
+
+    const { result } = renderHook(() => useSignersGroupService(), {
+      activeSafe: { address: mockSafeAddress, chainId: mockChainId },
+    })
+
+    expect(result.current.isFetching).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false)
+    })
+  })
+
+  it('updates group when signers in store change', async () => {
+    const owner = createMockAddressInfo()
+
+    server.use(
+      http.get(`${GATEWAY_URL}/v1/chains/${mockChainId}/safes/${mockSafeAddress}`, () => {
+        return HttpResponse.json({ owners: [owner] })
+      }),
+    )
+
+    const { result } = renderHook(() => useSignersGroupService(), {
+      activeSafe: { address: mockSafeAddress, chainId: mockChainId },
+      signers: {},
+    })
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false)
+    })
+
+    expect(result.current.group.notImported?.data).toHaveLength(1)
+    expect(result.current.group.imported?.data).toHaveLength(0)
+  })
+})

--- a/apps/mobile/src/hooks/coreSDK/safeCoreSDK.test.ts
+++ b/apps/mobile/src/hooks/coreSDK/safeCoreSDK.test.ts
@@ -1,0 +1,224 @@
+import { initSafeSDK, setSafeSDK, getSafeSDK } from './safeCoreSDK'
+import chains from '@safe-global/utils/config/chains'
+import Safe from '@safe-global/protocol-kit'
+import type { SafeCoreSDKProps } from '@safe-global/utils/hooks/coreSDK/types'
+import { generateChecksummedAddress, createMockProvider } from '@safe-global/test'
+
+const mockGetSafeSingletonDeployments = jest.fn()
+const mockGetSafeL2SingletonDeployments = jest.fn()
+
+jest.mock('@safe-global/safe-deployments', () => ({
+  getSafeSingletonDeployments: (...args: unknown[]) => mockGetSafeSingletonDeployments(...args),
+  getSafeL2SingletonDeployments: (...args: unknown[]) => mockGetSafeL2SingletonDeployments(...args),
+}))
+
+jest.mock('@safe-global/protocol-kit', () => ({
+  __esModule: true,
+  default: {
+    init: jest.fn(),
+  },
+}))
+
+jest.mock('@safe-global/utils/types/contracts', () => ({
+  Gnosis_safe__factory: {
+    connect: jest.fn().mockReturnValue({
+      VERSION: jest.fn().mockResolvedValue('1.3.0'),
+    }),
+  },
+}))
+
+const mockIsValidMasterCopy = jest.fn()
+jest.mock('@safe-global/utils/services/contracts/safeContracts', () => ({
+  isValidMasterCopy: (...args: unknown[]) => mockIsValidMasterCopy(...args),
+}))
+
+const mockIsLegacyVersion = jest.fn()
+jest.mock('@safe-global/utils/services/contracts/utils', () => ({
+  isLegacyVersion: (...args: unknown[]) => mockIsLegacyVersion(...args),
+}))
+
+const mockIsInDeployments = jest.fn()
+jest.mock('@safe-global/utils/hooks/coreSDK/utils', () => ({
+  isInDeployments: (...args: unknown[]) => mockIsInDeployments(...args),
+}))
+
+describe('initSafeSDK', () => {
+  const mockAddress = generateChecksummedAddress()
+  const mockImplementation = generateChecksummedAddress()
+  const mockChainId = '1'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsValidMasterCopy.mockReturnValue(true)
+    mockIsLegacyVersion.mockReturnValue(false)
+    mockIsInDeployments.mockReturnValue(true)
+    mockGetSafeSingletonDeployments.mockReturnValue({
+      networkAddresses: { [mockChainId]: [mockImplementation] },
+    })
+    mockGetSafeL2SingletonDeployments.mockReturnValue({
+      networkAddresses: { [mockChainId]: [mockImplementation] },
+    })
+  })
+
+  const createDefaultProps = (overrides?: Partial<SafeCoreSDKProps>): SafeCoreSDKProps => ({
+    provider: createMockProvider({ chainId: mockChainId }) as unknown as SafeCoreSDKProps['provider'],
+    chainId: mockChainId,
+    address: mockAddress,
+    version: '1.3.0',
+    implementationVersionState: 'UP_TO_DATE',
+    implementation: mockImplementation,
+    ...overrides,
+  })
+
+  it('returns undefined when provider network does not match chainId', async () => {
+    const props = createDefaultProps({
+      provider: createMockProvider({ chainId: '137' }) as unknown as SafeCoreSDKProps['provider'],
+    })
+
+    const result = await initSafeSDK(props)
+
+    expect(result).toBeUndefined()
+    expect(Safe.init).not.toHaveBeenCalled()
+  })
+
+  it('initializes Safe SDK with correct parameters for valid master copy', async () => {
+    const mockSafe = { address: mockAddress }
+    ;(Safe.init as jest.Mock).mockResolvedValue(mockSafe)
+    const props = createDefaultProps()
+
+    const result = await initSafeSDK(props)
+
+    expect(Safe.init).toHaveBeenCalledWith({
+      provider: 'https://rpc.example.com',
+      safeAddress: mockAddress,
+      isL1SafeSingleton: true,
+    })
+    expect(result).toBe(mockSafe)
+  })
+
+  it('uses isL1SafeSingleton=true for Ethereum mainnet', async () => {
+    const mockSafe = { address: mockAddress }
+    ;(Safe.init as jest.Mock).mockResolvedValue(mockSafe)
+    const props = createDefaultProps({ chainId: chains.eth })
+
+    await initSafeSDK(props)
+
+    expect(Safe.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isL1SafeSingleton: true,
+      }),
+    )
+  })
+
+  it('uses isL1SafeSingleton=false for L2 chains when master copy is L2', async () => {
+    const mockSafe = { address: mockAddress }
+    ;(Safe.init as jest.Mock).mockResolvedValue(mockSafe)
+    mockIsValidMasterCopy.mockReturnValue(false)
+    mockIsInDeployments.mockImplementation((_, deployments) => {
+      return deployments === mockImplementation
+    })
+    mockGetSafeSingletonDeployments.mockReturnValue({
+      networkAddresses: { '137': ['0xDifferentAddress'] },
+    })
+    mockGetSafeL2SingletonDeployments.mockReturnValue({
+      networkAddresses: { '137': mockImplementation },
+    })
+
+    const props = createDefaultProps({
+      chainId: '137',
+      provider: createMockProvider({ chainId: '137' }) as unknown as SafeCoreSDKProps['provider'],
+    })
+
+    await initSafeSDK(props)
+
+    expect(Safe.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isL1SafeSingleton: false,
+      }),
+    )
+  })
+
+  it('returns undefined for unknown deployment when master copy is invalid', async () => {
+    mockIsValidMasterCopy.mockReturnValue(false)
+    mockIsInDeployments.mockReturnValue(false)
+
+    const props = createDefaultProps({ implementationVersionState: 'UNKNOWN' })
+
+    const result = await initSafeSDK(props)
+
+    expect(result).toBeUndefined()
+    expect(Safe.init).not.toHaveBeenCalled()
+  })
+
+  it('sets isL1SafeSingleton=true for legacy versions', async () => {
+    const mockSafe = { address: mockAddress }
+    ;(Safe.init as jest.Mock).mockResolvedValue(mockSafe)
+    mockIsLegacyVersion.mockReturnValue(true)
+
+    const props = createDefaultProps({
+      version: '1.1.1',
+      chainId: '137',
+      provider: createMockProvider({ chainId: '137' }) as unknown as SafeCoreSDKProps['provider'],
+    })
+
+    await initSafeSDK(props)
+
+    expect(Safe.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isL1SafeSingleton: true,
+      }),
+    )
+  })
+
+  it('fetches version from contract when version is not provided', async () => {
+    const mockSafe = { address: mockAddress }
+    ;(Safe.init as jest.Mock).mockResolvedValue(mockSafe)
+
+    const props = createDefaultProps({ version: undefined })
+
+    await initSafeSDK(props)
+
+    expect(Safe.init).toHaveBeenCalled()
+  })
+
+  it('checks L1 deployment first when master copy is invalid', async () => {
+    mockIsValidMasterCopy.mockReturnValue(false)
+    mockIsInDeployments.mockReturnValueOnce(true).mockReturnValueOnce(false)
+
+    const props = createDefaultProps({ implementationVersionState: 'UNKNOWN' })
+
+    await initSafeSDK(props)
+
+    expect(mockGetSafeSingletonDeployments).toHaveBeenCalledWith({
+      network: mockChainId,
+      version: '1.3.0',
+    })
+    expect(mockGetSafeL2SingletonDeployments).toHaveBeenCalledWith({
+      network: mockChainId,
+      version: '1.3.0',
+    })
+  })
+})
+
+describe('ExternalStore exports', () => {
+  beforeEach(() => {
+    setSafeSDK(undefined)
+  })
+
+  it('getSafeSDK returns undefined initially', () => {
+    expect(getSafeSDK()).toBeUndefined()
+  })
+
+  it('setSafeSDK updates the store value', () => {
+    const mockSafe = { address: '0x123' } as unknown as Safe
+    setSafeSDK(mockSafe)
+    expect(getSafeSDK()).toBe(mockSafe)
+  })
+
+  it('setSafeSDK can reset to undefined', () => {
+    const mockSafe = { address: '0x123' } as unknown as Safe
+    setSafeSDK(mockSafe)
+    setSafeSDK(undefined)
+    expect(getSafeSDK()).toBeUndefined()
+  })
+})

--- a/apps/mobile/src/hooks/coreSDK/useInitSafeCoreSDK.test.ts
+++ b/apps/mobile/src/hooks/coreSDK/useInitSafeCoreSDK.test.ts
@@ -1,0 +1,217 @@
+import { renderHook, waitFor } from '@testing-library/react-native'
+import { useInitSafeCoreSDK } from './useInitSafeCoreSDK'
+import * as useSafeInfoHook from '@/src/hooks/useSafeInfo'
+import * as web3Hook from '@/src/hooks/wallets/web3'
+import * as safeCoreSDK from './safeCoreSDK'
+import Safe from '@safe-global/protocol-kit'
+import { generateChecksummedAddress, createMockProvider } from '@safe-global/test'
+
+jest.mock('@/src/hooks/useSafeInfo')
+jest.mock('@/src/hooks/wallets/web3')
+jest.mock('./safeCoreSDK', () => ({
+  initSafeSDK: jest.fn(),
+  setSafeSDK: jest.fn(),
+}))
+jest.mock('@/src/utils/logger', () => ({
+  error: jest.fn(),
+}))
+
+const createMockSafe = (overrides = {}) => ({
+  chainId: '1',
+  address: { value: generateChecksummedAddress() },
+  version: '1.3.0',
+  implementationVersionState: 'UP_TO_DATE' as const,
+  implementation: { value: generateChecksummedAddress() },
+  ...overrides,
+})
+
+describe('useInitSafeCoreSDK', () => {
+  const mockUseSafeInfo = useSafeInfoHook.default as jest.Mock
+  const mockUseWeb3ReadOnly = web3Hook.useWeb3ReadOnly as jest.Mock
+  const mockInitSafeSDK = safeCoreSDK.initSafeSDK as jest.Mock
+  const mockSetSafeSDK = safeCoreSDK.setSafeSDK as jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseSafeInfo.mockReturnValue({ safe: createMockSafe(), safeLoaded: false })
+    mockUseWeb3ReadOnly.mockReturnValue(undefined)
+  })
+
+  it('resets SDK to undefined when safe is not loaded', () => {
+    mockUseSafeInfo.mockReturnValue({ safe: createMockSafe(), safeLoaded: false })
+    mockUseWeb3ReadOnly.mockReturnValue(createMockProvider())
+
+    renderHook(() => useInitSafeCoreSDK())
+
+    expect(mockSetSafeSDK).toHaveBeenCalledWith(undefined)
+    expect(mockInitSafeSDK).not.toHaveBeenCalled()
+  })
+
+  it('resets SDK to undefined when web3ReadOnly is not available', () => {
+    mockUseSafeInfo.mockReturnValue({ safe: createMockSafe(), safeLoaded: true })
+    mockUseWeb3ReadOnly.mockReturnValue(undefined)
+
+    renderHook(() => useInitSafeCoreSDK())
+
+    expect(mockSetSafeSDK).toHaveBeenCalledWith(undefined)
+    expect(mockInitSafeSDK).not.toHaveBeenCalled()
+  })
+
+  it('initializes SDK when safe is loaded and web3ReadOnly is available', async () => {
+    const mockSafe = createMockSafe()
+    const mockProvider = createMockProvider()
+    const mockSafeInstance = { address: mockSafe.address.value } as unknown as Safe
+
+    mockUseSafeInfo.mockReturnValue({ safe: mockSafe, safeLoaded: true })
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockInitSafeSDK.mockResolvedValue(mockSafeInstance)
+
+    renderHook(() => useInitSafeCoreSDK())
+
+    await waitFor(() => {
+      expect(mockInitSafeSDK).toHaveBeenCalledWith({
+        provider: mockProvider,
+        chainId: mockSafe.chainId,
+        address: mockSafe.address.value,
+        version: mockSafe.version,
+        implementationVersionState: mockSafe.implementationVersionState,
+        implementation: mockSafe.implementation.value,
+      })
+    })
+
+    await waitFor(() => {
+      expect(mockSetSafeSDK).toHaveBeenCalledWith(mockSafeInstance)
+    })
+  })
+
+  it('handles initSafeSDK errors gracefully', async () => {
+    const mockSafe = createMockSafe()
+    const mockProvider = createMockProvider()
+    const Logger = require('@/src/utils/logger')
+
+    mockUseSafeInfo.mockReturnValue({ safe: mockSafe, safeLoaded: true })
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockInitSafeSDK.mockRejectedValue(new Error('Init failed'))
+
+    renderHook(() => useInitSafeCoreSDK())
+
+    await waitFor(() => {
+      expect(Logger.error).toHaveBeenCalledWith('error init', expect.any(Error))
+    })
+  })
+
+  it('reinitializes SDK when safe address changes', async () => {
+    const mockSafe1 = createMockSafe()
+    const mockSafe2 = createMockSafe()
+    const mockProvider = createMockProvider()
+    const mockSafeInstance = {} as unknown as Safe
+
+    mockUseSafeInfo.mockReturnValue({ safe: mockSafe1, safeLoaded: true })
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockInitSafeSDK.mockResolvedValue(mockSafeInstance)
+
+    const { rerender } = renderHook(() => useInitSafeCoreSDK())
+
+    await waitFor(() => {
+      expect(mockInitSafeSDK).toHaveBeenCalledTimes(1)
+    })
+
+    mockUseSafeInfo.mockReturnValue({ safe: mockSafe2, safeLoaded: true })
+
+    rerender({})
+
+    await waitFor(() => {
+      expect(mockInitSafeSDK).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('reinitializes SDK when chainId changes', async () => {
+    const mockSafe = createMockSafe()
+    const mockProvider = createMockProvider()
+    const mockSafeInstance = {} as unknown as Safe
+
+    mockUseSafeInfo.mockReturnValue({ safe: mockSafe, safeLoaded: true })
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockInitSafeSDK.mockResolvedValue(mockSafeInstance)
+
+    const { rerender } = renderHook(() => useInitSafeCoreSDK())
+
+    await waitFor(() => {
+      expect(mockInitSafeSDK).toHaveBeenCalledTimes(1)
+    })
+
+    const updatedSafe = { ...mockSafe, chainId: '137' }
+    mockUseSafeInfo.mockReturnValue({ safe: updatedSafe, safeLoaded: true })
+
+    rerender({})
+
+    await waitFor(() => {
+      expect(mockInitSafeSDK).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('reinitializes SDK when implementation changes', async () => {
+    const mockSafe = createMockSafe()
+    const mockProvider = createMockProvider()
+    const mockSafeInstance = {} as unknown as Safe
+
+    mockUseSafeInfo.mockReturnValue({ safe: mockSafe, safeLoaded: true })
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockInitSafeSDK.mockResolvedValue(mockSafeInstance)
+
+    const { rerender } = renderHook(() => useInitSafeCoreSDK())
+
+    await waitFor(() => {
+      expect(mockInitSafeSDK).toHaveBeenCalledTimes(1)
+    })
+
+    const updatedSafe = { ...mockSafe, implementation: { value: generateChecksummedAddress() } }
+    mockUseSafeInfo.mockReturnValue({ safe: updatedSafe, safeLoaded: true })
+
+    rerender({})
+
+    await waitFor(() => {
+      expect(mockInitSafeSDK).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('reinitializes SDK when web3ReadOnly provider changes', async () => {
+    const mockSafe = createMockSafe()
+    const mockProvider1 = createMockProvider()
+    const mockProvider2 = createMockProvider()
+    const mockSafeInstance = {} as unknown as Safe
+
+    mockUseSafeInfo.mockReturnValue({ safe: mockSafe, safeLoaded: true })
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider1)
+    mockInitSafeSDK.mockResolvedValue(mockSafeInstance)
+
+    const { rerender } = renderHook(() => useInitSafeCoreSDK())
+
+    await waitFor(() => {
+      expect(mockInitSafeSDK).toHaveBeenCalledTimes(1)
+    })
+
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider2)
+
+    rerender({})
+
+    await waitFor(() => {
+      expect(mockInitSafeSDK).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('sets SDK to result of initSafeSDK even if undefined', async () => {
+    const mockSafe = createMockSafe()
+    const mockProvider = createMockProvider()
+
+    mockUseSafeInfo.mockReturnValue({ safe: mockSafe, safeLoaded: true })
+    mockUseWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockInitSafeSDK.mockResolvedValue(undefined)
+
+    renderHook(() => useInitSafeCoreSDK())
+
+    await waitFor(() => {
+      expect(mockSetSafeSDK).toHaveBeenLastCalledWith(undefined)
+    })
+  })
+})

--- a/apps/mobile/src/hooks/useBiometrics.test.ts
+++ b/apps/mobile/src/hooks/useBiometrics.test.ts
@@ -1,0 +1,283 @@
+import { act, waitFor } from '@testing-library/react-native'
+import { renderHook, type TestStore } from '@/src/tests/test-utils'
+import { useBiometrics } from './useBiometrics'
+import * as Keychain from 'react-native-keychain'
+import { Linking } from 'react-native'
+
+const mockGetSupportedBiometryType = Keychain.getSupportedBiometryType as jest.Mock
+const mockSetGenericPassword = Keychain.setGenericPassword as jest.Mock
+const mockGetGenericPassword = Keychain.getGenericPassword as jest.Mock
+const mockResetGenericPassword = Keychain.resetGenericPassword as jest.Mock
+
+describe('useBiometrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetSupportedBiometryType.mockResolvedValue(null)
+  })
+
+  describe('initial state', () => {
+    it('returns initial state with biometrics disabled', () => {
+      const { result } = renderHook(() => useBiometrics())
+
+      expect(result.current.isBiometricsEnabled).toBe(false)
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    it('provides getBiometricsUIInfo function', () => {
+      const { result } = renderHook(() => useBiometrics())
+
+      const uiInfo = result.current.getBiometricsUIInfo()
+      expect(uiInfo).toHaveProperty('label')
+      expect(uiInfo).toHaveProperty('icon')
+    })
+  })
+
+  describe('getBiometricsUIInfo', () => {
+    it('returns Face ID info when biometrics type is FACE_ID', () => {
+      const { result } = renderHook(() => useBiometrics(), {
+        biometrics: { isEnabled: false, isSupported: true, type: 'FACE_ID', userAttempts: 0 },
+      })
+
+      const uiInfo = result.current.getBiometricsUIInfo()
+      expect(uiInfo.icon).toBe('face-id')
+      expect(uiInfo.label).toBe('Enable biometrics')
+    })
+
+    it('returns fingerprint info when biometrics type is TOUCH_ID', () => {
+      const { result } = renderHook(() => useBiometrics(), {
+        biometrics: { isEnabled: false, isSupported: true, type: 'TOUCH_ID', userAttempts: 0 },
+      })
+
+      const uiInfo = result.current.getBiometricsUIInfo()
+      expect(uiInfo.icon).toBe('fingerprint')
+    })
+
+    it('returns fingerprint info when biometrics type is FINGERPRINT', () => {
+      const { result } = renderHook(() => useBiometrics(), {
+        biometrics: { isEnabled: false, isSupported: true, type: 'FINGERPRINT', userAttempts: 0 },
+      })
+
+      const uiInfo = result.current.getBiometricsUIInfo()
+      expect(uiInfo.icon).toBe('fingerprint')
+    })
+
+    it('returns default face-id icon when biometrics type is NONE', () => {
+      const { result } = renderHook(() => useBiometrics(), {
+        biometrics: { isEnabled: false, isSupported: false, type: 'NONE', userAttempts: 0 },
+      })
+
+      const uiInfo = result.current.getBiometricsUIInfo()
+      expect(uiInfo.icon).toBe('face-id')
+    })
+  })
+
+  describe('checkBiometricsOSSettingsStatus', () => {
+    it('returns biometricsEnabled true when biometrics is available', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(Keychain.BIOMETRY_TYPE.FACE_ID)
+      const { result } = renderHook(() => useBiometrics())
+
+      const status = await result.current.checkBiometricsOSSettingsStatus()
+
+      expect(status.biometricsEnabled).toBe(true)
+      expect(status.biometryType).toBe('FaceID')
+    })
+
+    it('returns biometricsEnabled false when biometrics is not available', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(null)
+      const { result } = renderHook(() => useBiometrics())
+
+      const status = await result.current.checkBiometricsOSSettingsStatus()
+
+      expect(status.biometricsEnabled).toBe(false)
+      expect(status.biometryType).toBeNull()
+    })
+
+    it('handles errors and returns disabled state', async () => {
+      mockGetSupportedBiometryType.mockRejectedValue(new Error('Keychain error'))
+      const { result } = renderHook(() => useBiometrics())
+
+      const status = await result.current.checkBiometricsOSSettingsStatus()
+
+      expect(status.biometricsEnabled).toBe(false)
+      expect(status.biometryType).toBeNull()
+    })
+  })
+
+  describe('toggleBiometrics', () => {
+    it('enables biometrics when all conditions are met', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(Keychain.BIOMETRY_TYPE.FACE_ID)
+      mockSetGenericPassword.mockResolvedValue(true)
+      mockGetGenericPassword.mockResolvedValue({ password: 'biometrics-enabled' })
+
+      const hookResult = renderHook(() => useBiometrics())
+      const store = hookResult.store as TestStore
+
+      await act(async () => {
+        await hookResult.result.current.toggleBiometrics(true)
+      })
+
+      await waitFor(() => {
+        expect(store.getState().biometrics.isEnabled).toBe(true)
+      })
+    })
+
+    it('disables biometrics correctly', async () => {
+      mockResetGenericPassword.mockResolvedValue(true)
+
+      const hookResult = renderHook(() => useBiometrics(), {
+        biometrics: { isEnabled: true, isSupported: true, type: 'FACE_ID', userAttempts: 0 },
+      })
+      const store = hookResult.store as TestStore
+
+      await act(async () => {
+        await hookResult.result.current.toggleBiometrics(false)
+      })
+
+      await waitFor(() => {
+        expect(store.getState().biometrics.isEnabled).toBe(false)
+      })
+      expect(mockResetGenericPassword).toHaveBeenCalled()
+    })
+
+    it('handles user cancellation during biometrics setup', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(Keychain.BIOMETRY_TYPE.FACE_ID)
+      mockSetGenericPassword.mockRejectedValue({
+        code: '-128',
+        message: 'User pressed Cancel',
+      })
+      mockResetGenericPassword.mockResolvedValue(true)
+
+      const hookResult = renderHook(() => useBiometrics())
+      const store = hookResult.store as TestStore
+
+      await act(async () => {
+        const returnValue = await hookResult.result.current.toggleBiometrics(true)
+        expect(returnValue).toBe(false)
+      })
+
+      await waitFor(() => {
+        expect(store.getState().biometrics.isEnabled).toBe(false)
+      })
+    })
+
+    it('handles authentication failed error', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(Keychain.BIOMETRY_TYPE.FACE_ID)
+      mockSetGenericPassword.mockRejectedValue({
+        code: 'AuthenticationFailed',
+        message: 'Authentication failed',
+      })
+      mockResetGenericPassword.mockResolvedValue(true)
+
+      const { result } = renderHook(() => useBiometrics())
+
+      await act(async () => {
+        const returnValue = await result.current.toggleBiometrics(true)
+        expect(returnValue).toBe(false)
+      })
+    })
+
+    it('handles error with cancel message', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(Keychain.BIOMETRY_TYPE.FACE_ID)
+      mockSetGenericPassword.mockRejectedValue({
+        code: 'unknown',
+        message: 'User did cancel the operation',
+      })
+      mockResetGenericPassword.mockResolvedValue(true)
+
+      const { result } = renderHook(() => useBiometrics())
+
+      await act(async () => {
+        const returnValue = await result.current.toggleBiometrics(true)
+        expect(returnValue).toBe(false)
+      })
+    })
+
+    it('handles passphrase error', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(Keychain.BIOMETRY_TYPE.FACE_ID)
+      mockSetGenericPassword.mockRejectedValue({
+        code: 'unknown',
+        message: 'user name or passphrase you entered is not correct',
+      })
+      mockResetGenericPassword.mockResolvedValue(true)
+
+      const { result } = renderHook(() => useBiometrics())
+
+      await act(async () => {
+        const returnValue = await result.current.toggleBiometrics(true)
+        expect(returnValue).toBe(false)
+      })
+    })
+
+    it('does not enable when biometrics is not supported', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(null)
+
+      const hookResult = renderHook(() => useBiometrics())
+      const store = hookResult.store as TestStore
+
+      await act(async () => {
+        await hookResult.result.current.toggleBiometrics(true)
+      })
+
+      expect(store.getState().biometrics.isEnabled).toBe(false)
+    })
+
+    it('handles unexpected errors during biometrics setup', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(Keychain.BIOMETRY_TYPE.FACE_ID)
+      mockSetGenericPassword.mockRejectedValue(new Error('Unexpected storage error'))
+      mockResetGenericPassword.mockResolvedValue(true)
+
+      const hookResult = renderHook(() => useBiometrics())
+      const store = hookResult.store as TestStore
+
+      await act(async () => {
+        const returnValue = await hookResult.result.current.toggleBiometrics(true)
+        expect(returnValue).toBe(false)
+      })
+
+      expect(store.getState().biometrics.isEnabled).toBe(false)
+      expect(mockResetGenericPassword).toHaveBeenCalled()
+    })
+
+    it('handles failed verification after setting password', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(Keychain.BIOMETRY_TYPE.FACE_ID)
+      mockSetGenericPassword.mockResolvedValue(true)
+      mockGetGenericPassword.mockResolvedValue(false)
+      mockResetGenericPassword.mockResolvedValue(true)
+
+      const { result } = renderHook(() => useBiometrics())
+
+      await act(async () => {
+        const returnValue = await result.current.toggleBiometrics(true)
+        expect(returnValue).toBe(false)
+      })
+    })
+  })
+
+  describe('openBiometricSettings', () => {
+    it('opens settings when called', () => {
+      const openURLSpy = jest.spyOn(Linking, 'openURL').mockImplementation(jest.fn())
+      const { result } = renderHook(() => useBiometrics())
+
+      result.current.openBiometricSettings()
+
+      expect(openURLSpy).toHaveBeenCalledWith('app-settings:')
+      openURLSpy.mockRestore()
+    })
+  })
+
+  describe('useLayoutEffect cleanup', () => {
+    it('disables biometrics when OS-level biometrics is disabled', async () => {
+      mockGetSupportedBiometryType.mockResolvedValue(null)
+      mockResetGenericPassword.mockResolvedValue(true)
+
+      const hookResult = renderHook(() => useBiometrics(), {
+        biometrics: { isEnabled: true, isSupported: true, type: 'FACE_ID', userAttempts: 0 },
+      })
+      const store = hookResult.store as TestStore
+
+      await waitFor(() => {
+        expect(store.getState().biometrics.isEnabled).toBe(false)
+      })
+    })
+  })
+})

--- a/apps/mobile/src/hooks/useFeeParams/useFeeParams.test.ts
+++ b/apps/mobile/src/hooks/useFeeParams/useFeeParams.test.ts
@@ -1,0 +1,372 @@
+import { waitFor } from '@testing-library/react-native'
+import { createTestStore, renderHookWithStore, type RootState, type TestStore } from '@/src/tests/test-utils'
+import { useFeeParams } from './useFeeParams'
+import type { EstimatedFeeValues } from '@/src/store/estimatedFeeSlice'
+import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import type { Address } from '@/src/types/address'
+import { apiSliceWithChainsConfig } from '@safe-global/store/gateway/chains'
+
+const mockUseWeb3ReadOnly = jest.fn()
+const mockUseDefaultGasPrice = jest.fn()
+const mockUseAsync = jest.fn()
+const mockUseGasLimit = jest.fn()
+const mockUseSafeSDK = jest.fn()
+const mockUseSafeTx = jest.fn()
+
+jest.mock('@/src/hooks/wallets/web3', () => ({
+  useWeb3ReadOnly: () => mockUseWeb3ReadOnly(),
+  getUserNonce: jest.fn(),
+}))
+
+jest.mock('@safe-global/utils/hooks/useDefaultGasPrice', () => ({
+  useDefaultGasPrice: (...args: unknown[]) => mockUseDefaultGasPrice(...args),
+}))
+
+jest.mock('@safe-global/utils/hooks/useAsync', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockUseAsync(...args),
+}))
+
+jest.mock('@safe-global/utils/hooks/useDefaultGasLimit', () => ({
+  useGasLimit: (...args: unknown[]) => mockUseGasLimit(...args),
+}))
+
+jest.mock('@/src/hooks/coreSDK/safeCoreSDK', () => ({
+  useSafeSDK: () => mockUseSafeSDK(),
+}))
+
+jest.mock('@/src/hooks/useSafeTx', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockUseSafeTx(...args),
+}))
+
+const SAFE_ADDRESS = '0x1234567890123456789012345678901234567890' as Address
+const SIGNER_ADDRESS = '0x0987654321098765432109876543210987654321'
+
+const createStoreWithChains = async (overrides?: Partial<RootState>): Promise<TestStore> => {
+  const store = createTestStore({
+    activeSafe: {
+      address: SAFE_ADDRESS,
+      chainId: '1',
+    },
+    activeSigner: {
+      [SAFE_ADDRESS]: {
+        value: SIGNER_ADDRESS,
+        name: 'Test Signer',
+        logoUri: null,
+        type: 'private-key' as const,
+      },
+    },
+    safes: {
+      [SAFE_ADDRESS]: {
+        '1': { threshold: 2 },
+      },
+    } as unknown as RootState['safes'],
+    ...overrides,
+  })
+
+  await store.dispatch(apiSliceWithChainsConfig.endpoints.getChainsConfig.initiate())
+
+  return store
+}
+
+describe('useFeeParams', () => {
+  const mockTxDetails = { txId: 'tx123' } as unknown as TransactionDetails
+
+  const mockGasPrice = {
+    maxFeePerGas: BigInt('2000000000'),
+    maxPriorityFeePerGas: BigInt('1000000000'),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseWeb3ReadOnly.mockReturnValue({})
+    mockUseDefaultGasPrice.mockReturnValue([mockGasPrice, undefined, false])
+    mockUseAsync.mockReturnValue([10, undefined, false])
+    mockUseGasLimit.mockReturnValue({
+      gasLimit: BigInt('21000'),
+      gasLimitLoading: false,
+      gasLimitError: undefined,
+    })
+    mockUseSafeSDK.mockReturnValue({})
+    mockUseSafeTx.mockReturnValue({})
+  })
+
+  describe('with manual params', () => {
+    it('should return manual params when provided', async () => {
+      const manualParams: EstimatedFeeValues = {
+        maxFeePerGas: BigInt('5000000000'),
+        maxPriorityFeePerGas: BigInt('2000000000'),
+        gasLimit: BigInt('50000'),
+        nonce: 15,
+      }
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, manualParams), store)
+
+      expect(result.current.maxFeePerGas).toBe(manualParams.maxFeePerGas)
+      expect(result.current.maxPriorityFeePerGas).toBe(manualParams.maxPriorityFeePerGas)
+      expect(result.current.gasLimit).toBe(manualParams.gasLimit)
+      expect(result.current.nonce).toBe(manualParams.nonce)
+    })
+
+    it('should still include loading states with manual params', async () => {
+      const manualParams: EstimatedFeeValues = {
+        maxFeePerGas: BigInt('5000000000'),
+        maxPriorityFeePerGas: BigInt('2000000000'),
+        gasLimit: BigInt('50000'),
+        nonce: 15,
+      }
+
+      mockUseDefaultGasPrice.mockReturnValue([mockGasPrice, undefined, true])
+      mockUseGasLimit.mockReturnValue({
+        gasLimit: BigInt('21000'),
+        gasLimitLoading: true,
+        gasLimitError: undefined,
+      })
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, manualParams), store)
+
+      expect(result.current.isLoadingGasPrice).toBe(true)
+      expect(result.current.gasLimitLoading).toBe(true)
+    })
+
+    it('should include gas limit error with manual params', async () => {
+      const manualParams: EstimatedFeeValues = {
+        maxFeePerGas: BigInt('5000000000'),
+        maxPriorityFeePerGas: BigInt('2000000000'),
+        gasLimit: BigInt('50000'),
+        nonce: 15,
+      }
+
+      const gasError = new Error('Gas estimation failed')
+      mockUseGasLimit.mockReturnValue({
+        gasLimit: undefined,
+        gasLimitLoading: false,
+        gasLimitError: gasError,
+      })
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, manualParams), store)
+
+      expect(result.current.gasLimitError).toBe(gasError)
+    })
+  })
+
+  describe('without manual params', () => {
+    it('should return estimated gas price values', async () => {
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      await waitFor(() => {
+        expect(result.current.maxFeePerGas).toBe(mockGasPrice.maxFeePerGas)
+        expect(result.current.maxPriorityFeePerGas).toBe(mockGasPrice.maxPriorityFeePerGas)
+      })
+    })
+
+    it('should return estimated gas limit', async () => {
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.gasLimit).toBe(BigInt('21000'))
+    })
+
+    it('should return user nonce from async hook', async () => {
+      mockUseAsync.mockReturnValue([42, undefined, false])
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.nonce).toBe(42)
+    })
+
+    it('should handle undefined gas price gracefully', async () => {
+      mockUseDefaultGasPrice.mockReturnValue([undefined, undefined, false])
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.maxFeePerGas).toBeUndefined()
+      expect(result.current.maxPriorityFeePerGas).toBeUndefined()
+    })
+
+    it('should handle undefined gas limit gracefully', async () => {
+      mockUseGasLimit.mockReturnValue({
+        gasLimit: undefined,
+        gasLimitLoading: false,
+        gasLimitError: undefined,
+      })
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.gasLimit).toBeUndefined()
+    })
+
+    it('should handle undefined user nonce', async () => {
+      mockUseAsync.mockReturnValue([undefined, undefined, false])
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.nonce).toBeUndefined()
+    })
+  })
+
+  describe('loading states', () => {
+    it('should return loading true when gas price is loading', async () => {
+      mockUseDefaultGasPrice.mockReturnValue([undefined, undefined, true])
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.isLoadingGasPrice).toBe(true)
+    })
+
+    it('should return loading false when gas price is loaded', async () => {
+      mockUseDefaultGasPrice.mockReturnValue([mockGasPrice, undefined, false])
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.isLoadingGasPrice).toBe(false)
+    })
+
+    it('should return gas limit loading state', async () => {
+      mockUseGasLimit.mockReturnValue({
+        gasLimit: undefined,
+        gasLimitLoading: true,
+        gasLimitError: undefined,
+      })
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.gasLimitLoading).toBe(true)
+    })
+  })
+
+  describe('error states', () => {
+    it('should return gas limit error', async () => {
+      const gasError = new Error('Failed to estimate gas')
+      mockUseGasLimit.mockReturnValue({
+        gasLimit: undefined,
+        gasLimitLoading: false,
+        gasLimitError: gasError,
+      })
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.gasLimitError).toBe(gasError)
+    })
+
+    it('should handle gas price error gracefully', async () => {
+      const gasPriceError = new Error('Failed to fetch gas price')
+      mockUseDefaultGasPrice.mockReturnValue([undefined, gasPriceError, false])
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(result.current.maxFeePerGas).toBeUndefined()
+      expect(result.current.maxPriorityFeePerGas).toBeUndefined()
+    })
+  })
+
+  describe('settings', () => {
+    it('should pass pooling setting to useDefaultGasPrice', async () => {
+      const store = await createStoreWithChains()
+      renderHookWithStore(() => useFeeParams(mockTxDetails, null, { pooling: false }), store)
+
+      expect(mockUseDefaultGasPrice).toHaveBeenCalledWith(
+        expect.objectContaining({ chainId: '1' }),
+        expect.anything(),
+        expect.objectContaining({ withPooling: false }),
+      )
+    })
+
+    it('should default pooling to true', async () => {
+      const store = await createStoreWithChains()
+      renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(mockUseDefaultGasPrice).toHaveBeenCalledWith(
+        expect.objectContaining({ chainId: '1' }),
+        expect.anything(),
+        expect.objectContaining({ withPooling: true }),
+      )
+    })
+
+    it('should pass logError to useDefaultGasPrice', async () => {
+      const logError = jest.fn()
+      const store = await createStoreWithChains()
+      renderHookWithStore(() => useFeeParams(mockTxDetails, null, { logError }), store)
+
+      expect(mockUseDefaultGasPrice).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ logError }),
+      )
+    })
+
+    it('should pass logError to useGasLimit', async () => {
+      const logError = jest.fn()
+      const store = await createStoreWithChains()
+      renderHookWithStore(() => useFeeParams(mockTxDetails, null, { logError }), store)
+
+      expect(mockUseGasLimit).toHaveBeenCalledWith(expect.objectContaining({ logError }))
+    })
+  })
+
+  describe('hook dependencies', () => {
+    it('should call useSafeTx with txDetails', async () => {
+      const store = await createStoreWithChains()
+      renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(mockUseSafeTx).toHaveBeenCalledWith(mockTxDetails)
+    })
+
+    it('should handle undefined txDetails', async () => {
+      mockUseSafeTx.mockReturnValue(undefined)
+
+      const store = await createStoreWithChains()
+      const { result } = renderHookWithStore(() => useFeeParams(undefined, null), store)
+
+      expect(mockUseSafeTx).toHaveBeenCalledWith(undefined)
+      expect(result.current).toBeDefined()
+    })
+
+    it('should pass correct params to useGasLimit', async () => {
+      const mockSafeTx = { data: { to: '0x123' } }
+      mockUseSafeTx.mockReturnValue(mockSafeTx)
+
+      const store = await createStoreWithChains()
+      renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(mockUseGasLimit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          safeTx: mockSafeTx,
+          chainId: '1',
+          safeAddress: SAFE_ADDRESS,
+          threshold: 2,
+          walletAddress: SIGNER_ADDRESS,
+          isOwner: true,
+        }),
+      )
+    })
+
+    it('should use 0 threshold when safeInfo is undefined', async () => {
+      const store = await createStoreWithChains({ safes: {} as RootState['safes'] })
+      renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(mockUseGasLimit).toHaveBeenCalledWith(expect.objectContaining({ threshold: 0 }))
+    })
+
+    it('should use empty string for walletAddress when activeSigner is undefined', async () => {
+      const store = await createStoreWithChains({ activeSigner: {} })
+      renderHookWithStore(() => useFeeParams(mockTxDetails, null), store)
+
+      expect(mockUseGasLimit).toHaveBeenCalledWith(expect.objectContaining({ walletAddress: '' }))
+    })
+  })
+})

--- a/apps/mobile/src/hooks/useMakeSafesWithChainId/useMakeSafesWithChainId.test.ts
+++ b/apps/mobile/src/hooks/useMakeSafesWithChainId/useMakeSafesWithChainId.test.ts
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react-native'
+import { useMakeSafesWithChainId } from './useMakeSafesWithChainId'
+
+const mockSelectAllChainsIds = jest.fn()
+
+jest.mock('@/src/store/hooks', () => ({
+  useAppSelector: (selector: () => unknown) => selector(),
+}))
+
+jest.mock('@/src/store/chains', () => ({
+  selectAllChainsIds: () => mockSelectAllChainsIds(),
+}))
+
+describe('useMakeSafesWithChainId', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return comma-separated safe IDs for all chains', () => {
+    mockSelectAllChainsIds.mockReturnValue(['1', '137', '10'])
+    const safeAddress = '0x1234567890123456789012345678901234567890'
+
+    const { result } = renderHook(() => useMakeSafesWithChainId(safeAddress))
+
+    expect(result.current).toBe(`1:${safeAddress},137:${safeAddress},10:${safeAddress}`)
+  })
+
+  it('should return single safe ID when only one chain', () => {
+    mockSelectAllChainsIds.mockReturnValue(['1'])
+    const safeAddress = '0xSafeAddress'
+
+    const { result } = renderHook(() => useMakeSafesWithChainId(safeAddress))
+
+    expect(result.current).toBe('1:0xSafeAddress')
+  })
+
+  it('should return empty string when no chains', () => {
+    mockSelectAllChainsIds.mockReturnValue([])
+    const safeAddress = '0xSafeAddress'
+
+    const { result } = renderHook(() => useMakeSafesWithChainId(safeAddress))
+
+    expect(result.current).toBe('')
+  })
+
+  it('should update when safeAddress changes', () => {
+    mockSelectAllChainsIds.mockReturnValue(['1', '137'])
+
+    const { result, rerender } = renderHook(({ address }) => useMakeSafesWithChainId(address), {
+      initialProps: { address: '0xFirstAddress' },
+    })
+
+    expect(result.current).toBe('1:0xFirstAddress,137:0xFirstAddress')
+
+    rerender({ address: '0xSecondAddress' })
+
+    expect(result.current).toBe('1:0xSecondAddress,137:0xSecondAddress')
+  })
+
+  it('should update when chainIds change', () => {
+    mockSelectAllChainsIds.mockReturnValue(['1'])
+    const safeAddress = '0xSafeAddress'
+
+    const { result, rerender } = renderHook(() => useMakeSafesWithChainId(safeAddress))
+
+    expect(result.current).toBe('1:0xSafeAddress')
+
+    mockSelectAllChainsIds.mockReturnValue(['1', '56', '42161'])
+
+    rerender({})
+
+    expect(result.current).toBe('1:0xSafeAddress,56:0xSafeAddress,42161:0xSafeAddress')
+  })
+
+  it('should memoize result for same inputs', () => {
+    mockSelectAllChainsIds.mockReturnValue(['1', '137'])
+    const safeAddress = '0xSafeAddress'
+
+    const { result, rerender } = renderHook(() => useMakeSafesWithChainId(safeAddress))
+
+    const firstResult = result.current
+
+    rerender({})
+
+    expect(result.current).toBe(firstResult)
+  })
+
+  it('should handle various chain IDs', () => {
+    mockSelectAllChainsIds.mockReturnValue(['1', '56', '137', '42161', '10', '8453'])
+    const safeAddress = '0xTest'
+
+    const { result } = renderHook(() => useMakeSafesWithChainId(safeAddress))
+
+    expect(result.current).toBe('1:0xTest,56:0xTest,137:0xTest,42161:0xTest,10:0xTest,8453:0xTest')
+  })
+})

--- a/apps/mobile/src/hooks/wallets/web3.test.ts
+++ b/apps/mobile/src/hooks/wallets/web3.test.ts
@@ -1,0 +1,216 @@
+import { JsonRpcProvider, BrowserProvider } from 'ethers'
+import {
+  getRpcServiceUrl,
+  createWeb3ReadOnly,
+  createWeb3,
+  createSafeAppsWeb3Provider,
+  getUserNonce,
+  getWeb3ReadOnly,
+  setWeb3ReadOnly,
+} from './web3'
+import { RPC_AUTHENTICATION } from '@safe-global/store/gateway/types'
+import type { Chain, RpcUri } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+
+jest.mock('ethers', () => ({
+  JsonRpcProvider: jest.fn().mockImplementation(() => ({
+    getTransactionCount: jest.fn(),
+  })),
+  BrowserProvider: jest.fn().mockImplementation(() => ({})),
+}))
+
+jest.mock('@safe-global/utils/config/constants', () => ({
+  INFURA_TOKEN: 'test-infura-token',
+  SAFE_APPS_INFURA_TOKEN: 'test-safe-apps-infura-token',
+}))
+
+describe('web3', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setWeb3ReadOnly(undefined)
+  })
+
+  describe('getRpcServiceUrl', () => {
+    it('should append token when authentication is API_KEY_PATH', () => {
+      const rpcUri: RpcUri = {
+        authentication: RPC_AUTHENTICATION.API_KEY_PATH,
+        value: 'https://mainnet.infura.io/v3/',
+      }
+
+      const result = getRpcServiceUrl(rpcUri)
+
+      expect(result).toBe('https://mainnet.infura.io/v3/test-infura-token')
+    })
+
+    it('should return value without token when authentication is not API_KEY_PATH', () => {
+      const rpcUri: RpcUri = {
+        authentication: RPC_AUTHENTICATION.NO_AUTHENTICATION,
+        value: 'https://rpc.ankr.com/eth',
+      }
+
+      const result = getRpcServiceUrl(rpcUri)
+
+      expect(result).toBe('https://rpc.ankr.com/eth')
+    })
+  })
+
+  describe('createWeb3ReadOnly', () => {
+    it('should create JsonRpcProvider with chain RPC URL', () => {
+      const chain: Chain = {
+        chainId: '1',
+        rpcUri: {
+          authentication: RPC_AUTHENTICATION.NO_AUTHENTICATION,
+          value: 'https://rpc.ankr.com/eth',
+        },
+      } as Chain
+
+      const result = createWeb3ReadOnly(chain)
+
+      expect(JsonRpcProvider).toHaveBeenCalledWith('https://rpc.ankr.com/eth', 1, {
+        staticNetwork: true,
+        batchMaxCount: 3,
+      })
+      expect(result).toBeDefined()
+    })
+
+    it('should use custom RPC URL when provided', () => {
+      const chain: Chain = {
+        chainId: '1',
+        rpcUri: {
+          authentication: RPC_AUTHENTICATION.NO_AUTHENTICATION,
+          value: 'https://default-rpc.com',
+        },
+      } as Chain
+
+      createWeb3ReadOnly(chain, 'https://custom-rpc.com')
+
+      expect(JsonRpcProvider).toHaveBeenCalledWith('https://custom-rpc.com', 1, {
+        staticNetwork: true,
+        batchMaxCount: 3,
+      })
+    })
+
+    it('should return undefined when custom RPC is empty string', () => {
+      const chain: Chain = {
+        chainId: '1',
+        rpcUri: {
+          authentication: RPC_AUTHENTICATION.NO_AUTHENTICATION,
+          value: '',
+        },
+      } as Chain
+
+      const result = createWeb3ReadOnly(chain, '')
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('createWeb3', () => {
+    it('should create BrowserProvider with wallet provider', () => {
+      const mockWalletProvider = { request: jest.fn() }
+
+      const result = createWeb3(mockWalletProvider)
+
+      expect(BrowserProvider).toHaveBeenCalledWith(mockWalletProvider)
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('createSafeAppsWeb3Provider', () => {
+    it('should create JsonRpcProvider for Safe Apps', () => {
+      const chain: Chain = {
+        chainId: '1',
+        rpcUri: {
+          authentication: RPC_AUTHENTICATION.NO_AUTHENTICATION,
+          value: 'https://rpc.ankr.com/eth',
+        },
+      } as Chain
+
+      const result = createSafeAppsWeb3Provider(chain)
+
+      expect(JsonRpcProvider).toHaveBeenCalledWith('https://rpc.ankr.com/eth', undefined, {
+        staticNetwork: true,
+        batchMaxCount: 3,
+      })
+      expect(result).toBeDefined()
+    })
+
+    it('should use custom RPC URL when provided', () => {
+      const chain: Chain = {
+        chainId: '1',
+        rpcUri: {
+          authentication: RPC_AUTHENTICATION.NO_AUTHENTICATION,
+          value: 'https://default-rpc.com',
+        },
+      } as Chain
+
+      createSafeAppsWeb3Provider(chain, 'https://custom-safe-apps-rpc.com')
+
+      expect(JsonRpcProvider).toHaveBeenCalledWith('https://custom-safe-apps-rpc.com', undefined, {
+        staticNetwork: true,
+        batchMaxCount: 3,
+      })
+    })
+
+    it('should return undefined when custom RPC is empty string', () => {
+      const chain: Chain = {
+        chainId: '1',
+        rpcUri: {
+          authentication: RPC_AUTHENTICATION.NO_AUTHENTICATION,
+          value: '',
+        },
+      } as Chain
+
+      const result = createSafeAppsWeb3Provider(chain, '')
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('getUserNonce', () => {
+    it('should return -1 when web3 is not set', async () => {
+      setWeb3ReadOnly(undefined)
+
+      const result = await getUserNonce('0xUserAddress')
+
+      expect(result).toBe(-1)
+    })
+
+    it('should return transaction count from provider', async () => {
+      const mockProvider = {
+        getTransactionCount: jest.fn().mockResolvedValue(42),
+      }
+      setWeb3ReadOnly(mockProvider as unknown as JsonRpcProvider)
+
+      const result = await getUserNonce('0xUserAddress')
+
+      expect(mockProvider.getTransactionCount).toHaveBeenCalledWith('0xUserAddress', 'pending')
+      expect(result).toBe(42)
+    })
+
+    it('should reject when getTransactionCount fails', async () => {
+      const mockError = new Error('RPC error')
+      const mockProvider = {
+        getTransactionCount: jest.fn().mockRejectedValue(mockError),
+      }
+      setWeb3ReadOnly(mockProvider as unknown as JsonRpcProvider)
+
+      await expect(getUserNonce('0xUserAddress')).rejects.toThrow('RPC error')
+    })
+  })
+
+  describe('External stores', () => {
+    it('should set and get web3ReadOnly', () => {
+      const mockProvider = { mock: 'provider' } as unknown as JsonRpcProvider
+
+      setWeb3ReadOnly(mockProvider)
+
+      expect(getWeb3ReadOnly()).toBe(mockProvider)
+    })
+
+    it('should return undefined when web3ReadOnly is not set', () => {
+      setWeb3ReadOnly(undefined)
+
+      expect(getWeb3ReadOnly()).toBeUndefined()
+    })
+  })
+})

--- a/apps/mobile/src/services/key-storage/key-storage.service.test.ts
+++ b/apps/mobile/src/services/key-storage/key-storage.service.test.ts
@@ -1,0 +1,268 @@
+import { faker } from '@faker-js/faker'
+import { KeyStorageService } from './key-storage.service'
+import DeviceCrypto from 'react-native-device-crypto'
+import * as Keychain from 'react-native-keychain'
+import DeviceInfo from 'react-native-device-info'
+import { Platform } from 'react-native'
+
+const mockDeviceCrypto = DeviceCrypto as jest.Mocked<typeof DeviceCrypto>
+const mockKeychain = Keychain as jest.Mocked<typeof Keychain>
+const mockDeviceInfo = DeviceInfo as jest.Mocked<typeof DeviceInfo>
+
+describe('KeyStorageService', () => {
+  let service: KeyStorageService
+  const userId = faker.finance.ethereumAddress()
+  const privateKey = faker.string.hexadecimal({ length: 64, prefix: '0x' })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = new KeyStorageService()
+    ;(Platform.OS as string) = 'ios'
+  })
+
+  describe('storePrivateKey', () => {
+    describe('on iOS', () => {
+      beforeEach(() => {
+        ;(Platform.OS as string) = 'ios'
+        mockDeviceInfo.isEmulator.mockResolvedValue(false)
+      })
+
+      it('stores private key with asymmetric encryption', async () => {
+        mockDeviceCrypto.getOrCreateAsymmetricKey.mockResolvedValue('key-name')
+        mockDeviceCrypto.encrypt.mockResolvedValue({
+          encryptedText: 'encrypted',
+          iv: 'iv-value',
+        })
+        mockKeychain.setGenericPassword.mockResolvedValue({
+          service: 'test-service',
+          storage: Keychain.STORAGE_TYPE.AES_GCM,
+        })
+
+        await service.storePrivateKey(userId, privateKey)
+
+        expect(mockDeviceCrypto.getOrCreateAsymmetricKey).toHaveBeenCalled()
+        expect(mockDeviceCrypto.encrypt).toHaveBeenCalled()
+        expect(mockKeychain.setGenericPassword).toHaveBeenCalled()
+      })
+
+      it('stores private key without authentication when option is false', async () => {
+        mockDeviceCrypto.getOrCreateAsymmetricKey.mockResolvedValue('key-name')
+        mockDeviceCrypto.encrypt.mockResolvedValue({
+          encryptedText: 'encrypted',
+          iv: 'iv-value',
+        })
+        mockKeychain.setGenericPassword.mockResolvedValue({
+          service: 'test-service',
+          storage: Keychain.STORAGE_TYPE.AES_GCM,
+        })
+
+        await service.storePrivateKey(userId, privateKey, { requireAuthentication: false })
+
+        expect(mockDeviceCrypto.getOrCreateAsymmetricKey).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ accessLevel: 1 }),
+        )
+      })
+
+      it('uses lower access level on emulator', async () => {
+        mockDeviceInfo.isEmulator.mockResolvedValue(true)
+        mockDeviceCrypto.getOrCreateAsymmetricKey.mockResolvedValue('key-name')
+        mockDeviceCrypto.encrypt.mockResolvedValue({
+          encryptedText: 'encrypted',
+          iv: 'iv-value',
+        })
+        mockKeychain.setGenericPassword.mockResolvedValue({
+          service: 'test-service',
+          storage: Keychain.STORAGE_TYPE.AES_GCM,
+        })
+
+        await service.storePrivateKey(userId, privateKey)
+
+        expect(mockDeviceCrypto.getOrCreateAsymmetricKey).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ accessLevel: 1 }),
+        )
+      })
+
+      it('throws error on key creation failure', async () => {
+        mockDeviceCrypto.getOrCreateAsymmetricKey.mockRejectedValue(new Error('Key creation failed'))
+
+        await expect(service.storePrivateKey(userId, privateKey)).rejects.toThrow('Failed to store private key')
+      })
+
+      it('throws error on encryption failure', async () => {
+        mockDeviceCrypto.getOrCreateAsymmetricKey.mockResolvedValue('key-name')
+        mockDeviceCrypto.encrypt.mockRejectedValue(new Error('Encryption failed'))
+
+        await expect(service.storePrivateKey(userId, privateKey)).rejects.toThrow('Failed to store private key')
+      })
+    })
+
+    describe('on Android', () => {
+      beforeEach(() => {
+        ;(Platform.OS as string) = 'android'
+      })
+
+      it('stores private key with symmetric encryption', async () => {
+        mockDeviceCrypto.getOrCreateSymmetricKey.mockResolvedValue(undefined as never)
+        mockDeviceCrypto.encrypt.mockResolvedValue({
+          encryptedText: 'encrypted',
+          iv: 'iv-value',
+        })
+        mockKeychain.setGenericPassword.mockResolvedValue({
+          service: 'test-service',
+          storage: Keychain.STORAGE_TYPE.AES_GCM,
+        })
+
+        await service.storePrivateKey(userId, privateKey)
+
+        expect(mockDeviceCrypto.getOrCreateSymmetricKey).toHaveBeenCalled()
+        expect(mockDeviceCrypto.encrypt).toHaveBeenCalled()
+        expect(mockKeychain.setGenericPassword).toHaveBeenCalled()
+      })
+
+      it('throws error on symmetric key creation failure', async () => {
+        mockDeviceCrypto.getOrCreateSymmetricKey.mockRejectedValue(new Error('Symmetric key creation failed'))
+
+        await expect(service.storePrivateKey(userId, privateKey)).rejects.toThrow('Failed to store private key')
+      })
+    })
+  })
+
+  describe('getPrivateKey', () => {
+    it('retrieves and decrypts private key', async () => {
+      const encryptedData = JSON.stringify({ encryptedPassword: 'encrypted', iv: 'iv-value' })
+      mockKeychain.getGenericPassword.mockResolvedValue({
+        username: 'signer_address',
+        password: encryptedData,
+        service: 'test-service',
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
+      })
+      mockDeviceCrypto.decrypt.mockResolvedValue(privateKey)
+
+      const result = await service.getPrivateKey(userId)
+
+      expect(result).toBe(privateKey)
+      expect(mockKeychain.getGenericPassword).toHaveBeenCalled()
+      expect(mockDeviceCrypto.decrypt).toHaveBeenCalled()
+    })
+
+    it('returns undefined when password not found', async () => {
+      mockKeychain.getGenericPassword.mockResolvedValue(false)
+
+      const result = await service.getPrivateKey(userId)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined on decryption error', async () => {
+      const encryptedData = JSON.stringify({ encryptedPassword: 'encrypted', iv: 'iv-value' })
+      mockKeychain.getGenericPassword.mockResolvedValue({
+        username: 'signer_address',
+        password: encryptedData,
+        service: 'test-service',
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
+      })
+      mockDeviceCrypto.decrypt.mockRejectedValue(new Error('Decryption failed'))
+
+      const result = await service.getPrivateKey(userId)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('applies access control when authentication is required', async () => {
+      const encryptedData = JSON.stringify({ encryptedPassword: 'encrypted', iv: 'iv-value' })
+      mockKeychain.getGenericPassword.mockResolvedValue({
+        username: 'signer_address',
+        password: encryptedData,
+        service: 'test-service',
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
+      })
+      mockDeviceCrypto.decrypt.mockResolvedValue(privateKey)
+
+      await service.getPrivateKey(userId, { requireAuthentication: true })
+
+      expect(mockKeychain.getGenericPassword).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE,
+        }),
+      )
+    })
+  })
+
+  describe('removePrivateKey', () => {
+    it('removes key from keychain and device crypto', async () => {
+      mockKeychain.getGenericPassword.mockResolvedValue({
+        username: 'signer_address',
+        password: 'encrypted',
+        service: 'test-service',
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
+      })
+      mockKeychain.resetGenericPassword.mockResolvedValue(true)
+      mockDeviceCrypto.deleteKey.mockResolvedValue(undefined as never)
+
+      await service.removePrivateKey(userId)
+
+      expect(mockKeychain.resetGenericPassword).toHaveBeenCalled()
+      expect(mockDeviceCrypto.deleteKey).toHaveBeenCalled()
+    })
+
+    it('continues to delete crypto key even if keychain key not found', async () => {
+      mockKeychain.getGenericPassword.mockResolvedValue(false)
+      mockDeviceCrypto.deleteKey.mockResolvedValue(undefined as never)
+
+      await service.removePrivateKey(userId)
+
+      expect(mockKeychain.resetGenericPassword).not.toHaveBeenCalled()
+      expect(mockDeviceCrypto.deleteKey).toHaveBeenCalled()
+    })
+
+    it('handles keychain authentication failure gracefully', async () => {
+      mockKeychain.getGenericPassword.mockRejectedValue(new Error('Auth failed'))
+      mockDeviceCrypto.deleteKey.mockResolvedValue(undefined as never)
+
+      await service.removePrivateKey(userId)
+
+      expect(mockDeviceCrypto.deleteKey).toHaveBeenCalled()
+    })
+
+    it('handles device crypto delete failure gracefully', async () => {
+      mockKeychain.getGenericPassword.mockResolvedValue(false)
+      mockDeviceCrypto.deleteKey.mockRejectedValue(new Error('Key not found'))
+
+      await expect(service.removePrivateKey(userId)).resolves.not.toThrow()
+    })
+
+    it('handles all failures gracefully without throwing', async () => {
+      mockKeychain.getGenericPassword.mockRejectedValue(new Error('Unexpected error'))
+      mockDeviceCrypto.deleteKey.mockRejectedValue(new Error('Also fails'))
+
+      await expect(service.removePrivateKey(userId)).resolves.not.toThrow()
+    })
+  })
+
+  describe('key invalidation handling', () => {
+    it('retries storage after key invalidation', async () => {
+      ;(Platform.OS as string) = 'ios'
+      mockDeviceInfo.isEmulator.mockResolvedValue(false)
+      mockDeviceCrypto.getOrCreateAsymmetricKey.mockResolvedValue('key-name')
+
+      mockDeviceCrypto.encrypt
+        .mockRejectedValueOnce(new Error('Key permanently invalidated'))
+        .mockResolvedValueOnce({ encryptedText: 'encrypted', iv: 'iv-value' })
+
+      mockKeychain.getGenericPassword.mockResolvedValue(false)
+      mockKeychain.resetGenericPassword.mockResolvedValue(true)
+      mockDeviceCrypto.deleteKey.mockResolvedValue(undefined as never)
+      mockKeychain.setGenericPassword.mockResolvedValue({
+        service: 'test-service',
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
+      })
+
+      await service.storePrivateKey(userId, privateKey)
+
+      expect(mockDeviceCrypto.encrypt).toHaveBeenCalledTimes(2)
+      expect(mockDeviceCrypto.deleteKey).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/mobile/src/services/ledger/ledger-dmk.service.test.ts
+++ b/apps/mobile/src/services/ledger/ledger-dmk.service.test.ts
@@ -1,0 +1,256 @@
+import type { DiscoveredDevice } from '@ledgerhq/device-management-kit'
+
+const mockStartDiscovering = jest.fn()
+const mockStopDiscovering = jest.fn().mockResolvedValue(undefined)
+const mockListenToAvailableDevices = jest.fn()
+const mockConnect = jest.fn()
+const mockDisconnect = jest.fn()
+const mockGetConnectedDevice = jest.fn()
+const mockGetDeviceSessionState = jest.fn()
+const mockLoggerError = jest.fn()
+const mockLoggerWarn = jest.fn()
+const mockLoggerInfo = jest.fn()
+
+jest.mock('@ledgerhq/device-management-kit', () => {
+  return {
+    DeviceManagementKitBuilder: jest.fn().mockImplementation(() => ({
+      addLogger: jest.fn().mockReturnThis(),
+      addTransport: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({
+        startDiscovering: (...args: unknown[]) => mockStartDiscovering(...args),
+        stopDiscovering: (...args: unknown[]) => mockStopDiscovering(...args),
+        listenToAvailableDevices: (...args: unknown[]) => mockListenToAvailableDevices(...args),
+        connect: (...args: unknown[]) => mockConnect(...args),
+        disconnect: (...args: unknown[]) => mockDisconnect(...args),
+        getConnectedDevice: (...args: unknown[]) => mockGetConnectedDevice(...args),
+        getDeviceSessionState: (...args: unknown[]) => mockGetDeviceSessionState(...args),
+      }),
+    })),
+    ConsoleLogger: jest.fn(),
+    DeviceStatus: {
+      NOT_CONNECTED: 'not-connected',
+      CONNECTED: 'connected',
+    },
+  }
+})
+
+jest.mock('@ledgerhq/device-transport-kit-react-native-ble', () => ({
+  RNBleTransportFactory: {},
+}))
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+  },
+}))
+
+import { ledgerDMKService, LedgerDMKService } from './ledger-dmk.service'
+
+describe('LedgerDMKService', () => {
+  const mockDevice = {
+    id: 'device-123',
+    name: 'Nano X',
+    type: 'BLE',
+    deviceModel: { id: 'nanoX', productName: 'Nano X' },
+    transport: 'BLE',
+  } as unknown as DiscoveredDevice
+
+  const mockSessionId = 'session-456'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockStopDiscovering.mockResolvedValue(undefined)
+    mockConnect.mockResolvedValue(mockSessionId)
+    mockDisconnect.mockResolvedValue(undefined)
+    mockListenToAvailableDevices.mockReturnValue({
+      subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+    })
+    mockGetDeviceSessionState.mockReturnValue({
+      subscribe: jest.fn(({ next }) => {
+        next({ deviceStatus: 'connected' })
+        return { unsubscribe: jest.fn() }
+      }),
+    })
+  })
+
+  describe('getInstance', () => {
+    it('should return singleton instance', () => {
+      const instance1 = LedgerDMKService.getInstance()
+      const instance2 = LedgerDMKService.getInstance()
+
+      expect(instance1).toBe(instance2)
+    })
+
+    it('should return same instance as exported singleton', () => {
+      expect(ledgerDMKService).toBe(LedgerDMKService.getInstance())
+    })
+  })
+
+  describe('startScanning', () => {
+    it('should start BLE discovery and subscribe to available devices', () => {
+      const onDeviceFound = jest.fn()
+      const onError = jest.fn()
+
+      ledgerDMKService.startScanning(onDeviceFound, onError)
+
+      expect(mockStartDiscovering).toHaveBeenCalledWith({})
+      expect(mockListenToAvailableDevices).toHaveBeenCalledWith({})
+    })
+
+    it('should call onDeviceFound when devices are discovered', () => {
+      const mockSubscribe = jest.fn(({ next }) => {
+        next([mockDevice])
+        return { unsubscribe: jest.fn() }
+      })
+      mockListenToAvailableDevices.mockReturnValue({ subscribe: mockSubscribe })
+
+      const onDeviceFound = jest.fn()
+      const onError = jest.fn()
+
+      ledgerDMKService.startScanning(onDeviceFound, onError)
+
+      expect(onDeviceFound).toHaveBeenCalledWith(mockDevice)
+    })
+
+    it('should call onError when scanning fails', () => {
+      const mockError = new Error('BLE error')
+      const mockSubscribe = jest.fn(({ error }) => {
+        error(mockError)
+        return { unsubscribe: jest.fn() }
+      })
+      mockListenToAvailableDevices.mockReturnValue({ subscribe: mockSubscribe })
+
+      const onDeviceFound = jest.fn()
+      const onError = jest.fn()
+
+      ledgerDMKService.startScanning(onDeviceFound, onError)
+
+      expect(onError).toHaveBeenCalledWith(mockError)
+      expect(mockLoggerError).toHaveBeenCalled()
+    })
+
+    it('should return cleanup function', () => {
+      const mockUnsubscribe = jest.fn()
+      mockListenToAvailableDevices.mockReturnValue({
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: mockUnsubscribe }),
+      })
+
+      const cleanup = ledgerDMKService.startScanning(jest.fn(), jest.fn())
+
+      expect(typeof cleanup).toBe('function')
+
+      cleanup()
+
+      expect(mockUnsubscribe).toHaveBeenCalled()
+    })
+  })
+
+  describe('stopScanning', () => {
+    it('should stop BLE discovery', () => {
+      const mockUnsubscribe = jest.fn()
+      mockListenToAvailableDevices.mockReturnValue({
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: mockUnsubscribe }),
+      })
+
+      ledgerDMKService.startScanning(jest.fn(), jest.fn())
+      ledgerDMKService.stopScanning()
+
+      expect(mockUnsubscribe).toHaveBeenCalled()
+    })
+  })
+
+  describe('connectToDevice', () => {
+    it('should connect to device and return session', async () => {
+      mockGetConnectedDevice.mockImplementation(() => {
+        throw new Error('Not connected')
+      })
+
+      const session = await ledgerDMKService.connectToDevice(mockDevice)
+
+      expect(mockConnect).toHaveBeenCalledWith({ device: mockDevice })
+      expect(session).toBe(mockSessionId)
+    })
+
+    it('should reuse existing session for same device', async () => {
+      mockGetConnectedDevice.mockReturnValue({ id: mockDevice.id })
+
+      await ledgerDMKService.connectToDevice(mockDevice)
+      mockConnect.mockClear()
+
+      await ledgerDMKService.connectToDevice(mockDevice)
+    })
+
+    it('should throw error when connection fails', async () => {
+      const connectionError = { _tag: 'ConnectionError', message: 'Device busy' }
+      mockConnect.mockRejectedValue(connectionError)
+      mockGetConnectedDevice.mockImplementation(() => {
+        throw new Error('Not connected')
+      })
+      mockGetDeviceSessionState.mockReturnValue({
+        subscribe: jest.fn(({ next }) => {
+          next({ deviceStatus: 'not-connected' })
+          return { unsubscribe: jest.fn() }
+        }),
+      })
+
+      await expect(ledgerDMKService.connectToDevice(mockDevice)).rejects.toEqual({
+        _tag: 'ConnectionError',
+        message: 'Device busy',
+      })
+    })
+  })
+
+  describe('disconnect', () => {
+    it('should disconnect from current session', async () => {
+      mockGetConnectedDevice.mockImplementation(() => {
+        throw new Error('Not connected')
+      })
+
+      await ledgerDMKService.connectToDevice(mockDevice)
+      await ledgerDMKService.disconnect()
+
+      expect(mockDisconnect).toHaveBeenCalledWith({ sessionId: mockSessionId })
+    })
+
+    it('should throw error when disconnect fails', async () => {
+      const disconnectError = new Error('Disconnect failed')
+      mockDisconnect.mockRejectedValue(disconnectError)
+      mockGetConnectedDevice.mockImplementation(() => {
+        throw new Error('Not connected')
+      })
+
+      await ledgerDMKService.connectToDevice(mockDevice)
+
+      await expect(ledgerDMKService.disconnect()).rejects.toThrow('Disconnect failed')
+    })
+  })
+
+  describe('getCurrentSession', () => {
+    it('should return session ID after successfully connecting to a new device', async () => {
+      mockGetConnectedDevice.mockImplementation(() => {
+        throw new Error('Not connected')
+      })
+
+      await ledgerDMKService.connectToDevice(mockDevice)
+
+      expect(ledgerDMKService.getCurrentSession()).toBe(mockSessionId)
+    })
+  })
+
+  describe('dispose', () => {
+    it('should clean up resources', async () => {
+      mockGetConnectedDevice.mockImplementation(() => {
+        throw new Error('Not connected')
+      })
+
+      await ledgerDMKService.connectToDevice(mockDevice)
+
+      ledgerDMKService.dispose()
+
+      expect(mockDisconnect).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/mobile/src/services/ledger/ledger-ethereum.service.test.ts
+++ b/apps/mobile/src/services/ledger/ledger-ethereum.service.test.ts
@@ -1,0 +1,272 @@
+import type { DeviceSessionId } from '@ledgerhq/device-management-kit'
+import type { TypedData } from '@ledgerhq/device-signer-kit-ethereum'
+import { LedgerEthereumService } from './ledger-ethereum.service'
+
+const mockSignerBuild = jest.fn()
+const mockGetAddress = jest.fn()
+const mockSignTransaction = jest.fn()
+const mockSignTypedData = jest.fn()
+const mockLoggerError = jest.fn()
+
+jest.mock('@ledgerhq/device-signer-kit-ethereum', () => ({
+  SignerEthBuilder: jest.fn().mockImplementation(() => ({
+    build: () => mockSignerBuild(),
+  })),
+}))
+
+jest.mock('ethers', () => ({
+  getAccountPath: (index: number) => `m/44'/60'/${index}'/0/0`,
+}))
+
+jest.mock('./ledger-dmk.service', () => ({
+  ledgerDMKService: {
+    dmk: {},
+  },
+}))
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  },
+}))
+
+describe('LedgerEthereumService', () => {
+  const mockSessionId = 'session-123' as DeviceSessionId
+  const mockDerivationPath = "44'/60'/0'/0/0"
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockSignerBuild.mockReturnValue({
+      getAddress: mockGetAddress,
+      signTransaction: mockSignTransaction,
+      signTypedData: mockSignTypedData,
+    })
+  })
+
+  describe('getInstance', () => {
+    it('should return singleton instance', () => {
+      const instance1 = LedgerEthereumService.getInstance()
+      const instance2 = LedgerEthereumService.getInstance()
+
+      expect(instance1).toBe(instance2)
+    })
+  })
+
+  describe('getEthereumAddresses', () => {
+    it('should return addresses from Ledger device', async () => {
+      const mockAddress = { address: '0x1234567890123456789012345678901234567890' }
+      mockGetAddress.mockReturnValue({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({ status: 'completed', output: mockAddress })
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+      const addresses = await service.getEthereumAddresses(mockSessionId, 1, 0)
+
+      expect(addresses).toHaveLength(1)
+      expect(addresses[0].address).toBe(mockAddress.address)
+      expect(addresses[0].index).toBe(0)
+    })
+
+    it('should return multiple addresses', async () => {
+      let callIndex = 0
+      mockGetAddress.mockImplementation(() => ({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({
+              status: 'completed',
+              output: { address: `0x${callIndex++}000000000000000000000000000000000000000` },
+            })
+          },
+        },
+      }))
+
+      const service = LedgerEthereumService.getInstance()
+      const addresses = await service.getEthereumAddresses(mockSessionId, 3, 0)
+
+      expect(addresses).toHaveLength(3)
+      expect(addresses[0].index).toBe(0)
+      expect(addresses[1].index).toBe(1)
+      expect(addresses[2].index).toBe(2)
+    })
+
+    it('should use legacy derivation path when specified', async () => {
+      mockGetAddress.mockReturnValue({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({ status: 'completed', output: { address: '0x123' } })
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+      await service.getEthereumAddresses(mockSessionId, 1, 0, 'legacy-ledger')
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0")
+    })
+
+    it('should continue on address fetch error', async () => {
+      let callCount = 0
+      mockGetAddress.mockImplementation(() => ({
+        observable: {
+          subscribe: ({ next, error }: { next: (state: unknown) => void; error: (e: Error) => void }) => {
+            callCount++
+            if (callCount === 2) {
+              error(new Error('Device error'))
+            } else {
+              next({ status: 'completed', output: { address: `0x${callCount}` } })
+            }
+          },
+        },
+      }))
+
+      const service = LedgerEthereumService.getInstance()
+      const addresses = await service.getEthereumAddresses(mockSessionId, 3, 0)
+
+      expect(addresses).toHaveLength(2)
+      expect(mockLoggerError).toHaveBeenCalled()
+    })
+
+    it('should handle device action error state', async () => {
+      mockGetAddress.mockReturnValue({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({ status: 'error', error: new Error('Device rejected') })
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+      const addresses = await service.getEthereumAddresses(mockSessionId, 1, 0)
+
+      expect(addresses).toHaveLength(0)
+    })
+  })
+
+  describe('getEthereumAddress', () => {
+    it('should return single address by index', async () => {
+      const mockAddress = { address: '0xSingleAddress' }
+      mockGetAddress.mockReturnValue({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({ status: 'completed', output: mockAddress })
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+      const address = await service.getEthereumAddress(mockSessionId, 5)
+
+      expect(address.address).toBe(mockAddress.address)
+      expect(address.index).toBe(5)
+    })
+
+    it('should throw when address retrieval fails', async () => {
+      mockGetAddress.mockReturnValue({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({ status: 'error', error: new Error('Failed') })
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+
+      await expect(service.getEthereumAddress(mockSessionId, 0)).rejects.toThrow(
+        'Failed to retrieve address at index 0',
+      )
+    })
+  })
+
+  describe('signTransaction', () => {
+    it('should sign transaction and return formatted signature', async () => {
+      const mockSignature = {
+        r: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        s: '0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321',
+        v: 27,
+      }
+      mockSignTransaction.mockReturnValue({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({ status: 'completed', output: mockSignature })
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+      const txBuffer = new Uint8Array([1, 2, 3])
+      const signature = await service.signTransaction(mockSessionId, mockDerivationPath, txBuffer)
+
+      expect(signature).toMatch(/^0x[a-fA-F0-9]+$/)
+      expect(mockSignTransaction).toHaveBeenCalledWith(mockDerivationPath, txBuffer)
+    })
+
+    it('should throw error when signing fails', async () => {
+      mockSignTransaction.mockReturnValue({
+        observable: {
+          subscribe: ({ error }: { error: (e: Error) => void }) => {
+            error(new Error('User rejected'))
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+      const txBuffer = new Uint8Array([1, 2, 3])
+
+      await expect(service.signTransaction(mockSessionId, mockDerivationPath, txBuffer)).rejects.toThrow(
+        'Failed to sign transaction: User rejected',
+      )
+    })
+  })
+
+  describe('signTypedData', () => {
+    const mockTypedData: TypedData = {
+      domain: { verifyingContract: '0xSafe', chainId: 1 },
+      types: { SafeTx: [{ name: 'to', type: 'address' }] },
+      primaryType: 'SafeTx',
+      message: { to: '0xRecipient' },
+    }
+
+    it('should sign typed data and return formatted signature', async () => {
+      const mockSignature = {
+        r: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        s: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        v: 28,
+      }
+      mockSignTypedData.mockReturnValue({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({ status: 'completed', output: mockSignature })
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+      const signature = await service.signTypedData(mockSessionId, mockDerivationPath, mockTypedData)
+
+      expect(signature).toMatch(/^0x[a-fA-F0-9]+$/)
+      expect(mockSignTypedData).toHaveBeenCalledWith(mockDerivationPath, mockTypedData)
+    })
+
+    it('should throw error when signing typed data fails', async () => {
+      mockSignTypedData.mockReturnValue({
+        observable: {
+          subscribe: ({ error }: { error: (e: Error) => void }) => {
+            error(new Error('Signing rejected'))
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+
+      await expect(service.signTypedData(mockSessionId, mockDerivationPath, mockTypedData)).rejects.toThrow(
+        'Failed to sign typed data: Signing rejected',
+      )
+    })
+  })
+})

--- a/apps/mobile/src/services/ledger/ledger-execution.service.test.ts
+++ b/apps/mobile/src/services/ledger/ledger-execution.service.test.ts
@@ -1,0 +1,258 @@
+import type { SafeInfo } from '@/src/types/address'
+import type { EstimatedFeeValues } from '@/src/store/estimatedFeeSlice'
+import { LedgerExecutionService } from './ledger-execution.service'
+import {
+  generateChecksummedAddress,
+  createMockChain,
+  createMockSafeInfo,
+  createMockSafeTx,
+  createMockProtocolKit,
+  createMockProvider,
+} from '@safe-global/test'
+
+const mockGetCurrentSession = jest.fn()
+const mockSignTransaction = jest.fn()
+const mockCreateWeb3ReadOnly = jest.fn()
+const mockFetchTransactionDetails = jest.fn()
+const mockExtractTxInfo = jest.fn()
+const mockCreateExistingTx = jest.fn()
+const mockGetSafeSDK = jest.fn()
+const mockLoggerError = jest.fn()
+const mockLoggerInfo = jest.fn()
+
+jest.mock('./ledger-dmk.service', () => ({
+  ledgerDMKService: {
+    getCurrentSession: () => mockGetCurrentSession(),
+  },
+}))
+
+jest.mock('./ledger-ethereum.service', () => ({
+  ledgerEthereumService: {
+    signTransaction: (...args: unknown[]) => mockSignTransaction(...args),
+  },
+}))
+
+jest.mock('@/src/services/web3', () => ({
+  createWeb3ReadOnly: (...args: unknown[]) => mockCreateWeb3ReadOnly(...args),
+}))
+
+jest.mock('../tx/fetchTransactionDetails', () => ({
+  fetchTransactionDetails: (...args: unknown[]) => mockFetchTransactionDetails(...args),
+}))
+
+jest.mock('../tx/extractTx', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockExtractTxInfo(...args),
+}))
+
+jest.mock('../tx/tx-sender/create', () => ({
+  createExistingTx: (...args: unknown[]) => mockCreateExistingTx(...args),
+}))
+
+jest.mock('@/src/hooks/coreSDK/safeCoreSDK', () => ({
+  getSafeSDK: () => mockGetSafeSDK(),
+}))
+
+jest.mock('@safe-global/protocol-kit/dist/src/utils', () => ({
+  generatePreValidatedSignature: (owner: string) => ({ signer: owner, data: '0xPreValidated' }),
+}))
+
+jest.mock('ethers', () => ({
+  Transaction: {
+    from: jest.fn().mockImplementation((data) => ({
+      ...data,
+      unsignedSerialized: '0x1234',
+      serialized: '0x5678',
+      signature: null,
+    })),
+  },
+}))
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+  },
+}))
+
+describe('LedgerExecutionService', () => {
+  const mockSessionId = 'session-123'
+  const mockChain = createMockChain()
+  const mockActiveSafe: SafeInfo = createMockSafeInfo()
+
+  const mockFeeParams: EstimatedFeeValues = {
+    maxFeePerGas: BigInt('2000000000'),
+    maxPriorityFeePerGas: BigInt('1000000000'),
+    gasLimit: BigInt('100000'),
+    nonce: 5,
+  }
+
+  const mockTxParams = {
+    to: generateChecksummedAddress(),
+    value: '1000000000000000000',
+    data: '0x',
+    nonce: 1,
+  }
+
+  const mockSignatures = {
+    [generateChecksummedAddress()]: '0xSignature1',
+  }
+
+  const mockSafeTx = {
+    ...createMockSafeTx(),
+    data: mockTxParams,
+    signatures: new Map([['0xowner1', { data: '0xSig1' }]]),
+  }
+
+  const mockSafeSDK = createMockProtocolKit()
+  const mockProvider = createMockProvider()
+
+  const defaultParams = {
+    chain: mockChain,
+    activeSafe: mockActiveSafe,
+    txId: 'tx123',
+    signerAddress: generateChecksummedAddress(),
+    derivationPath: "44'/60'/0'/0/0",
+    feeParams: mockFeeParams,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockGetCurrentSession.mockReturnValue(mockSessionId)
+    mockGetSafeSDK.mockReturnValue(mockSafeSDK)
+    mockCreateWeb3ReadOnly.mockReturnValue(mockProvider)
+    mockFetchTransactionDetails.mockResolvedValue({ id: 'tx123' })
+    mockExtractTxInfo.mockReturnValue({ txParams: mockTxParams, signatures: mockSignatures })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+    mockSignTransaction.mockResolvedValue(
+      '0x' + 'a'.repeat(64) + 'b'.repeat(64) + '1b', // r + s + v
+    )
+  })
+
+  describe('getInstance', () => {
+    it('should return singleton instance', () => {
+      const instance1 = LedgerExecutionService.getInstance()
+      const instance2 = LedgerExecutionService.getInstance()
+
+      expect(instance1).toBe(instance2)
+    })
+  })
+
+  describe('ensureLedgerConnection', () => {
+    it('should not throw when session exists', async () => {
+      const service = LedgerExecutionService.getInstance()
+
+      await expect(service.ensureLedgerConnection()).resolves.toBeUndefined()
+    })
+
+    it('should throw when no session exists', async () => {
+      mockGetCurrentSession.mockReturnValue(null)
+
+      const service = LedgerExecutionService.getInstance()
+
+      await expect(service.ensureLedgerConnection()).rejects.toThrow('No active Ledger session found')
+    })
+  })
+
+  describe('executeTransaction', () => {
+    it('should execute transaction successfully', async () => {
+      const service = LedgerExecutionService.getInstance()
+      const result = await service.executeTransaction(defaultParams)
+
+      expect(result.hash).toBeDefined()
+      expect(mockFetchTransactionDetails).toHaveBeenCalledWith('1', 'tx123')
+      expect(mockExtractTxInfo).toHaveBeenCalled()
+      expect(mockCreateExistingTx).toHaveBeenCalled()
+      expect(mockSignTransaction).toHaveBeenCalled()
+      expect(mockProvider.broadcastTransaction).toHaveBeenCalled()
+    })
+
+    it('should use provided fee params', async () => {
+      const service = LedgerExecutionService.getInstance()
+      await service.executeTransaction(defaultParams)
+
+      expect(mockProvider.getTransactionCount).not.toHaveBeenCalled()
+      expect(mockProvider.getFeeData).not.toHaveBeenCalled()
+      expect(mockProvider.estimateGas).not.toHaveBeenCalled()
+    })
+
+    it('should fetch fee params from provider when not provided', async () => {
+      const service = LedgerExecutionService.getInstance()
+      await service.executeTransaction({
+        ...defaultParams,
+        feeParams: undefined,
+      })
+
+      expect(mockProvider.getTransactionCount).toHaveBeenCalled()
+      expect(mockProvider.getFeeData).toHaveBeenCalled()
+      expect(mockProvider.estimateGas).toHaveBeenCalled()
+    })
+
+    it('should throw when no Ledger session', async () => {
+      mockGetCurrentSession.mockReturnValue(null)
+
+      const service = LedgerExecutionService.getInstance()
+
+      await expect(service.executeTransaction(defaultParams)).rejects.toThrow('No active Ledger session found')
+    })
+
+    it('should throw when Safe SDK not initialized', async () => {
+      mockGetSafeSDK.mockReturnValue(null)
+
+      const service = LedgerExecutionService.getInstance()
+
+      await expect(service.executeTransaction(defaultParams)).rejects.toThrow('Safe SDK not initialized')
+    })
+
+    it('should throw when provider creation fails', async () => {
+      mockCreateWeb3ReadOnly.mockReturnValue(null)
+
+      const service = LedgerExecutionService.getInstance()
+
+      await expect(service.executeTransaction(defaultParams)).rejects.toThrow('Failed to create provider')
+    })
+
+    it('should throw when not enough signatures', async () => {
+      mockSafeSDK.getThreshold.mockResolvedValue(3)
+      mockSafeSDK.getOwners.mockResolvedValue([generateChecksummedAddress()])
+
+      const service = LedgerExecutionService.getInstance()
+
+      await expect(service.executeTransaction(defaultParams)).rejects.toThrow('signature')
+    })
+
+    it('should add pre-validated signatures for owners who approved', async () => {
+      mockSafeSDK.getThreshold.mockResolvedValue(1)
+      mockSafeSDK.getOwnersWhoApprovedTx.mockResolvedValue([generateChecksummedAddress()])
+      mockSafeTx.signatures = new Map([['0xowner1', { data: '0xSig1' }]])
+
+      const service = LedgerExecutionService.getInstance()
+      await service.executeTransaction(defaultParams)
+
+      expect(mockSafeTx.addSignature).toHaveBeenCalled()
+    })
+
+    it('should log transaction info', async () => {
+      mockSafeSDK.getThreshold.mockResolvedValue(1)
+      mockSafeTx.signatures = new Map([['0xowner1', { data: '0xSig1' }]])
+
+      const service = LedgerExecutionService.getInstance()
+      await service.executeTransaction(defaultParams)
+
+      expect(mockLoggerInfo).toHaveBeenCalledWith('Signing transaction with Ledger', expect.any(Object))
+      expect(mockLoggerInfo).toHaveBeenCalledWith('Sending signed transaction', expect.any(Object))
+      expect(mockLoggerInfo).toHaveBeenCalledWith('Transaction executed successfully', expect.any(Object))
+    })
+
+    it('should log error on failure', async () => {
+      mockSignTransaction.mockRejectedValue(new Error('User rejected'))
+
+      const service = LedgerExecutionService.getInstance()
+
+      await expect(service.executeTransaction(defaultParams)).rejects.toThrow()
+      expect(mockLoggerError).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/mobile/src/services/ledger/ledger-safe-signing.service.test.ts
+++ b/apps/mobile/src/services/ledger/ledger-safe-signing.service.test.ts
@@ -1,0 +1,274 @@
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeInfo } from '@/src/types/address'
+import type { SafeVersion } from '@safe-global/types-kit'
+import { LedgerSafeSigningService } from './ledger-safe-signing.service'
+
+const mockGetCurrentSession = jest.fn()
+const mockSignTypedData = jest.fn()
+const mockFetchTransactionDetails = jest.fn()
+const mockExtractTxInfo = jest.fn()
+const mockCreateExistingTx = jest.fn()
+const mockGenerateTypedData = jest.fn()
+const mockLoggerError = jest.fn()
+const mockLoggerInfo = jest.fn()
+const mockTypedDataEncoderHash = jest.fn()
+
+jest.mock('./ledger-dmk.service', () => ({
+  ledgerDMKService: {
+    getCurrentSession: () => mockGetCurrentSession(),
+  },
+}))
+
+jest.mock('./ledger-ethereum.service', () => ({
+  ledgerEthereumService: {
+    signTypedData: (...args: unknown[]) => mockSignTypedData(...args),
+  },
+}))
+
+jest.mock('../tx/fetchTransactionDetails', () => ({
+  fetchTransactionDetails: (...args: unknown[]) => mockFetchTransactionDetails(...args),
+}))
+
+jest.mock('../tx/extractTx', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockExtractTxInfo(...args),
+}))
+
+jest.mock('../tx/tx-sender/create', () => ({
+  createExistingTx: (...args: unknown[]) => mockCreateExistingTx(...args),
+}))
+
+jest.mock('@safe-global/protocol-kit/dist/src/utils/eip-712', () => ({
+  generateTypedData: (...args: unknown[]) => mockGenerateTypedData(...args),
+}))
+
+jest.mock('ethers', () => ({
+  TypedDataEncoder: {
+    hash: (...args: unknown[]) => mockTypedDataEncoderHash(...args),
+  },
+}))
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    info: (...args: unknown[]) => mockLoggerInfo(...args),
+  },
+}))
+
+describe('LedgerSafeSigningService', () => {
+  const mockSessionId = 'session-123'
+
+  const mockChain: Chain = {
+    chainId: '1',
+    chainName: 'Ethereum',
+  } as Chain
+
+  const mockActiveSafe: SafeInfo = {
+    address: '0xSafeAddress',
+    chainId: '1',
+  }
+
+  const mockTxParams = {
+    to: '0xRecipient',
+    value: '1000000000000000000',
+    data: '0x',
+    nonce: 1,
+  }
+
+  const mockSignatures = {
+    '0xOwner1': '0xSignature1',
+  }
+
+  const mockSafeTx = {
+    data: mockTxParams,
+  }
+
+  const mockTypedData = {
+    domain: {
+      verifyingContract: '0xSafeAddress',
+      chainId: 1n,
+    },
+    types: {
+      EIP712Domain: [{ name: 'verifyingContract', type: 'address' }],
+      SafeTx: [{ name: 'to', type: 'address' }],
+    },
+    primaryType: 'SafeTx',
+    message: { to: '0xRecipient' },
+  }
+
+  const defaultParams = {
+    chain: mockChain,
+    activeSafe: mockActiveSafe,
+    txId: 'tx123',
+    signerAddress: '0xSignerAddress',
+    derivationPath: "44'/60'/0'/0/0",
+    safeVersion: '1.3.0' as SafeVersion,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockGetCurrentSession.mockReturnValue(mockSessionId)
+    mockFetchTransactionDetails.mockResolvedValue({ id: 'tx123' })
+    mockExtractTxInfo.mockReturnValue({ txParams: mockTxParams, signatures: mockSignatures })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+    mockGenerateTypedData.mockReturnValue(mockTypedData)
+    mockTypedDataEncoderHash.mockReturnValue('0xSafeTransactionHash')
+    mockSignTypedData.mockResolvedValue('0x' + 'a'.repeat(130))
+  })
+
+  describe('getInstance', () => {
+    it('should return singleton instance', () => {
+      const instance1 = LedgerSafeSigningService.getInstance()
+      const instance2 = LedgerSafeSigningService.getInstance()
+
+      expect(instance1).toBe(instance2)
+    })
+  })
+
+  describe('signSafeTransaction', () => {
+    it('should sign transaction successfully', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+      const result = await service.signSafeTransaction(defaultParams)
+
+      expect(result.signature).toMatch(/^0x[a-fA-F0-9]+$/)
+      expect(result.safeTransactionHash).toBe('0xSafeTransactionHash')
+    })
+
+    it('should fetch transaction details', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+      await service.signSafeTransaction(defaultParams)
+
+      expect(mockFetchTransactionDetails).toHaveBeenCalledWith('1', 'tx123')
+    })
+
+    it('should extract tx info from details', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+      await service.signSafeTransaction(defaultParams)
+
+      expect(mockExtractTxInfo).toHaveBeenCalled()
+    })
+
+    it('should create existing tx with signatures', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+      await service.signSafeTransaction(defaultParams)
+
+      expect(mockCreateExistingTx).toHaveBeenCalledWith(mockTxParams, mockSignatures)
+    })
+
+    it('should generate typed data for signing', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+      await service.signSafeTransaction(defaultParams)
+
+      expect(mockGenerateTypedData).toHaveBeenCalledWith({
+        safeAddress: '0xSafeAddress',
+        safeVersion: '1.3.0',
+        chainId: BigInt(1),
+        data: mockTxParams,
+      })
+    })
+
+    it('should sign typed data with Ledger', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+      await service.signSafeTransaction(defaultParams)
+
+      expect(mockSignTypedData).toHaveBeenCalledWith(mockSessionId, defaultParams.derivationPath, expect.any(Object))
+    })
+
+    it('should throw when no Ledger session', async () => {
+      mockGetCurrentSession.mockReturnValue(null)
+
+      const service = LedgerSafeSigningService.getInstance()
+
+      await expect(service.signSafeTransaction(defaultParams)).rejects.toThrow('No active Ledger session found')
+    })
+
+    it('should throw when safeTx creation fails', async () => {
+      mockCreateExistingTx.mockResolvedValue(null)
+
+      const service = LedgerSafeSigningService.getInstance()
+
+      await expect(service.signSafeTransaction(defaultParams)).rejects.toThrow('Safe transaction not found')
+    })
+
+    it('should throw on signing error', async () => {
+      mockSignTypedData.mockRejectedValue(new Error('User rejected'))
+
+      const service = LedgerSafeSigningService.getInstance()
+
+      await expect(service.signSafeTransaction(defaultParams)).rejects.toThrow('Ledger signing failed: User rejected')
+    })
+
+    it('should log success info', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+      await service.signSafeTransaction(defaultParams)
+
+      expect(mockLoggerInfo).toHaveBeenCalledWith('Successfully signed transaction with Ledger', expect.any(Object))
+    })
+
+    it('should log error on failure', async () => {
+      mockSignTypedData.mockRejectedValue(new Error('Failed'))
+
+      const service = LedgerSafeSigningService.getInstance()
+
+      await expect(service.signSafeTransaction(defaultParams)).rejects.toThrow()
+      expect(mockLoggerError).toHaveBeenCalled()
+    })
+  })
+
+  describe('isLedgerReady', () => {
+    it('should return true when session exists', () => {
+      const service = LedgerSafeSigningService.getInstance()
+
+      expect(service.isLedgerReady()).toBe(true)
+    })
+
+    it('should return false when no session', () => {
+      mockGetCurrentSession.mockReturnValue(null)
+
+      const service = LedgerSafeSigningService.getInstance()
+
+      expect(service.isLedgerReady()).toBe(false)
+    })
+  })
+
+  describe('ensureLedgerConnection', () => {
+    it('should not throw when connected', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+
+      await expect(service.ensureLedgerConnection()).resolves.toBeUndefined()
+    })
+
+    it('should throw when not connected', async () => {
+      mockGetCurrentSession.mockReturnValue(null)
+
+      const service = LedgerSafeSigningService.getInstance()
+
+      await expect(service.ensureLedgerConnection()).rejects.toThrow('Ledger device not connected')
+    })
+  })
+
+  describe('convertToLedgerFormat', () => {
+    it('should remove EIP712Domain from types', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+      await service.signSafeTransaction(defaultParams)
+
+      const signCall = mockSignTypedData.mock.calls[0]
+      const ledgerTypedData = signCall[2]
+
+      expect(ledgerTypedData.types).not.toHaveProperty('EIP712Domain')
+      expect(ledgerTypedData.types).toHaveProperty('SafeTx')
+    })
+
+    it('should convert chainId to number', async () => {
+      const service = LedgerSafeSigningService.getInstance()
+      await service.signSafeTransaction(defaultParams)
+
+      const signCall = mockSignTypedData.mock.calls[0]
+      const ledgerTypedData = signCall[2]
+
+      expect(typeof ledgerTypedData.domain.chainId).toBe('number')
+    })
+  })
+})

--- a/apps/mobile/src/services/notifications/NotificationService.test.ts
+++ b/apps/mobile/src/services/notifications/NotificationService.test.ts
@@ -1,0 +1,379 @@
+import { AuthorizationStatus, EventType } from '@notifee/react-native'
+import { ChannelId } from '@/src/utils/notifications'
+
+jest.mock('./notificationParser', () => ({
+  parseNotification: jest.fn(() => ({ title: 'Test Title', body: 'Test Body' })),
+}))
+
+jest.mock('./notificationNavigationHandler', () => ({
+  NotificationNavigationHandler: {
+    handleNotificationPress: jest.fn(() => Promise.resolve()),
+  },
+}))
+
+jest.mock('./BadgeManager', () => ({
+  __esModule: true,
+  default: {
+    incrementBadgeCount: jest.fn(),
+  },
+}))
+
+jest.mock('@/src/store/utils/singletonStore', () => ({
+  getStore: jest.fn(() => ({
+    dispatch: jest.fn(),
+  })),
+}))
+
+import notifee from '@notifee/react-native'
+import NotificationsService from './NotificationService'
+
+describe('NotificationsService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getBlockedNotifications', () => {
+    it('returns blocked channels when permission is denied', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.DENIED,
+      })
+      ;(notifee.getChannels as jest.Mock).mockResolvedValue([])
+
+      const result = await NotificationsService.getBlockedNotifications()
+
+      expect(result.size).toBeGreaterThan(0)
+    })
+
+    it('returns blocked channels when status is NOT_DETERMINED', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.NOT_DETERMINED,
+      })
+      ;(notifee.getChannels as jest.Mock).mockResolvedValue([])
+
+      const result = await NotificationsService.getBlockedNotifications()
+
+      expect(result.size).toBeGreaterThan(0)
+    })
+
+    it('returns blocked channels from channel list when authorized', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.AUTHORIZED,
+      })
+      ;(notifee.getChannels as jest.Mock).mockResolvedValue([
+        { id: 'DEFAULT_NOTIFICATION_CHANNEL_ID', blocked: true },
+        { id: 'ANNOUNCEMENT_NOTIFICATION_CHANNEL_ID', blocked: false },
+      ])
+
+      const result = await NotificationsService.getBlockedNotifications()
+
+      expect(result.get('DEFAULT_NOTIFICATION_CHANNEL_ID' as ChannelId)).toBe(true)
+      expect(result.has('ANNOUNCEMENT_NOTIFICATION_CHANNEL_ID' as ChannelId)).toBe(false)
+    })
+
+    it('returns empty map on error', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockRejectedValue(new Error('Test error'))
+
+      const result = await NotificationsService.getBlockedNotifications()
+
+      expect(result.size).toBe(0)
+    })
+  })
+
+  describe('enableNotifications', () => {
+    it('dispatches actions to enable notifications', () => {
+      const { getStore } = jest.requireMock('@/src/store/utils/singletonStore')
+      const mockDispatch = jest.fn()
+      getStore.mockReturnValue({ dispatch: mockDispatch })
+
+      NotificationsService.enableNotifications()
+
+      expect(mockDispatch).toHaveBeenCalledTimes(4)
+    })
+  })
+
+  describe('getAllPermissions', () => {
+    it('returns permission and blocked notifications when authorized', async () => {
+      ;(notifee.createChannel as jest.Mock).mockResolvedValue('channel-id')
+      ;(notifee.requestPermission as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.AUTHORIZED,
+      })
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.AUTHORIZED,
+      })
+      ;(notifee.getChannels as jest.Mock).mockResolvedValue([])
+
+      const result = await NotificationsService.getAllPermissions()
+
+      expect(result.permission).toBe('granted')
+      expect(result.blockedNotifications).toBeInstanceOf(Map)
+    })
+
+    it('returns denied permission when authorization is denied', async () => {
+      ;(notifee.createChannel as jest.Mock).mockResolvedValue('channel-id')
+      ;(notifee.requestPermission as jest.Mock).mockResolvedValue({ authorizationStatus: AuthorizationStatus.DENIED })
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.DENIED,
+      })
+      ;(notifee.getChannels as jest.Mock).mockResolvedValue([])
+
+      const result = await NotificationsService.getAllPermissions(false)
+
+      expect(result.permission).toBe('denied')
+    })
+
+    it('returns denied on error', async () => {
+      ;(notifee.createChannel as jest.Mock).mockRejectedValue(new Error('Channel error'))
+      ;(notifee.requestPermission as jest.Mock).mockRejectedValue(new Error('Permission error'))
+      ;(notifee.getNotificationSettings as jest.Mock).mockRejectedValue(new Error('Settings error'))
+
+      const result = await NotificationsService.getAllPermissions()
+
+      expect(result.permission).toBe('denied')
+    })
+  })
+
+  describe('isDeviceNotificationEnabled', () => {
+    it('returns true when authorized', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.AUTHORIZED,
+      })
+
+      const result = await NotificationsService.isDeviceNotificationEnabled()
+
+      expect(result).toBe(true)
+    })
+
+    it('returns true when provisional', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.PROVISIONAL,
+      })
+
+      const result = await NotificationsService.isDeviceNotificationEnabled()
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when denied', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.DENIED,
+      })
+
+      const result = await NotificationsService.isDeviceNotificationEnabled()
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getAuthorizationStatus', () => {
+    it('returns the authorization status', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.AUTHORIZED,
+      })
+
+      const result = await NotificationsService.getAuthorizationStatus()
+
+      expect(result).toBe(AuthorizationStatus.AUTHORIZED)
+    })
+  })
+
+  describe('isAuthorizationDenied', () => {
+    it('returns true when denied', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.DENIED,
+      })
+
+      const result = await NotificationsService.isAuthorizationDenied()
+
+      expect(result).toBe(true)
+    })
+
+    it('returns false when authorized', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.AUTHORIZED,
+      })
+
+      const result = await NotificationsService.isAuthorizationDenied()
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('checkCurrentPermissions', () => {
+    it('returns granted when authorized', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.AUTHORIZED,
+      })
+
+      const result = await NotificationsService.checkCurrentPermissions()
+
+      expect(result).toBe('granted')
+    })
+
+    it('returns granted when provisional', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.PROVISIONAL,
+      })
+
+      const result = await NotificationsService.checkCurrentPermissions()
+
+      expect(result).toBe('granted')
+    })
+
+    it('returns denied when not authorized', async () => {
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.DENIED,
+      })
+
+      const result = await NotificationsService.checkCurrentPermissions()
+
+      expect(result).toBe('denied')
+    })
+  })
+
+  describe('onForegroundEvent', () => {
+    it('registers foreground event observer', () => {
+      const observer = jest.fn()
+
+      NotificationsService.onForegroundEvent(observer)
+
+      expect(notifee.onForegroundEvent).toHaveBeenCalledWith(observer)
+    })
+  })
+
+  describe('onBackgroundEvent', () => {
+    it('registers background event observer', () => {
+      const observer = jest.fn()
+
+      NotificationsService.onBackgroundEvent(observer)
+
+      expect(notifee.onBackgroundEvent).toHaveBeenCalledWith(observer)
+    })
+  })
+
+  describe('handleNotificationEvent', () => {
+    it('increments badge count on DELIVERED event', async () => {
+      const BadgeManager = jest.requireMock('./BadgeManager').default
+
+      await NotificationsService.handleNotificationEvent({
+        type: EventType.DELIVERED,
+        detail: {},
+      })
+
+      expect(BadgeManager.incrementBadgeCount).toHaveBeenCalledWith(1)
+    })
+
+    it('handles notification press on PRESS event with data', async () => {
+      const { NotificationNavigationHandler } = jest.requireMock('./notificationNavigationHandler')
+      ;(notifee.cancelTriggerNotification as jest.Mock).mockResolvedValue(undefined)
+
+      await NotificationsService.handleNotificationPress({
+        detail: {
+          notification: {
+            id: 'test-id',
+            data: { type: 'test' },
+          },
+        },
+      })
+
+      expect(notifee.cancelTriggerNotification).toHaveBeenCalledWith('test-id')
+      expect(NotificationNavigationHandler.handleNotificationPress).toHaveBeenCalled()
+    })
+  })
+
+  describe('cancelTriggerNotification', () => {
+    it('cancels notification with id', async () => {
+      ;(notifee.cancelTriggerNotification as jest.Mock).mockResolvedValue(undefined)
+
+      await NotificationsService.cancelTriggerNotification('test-id')
+
+      expect(notifee.cancelTriggerNotification).toHaveBeenCalledWith('test-id')
+    })
+
+    it('does nothing when id is undefined', async () => {
+      await NotificationsService.cancelTriggerNotification(undefined)
+
+      expect(notifee.cancelTriggerNotification).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getInitialNotification', () => {
+    it('calls callback with notification data when present', async () => {
+      const callback = jest.fn()
+      ;(notifee.getInitialNotification as jest.Mock).mockResolvedValue({
+        notification: { data: { type: 'test' } },
+      })
+
+      await NotificationsService.getInitialNotification(callback)
+
+      expect(callback).toHaveBeenCalledWith({ type: 'test' })
+    })
+
+    it('does not call callback when no initial notification', async () => {
+      const callback = jest.fn()
+      ;(notifee.getInitialNotification as jest.Mock).mockResolvedValue(null)
+
+      await NotificationsService.getInitialNotification(callback)
+
+      expect(callback).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cancelAllNotifications', () => {
+    it('cancels all notifications', async () => {
+      ;(notifee.cancelAllNotifications as jest.Mock).mockResolvedValue(undefined)
+
+      await NotificationsService.cancelAllNotifications()
+
+      expect(notifee.cancelAllNotifications).toHaveBeenCalled()
+    })
+  })
+
+  describe('createChannel', () => {
+    it('creates notification channel', async () => {
+      ;(notifee.createChannel as jest.Mock).mockResolvedValue('channel-id')
+
+      const result = await NotificationsService.createChannel({
+        id: 'test',
+        name: 'Test Channel',
+      })
+
+      expect(result).toBe('channel-id')
+      expect(notifee.createChannel).toHaveBeenCalledWith({
+        id: 'test',
+        name: 'Test Channel',
+      })
+    })
+  })
+
+  describe('displayNotification', () => {
+    it('displays notification with provided params', async () => {
+      ;(notifee.displayNotification as jest.Mock).mockResolvedValue('notification-id')
+
+      await NotificationsService.displayNotification({
+        channelId: 'default' as never,
+        title: 'Test Title',
+        body: 'Test Body',
+        data: { key: 'value' },
+      })
+
+      expect(notifee.displayNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Test Title',
+          body: 'Test Body',
+          data: { key: 'value' },
+        }),
+      )
+    })
+
+    it('handles display error gracefully', async () => {
+      ;(notifee.displayNotification as jest.Mock).mockRejectedValue(new Error('Display error'))
+
+      await expect(
+        NotificationsService.displayNotification({
+          channelId: 'default' as never,
+          title: 'Test',
+        }),
+      ).resolves.not.toThrow()
+    })
+  })
+})

--- a/apps/mobile/src/services/notifications/notificationParser.test.ts
+++ b/apps/mobile/src/services/notifications/notificationParser.test.ts
@@ -1,0 +1,209 @@
+import { faker } from '@faker-js/faker'
+import { parseNotification } from './notificationParser'
+
+jest.mock('@/src/store/utils/singletonStore', () => ({
+  getStore: jest.fn(() => ({
+    getState: jest.fn(() => ({
+      chains: {
+        data: {
+          '1': {
+            chainId: '1',
+            chainName: 'Ethereum',
+            nativeCurrency: { symbol: 'ETH', decimals: 18 },
+          },
+          '137': {
+            chainId: '137',
+            chainName: 'Polygon',
+            nativeCurrency: { symbol: 'POL', decimals: 18 },
+          },
+        },
+      },
+    })),
+  })),
+}))
+
+jest.mock('@/src/store/chains', () => ({
+  selectChainById: jest.fn((state, chainId) => state.chains.data[chainId] || null),
+}))
+
+jest.mock('@/src/store/addressBookSlice', () => ({
+  selectContactByAddress: jest.fn(() => () => null),
+}))
+
+jest.mock('./store-sync/read', () => ({
+  getExtensionData: jest.fn(() => null),
+}))
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}))
+
+describe('parseNotification', () => {
+  const address = faker.finance.ethereumAddress()
+
+  describe('returns null for invalid data', () => {
+    it('returns null when data is undefined', () => {
+      const result = parseNotification(undefined)
+      expect(result).toBeNull()
+    })
+
+    it('returns null when data has no type', () => {
+      const result = parseNotification({ chainId: '1' })
+      expect(result).toBeNull()
+    })
+
+    it('returns null for unknown notification type', () => {
+      const result = parseNotification({
+        type: 'UNKNOWN_TYPE',
+        chainId: '1',
+        address,
+      })
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('INCOMING_ETHER', () => {
+    it('parses incoming ether notification with value', () => {
+      const result = parseNotification({
+        type: 'INCOMING_ETHER',
+        chainId: '1',
+        address,
+        value: '1000000000000000000',
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.title).toBe('Incoming ETH (Ethereum)')
+      expect(result?.body).toContain('1.0')
+      expect(result?.body).toContain('ETH received')
+    })
+
+    it('parses incoming ether on Polygon', () => {
+      const result = parseNotification({
+        type: 'INCOMING_ETHER',
+        chainId: '137',
+        address,
+        value: '2500000000000000000',
+      })
+
+      expect(result?.title).toBe('Incoming POL (Polygon)')
+      expect(result?.body).toContain('2.5')
+      expect(result?.body).toContain('POL received')
+    })
+
+    it('handles missing value gracefully', () => {
+      const result = parseNotification({
+        type: 'INCOMING_ETHER',
+        chainId: '1',
+        address,
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.title).toBe('Incoming ETH (Ethereum)')
+      expect(result?.body).toContain('ETH received')
+    })
+
+    it('uses fallback chain name for unknown chain', () => {
+      const result = parseNotification({
+        type: 'INCOMING_ETHER',
+        chainId: '999999',
+        address,
+        value: '1000000000000000000',
+      })
+
+      expect(result?.title).toContain('Chain Id 999999')
+    })
+  })
+
+  describe('INCOMING_TOKEN', () => {
+    it('parses incoming token notification', () => {
+      const result = parseNotification({
+        type: 'INCOMING_TOKEN',
+        chainId: '1',
+        address,
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.title).toBe('Incoming token (Ethereum)')
+      expect(result?.body).toContain('tokens received')
+    })
+
+    it('parses incoming token on different chain', () => {
+      const result = parseNotification({
+        type: 'INCOMING_TOKEN',
+        chainId: '137',
+        address,
+      })
+
+      expect(result?.title).toBe('Incoming token (Polygon)')
+    })
+  })
+
+  describe('EXECUTED_MULTISIG_TRANSACTION', () => {
+    it('parses successful transaction notification', () => {
+      const result = parseNotification({
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        chainId: '1',
+        address,
+        failed: 'false',
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.title).toBe('Transaction successful (Ethereum)')
+      expect(result?.body).toContain('Transaction successful')
+    })
+
+    it('parses failed transaction notification', () => {
+      const result = parseNotification({
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        chainId: '1',
+        address,
+        failed: 'true',
+      })
+
+      expect(result?.title).toBe('Transaction failed (Ethereum)')
+      expect(result?.body).toContain('Transaction failed')
+    })
+  })
+
+  describe('CONFIRMATION_REQUEST', () => {
+    it('parses confirmation request notification', () => {
+      const result = parseNotification({
+        type: 'CONFIRMATION_REQUEST',
+        chainId: '1',
+        address,
+      })
+
+      expect(result).not.toBeNull()
+      expect(result?.title).toBe('Confirmation required (Ethereum)')
+      expect(result?.body).toContain('requires your confirmation')
+    })
+  })
+
+  describe('address formatting', () => {
+    it('shortens address when no contact name is found', () => {
+      const result = parseNotification({
+        type: 'INCOMING_ETHER',
+        chainId: '1',
+        address: '0x1234567890123456789012345678901234567890',
+        value: '1000000000000000000',
+      })
+
+      expect(result?.body).toContain('0x1234...7890')
+    })
+
+    it('handles empty address', () => {
+      const result = parseNotification({
+        type: 'INCOMING_TOKEN',
+        chainId: '1',
+        address: '',
+      })
+
+      expect(result).not.toBeNull()
+    })
+  })
+})

--- a/apps/mobile/src/services/notifications/utils/messageDeduplication.test.ts
+++ b/apps/mobile/src/services/notifications/utils/messageDeduplication.test.ts
@@ -1,0 +1,117 @@
+import { faker } from '@faker-js/faker'
+import { checkAndMarkMessageProcessed, clearProcessedMessages } from './messageDeduplication'
+
+describe('messageDeduplication', () => {
+  beforeEach(() => {
+    clearProcessedMessages()
+  })
+
+  describe('checkAndMarkMessageProcessed', () => {
+    it('returns false for a new message', () => {
+      const messageId = faker.string.uuid()
+
+      const result = checkAndMarkMessageProcessed(messageId)
+
+      expect(result).toBe(false)
+    })
+
+    it('returns true for an already processed message', () => {
+      const messageId = faker.string.uuid()
+
+      checkAndMarkMessageProcessed(messageId)
+      const result = checkAndMarkMessageProcessed(messageId)
+
+      expect(result).toBe(true)
+    })
+
+    it('handles multiple different messages independently', () => {
+      const messageId1 = faker.string.uuid()
+      const messageId2 = faker.string.uuid()
+
+      const result1 = checkAndMarkMessageProcessed(messageId1)
+      const result2 = checkAndMarkMessageProcessed(messageId2)
+
+      expect(result1).toBe(false)
+      expect(result2).toBe(false)
+    })
+
+    it('cleans up old messages when exceeding maxStoredMessages', () => {
+      const maxStoredMessages = 5
+
+      for (let i = 0; i < maxStoredMessages + 3; i++) {
+        checkAndMarkMessageProcessed(`message-${i}`, maxStoredMessages)
+      }
+
+      // Old messages should be cleaned up, so checking them again should return false
+      const oldMessageResult = checkAndMarkMessageProcessed('message-0', maxStoredMessages)
+      expect(oldMessageResult).toBe(false)
+
+      // Recent messages should still be tracked
+      const recentMessageResult = checkAndMarkMessageProcessed(`message-${maxStoredMessages + 2}`, maxStoredMessages)
+      expect(recentMessageResult).toBe(true)
+    })
+
+    it('preserves most recent messages during cleanup', () => {
+      const maxStoredMessages = 3
+
+      checkAndMarkMessageProcessed('message-1', maxStoredMessages)
+      checkAndMarkMessageProcessed('message-2', maxStoredMessages)
+      checkAndMarkMessageProcessed('message-3', maxStoredMessages)
+      checkAndMarkMessageProcessed('message-4', maxStoredMessages)
+      checkAndMarkMessageProcessed('message-5', maxStoredMessages)
+
+      // Most recent should still be tracked
+      expect(checkAndMarkMessageProcessed('message-5', maxStoredMessages)).toBe(true)
+    })
+  })
+
+  describe('clearProcessedMessages', () => {
+    it('clears all processed messages from storage', () => {
+      checkAndMarkMessageProcessed('message-1')
+      checkAndMarkMessageProcessed('message-2')
+      checkAndMarkMessageProcessed('message-3')
+
+      // Verify they're tracked
+      expect(checkAndMarkMessageProcessed('message-1')).toBe(true)
+
+      clearProcessedMessages()
+
+      // After clearing, messages should be treated as new
+      expect(checkAndMarkMessageProcessed('message-1')).toBe(false)
+      expect(checkAndMarkMessageProcessed('message-2')).toBe(false)
+      expect(checkAndMarkMessageProcessed('message-3')).toBe(false)
+    })
+
+    it('handles empty storage gracefully', () => {
+      expect(() => clearProcessedMessages()).not.toThrow()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty message ID', () => {
+      const result = checkAndMarkMessageProcessed('')
+
+      expect(result).toBe(false)
+      // Calling again with empty should return true (it was tracked)
+      expect(checkAndMarkMessageProcessed('')).toBe(true)
+    })
+
+    it('handles special characters in message ID', () => {
+      const specialId = 'msg-!@#$%^&*()_+-=[]{}|;:,.<>?'
+
+      const result = checkAndMarkMessageProcessed(specialId)
+
+      expect(result).toBe(false)
+      expect(checkAndMarkMessageProcessed(specialId)).toBe(true)
+    })
+
+    it('handles very long message IDs', () => {
+      const longId = 'a'.repeat(1000)
+
+      const result = checkAndMarkMessageProcessed(longId)
+
+      expect(result).toBe(false)
+      expect(checkAndMarkMessageProcessed(longId)).toBe(true)
+    })
+  })
+})

--- a/apps/mobile/src/services/tx-execution/privateKeyExecutor.test.ts
+++ b/apps/mobile/src/services/tx-execution/privateKeyExecutor.test.ts
@@ -1,0 +1,171 @@
+import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
+import type { EstimatedFeeValues } from '@/src/store/estimatedFeeSlice'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeInfo } from '@/src/types/address'
+import { executePrivateKeyTx } from './privateKeyExecutor'
+import { createMockChain, createMockSafeInfo } from '@safe-global/test'
+
+const mockExecuteTx = jest.fn()
+const mockGetUserNonce = jest.fn()
+const mockGetPrivateKey = jest.fn()
+const mockLoggerError = jest.fn()
+
+jest.mock('@/src/services/tx/tx-sender/execute', () => ({
+  executeTx: (...args: unknown[]) => mockExecuteTx(...args),
+}))
+
+jest.mock('@/src/services/web3', () => ({
+  getUserNonce: (...args: unknown[]) => mockGetUserNonce(...args),
+}))
+
+jest.mock('@/src/hooks/useSign/useSign', () => ({
+  getPrivateKey: (...args: unknown[]) => mockGetPrivateKey(...args),
+}))
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  },
+}))
+
+describe('executePrivateKeyTx', () => {
+  const mockChain: Chain = createMockChain()
+  const mockActiveSafe: SafeInfo = createMockSafeInfo()
+
+  const mockFeeParams: EstimatedFeeValues = {
+    maxFeePerGas: BigInt('1000000000'),
+    maxPriorityFeePerGas: BigInt('100000000'),
+    gasLimit: BigInt('21000'),
+    nonce: 5,
+  }
+
+  const defaultParams = {
+    chain: mockChain,
+    activeSafe: mockActiveSafe,
+    txId: 'tx123',
+    signerAddress: '0xSignerAddress',
+    feeParams: mockFeeParams,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetPrivateKey.mockResolvedValue('0xPrivateKey123')
+    mockGetUserNonce.mockResolvedValue(10)
+    mockExecuteTx.mockResolvedValue({ hash: '0xTransactionHash' })
+  })
+
+  describe('success cases', () => {
+    it('should execute transaction successfully with private key', async () => {
+      const result = await executePrivateKeyTx(defaultParams)
+
+      expect(mockGetPrivateKey).toHaveBeenCalledWith('0xSignerAddress')
+      expect(mockGetUserNonce).toHaveBeenCalledWith(mockChain, '0xSignerAddress')
+      expect(mockExecuteTx).toHaveBeenCalledWith({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: 'tx123',
+        privateKey: '0xPrivateKey123',
+        feeParams: mockFeeParams,
+      })
+
+      expect(result).toEqual({
+        type: ExecutionMethod.WITH_PK,
+        txId: 'tx123',
+        chainId: mockActiveSafe.chainId,
+        safeAddress: mockActiveSafe.address,
+        txHash: '0xTransactionHash',
+        walletAddress: '0xSignerAddress',
+        walletNonce: 10,
+      })
+    })
+
+    it('should handle null feeParams', async () => {
+      const result = await executePrivateKeyTx({
+        ...defaultParams,
+        feeParams: null,
+      })
+
+      expect(mockExecuteTx).toHaveBeenCalledWith(
+        expect.objectContaining({
+          feeParams: null,
+        }),
+      )
+      expect(result).toBeDefined()
+      expect(result.txHash).toBe('0xTransactionHash')
+    })
+  })
+
+  describe('error cases', () => {
+    it('should throw and log error when getPrivateKey fails', async () => {
+      const keyError = new Error('Failed to load key')
+      mockGetPrivateKey.mockRejectedValue(keyError)
+
+      await expect(executePrivateKeyTx(defaultParams)).rejects.toThrow('Failed to load key')
+
+      expect(mockLoggerError).toHaveBeenCalledWith('Error loading private key:', keyError)
+      expect(mockExecuteTx).not.toHaveBeenCalled()
+      expect(mockGetUserNonce).not.toHaveBeenCalled()
+    })
+
+    it('should throw error when private key is not found (null)', async () => {
+      mockGetPrivateKey.mockResolvedValue(null)
+
+      await expect(executePrivateKeyTx(defaultParams)).rejects.toThrow('Private key not found')
+
+      expect(mockExecuteTx).not.toHaveBeenCalled()
+      expect(mockGetUserNonce).not.toHaveBeenCalled()
+    })
+
+    it('should throw error when private key is not found (undefined)', async () => {
+      mockGetPrivateKey.mockResolvedValue(undefined)
+
+      await expect(executePrivateKeyTx(defaultParams)).rejects.toThrow('Private key not found')
+
+      expect(mockExecuteTx).not.toHaveBeenCalled()
+    })
+
+    it('should propagate error from getUserNonce', async () => {
+      const nonceError = new Error('Failed to get nonce')
+      mockGetUserNonce.mockRejectedValue(nonceError)
+
+      await expect(executePrivateKeyTx(defaultParams)).rejects.toThrow('Failed to get nonce')
+
+      expect(mockGetPrivateKey).toHaveBeenCalled()
+      expect(mockExecuteTx).not.toHaveBeenCalled()
+    })
+
+    it('should propagate error from executeTx', async () => {
+      const executionError = new Error('Execution failed')
+      mockExecuteTx.mockRejectedValue(executionError)
+
+      await expect(executePrivateKeyTx(defaultParams)).rejects.toThrow('Execution failed')
+
+      expect(mockGetPrivateKey).toHaveBeenCalled()
+      expect(mockGetUserNonce).toHaveBeenCalled()
+    })
+  })
+
+  describe('execution flow', () => {
+    it('should call services in correct order', async () => {
+      const callOrder: string[] = []
+
+      mockGetPrivateKey.mockImplementation(async () => {
+        callOrder.push('getPrivateKey')
+        return '0xPrivateKey'
+      })
+      mockGetUserNonce.mockImplementation(async () => {
+        callOrder.push('getUserNonce')
+        return 10
+      })
+      mockExecuteTx.mockImplementation(async () => {
+        callOrder.push('executeTx')
+        return { hash: '0xHash' }
+      })
+
+      await executePrivateKeyTx(defaultParams)
+
+      expect(callOrder).toEqual(['getPrivateKey', 'getUserNonce', 'executeTx'])
+    })
+  })
+})

--- a/apps/mobile/src/services/tx-execution/relayExecutor.test.ts
+++ b/apps/mobile/src/services/tx-execution/relayExecutor.test.ts
@@ -1,0 +1,264 @@
+import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
+import { executeRelayTx } from './relayExecutor'
+import {
+  generateChecksummedAddress,
+  createMockChain,
+  createMockSafeInfo,
+  createMockSafeState,
+  createMockSafeTx,
+} from '@safe-global/test'
+
+const mockFetchTransactionDetails = jest.fn()
+const mockExtractTxInfo = jest.fn()
+const mockCreateTx = jest.fn()
+const mockAddSignaturesToTx = jest.fn()
+const mockGetReadOnlyCurrentGnosisSafeContract = jest.fn()
+const mockGetLatestSafeVersion = jest.fn()
+
+jest.mock('@/src/services/tx/fetchTransactionDetails', () => ({
+  fetchTransactionDetails: (...args: unknown[]) => mockFetchTransactionDetails(...args),
+}))
+
+jest.mock('@/src/services/tx/extractTx', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockExtractTxInfo(...args),
+}))
+
+jest.mock('@/src/services/tx/tx-sender/create', () => ({
+  createTx: (...args: unknown[]) => mockCreateTx(...args),
+  addSignaturesToTx: (...args: unknown[]) => mockAddSignaturesToTx(...args),
+}))
+
+jest.mock('@/src/services/contracts/safeContracts', () => ({
+  getReadOnlyCurrentGnosisSafeContract: (...args: unknown[]) => mockGetReadOnlyCurrentGnosisSafeContract(...args),
+}))
+
+jest.mock('@safe-global/utils/utils/chains', () => ({
+  getLatestSafeVersion: (...args: unknown[]) => mockGetLatestSafeVersion(...args),
+}))
+
+describe('executeRelayTx', () => {
+  const mockChain = createMockChain()
+  const mockActiveSafe = createMockSafeInfo()
+  const mockSafe = createMockSafeState({
+    address: mockActiveSafe.address,
+    chainId: mockActiveSafe.chainId,
+    nonce: 5,
+    threshold: 2,
+    owners: [generateChecksummedAddress()],
+    version: '1.3.0',
+  })
+
+  const mockTxParams = {
+    to: generateChecksummedAddress(),
+    value: '1000000000000000000',
+    data: '0x',
+    operation: 0,
+    safeTxGas: '0',
+    baseGas: '0',
+    gasPrice: '0',
+    gasToken: '0x0000000000000000000000000000000000000000',
+    refundReceiver: '0x0000000000000000000000000000000000000000',
+    nonce: 5,
+  }
+
+  const mockSignatures = {
+    [generateChecksummedAddress()]: '0xSignature1',
+  }
+
+  const mockSafeTx = {
+    ...createMockSafeTx(),
+    data: mockTxParams,
+    encodedSignatures: jest.fn().mockReturnValue('0xEncodedSignatures'),
+  }
+
+  const mockEncode = jest.fn().mockReturnValue('0xEncodedExecTransaction')
+
+  const mockRelayMutation = jest.fn()
+
+  const defaultParams = {
+    chain: mockChain,
+    activeSafe: mockActiveSafe,
+    safe: mockSafe,
+    txId: 'tx123',
+    relayMutation: mockRelayMutation,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockFetchTransactionDetails.mockResolvedValue({ id: 'tx123' })
+    mockExtractTxInfo.mockReturnValue({ txParams: mockTxParams, signatures: mockSignatures })
+    mockCreateTx.mockResolvedValue(mockSafeTx)
+    mockGetReadOnlyCurrentGnosisSafeContract.mockResolvedValue({ encode: mockEncode })
+    mockGetLatestSafeVersion.mockReturnValue('1.4.1')
+    mockRelayMutation.mockResolvedValue({ taskId: 'task456' })
+  })
+
+  describe('success cases', () => {
+    it('should execute relay transaction successfully', async () => {
+      const result = await executeRelayTx(defaultParams)
+
+      expect(mockFetchTransactionDetails).toHaveBeenCalledWith('1', 'tx123')
+      expect(mockExtractTxInfo).toHaveBeenCalledWith({ id: 'tx123' }, mockActiveSafe.address)
+      expect(mockCreateTx).toHaveBeenCalledWith(mockTxParams, mockTxParams.nonce)
+      expect(mockAddSignaturesToTx).toHaveBeenCalledWith(mockSafeTx, mockSignatures)
+      expect(mockGetReadOnlyCurrentGnosisSafeContract).toHaveBeenCalledWith(mockSafe)
+      expect(mockEncode).toHaveBeenCalledWith('execTransaction', [
+        mockTxParams.to,
+        mockTxParams.value,
+        mockTxParams.data,
+        mockTxParams.operation,
+        mockTxParams.safeTxGas,
+        mockTxParams.baseGas,
+        mockTxParams.gasPrice,
+        mockTxParams.gasToken,
+        mockTxParams.refundReceiver,
+        '0xEncodedSignatures',
+      ])
+      expect(mockRelayMutation).toHaveBeenCalledWith({
+        chainId: '1',
+        relayDto: {
+          to: mockActiveSafe.address,
+          data: '0xEncodedExecTransaction',
+          version: '1.3.0',
+        },
+      })
+
+      expect(result).toEqual({
+        type: ExecutionMethod.WITH_RELAY,
+        txId: 'tx123',
+        taskId: 'task456',
+        chainId: '1',
+        safeAddress: mockActiveSafe.address,
+      })
+    })
+
+    it('should use getLatestSafeVersion when safe version is null', async () => {
+      const safeWithoutVersion = createMockSafeState({ version: null })
+
+      await executeRelayTx({
+        ...defaultParams,
+        safe: safeWithoutVersion,
+      })
+
+      expect(mockGetLatestSafeVersion).toHaveBeenCalledWith(mockChain)
+      expect(mockRelayMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relayDto: expect.objectContaining({
+            version: '1.4.1',
+          }),
+        }),
+      )
+    })
+
+    it('should use getLatestSafeVersion when safe version is undefined', async () => {
+      const safeWithoutVersion = createMockSafeState({ version: undefined })
+
+      await executeRelayTx({
+        ...defaultParams,
+        safe: safeWithoutVersion,
+      })
+
+      expect(mockGetLatestSafeVersion).toHaveBeenCalledWith(mockChain)
+    })
+  })
+
+  describe('error cases', () => {
+    it('should throw error when createTx returns null', async () => {
+      mockCreateTx.mockResolvedValue(null)
+
+      await expect(executeRelayTx(defaultParams)).rejects.toThrow('Safe transaction not found')
+
+      expect(mockAddSignaturesToTx).not.toHaveBeenCalled()
+      expect(mockRelayMutation).not.toHaveBeenCalled()
+    })
+
+    it('should throw error when relay mutation returns no taskId', async () => {
+      mockRelayMutation.mockResolvedValue({ taskId: null })
+
+      await expect(executeRelayTx(defaultParams)).rejects.toThrow('Transaction could not be relayed')
+    })
+
+    it('should throw error when relay mutation returns undefined taskId', async () => {
+      mockRelayMutation.mockResolvedValue({})
+
+      await expect(executeRelayTx(defaultParams)).rejects.toThrow('Transaction could not be relayed')
+    })
+
+    it('should propagate error from fetchTransactionDetails', async () => {
+      const fetchError = new Error('Failed to fetch transaction')
+      mockFetchTransactionDetails.mockRejectedValue(fetchError)
+
+      await expect(executeRelayTx(defaultParams)).rejects.toThrow('Failed to fetch transaction')
+
+      expect(mockExtractTxInfo).not.toHaveBeenCalled()
+    })
+
+    it('should propagate error from createTx', async () => {
+      const createError = new Error('Failed to create transaction')
+      mockCreateTx.mockRejectedValue(createError)
+
+      await expect(executeRelayTx(defaultParams)).rejects.toThrow('Failed to create transaction')
+
+      expect(mockAddSignaturesToTx).not.toHaveBeenCalled()
+    })
+
+    it('should propagate error from getReadOnlyCurrentGnosisSafeContract', async () => {
+      const contractError = new Error('Safe SDK not found.')
+      mockGetReadOnlyCurrentGnosisSafeContract.mockRejectedValue(contractError)
+
+      await expect(executeRelayTx(defaultParams)).rejects.toThrow('Safe SDK not found.')
+
+      expect(mockRelayMutation).not.toHaveBeenCalled()
+    })
+
+    it('should propagate error from relayMutation', async () => {
+      const relayError = new Error('Relay service unavailable')
+      mockRelayMutation.mockRejectedValue(relayError)
+
+      await expect(executeRelayTx(defaultParams)).rejects.toThrow('Relay service unavailable')
+    })
+  })
+
+  describe('execution flow', () => {
+    it('should call services in correct order', async () => {
+      const callOrder: string[] = []
+
+      mockFetchTransactionDetails.mockImplementation(async () => {
+        callOrder.push('fetchTransactionDetails')
+        return { id: 'tx123' }
+      })
+      mockExtractTxInfo.mockImplementation(() => {
+        callOrder.push('extractTxInfo')
+        return { txParams: mockTxParams, signatures: mockSignatures }
+      })
+      mockCreateTx.mockImplementation(async () => {
+        callOrder.push('createTx')
+        return mockSafeTx
+      })
+      mockAddSignaturesToTx.mockImplementation(() => {
+        callOrder.push('addSignaturesToTx')
+      })
+      mockGetReadOnlyCurrentGnosisSafeContract.mockImplementation(async () => {
+        callOrder.push('getReadOnlyCurrentGnosisSafeContract')
+        return { encode: mockEncode }
+      })
+      mockRelayMutation.mockImplementation(async () => {
+        callOrder.push('relayMutation')
+        return { taskId: 'task456' }
+      })
+
+      await executeRelayTx(defaultParams)
+
+      expect(callOrder).toEqual([
+        'fetchTransactionDetails',
+        'extractTxInfo',
+        'createTx',
+        'addSignaturesToTx',
+        'getReadOnlyCurrentGnosisSafeContract',
+        'relayMutation',
+      ])
+    })
+  })
+})

--- a/apps/mobile/src/services/tx/extractTx.test.ts
+++ b/apps/mobile/src/services/tx/extractTx.test.ts
@@ -1,0 +1,388 @@
+import { faker } from '@faker-js/faker'
+import extractTxInfo from './extractTx'
+import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { generateAddress, generateSignature, generateSafeTxHash } from '@safe-global/test'
+
+const createMultisigExecutionInfo = (overrides = {}) => ({
+  type: 'MULTISIG' as const,
+  nonce: faker.number.int({ min: 0, max: 100 }),
+  confirmationsRequired: 2,
+  confirmationsSubmitted: 1,
+  confirmations: [],
+  missingSigners: null,
+  baseGas: '21000',
+  gasPrice: '1000000000',
+  safeTxGas: '50000',
+  gasToken: '0x0000000000000000000000000000000000000000',
+  refundReceiver: { value: '0x0000000000000000000000000000000000000000' },
+  submittedAt: Date.now(),
+  safeTxHash: generateSafeTxHash(),
+  signers: [{ value: generateAddress() }],
+  rejectors: [],
+  trusted: true,
+  ...overrides,
+})
+
+const createBaseTxDetails = (overrides: Partial<TransactionDetails> = {}): TransactionDetails =>
+  ({
+    safeAddress: generateAddress(),
+    txId: faker.string.uuid(),
+    executedAt: null,
+    txStatus: 'AWAITING_CONFIRMATIONS',
+    txInfo: {
+      type: 'Custom',
+      to: { value: generateAddress() },
+      value: '0',
+      dataSize: '0',
+      methodName: null,
+      isCancellation: false,
+    },
+    txData: {
+      hexData: '0x',
+      dataDecoded: null,
+      to: { value: generateAddress() },
+      value: '0',
+      operation: 0,
+      addressInfoIndex: null,
+      trustedDelegateCallTarget: null,
+    },
+    detailedExecutionInfo: createMultisigExecutionInfo(),
+    txHash: null,
+    safeAppInfo: null,
+    ...overrides,
+  }) as TransactionDetails
+
+describe('extractTxInfo', () => {
+  const safeAddress = generateAddress()
+
+  describe('Native Transfer transactions', () => {
+    it('extracts native token transfer correctly', () => {
+      const recipientAddress = generateAddress()
+      const txDetails = createBaseTxDetails({
+        txInfo: {
+          type: 'Transfer',
+          sender: { value: safeAddress },
+          recipient: { value: recipientAddress },
+          direction: 'OUTGOING',
+          transferInfo: {
+            type: 'NATIVE_COIN',
+            value: '1000000000000000000',
+          },
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.value).toBe('1000000000000000000')
+      expect(result.txParams.to).toBe(recipientAddress)
+      expect(result.txParams.data).toBe('0x')
+    })
+  })
+
+  describe('ERC20 Transfer transactions', () => {
+    it('extracts ERC20 token transfer correctly', () => {
+      const tokenAddress = generateAddress()
+      const recipientAddress = generateAddress()
+      const txDetails = createBaseTxDetails({
+        txInfo: {
+          type: 'Transfer',
+          sender: { value: safeAddress },
+          recipient: { value: recipientAddress },
+          direction: 'OUTGOING',
+          transferInfo: {
+            type: 'ERC20',
+            tokenAddress,
+            tokenName: 'Test Token',
+            tokenSymbol: 'TST',
+            logoUri: null,
+            decimals: 18,
+            value: '1000000000000000000',
+            trusted: true,
+            imitation: false,
+          },
+        },
+        txData: {
+          hexData: '0xa9059cbb',
+          dataDecoded: null,
+          to: { value: tokenAddress },
+          value: '0',
+          operation: 0,
+          addressInfoIndex: null,
+          trustedDelegateCallTarget: null,
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.to).toBe(tokenAddress)
+      expect(result.txParams.value).toBe('0')
+    })
+  })
+
+  describe('Custom transactions', () => {
+    it('extracts custom transaction correctly', () => {
+      const toAddress = generateAddress()
+      const value = '500000000000000000'
+      const txDetails = createBaseTxDetails({
+        txInfo: {
+          type: 'Custom',
+          to: { value: toAddress },
+          value,
+          dataSize: '68',
+          methodName: 'transfer',
+          isCancellation: false,
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.to).toBe(toAddress)
+      expect(result.txParams.value).toBe(value)
+    })
+  })
+
+  describe('SwapOrder transactions', () => {
+    it('extracts SwapOrder transaction correctly', () => {
+      const toAddress = generateAddress()
+      const txDetails = createBaseTxDetails({
+        txInfo: {
+          type: 'SwapOrder',
+          uid: faker.string.uuid(),
+          status: 'presignaturePending',
+          kind: 'sell',
+          validUntil: Math.floor(Date.now() / 1000) + 3600,
+          sellToken: {
+            address: generateAddress(),
+            decimals: 18,
+            logoUri: null,
+            name: 'Ether',
+            symbol: 'ETH',
+            trusted: true,
+          },
+          buyToken: {
+            address: generateAddress(),
+            decimals: 6,
+            logoUri: null,
+            name: 'USD Coin',
+            symbol: 'USDC',
+            trusted: true,
+          },
+          sellAmount: '1000000000000000000',
+          buyAmount: '2000000000',
+          executedSellAmount: '0',
+          executedBuyAmount: '0',
+          explorerUrl: 'https://explorer.cow.fi',
+          orderClass: 'market',
+          executedFee: '0',
+          executedFeeToken: {
+            address: generateAddress(),
+            decimals: 18,
+            logoUri: null,
+            name: 'Ether',
+            symbol: 'ETH',
+            trusted: true,
+          },
+          humanDescription: null,
+          receiver: safeAddress,
+          owner: safeAddress,
+          fullAppData: null,
+        },
+        txData: {
+          hexData: '0x1234',
+          dataDecoded: null,
+          to: { value: toAddress },
+          value: '0',
+          operation: 0,
+          addressInfoIndex: null,
+          trustedDelegateCallTarget: null,
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.to).toBe(toAddress)
+      expect(result.txParams.value).toBe('0')
+    })
+  })
+
+  describe('SettingsChange transactions', () => {
+    it('extracts SettingsChange transaction with safe address as to', () => {
+      const txDetails = createBaseTxDetails({
+        txInfo: {
+          type: 'SettingsChange',
+          dataDecoded: {
+            method: 'addOwnerWithThreshold',
+            parameters: [
+              { name: 'owner', type: 'address', value: generateAddress() },
+              { name: '_threshold', type: 'uint256', value: '2' },
+            ],
+          },
+          settingsInfo: {
+            type: 'ADD_OWNER',
+            owner: { value: generateAddress() },
+            threshold: 2,
+          },
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.to).toBe(safeAddress)
+      expect(result.txParams.value).toBe('0')
+    })
+  })
+
+  describe('Creation transactions', () => {
+    it('extracts Creation transaction with safe address as to', () => {
+      const txDetails = createBaseTxDetails({
+        txInfo: {
+          type: 'Creation',
+          creator: { value: generateAddress() },
+          transactionHash: generateSafeTxHash(),
+          implementation: { value: generateAddress() },
+          factory: { value: generateAddress() },
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.to).toBe(safeAddress)
+      expect(result.txParams.value).toBe('0')
+    })
+  })
+
+  describe('Signature extraction', () => {
+    it('extracts signatures from confirmations', () => {
+      const signer1 = generateAddress()
+      const signer2 = generateAddress()
+      const signature1 = generateSignature()
+      const signature2 = generateSignature()
+
+      const txDetails = createBaseTxDetails({
+        detailedExecutionInfo: createMultisigExecutionInfo({
+          confirmations: [
+            { signer: { value: signer1 }, signature: signature1, submittedAt: Date.now() },
+            { signer: { value: signer2 }, signature: signature2, submittedAt: Date.now() },
+          ],
+        }),
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.signatures[signer1]).toBe(signature1)
+      expect(result.signatures[signer2]).toBe(signature2)
+    })
+
+    it('handles missing signatures gracefully', () => {
+      const signer = generateAddress()
+      const txDetails = createBaseTxDetails({
+        detailedExecutionInfo: createMultisigExecutionInfo({
+          confirmations: [{ signer: { value: signer }, signature: null, submittedAt: Date.now() }],
+        }),
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.signatures[signer]).toBe('')
+    })
+  })
+
+  describe('Gas parameters extraction', () => {
+    it('extracts gas parameters from multisig execution info', () => {
+      const txDetails = createBaseTxDetails({
+        detailedExecutionInfo: createMultisigExecutionInfo({
+          baseGas: '50000',
+          gasPrice: '2000000000',
+          safeTxGas: '100000',
+          gasToken: generateAddress(),
+          refundReceiver: { value: generateAddress() },
+        }),
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.baseGas).toBe('50000')
+      expect(result.txParams.gasPrice).toBe('2000000000')
+      expect(result.txParams.safeTxGas).toBe('100000')
+    })
+
+    it('uses default values when no multisig execution info', () => {
+      const txDetails = createBaseTxDetails({
+        detailedExecutionInfo: {
+          type: 'MODULE',
+          address: { value: generateAddress() },
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.baseGas).toBe('0')
+      expect(result.txParams.gasPrice).toBe('0')
+      expect(result.txParams.safeTxGas).toBe('0')
+      expect(result.txParams.gasToken).toBe('0x0000000000000000000000000000000000000000')
+    })
+  })
+
+  describe('Operation type', () => {
+    it('extracts CALL operation', () => {
+      const txDetails = createBaseTxDetails({
+        txData: {
+          hexData: '0x',
+          dataDecoded: null,
+          to: { value: generateAddress() },
+          value: '0',
+          operation: 0,
+          addressInfoIndex: null,
+          trustedDelegateCallTarget: null,
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.operation).toBe(0)
+    })
+
+    it('extracts DELEGATECALL operation', () => {
+      const txDetails = createBaseTxDetails({
+        txData: {
+          hexData: '0x',
+          dataDecoded: null,
+          to: { value: generateAddress() },
+          value: '0',
+          operation: 1,
+          addressInfoIndex: null,
+          trustedDelegateCallTarget: null,
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.operation).toBe(1)
+    })
+  })
+
+  describe('Nonce extraction', () => {
+    it('extracts nonce from multisig execution info', () => {
+      const txDetails = createBaseTxDetails({
+        detailedExecutionInfo: createMultisigExecutionInfo({ nonce: 42 }),
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.nonce).toBe(42)
+    })
+
+    it('defaults to 0 for non-multisig execution', () => {
+      const txDetails = createBaseTxDetails({
+        detailedExecutionInfo: {
+          type: 'MODULE',
+          address: { value: generateAddress() },
+        },
+      })
+
+      const result = extractTxInfo(txDetails, safeAddress)
+
+      expect(result.txParams.nonce).toBe(0)
+    })
+  })
+})

--- a/apps/mobile/src/services/tx/tx-sender/create.test.ts
+++ b/apps/mobile/src/services/tx/tx-sender/create.test.ts
@@ -1,0 +1,253 @@
+import { faker } from '@faker-js/faker'
+import { createTx, addSignaturesToTx, createExistingTx, proposeTx } from './create'
+import { getSafeSDK } from '@/src/hooks/coreSDK/safeCoreSDK'
+import { createConnectedWallet } from '@/src/services/web3'
+import { fetchTransactionDetails } from '@/src/services/tx/fetchTransactionDetails'
+import extractTxInfo from '@/src/services/tx/extractTx'
+import type { SafeTransactionDataPartial } from '@safe-global/types-kit'
+import type { SafeInfo } from '@/src/types/address'
+import {
+  generateChecksummedAddress,
+  createMockSafeTx,
+  createMockChain,
+  createMockSafeInfo,
+  createMockProtocolKit,
+} from '@safe-global/test'
+
+jest.mock('@/src/hooks/coreSDK/safeCoreSDK')
+jest.mock('@/src/services/web3')
+jest.mock('@/src/services/tx/fetchTransactionDetails')
+jest.mock('@/src/services/tx/extractTx')
+
+describe('create.ts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('createTx', () => {
+    const mockSafeSDK = {
+      createTransaction: jest.fn(),
+    }
+
+    beforeEach(() => {
+      ;(getSafeSDK as jest.Mock).mockReturnValue(mockSafeSDK)
+    })
+
+    it('creates a transaction using safe SDK', async () => {
+      const txParams: SafeTransactionDataPartial = {
+        to: generateChecksummedAddress(),
+        value: '1000000000000000000',
+        data: '0x',
+      }
+      const mockTx = createMockSafeTx()
+      mockSafeSDK.createTransaction.mockResolvedValue(mockTx)
+
+      const result = await createTx(txParams)
+
+      expect(mockSafeSDK.createTransaction).toHaveBeenCalledWith({
+        transactions: [txParams],
+      })
+      expect(result).toBe(mockTx)
+    })
+
+    it('includes nonce when provided', async () => {
+      const txParams: SafeTransactionDataPartial = {
+        to: generateChecksummedAddress(),
+        value: '0',
+        data: '0x',
+      }
+      const nonce = 42
+      const mockTx = createMockSafeTx()
+      mockSafeSDK.createTransaction.mockResolvedValue(mockTx)
+
+      await createTx(txParams, nonce)
+
+      expect(mockSafeSDK.createTransaction).toHaveBeenCalledWith({
+        transactions: [{ ...txParams, nonce }],
+      })
+    })
+
+    it('throws error when SDK is not initialized', async () => {
+      ;(getSafeSDK as jest.Mock).mockReturnValue(null)
+      const txParams: SafeTransactionDataPartial = {
+        to: generateChecksummedAddress(),
+        value: '0',
+        data: '0x',
+      }
+
+      await expect(createTx(txParams)).rejects.toThrow(
+        'The Safe SDK could not be initialized. Please be aware that we only support v1.0.0 Safe Accounts and up.',
+      )
+    })
+  })
+
+  describe('addSignaturesToTx', () => {
+    it('adds signatures to transaction', () => {
+      const mockTx = createMockSafeTx()
+      const signer1 = generateChecksummedAddress()
+      const signer2 = generateChecksummedAddress()
+      const signatures = {
+        [signer1]: '0xsignature1',
+        [signer2]: '0xsignature2',
+      }
+
+      addSignaturesToTx(mockTx, signatures)
+
+      expect(mockTx.addSignature).toHaveBeenCalledTimes(2)
+      expect(mockTx.addSignature).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signer: signer1,
+          data: '0xsignature1',
+          isContractSignature: false,
+        }),
+      )
+      expect(mockTx.addSignature).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signer: signer2,
+          data: '0xsignature2',
+          isContractSignature: false,
+        }),
+      )
+    })
+
+    it('handles empty signatures', () => {
+      const mockTx = createMockSafeTx()
+
+      addSignaturesToTx(mockTx, {})
+
+      expect(mockTx.addSignature).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('createExistingTx', () => {
+    const mockSafeSDK = {
+      createTransaction: jest.fn(),
+    }
+
+    beforeEach(() => {
+      ;(getSafeSDK as jest.Mock).mockReturnValue(mockSafeSDK)
+    })
+
+    it('creates transaction and adds signatures', async () => {
+      const txParams: SafeTransactionDataPartial = {
+        to: generateChecksummedAddress(),
+        value: '0',
+        data: '0x',
+        nonce: 5,
+      }
+      const signer = generateChecksummedAddress()
+      const signatures = { [signer]: '0xsignature' }
+      const mockTx = createMockSafeTx()
+      mockSafeSDK.createTransaction.mockResolvedValue(mockTx)
+
+      const result = await createExistingTx(txParams, signatures)
+
+      expect(mockSafeSDK.createTransaction).toHaveBeenCalled()
+      expect(mockTx.addSignature).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signer,
+          data: '0xsignature',
+        }),
+      )
+      expect(result).toBe(mockTx)
+    })
+  })
+
+  describe('proposeTx', () => {
+    const mockChain = createMockChain()
+    const mockActiveSafe: SafeInfo = createMockSafeInfo()
+    const mockPrivateKey = faker.string.hexadecimal({ length: 64, prefix: '0x' })
+    const mockTxId = faker.string.uuid()
+
+    const mockProtocolKit = createMockProtocolKit()
+
+    beforeEach(() => {
+      ;(createConnectedWallet as jest.Mock).mockResolvedValue({
+        wallet: { address: generateChecksummedAddress() },
+        protocolKit: mockProtocolKit,
+      })
+    })
+
+    it('fetches transaction details when not provided', async () => {
+      const mockTxDetails = { txId: mockTxId }
+      const mockTxParams = { to: generateChecksummedAddress(), value: '0', data: '0x' }
+      const mockSignatures = {}
+      const mockTx = createMockSafeTx()
+
+      ;(fetchTransactionDetails as jest.Mock).mockResolvedValue(mockTxDetails)
+      ;(extractTxInfo as jest.Mock).mockReturnValue({ txParams: mockTxParams, signatures: mockSignatures })
+      mockProtocolKit.createTransaction.mockResolvedValue(mockTx)
+
+      await proposeTx({
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: mockPrivateKey,
+        chain: mockChain,
+      })
+
+      expect(fetchTransactionDetails).toHaveBeenCalledWith(mockActiveSafe.chainId, mockTxId)
+      expect(extractTxInfo).toHaveBeenCalledWith(mockTxDetails, mockActiveSafe.address)
+    })
+
+    it('uses provided transaction details', async () => {
+      const mockTxDetails = { txId: mockTxId }
+      const mockTxParams = { to: generateChecksummedAddress(), value: '0', data: '0x' }
+      const mockSignatures = {}
+      const mockTx = createMockSafeTx()
+
+      ;(extractTxInfo as jest.Mock).mockReturnValue({ txParams: mockTxParams, signatures: mockSignatures })
+      mockProtocolKit.createTransaction.mockResolvedValue(mockTx)
+
+      await proposeTx({
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: mockPrivateKey,
+        txDetails: mockTxDetails as never,
+        chain: mockChain,
+      })
+
+      expect(fetchTransactionDetails).not.toHaveBeenCalled()
+      expect(extractTxInfo).toHaveBeenCalledWith(mockTxDetails, mockActiveSafe.address)
+    })
+
+    it('returns safeTx and signatures', async () => {
+      const mockTxDetails = { txId: mockTxId }
+      const mockTxParams = { to: generateChecksummedAddress(), value: '0', data: '0x' }
+      const signer = generateChecksummedAddress()
+      const mockSignatures = { [signer]: '0xsig' }
+      const mockTx = createMockSafeTx()
+
+      ;(fetchTransactionDetails as jest.Mock).mockResolvedValue(mockTxDetails)
+      ;(extractTxInfo as jest.Mock).mockReturnValue({ txParams: mockTxParams, signatures: mockSignatures })
+      mockProtocolKit.createTransaction.mockResolvedValue(mockTx)
+
+      const result = await proposeTx({
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: mockPrivateKey,
+        chain: mockChain,
+      })
+
+      expect(result).toEqual({ safeTx: mockTx, signatures: mockSignatures })
+    })
+
+    it('creates connected wallet with correct params', async () => {
+      const mockTxDetails = { txId: mockTxId }
+      const mockTxParams = { to: generateChecksummedAddress(), value: '0', data: '0x' }
+      const mockTx = createMockSafeTx()
+
+      ;(fetchTransactionDetails as jest.Mock).mockResolvedValue(mockTxDetails)
+      ;(extractTxInfo as jest.Mock).mockReturnValue({ txParams: mockTxParams, signatures: {} })
+      mockProtocolKit.createTransaction.mockResolvedValue(mockTx)
+
+      await proposeTx({
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: mockPrivateKey,
+        chain: mockChain,
+      })
+
+      expect(createConnectedWallet).toHaveBeenCalledWith(mockPrivateKey, mockActiveSafe, mockChain)
+    })
+  })
+})

--- a/apps/mobile/src/services/tx/tx-sender/execute.test.ts
+++ b/apps/mobile/src/services/tx/tx-sender/execute.test.ts
@@ -1,0 +1,163 @@
+import { executeTx } from './execute'
+import { proposeTx, addSignaturesToTx } from './create'
+import { createConnectedWallet } from '@/src/services/web3'
+import type { SafeInfo } from '@/src/types/address'
+import type { EstimatedFeeValues } from '@/src/store/estimatedFeeSlice'
+import {
+  generateChecksummedAddress,
+  generatePrivateKey,
+  generateTxId,
+  createMockSafeTx,
+  createMockChain,
+  createMockSafeInfo,
+  createMockProtocolKit,
+} from '@safe-global/test'
+
+jest.mock('./create')
+jest.mock('@/src/services/web3')
+
+describe('executeTx', () => {
+  const mockChain = createMockChain()
+  const mockActiveSafe: SafeInfo = createMockSafeInfo()
+  const mockPrivateKey = generatePrivateKey()
+  const mockTxId = generateTxId()
+
+  const mockProtocolKit = createMockProtocolKit()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(createConnectedWallet as jest.Mock).mockResolvedValue({
+      wallet: { address: generateChecksummedAddress() },
+      protocolKit: mockProtocolKit,
+    })
+  })
+
+  it('throws error when chain is not provided', async () => {
+    await expect(
+      executeTx({
+        chain: undefined as never,
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: mockPrivateKey,
+        feeParams: null,
+      }),
+    ).rejects.toThrow('Active chain not found')
+  })
+
+  it('throws error when private key is not provided', async () => {
+    await expect(
+      executeTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: '',
+        feeParams: null,
+      }),
+    ).rejects.toThrow('Private key not found')
+  })
+
+  it('throws error when safeTx is not found', async () => {
+    const mockSignatures = {}
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: null, signatures: mockSignatures })
+
+    await expect(
+      executeTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: mockPrivateKey,
+        feeParams: null,
+      }),
+    ).rejects.toThrow('Safe transaction not found')
+  })
+
+  it('executes transaction without fee params', async () => {
+    const mockTx = createMockSafeTx()
+    const signer = generateChecksummedAddress()
+    const mockSignatures = { [signer]: '0xsignature' }
+    const mockExecuteResult = { hash: '0xtxhash' }
+
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: mockSignatures })
+    mockProtocolKit.executeTransaction.mockResolvedValue(mockExecuteResult)
+
+    const result = await executeTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      privateKey: mockPrivateKey,
+      feeParams: null,
+    })
+
+    expect(addSignaturesToTx).toHaveBeenCalledWith(mockTx, mockSignatures)
+    expect(mockProtocolKit.executeTransaction).toHaveBeenCalledWith(mockTx, undefined)
+    expect(result).toBe(mockExecuteResult)
+  })
+
+  it('executes transaction with fee params', async () => {
+    const mockTx = createMockSafeTx()
+    const mockSignatures = {}
+    const mockExecuteResult = { hash: '0xtxhash' }
+    const feeParams: EstimatedFeeValues = {
+      gasLimit: BigInt(100000),
+      maxFeePerGas: BigInt(20000000000),
+      maxPriorityFeePerGas: BigInt(1500000000),
+      nonce: 10,
+    }
+
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: mockSignatures })
+    mockProtocolKit.executeTransaction.mockResolvedValue(mockExecuteResult)
+
+    const result = await executeTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      privateKey: mockPrivateKey,
+      feeParams,
+    })
+
+    expect(mockProtocolKit.executeTransaction).toHaveBeenCalledWith(mockTx, {
+      gasLimit: '100000',
+      maxFeePerGas: '20000000000',
+      maxPriorityFeePerGas: '1500000000',
+      nonce: 10,
+    })
+    expect(result).toBe(mockExecuteResult)
+  })
+
+  it('calls proposeTx with correct parameters', async () => {
+    const mockTx = createMockSafeTx()
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: {} })
+    mockProtocolKit.executeTransaction.mockResolvedValue({ hash: '0x' })
+
+    await executeTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      privateKey: mockPrivateKey,
+      feeParams: null,
+    })
+
+    expect(proposeTx).toHaveBeenCalledWith({
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      chain: mockChain,
+      privateKey: mockPrivateKey,
+    })
+  })
+
+  it('creates connected wallet before execution', async () => {
+    const mockTx = createMockSafeTx()
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: {} })
+    mockProtocolKit.executeTransaction.mockResolvedValue({ hash: '0x' })
+
+    await executeTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      privateKey: mockPrivateKey,
+      feeParams: null,
+    })
+
+    expect(createConnectedWallet).toHaveBeenCalledWith(mockPrivateKey, mockActiveSafe, mockChain)
+  })
+})

--- a/apps/mobile/src/services/tx/tx-sender/sign.test.ts
+++ b/apps/mobile/src/services/tx/tx-sender/sign.test.ts
@@ -1,0 +1,190 @@
+import { signTx } from './sign'
+import { proposeTx } from './create'
+import { createConnectedWallet } from '@/src/services/web3'
+import type { SafeInfo } from '@/src/types/address'
+import { SigningMethod } from '@safe-global/protocol-kit'
+import {
+  generateChecksummedAddress,
+  generateSignature,
+  generateSafeTxHash,
+  generatePrivateKey,
+  generateTxId,
+  createMockSafeTxWithSigner,
+  createMockChain,
+  createMockSafeInfo,
+  createMockProtocolKit,
+} from '@safe-global/test'
+
+jest.mock('./create')
+jest.mock('@/src/services/web3')
+
+describe('signTx', () => {
+  const mockChain = createMockChain()
+  const mockActiveSafe: SafeInfo = createMockSafeInfo()
+  const mockPrivateKey = generatePrivateKey()
+  const mockTxId = generateTxId()
+  const mockWalletAddress = generateChecksummedAddress()
+  const mockSignature = generateSignature()
+  const mockSafeTxHash = generateSafeTxHash()
+
+  const mockProtocolKit = createMockProtocolKit()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(createConnectedWallet as jest.Mock).mockResolvedValue({
+      wallet: { address: mockWalletAddress },
+      protocolKit: mockProtocolKit,
+    })
+  })
+
+  it('throws error when chain is not provided', async () => {
+    await expect(
+      signTx({
+        chain: undefined as never,
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: mockPrivateKey,
+      }),
+    ).rejects.toThrow('Active chain not found')
+  })
+
+  it('throws error when private key is not provided', async () => {
+    await expect(
+      signTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: undefined,
+      }),
+    ).rejects.toThrow('Private key not found')
+  })
+
+  it('throws error when safeTx is not found', async () => {
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: null, signatures: {} })
+
+    await expect(
+      signTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: mockPrivateKey,
+      }),
+    ).rejects.toThrow('Safe transaction not found')
+  })
+
+  it('throws error when signature is not found after signing', async () => {
+    const mockTx = createMockSafeTxWithSigner('different-address', mockSignature)
+    const mockSignedTx = createMockSafeTxWithSigner('different-address', mockSignature)
+    mockSignedTx.getSignature = jest.fn().mockReturnValue(undefined)
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: {} })
+    mockProtocolKit.signTransaction.mockResolvedValue(mockSignedTx)
+    mockProtocolKit.getTransactionHash.mockResolvedValue(mockSafeTxHash)
+
+    await expect(
+      signTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: mockTxId,
+        privateKey: mockPrivateKey,
+      }),
+    ).rejects.toThrow('Signature not found')
+  })
+
+  it('signs transaction and returns signature with hash', async () => {
+    const mockTx = createMockSafeTxWithSigner(mockWalletAddress, '')
+    const mockSignedTx = createMockSafeTxWithSigner(mockWalletAddress, mockSignature)
+
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: {} })
+    mockProtocolKit.signTransaction.mockResolvedValue(mockSignedTx)
+    mockProtocolKit.getTransactionHash.mockResolvedValue(mockSafeTxHash)
+
+    const result = await signTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      privateKey: mockPrivateKey,
+    })
+
+    expect(result).toEqual({
+      signature: mockSignature,
+      safeTransactionHash: mockSafeTxHash,
+    })
+  })
+
+  it('uses ETH_SIGN_TYPED_DATA_V4 signing method', async () => {
+    const mockTx = createMockSafeTxWithSigner(mockWalletAddress, '')
+    const mockSignedTx = createMockSafeTxWithSigner(mockWalletAddress, mockSignature)
+
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: {} })
+    mockProtocolKit.signTransaction.mockResolvedValue(mockSignedTx)
+    mockProtocolKit.getTransactionHash.mockResolvedValue(mockSafeTxHash)
+
+    await signTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      privateKey: mockPrivateKey,
+    })
+
+    expect(mockProtocolKit.signTransaction).toHaveBeenCalledWith(mockTx, SigningMethod.ETH_SIGN_TYPED_DATA_V4)
+  })
+
+  it('gets signature for wallet address', async () => {
+    const mockTx = createMockSafeTxWithSigner(mockWalletAddress, '')
+    const mockSignedTx = createMockSafeTxWithSigner(mockWalletAddress, mockSignature)
+
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: {} })
+    mockProtocolKit.signTransaction.mockResolvedValue(mockSignedTx)
+    mockProtocolKit.getTransactionHash.mockResolvedValue(mockSafeTxHash)
+
+    await signTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      privateKey: mockPrivateKey,
+    })
+
+    expect(mockSignedTx.getSignature).toHaveBeenCalledWith(mockWalletAddress)
+  })
+
+  it('creates connected wallet with correct params', async () => {
+    const mockTx = createMockSafeTxWithSigner(mockWalletAddress, '')
+    const mockSignedTx = createMockSafeTxWithSigner(mockWalletAddress, mockSignature)
+
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: {} })
+    mockProtocolKit.signTransaction.mockResolvedValue(mockSignedTx)
+    mockProtocolKit.getTransactionHash.mockResolvedValue(mockSafeTxHash)
+
+    await signTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      privateKey: mockPrivateKey,
+    })
+
+    expect(createConnectedWallet).toHaveBeenCalledWith(mockPrivateKey, mockActiveSafe, mockChain)
+  })
+
+  it('calls proposeTx with correct parameters', async () => {
+    const mockTx = createMockSafeTxWithSigner(mockWalletAddress, '')
+    const mockSignedTx = createMockSafeTxWithSigner(mockWalletAddress, mockSignature)
+
+    ;(proposeTx as jest.Mock).mockResolvedValue({ safeTx: mockTx, signatures: {} })
+    mockProtocolKit.signTransaction.mockResolvedValue(mockSignedTx)
+    mockProtocolKit.getTransactionHash.mockResolvedValue(mockSafeTxHash)
+
+    await signTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      privateKey: mockPrivateKey,
+    })
+
+    expect(proposeTx).toHaveBeenCalledWith({
+      activeSafe: mockActiveSafe,
+      txId: mockTxId,
+      chain: mockChain,
+      privateKey: mockPrivateKey,
+    })
+  })
+})

--- a/apps/mobile/src/store/middleware/__tests__/pendingTxs.test.ts
+++ b/apps/mobile/src/store/middleware/__tests__/pendingTxs.test.ts
@@ -1,0 +1,340 @@
+import { configureStore, createListenerMiddleware } from '@reduxjs/toolkit'
+import { pendingTxsSlice, PendingStatus, addPendingTx, setPendingTxStatus, clearPendingTx } from '../../pendingTxsSlice'
+import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
+import pendingTxsListeners from '../pendingTxs'
+import { cgwApi } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import type { AppStartListening } from '@/src/store'
+import { generateAddress, generateTxId, generateTxHash, generateTaskId } from '@safe-global/test'
+
+jest.mock('@safe-global/utils/services/SimpleTxWatcher', () => ({
+  SimpleTxWatcher: {
+    getInstance: jest.fn(() => ({
+      watchTxHash: jest.fn(() => Promise.resolve()),
+    })),
+  },
+}))
+
+jest.mock('@safe-global/utils/services/RelayTxWatcher', () => ({
+  RelayTxWatcher: {
+    getInstance: jest.fn(() => ({
+      watchTaskId: jest.fn(() => Promise.resolve({ transactionHash: '0xabc123' })),
+      stopWatchingTaskId: jest.fn(),
+    })),
+  },
+  TIMEOUT_ERROR_CODE: 'TIMEOUT',
+}))
+
+jest.mock('@safe-global/utils/services/SimplePoller', () => ({
+  SimplePoller: {
+    getInstance: jest.fn(() => ({
+      watch: jest.fn(() => Promise.resolve()),
+    })),
+  },
+}))
+
+jest.mock('@/src/store/chains', () => ({
+  selectChainById: jest.fn(() => ({
+    chainId: '1',
+    chainName: 'Ethereum',
+    rpcUri: { value: 'https://rpc.example.com' },
+  })),
+}))
+
+jest.mock('@/src/services/web3', () => ({
+  createWeb3ReadOnly: jest.fn(() => ({})),
+}))
+
+jest.mock('@safe-global/utils/utils/helpers', () => ({
+  delay: jest.fn(() => Promise.resolve()),
+}))
+
+describe('pendingTxsListeners', () => {
+  const createTestStore = () => {
+    const listenerMiddleware = createListenerMiddleware()
+    pendingTxsListeners(listenerMiddleware.startListening as AppStartListening)
+
+    return configureStore({
+      reducer: {
+        pendingTxs: pendingTxsSlice.reducer,
+        chains: () => ({
+          data: {
+            '1': {
+              chainId: '1',
+              chainName: 'Ethereum',
+              rpcUri: { value: 'https://rpc.example.com' },
+            },
+          },
+        }),
+        [cgwApi.reducerPath]: cgwApi.reducer,
+      },
+      middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({ serializableCheck: false })
+          .prepend(listenerMiddleware.middleware)
+          .concat(cgwApi.middleware),
+    })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('addPendingTx listener', () => {
+    it('should add PK transaction to pending state with PROCESSING status', () => {
+      const store = createTestStore()
+      const txId = generateTxId()
+      const txHash = generateTxHash()
+      const walletAddress = generateAddress()
+      const safeAddress = generateAddress()
+
+      store.dispatch(
+        addPendingTx({
+          txId,
+          type: ExecutionMethod.WITH_PK,
+          chainId: '1',
+          safeAddress,
+          txHash,
+          walletAddress,
+          walletNonce: 5,
+        }),
+      )
+
+      const state = store.getState()
+      expect(state.pendingTxs[txId]).toBeDefined()
+      expect(state.pendingTxs[txId].status).toBe(PendingStatus.PROCESSING)
+      expect(state.pendingTxs[txId].type).toBe(ExecutionMethod.WITH_PK)
+    })
+
+    it('should add relay transaction to pending state with PROCESSING status', () => {
+      const store = createTestStore()
+      const txId = generateTxId()
+      const taskId = generateTaskId()
+      const safeAddress = generateAddress()
+
+      store.dispatch(
+        addPendingTx({
+          txId,
+          type: ExecutionMethod.WITH_RELAY,
+          chainId: '1',
+          safeAddress,
+          taskId,
+        }),
+      )
+
+      const state = store.getState()
+      expect(state.pendingTxs[txId]).toBeDefined()
+      expect(state.pendingTxs[txId].status).toBe(PendingStatus.PROCESSING)
+      expect(state.pendingTxs[txId].type).toBe(ExecutionMethod.WITH_RELAY)
+    })
+  })
+
+  describe('setPendingTxStatus listener', () => {
+    it('should update pending tx status to INDEXING', () => {
+      const store = createTestStore()
+      const txId = generateTxId()
+      const txHash = generateTxHash()
+      const walletAddress = generateAddress()
+      const safeAddress = generateAddress()
+
+      store.dispatch(
+        addPendingTx({
+          txId,
+          type: ExecutionMethod.WITH_PK,
+          chainId: '1',
+          safeAddress,
+          txHash,
+          walletAddress,
+          walletNonce: 5,
+        }),
+      )
+
+      store.dispatch(setPendingTxStatus({ txId, chainId: '1', status: PendingStatus.INDEXING }))
+
+      const state = store.getState()
+      expect(state.pendingTxs[txId].status).toBe(PendingStatus.INDEXING)
+    })
+
+    it('should update pending tx status to FAILED with error', () => {
+      const store = createTestStore()
+      const txId = generateTxId()
+      const txHash = generateTxHash()
+      const walletAddress = generateAddress()
+      const safeAddress = generateAddress()
+
+      store.dispatch(
+        addPendingTx({
+          txId,
+          type: ExecutionMethod.WITH_PK,
+          chainId: '1',
+          safeAddress,
+          txHash,
+          walletAddress,
+          walletNonce: 5,
+        }),
+      )
+
+      store.dispatch(
+        setPendingTxStatus({
+          txId,
+          chainId: '1',
+          status: PendingStatus.FAILED,
+          error: 'Transaction reverted',
+        }),
+      )
+
+      const state = store.getState()
+      expect(state.pendingTxs[txId].status).toBe(PendingStatus.FAILED)
+      expect((state.pendingTxs[txId] as { error: string }).error).toBe('Transaction reverted')
+    })
+
+    it('should update pending tx status to SUCCESS', async () => {
+      jest.useFakeTimers()
+      const store = createTestStore()
+      const txId = generateTxId()
+      const txHash = generateTxHash()
+      const walletAddress = generateAddress()
+      const safeAddress = generateAddress()
+
+      store.dispatch(
+        addPendingTx({
+          txId,
+          type: ExecutionMethod.WITH_PK,
+          chainId: '1',
+          safeAddress,
+          txHash,
+          walletAddress,
+          walletNonce: 5,
+        }),
+      )
+
+      store.dispatch(setPendingTxStatus({ txId, chainId: '1', status: PendingStatus.SUCCESS }))
+
+      const stateAfterSuccess = store.getState()
+      expect(stateAfterSuccess.pendingTxs[txId].status).toBe(PendingStatus.SUCCESS)
+
+      jest.useRealTimers()
+    })
+
+    it('should not update status if tx does not exist', () => {
+      const store = createTestStore()
+      const txId = generateTxId()
+
+      store.dispatch(setPendingTxStatus({ txId, chainId: '1', status: PendingStatus.INDEXING }))
+
+      const state = store.getState()
+      expect(state.pendingTxs[txId]).toBeUndefined()
+    })
+  })
+
+  describe('clearPendingTx action', () => {
+    it('should remove pending tx from state', () => {
+      const store = createTestStore()
+      const txId = generateTxId()
+      const txHash = generateTxHash()
+      const walletAddress = generateAddress()
+      const safeAddress = generateAddress()
+
+      store.dispatch(
+        addPendingTx({
+          txId,
+          type: ExecutionMethod.WITH_PK,
+          chainId: '1',
+          safeAddress,
+          txHash,
+          walletAddress,
+          walletNonce: 5,
+        }),
+      )
+
+      expect(store.getState().pendingTxs[txId]).toBeDefined()
+
+      store.dispatch(clearPendingTx({ txId }))
+
+      expect(store.getState().pendingTxs[txId]).toBeUndefined()
+    })
+  })
+
+  describe('setRelayTxHash action', () => {
+    it('should update txHash for relay transaction', () => {
+      const store = createTestStore()
+      const txId = generateTxId()
+      const taskId = generateTaskId()
+      const safeAddress = generateAddress()
+      const newTxHash = generateTxHash()
+
+      store.dispatch(
+        addPendingTx({
+          txId,
+          type: ExecutionMethod.WITH_RELAY,
+          chainId: '1',
+          safeAddress,
+          taskId,
+        }),
+      )
+
+      store.dispatch(pendingTxsSlice.actions.setRelayTxHash({ txId, txHash: newTxHash }))
+
+      const state = store.getState()
+      expect((state.pendingTxs[txId] as { txHash?: string }).txHash).toBe(newTxHash)
+    })
+
+    it('should not update txHash for PK transaction', () => {
+      const store = createTestStore()
+      const txId = generateTxId()
+      const txHash = generateTxHash()
+      const walletAddress = generateAddress()
+      const safeAddress = generateAddress()
+      const newTxHash = generateTxHash()
+
+      store.dispatch(
+        addPendingTx({
+          txId,
+          type: ExecutionMethod.WITH_PK,
+          chainId: '1',
+          safeAddress,
+          txHash,
+          walletAddress,
+          walletNonce: 5,
+        }),
+      )
+
+      store.dispatch(pendingTxsSlice.actions.setRelayTxHash({ txId, txHash: newTxHash }))
+
+      const state = store.getState()
+      expect((state.pendingTxs[txId] as { txHash: string }).txHash).toBe(txHash)
+    })
+  })
+
+  describe('clearAllPendingTxs action', () => {
+    it('should clear all pending transactions', () => {
+      const store = createTestStore()
+
+      store.dispatch(
+        addPendingTx({
+          txId: generateTxId(),
+          type: ExecutionMethod.WITH_PK,
+          chainId: '1',
+          safeAddress: generateAddress(),
+          txHash: generateTxHash(),
+          walletAddress: generateAddress(),
+          walletNonce: 1,
+        }),
+      )
+
+      store.dispatch(
+        addPendingTx({
+          txId: generateTxId(),
+          type: ExecutionMethod.WITH_RELAY,
+          chainId: '1',
+          safeAddress: generateAddress(),
+          taskId: generateTaskId(),
+        }),
+      )
+
+      expect(Object.keys(store.getState().pendingTxs).length).toBe(2)
+
+      store.dispatch(pendingTxsSlice.actions.clearAllPendingTxs())
+
+      expect(Object.keys(store.getState().pendingTxs).length).toBe(0)
+    })
+  })
+})

--- a/apps/mobile/src/tests/jest.setup.tsx
+++ b/apps/mobile/src/tests/jest.setup.tsx
@@ -25,37 +25,23 @@ jest.mock('@/src/navigation/useScrollableHeader', () => ({
   }),
 }))
 
-jest.mock('react-native-mmkv', () => ({
-  MMKV: function () {
-    // @ts-ignore
-    this.getString = jest.fn()
-    // @ts-ignore
-    this.delete = jest.fn()
-    // @ts-ignore
-    this.set = jest.fn()
-  },
+jest.mock('react-native-device-info', () => mockRNDeviceInfo)
+jest.mock('react-native-device-crypto', () => ({
+  getOrCreateAsymmetricKey: jest.fn(),
+  getOrCreateSymmetricKey: jest.fn(),
+  encrypt: jest.fn(),
+  decrypt: jest.fn(),
+  deleteKey: jest.fn(),
 }))
 
-jest.mock('react-native-device-info', () => mockRNDeviceInfo)
-jest.mock('react-native-device-crypto', () => {
-  return {
-    getOrCreateAsymmetricKey: jest.fn(),
-    encrypt: jest.fn((_asymmetricKey: string, privateKey: string) => {
-      return Promise.resolve({
-        encryptedText: 'encryptedText',
-        iv: privateKey + '000',
-      })
-    }),
-    decrypt: jest.fn((_name, _password, iv) => Promise.resolve(iv.slice(0, -3))),
-  }
-})
-
 jest.mock('react-native-keychain', () => {
+  const actual = jest.requireActual('react-native-keychain')
   let password: string | null = null
   return {
+    ...actual,
+    getSupportedBiometryType: jest.fn(),
     setGenericPassword: jest.fn((_user, newPassword: string) => {
       password = newPassword
-
       return Promise.resolve(password)
     }),
     getGenericPassword: jest.fn(() =>
@@ -67,12 +53,6 @@ jest.mock('react-native-keychain', () => {
       password = null
       Promise.resolve(null)
     }),
-    ACCESS_CONTROL: {
-      BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE: 'BIOMETRY_CURRENT_SET_OR_DEVICE_PASSCODE',
-    },
-    ACCESSIBLE: {
-      WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
-    },
   }
 })
 
@@ -121,34 +101,7 @@ jest.mock('@react-native-firebase/messaging', () => {
   return module
 })
 
-jest.mock('@notifee/react-native', () => {
-  const notifee = {
-    getInitialNotification: jest.fn().mockResolvedValue(null),
-    displayNotification: jest.fn().mockResolvedValue({}),
-    onForegroundEvent: jest.fn().mockReturnValue(jest.fn()),
-    onBackgroundEvent: jest.fn(),
-    createChannelGroup: jest.fn().mockResolvedValue('channel-group-id'),
-    createChannel: jest.fn().mockResolvedValue({}),
-  }
-
-  return {
-    ...jest.requireActual('@notifee/react-native/dist/types/Notification'),
-    __esModule: true,
-    default: notifee,
-    AndroidImportance: {
-      NONE: 0,
-      MIN: 1,
-      LOW: 2,
-      DEFAULT: 3,
-      HIGH: 4,
-    },
-    AndroidVisibility: {
-      SECRET: -1,
-      PRIVATE: 0,
-      PUBLIC: 1,
-    },
-  }
-})
+jest.mock('@notifee/react-native', () => require('@notifee/react-native/jest-mock'))
 
 jest.mock('@gorhom/bottom-sheet', () => {
   const reactNative = jest.requireActual('react-native')

--- a/apps/mobile/src/tests/mocks.ts
+++ b/apps/mobile/src/tests/mocks.ts
@@ -19,7 +19,7 @@ import {
   AddressInfo,
   Transaction,
 } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
-import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { createMockChain as createSharedMockChain } from '@safe-global/test'
 
 export const mockBalanceData = {
   items: [
@@ -36,53 +36,7 @@ export const mockBalanceData = {
   ],
 }
 
-export const mockChain: Chain = {
-  chainId: '1',
-  chainName: 'Ethereum',
-  shortName: 'eth',
-  description: 'Ethereum Mainnet',
-  l2: false,
-  isTestnet: false,
-  nativeCurrency: {
-    name: 'Ether',
-    symbol: 'ETH',
-    decimals: 18,
-    logoUri: '',
-  },
-  blockExplorerUriTemplate: {
-    address: 'https://etherscan.io/address/{{address}}',
-    txHash: 'https://etherscan.io/tx/{{txHash}}',
-    api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
-  },
-  transactionService: 'https://safe-transaction-mainnet.safe.global',
-  chainLogoUri: '',
-  theme: {
-    textColor: '#001428',
-    backgroundColor: '#E8E7E6',
-  },
-  rpcUri: {
-    authentication: 'NO_AUTHENTICATION',
-    value: 'https://eth.llamarpc.com',
-  },
-  safeAppsRpcUri: {
-    authentication: 'NO_AUTHENTICATION',
-    value: 'https://eth.llamarpc.com',
-  },
-  publicRpcUri: {
-    authentication: 'NO_AUTHENTICATION',
-    value: 'https://eth.llamarpc.com',
-  },
-  features: [],
-  gasPrice: [],
-  ensRegistryAddress: '',
-  disabledWallets: [],
-  contractAddresses: {},
-  balancesProvider: '',
-  beaconChainExplorerUriTemplate: {
-    address: '',
-    api: '',
-  },
-} as unknown as Chain
+export const mockChain = createSharedMockChain()
 
 export const mockNFTData = {
   count: 2,

--- a/apps/mobile/src/utils/swapOrderUtils.test.tsx
+++ b/apps/mobile/src/utils/swapOrderUtils.test.tsx
@@ -1,0 +1,436 @@
+import { faker } from '@faker-js/faker'
+import {
+  priceRow,
+  statusRow,
+  expiryRow,
+  orderIdRow,
+  networkRow,
+  slippageRow,
+  widgetFeeRow,
+  totalFeesRow,
+  numberOfPartsRow,
+  partSellAmountRow,
+  partBuyAmountRow,
+  formatSwapOrderItemsForConfirmation,
+  formatSwapOrderItemsForHistory,
+  formatTwapOrderItemsForHistory,
+  formatTwapOrderItemsForConfirmation,
+} from './swapOrderUtils'
+import { OrderTransactionInfo, StartTimeValue } from '@safe-global/store/gateway/types'
+import { TwapOrderTransactionInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { generateAddress, createMockChain } from '@safe-global/test'
+
+type LabelValueItem = {
+  label: string | React.ReactNode
+  value?: string
+}
+
+jest.mock('@/src/features/ConfirmTx/components/confirmation-views/SwapOrder/StatusLabel', () => ({
+  __esModule: true,
+  default: ({ status }: { status: string }) => `StatusLabel: ${status}`,
+}))
+
+const createMockToken = (overrides?: Partial<OrderTransactionInfo['sellToken']>) => ({
+  address: generateAddress(),
+  decimals: 18,
+  logoUri: faker.image.url(),
+  name: faker.finance.currencyName(),
+  symbol: faker.finance.currencyCode(),
+  trusted: true,
+  ...overrides,
+})
+
+const createMockOrder = (overrides?: Record<string, unknown>): OrderTransactionInfo =>
+  ({
+    type: 'SwapOrder',
+    status: 'open',
+    uid: faker.string.uuid(),
+    kind: 'sell',
+    sellToken: createMockToken({ symbol: 'ETH', decimals: 18 }),
+    buyToken: createMockToken({ symbol: 'USDC', decimals: 6 }),
+    sellAmount: '1000000000000000000',
+    buyAmount: '2000000000',
+    executedSellAmount: '0',
+    executedBuyAmount: '0',
+    validUntil: Math.floor(Date.now() / 1000) + 3600,
+    explorerUrl: 'https://explorer.cow.fi/orders/test',
+    orderClass: 'market',
+    executedFee: '0',
+    executedFeeToken: createMockToken({ symbol: 'ETH', decimals: 18 }),
+    humanDescription: null,
+    receiver: generateAddress(),
+    owner: generateAddress(),
+    fullAppData: null,
+    ...overrides,
+  }) as OrderTransactionInfo
+
+describe('swapOrderUtils', () => {
+  describe('priceRow', () => {
+    it('returns execution price for fulfilled orders', () => {
+      const order = createMockOrder({
+        status: 'fulfilled',
+        sellAmount: '1000000000000000000',
+        buyAmount: '2000000000',
+        executedSellAmount: '1000000000000000000',
+        executedBuyAmount: '2100000000',
+      })
+
+      const result = priceRow(order)
+
+      expect(result.label).toBe('Execution price')
+      expect(result.value).toContain('1 USDC =')
+      expect(result.value).toContain('ETH')
+    })
+
+    it('returns limit price for non-fulfilled orders', () => {
+      const order = createMockOrder({ status: 'open' })
+
+      const result = priceRow(order)
+
+      expect(result.label).toBe('Limit price')
+      expect(result.value).toContain('1 USDC =')
+    })
+
+    it('returns limit price for cancelled orders', () => {
+      const order = createMockOrder({ status: 'cancelled' })
+
+      const result = priceRow(order)
+
+      expect(result.label).toBe('Limit price')
+    })
+  })
+
+  describe('statusRow', () => {
+    it('returns status row with correct label', () => {
+      const order = createMockOrder({ status: 'open' })
+
+      const result = statusRow(order)
+
+      expect(result.label).toBe('Status')
+      expect(result.render).toBeDefined()
+    })
+
+    it('shows partiallyFilled status when order is partially filled', () => {
+      const order = createMockOrder({
+        status: 'open',
+        executedSellAmount: '500000000000000000',
+        sellAmount: '1000000000000000000',
+      })
+
+      const result = statusRow(order)
+
+      expect(result.label).toBe('Status')
+    })
+  })
+
+  describe('expiryRow', () => {
+    it('returns formatted expiry date', () => {
+      const validUntil = Math.floor(new Date('2025-12-25T14:30:00Z').getTime() / 1000)
+      const order = createMockOrder({ validUntil })
+
+      const result = expiryRow(order)
+
+      expect(result.label).toBe('Expiry')
+      expect(result.value).toMatch(/\d{2}\/\d{2}\/\d{4}, \d{2}:\d{2}/)
+    })
+  })
+
+  describe('orderIdRow', () => {
+    it('returns order ID row with uid', () => {
+      const uid = 'order-123-abc-456'
+      const order = createMockOrder({ uid })
+
+      const result = orderIdRow(order)
+
+      expect(result).not.toBeNull()
+      expect(result?.label).toBe('Order ID')
+      expect(result?.render).toBeDefined()
+    })
+
+    it('returns null for orders without uid', () => {
+      const order = createMockOrder()
+      delete (order as Record<string, unknown>).uid
+
+      const result = orderIdRow(order as OrderTransactionInfo)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('networkRow', () => {
+    it('returns network row with chain info', () => {
+      const chain = createMockChain({ chainName: 'Polygon' })
+
+      const result = networkRow(chain)
+
+      expect(result.label).toBe('Network')
+      expect(result.render).toBeDefined()
+    })
+  })
+
+  describe('slippageRow', () => {
+    it('returns null for limit orders', () => {
+      const order = createMockOrder({
+        fullAppData: {
+          appCode: 'safe',
+          metadata: {
+            orderClass: { orderClass: 'limit' },
+          },
+        },
+      })
+
+      const result = slippageRow(order)
+
+      expect(result).toBeNull()
+    })
+
+    it('returns slippage percentage for market orders', () => {
+      const order = createMockOrder({
+        fullAppData: {
+          appCode: 'safe',
+          metadata: {
+            orderClass: { orderClass: 'market' },
+          },
+        },
+      })
+
+      const result = slippageRow(order)
+
+      expect(result).not.toBeNull()
+      expect(result?.label).toBe('Slippage')
+      expect(result?.value).toContain('%')
+    })
+  })
+
+  describe('widgetFeeRow', () => {
+    it('returns widget fee percentage', () => {
+      const order = createMockOrder({
+        fullAppData: {
+          appCode: 'safe',
+          metadata: {
+            partnerFee: { bps: 50, recipient: faker.finance.ethereumAddress() },
+          },
+        },
+      })
+
+      const result = widgetFeeRow(order)
+
+      expect(result.label).toBe('Widget fee')
+      expect(result.value).toContain('%')
+    })
+
+    it('returns 0% when no partner fee metadata', () => {
+      const order = createMockOrder({ fullAppData: null })
+
+      const result = widgetFeeRow(order)
+
+      expect(result.value).toBe('0 %')
+    })
+  })
+
+  describe('totalFeesRow', () => {
+    it('returns null when no executed fee', () => {
+      const order = createMockOrder({ executedFee: '0' })
+
+      const result = totalFeesRow(order)
+
+      expect(result).toBeNull()
+    })
+
+    it('returns formatted fee with buyToken for sell orders', () => {
+      const order = createMockOrder({
+        kind: 'sell',
+        executedFee: '1000000',
+        executedFeeToken: createMockToken({ symbol: 'USDC', decimals: 6 }),
+      })
+
+      const result = totalFeesRow(order)
+
+      expect(result).not.toBeNull()
+      expect(result?.label).toBe('Total fees')
+    })
+
+    it('returns formatted fee with sellToken for buy orders', () => {
+      const order = createMockOrder({
+        kind: 'buy',
+        executedFee: '1000000000000000',
+        executedFeeToken: createMockToken({ symbol: 'ETH', decimals: 18 }),
+      })
+
+      const result = totalFeesRow(order)
+
+      expect(result).not.toBeNull()
+    })
+
+    it('returns formatted fee when executedFeeToken is TokenInfo object', () => {
+      const feeToken = createMockToken({ symbol: 'DAI', decimals: 18 })
+      const order = createMockOrder({
+        executedFee: '1000000000000000000',
+        executedFeeToken: feeToken,
+      })
+
+      const result = totalFeesRow(order)
+
+      expect(result).not.toBeNull()
+      expect(result?.value).toContain('DAI')
+    })
+  })
+
+  describe('numberOfPartsRow', () => {
+    it('returns number of parts', () => {
+      const order = { numberOfParts: '5' }
+
+      const result = numberOfPartsRow(order)
+
+      expect(result.label).toBe('No of parts')
+      expect(result.value).toBe('5')
+    })
+  })
+
+  describe('partSellAmountRow', () => {
+    it('returns formatted sell amount per part', () => {
+      const order = {
+        partSellAmount: '500000000000000000',
+        sellToken: { decimals: 18, symbol: 'ETH' },
+      }
+
+      const result = partSellAmountRow(order)
+
+      expect(result.label).toBe('Sell amount')
+      expect(result.value).toContain('ETH per part')
+    })
+  })
+
+  describe('partBuyAmountRow', () => {
+    it('returns formatted buy amount per part', () => {
+      const order = {
+        minPartLimit: '1000000000',
+        buyToken: { decimals: 6, symbol: 'USDC' },
+      }
+
+      const result = partBuyAmountRow(order)
+
+      expect(result.label).toBe('Buy amount')
+      expect(result.value).toContain('USDC per part')
+    })
+  })
+
+  describe('formatSwapOrderItemsForConfirmation', () => {
+    it('returns array of list items for confirmation view', () => {
+      const order = createMockOrder()
+      const chain = createMockChain()
+
+      const result = formatSwapOrderItemsForConfirmation(order, chain) as LabelValueItem[]
+
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.length).toBeGreaterThan(0)
+      expect(result.some((item) => item.label === 'Expiry')).toBe(true)
+      expect(result.some((item) => item.label === 'Network')).toBe(true)
+      expect(result.some((item) => item.label === 'Status')).toBe(true)
+    })
+
+    it('filters out null items', () => {
+      const order = createMockOrder({
+        fullAppData: {
+          appCode: 'safe',
+          metadata: {
+            orderClass: { orderClass: 'limit' },
+          },
+        },
+      })
+      delete (order as Record<string, unknown>).uid
+      const chain = createMockChain()
+
+      const result = formatSwapOrderItemsForConfirmation(order as OrderTransactionInfo, chain)
+
+      expect(result.every((item) => item !== null)).toBe(true)
+    })
+  })
+
+  describe('formatSwapOrderItemsForHistory', () => {
+    it('returns array of list items for history view', () => {
+      const order = createMockOrder()
+      const chain = createMockChain()
+
+      const result = formatSwapOrderItemsForHistory(order, chain) as LabelValueItem[]
+
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.some((item) => item.label === 'Order ID')).toBe(true)
+      expect(result.some((item) => item.label === 'Network')).toBe(true)
+      expect(result.some((item) => item.label === 'Status')).toBe(true)
+    })
+  })
+
+  describe('formatTwapOrderItemsForHistory', () => {
+    it('returns array of list items for TWAP order history', () => {
+      const order = createMockOrder({
+        numberOfParts: '4',
+        partSellAmount: '250000000000000000',
+        minPartLimit: '500000000',
+        timeBetweenParts: 3600,
+      }) as unknown as TwapOrderTransactionInfo
+      const chain = createMockChain()
+
+      const result = formatTwapOrderItemsForHistory(order, chain) as LabelValueItem[]
+
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.some((item) => item.label === 'No of parts')).toBe(true)
+      expect(result.some((item) => item.label === 'Sell amount')).toBe(true)
+      expect(result.some((item) => item.label === 'Buy amount')).toBe(true)
+    })
+  })
+
+  describe('formatTwapOrderItemsForConfirmation', () => {
+    it('returns items with start time "Now" for AT_MINING_TIME', () => {
+      const order = {
+        numberOfParts: '4',
+        partSellAmount: '250000000000000000',
+        minPartLimit: '500000000',
+        timeBetweenParts: '3600',
+        sellToken: { decimals: 18, symbol: 'ETH' },
+        buyToken: { decimals: 6, symbol: 'USDC' },
+        startTime: { startType: StartTimeValue.AT_MINING_TIME },
+      } as unknown as TwapOrderTransactionInfo
+
+      const result = formatTwapOrderItemsForConfirmation(order)
+
+      expect(Array.isArray(result)).toBe(true)
+      const startTimeItem = result.find((item) => item.label === 'Start time')
+      expect(startTimeItem?.value).toBe('Now')
+    })
+
+    it('returns items with epoch block number for AT_EPOCH', () => {
+      const order = {
+        numberOfParts: '4',
+        partSellAmount: '250000000000000000',
+        minPartLimit: '500000000',
+        timeBetweenParts: '3600',
+        sellToken: { decimals: 18, symbol: 'ETH' },
+        buyToken: { decimals: 6, symbol: 'USDC' },
+        startTime: { startType: StartTimeValue.AT_EPOCH, epoch: 12345678 },
+      } as unknown as TwapOrderTransactionInfo
+
+      const result = formatTwapOrderItemsForConfirmation(order)
+
+      const startTimeItem = result.find((item) => item.label === 'Start time')
+      expect(startTimeItem?.value).toContain('12345678')
+    })
+
+    it('includes part duration and total duration', () => {
+      const order = {
+        numberOfParts: '4',
+        partSellAmount: '250000000000000000',
+        minPartLimit: '500000000',
+        timeBetweenParts: '3600',
+        sellToken: { decimals: 18, symbol: 'ETH' },
+        buyToken: { decimals: 6, symbol: 'USDC' },
+        startTime: { startType: StartTimeValue.AT_MINING_TIME },
+      } as unknown as TwapOrderTransactionInfo
+
+      const result = formatTwapOrderItemsForConfirmation(order)
+
+      expect(result.some((item) => item.label === 'Part duration')).toBe(true)
+      expect(result.some((item) => item.label === 'Total duration')).toBe(true)
+    })
+  })
+})

--- a/config/test/factories/addresses.ts
+++ b/config/test/factories/addresses.ts
@@ -1,0 +1,36 @@
+import { faker } from '@faker-js/faker'
+import { getAddress } from 'ethers'
+
+export const generateAddress = (): string => {
+  return faker.finance.ethereumAddress()
+}
+
+export const generateChecksummedAddress = (): `0x${string}` => {
+  return getAddress(faker.finance.ethereumAddress()) as `0x${string}`
+}
+
+export const generatePrivateKey = (): string => {
+  return faker.string.hexadecimal({ length: 64, prefix: '0x' })
+}
+
+export const generateTxHash = (): string => {
+  return `0x${faker.string.hexadecimal({ length: 64, prefix: '' })}`
+}
+
+export const generateSafeTxHash = (): string => {
+  return `0x${faker.string.hexadecimal({ length: 64, prefix: '' })}`
+}
+
+export const generateSignature = (): string => {
+  return faker.string.hexadecimal({ length: 130, prefix: '0x' })
+}
+
+export const generateTaskId = (): string => {
+  return faker.string.uuid()
+}
+
+export const generateTxId = (): string => {
+  return faker.string.uuid()
+}
+
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as const

--- a/config/test/factories/chains.ts
+++ b/config/test/factories/chains.ts
@@ -1,0 +1,93 @@
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+
+export interface MockChainOptions {
+  chainId?: string
+  chainName?: string
+  shortName?: string
+  l2?: boolean
+  isTestnet?: boolean
+  nativeCurrency?: Partial<Chain['nativeCurrency']>
+  rpcUri?: string
+}
+
+export const createMockChain = (options: MockChainOptions = {}): Chain => {
+  const chainId = options.chainId ?? '1'
+  const chainName = options.chainName ?? 'Ethereum'
+  const shortName = options.shortName ?? 'eth'
+  const rpcUri = options.rpcUri ?? 'https://eth.llamarpc.com'
+
+  return {
+    chainId,
+    chainName,
+    shortName,
+    description: `${chainName} Mainnet`,
+    l2: options.l2 ?? false,
+    isTestnet: options.isTestnet ?? false,
+    zk: false,
+    nativeCurrency: {
+      name: options.nativeCurrency?.name ?? 'Ether',
+      symbol: options.nativeCurrency?.symbol ?? 'ETH',
+      decimals: options.nativeCurrency?.decimals ?? 18,
+      logoUri: options.nativeCurrency?.logoUri ?? '',
+    },
+    blockExplorerUriTemplate: {
+      address: `https://etherscan.io/address/{{address}}`,
+      txHash: `https://etherscan.io/tx/{{txHash}}`,
+      api: 'https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}',
+    },
+    transactionService: `https://safe-transaction-${shortName}.safe.global`,
+    chainLogoUri: '',
+    theme: {
+      textColor: '#001428',
+      backgroundColor: '#E8E7E6',
+    },
+    rpcUri: {
+      authentication: 'NO_AUTHENTICATION',
+      value: rpcUri,
+    },
+    safeAppsRpcUri: {
+      authentication: 'NO_AUTHENTICATION',
+      value: rpcUri,
+    },
+    publicRpcUri: {
+      authentication: 'NO_AUTHENTICATION',
+      value: rpcUri,
+    },
+    features: [],
+    gasPrice: [],
+    ensRegistryAddress: '',
+    disabledWallets: [],
+    contractAddresses: {},
+    balancesProvider: {
+      chainName: shortName,
+      enabled: true,
+    },
+    beaconChainExplorerUriTemplate: {
+      address: '',
+      api: '',
+    },
+  } as Chain
+}
+
+export const ETHEREUM_CHAIN = createMockChain()
+
+export const POLYGON_CHAIN = createMockChain({
+  chainId: '137',
+  chainName: 'Polygon',
+  shortName: 'matic',
+  l2: true,
+  nativeCurrency: {
+    name: 'MATIC',
+    symbol: 'MATIC',
+    decimals: 18,
+  },
+  rpcUri: 'https://polygon-rpc.com',
+})
+
+export const ARBITRUM_CHAIN = createMockChain({
+  chainId: '42161',
+  chainName: 'Arbitrum One',
+  shortName: 'arb1',
+  l2: true,
+  rpcUri: 'https://arbitrum-one.publicnode.com',
+})

--- a/config/test/factories/index.ts
+++ b/config/test/factories/index.ts
@@ -1,0 +1,6 @@
+export * from './addresses'
+export * from './safeTx'
+export * from './protocolKit'
+export * from './chains'
+export * from './provider'
+export * from './safeInfo'

--- a/config/test/factories/protocolKit.ts
+++ b/config/test/factories/protocolKit.ts
@@ -1,0 +1,29 @@
+import { generateChecksummedAddress, generateTxHash } from './addresses'
+
+export interface MockProtocolKitOptions {
+  address?: string
+  threshold?: number
+  owners?: string[]
+  nonce?: number
+  version?: string
+}
+
+export const createMockProtocolKit = (options: MockProtocolKitOptions = {}) => ({
+  createTransaction: jest.fn(),
+  signTransaction: jest.fn(),
+  executeTransaction: jest.fn(),
+  getTransactionHash: jest.fn().mockResolvedValue(generateTxHash()),
+  getThreshold: jest.fn().mockResolvedValue(options.threshold ?? 1),
+  getOwners: jest.fn().mockResolvedValue(options.owners ?? [generateChecksummedAddress()]),
+  getOwnersWhoApprovedTx: jest.fn().mockResolvedValue([]),
+  getEncodedTransaction: jest.fn().mockResolvedValue('0x'),
+  getAddress: jest.fn().mockResolvedValue(options.address ?? generateChecksummedAddress()),
+  getNonce: jest.fn().mockResolvedValue(options.nonce ?? 0),
+  getContractVersion: jest.fn().mockResolvedValue(options.version ?? '1.3.0'),
+})
+
+export type MockProtocolKit = ReturnType<typeof createMockProtocolKit>
+
+export const createMockSafeSDK = (options: MockProtocolKitOptions = {}) => {
+  return createMockProtocolKit(options)
+}

--- a/config/test/factories/provider.ts
+++ b/config/test/factories/provider.ts
@@ -1,0 +1,41 @@
+import { generateTxHash } from './addresses'
+
+export interface MockProviderOptions {
+  chainId?: bigint | string
+  rpcUrl?: string
+  blockNumber?: number
+  gasPrice?: bigint
+  maxFeePerGas?: bigint
+  maxPriorityFeePerGas?: bigint
+  nonce?: number
+  gasLimit?: bigint
+}
+
+export const createMockProvider = (options: MockProviderOptions = {}) => {
+  const chainId = typeof options.chainId === 'string' ? BigInt(options.chainId) : options.chainId ?? BigInt(1)
+  const rpcUrl = options.rpcUrl ?? 'https://rpc.example.com'
+
+  return {
+    getNetwork: jest.fn().mockResolvedValue({ chainId }),
+    _getConnection: jest.fn().mockReturnValue({ url: rpcUrl }),
+    getBlockNumber: jest.fn().mockResolvedValue(options.blockNumber ?? 12345678),
+    getTransactionCount: jest.fn().mockResolvedValue(options.nonce ?? 0),
+    getFeeData: jest.fn().mockResolvedValue({
+      gasPrice: options.gasPrice ?? BigInt('1000000000'),
+      maxFeePerGas: options.maxFeePerGas ?? BigInt('2000000000'),
+      maxPriorityFeePerGas: options.maxPriorityFeePerGas ?? BigInt('1000000000'),
+    }),
+    estimateGas: jest.fn().mockResolvedValue(options.gasLimit ?? BigInt('21000')),
+    broadcastTransaction: jest.fn().mockResolvedValue({ hash: generateTxHash() }),
+    getTransaction: jest.fn().mockResolvedValue(null),
+    getTransactionReceipt: jest.fn().mockResolvedValue(null),
+    call: jest.fn().mockResolvedValue('0x'),
+    send: jest.fn().mockResolvedValue('0x'),
+  }
+}
+
+export type MockProvider = ReturnType<typeof createMockProvider>
+
+export const createMockWeb3ReadOnly = (options: MockProviderOptions = {}) => {
+  return createMockProvider(options)
+}

--- a/config/test/factories/safeInfo.ts
+++ b/config/test/factories/safeInfo.ts
@@ -1,0 +1,45 @@
+import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { generateChecksummedAddress } from './addresses'
+
+export interface SafeInfo {
+  address: `0x${string}`
+  chainId: string
+}
+
+export interface MockSafeInfoOptions {
+  address?: `0x${string}`
+  chainId?: string
+}
+
+export const createMockSafeInfo = (options: MockSafeInfoOptions = {}): SafeInfo => ({
+  address: options.address ?? generateChecksummedAddress(),
+  chainId: options.chainId ?? '1',
+})
+
+export interface MockSafeStateOptions {
+  address?: string
+  chainId?: string
+  nonce?: number
+  threshold?: number
+  owners?: string[]
+  version?: string | null
+  implementationVersionState?: 'UP_TO_DATE' | 'OUTDATED' | 'UNKNOWN'
+}
+
+export const createMockSafeState = (options: MockSafeStateOptions = {}): SafeState => {
+  const address = options.address ?? generateChecksummedAddress()
+  const owners = options.owners ?? [generateChecksummedAddress()]
+
+  const version = 'version' in options ? options.version : '1.3.0'
+
+  return {
+    address: { value: address, name: null, logoUri: null },
+    chainId: options.chainId ?? '1',
+    nonce: options.nonce ?? 0,
+    threshold: options.threshold ?? 1,
+    owners: owners.map((owner) => ({ value: owner, name: null, logoUri: null })),
+    implementation: { value: generateChecksummedAddress(), name: null, logoUri: null },
+    version,
+    implementationVersionState: options.implementationVersionState ?? 'UP_TO_DATE',
+  } as SafeState
+}

--- a/config/test/factories/safeTx.ts
+++ b/config/test/factories/safeTx.ts
@@ -1,0 +1,54 @@
+import type { SafeTransaction, SafeSignature, SafeTransactionData } from '@safe-global/types-kit'
+import { generateChecksummedAddress, ZERO_ADDRESS } from './addresses'
+
+export interface MockSafeTxOptions {
+  to?: string
+  value?: string
+  data?: string
+  operation?: number
+  safeTxGas?: string
+  baseGas?: string
+  gasPrice?: string
+  gasToken?: string
+  refundReceiver?: string
+  nonce?: number
+  signatures?: Map<string, SafeSignature>
+}
+
+export const createMockSafeTx = (options: MockSafeTxOptions = {}): SafeTransaction => {
+  const signatures = options.signatures ?? new Map<string, SafeSignature>()
+
+  const txData: SafeTransactionData = {
+    to: options.to ?? generateChecksummedAddress(),
+    value: options.value ?? '0',
+    data: options.data ?? '0x',
+    operation: options.operation ?? 0,
+    safeTxGas: options.safeTxGas ?? '0',
+    baseGas: options.baseGas ?? '0',
+    gasPrice: options.gasPrice ?? '0',
+    gasToken: options.gasToken ?? ZERO_ADDRESS,
+    refundReceiver: options.refundReceiver ?? ZERO_ADDRESS,
+    nonce: options.nonce ?? 0,
+  }
+
+  return {
+    data: txData,
+    signatures,
+    addSignature: jest.fn((sig: SafeSignature) => {
+      signatures.set(sig.signer, sig)
+    }),
+    getSignature: jest.fn((signer: string) => signatures.get(signer)),
+    encodedSignatures: jest.fn(() => '0x'),
+  } as unknown as SafeTransaction
+}
+
+export const createMockSafeTxWithSigner = (
+  signerAddress: string,
+  signatureData: string,
+  options: MockSafeTxOptions = {},
+): SafeTransaction => {
+  const signatures = new Map<string, SafeSignature>()
+  signatures.set(signerAddress, { signer: signerAddress, data: signatureData } as SafeSignature)
+
+  return createMockSafeTx({ ...options, signatures })
+}

--- a/config/test/index.ts
+++ b/config/test/index.ts
@@ -1,0 +1,3 @@
+export * from './factories'
+export * from './msw/handlers'
+export * from './msw/mockSafeApps'

--- a/config/test/package.json
+++ b/config/test/package.json
@@ -1,13 +1,20 @@
 {
   "name": "@safe-global/test",
   "version": "0.0.0",
+  "main": "index.ts",
   "dependencies": {
+    "@faker-js/faker": "^9.2.0",
     "@safe-global/store": "workspace:^",
+    "@safe-global/types-kit": "^1.0.0",
+    "ethers": "^6.13.4",
     "jest": "^29.7.0",
     "ts-jest": "29.2.5"
   },
   "devDependencies": {
     "jest-transform-stub": "2.0.0"
+  },
+  "peerDependencies": {
+    "msw": "^2.6.0"
   },
   "license": "MIT",
   "private": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -5284,6 +5284,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@faker-js/faker@npm:^9.2.0":
+  version: 9.9.0
+  resolution: "@faker-js/faker@npm:9.9.0"
+  checksum: 10/b24b1be0fb3090d54abaaa3a814f37d1a7551f1207dcd330a1af2c70f6312a8b95ebb82653577757dd62f4cbbb56caa3c83513053253654dc3e286a05040ecbe
+  languageName: node
+  linkType: hard
+
 "@figspec/components@npm:^1.0.1":
   version: 1.0.3
   resolution: "@figspec/components@npm:1.0.3"
@@ -10349,10 +10356,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@safe-global/test@workspace:config/test"
   dependencies:
+    "@faker-js/faker": "npm:^9.2.0"
     "@safe-global/store": "workspace:^"
+    "@safe-global/types-kit": "npm:^1.0.0"
+    ethers: "npm:^6.13.4"
     jest: "npm:^29.7.0"
     jest-transform-stub: "npm:2.0.0"
     ts-jest: "npm:29.2.5"
+  peerDependencies:
+    msw: ^2.6.0
   languageName: unknown
   linkType: soft
 
@@ -10362,7 +10374,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@safe-global/types-kit@npm:^1.0.1, @safe-global/types-kit@npm:^1.0.5":
+"@safe-global/types-kit@npm:^1.0.0, @safe-global/types-kit@npm:^1.0.1, @safe-global/types-kit@npm:^1.0.5":
   version: 1.0.5
   resolution: "@safe-global/types-kit@npm:1.0.5"
   dependencies:
@@ -21207,6 +21219,21 @@ __metadata:
     tslib: "npm:2.7.0"
     ws: "npm:8.17.1"
   checksum: 10/ce68b962f117fd651090bd8096fde708428ce23f0d044c365bc8cbf2e8f3cb70e1661ff0194364848ccac06d607d4a977f2a0c9e370b9712809c0ca6c36131f9
+  languageName: node
+  linkType: hard
+
+"ethers@npm:^6.13.4":
+  version: 6.15.0
+  resolution: "ethers@npm:6.15.0"
+  dependencies:
+    "@adraffy/ens-normalize": "npm:1.10.1"
+    "@noble/curves": "npm:1.2.0"
+    "@noble/hashes": "npm:1.3.2"
+    "@types/node": "npm:22.7.5"
+    aes-js: "npm:4.0.0-beta.5"
+    tslib: "npm:2.7.0"
+    ws: "npm:8.17.1"
+  checksum: 10/21ab1d31e1b89f62dce5611c3686e4b81e000107aff8dccdbeaa1eac2da43459d5b590efa127470208729ca99a3b5757dd690943cf60745c2393d13db6a3218a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves
Ads unit tests to hooks, services and utils files increasing code coverage.


---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds broad unit tests across mobile hooks, services, utils, and tx flows, plus a shared test helpers package and updated test setup.
> 
> - **Mobile tests**:
>   - Hooks: `useImportSafe`, `useGasFee`, `useFeeParams`, `useMakeSafesWithChainId`, `useBiometrics`, core SDK init (`safeCoreSDK`, `useInitSafeCoreSDK`).
>   - Features/Utils: Address book schema/actions, advanced details value formatters, history header, swap order utilities, web3 helpers.
>   - Services: Key storage, notifications (service, parser, dedup), Ledger (DMK, Ethereum, execution, safe-signing), tx extraction/sender (`create`, `execute`, `sign`), tx execution (PK, relay).
>   - Store: Pending txs middleware listeners.
> - **Testing infrastructure**:
>   - New shared package `config/test` -> `@safe-global/test` with factories (`addresses`, `chains`, `provider`, `protocolKit`, `safeInfo`, `safeTx`) and exports.
>   - Jest setup expanded: mocks for device crypto, keychain, notifee, RN libs; MSW server hooks.
>   - Yarn lock updated for new dev deps.
> - **Docs**:
>   - `AGENTS.md`: clarifies workflow, adds mobile commands and testing guidelines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86f96ac8847fc9b3f80d23de9149466edf6b59f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->