### PR TITLE
fix(SafeShield): moderate color marking for threat warnings

### DIFF
--- a/apps/web/src/features/safe-shield/components/AnalysisGroupCard/AnalysisGroupCardItem.tsx
+++ b/apps/web/src/features/safe-shield/components/AnalysisGroupCard/AnalysisGroupCardItem.tsx
@@ -1,12 +1,12 @@
 import { Stack, Typography } from '@mui/material'
 import { Box } from '@mui/material'
+import type { Severity } from '@safe-global/utils/features/safe-shield/types'
 import {
-  type Severity,
   type AnalysisResult,
   type MaliciousOrModerateThreatAnalysisResult,
 } from '@safe-global/utils/features/safe-shield/types'
 import { isAddressChange } from '@safe-global/utils/features/safe-shield/utils'
-import { SEVERITY_COLORS } from '../../constants'
+import { SEVERITY_COLORS, ISSUE_BACKGROUND_COLORS } from '../../constants'
 import { AnalysisIssuesDisplay } from '../AnalysisIssuesDisplay'
 import { AddressChanges } from '../AddressChanges'
 import { ShowAllAddress } from '../ShowAllAddress/ShowAllAddress'
@@ -20,6 +20,7 @@ interface AnalysisGroupCardItemProps {
 
 export const AnalysisGroupCardItem = ({ result, description, severity, showImage }: AnalysisGroupCardItemProps) => {
   const borderColor = severity ? SEVERITY_COLORS[severity].main : 'var(--color-border-main)'
+  const issueBackgroundColor = severity ? (ISSUE_BACKGROUND_COLORS[severity] ?? '') : ''
   const displayDescription = description ?? result.description
   // Double-check in case if issues are undefined:
   const hasIssues = 'issues' in result && !!(result as MaliciousOrModerateThreatAnalysisResult).issues
@@ -32,7 +33,7 @@ export const AnalysisGroupCardItem = ({ result, description, severity, showImage
             {displayDescription}
           </Typography>
 
-          <AnalysisIssuesDisplay result={result} borderColor={borderColor} />
+          <AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />
 
           {isAddressChange(result) && <AddressChanges result={result} />}
 

--- a/apps/web/src/features/safe-shield/components/AnalysisIssuesDisplay/AnalysisIssuesDisplay.tsx
+++ b/apps/web/src/features/safe-shield/components/AnalysisIssuesDisplay/AnalysisIssuesDisplay.tsx
@@ -12,7 +12,7 @@ import { useState } from 'react'
 
 interface AnalysisIssuesDisplayProps {
   result: AnalysisResult
-  borderColor: string
+  issueBackgroundColor: string
 }
 
 const issueBoxStyles = {
@@ -37,7 +37,7 @@ const addressTypographyStyles = {
   },
 } as const
 
-export const AnalysisIssuesDisplay = ({ result, borderColor }: AnalysisIssuesDisplayProps) => {
+export const AnalysisIssuesDisplay = ({ result, issueBackgroundColor }: AnalysisIssuesDisplayProps) => {
   const currentChain = useCurrentChain()
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
 
@@ -101,7 +101,7 @@ export const AnalysisIssuesDisplay = ({ result, borderColor }: AnalysisIssuesDis
 
               <Box
                 sx={{
-                  bgcolor: issue.address ? borderColor : 'transparent',
+                  bgcolor: issue.address ? issueBackgroundColor : 'transparent',
                   px: 1,
                   py: 0.5,
                   width: '100%',
@@ -109,7 +109,7 @@ export const AnalysisIssuesDisplay = ({ result, borderColor }: AnalysisIssuesDis
               >
                 <Typography
                   variant="body2"
-                  color="text.primary"
+                  color={issue.address ? 'static.main' : 'text.primary'}
                   fontSize={12}
                   lineHeight="14px"
                   sx={{

--- a/apps/web/src/features/safe-shield/components/AnalysisIssuesDisplay/__tests__/AnalysisIssuesDisplay.test.tsx
+++ b/apps/web/src/features/safe-shield/components/AnalysisIssuesDisplay/__tests__/AnalysisIssuesDisplay.test.tsx
@@ -4,10 +4,7 @@ import { AnalysisIssuesDisplay } from '../AnalysisIssuesDisplay'
 import { ThreatAnalysisResultBuilder } from '@safe-global/utils/features/safe-shield/builders/threat-analysis-result.builder'
 import { Severity } from '@safe-global/utils/features/safe-shield/types'
 import { faker } from '@faker-js/faker'
-import { SEVERITY_COLORS } from '@/features/safe-shield/constants'
-
-const WARN_BORDER_COLOR = SEVERITY_COLORS[Severity.WARN].main
-const CRITICAL_BORDER_COLOR = SEVERITY_COLORS[Severity.CRITICAL].main
+import { ISSUE_BACKGROUND_COLORS } from '@/features/safe-shield/constants'
 
 describe('AnalysisIssuesDisplay', () => {
   beforeEach(() => {
@@ -17,16 +14,20 @@ describe('AnalysisIssuesDisplay', () => {
   describe('Basic Rendering', () => {
     it('should return null when result has no issues', () => {
       const result = ThreatAnalysisResultBuilder.noThreat().build()
-      const borderColor = WARN_BORDER_COLOR
-      const { container } = render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      const { container } = render(
+        <AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />,
+      )
 
       expect(container.firstChild).toBeNull()
     })
 
     it('should render nothing for non-threat results', () => {
       const result = ThreatAnalysisResultBuilder.ownershipChange().build()
-      const borderColor = WARN_BORDER_COLOR
-      const { container } = render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      const { container } = render(
+        <AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />,
+      )
 
       expect(container.firstChild).toBeNull()
     })
@@ -44,8 +45,8 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = WARN_BORDER_COLOR
-      render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      render(<AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />)
 
       expect(screen.getByText(address)).toBeInTheDocument()
       expect(screen.getByText('This address is untrusted')).toBeInTheDocument()
@@ -66,8 +67,8 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = WARN_BORDER_COLOR
-      render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      render(<AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />)
 
       expect(screen.getByText(address)).toBeInTheDocument()
       // Explorer button may not be present if currentChain is not available in test context
@@ -100,8 +101,10 @@ describe('AnalysisIssuesDisplay', () => {
         },
       })
 
-      const borderColor = WARN_BORDER_COLOR
-      const { container } = render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      const { container } = render(
+        <AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />,
+      )
 
       const addressElement = screen.getByText(address)
       const allTypography = container.querySelectorAll('p.MuiTypography-body2')
@@ -139,8 +142,8 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = WARN_BORDER_COLOR
-      render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      render(<AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />)
 
       const descriptionElement = screen.getByText('This address is untrusted')
       expect(descriptionElement).toBeInTheDocument()
@@ -157,8 +160,8 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = WARN_BORDER_COLOR
-      render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      render(<AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />)
 
       expect(screen.getByText('Issue without address')).toBeInTheDocument()
       expect(screen.queryByText(/0x/)).not.toBeInTheDocument()
@@ -184,8 +187,10 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = WARN_BORDER_COLOR
-      const { container } = render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      const { container } = render(
+        <AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />,
+      )
 
       expect(container.querySelectorAll('[class*="MuiBox-root"]').length).toBeGreaterThanOrEqual(2)
 
@@ -215,8 +220,8 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = CRITICAL_BORDER_COLOR
-      render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.CRITICAL]!
+      render(<AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />)
 
       expect(screen.getByText(criticalAddress)).toBeInTheDocument()
       expect(screen.getByText(warnAddress)).toBeInTheDocument()
@@ -244,8 +249,10 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = CRITICAL_BORDER_COLOR
-      const { container } = render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.CRITICAL]!
+      const { container } = render(
+        <AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />,
+      )
 
       const textContent = container.textContent || ''
       const criticalIndex = textContent.indexOf('Critical issue')
@@ -259,9 +266,11 @@ describe('AnalysisIssuesDisplay', () => {
   describe('Edge Cases', () => {
     it('should handle empty issues object', () => {
       const result = ThreatAnalysisResultBuilder.moderate().issues({}).build()
-      const borderColor = WARN_BORDER_COLOR
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
 
-      const { container } = render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const { container } = render(
+        <AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />,
+      )
 
       expect(container.firstChild).toBeNull()
     })
@@ -273,15 +282,17 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = WARN_BORDER_COLOR
-      const { container } = render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      const { container } = render(
+        <AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />,
+      )
 
       expect(container.firstChild).toBeNull()
     })
   })
 
-  describe('Border Color', () => {
-    it('should apply CRITICAL border color when provided', () => {
+  describe('Issue Background Color', () => {
+    it('should apply CRITICAL issue background color when provided', () => {
       const address = faker.finance.ethereumAddress()
       const result = ThreatAnalysisResultBuilder.malicious()
         .issues({
@@ -294,14 +305,14 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = CRITICAL_BORDER_COLOR
-      render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.CRITICAL]!
+      render(<AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />)
 
       expect(screen.getByText(address)).toBeInTheDocument()
       expect(screen.getByText('Critical issue')).toBeInTheDocument()
     })
 
-    it('should apply WARN border color when provided', () => {
+    it('should apply WARN issue background color when provided', () => {
       const address = faker.finance.ethereumAddress()
       const result = ThreatAnalysisResultBuilder.moderate()
         .issues({
@@ -314,8 +325,8 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = WARN_BORDER_COLOR
-      render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      render(<AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />)
 
       expect(screen.getByText(address)).toBeInTheDocument()
       expect(screen.getByText('Warning issue')).toBeInTheDocument()
@@ -332,14 +343,14 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = WARN_BORDER_COLOR
-      render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.WARN]!
+      render(<AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />)
 
       expect(screen.getByText('Issue without address')).toBeInTheDocument()
       expect(screen.queryByText(/0x/)).not.toBeInTheDocument()
     })
 
-    it('should apply CRITICAL border color to multiple issues', () => {
+    it('should apply CRITICAL issue background color to multiple issues', () => {
       const address1 = faker.finance.ethereumAddress()
       const address2 = faker.finance.ethereumAddress()
       const result = ThreatAnalysisResultBuilder.malicious()
@@ -357,8 +368,8 @@ describe('AnalysisIssuesDisplay', () => {
         })
         .build()
 
-      const borderColor = CRITICAL_BORDER_COLOR
-      render(<AnalysisIssuesDisplay result={result} borderColor={borderColor} />)
+      const issueBackgroundColor = ISSUE_BACKGROUND_COLORS[Severity.CRITICAL]!
+      render(<AnalysisIssuesDisplay result={result} issueBackgroundColor={issueBackgroundColor} />)
 
       expect(screen.getByText(address1)).toBeInTheDocument()
       expect(screen.getByText(address2)).toBeInTheDocument()

--- a/apps/web/src/features/safe-shield/constants.ts
+++ b/apps/web/src/features/safe-shield/constants.ts
@@ -7,3 +7,8 @@ export const SEVERITY_COLORS: Record<Severity, Record<'main' | 'background', str
   INFO: { main: 'var(--color-info-main)', background: 'var(--color-info-background)' },
   ERROR: { main: 'var(--color-warning-main)', background: 'var(--color-warning-background)' },
 }
+
+export const ISSUE_BACKGROUND_COLORS: Partial<Record<Severity, string>> = {
+  CRITICAL: 'var(--color-error-light)',
+  WARN: 'var(--color-warning-light)',
+}


### PR DESCRIPTION
## What it solves

Threats with moderate severity get orange marking instead of critical (red).

Resolves: [COR-1028](https://linear.app/safe-global/issue/COR-1028/design-qa-change-color-of-sub-message)

## How this PR fixes it

- Makes `borderColor` a required prop in `AnalysisIssuesDisplay`
- Removes hardcoded fallback `'var(--color-error-background)'`
- Updates all tests to pass `borderColor` prop
- Extracts `WARN_BORDER_COLOR` and `CRITICAL_BORDER_COLOR` constants in tests

## How to test it

Go to a safe with Malicious transactions - choose one with Moderate warning. The description background color should be the one for warnings, not for errors.

## Screenshots

<img width="1888" height="882" alt="image" src="https://github.com/user-attachments/assets/e6f24ad2-91cc-4c44-a07b-439b6d568f8e" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).