### PR TITLE
chore: trigger release v1.76.0

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -167,9 +167,7 @@ yarn workspace @safe-global/web cmp MyNewComponent
 
 ## Pre-push hooks
 
-This repo has a pre-push hook that runs the linter (always) and the tests (if the `RUN_TESTS_ON_PUSH` env variable is
-set to true)
-before pushing. If you want to skip the hooks, you can use the `--no-verify` flag.
+This repo has a pre-push hook that runs the linter (always) and the tests (if the `RUN_TESTS_ON_PUSH` env variable is set to true) before pushing. If you want to skip the hooks, you can use the `--no-verify` flag.
 
 ## Frameworks
 


### PR DESCRIPTION
Minimal change to trigger the `web-tag-release.yml` workflow after fixing the checkout issue in #6767.

When merged, this will create the v1.76.0 tag and complete the release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reflows the pre-push hooks description in `apps/web/README.md` into a single concise line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c78c9ef28bf715b843d4a5ed9404ce3980fbf66c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->