### PR TITLE
fix(tx flow): no misleading confirmation section in the tx flow

### DIFF
--- a/apps/mobile/src/features/SafeShield/components/AnalysisLabel/AnalysisLabel.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisLabel/AnalysisLabel.tsx
@@ -19,7 +19,7 @@ export function AnalysisLabel({ label, severity, highlighted }: AnalysisLabelPro
         <SafeFontIcon
           testID={`${iconName}-icon`}
           name={iconName}
-          color={highlighted ? '$icon' : '$colorLight'}
+          color={highlighted ? '$icon' : '$borderMain'}
           size={16}
         />
 

--- a/apps/mobile/src/features/SafeShield/components/TransactionSimulation/TransactionSimulation.tsx
+++ b/apps/mobile/src/features/SafeShield/components/TransactionSimulation/TransactionSimulation.tsx
@@ -57,7 +57,7 @@ export function TransactionSimulation({
           <SafeFontIcon
             testID={`transaction-simulation-icon`}
             name={iconName}
-            color={highlighted ? '$icon' : '$colorLight'}
+            color={highlighted ? '$icon' : '$borderMain'}
             size={16}
           />
 

--- a/apps/web/src/features/hypernative/hooks/useTrackBannerEligibilityOnConnect.ts
+++ b/apps/web/src/features/hypernative/hooks/useTrackBannerEligibilityOnConnect.ts
@@ -31,7 +31,7 @@ export const useTrackBannerEligibilityOnConnect = (
   const dispatch = useAppDispatch()
   const store = useStore()
   const chainId = useChainId()
-  const { safeAddress, safeLoaded, safeLoading } = useSafeInfo()
+  const { safeAddress, safeLoaded, safeLoading, safe } = useSafeInfo()
   const safeHnState = useAppSelector((state) => selectSafeHnState(state, chainId, safeAddress))
 
   // Use ref to track if we've already initiated tracking for this Safe (prevents race condition)
@@ -59,6 +59,11 @@ export const useTrackBannerEligibilityOnConnect = (
     // - TxReportButton: shows even when guard is already installed
     // - Pending: only appears after promo banner was viewed (which already triggered tracking)
     if (bannerType === BannerType.TxReportButton || bannerType === BannerType.Pending) {
+      return
+    }
+
+    // Dashboard banner on the FirstSteps page: Only when banner is visible (for undeployed Safes)
+    if (bannerType === BannerType.NoBalanceCheck && safe?.deployed) {
       return
     }
 
@@ -124,5 +129,6 @@ export const useTrackBannerEligibilityOnConnect = (
     dispatch,
     bannerType,
     store,
+    safe.deployed,
   ])
 }


### PR DESCRIPTION
## What it solves

Removes confusing "Confirm" section and "You're about to..." messaging from the transaction review step, as users are reviewing details at this stage, not confirming or executing yet.

Resolves: [COR-804](https://linear.app/safe-global/issue/COR-804/remove-youre-about-to-section-completely)

## How this PR fixes it

Removes the `ConfirmationTitle` component from `ReviewTransactionContent.tsx`. This component displayed "Confirm" heading and "You're about to..." text, which was misleading since the user is still in the review phase. The actual confirmation happens in the next step (`ConfirmTxReceipt`).

## How to test it

1. Navigate to any transaction flow (e.g., Send tokens, Add owner, etc.)
2. Complete the initial form step
3. Verify the review step no longer shows:
   - "Confirm" heading
   - "You're about to..." text
4. Verify the "Continue" button is still present and functional
5. Click "Continue" and verify the final confirmation step (`ConfirmTxReceipt`) still appears correctly

## Screenshots

<img width="1307" height="775" alt="image" src="https://github.com/user-attachments/assets/60b740aa-f925-438a-93e1-287dffcc539b" />

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `ConfirmationTitle` and "You're about to..." from the review screen, updating tests to assert the Continue button and tweaking divider spacing.
> 
> - **Frontend**
>   - `apps/web/src/components/tx/ReviewTransactionV2/ReviewTransactionContent.tsx`:
>     - Remove `ConfirmationTitle` and related `TxFlowContext` props (`willExecute`, `isProposing`).
>     - Add `data-testid="continue-sign-btn"` to the Continue button and adjust `Divider` margins.
> - **Tests**
>   - `apps/web/src/components/tx/ReviewTransactionV2/__tests__/index.test.tsx`:
>     - Replace text assertion with query for `continue-sign-btn`.
>   - `__snapshots__/index.test.tsx.snap`:
>     - Update snapshots to reflect removal of the confirmation section and new divider class.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4506980212abfd61e696cc1c0d94a77420462914. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->