### PR TITLE
chore(ci): use secret instead of variable for Slack webhook

### DIFF
--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -174,7 +174,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Notify on Slack
-        if: vars.SLACK_WEBHOOK_URL
+        if: secrets.SLACK_WEBHOOK_URL
         continue-on-error: true
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -203,6 +203,6 @@ jobs:
                   }
                 }
               ]
-            }' | curl -X POST "${{ vars.SLACK_WEBHOOK_URL }}" \
+            }' | curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
               -H 'Content-Type: application/json' \
               -d @-


### PR DESCRIPTION
## Summary
- Fix Slack notification step in release workflow that was being skipped
- Change `vars.SLACK_WEBHOOK_URL` to `secrets.SLACK_WEBHOOK_URL` since the webhook URL is configured as a repository secret, not a variable

## Test plan
- [ ] Verify the next release workflow run sends Slack notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)