### PR TITLE
fix(mobile): require cycle in store code

### DIFF
--- a/apps/mobile/src/features/DataImport/helpers/transforms.test.ts
+++ b/apps/mobile/src/features/DataImport/helpers/transforms.test.ts
@@ -10,7 +10,7 @@ import {
   ImportProgressCallback,
 } from './transforms'
 import { addContact, addContacts } from '@/src/store/addressBookSlice'
-import { addSignerWithEffects } from '@/src/store/signersSlice'
+import { addSignerWithEffects } from '@/src/store/signerThunks'
 import { storePrivateKey } from '@/src/hooks/useSign/useSign'
 import { additionalSafesRtkApi } from '@safe-global/store/gateway/safes'
 
@@ -18,7 +18,7 @@ jest.mock('@/src/hooks/useSign/useSign', () => ({
   storePrivateKey: jest.fn(),
 }))
 
-jest.mock('@/src/store/signersSlice', () => ({
+jest.mock('@/src/store/signerThunks', () => ({
   addSignerWithEffects: jest.fn(),
 }))
 

--- a/apps/mobile/src/features/DataImport/helpers/transforms.ts
+++ b/apps/mobile/src/features/DataImport/helpers/transforms.ts
@@ -25,13 +25,11 @@ export interface LegacyDataStructure {
 
 import { AppDispatch } from '@/src/store'
 import { addSafe as _addSafe } from '@/src/store/safesSlice'
-import { addSignerWithEffects as _addSignerWithEffects } from '@/src/store/signersSlice'
+import { addSignerWithEffects } from '@/src/store/signerThunks'
 import { addContact as _addContact, addContacts, Contact } from '@/src/store/addressBookSlice'
-import { storePrivateKey as _storePrivateKey } from '@/src/hooks/useSign/useSign'
 import { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { additionalSafesRtkApi } from '@safe-global/store/gateway/safes'
-import { addSignerWithEffects } from '@/src/store/signersSlice'
 import { storePrivateKey } from '@/src/hooks/useSign/useSign'
 import Logger from '@/src/utils/logger'
 

--- a/apps/mobile/src/features/ImportSigner/components/LoadingImport/LoadingImport.container.tsx
+++ b/apps/mobile/src/features/ImportSigner/components/LoadingImport/LoadingImport.container.tsx
@@ -1,7 +1,7 @@
 import { useAppDispatch } from '@/src/store/hooks'
 import { useCallback, useEffect } from 'react'
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { addSignerWithEffects } from '@/src/store/signersSlice'
+import { addSignerWithEffects } from '@/src/store/signerThunks'
 import { LoadingScreen } from '@/src/components/LoadingScreen'
 import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipValidation'
 

--- a/apps/mobile/src/features/ImportSigner/hooks/useImportSeedPhraseAddress.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useImportSeedPhraseAddress.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useAppDispatch } from '@/src/store/hooks'
-import { addSignerWithEffects } from '@/src/store/signersSlice'
+import { addSignerWithEffects } from '@/src/store/signerThunks'
 import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipValidation'
 import { storePrivateKey } from '@/src/hooks/useSign/useSign'
 import useDelegate from '@/src/hooks/useDelegate'

--- a/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.ts
+++ b/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useAppDispatch } from '@/src/store/hooks'
-import { addSignerWithEffects } from '@/src/store/signersSlice'
+import { addSignerWithEffects } from '@/src/store/signerThunks'
 import { ledgerDMKService } from '@/src/services/ledger/ledger-dmk.service'
 import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipValidation'
 import logger from '@/src/utils/logger'

--- a/apps/mobile/src/store/__tests__/signersSlice.test.ts
+++ b/apps/mobile/src/store/__tests__/signersSlice.test.ts
@@ -1,4 +1,5 @@
-import signersReducer, { addSigner, addSignerWithEffects, selectSigners, selectTotalSignerCount } from '../signersSlice'
+import signersReducer, { addSigner, selectSigners, selectTotalSignerCount } from '../signersSlice'
+import { addSignerWithEffects } from '../signerThunks'
 import { selectActiveSigner } from '../activeSignerSlice'
 import { selectAllContacts, selectContactByAddress } from '../addressBookSlice'
 import type { RootState } from '../index'

--- a/apps/mobile/src/store/signerThunks.ts
+++ b/apps/mobile/src/store/signerThunks.ts
@@ -1,0 +1,24 @@
+import { AppDispatch, RootState } from '.'
+import { addSigner, Signer } from './signersSlice'
+import { setActiveSigner } from './activeSignerSlice'
+import { addContact } from './addressBookSlice'
+
+export const addSignerWithEffects =
+  (signerInfo: Signer) => async (dispatch: AppDispatch, getState: () => RootState) => {
+    const { activeSafe, activeSigner } = getState()
+    const signerName = signerInfo.name || `Signer-${signerInfo.value.slice(-4)}`
+
+    dispatch(addSigner(signerInfo))
+
+    if (activeSafe && !activeSigner[activeSafe.address]) {
+      dispatch(setActiveSigner({ safeAddress: activeSafe.address, signer: signerInfo }))
+    }
+
+    dispatch(
+      addContact({
+        value: signerInfo.value,
+        name: signerName,
+        chainIds: [],
+      }),
+    )
+  }

--- a/apps/mobile/src/store/signersSlice.ts
+++ b/apps/mobile/src/store/signersSlice.ts
@@ -1,9 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 
-import { AppDispatch, RootState } from '.'
-import { setActiveSigner } from './activeSignerSlice'
-import { addContact } from './addressBookSlice'
+import { RootState } from '@/src/store'
 import logger from '@/src/utils/logger'
 
 export type Signer = AddressInfo &
@@ -36,26 +34,6 @@ const signersSlice = createSlice({
     },
   },
 })
-
-export const addSignerWithEffects =
-  (signerInfo: Signer) => async (dispatch: AppDispatch, getState: () => RootState) => {
-    const { activeSafe, activeSigner } = getState()
-    const signerName = signerInfo.name || `Signer-${signerInfo.value.slice(-4)}`
-
-    dispatch(addSigner(signerInfo))
-
-    if (activeSafe && !activeSigner[activeSafe.address]) {
-      dispatch(setActiveSigner({ safeAddress: activeSafe.address, signer: signerInfo }))
-    }
-
-    dispatch(
-      addContact({
-        value: signerInfo.value,
-        name: signerName,
-        chainIds: [],
-      }),
-    )
-  }
 
 export const { addSigner, removeSigner } = signersSlice.actions
 


### PR DESCRIPTION
## What it solves
We had a require cycle that was polluting the dev terminal. I've restructured the files and now it is gone. 

## How to test it
Start the app in dev mode and observe that the terminal no longer shows "Require cycle: src/store/signersSlice.ts -> src/store/activeSignerSlice.ts -> src/store/signersSlice.ts"

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
