### PR TITLE
fix(mobile): change safe-shield analysis details text colors

### DIFF
--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/AnalysisDisplay.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/AnalysisDisplay.tsx
@@ -41,7 +41,7 @@ export function AnalysisDisplay({ result, description, severity }: AnalysisDispl
         }}
       >
         <Stack gap="$3">
-          <Text fontSize="$4" color="$colorSecondary">
+          <Text fontSize="$4" color="$colorLight">
             {displayDescription}
           </Text>
 

--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/AddressChanges.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/AddressChanges.tsx
@@ -33,7 +33,7 @@ export function AddressChanges({ result }: AddressChangesProps) {
           gap="$1"
           overflow="hidden"
         >
-          <Text letterSpacing={1} fontSize="$3" color="$colorSecondary">
+          <Text letterSpacing={1} fontSize="$3" color="$colorLight">
             {item.label}
           </Text>
           <Text fontSize="$4" style={{ wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>

--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/AddressListItem.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/AddressListItem.tsx
@@ -42,7 +42,7 @@ export function AddressListItem({
         <Text
           onPress={() => onCopy(address, index)}
           fontSize="$3"
-          color={copiedIndex === index ? '$color' : '$colorSecondary'}
+          color={copiedIndex === index ? '$color' : '$colorLight'}
         >
           {address}
         </Text>{' '}
@@ -52,7 +52,7 @@ export function AddressListItem({
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             style={{ flexShrink: 0, transform: [{ translateY: 2 }] }}
           >
-            <SafeFontIcon name="external-link" size={14} color="$colorSecondary" />
+            <SafeFontIcon name="external-link" size={14} color="$colorLight" />
           </TouchableOpacity>
         )}
       </Text>

--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/AnalysisIssuesDisplay.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/AnalysisIssuesDisplay.tsx
@@ -23,8 +23,8 @@ export function AnalysisIssuesDisplay({ result }: AnalysisIssuesDisplayProps) {
       {sortedIssues.flatMap(({ severity, issues }) =>
         issues.map((issue, index) => (
           <View key={`${severity}-${index}`} flexDirection="row" gap="$1" paddingLeft="$4" alignItems="flex-start">
-            <View width={4} height={4} borderRadius={3} backgroundColor="$colorSecondary" marginTop={8} />
-            <Text fontSize="$4" color="$colorSecondary" fontStyle="italic" flex={1}>
+            <View width={4} height={4} borderRadius={3} backgroundColor="$colorLight" marginTop={8} />
+            <Text fontSize="$4" color="$colorLight" fontStyle="italic" flex={1}>
               {issue}
             </Text>
           </View>

--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/ShowAllAddress.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/components/ShowAllAddress.tsx
@@ -54,7 +54,7 @@ export function ShowAllAddress({ addresses }: ShowAllAddressProps) {
           overflow="hidden"
           marginBottom={expanded ? '$1' : 0}
         >
-          <Text fontSize="$3" color="$colorSecondary" letterSpacing={1}>
+          <Text fontSize="$3" color="$colorLight" letterSpacing={1}>
             {expanded ? 'Hide all' : 'Show all'}
           </Text>
           <View
@@ -62,7 +62,7 @@ export function ShowAllAddress({ addresses }: ShowAllAddressProps) {
               transform: [{ rotate: expanded ? '180deg' : '0deg' }],
             }}
           >
-            <SafeFontIcon name="chevron-down" size={16} color="$colorSecondary" />
+            <SafeFontIcon name="chevron-down" size={16} color="$colorLight" />
           </View>
         </View>
       </TouchableOpacity>


### PR DESCRIPTION
We're showing the wrong text color in the analysis details component due to the usage of the wrong theme color

## How this PR fixes it
colorSecondary > colorLight

## How to test it
open any analysis details and compare it with figma

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `$colorSecondary` with `$colorLight` for text, bullets, and icons across SafeShield analysis detail components.
> 
> - **Mobile – SafeShield analysis details**:
>   - **Color updates**: Switch `'$colorSecondary'` to `'$colorLight'` for labels/text and icons.
>     - `AnalysisDisplay.tsx`: description text color.
>     - `components/AnalysisIssuesDisplay.tsx`: bullet dot and issue text colors.
>     - `components/AddressChanges.tsx`: section label color.
>     - `components/AddressListItem.tsx`: address text (when not copied) and external-link icon color.
>     - `components/ShowAllAddress.tsx`: toggle text and chevron icon colors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a865e869b59e7b66688b789c215d253b41d29fdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->