### PR TITLE
fix(Hypernative): reduce signup modal height

### DIFF
--- a/apps/web/src/features/hypernative/components/HnSignupFlow/styles.module.css
+++ b/apps/web/src/features/hypernative/components/HnSignupFlow/styles.module.css
@@ -1,6 +1,6 @@
 .container {
   overflow: hidden;
-  height: 655px;
+  height: 660px;
   max-height: 90vh;
 }
 
@@ -72,7 +72,7 @@
 
 .cancelButtonWrapper {
   z-index: 1;
-  margin-top: -87px;
+  margin-top: -86px;
 }
 
 .cancelButton {


### PR DESCRIPTION
## What it solves

A small fix for the Hypernative modal: the HubSpot form is now small thanks to fewer fields, so we can adjust the modal to be smaller too.

<img width="932" height="685" alt="Screenshot 2025-12-15 at 15 55 30" src="https://github.com/user-attachments/assets/338359ea-aef6-47f5-8ba0-5bf438ee2aad" />