### PR TITLE
chore(mobile): update ssl pins for staging

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,13 +1,13 @@
 import { ExpoConfig } from 'expo/config'
- 
+
 const IS_DEV = process.env.APP_VARIANT === 'development'
 
 const appleDevTeamId = '86487MHG6V'
 
 const sslPinningDomains = {
   'safe-client.staging.5afe.dev': [
-    'q4C71761+V3iWTrVYmUj59dTVrOeoD7KYtOrtA74QBs=', // 🍃 Leaf cert (Valid: Oct 23 00:00:00 2025 GMT → Nov 21 23:59:59 2026 GMT)
-    'DxH4tt40L+eduF6szpY6TONlxhZhBd+pJ9wbHlQ2fuw=', // 🔗 Intermediate (Valid: Aug 23 22:21:28 2022 GMT → Aug 23 22:21:28 2030 GMT)
+    'QHATxmJ9BkdBNaheGWDzmef6AvXrsvSm6//NSIir448=', // 🍃 Leaf cert (Valid: Jul 12 00:00:00 2025 GMT → Aug 10 23:59:59 2026 GMT)
+    'G9LNNAql897egYsabashkzUCTEJkWBzgoEtk8X/678c=', // 🔗 Intermediate (Valid: Aug 23 22:25:30 2022 GMT → Aug 23 22:25:30 2030 GMT)
   ],
   'safe-client.safe.global': [
     'VOstDe9L/YZ7RKPPd7iwAMbsAwCqqblfg3l1IqjUvuE=', // 🍃 Leaf cert (Valid: Jul 12 00:00:00 2025 GMT → Aug 10 23:59:59 2026 GMT)


### PR DESCRIPTION
## What it solves
Staging certs have changed and that broke the staging version of the app.

## How this PR fixes it
update certs

## How to test it
New staging build should work. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
