### PR TITLE
fix: wrong apple-app-site-association config

### DIFF
--- a/apps/web/public/.well-known/apple-app-site-association
+++ b/apps/web/public/.well-known/apple-app-site-association
@@ -24,5 +24,5 @@
             "86487MHG6V.global.safe.mobileapp.ios",
             "86487MHG6V.global.safe.mobileapp.ios.dev"
         ]
-  }
+    }
 }


### PR DESCRIPTION
## What it solves
Yesterday I updated the apple-app-site-association config file, but I made a mistake. I don't want to support universal links, but rather just webcredentials.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
