### PR TITLE
fix(ci): Fix web Storybook screenshots workflow

### DIFF
--- a/.github/scripts/generate-story-urls.js
+++ b/.github/scripts/generate-story-urls.js
@@ -21,9 +21,43 @@ const files = changedFiles.split('\n').filter(Boolean)
 console.log('Processing files:', files)
 
 /**
- * Convert file path to Storybook story ID
+ * Extract the title from the story file's meta export
+ * Parses: title: 'Components/Common/Button' or title: "Components/Common/Button"
+ */
+function extractTitleFromFile(filePath) {
+  try {
+    const fullPath = path.join(process.cwd(), filePath)
+    if (!fs.existsSync(fullPath)) {
+      return null
+    }
+
+    const content = fs.readFileSync(fullPath, 'utf-8')
+
+    // Match title with proper quote handling (separate patterns for single/double quotes)
+    const titleMatch = content.match(/title:\s*(?:"([^"]+)"|'([^']+)')/)
+    if (titleMatch) {
+      return titleMatch[1] || titleMatch[2]
+    }
+
+    return null
+  } catch (error) {
+    console.error(`Error extracting title from ${filePath}:`, error.message)
+    return null
+  }
+}
+
+/**
+ * Convert title to Storybook story ID
+ * Example: 'Features/Portfolio/PortfolioRefreshHint' -> 'features-portfolio-portfoliorefreshhint'
+ */
+function titleToStoryId(title) {
+  return title.replace(/\//g, '-').replace(/\s+/g, '-').toLowerCase()
+}
+
+/**
+ * Convert file path to Storybook story ID (fallback when title can't be extracted)
  * Example: src/components/common/CopyButton/index.stories.tsx
- * -> components-common-copybutton--default
+ * -> components-common-copybutton
  */
 function filePathToStoryId(filePath) {
   // Remove apps/web/ prefix if present
@@ -90,10 +124,13 @@ for (const file of files) {
     continue
   }
 
-  const storyId = filePathToStoryId(file)
+  // Try to extract title from meta export, fall back to file path
+  const title = extractTitleFromFile(file)
+  const storyId = title ? titleToStoryId(title) : filePathToStoryId(file)
   const storyNames = extractStoryNames(file)
 
   console.log(`File: ${file}`)
+  console.log(`Title: ${title || '(not found, using file path)'}`)
   console.log(`Story ID: ${storyId}`)
   console.log(`Stories: ${storyNames.join(', ')}`)
 
@@ -105,10 +142,12 @@ for (const file of files) {
     storyUrls.push({
       url,
       file,
-      componentName: storyId
-        .split('-')
-        .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-        .join(''),
+      componentName:
+        title ||
+        storyId
+          .split('-')
+          .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+          .join(''),
       storyName,
     })
   }

--- a/.github/workflows/web-storybook-screenshots.yml
+++ b/.github/workflows/web-storybook-screenshots.yml
@@ -119,28 +119,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Configure git identity
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'
 
-          # Configure git credentials using extraheader (token not visible in process list)
-          git config --global credential.helper store
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
-
-          # Create a unique directory for this PR's screenshots
           SCREENSHOT_DIR="storybook-screenshots/${{ steps.pr.outputs.number }}"
 
-          # Clone the storage branch in a separate directory
           cd /tmp
           rm -rf screenshots-storage
 
-          # Use gh CLI to clone (token handled securely)
-          if gh repo clone ${{ github.repository }} screenshots-storage -- --depth 1 --branch storybook-screenshots-storage; then
+          if git clone --depth 1 --branch storybook-screenshots-storage https://github.com/${{ github.repository }}.git screenshots-storage; then
             echo "Cloned existing storage branch"
             cd screenshots-storage
           else
             echo "Storage branch doesn't exist, creating it"
-            gh repo clone ${{ github.repository }} screenshots-storage -- --depth 1
+            git clone --depth 1 https://github.com/${{ github.repository }}.git screenshots-storage
             cd screenshots-storage
             git checkout --orphan storybook-screenshots-storage
             git rm -rf . 2>/dev/null || true
@@ -149,11 +142,9 @@ jobs:
             git commit -m "Initialize storybook-screenshots-storage branch"
           fi
 
-          # Copy screenshots to PR directory
           mkdir -p "$SCREENSHOT_DIR"
           cp $GITHUB_WORKSPACE/screenshots/*.png "$SCREENSHOT_DIR/" 2>/dev/null || true
 
-          # Commit and push
           git add "$SCREENSHOT_DIR"
           if git commit -m "Add screenshots for PR #${{ steps.pr.outputs.number }}"; then
             git push origin storybook-screenshots-storage


### PR DESCRIPTION
## Summary

Fix the web Storybook screenshots workflow that was failing to post screenshots to PRs.

## Issues Fixed

### 1. Story ID Generation
The script was generating incorrect story IDs from file paths instead of using the `title` from the story's meta export:
- **Before**: `features-portfolio-components-portfoliorefreshhint` (from file path)
- **After**: `features-portfolio-portfoliorefreshhint` (from `title: 'Features/Portfolio/PortfolioRefreshHint'`)

This caused screenshots to fail because the generated URLs didn't match actual Storybook story IDs.

### 2. Git Credentials
The workflow was failing with `fatal: could not read Username for 'https://github.com'` when trying to push screenshots to the storage branch. Fixed by using the same credential helper approach as the working `page-screenshots.yml` workflow.

## Changes

- `.github/scripts/generate-story-urls.js`: Added title extraction from meta export with proper quote handling
- `.github/workflows/web-storybook-screenshots.yml`: Fixed git credential configuration

## Test plan

- [ ] Merge this PR
- [ ] Create a PR that modifies a `.stories.tsx` file
- [ ] Verify screenshots are posted as a comment on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)