### PR TITLE
tests(e2e): fix test requiring sign btn

### DIFF
--- a/apps/web/cypress/e2e/happypath_2/nested_safes.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/nested_safes.cy.js
@@ -37,6 +37,7 @@ describe('Nested safes happy path tests', () => {
     nsafes.typeName(safe)
     nsafes.clickOnAddNextBtn()
     createTx.clickOnContinueSignTransactionBtn()
+    createTx.selectComboButtonOption('sign')
     createTx.clickOnSignTransactionBtn()
     createTx.clickViewTransaction()
     main.verifyValuesExist(createTx.transactionItem, [

--- a/apps/web/cypress/e2e/happypath_2/tx-builder.cy.js
+++ b/apps/web/cypress/e2e/happypath_2/tx-builder.cy.js
@@ -73,6 +73,7 @@ describe('Transaction Builder happy path tests', { defaultCommandTimeout: 20000 
       navigation.verifyTxBtnStatus(constants.enabledStates.enabled)
       createtx.clickOnConfirmTransactionBtn()
       createtx.clickOnContinueSignTransactionBtn()
+      createtx.selectComboButtonOption('sign')
       createtx.clickOnSignTransactionBtn()
       navigation.clickOnWalletExpandMoreIcon()
       navigation.clickOnDisconnectBtn()


### PR DESCRIPTION
## What it solves
Some tests require the sign button to show in the tx form. We recently changed so if a tx can be executed now, the execute button shows instead

## How this PR fixes it
Adds an extra step in those test to change the execute button to sign button

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures e2e flows explicitly choose the sign action where the UI may default to execute.
> 
> - In `nested_safes.cy.js` and `tx-builder.cy.js`, add `selectComboButtonOption('sign')` before `clickOnSignTransactionBtn()` to force the sign path in the tx form
> - Keeps existing flows unchanged aside from this selection to stabilize tests under the updated execute/sign combo button
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24d550681232bbb439684a95e4de38d05ccf72b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->