### PR TITLE
feat: hide Safe Labs terms screen in non-production environments

### DIFF
--- a/apps/web/src/hooks/__tests__/useSafeLabsTerms.test.ts
+++ b/apps/web/src/hooks/__tests__/useSafeLabsTerms.test.ts
@@ -25,6 +25,12 @@ jest.mock('@/hooks/useIsOfficialHost', () => ({
   useIsOfficialHost: jest.fn(),
 }))
 
+jest.mock('@/config/constants', () => ({
+  ...jest.requireActual('@/config/constants'),
+  IS_PRODUCTION: true,
+  IS_TEST_E2E: false,
+}))
+
 const mockRouter = {
   pathname: '/home',
   asPath: '/home',

--- a/apps/web/src/hooks/useSafeLabsTerms.ts
+++ b/apps/web/src/hooks/useSafeLabsTerms.ts
@@ -7,7 +7,7 @@ import useOnboard from '@/hooks/wallets/useOnboard'
 import { AppRoutes } from '@/config/routes'
 import { useIsOfficialHost } from '@/hooks/useIsOfficialHost'
 import type { OnboardAPI, WalletState } from '@web3-onboard/core'
-import { IS_TEST_E2E } from '@/config/constants'
+import { IS_PRODUCTION, IS_TEST_E2E } from '@/config/constants'
 
 const TERMS_REDIRECT_EXCEPTIONS = [
   AppRoutes.safeLabsTerms,
@@ -85,6 +85,7 @@ export const useSafeLabsTerms = (): UseSafeLabsTermsReturnType => {
     if (
       !isOfficialHost ||
       isFeatureDisabled ||
+      !IS_PRODUCTION ||
       IS_TEST_E2E ||
       termsAccepted ||
       TERMS_REDIRECT_EXCEPTIONS.includes(router.pathname)
@@ -107,7 +108,7 @@ export const useSafeLabsTerms = (): UseSafeLabsTermsReturnType => {
 
   useEffect(() => {
     const termsAccepted = hasAcceptedSafeLabsTerms()
-    if (!isOfficialHost || !onboard || isFeatureDisabled || IS_TEST_E2E || termsAccepted) {
+    if (!isOfficialHost || !onboard || isFeatureDisabled || !IS_PRODUCTION || IS_TEST_E2E || termsAccepted) {
       return
     }
 
@@ -132,7 +133,7 @@ export const useSafeLabsTerms = (): UseSafeLabsTermsReturnType => {
   return {
     isFeatureDisabled,
     hasAccepted: termsAccepted,
-    shouldBypassTermsCheck: !isOfficialHost || isFeatureDisabled || IS_TEST_E2E || termsAccepted,
+    shouldBypassTermsCheck: !isOfficialHost || isFeatureDisabled || !IS_PRODUCTION || IS_TEST_E2E || termsAccepted,
     shouldShowContent,
   }
 }


### PR DESCRIPTION
## Summary

Hides the "Welcome to Safe{Wallet} by Safe Labs" terms acceptance screen in non-production environments (development, staging, test) to improve developer experience. The terms screen will only appear in production where users need to accept the terms.

## Changes

- Add `IS_PRODUCTION` check to `useSafeLabsTerms` hook
- Skip terms redirect when not in production
- Skip wallet disconnection when not in production  
- Update tests to mock `IS_PRODUCTION` constant

## Test plan

- [ ] Verify terms screen appears in production environment (`NEXT_PUBLIC_IS_PRODUCTION=true`)
- [ ] Verify terms screen is hidden in development environment (default)
- [ ] Verify terms screen is hidden in staging environment
- [ ] Run unit tests: `yarn workspace @safe-global/web test --testPathPattern=useSafeLabsTerms`
- [ ] Run type-check: `yarn workspace @safe-global/web type-check`
- [ ] Run linter: `yarn workspace @safe-global/web lint`

## Related files

- `apps/web/src/hooks/useSafeLabsTerms.ts` - Main logic changes
- `apps/web/src/hooks/__tests__/useSafeLabsTerms.test.ts` - Test updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)