### PR TITLE
chore(ci): remove Next.js cache restore-keys fallback

### DIFF
--- a/.github/actions/cache-deps/action.yml
+++ b/.github/actions/cache-deps/action.yml
@@ -66,9 +66,9 @@ runs:
       with:
         path: |
           ${{ github.workspace }}/apps/web/.next/cache
-        key: ${{ runner.os }}-nextjs-cypress-${{ hashFiles('apps/web/package.json', 'apps/web/yarn.lock') }}-${{ hashFiles('apps/web/src/**/*', 'apps/web/public/**/*', 'apps/web/*.{js,jsx,cjs,ts,mjs,tsx,json} ') }}
-        restore-keys: |
-          ${{ runner.os }}-nextjs-${{ hashFiles('apps/web/package.json', 'apps/web/yarn.lock') }}-
+        # No restore-keys fallback - we must not restore stale cache from different source code
+        # as this can cause a mix of old and new code in the build output
+        key: ${{ runner.os }}-nextjs-cypress-${{ hashFiles('apps/web/package.json', 'apps/web/yarn.lock') }}-${{ hashFiles('apps/web/src/**/*', 'apps/web/public/**/*', 'apps/web/*.{js,jsx,cjs,ts,mjs,tsx,json}') }}
 
     - name: Set composite outputs nc
       if: ${{ inputs.mode == 'restore-nc' }}


### PR DESCRIPTION
## Summary

Fixes an issue where production builds could contain a mix of old and new code due to stale Next.js build cache being restored.

### Root Cause

The `restore-keys` fallback in the Next.js cache configuration was:
```yaml
restore-keys: |
  ${{ runner.os }}-nextjs-${{ hashFiles('apps/web/package.json', 'apps/web/yarn.lock') }}-
```

When the exact cache key didn't match (because source files changed), GitHub Actions would fall back to **any** cache matching this prefix - including caches from builds with completely different source code. Next.js's incremental compilation would then use stale cached chunks, resulting in corrupted builds.

### Changes

- Remove `restore-keys` fallback for Next.js cache - cache will only restore on exact match
- Fix trailing space in `hashFiles` pattern that could cause incorrect cache key computation

### Trade-off

Builds will be slower when there's no exact cache hit, but this is preferable to corrupted production builds.

## Test plan

- [ ] Verify release builds contain only the expected code
- [ ] Monitor build times for any significant regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)