### PR TITLE
fix(mobile): change risk acknowledgment checkbox on mobile to follow figma specs

### DIFF
--- a/apps/mobile/src/components/RiskAcknowledgmentCheckbox/RiskAcknowledgmentCheckbox.tsx
+++ b/apps/mobile/src/components/RiskAcknowledgmentCheckbox/RiskAcknowledgmentCheckbox.tsx
@@ -16,10 +16,10 @@ export const RiskAcknowledgmentCheckbox = ({ checked, onToggle, label }: RiskAck
         <View
           width={20}
           height={20}
-          borderWidth={1}
-          borderColor={checked ? '$primary' : '$borderLight'}
+          borderWidth={2}
+          borderColor={checked ? '$primary' : '$colorBackdrop'}
           backgroundColor={checked ? '$primary' : 'transparent'}
-          borderRadius={4}
+          borderRadius={2}
           alignItems="center"
           justifyContent="center"
         >


### PR DESCRIPTION
## What it solves
It changes the checkbox colors and border width to follow the same colors from figma.

## How this PR fixes it
changed the color of the checkbox to use `colorBackdrop` token.

## How to test it

## Screenshots
<img width="543" height="1036" alt="Screenshot 2025-12-08 at 17 33 33" src="https://github.com/user-attachments/assets/61d7f9bc-79c4-420e-897b-97e77a760fcd" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
