### PR TITLE
fix: next tx execute button shouldnt be disabled on prev's indexind state

### DIFF
--- a/apps/web/src/hooks/useIsPending.ts
+++ b/apps/web/src/hooks/useIsPending.ts
@@ -1,9 +1,16 @@
 import { useAppSelector } from '@/store'
-import { selectPendingTxs } from '@/store/pendingTxsSlice'
+import { PendingStatus, selectPendingTxs } from '@/store/pendingTxsSlice'
 
 const useIsPending = (txId: string): boolean => {
   const pendingTxs = useAppSelector(selectPendingTxs)
-  return !!pendingTxs[txId]
+  const pendingTx = pendingTxs[txId]
+
+  // INDEXING status means the tx is already processed on-chain and shouldn't block execution
+  if (pendingTx?.status === PendingStatus.INDEXING) {
+    return false
+  }
+
+  return !!pendingTx
 }
 
 export default useIsPending


### PR DESCRIPTION
## What it solves

The UI blocks the user from executing next tx even when there is no reason to block it. "Indexing" state is offchain indexing, the tx has already executed onchain.

Resolves:

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the UI doesn't block execution when a previous tx is only being indexed off-chain.
> 
> - Updates `useIsPending` to import `PendingStatus` and return `false` when `pendingTx.status === PendingStatus.INDEXING`
> - Falls back to pending based on presence of `pendingTx` for other statuses
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30173d132e5deec50c1259b8f3795049508c3f3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->