### PR TITLE
chore: update apple-app-site-association with new mobile app

### DIFF
--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -8,7 +8,9 @@
                     "ZKG876RKJ8.io.gnosis.multisig.dev.mainnet",
                     "ZKG876RKJ8.io.gnosis.multisig.dev.rinkeby",
                     "ZKG876RKJ8.io.gnosis.multisig.staging.mainnet",
-                    "ZKG876RKJ8.io.gnosis.multisig.staging.rinkeby"
+                    "ZKG876RKJ8.io.gnosis.multisig.staging.rinkeby",
+                    "86487MHG6V.global.safe.mobileapp.ios",
+                    "86487MHG6V.global.safe.mobileapp.ios.dev"
                 ],
                 "components": [
                     {


### PR DESCRIPTION
## What it solves
Updating our apple-app-site-association file with the new app bundle ids

More info on Associated domains here: https://developer.apple.com/documentation/xcode/supporting-associated-domains

> Associated domains establish a secure association between domains and your app so you can share credentials or provide features in your app from your website. For example, an online retailer may offer an app to accompany their website and enhance the user experience.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
