### PR TITLE
fix(web): token icons in tx list

### DIFF
--- a/apps/web/src/components/common/IframeIcon/index.tsx
+++ b/apps/web/src/components/common/IframeIcon/index.tsx
@@ -1,24 +1,18 @@
 import type { ReactElement } from 'react'
 
-const getIframeContent = (
-  url: string,
-  width: number,
-  height: number,
-  borderRadius?: string,
-  fallbackSrc?: string,
-): string => {
+const getIframeContent = (url: string, height: number, borderRadius?: string, fallbackSrc?: string): string => {
   const style = borderRadius ? `border-radius: ${borderRadius};` : ''
   const fallback = fallbackSrc ? encodeURI(fallbackSrc) : ''
   return `
-     <body style="margin: 0; overflow: hidden; display: flex;">
-       <img src="${encodeURI(url)}" alt="Safe App logo" width="${width}" height="${height}" style="${style}" />
-       <script>
-          document.querySelector('img').onerror = (e) => {
-           e.target.onerror = null
-           e.target.src = "${fallback}"
-         }
-       </script>
-     </body>
+    <body style="margin: 0; overflow: hidden; display: flex; align-items: center; justify-content: center;">
+      <img src="${encodeURI(url)}" alt="Safe App logo" height="${height}" width="auto" style="${style}" />
+      <script>
+        document.querySelector('img').onerror = (e) => {
+          e.target.onerror = null
+          e.target.src = "${fallback}"
+        }
+      </script>
+    </body>
   `
 }
 
@@ -40,12 +34,12 @@ const IframeIcon = ({
   return (
     <iframe
       title={alt}
-      srcDoc={getIframeContent(src, width, height, borderRadius, fallbackSrc)}
+      srcDoc={getIframeContent(src, height, borderRadius, fallbackSrc)}
       sandbox="allow-scripts"
       referrerPolicy="strict-origin"
       width={width}
       height={height}
-      style={{ pointerEvents: 'none', border: 0 }}
+      style={{ pointerEvents: 'none', border: 0, display: 'block' }}
       tabIndex={-1}
       loading="lazy"
     />

--- a/apps/web/src/components/common/TokenAmount/index.tsx
+++ b/apps/web/src/components/common/TokenAmount/index.tsx
@@ -47,6 +47,7 @@ const TokenAmount = ({
             fallbackSrc={fallbackSrc}
             size={iconSize}
             chainId={chainId}
+            noRadius
           />
         )}
         <b className={css.tokenText}>

--- a/apps/web/src/components/common/TokenIcon/index.tsx
+++ b/apps/web/src/components/common/TokenIcon/index.tsx
@@ -13,12 +13,14 @@ const TokenIcon = ({
   size = 26,
   fallbackSrc,
   chainId,
+  noRadius,
 }: {
   logoUri?: string
   tokenSymbol?: string | null
   size?: number
   fallbackSrc?: string
   chainId?: string
+  noRadius?: boolean
 }): ReactElement => {
   const src = useMemo(() => {
     return upgradeCoinGeckoThumbToQuality(logoUri || undefined, 'small')
@@ -33,7 +35,7 @@ const TokenIcon = ({
         alt={tokenSymbol ?? ''}
         width={size}
         height={size}
-        borderRadius="100%"
+        borderRadius={noRadius ? undefined : '100%'}
         fallbackSrc={fallback}
       />
       {chainId && (

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -269,17 +269,17 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
                                   referrerpolicy="strict-origin"
                                   sandbox="allow-scripts"
                                   srcdoc="
-     <body style="margin: 0; overflow: hidden; display: flex;">
-       <img src="/images/common/token-placeholder.svg" alt="Safe App logo" width="26" height="26" style="border-radius: 100%;" />
-       <script>
-          document.querySelector('img').onerror = (e) => {
-           e.target.onerror = null
-           e.target.src = "/images/common/token-placeholder.svg"
-         }
-       </script>
-     </body>
+    <body style="margin: 0; overflow: hidden; display: flex; align-items: center; justify-content: center;">
+      <img src="/images/common/token-placeholder.svg" alt="Safe App logo" height="26" width="auto" style="border-radius: 100%;" />
+      <script>
+        document.querySelector('img').onerror = (e) => {
+          e.target.onerror = null
+          e.target.src = "/images/common/token-placeholder.svg"
+        }
+      </script>
+    </body>
   "
-                                  style="pointer-events: none; border: 0px;"
+                                  style="pointer-events: none; border: 0px; display: block;"
                                   tabindex="-1"
                                   title="ETH"
                                   width="26"


### PR DESCRIPTION
## What it solves

Resolves https://linear.app/safe-global/issue/COR-938/token-logos-in-tx-history-iframe-appear-stretched-and-cropped

Non-square token icons were stretched in tx queue/history.

After the fix:

<img width="422" height="275" alt="Screenshot 2025-12-03 at 11 17 56" src="https://github.com/user-attachments/assets/7d6bf7a1-4803-4650-8085-532d8ba41a7a" />
