### PR TITLE
chore(ci): fix syntax error in Slack notification condition

### DIFF
--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -174,7 +174,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Notify on Slack
-        if: secrets.SLACK_WEBHOOK_URL
+        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
         continue-on-error: true
         run: |
           VERSION="${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Fix invalid syntax `if: secrets.SLACK_WEBHOOK_URL` in the web-tag-release workflow
- Secrets context requires proper expression syntax: `${{ secrets.SLACK_WEBHOOK_URL != '' }}`

## Test plan

- [ ] Verify workflow YAML is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)