### PR TITLE
Hotfix(Hypernative): Tracking: Prevent unnecessary hook re-runs (1 tracking event per Safe)

### DIFF
--- a/apps/web/src/features/hypernative/hooks/useTrackBannerEligibilityOnConnect.ts
+++ b/apps/web/src/features/hypernative/hooks/useTrackBannerEligibilityOnConnect.ts
@@ -72,12 +72,12 @@ export const useTrackBannerEligibilityOnConnect = (
     // Skip tracking for:
     // - TxReportButton: shows even when guard is already installed
     // - Pending: only appears after promo banner was viewed (which already triggered tracking)
-    if (bannerType === BannerType.TxReportButton || bannerType === BannerType.Pending) {
-      return
-    }
-
-    // Dashboard banner on the FirstSteps page: Only when banner is visible (for undeployed Safes)
-    if (bannerType === BannerType.NoBalanceCheck && safeDeployed) {
+    // - NoBalanceCheck: HnDashboardBanner on FirstSteps page (should not trigger tracking)
+    if (
+      bannerType === BannerType.TxReportButton ||
+      bannerType === BannerType.Pending ||
+      bannerType === BannerType.NoBalanceCheck
+    ) {
       return
     }
 


### PR DESCRIPTION
## What it solves

The `GUARDIAN_BANNER_VIEWED` event fired multiple times in production in case when some components called the tracking hook simultaneously. Object references changed (e.g., visibilityResult, safeHnState) even when values didn't.
The effect dependency array caused unnecessary re-runs and hence >1 event firing.

Also there was an event tracked for the banner on the First Steps page. This event is removed.

Resolves: [WA-1173](https://linear.app/safe-global/issue/WA-1173/guardian-banner-viewed-event-fired-too-frequently)

## How this PR fixes it
The event now fires once per Safe connection, even with multiple components mounting simultaneously or object references changing. 

- Extract primitives from objects (`showBanner`, `isLoading`, `bannerEligibilityTracked`, `safeDeployed`) to avoid re-runs on reference changes
- Add session-level tracking ref (`hasTrackedRef`) to prevent re-tracking on re-renders
- Memoize safeKey to avoid recalculations
- Added tests for multiple hook instances, object reference changes, dependency stability, race conditions, and rapid visibilityResult changes

- Remove the tracking event when the banner is visible on Safe creation

## How to test it
- The Mixpanel event `GUARDIAN_BANNER_VIEWED` should be tracked only once per eligible Safe.
- No such tracking event for newly created Safes (banner on the First Steps page).

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
