### PR TITLE
fix(portfolio): remove polling and refetch on history change

### DIFF
--- a/apps/web/src/config/constants.ts
+++ b/apps/web/src/config/constants.ts
@@ -24,7 +24,6 @@ export const GATEWAY_URL_STAGING = process.env.NEXT_PUBLIC_GATEWAY_URL_STAGING |
 
 // Magic numbers
 export const POLLING_INTERVAL = 15_000
-export const PORTFOLIO_POLLING_INTERVAL = 60_000
 export const BASE_TX_GAS = 21_000
 export const LS_NAMESPACE = 'SAFE_v2__'
 export const DUST_THRESHOLD = 0.01


### PR DESCRIPTION
## What it solves

Resolves https://linear.app/safe-global/issue/WA-984/optimize-calls-to-portfolio-endpoint

Reduces Zerion API costs by not refetching every 60 seconds. Only on tab focus and when tx history changes. 

Also remove refetchOnFocus because it triggers when connecting a wallet (because the wallet extension is a different window).