### PR TITLE
fix(web): Add DataTestId to expand connected wallet 

### DIFF
--- a/apps/web/src/components/common/ConnectWallet/AccountCenter.tsx
+++ b/apps/web/src/components/common/ConnectWallet/AccountCenter.tsx
@@ -39,7 +39,7 @@ export const AccountCenter = ({ wallet }: { wallet: ConnectedWallet }) => {
             {open ? (
               <ExpandLessIcon color="border" sx={{ fontSize: 16 }} />
             ) : (
-              <ExpandMoreIcon color="border" sx={{ fontSize: 16 }} />
+              <ExpandMoreIcon data-testid="ExpandMoreIcon" color="border" sx={{ fontSize: 16 }} />
             )}
           </Box>
         </Box>


### PR DESCRIPTION
## What it solves
dataTestId to expand Connected wallet modal was missing after laterst UI changes 
Resolves:

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a testing hook to the wallet expand control.
> 
> - Adds `data-testid="ExpandMoreIcon"` to the collapsed-state `ExpandMoreIcon` in `AccountCenter.tsx` to enable reliable UI/e2e selection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 664bba29085ea8f2b19de1e0dd7f3659f0cba500. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->