### PR TITLE
refactor: tx service balances

### DIFF
--- a/apps/web/cypress/e2e/smoke/balances_endpoints.cy.js
+++ b/apps/web/cypress/e2e/smoke/balances_endpoints.cy.js
@@ -6,7 +6,7 @@ import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
 let staticSafes = []
 
 const commonTokens = ['ETH', 'GNO', 'SAFE', 'USDT', 'SAI', 'OMG', 'OWL']
-const legacyOnlyTokens = ['cSAI', 'LUNC', 'BUN']
+const txServiceOnlyTokens = ['cSAI', 'LUNC', 'BUN']
 
 describe('[SMOKE] Balances endpoint tests', () => {
   before(async () => {
@@ -21,22 +21,22 @@ describe('[SMOKE] Balances endpoint tests', () => {
     assets.toggleShowAllTokens(false)
     assets.toggleHideDust(false)
     main.verifyValuesExist(assets.tokenListTable, commonTokens)
-    main.verifyValuesDoNotExist(assets.tokenListTable, legacyOnlyTokens)
+    main.verifyValuesDoNotExist(assets.tokenListTable, txServiceOnlyTokens)
   })
 
   it('[SMOKE] Verify all tokens list shows additional tokens', () => {
     assets.toggleHideDust(false)
     assets.toggleShowAllTokens(true)
     main.verifyValuesExist(assets.tokenListTable, commonTokens)
-    main.verifyValuesExist(assets.tokenListTable, legacyOnlyTokens)
+    main.verifyValuesExist(assets.tokenListTable, txServiceOnlyTokens)
   })
 
   it('[SMOKE] Verify switching token list updates displayed tokens', () => {
     assets.toggleHideDust(false)
     assets.toggleShowAllTokens(true)
-    main.verifyValuesExist(assets.tokenListTable, legacyOnlyTokens)
+    main.verifyValuesExist(assets.tokenListTable, txServiceOnlyTokens)
     assets.toggleShowAllTokens(false)
-    main.verifyValuesDoNotExist(assets.tokenListTable, legacyOnlyTokens)
+    main.verifyValuesDoNotExist(assets.tokenListTable, txServiceOnlyTokens)
     main.verifyValuesExist(assets.tokenListTable, commonTokens)
   })
 })

--- a/apps/web/src/features/portfolio/hooks/__tests__/usePortfolioBalances.test.ts
+++ b/apps/web/src/features/portfolio/hooks/__tests__/usePortfolioBalances.test.ts
@@ -108,7 +108,7 @@ describe('usePortfolioBalances', () => {
       refetch: jest.fn(),
     } as any)
 
-    jest.spyOn(useLoadBalances, 'useLegacyBalances').mockReturnValue([undefined, undefined, false])
+    jest.spyOn(useLoadBalances, 'useTxServiceBalances').mockReturnValue([undefined, undefined, false])
   })
 
   describe('when skip is true', () => {
@@ -190,8 +190,8 @@ describe('usePortfolioBalances', () => {
   })
 
   describe('error handling', () => {
-    it('should fallback to legacy when portfolio endpoint fails for deployed safe', async () => {
-      const mockLegacyBalances = {
+    it('should fallback to transaction service when portfolio endpoint fails for deployed safe', async () => {
+      const mockTxServiceBalances = {
         fiatTotal: '500',
         items: [],
         tokensFiatTotal: '500',
@@ -205,18 +205,18 @@ describe('usePortfolioBalances', () => {
         refetch: jest.fn(),
       } as any)
 
-      jest.spyOn(useLoadBalances, 'useLegacyBalances').mockReturnValue([mockLegacyBalances, undefined, false])
+      jest.spyOn(useLoadBalances, 'useTxServiceBalances').mockReturnValue([mockTxServiceBalances, undefined, false])
 
       const { result } = renderHook(() => usePortfolioBalances(false))
 
       await waitFor(() => {
-        expect(result.current[0]).toBe(mockLegacyBalances)
+        expect(result.current[0]).toBe(mockTxServiceBalances)
         expect(result.current[1]).toBeUndefined()
       })
     })
 
-    it('should return legacy error when both portfolio and legacy fail', async () => {
-      const legacyError = new Error('Legacy error')
+    it('should return transaction service error when both portfolio and transaction service fail', async () => {
+      const txServiceError = new Error('Transaction service error')
 
       jest.spyOn(portfolioQueries, 'usePortfolioGetPortfolioV1Query').mockReturnValue({
         currentData: undefined,
@@ -225,20 +225,20 @@ describe('usePortfolioBalances', () => {
         refetch: jest.fn(),
       } as any)
 
-      jest.spyOn(useLoadBalances, 'useLegacyBalances').mockReturnValue([undefined, legacyError, false])
+      jest.spyOn(useLoadBalances, 'useTxServiceBalances').mockReturnValue([undefined, txServiceError, false])
 
       const { result } = renderHook(() => usePortfolioBalances(false))
 
       await waitFor(() => {
-        expect(result.current[1]).toBe(legacyError)
+        expect(result.current[1]).toBe(txServiceError)
       })
     })
   })
 
-  describe('legacy fallback', () => {
-    it('should fallback to legacy when portfolio returns empty for deployed safe', async () => {
+  describe('transaction service fallback', () => {
+    it('should fallback to transaction service when portfolio returns empty for deployed safe', async () => {
       const mockEmptyPortfolio = createMockEmptyPortfolio()
-      const mockLegacyBalances = {
+      const mockTxServiceBalances = {
         fiatTotal: '1000',
         items: [],
         tokensFiatTotal: '1000',
@@ -252,12 +252,12 @@ describe('usePortfolioBalances', () => {
         refetch: jest.fn(),
       } as any)
 
-      jest.spyOn(useLoadBalances, 'useLegacyBalances').mockReturnValue([mockLegacyBalances, undefined, false])
+      jest.spyOn(useLoadBalances, 'useTxServiceBalances').mockReturnValue([mockTxServiceBalances, undefined, false])
 
       const { result } = renderHook(() => usePortfolioBalances(false))
 
       await waitFor(() => {
-        expect(result.current[0]).toBe(mockLegacyBalances)
+        expect(result.current[0]).toBe(mockTxServiceBalances)
       })
     })
 
@@ -287,8 +287,8 @@ describe('usePortfolioBalances', () => {
       })
     })
 
-    it('should fallback to legacy on portfolio error', async () => {
-      const mockLegacyBalances = {
+    it('should fallback to transaction service on portfolio error', async () => {
+      const mockTxServiceBalances = {
         fiatTotal: '500',
         items: [],
         tokensFiatTotal: '500',
@@ -302,12 +302,12 @@ describe('usePortfolioBalances', () => {
         refetch: jest.fn(),
       } as any)
 
-      jest.spyOn(useLoadBalances, 'useLegacyBalances').mockReturnValue([mockLegacyBalances, undefined, false])
+      jest.spyOn(useLoadBalances, 'useTxServiceBalances').mockReturnValue([mockTxServiceBalances, undefined, false])
 
       const { result } = renderHook(() => usePortfolioBalances(false))
 
       await waitFor(() => {
-        expect(result.current[0]).toBe(mockLegacyBalances)
+        expect(result.current[0]).toBe(mockTxServiceBalances)
       })
     })
   })

--- a/apps/web/src/features/positions/hooks/__tests__/usePositions.test.ts
+++ b/apps/web/src/features/positions/hooks/__tests__/usePositions.test.ts
@@ -169,7 +169,7 @@ describe('usePositions', () => {
     })
   })
 
-  describe('legacy positions endpoint', () => {
+  describe('positions endpoint', () => {
     beforeEach(() => {
       jest.spyOn(useChains, 'useHasFeature').mockImplementation((feature) => {
         if (feature === FEATURES.PORTFOLIO_ENDPOINT) {
@@ -179,7 +179,7 @@ describe('usePositions', () => {
       })
     })
 
-    it('should return positions from legacy endpoint when portfolio endpoint is disabled', async () => {
+    it('should return positions from positions endpoint when portfolio endpoint is disabled', async () => {
       const mockProtocols = [createMockProtocol()]
 
       jest.spyOn(positionsQueries, 'usePositionsGetPositionsV1Query').mockReturnValue({
@@ -200,7 +200,7 @@ describe('usePositions', () => {
       expect(result.current.isLoading).toBe(false)
     })
 
-    it('should handle loading state from legacy endpoint', async () => {
+    it('should handle loading state from positions endpoint', async () => {
       jest.spyOn(positionsQueries, 'usePositionsGetPositionsV1Query').mockReturnValue({
         currentData: undefined,
         isLoading: true,
@@ -214,8 +214,8 @@ describe('usePositions', () => {
       expect(result.current.data).toBeUndefined()
     })
 
-    it('should handle errors from legacy endpoint', async () => {
-      const mockError = new Error('Legacy positions endpoint error')
+    it('should handle errors from positions endpoint', async () => {
+      const mockError = new Error('Positions endpoint error')
 
       jest.spyOn(positionsQueries, 'usePositionsGetPositionsV1Query').mockReturnValue({
         currentData: undefined,

--- a/apps/web/src/features/positions/hooks/__tests__/useRefetch.test.ts
+++ b/apps/web/src/features/positions/hooks/__tests__/useRefetch.test.ts
@@ -107,24 +107,24 @@ describe('useRefetch', () => {
       expect(portfolioRefetch).toHaveBeenCalled()
     })
 
-    it('should call legacy refetch functions when portfolio endpoint is disabled', async () => {
-      const legacyPositionsRefetch = jest.fn().mockResolvedValue({})
-      const legacyBalancesRefetch = jest.fn().mockResolvedValue({})
+    it('should call positions and balances refetch functions when portfolio endpoint is disabled', async () => {
+      const positionsRefetch = jest.fn().mockResolvedValue({})
+      const txServiceBalancesRefetch = jest.fn().mockResolvedValue({})
 
       jest.spyOn(useChains, 'useHasFeature').mockReturnValue(false)
       jest.spyOn(positionsQueries, 'usePositionsGetPositionsV1Query').mockReturnValue({
-        refetch: legacyPositionsRefetch,
+        refetch: positionsRefetch,
       } as any)
       jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockReturnValue({
-        refetch: legacyBalancesRefetch,
+        refetch: txServiceBalancesRefetch,
       } as any)
 
       const { result } = renderHook(() => useRefetch())
 
       await result.current.refetch()
 
-      expect(legacyPositionsRefetch).toHaveBeenCalled()
-      expect(legacyBalancesRefetch).toHaveBeenCalled()
+      expect(positionsRefetch).toHaveBeenCalled()
+      expect(txServiceBalancesRefetch).toHaveBeenCalled()
     })
   })
 
@@ -144,23 +144,23 @@ describe('useRefetch', () => {
     })
 
     it('should only call positions refetch when portfolio endpoint is disabled', async () => {
-      const legacyPositionsRefetch = jest.fn().mockResolvedValue({})
-      const legacyBalancesRefetch = jest.fn().mockResolvedValue({})
+      const positionsRefetch = jest.fn().mockResolvedValue({})
+      const txServiceBalancesRefetch = jest.fn().mockResolvedValue({})
 
       jest.spyOn(useChains, 'useHasFeature').mockReturnValue(false)
       jest.spyOn(positionsQueries, 'usePositionsGetPositionsV1Query').mockReturnValue({
-        refetch: legacyPositionsRefetch,
+        refetch: positionsRefetch,
       } as any)
       jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockReturnValue({
-        refetch: legacyBalancesRefetch,
+        refetch: txServiceBalancesRefetch,
       } as any)
 
       const { result } = renderHook(() => useRefetch())
 
       await result.current.refetchPositions()
 
-      expect(legacyPositionsRefetch).toHaveBeenCalled()
-      expect(legacyBalancesRefetch).not.toHaveBeenCalled()
+      expect(positionsRefetch).toHaveBeenCalled()
+      expect(txServiceBalancesRefetch).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/web/src/features/positions/hooks/usePositions.ts
+++ b/apps/web/src/features/positions/hooks/usePositions.ts
@@ -43,7 +43,7 @@ const transformAppBalancesToProtocols = (appBalances?: AppBalance[]): Protocol[]
 
 /**
  * Hook to load positions data.
- * Uses portfolio endpoint when enabled, otherwise falls back to legacy positions endpoint.
+ * Uses portfolio endpoint when enabled, otherwise falls back to positions endpoint.
  */
 const usePositions = () => {
   const chainId = useChainId()
@@ -56,9 +56,9 @@ const usePositions = () => {
   const shouldUsePositionEndpoint = isPositionsEnabled && !shouldUsePortfolioEndpoint
 
   const {
-    currentData: legacyPositionsData,
-    error: legacyPositionsError,
-    isLoading: legacyPositionsLoading,
+    currentData: positionsData,
+    error: positionsError,
+    isLoading: positionsLoading,
   } = usePositionsGetPositionsV1Query(
     { chainId, safeAddress, fiatCode: currency },
     {
@@ -73,18 +73,18 @@ const usePositions = () => {
 
   return useMemo(
     () => ({
-      data: shouldUsePortfolioEndpoint ? transformAppBalancesToProtocols(balances?.positions) : legacyPositionsData,
-      error: shouldUsePortfolioEndpoint ? balancesError : legacyPositionsError,
-      isLoading: shouldUsePortfolioEndpoint ? balancesLoading : legacyPositionsLoading,
+      data: shouldUsePortfolioEndpoint ? transformAppBalancesToProtocols(balances?.positions) : positionsData,
+      error: shouldUsePortfolioEndpoint ? balancesError : positionsError,
+      isLoading: shouldUsePortfolioEndpoint ? balancesLoading : positionsLoading,
     }),
     [
       shouldUsePortfolioEndpoint,
       balances?.positions,
-      legacyPositionsData,
+      positionsData,
       balancesError,
-      legacyPositionsError,
+      positionsError,
       balancesLoading,
-      legacyPositionsLoading,
+      positionsLoading,
     ],
   )
 }

--- a/apps/web/src/features/positions/hooks/useRefetch.ts
+++ b/apps/web/src/features/positions/hooks/useRefetch.ts
@@ -13,7 +13,7 @@ import useIsPositionsFeatureEnabled from './useIsPositionsFeatureEnabled'
 
 /**
  * Hook for refetching positions and balances data.
- * Automatically selects the appropriate endpoint (portfolio or legacy) based on feature flags.
+ * Automatically selects the appropriate endpoint (portfolio or positions/balances) based on feature flags.
  *
  * @returns Object containing:
  *   - `refetch`: Function to refetch all data (positions + balances)
@@ -49,14 +49,14 @@ export const useRefetch = () => {
     },
   )
 
-  const { refetch: legacyPositionsRefetch, isFetching: legacyPositionsIsFetching } = usePositionsGetPositionsV1Query(
+  const { refetch: positionsRefetch, isFetching: positionsIsFetching } = usePositionsGetPositionsV1Query(
     { chainId, safeAddress, fiatCode: currency },
     {
       skip: shouldUsePortfolioEndpoint || !safeAddress || !chainId || !currency,
     },
   )
 
-  const { refetch: legacyBalancesRefetch, isFetching: legacyBalancesIsFetching } = useBalancesGetBalancesV1Query(
+  const { refetch: txServiceBalancesRefetch, isFetching: txServiceBalancesIsFetching } = useBalancesGetBalancesV1Query(
     {
       chainId: safe.chainId,
       safeAddress,
@@ -72,21 +72,21 @@ export const useRefetch = () => {
     if (shouldUsePortfolioEndpoint) {
       return portfolioRefetch()
     }
-    await Promise.all([legacyPositionsRefetch(), legacyBalancesRefetch()])
-  }, [shouldUsePortfolioEndpoint, portfolioRefetch, legacyPositionsRefetch, legacyBalancesRefetch])
+    await Promise.all([positionsRefetch(), txServiceBalancesRefetch()])
+  }, [shouldUsePortfolioEndpoint, portfolioRefetch, positionsRefetch, txServiceBalancesRefetch])
 
   const refetchPositions = useCallback(async () => {
     if (shouldUsePortfolioEndpoint) {
       return portfolioRefetch()
     }
-    return legacyPositionsRefetch()
-  }, [shouldUsePortfolioEndpoint, portfolioRefetch, legacyPositionsRefetch])
+    return positionsRefetch()
+  }, [shouldUsePortfolioEndpoint, portfolioRefetch, positionsRefetch])
 
   const fulfilledTimeStamp = shouldUsePortfolioEndpoint ? portfolioFulfilledTimeStamp : undefined
 
   const isFetching = shouldUsePortfolioEndpoint
     ? portfolioIsFetching
-    : legacyPositionsIsFetching || legacyBalancesIsFetching
+    : positionsIsFetching || txServiceBalancesIsFetching
 
   return { refetch, refetchPositions, shouldUsePortfolioEndpoint, fulfilledTimeStamp, isFetching }
 }

--- a/apps/web/src/hooks/loadables/__tests__/useLoadBalances.test.ts
+++ b/apps/web/src/hooks/loadables/__tests__/useLoadBalances.test.ts
@@ -18,7 +18,7 @@ import type { Balances } from '@safe-global/store/gateway/AUTO_GENERATED/balance
 const SAFE_ADDRESS = toBeHex('0x1234', 20)
 const CHAIN_ID = '5'
 
-const createMockLegacyBalances = (): Balances => ({
+const createMockTxServiceBalances = (): Balances => ({
   fiatTotal: '1000',
   items: [
     {
@@ -167,9 +167,9 @@ describe('useLoadBalances', () => {
     jest.spyOn(useCounterfactualBalances, 'useCounterfactualBalances').mockReturnValue([undefined, undefined, false])
   })
 
-  describe('legacy endpoint', () => {
-    it('should return legacy balances when portfolio endpoint is disabled', async () => {
-      const mockBalances = createMockLegacyBalances()
+  describe('transaction service endpoint', () => {
+    it('should return transaction service balances when portfolio endpoint is disabled', async () => {
+      const mockBalances = createMockTxServiceBalances()
 
       jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockReturnValue({
         currentData: mockBalances,
@@ -194,7 +194,7 @@ describe('useLoadBalances', () => {
       expect(loading).toBe(false)
     })
 
-    it('should return counterfactual balances for counterfactual safe with legacy endpoint', async () => {
+    it('should return counterfactual balances for counterfactual safe with transaction service endpoint', async () => {
       const mockCfBalances = createMockCounterfactualBalances()
 
       jest.spyOn(useSafeInfo, 'default').mockReturnValue({
@@ -225,8 +225,8 @@ describe('useLoadBalances', () => {
       expect(loading).toBe(false)
     })
 
-    it('should handle legacy endpoint errors', async () => {
-      const mockError = new Error('Legacy endpoint error')
+    it('should handle transaction service endpoint errors', async () => {
+      const mockError = new Error('Transaction service endpoint error')
 
       jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockReturnValue({
         currentData: undefined,
@@ -245,7 +245,7 @@ describe('useLoadBalances', () => {
 
       expect(balances).toBeUndefined()
       expect(error).toBeInstanceOf(Error)
-      expect(error?.message).toBe('Error: Legacy endpoint error')
+      expect(error?.message).toBe('Error: Transaction service endpoint error')
     })
   })
 
@@ -261,7 +261,7 @@ describe('useLoadBalances', () => {
         return false
       })
 
-      // Set token list to TRUSTED to use portfolio endpoint (ALL uses legacy)
+      // Set token list to TRUSTED to use portfolio endpoint (ALL uses transaction service)
       jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
         selector({
           chains: {
@@ -380,9 +380,9 @@ describe('useLoadBalances', () => {
       expect(balances?.tokensFiatTotal).toBe(mockPortfolio.totalTokenBalanceFiat)
     })
 
-    it('should fallback to legacy endpoint when portfolio fails', async () => {
+    it('should fallback to transaction service endpoint when portfolio fails', async () => {
       const mockPortfolioError = new Error('Portfolio endpoint error')
-      const mockLegacyBalances = createMockLegacyBalances()
+      const mockTxServiceBalances = createMockTxServiceBalances()
 
       jest.spyOn(portfolioQueries, 'usePortfolioGetPortfolioV1Query').mockReturnValue({
         currentData: undefined,
@@ -392,7 +392,7 @@ describe('useLoadBalances', () => {
       } as any)
 
       jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockReturnValue({
-        currentData: mockLegacyBalances,
+        currentData: mockTxServiceBalances,
         isLoading: false,
         error: undefined,
         refetch: jest.fn(),
@@ -406,14 +406,14 @@ describe('useLoadBalances', () => {
 
       const [balances, error] = result.current
 
-      // Should fallback to legacy balances when portfolio fails
-      expect(balances?.fiatTotal).toBe(mockLegacyBalances.fiatTotal)
+      // Should fallback to transaction service balances when portfolio fails
+      expect(balances?.fiatTotal).toBe(mockTxServiceBalances.fiatTotal)
       expect(error).toBeUndefined()
     })
 
-    it('should return error when both portfolio and legacy fail', async () => {
+    it('should return error when both portfolio and transaction service fail', async () => {
       const mockPortfolioError = new Error('Portfolio endpoint error')
-      const mockLegacyError = new Error('Legacy endpoint error')
+      const mockTxServiceError = new Error('Transaction service endpoint error')
 
       jest.spyOn(portfolioQueries, 'usePortfolioGetPortfolioV1Query').mockReturnValue({
         currentData: undefined,
@@ -425,7 +425,7 @@ describe('useLoadBalances', () => {
       jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockReturnValue({
         currentData: undefined,
         isLoading: false,
-        error: mockLegacyError,
+        error: mockTxServiceError,
         refetch: jest.fn(),
       } as any)
 
@@ -454,8 +454,8 @@ describe('useLoadBalances', () => {
       expect(result.current[2]).toBe(true)
     })
 
-    it('should merge portfolio fiatTotal with legacy items when "All tokens" is selected', async () => {
-      const mockLegacyBalances = createMockLegacyBalances()
+    it('should merge portfolio fiatTotal with transaction service items when "All tokens" is selected', async () => {
+      const mockTxServiceBalances = createMockTxServiceBalances()
       const mockPortfolio = createMockPortfolio()
 
       // Set token list to ALL
@@ -483,7 +483,7 @@ describe('useLoadBalances', () => {
       )
 
       jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockReturnValue({
-        currentData: mockLegacyBalances,
+        currentData: mockTxServiceBalances,
         isLoading: false,
         error: undefined,
         refetch: jest.fn(),
@@ -506,14 +506,14 @@ describe('useLoadBalances', () => {
 
       // fiatTotal should come from portfolio (Zerion)
       expect(balances?.fiatTotal).toBe(mockPortfolio.totalBalanceFiat)
-      // tokensFiatTotal should be calculated from legacy items
+      // tokensFiatTotal should be calculated from transaction service items
       expect(balances?.tokensFiatTotal).toBe('1000')
       // positionsFiatTotal should come from portfolio
       expect(balances?.positionsFiatTotal).toBe(mockPortfolio.totalPositionsBalanceFiat)
       // positions should come from portfolio
       expect(balances?.positions).toEqual(mockPortfolio.positionBalances)
-      // items should come from legacy (transaction service)
-      expect(balances?.items).toEqual(mockLegacyBalances.items)
+      // items should come from transaction service
+      expect(balances?.items).toEqual(mockTxServiceBalances.items)
       // isAllTokensMode flag should be true
       expect(balances?.isAllTokensMode).toBe(true)
       expect(error).toBeUndefined()
@@ -542,7 +542,7 @@ describe('useLoadBalances', () => {
     })
 
     it('should use portfolio endpoint when "Default tokens" is selected', async () => {
-      const mockLegacyBalances = createMockLegacyBalances()
+      const mockTxServiceBalances = createMockTxServiceBalances()
       const mockPortfolio = createMockPortfolio()
 
       // Set token list to TRUSTED
@@ -570,7 +570,7 @@ describe('useLoadBalances', () => {
       )
 
       jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockReturnValue({
-        currentData: mockLegacyBalances,
+        currentData: mockTxServiceBalances,
         isLoading: false,
         error: undefined,
         refetch: jest.fn(),

--- a/apps/web/src/hooks/loadables/useTrustedTokenBalances.ts
+++ b/apps/web/src/hooks/loadables/useTrustedTokenBalances.ts
@@ -9,8 +9,8 @@ import type { AsyncResult } from '@safe-global/utils/hooks/useAsync'
 import { type PortfolioBalances, createPortfolioBalances, useTokenListSetting } from './useLoadBalances'
 
 /**
- * Hook to load balances using the legacy endpoint with trusted tokenlist.
- * Always uses the legacy endpoint regardless of portfolio endpoint status or user settings.
+ * Hook to load balances using the Transaction Service endpoint with trusted tokenlist.
+ * Always uses the Transaction Service endpoint regardless of portfolio endpoint status or user settings.
  * Used specifically for the send flow to ensure consistent token availability.
  */
 export const useTrustedTokenBalances = (): AsyncResult<PortfolioBalances> => {
@@ -21,9 +21,9 @@ export const useTrustedTokenBalances = (): AsyncResult<PortfolioBalances> => {
   const isCounterfactual = !safe.deployed
 
   const {
-    currentData: legacyBalances,
-    isLoading: legacyLoading,
-    error: legacyError,
+    currentData: txServiceBalances,
+    isLoading: txServiceLoading,
+    error: txServiceError,
   } = useBalancesGetBalancesV1Query(
     {
       chainId: safe.chainId,
@@ -46,12 +46,12 @@ export const useTrustedTokenBalances = (): AsyncResult<PortfolioBalances> => {
       return [createPortfolioBalances(cfData), cfError, cfLoading]
     }
 
-    if (legacyBalances) {
-      const error = legacyError ? new Error(String(legacyError)) : undefined
-      return [createPortfolioBalances(legacyBalances), error, legacyLoading]
+    if (txServiceBalances) {
+      const error = txServiceError ? new Error(String(txServiceError)) : undefined
+      return [createPortfolioBalances(txServiceBalances), error, txServiceLoading]
     }
 
-    const error = legacyError ? new Error(String(legacyError)) : undefined
+    const error = txServiceError ? new Error(String(txServiceError)) : undefined
     return [undefined, error, true]
-  }, [isCounterfactual, cfData, cfError, cfLoading, legacyBalances, legacyError, legacyLoading])
+  }, [isCounterfactual, cfData, cfError, cfLoading, txServiceBalances, txServiceError, txServiceLoading])
 }


### PR DESCRIPTION
## What it solves

Removes the expression `legacy` and differentiates between:

* portfolio endpoint (for balances and positions)
* tx service balances
* positions

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
