### PR TITLE
chore(ci): Detect story changes from test files and snapshots in screenshot workflow

### DIFF
--- a/.github/workflows/web-storybook-screenshots.yml
+++ b/.github/workflows/web-storybook-screenshots.yml
@@ -61,11 +61,16 @@ jobs:
           BASE_SHA=${{ github.event.workflow_run.pull_requests[0].base.sha }}
           HEAD_SHA=${{ github.event.workflow_run.head_sha }}
 
-          # Get all changed files in web app
+          # Get all changed files in web app (excluding test files for now)
           ALL_CHANGED=$(git diff --name-only $BASE_SHA $HEAD_SHA | grep -E '^apps/web/src/.*\.(tsx?|jsx?)$' | grep -v '\.test\.' || true)
+
+          # Get changed story test files and snapshot files separately
+          STORY_TEST_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA | grep -E '^apps/web/src/.*\.stories\.test\.(tsx?|jsx?)$' || true)
+          SNAPSHOT_FILES=$(git diff --name-only $BASE_SHA $HEAD_SHA | grep -E '^apps/web/src/.*__snapshots__/.*\.stories\.test\.(tsx?|jsx?)\.snap$' || true)
 
           STORY_FILES=""
 
+          # Process regular component and story files
           for file in $ALL_CHANGED; do
             # If it's already a story file, include it
             if [[ "$file" =~ \.(stories|story)\.(tsx?|jsx?)$ ]]; then
@@ -100,6 +105,30 @@ jobs:
                   fi
                 done
               done
+            fi
+          done
+
+          # Process story test files - find corresponding .stories.tsx files
+          for file in $STORY_TEST_FILES; do
+            # Convert MyComponent.stories.test.tsx -> MyComponent.stories.tsx
+            story_file=$(echo "$file" | sed -E 's/\.stories\.test\.(tsx?)$/.stories.\1/')
+            if [ -f "$story_file" ]; then
+              STORY_FILES="$STORY_FILES$story_file"$'\n'
+              echo "Found story file from test file: $story_file"
+            fi
+          done
+
+          # Process snapshot files - extract corresponding .stories.tsx files
+          for file in $SNAPSHOT_FILES; do
+            # Convert apps/web/src/features/safe-shield/__snapshots__/SafeShield.stories.test.tsx.snap
+            # -> apps/web/src/features/safe-shield/SafeShield.stories.tsx
+            dir=$(dirname "$file")
+            parent_dir=$(dirname "$dir")
+            base=$(basename "$file" | sed -E 's/\.stories\.test\.(tsx?)\.snap$/.stories.\1/')
+            story_file="$parent_dir/$base"
+            if [ -f "$story_file" ]; then
+              STORY_FILES="$STORY_FILES$story_file"$'\n'
+              echo "Found story file from snapshot: $story_file"
             fi
           done
 


### PR DESCRIPTION
## Summary

The Storybook Screenshots workflow now detects story file changes from three sources instead of just one:

1. **Direct .stories.tsx file changes** (existing behavior)
2. **.stories.test.tsx file changes** - automatically finds the corresponding .stories.tsx file
3. **__snapshots__/*.stories.test.tsx.snap changes** - extracts and captures the corresponding .stories.tsx file

## Problem

In PR #6911, the workflow didn't capture screenshots even though `SafeShield.stories.test.tsx.snap` was modified, indicating visual changes to the stories. The workflow only looked at direct story file changes and ignored test/snapshot files.

## Solution

Enhanced the "Get changed story files" step to:
- Detect `.stories.test.tsx` file changes and map them to `.stories.tsx` files
- Detect snapshot file changes in `__snapshots__/` directories and extract the corresponding story files
- Maintain all existing behavior for direct story and component file changes

## Test Plan

- [ ] Modify a story snapshot file and verify screenshots are captured
- [ ] Modify a .stories.test.tsx file and verify screenshots are captured
- [ ] Verify existing behavior still works for direct story file changes
- [ ] Verify component file changes still trigger screenshots when stories exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)