### PR TITLE
chore(ci): resolve back-merge "unrelated histories" error

### DIFF
--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -141,8 +141,8 @@ jobs:
           # Fetch latest changes
           git fetch origin main dev
 
-          # Checkout dev branch
-          git checkout dev
+          # Checkout dev branch with proper tracking (fixes "unrelated histories" error)
+          git checkout -B dev origin/dev
 
           # Attempt to merge main into dev
           if git merge origin/main -m "chore: back-merge main to dev after release ${{ steps.version.outputs.version }}"; then


### PR DESCRIPTION
## Summary

Fixes the back-merge step in the tag-release-deploy workflow that was failing with:
```
fatal: refusing to merge unrelated histories
```

**Root cause:** The workflow checks out a specific commit SHA (`merge_commit_sha`), then tries to switch to `dev` branch. Without proper tracking, git sees the branches as having no common ancestor.

**Fix:** Change `git checkout dev` to `git checkout -B dev origin/dev` to ensure the local branch is properly created/reset with correct history tracking.

**Failed run:** https://github.com/safe-global/safe-wallet-monorepo/actions/runs/20340764679/job/58439175959

## Test plan

- [ ] Next release merge to main should automatically back-merge to dev without the "unrelated histories" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)