### PR TITLE
fix(mobile): flicker when scrolling in history

### DIFF
--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.test.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.test.tsx
@@ -133,12 +133,6 @@ describe('TxHistoryList', () => {
       expect(screen.queryByTestId('tx-history-initial-loader')).toBeNull()
     })
 
-    it('shows header loading component when loading with existing transactions', () => {
-      render(<TxHistoryList {...defaultProps} isLoading={true} transactions={mockTransactions} />)
-
-      expect(screen.getByTestId('tx-history-previous-loader')).toBeTruthy()
-    })
-
     it('shows footer loading component when loading next page', () => {
       render(<TxHistoryList {...defaultProps} isLoadingNext={true} transactions={mockTransactions} />)
 

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
@@ -11,7 +11,7 @@ import { TxCardPress } from '@/src/components/TxInfo/types'
 import { GroupedTransactionItem } from './components/GroupedTransactionItem'
 import { DateHeaderItem } from './components/DateHeaderItem'
 import { TransactionListItem } from './components/TransactionListItem'
-import { EmptyComponent, HeaderComponent, FooterComponent } from './components/LoadingComponents'
+import { EmptyComponent, FooterComponent } from './components/LoadingComponents'
 import { ErrorComponent } from './components/ErrorComponent'
 import { keyExtractor, getItemType } from './utils'
 import { EMPTY_ARRAY } from './constants'
@@ -122,7 +122,6 @@ export function TxHistoryList({
         refreshControl={<RefreshControl refreshing={!!refreshing} onRefresh={onRefresh} />}
         contentContainerStyle={contentContainerStyle}
         ListEmptyComponent={listEmptyComponent}
-        ListHeaderComponent={isLoading && hasTransactions ? <HeaderComponent /> : null}
         ListFooterComponent={isLoadingNext && hasTransactions ? <FooterComponent /> : null}
         contentInsetAdjustmentBehavior="automatic"
       />


### PR DESCRIPTION
## What it solves
I think that I re-introduced the bug when I fixed the missing skeleton loader in the footer. It seems that the flicker was due to the listHeaderComponent briefly rendering when we were scrolling down which would push the content down and then it will jump again up. I think that right now we don’t need ListHeaderComponent at all. I was trying to have 2 way infinite scroll, but it is not supported by RTK right now. Removing the ListHeaderComponent all together seems to have solved the flicker.

Resolves https://linear.app/safe-global/issue/COR-738/scroll-is-jumping-on-transaction-history-list-on-android

## How this PR fixes it
Removes the listHeader that was being erroneously rendered when scrolling down.

## How to test it
Open a safe with a lot of transactions and start slowly scrolling down. You should not see any jump in the list

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
