### PR TITLE
fix(mobile): deprecated analytics call

### DIFF
--- a/apps/mobile/src/services/analytics/firebaseAnalytics.ts
+++ b/apps/mobile/src/services/analytics/firebaseAnalytics.ts
@@ -9,7 +9,6 @@
 import {
   getAnalytics,
   logEvent,
-  logScreenView,
   setAnalyticsCollectionEnabled as setAnalyticsCollectionEnabledFirebase,
 } from '@react-native-firebase/analytics'
 import type { AnalyticsEvent } from './types'
@@ -117,7 +116,10 @@ export const trackScreenView = async (screenName: string, screenClass?: string):
   try {
     const analytics = getAnalytics()
 
-    await logScreenView(analytics, {
+    // there is a bug in the type definition (screen_name & screen_class are correct here)
+    // https://github.com/invertase/react-native-firebase/pull/8687
+    // @ts-expect-error
+    await logEvent(analytics, 'screen_view', {
       screen_name: screenName,
       screen_class: screenClass || screenName,
       ...commonEventParams,


### PR DESCRIPTION
## What it solves
The dev terminal was polluted with:

>  WARN  This method is deprecated (as well as all React Native Firebase namespaced API) and will be removed in the next major release as part of move to match Firebase Web modular SDK API. Please see migration guide for more details: https://rnfirebase.io/migrating-to-v22. Method called was `logScreenView`. Please use `logEvent()` instead.

The fix was not that easy, because there is a bug in the ts definition inside react-native-firebase. If we are to follow the ts defintion and send firebase_screen and firebase_screen_class we don't get the correct screen visited. There is an open PR, so I just set @ts-expect-error up until they fix it: https://github.com/invertase/react-native-firebase/pull/8687

## How to test it
I've tested the app in debug mode and I can see the correct events being sent to firebase @liliya-soroka 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
