### PR TITLE
chore(ci): Trigger Storybook screenshots on component changes

### DIFF
--- a/apps/mobile/src/components/SafeButton/SafeButton.tsx
+++ b/apps/mobile/src/components/SafeButton/SafeButton.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { styled, Button } from 'tamagui'
 import { Loader } from '@/src/components/Loader'
-
 // Create base styled button
-// Test change to trigger mobile Storybook screenshot workflow
 const BaseButton = styled(Button, {
   variants: {
     rounded: {

--- a/apps/web/src/components/common/UnreadBadge/index.tsx
+++ b/apps/web/src/components/common/UnreadBadge/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Badge, { type BadgeProps } from '@mui/material/Badge'
 
-// Test change to trigger web Storybook screenshot workflow
 const UnreadBadge = ({
   children,
   count,


### PR DESCRIPTION
## What it solves

Fixes the issue where Storybook screenshot workflows only triggered when story files were directly modified, missing visual changes when component files were updated.

Related to discussion in PR #6876 where component changes didn't generate screenshots.

## How this PR fixes it

Updates both mobile and web Storybook screenshot workflows to:
1. Trigger on component file changes (`.tsx`, `.ts`, excluding tests)
2. Detect which components have associated story files
3. Search for story files in same directory and common subdirectories (`components/`, `stories/`, `__stories__/`)
4. Capture screenshots for all affected stories

## Test plan

This PR includes test changes to two components:
- **Mobile**: `SafeButton` (has `SafeButton.stories.tsx`)
- **Web**: `UnreadBadge` (has `UnreadBadge.stories.tsx`)

Expected behavior:
- [ ] Mobile Storybook Screenshots workflow should run and post screenshots for SafeButton
- [ ] Web Storybook Screenshots workflow should run and post screenshots for UnreadBadge (after deploy completes)

## Impact

Going forward, any PR that modifies a component with an existing Storybook story will automatically get screenshot comments, providing better visibility into UI changes during code review without requiring developers to manually touch story files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)