### PR TITLE
fix(styles): Adjust text color for the Add Funds banner (dark theme)

### DIFF
--- a/apps/web/src/components/dashboard/AddFundsBanner/index.tsx
+++ b/apps/web/src/components/dashboard/AddFundsBanner/index.tsx
@@ -40,7 +40,7 @@ const AddFundsToGetStarted = () => {
         <SvgIcon component={FiatIcon} inheritViewBox fontSize="small" />
       </Box>
       <Box>
-        <Typography fontWeight="bold" color="static.main">
+        <Typography fontWeight="bold" color="text.primary">
           Add funds to get started
         </Typography>
         <Typography variant="body2" color="info.dark">


### PR DESCRIPTION
## What it solves

The text on the Add Funds banner in the dark mode was too dark with the most recent UI changes (mobile color scheme synced with the web color scheme). This PR provides a style fix.

## Screenshots
<img width="922" height="159" alt="image" src="https://github.com/user-attachments/assets/1d12d933-60ec-4dce-812e-d18bdb26b79a" />

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
