### PR TITLE
fix(ci): checkout merge commit SHA in release workflow

### DIFF
--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Extract version


### PR DESCRIPTION
## Problem

The release workflow `web-tag-release.yml` was failing because it was checking out the wrong commit.

When using `pull_request_target` event, `actions/checkout` without a `ref` parameter checks out the **base branch (main) at the commit when the PR event was created**, not the merged commit.

This caused the workflow to read the old version from `package.json` (1.75.2 instead of 1.76.0), attempting to create an already existing tag.

**Failed run:** https://github.com/safe-global/safe-wallet-monorepo/actions/runs/19856367352

## Solution

Added `ref: \${{ github.event.pull_request.merge_commit_sha }}` to explicitly checkout the merged commit.

## Testing

After merging, the v1.76.0 release will need to be triggered manually via GitHub UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Checkout the PR’s merge_commit_sha in the release workflow to ensure the correct version is tagged and released.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0527d8fbe6d1b42e2cde4055f67d323df0b4457d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->