### PR TITLE
feature(portfolio): add positions to hint text of total fiat

### DIFF
--- a/apps/web/src/components/sidebar/SidebarHeader/SafeHeaderInfo.tsx
+++ b/apps/web/src/components/sidebar/SidebarHeader/SafeHeaderInfo.tsx
@@ -46,7 +46,7 @@ const SafeHeaderInfo = (): ReactElement => {
             balances.fiatTotal ? (
               <>
                 <FiatValue value={balances.fiatTotal} />
-                {balances.isAllTokensMode && <InfoTooltip title="Total based on default tokens." />}
+                {balances.isAllTokensMode && <InfoTooltip title="Total based on default tokens and positions." />}
               </>
             ) : (
               <Skeleton variant="text" width={60} />


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/COR-1034/add-and-positions-to-hint-text-of-total-fiat-when-all-tokens-is

## How this PR fixes it

Adds "and positions" to tooltip.

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
