### PR TITLE
chore(ci): use env var for Slack webhook secret check

### DIFF
--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -174,9 +174,15 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Notify on Slack
-        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
         continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "No Slack webhook configured, skipping notification"
+            exit 0
+          fi
+
           VERSION="${{ steps.version.outputs.version }}"
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.version }}"
           BACKMERGE_STATUS="${{ steps.backmerge.outcome }}"
@@ -203,6 +209,6 @@ jobs:
                   }
                 }
               ]
-            }' | curl -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
+            }' | curl -X POST "$SLACK_WEBHOOK_URL" \
               -H 'Content-Type: application/json' \
               -d @-


### PR DESCRIPTION
## Summary

- Fix GitHub Actions workflow validation error: "Unrecognized named-value: 'secrets'"
- The `secrets` context cannot be used directly in step-level `if` conditions
- Move the secret check inside the script using an environment variable instead

## Changes

- Remove `if: secrets.SLACK_WEBHOOK_URL != ''` condition from the step
- Add `SLACK_WEBHOOK_URL` as an environment variable in the step
- Add bash check at script start to exit early if webhook URL is empty
- Use `$SLACK_WEBHOOK_URL` env var in curl command instead of direct secret reference

## Test plan

- [ ] Verify workflow validation passes in GitHub Actions
- [ ] Test release workflow still sends Slack notifications when webhook is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)