### PR TITLE
fix(web): update Beamer notification center link in privacy policy

### DIFF
--- a/apps/web/src/markdown/privacy/privacy.md
+++ b/apps/web/src/markdown/privacy/privacy.md
@@ -456,7 +456,7 @@ We use [**Sentry**](https://sentry.io/) to collect error reports and crashes to 
 
 ## 5.9. Beamer {#beamer}
 
-We use [**Beamer**](https://www.getbeamer.com/) providing updates to the user about changes in the app.Beamer's purpose and function are further explained under the following link [**https://www.getbeamer.com/showcase/notification-center**](https://www.getbeamer.com/showcase/notification-center).
+We use [**Beamer**](https://www.getbeamer.com/) providing updates to the user about changes in the app.Beamer's purpose and function are further explained under the following link [**https://www.getbeamer.com/in-app-notification-center**](https://www.getbeamer.com/in-app-notification-center).
 
 We do not store any information collected by Beamer.
 


### PR DESCRIPTION
Update the Beamer documentation URL in the privacy policy to point to the current in-app notification center page. The previous showcase link returns 404, so this change keeps the external reference valid and accurate for users who want to learn more about Beamer’s functionality.

https://www.getbeamer.com/showcase/notification-center - broken

https://www.getbeamer.com/in-app-notification-center - working

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates an external reference in the privacy policy to avoid a broken link.
> 
> - In `apps/web/src/markdown/privacy/privacy.md` under `5.9. Beamer`, replaces `https://www.getbeamer.com/showcase/notification-center` with `https://www.getbeamer.com/in-app-notification-center`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2436a719820cc024eac18c8310cc5ed3db49f56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->