### PR TITLE
fix(SafeAppsTx): ensure safeTxGas is a string

### DIFF
--- a/apps/web/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
+++ b/apps/web/src/components/tx-flow/flows/SafeAppsTx/ReviewSafeAppsTx.tsx
@@ -32,7 +32,6 @@ const ReviewSafeAppsTx = ({
       const tx = isMultiSend ? await createMultiSendCallOnlyTx(txs) : await createTx(txs[0])
 
       if (params?.safeTxGas !== undefined && !Number.isNaN(params.safeTxGas)) {
-        // FIXME: do it properly via the Core SDK
         tx.data.safeTxGas = String(params.safeTxGas)
       }
 


### PR DESCRIPTION
## What it solves
Resolves: [WA-1236](https://linear.app/safe-global/issue/WA-1236/safetxgas-is-sent-in-wrong-format-to-hn)
Hypernative assessments fail when `safeTxGas` is provided as a number.

## How this PR fixes it

Convert the value to string to ensure correct typing per `SafeTransaction` and proper request handling.

## How to test it
1. Open a Safe with a HN guard
2. Connect the Safe with https://examples.blockaid.io/
3. Send any example from Bloackaid
4. Verify that the Hypernative assessment does not fail with a 400 error

## Screenshots
<img width="1090" height="384" alt="Screenshot 2026-01-13 at 11 21 17" src="https://github.com/user-attachments/assets/624f9452-f2e9-498f-b817-15eef5e2dd3f" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
