### PR TITLE
docs(web): update README with current project state

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -33,7 +33,7 @@ yarn install
 ## Contributing
 
 Contributions, be it a bug report or a pull request, are very welcome. Please check
-our [contribution guidelines](CONTRIBUTING.md) beforehand.
+our [contribution guidelines](../../CONTRIBUTING.md) beforehand.
 
 ## Getting started with local development
 
@@ -43,34 +43,45 @@ Create a `.env` file with environment variables. You can use the `.env.example` 
 
 Here's the list of all the environment variables:
 
-| Env variable                                 | Description                                                                                                                                                                                   |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_BRAND_NAME`                     | The name of the app, defaults to "Wallet fork"                                                                                                                                                |
-| `NEXT_PUBLIC_BRAND_LOGO`                     | The URL of the app logo displayed in the header                                                                                                                                               |
-| `NEXT_PUBLIC_INFURA_TOKEN` ❕                | [Infura](https://docs.infura.io/infura/networks/ethereum/how-to/secure-a-project/project-id) RPC API token. **Required for wallet connection and transacting!**                               |
-| `NEXT_PUBLIC_SAFE_APPS_INFURA_TOKEN`         | Infura token for Safe Apps, falls back to `NEXT_PUBLIC_INFURA_TOKEN`                                                                                                                          |
-| `NEXT_PUBLIC_IS_PRODUCTION`                  | Set to `true` to build a minified production app                                                                                                                                              |
-| `NEXT_PUBLIC_DEFAULT_TESTNET_CHAIN_ID`       | The default chain ID used when `NEXT_PUBLIC_IS_PRODUCTION` is set to `false`. Defaults to 11155111 (sepolia)                                                                                  |
-| `NEXT_PUBLIC_DEFAULT_MAINNET_CHAIN_ID`       | The default chain ID used when `NEXT_PUBLIC_IS_PRODUCTION` is set to `true`. Defaults to 1 (mainnet). Must be set to another value if mainnet isn't configured in the chain configs from CGW. |
-| `NEXT_PUBLIC_GATEWAY_URL_PRODUCTION`         | The base URL for the [Safe Client Gateway](https://github.com/safe-global/safe-client-gateway)                                                                                                |
-| `NEXT_PUBLIC_GATEWAY_URL_STAGING`            | The base CGW URL on staging                                                                                                                                                                   |
-| `NEXT_PUBLIC_SAFE_VERSION`                   | The latest version of the Safe contract, defaults to 1.4.1                                                                                                                                    |
-| `NEXT_PUBLIC_WC_PROJECT_ID`                  | [WalletConnect v2](https://docs.walletconnect.com/2.0/cloud/relay) project ID                                                                                                                 |
-| `NEXT_PUBLIC_TENDERLY_ORG_NAME`              | [Tenderly](https://tenderly.co) org name for Transaction Simulation                                                                                                                           |
-| `NEXT_PUBLIC_TENDERLY_PROJECT_NAME`          | Tenderly project name                                                                                                                                                                         |
-| `NEXT_PUBLIC_TENDERLY_SIMULATE_ENDPOINT_URL` | Tenderly simulation URL                                                                                                                                                                       |
-| `NEXT_PUBLIC_BEAMER_ID`                      | [Beamer](https://www.getbeamer.com) is a news feed for in-app announcements                                                                                                                   |
-| `NEXT_PUBLIC_PROD_GA_TRACKING_ID`            | Prod GA property id                                                                                                                                                                           |
-| `NEXT_PUBLIC_TEST_GA_TRACKING_ID`            | Test GA property id                                                                                                                                                                           |
-| `NEXT_PUBLIC_SAFE_APPS_GA_TRACKING_ID`       | Safe Apps GA property id                                                                                                                                                                      |
-| `NEXT_PUBLIC_SENTRY_DSN`                     | [Sentry](https://sentry.io) id for tracking runtime errors                                                                                                                                    |
-| `NEXT_PUBLIC_IS_OFFICIAL_HOST`               | Whether it's the official distribution of the app, or a fork; has legal implications. Set to true only if you also update the legal pages like Imprint and Terms of use                       |
-| `NEXT_PUBLIC_FIREBASE_OPTIONS_PRODUCTION`    | Firebase Cloud Messaging (FCM) `initializeApp` options on production                                                                                                                          |
-| `NEXT_PUBLIC_FIREBASE_VAPID_KEY_PRODUCTION`  | FCM vapid key on production                                                                                                                                                                   |
-| `NEXT_PUBLIC_FIREBASE_OPTIONS_STAGING`       | FCM `initializeApp` options on staging                                                                                                                                                        |
-| `NEXT_PUBLIC_FIREBASE_VAPID_KEY_STAGING`     | FCM vapid key on staging                                                                                                                                                                      |
-| `NEXT_PUBLIC_PROD_MIXPANEL_TOKEN`            | [Mixpanel](https://mixpanel.com) token for production analytics tracking                                                                                                                      |
-| `NEXT_PUBLIC_STAGING_MIXPANEL_TOKEN`         | [Mixpanel](https://mixpanel.com) token for staging analytics tracking                                                                                                                         |
+| Env variable                                  | Description                                                                                                                                                                                   |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_INFURA_TOKEN` ❕                 | [Infura](https://docs.infura.io/infura/networks/ethereum/how-to/secure-a-project/project-id) RPC API token. **Required for wallet connection and transacting!**                               |
+| `NEXT_PUBLIC_WC_PROJECT_ID`                   | [WalletConnect v2](https://docs.walletconnect.com/2.0/cloud/relay) project ID                                                                                                                 |
+| `NEXT_PUBLIC_IS_OFFICIAL_HOST`                | Whether it's the official distribution of the app, or a fork; has legal implications. Set to true only if you also update the legal pages like Imprint and Terms of use                       |
+| `NEXT_PUBLIC_IS_PRODUCTION`                   | Set to `true` to build a minified production app                                                                                                                                              |
+| `NEXT_PUBLIC_BRAND_NAME`                      | The name of the app, defaults to "Wallet fork"                                                                                                                                                |
+| `NEXT_PUBLIC_BRAND_LOGO`                      | The URL of the app logo displayed in the header                                                                                                                                               |
+| `NEXT_PUBLIC_SAFE_APPS_INFURA_TOKEN`          | Infura token for Safe Apps, falls back to `NEXT_PUBLIC_INFURA_TOKEN`                                                                                                                          |
+| `NEXT_PUBLIC_DEFAULT_TESTNET_CHAIN_ID`        | The default chain ID used when `NEXT_PUBLIC_IS_PRODUCTION` is set to `false`. Defaults to 11155111 (sepolia)                                                                                  |
+| `NEXT_PUBLIC_DEFAULT_MAINNET_CHAIN_ID`        | The default chain ID used when `NEXT_PUBLIC_IS_PRODUCTION` is set to `true`. Defaults to 1 (mainnet). Must be set to another value if mainnet isn't configured in the chain configs from CGW. |
+| `NEXT_PUBLIC_GATEWAY_URL_PRODUCTION`          | The base URL for the [Safe Client Gateway](https://github.com/safe-global/safe-client-gateway)                                                                                                |
+| `NEXT_PUBLIC_GATEWAY_URL_STAGING`             | The base CGW URL on staging                                                                                                                                                                   |
+| `NEXT_PUBLIC_SAFE_VERSION`                    | The latest version of the Safe contract, defaults to 1.4.1                                                                                                                                    |
+| `NEXT_PUBLIC_SAFE_STATUS_PAGE_URL`            | URL to the Safe status page                                                                                                                                                                   |
+| `NEXT_PUBLIC_TENDERLY_ORG_NAME`               | [Tenderly](https://tenderly.co) org name for Transaction Simulation                                                                                                                           |
+| `NEXT_PUBLIC_TENDERLY_PROJECT_NAME`           | Tenderly project name                                                                                                                                                                         |
+| `NEXT_PUBLIC_TENDERLY_SIMULATE_ENDPOINT_URL`  | Tenderly simulation URL                                                                                                                                                                       |
+| `NEXT_PUBLIC_BLOCKAID_API`                    | [Blockaid](https://www.blockaid.io) API URL for transaction security scanning                                                                                                                 |
+| `NEXT_PUBLIC_BLOCKAID_CLIENT_ID`              | Blockaid client ID                                                                                                                                                                            |
+| `NEXT_PUBLIC_BEAMER_ID`                       | [Beamer](https://www.getbeamer.com) is a news feed for in-app announcements                                                                                                                   |
+| `NEXT_PUBLIC_PROD_GA_TRACKING_ID`             | Prod GA property id                                                                                                                                                                           |
+| `NEXT_PUBLIC_TEST_GA_TRACKING_ID`             | Test GA property id                                                                                                                                                                           |
+| `NEXT_PUBLIC_SAFE_APPS_GA_TRACKING_ID`        | Safe Apps GA property id                                                                                                                                                                      |
+| `NEXT_PUBLIC_SENTRY_DSN`                      | [Sentry](https://sentry.io) id for tracking runtime errors                                                                                                                                    |
+| `NEXT_PUBLIC_DATADOG_CLIENT_TOKEN`            | [Datadog](https://www.datadoghq.com) client token for monitoring                                                                                                                              |
+| `NEXT_PUBLIC_FIREBASE_OPTIONS_PRODUCTION`     | Firebase Cloud Messaging (FCM) `initializeApp` options on production                                                                                                                          |
+| `NEXT_PUBLIC_FIREBASE_VAPID_KEY_PRODUCTION`   | FCM vapid key on production                                                                                                                                                                   |
+| `NEXT_PUBLIC_FIREBASE_OPTIONS_STAGING`        | FCM `initializeApp` options on staging                                                                                                                                                        |
+| `NEXT_PUBLIC_FIREBASE_VAPID_KEY_STAGING`      | FCM vapid key on staging                                                                                                                                                                      |
+| `NEXT_PUBLIC_PROD_MIXPANEL_TOKEN`             | [Mixpanel](https://mixpanel.com) token for production analytics tracking                                                                                                                      |
+| `NEXT_PUBLIC_STAGING_MIXPANEL_TOKEN`          | Mixpanel token for staging analytics tracking                                                                                                                                                 |
+| `NEXT_PUBLIC_HUBSPOT_CONFIG`                  | HubSpot configuration for marketing integrations                                                                                                                                              |
+| `NEXT_PUBLIC_HYPERNATIVE_CALENDLY`            | Calendly URL for Hypernative scheduling                                                                                                                                                       |
+| `NEXT_PUBLIC_PROD_HYPERNATIVE_OUTREACH_ID`    | Hypernative outreach ID for production                                                                                                                                                        |
+| `NEXT_PUBLIC_STAGING_HYPERNATIVE_OUTREACH_ID` | Hypernative outreach ID for staging                                                                                                                                                           |
+| `NEXT_PUBLIC_ECOSYSTEM_ID_ADDRESS`            | Ecosystem ID address                                                                                                                                                                          |
+| `NEXT_PUBLIC_SPACES_SAFE_ACCOUNTS_LIMIT`      | Maximum number of Safe accounts allowed in Spaces                                                                                                                                             |
+| `NEXT_PUBLIC_IS_BEHIND_IAP`                   | Set to `true` when the app is behind an Identity-Aware Proxy                                                                                                                                  |
 
 If you don't provide some of the variables, the corresponding features will be disabled in the UI.
 
@@ -169,15 +180,26 @@ yarn workspace @safe-global/web cmp MyNewComponent
 
 This repo has a pre-push hook that runs the linter (always) and the tests (if the `RUN_TESTS_ON_PUSH` env variable is set to true) before pushing. If you want to skip the hooks, you can use the `--no-verify` flag.
 
+## Storybook
+
+This project uses Storybook for developing and documenting UI components in isolation.
+
+```bash
+yarn workspace @safe-global/web storybook
+```
+
+This will start Storybook on [http://localhost:6006](http://localhost:6006).
+
+When creating new components, add a corresponding `.stories.tsx` file for documentation. See `docs/storybook-snapshots.md` for more information on Storybook snapshot testing.
+
 ## Frameworks
 
 This app is built using the following frameworks:
 
-- [Safe Core SDK](https://github.com/safe-global/safe-core-sdk)
-- [Safe Gateway SDK](https://github.com/safe-global/safe-gateway-typescript-sdk)
-- Next.js
-- React
-- Redux
-- MUI
-- ethers.js
-- web3-onboard
+- [Safe Protocol Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/protocol-kit) and [API Kit](https://github.com/safe-global/safe-core-sdk/tree/main/packages/api-kit)
+- [Next.js 15](https://nextjs.org/)
+- [React 19](https://react.dev/)
+- [Redux Toolkit](https://redux-toolkit.js.org/)
+- [MUI v6](https://mui.com/)
+- [ethers.js v6](https://docs.ethers.org/v6/)
+- [web3-onboard](https://onboard.blocknative.com/)


### PR DESCRIPTION
## Summary

Updates the web app README.md to reflect the current state of the project:

- Reorganized and updated environment variables table with new variables (Blockaid, Datadog, Hypernative, Spaces, etc.)
- Fixed CONTRIBUTING.md link to point to the monorepo root (`../../CONTRIBUTING.md`)
- Added Storybook section with usage instructions
- Updated Frameworks section with current versions and correct SDK links

## Changes

### Environment Variables
- Reordered to prioritize essential variables (`INFURA_TOKEN`, `WC_PROJECT_ID`, `IS_OFFICIAL_HOST`)
- Added new variables:
  - `NEXT_PUBLIC_SAFE_STATUS_PAGE_URL`
  - `NEXT_PUBLIC_BLOCKAID_API` and `NEXT_PUBLIC_BLOCKAID_CLIENT_ID`
  - `NEXT_PUBLIC_DATADOG_CLIENT_TOKEN`
  - `NEXT_PUBLIC_HUBSPOT_CONFIG`
  - `NEXT_PUBLIC_HYPERNATIVE_CALENDLY` and Hypernative outreach IDs
  - `NEXT_PUBLIC_ECOSYSTEM_ID_ADDRESS`
  - `NEXT_PUBLIC_SPACES_SAFE_ACCOUNTS_LIMIT`
  - `NEXT_PUBLIC_IS_BEHIND_IAP`

### Documentation Links
- Fixed broken `CONTRIBUTING.md` link (file exists at monorepo root, not in apps/web)

### New Storybook Section
- Added instructions for running Storybook
- Referenced storybook-snapshots documentation

### Updated Frameworks
- Safe Core SDK → Safe Protocol Kit and API Kit (with direct GitHub links)
- Added version numbers: Next.js 15, React 19, MUI v6, ethers.js v6
- Added official documentation links for all frameworks

## Test plan

- [x] Verified all environment variables exist in codebase via grep
- [x] Verified CONTRIBUTING.md exists at monorepo root
- [x] Verified Storybook command works
- [x] Verified framework versions match package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)