### PR TITLE
fix(mobile): Add link to the delegate call analysis details

### DIFF
--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/AnalysisDisplay.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisDisplay/AnalysisDisplay.tsx
@@ -31,6 +31,18 @@ export function AnalysisDisplay({ result, description, severity }: AnalysisDispl
 
   const borderColor = getBorderColor()
 
+  const renderDescription = () => {
+    if (typeof displayDescription === 'string' || typeof displayDescription === 'number') {
+      return (
+        <Text fontSize="$4" color="$colorLight">
+          {displayDescription}
+        </Text>
+      )
+    }
+
+    return displayDescription
+  }
+
   return (
     <View backgroundColor="$backgroundPaper" borderRadius="$1" overflow="hidden">
       <View
@@ -41,9 +53,7 @@ export function AnalysisDisplay({ result, description, severity }: AnalysisDispl
         }}
       >
         <Stack gap="$3">
-          <Text fontSize="$4" color="$colorLight">
-            {displayDescription}
-          </Text>
+          {renderDescription()}
 
           <AnalysisIssuesDisplay result={result} />
 

--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisGroup.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/AnalysisGroup.tsx
@@ -1,4 +1,4 @@
-import { GroupedAnalysisResults, Severity } from '@safe-global/utils/features/safe-shield/types'
+import { ContractStatus, GroupedAnalysisResults, Severity } from '@safe-global/utils/features/safe-shield/types'
 import { mapVisibleAnalysisResults } from '@safe-global/utils/features/safe-shield/utils'
 import { getPrimaryAnalysisResult } from '@safe-global/utils/features/safe-shield/utils/getPrimaryAnalysisResult'
 import { isEmpty } from 'lodash'
@@ -6,6 +6,7 @@ import React, { useMemo } from 'react'
 import { Stack } from 'tamagui'
 import { AnalysisLabel } from '../AnalysisLabel'
 import { AnalysisDisplay } from './AnalysisDisplay'
+import { DelegateCallItem } from './DelegateCallItem'
 
 interface AnalysisGroup {
   data: Record<string, GroupedAnalysisResults>
@@ -32,6 +33,10 @@ export const AnalysisGroup = ({ data, highlightedSeverity }: AnalysisGroup) => {
       {visibleResults.map((result, index) => {
         const isPrimary = index === 0
         const shouldHighlight = isHighlighted && isPrimary && result.severity === primarySeverity
+
+        if (result.type === ContractStatus.UNEXPECTED_DELEGATECALL) {
+          return <DelegateCallItem key={result.title} result={result} isPrimary={isPrimary} />
+        }
 
         return (
           <AnalysisDisplay

--- a/apps/mobile/src/features/SafeShield/components/AnalysisGroup/DelegateCallItem.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisGroup/DelegateCallItem.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Link } from 'expo-router'
+import { Text } from 'tamagui'
+import type { AnalysisResult } from '@safe-global/utils/features/safe-shield/types'
+import { HelpCenterArticle } from '@safe-global/utils/config/constants'
+import { AnalysisDisplay } from './AnalysisDisplay'
+
+interface DelegateCallItemProps {
+  result: AnalysisResult
+  isPrimary?: boolean
+}
+
+export const DelegateCallItem = ({ result, isPrimary = false }: DelegateCallItemProps) => {
+  const description = (
+    <Text fontSize="$4" color="$colorLight">
+      This transaction calls a smart contract that will be able to modify your Safe account.{' '}
+      <Link href={HelpCenterArticle.UNEXPECTED_DELEGATE_CALL} asChild>
+        <Text fontSize="$4" color="$colorPrimary" fontWeight={700}>
+          Learn more
+        </Text>
+      </Link>
+    </Text>
+  )
+
+  return (
+    <AnalysisDisplay description={description} result={result} severity={isPrimary ? result.severity : undefined} />
+  )
+}


### PR DESCRIPTION
## What it solves
When a tx is a DELEGATE call, we're displaying a "Learn more" text without a link. When this feature came, we changed the web implementation but didn't implemented it on mobile.

## How this PR fixes it

## How to test it
- create a delegate call tx, like this one: https://safe-wallet-web.dev.5afe.dev/transactions/queue?safe=matic:0x65e1Ff7e0901055B3bea7D8b3AF457a659714013
- check the analysis details
- Click in the learn more link

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a linked “Learn more” to unexpected delegatecall analysis and updates `AnalysisDisplay` to accept rich descriptions.
> 
> - **SafeShield (mobile)**:
>   - **Delegatecall handling**:
>     - New `DelegateCallItem` renders a custom description with a "Learn more" link to `HelpCenterArticle.UNEXPECTED_DELEGATE_CALL`.
>     - `AnalysisGroup` routes `ContractStatus.UNEXPECTED_DELEGATECALL` results to `DelegateCallItem`.
>   - **Display improvements**:
>     - `AnalysisDisplay` now accepts `description: React.ReactNode` and renders it via `renderDescription()`; falls back to wrapping string/number descriptions in `Text`.
>     - Maintains severity-based border coloring and existing issue/address displays.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c1202080c26c8f5718a89ca85fb7d7accf3bba4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->