### PR TITLE
feat(web): add Linea to cow config

### DIFF
--- a/apps/web/src/features/swap/helpers/data/stablecoins.ts
+++ b/apps/web/src/features/swap/helpers/data/stablecoins.ts
@@ -2,7 +2,7 @@ export const stableCoinAddresses: {
   [address: string]: {
     name: string
     symbol: string
-    chains: Array<'gnosis' | 'ethereum' | 'arbitrum-one' | 'sepolia' | 'base'>
+    chains: Array<'gnosis' | 'ethereum' | 'arbitrum-one' | 'sepolia' | 'base' | 'linea'>
   }
 } = {
   '0xdd96b45877d0e8361a4ddb732da741e97f3191ff': {
@@ -571,5 +571,21 @@ export const stableCoinAddresses: {
     name: 'EURC',
     symbol: 'eurc',
     chains: ['base'],
+  },
+  // Linea
+  '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': {
+    name: 'USDC',
+    symbol: 'usdc',
+    chains: ['linea'],
+  },
+  '0xA219439258ca9da29E9Cc4cE5596924745e12B93': {
+    name: 'Tether USD',
+    symbol: 'usdt',
+    chains: ['linea'],
+  },
+  '0x4AF15ec2A0bd43Db75dd04E62FAA3B8EF36b00d5': {
+    name: 'Dai Stablecoin',
+    symbol: 'dai',
+    chains: ['linea'],
   },
 }

--- a/apps/web/src/features/swap/helpers/utils.ts
+++ b/apps/web/src/features/swap/helpers/utils.ts
@@ -26,7 +26,7 @@ function asDecimal(amount: number | bigint, decimals: number): number {
 export const TWAP_FALLBACK_HANDLER = '0x2f55e8b20D0B9FEFA187AA7d00B6Cbe563605bF5'
 
 // https://github.com/cowprotocol/composable-cow/blob/main/networks.json
-export const TWAP_FALLBACK_HANDLER_NETWORKS = ['1', '100', '137', '11155111', '8453', '42161', '43114', '232']
+export const TWAP_FALLBACK_HANDLER_NETWORKS = ['1', '100', '137', '11155111', '8453', '42161', '43114', '232', '59144']
 
 export const getExecutionPrice = (
   order: Pick<OrderTransactionInfo, 'executedSellAmount' | 'executedBuyAmount' | 'buyToken' | 'sellToken'>,


### PR DESCRIPTION
## What it solves
It adds linea network into the fallback handler and to the stable coins address

Resolves: https://linear.app/safe-global/issue/GRO-144/add-linea-network-for-cow

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Linea by including network ID 59144 in `TWAP_FALLBACK_HANDLER_NETWORKS` and registering Linea stablecoins (USDC, USDT, DAI).
> 
> - **Swap helpers**:
>   - `apps/web/src/features/swap/helpers/utils.ts`:
>     - Extend `TWAP_FALLBACK_HANDLER_NETWORKS` with `'59144'` (Linea).
>   - `apps/web/src/features/swap/helpers/data/stablecoins.ts`:
>     - Extend `chains` union to include `'linea'`.
>     - Add Linea stablecoin addresses: `USDC`, `USDT`, `DAI`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4fd87240b93101ad4e24faff1baff573cdc8594. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->