### PR TITLE
fix: run portfolio refetch only when it ran before

### DIFF
--- a/apps/web/src/features/portfolio/hooks/usePortfolioRefetchOnTxHistory.ts
+++ b/apps/web/src/features/portfolio/hooks/usePortfolioRefetchOnTxHistory.ts
@@ -10,7 +10,7 @@ import useSafeInfo from '@/hooks/useSafeInfo'
  */
 const usePortfolioRefetchOnTxHistory = (): void => {
   const { safe } = useSafeInfo()
-  const { refetch, fulfilledTimeStamp } = useRefetch()
+  const { refetch, fulfilledTimeStamp, shouldUsePortfolioEndpoint } = useRefetch()
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const prevTxHistoryTagRef = useRef<string | null | undefined>(undefined)
 
@@ -28,6 +28,11 @@ const usePortfolioRefetchOnTxHistory = (): void => {
 
     prevTxHistoryTagRef.current = safe.txHistoryTag
 
+    // Skip if portfolio endpoint isn't active or no successful fetch yet
+    if (!shouldUsePortfolioEndpoint || !fulfilledTimeStamp) {
+      return
+    }
+
     // Clear any existing scheduled refetch
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)
@@ -35,7 +40,7 @@ const usePortfolioRefetchOnTxHistory = (): void => {
     }
 
     const now = Date.now()
-    const timeSinceLastFetch = fulfilledTimeStamp ? now - fulfilledTimeStamp : Infinity
+    const timeSinceLastFetch = now - fulfilledTimeStamp
     const remainingCooldown = PORTFOLIO_CACHE_TIME_MS - timeSinceLastFetch
 
     if (remainingCooldown > 0) {
@@ -53,7 +58,7 @@ const usePortfolioRefetchOnTxHistory = (): void => {
         clearTimeout(timeoutRef.current)
       }
     }
-  }, [safe.txHistoryTag, refetch, fulfilledTimeStamp])
+  }, [safe.txHistoryTag, refetch, fulfilledTimeStamp, shouldUsePortfolioEndpoint])
 }
 
 export default usePortfolioRefetchOnTxHistory


### PR DESCRIPTION
## What it solves

Resolves an edge case: When switching Safes, we have a runtime condition, where the refetch due to tx history change could trigger a refetch. This refetch returns an error, when the actual call didn't happen before.

## How this PR fixes it

Only refetches/schedules a refetch when the original call did happen before.

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
