### PR TITLE
fix(tx flow): change last signature message from warning to info

### DIFF
--- a/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
+++ b/apps/web/src/components/tx-flow/actions/ComboSubmit.tsx
@@ -76,9 +76,8 @@ export const ComboSubmit = (props: SlotComponentProps<SlotName.Submit>) => {
 
       {showLastSignerWarning && (
         <Box mt={1}>
-          <ErrorMessage level="warning">
-            You are providing the last signature. Once signed, anyone can execute this transaction since the queue is
-            public.
+          <ErrorMessage level="info">
+            You&apos;re providing the last signature. After you sign, anyone can execute this transaction.
           </ErrorMessage>
         </Box>
       )}

--- a/apps/web/src/components/tx-flow/actions/__tests__/ComboSubmit.test.tsx
+++ b/apps/web/src/components/tx-flow/actions/__tests__/ComboSubmit.test.tsx
@@ -88,7 +88,7 @@ describe('ComboSubmit', () => {
       { safeTx: safeTransaction },
     )
 
-    expect(getByText(/You are providing the last signature/)).toBeInTheDocument()
+    expect(getByText(/You're providing the last signature/)).toBeInTheDocument()
   })
 
   it('does not show warning when user has already signed', () => {
@@ -104,7 +104,7 @@ describe('ComboSubmit', () => {
       { safeTx: safeTransaction },
     )
 
-    expect(queryByText(/You are providing the last signature/)).not.toBeInTheDocument()
+    expect(queryByText(/You're providing the last signature/)).not.toBeInTheDocument()
   })
 
   it('does not show warning when Execute is not available', () => {
@@ -120,7 +120,7 @@ describe('ComboSubmit', () => {
       { safeTx: safeTransaction },
     )
 
-    expect(queryByText(/You are providing the last signature/)).not.toBeInTheDocument()
+    expect(queryByText(/You're providing the last signature/)).not.toBeInTheDocument()
   })
 
   it('does not show warning when user selected Execute', () => {
@@ -136,7 +136,7 @@ describe('ComboSubmit', () => {
       { safeTx: safeTransaction },
     )
 
-    expect(queryByText(/You are providing the last signature/)).not.toBeInTheDocument()
+    expect(queryByText(/You're providing the last signature/)).not.toBeInTheDocument()
   })
 
   it('respects stored Sign preference when Execute is available', () => {
@@ -153,7 +153,7 @@ describe('ComboSubmit', () => {
     )
 
     // Should show warning when user has stored preference for Sign
-    expect(getByText(/You are providing the last signature/)).toBeInTheDocument()
+    expect(getByText(/You're providing the last signature/)).toBeInTheDocument()
   })
 
   it('falls back to first option when stored action is not available', () => {


### PR DESCRIPTION
## Summary

Resolves https://linear.app/safe-global/issue/COR-1030/adjust-last-signature-warning-severity-and-wording

- Changed the "last signature" message from warning (yellow) to info (blue) styling
- Updated message text from "You are providing the last signature. Once signed, anyone can execute this transaction since the queue is public." to "You're providing the last signature. After you sign, anyone can execute this transaction."

## Test plan
- [ ] Verify the message appears with info styling (blue) when selecting Sign while Execute is available
- [ ] Verify the message text displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)