### PR TITLE
fix(dashboard): remove empty position container from dashboard when no positions

### DIFF
--- a/apps/web/src/features/positions/components/PositionsWidget/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsWidget/index.tsx
@@ -20,7 +20,6 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import PositionsHeader from '@/features/positions/components/PositionsHeader'
 import { PositionGroup } from '@/features/positions/components/PositionGroup'
 import usePositions from '@/features/positions/hooks/usePositions'
-import PositionsEmpty from '@/features/positions/components/PositionsEmpty'
 import Track from '@/components/common/Track'
 import { trackEvent } from '@/services/analytics'
 import { POSITIONS_EVENTS, POSITIONS_LABELS } from '@/services/analytics/events/positions'
@@ -154,6 +153,8 @@ const PositionsWidget = () => {
 
   const protocols = data.slice(0, MAX_PROTOCOLS)
 
+  if (protocols.length === 0) return null
+
   return (
     <WidgetCard
       title="Top positions"
@@ -177,66 +178,62 @@ const PositionsWidget = () => {
       )}
 
       <Box>
-        {protocols.length === 0 ? (
-          <PositionsEmpty entryPoint="Dashboard" />
-        ) : (
-          protocols.map((protocol, protocolIndex) => {
-            const protocolValue = Number(protocol.fiatTotal) || 0
-            const isLast = protocolIndex === protocols.length - 1
+        {protocols.map((protocol, protocolIndex) => {
+          const protocolValue = Number(protocol.fiatTotal) || 0
+          const isLast = protocolIndex === protocols.length - 1
 
-            return (
-              <Accordion
-                key={protocol.protocol}
-                disableGutters
-                elevation={0}
-                variant="elevation"
+          return (
+            <Accordion
+              key={protocol.protocol}
+              disableGutters
+              elevation={0}
+              variant="elevation"
+              sx={{
+                borderBottom: 'none !important',
+              }}
+              onChange={(_, expanded) => {
+                if (expanded) {
+                  trackEvent(POSITIONS_EVENTS.POSITION_EXPANDED, {
+                    [MixpanelEventParams.PROTOCOL_NAME]: protocol.protocol,
+                    [MixpanelEventParams.LOCATION]: POSITIONS_LABELS.dashboard,
+                    [MixpanelEventParams.AMOUNT_USD]: protocolValue,
+                  })
+                }
+              }}
+            >
+              <AccordionSummary
+                className={css.position}
+                expandIcon={<ExpandMoreIcon fontSize="small" />}
                 sx={{
-                  borderBottom: 'none !important',
-                }}
-                onChange={(_, expanded) => {
-                  if (expanded) {
-                    trackEvent(POSITIONS_EVENTS.POSITION_EXPANDED, {
-                      [MixpanelEventParams.PROTOCOL_NAME]: protocol.protocol,
-                      [MixpanelEventParams.LOCATION]: POSITIONS_LABELS.dashboard,
-                      [MixpanelEventParams.AMOUNT_USD]: protocolValue,
-                    })
-                  }
+                  justifyContent: 'center',
+                  overflowX: 'auto',
+                  px: 1.5,
+                  position: 'relative',
+                  ...(!isLast && {
+                    '&:not(.Mui-expanded)::after': {
+                      content: '""',
+                      position: 'absolute',
+                      bottom: 0,
+                      left: '56px',
+                      right: 0,
+                      height: '1px',
+                      backgroundColor: 'rgba(0, 0, 0, 0.12)',
+                      opacity: 0.5,
+                    },
+                  }),
                 }}
               >
-                <AccordionSummary
-                  className={css.position}
-                  expandIcon={<ExpandMoreIcon fontSize="small" />}
-                  sx={{
-                    justifyContent: 'center',
-                    overflowX: 'auto',
-                    px: 1.5,
-                    position: 'relative',
-                    ...(!isLast && {
-                      '&:not(.Mui-expanded)::after': {
-                        content: '""',
-                        position: 'absolute',
-                        bottom: 0,
-                        left: '56px',
-                        right: 0,
-                        height: '1px',
-                        backgroundColor: 'rgba(0, 0, 0, 0.12)',
-                        opacity: 0.5,
-                      },
-                    }),
-                  }}
-                >
-                  <PositionsHeader protocol={protocol} fiatTotal={positionsFiatTotal} />
-                </AccordionSummary>
+                <PositionsHeader protocol={protocol} fiatTotal={positionsFiatTotal} />
+              </AccordionSummary>
 
-                <AccordionDetails sx={{ px: 1.5 }}>
-                  {protocol.items.map((group, groupIndex) => (
-                    <PositionGroup key={groupIndex} group={group} isLast={groupIndex === protocol.items.length - 1} />
-                  ))}
-                </AccordionDetails>
-              </Accordion>
-            )
-          })
-        )}
+              <AccordionDetails sx={{ px: 1.5 }}>
+                {protocol.items.map((group, groupIndex) => (
+                  <PositionGroup key={groupIndex} group={group} isLast={groupIndex === protocol.items.length - 1} />
+                ))}
+              </AccordionDetails>
+            </Accordion>
+          )
+        })}
       </Box>
     </WidgetCard>
   )


### PR DESCRIPTION


## What it solves

Resolves: https://linear.app/safe-global/issue/COR-983/no-empty-state-with-no-positions

## How this PR fixes it

## How to test it

Open dashboard with a Safe that doesn't have positions, observe dashboard, observe it doesn't show the empty positions object.

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide the dashboard "Top positions" widget when there are no positions, removing the empty state and simplifying rendering.
> 
> - **Frontend – Positions widget (`apps/web/src/features/positions/components/PositionsWidget/index.tsx`)**
>   - Hide widget when no positions by early returning `null` if `protocols.length === 0`.
>   - Remove `PositionsEmpty` import and conditional empty-state rendering; always map over `protocols` when present.
>   - Minor UI/styling cleanup in the accordion (keeps expansion tracking; adds bottom border suppression and non-expanded divider line).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09751def8c91f4df6242ba54c84b44e255d10807. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->