### PR TITLE
fix(mobile): use right colors for the non-highlight icons

### DIFF
--- a/apps/mobile/src/features/SafeShield/components/AnalysisLabel/AnalysisLabel.tsx
+++ b/apps/mobile/src/features/SafeShield/components/AnalysisLabel/AnalysisLabel.tsx
@@ -19,7 +19,7 @@ export function AnalysisLabel({ label, severity, highlighted }: AnalysisLabelPro
         <SafeFontIcon
           testID={`${iconName}-icon`}
           name={iconName}
-          color={highlighted ? '$icon' : '$colorLight'}
+          color={highlighted ? '$icon' : '$borderMain'}
           size={16}
         />
 

--- a/apps/mobile/src/features/SafeShield/components/TransactionSimulation/TransactionSimulation.tsx
+++ b/apps/mobile/src/features/SafeShield/components/TransactionSimulation/TransactionSimulation.tsx
@@ -57,7 +57,7 @@ export function TransactionSimulation({
           <SafeFontIcon
             testID={`transaction-simulation-icon`}
             name={iconName}
-            color={highlighted ? '$icon' : '$colorLight'}
+            color={highlighted ? '$icon' : '$borderMain'}
             size={16}
           />
 


### PR DESCRIPTION
## What it solves
it uses the right colors for the safe-shield non-highlight icons

## Screenshots
<img width="200" alt="Screenshot 2025-12-10 at 13 48 47" src="https://github.com/user-attachments/assets/4296e202-6f71-4717-8b04-c33fe7802fa3" />
<img width="200" alt="Screenshot 2025-12-10 at 13 48 51" src="https://github.com/user-attachments/assets/345ef79a-bfba-4349-8183-a5e1d44fd16a" />
<img  width="200" alt="Screenshot 2025-12-10 at 13 49 01" src="https://github.com/user-attachments/assets/0aa542aa-18ea-4fb4-b940-762f8c421d9e" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit affbf6c458122b30490e5cb888261a2bf292d4ba. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->