### PR TITLE
fix(mobile): Add optional chaining to theme property access

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -9,9 +9,9 @@ import TransactionHeader from '@/src/features/TxHistory/components/TransactionHe
 export default function TabLayout() {
   const theme = useTheme()
 
-  const activeTintColor = React.useMemo(() => theme.color.get(), [theme])
-  const inactiveTintColor = React.useMemo(() => theme.borderMain.get(), [theme])
-  const borderTopColor = React.useMemo(() => theme.borderLight.get(), [theme])
+  const activeTintColor = React.useMemo(() => theme.color?.get(), [theme])
+  const inactiveTintColor = React.useMemo(() => theme.borderMain?.get(), [theme])
+  const borderTopColor = React.useMemo(() => theme.borderLight?.get(), [theme])
 
   const screenOptions = React.useMemo(
     () => ({

--- a/apps/mobile/src/app/import-signers/ledger-error.tsx
+++ b/apps/mobile/src/app/import-signers/ledger-error.tsx
@@ -7,7 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export default function LedgerErrorPage() {
   const theme = useTheme()
-  const colors: [string, string] = [theme.errorDark.get(), 'transparent']
+  const colors: [string, string] = [theme.errorDark?.get() ?? '', 'transparent']
   const { bottom } = useSafeAreaInsets()
   return (
     <View flex={1} paddingBottom={Math.max(bottom, getTokenValue('$4'))}>

--- a/apps/mobile/src/app/import-signers/private-key-error.tsx
+++ b/apps/mobile/src/app/import-signers/private-key-error.tsx
@@ -7,7 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export default function App() {
   const theme = useTheme()
-  const colors: [string, string] = [theme.errorDark.get(), 'transparent']
+  const colors: [string, string] = [theme.errorDark?.get() ?? '', 'transparent']
   const { bottom } = useSafeAreaInsets()
   return (
     <View style={{ flex: 1 }} paddingBottom={Math.max(bottom, getTokenValue('$4'))}>

--- a/apps/mobile/src/components/LinearGradient/LinearGradien.tsx
+++ b/apps/mobile/src/components/LinearGradient/LinearGradien.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, ViewStyle } from 'react-native'
 
 export const AbsoluteLinearGradient = ({ colors, style }: { colors?: [string, string]; style?: ViewStyle }) => {
   const theme = useTheme()
-  const colorsToUse: [string, string] = colors || [theme.success.get(), 'transparent']
+  const colorsToUse: [string, string] = colors || [theme.success?.get() ?? '', 'transparent']
 
   return <ExpoLinearGradient colors={colorsToUse} style={[styles.background, style]} />
 }

--- a/apps/mobile/src/components/SafeSearchBar/SafeSearchBar.tsx
+++ b/apps/mobile/src/components/SafeSearchBar/SafeSearchBar.tsx
@@ -47,15 +47,15 @@ const SafeSearchBar: React.FC<SafeSearchBarProps> = ({ placeholder, onSearch, th
     onSearch('')
   }
 
-  const colorSecondary = theme.colorSecondary.get()
+  const colorSecondary = theme.colorSecondary?.get()
 
   return (
     <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.container}>
-      <View style={[styles.searchBar, { backgroundColor: theme.backgroundSecondary.get() }]}>
+      <View style={[styles.searchBar, { backgroundColor: theme.backgroundSecondary?.get() }]}>
         <SafeFontIcon name="search" size={18} color={colorSecondary} />
 
         <TextInput
-          style={[styles.input, { color: theme.color.get() }]}
+          style={[styles.input, { color: theme.color?.get() }]}
           placeholder={placeholder}
           placeholderTextColor={colorSecondary}
           value={searchQuery}

--- a/apps/mobile/src/features/Assets/components/NoFunds/EmptyNFT.tsx
+++ b/apps/mobile/src/features/Assets/components/NoFunds/EmptyNFT.tsx
@@ -5,7 +5,7 @@ import { useTheme } from 'tamagui'
 function EmptyNft() {
   const theme = useTheme()
 
-  const color = theme.background.get()
+  const color = theme.background?.get()
 
   return (
     <Svg width="101" height="100" viewBox="0 0 101 100" fill="none">

--- a/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewAndConfirmView.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewAndConfirmView.tsx
@@ -22,12 +22,12 @@ export function ReviewAndConfirmView({ txDetails, children, header }: ReviewAndC
     <MaterialTabBar
       {...props}
       indicatorStyle={{
-        backgroundColor: theme.color.get(),
+        backgroundColor: theme.color?.get(),
       }}
-      style={{ backgroundColor: isDark ? theme.background.get() : theme.backgroundPaper.get() }}
-      labelStyle={{ color: theme.color.get(), fontSize: 16, fontWeight: '600' }}
-      activeColor={theme.color.get()}
-      inactiveColor={theme.colorSecondary.get()}
+      style={{ backgroundColor: isDark ? theme.background?.get() : theme.backgroundPaper?.get() }}
+      labelStyle={{ color: theme.color?.get(), fontSize: 16, fontWeight: '600' }}
+      activeColor={theme.color?.get()}
+      inactiveColor={theme.colorSecondary?.get()}
       width={300}
     />
   )

--- a/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignError.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignError.tsx
@@ -11,7 +11,7 @@ import { AbsoluteLinearGradient } from '@/src/components/LinearGradient'
 export function SignError({ description }: { description?: string }) {
   const router = useRouter()
   const theme = useTheme()
-  const colors: [string, string] = [theme.errorDark.get(), 'transparent']
+  const colors: [string, string] = [theme.errorDark?.get() ?? '', 'transparent']
   const { bottom } = useSafeAreaInsets()
   return (
     <View flex={1} paddingBottom={Math.max(bottom, getTokenValue('$4'))}>

--- a/apps/mobile/src/features/DataImport/ImportError.container.tsx
+++ b/apps/mobile/src/features/DataImport/ImportError.container.tsx
@@ -6,7 +6,7 @@ import { ImportErrorView } from './components/ImportErrorView'
 
 export default function ImportError() {
   const theme = useTheme()
-  const colors: [string, string] = [theme.errorDark.get(), 'transparent']
+  const colors: [string, string] = [theme.errorDark?.get() ?? '', 'transparent']
   const insets = useSafeAreaInsets()
 
   return <ImportErrorView colors={colors} bottomInset={insets.bottom} onTryAgain={router.back} />

--- a/apps/mobile/src/features/ExecuteTx/components/ExecuteError.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ExecuteError.tsx
@@ -11,7 +11,7 @@ import { AbsoluteLinearGradient } from '@/src/components/LinearGradient'
 export function ExecuteError({ description }: { description?: string }) {
   const router = useRouter()
   const theme = useTheme()
-  const colors: [string, string] = [theme.errorDark.get(), 'transparent']
+  const colors: [string, string] = [theme.errorDark?.get() ?? '', 'transparent']
   const { bottom } = useSafeAreaInsets()
   return (
     <View flex={1} paddingBottom={Math.max(bottom, getTokenValue('$4'))}>

--- a/apps/mobile/src/features/PendingTx/components/PendingTxList/PendingTxList.container.tsx
+++ b/apps/mobile/src/features/PendingTx/components/PendingTxList/PendingTxList.container.tsx
@@ -128,7 +128,7 @@ export function PendingTxListContainer({
           padding="$2"
           testID="pending-tx-progress-indicator"
         >
-          <CircleSnail size={24} color={theme.color.get()} thickness={2} duration={600} spinDuration={1500} />
+          <CircleSnail size={24} color={theme.color?.get() ?? ''} thickness={2} duration={600} spinDuration={1500} />
         </View>
       )}
 


### PR DESCRIPTION
## Summary

Fix TypeScript errors where Tamagui theme properties are possibly undefined by adding optional chaining to all `theme.PROPERTY.get()` calls throughout the mobile codebase.

## Changes

- Add optional chaining (`theme.PROPERTY?.get()`) to all theme property accesses
- Add null coalescing (`?? ''`) where values are used in contexts requiring defined strings (e.g., gradient color arrays)

## Files Changed (11 files)

### Navigation
- `apps/mobile/src/app/(tabs)/_layout.tsx`

### Import Signers
- `apps/mobile/src/app/import-signers/ledger-error.tsx`
- `apps/mobile/src/app/import-signers/private-key-error.tsx`

### Components
- `apps/mobile/src/components/LinearGradient/LinearGradien.tsx`
- `apps/mobile/src/components/SafeSearchBar/SafeSearchBar.tsx`

### Features
- `apps/mobile/src/features/Assets/components/NoFunds/EmptyNFT.tsx`
- `apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewAndConfirmView.tsx`
- `apps/mobile/src/features/ConfirmTx/components/SignTransaction/SignError.tsx`
- `apps/mobile/src/features/DataImport/ImportError.container.tsx`
- `apps/mobile/src/features/ExecuteTx/components/ExecuteError.tsx`
- `apps/mobile/src/features/PendingTx/components/PendingTxList/PendingTxList.container.tsx`

## Impact

This resolves approximately 20 TypeScript errors that were blocking commits due to pre-commit type-check hooks.

## Test plan

- [x] All type-check errors resolved (`yarn workspace @safe-global/mobile type-check` passes)
- [x] Pre-commit hooks pass (prettier, lint, type-check)
- [ ] Verify affected components still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)