### PR TITLE
fix(web): enable Execute option for new transactions in 1/1 Safes

### DIFF
--- a/apps/web/src/components/tx-flow/TxFlowProvider.tsx
+++ b/apps/web/src/components/tx-flow/TxFlowProvider.tsx
@@ -189,7 +189,8 @@ const TxFlowProvider = <T extends unknown>({
   const preferThroughRole = canExecuteThroughRole && !isSafeOwner // execute through role if a non-owner role member wallet is connected
 
   // If checkbox is checked and the transaction is executable, execute it, otherwise sign it
-  const canExecute = isCorrectNonce && (isExecutable || isNewExecutableTx)
+  // For new transactions in 1/1 Safes (isNewExecutableTx), allow execution even before safeTx is created
+  const canExecute = isNewExecutableTx || (isCorrectNonce && isExecutable)
   const willExecute = (onlyExecute || shouldExecute) && canExecute && !preferThroughRole
   const willExecuteThroughRole =
     (onlyExecute || shouldExecute) && canExecuteThroughRole && (!canExecute || preferThroughRole)


### PR DESCRIPTION
## Summary

Fixes a bug where the Execute option was not available when creating transactions in 1/1 Safes (threshold=1) with no queued transactions.

## Problem

In 1/1 Safes, when creating a new transaction (e.g., replacing an owner), the UI only showed the "Sign" option instead of "Execute". This forced users to unnecessarily sign and then execute in two steps, even though 1/1 Safes can execute immediately.

## Root Cause

The `canExecute` logic required `isCorrectNonce` to be true:

```typescript
const canExecute = isCorrectNonce && (isExecutable || isNewExecutableTx)
```

For new transactions (`isNewExecutableTx`), the `safeTx` hasn't been created yet, so `isCorrectNonce` evaluates to false, preventing immediate execution.

## Solution

Prioritize `isNewExecutableTx` in the condition:

```typescript
const canExecute = isNewExecutableTx || (isCorrectNonce && isExecutable)
```

This allows immediate execution for new transactions in 1/1 Safes without waiting for full transaction creation and nonce validation.

## Test plan

- [ ] Open a 1/1 Safe (threshold=1)
- [ ] Initiate any transaction flow (e.g., Settings → Setup → Owners → Replace owner)
- [ ] Verify Execute option is available (not just Sign)
- [ ] Execute the transaction successfully
- [ ] Verify this doesn't break execution for multi-sig Safes

🤖 Generated with [Claude Code](https://claude.com/claude-code)