### PR TITLE
fix(web): don’t use package.json at runtime to read app version

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -1,3 +1,14 @@
+const path = require('path')
+const fs = require('fs')
+
+// Set environment variables before modules are loaded
+if (!process.env.NEXT_PUBLIC_APP_VERSION || !process.env.NEXT_PUBLIC_APP_HOMEPAGE) {
+  const packageJsonPath = path.join(__dirname, 'package.json')
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+  process.env.NEXT_PUBLIC_APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version
+  process.env.NEXT_PUBLIC_APP_HOMEPAGE = process.env.NEXT_PUBLIC_APP_HOMEPAGE || packageJson.homepage
+}
+
 const nextJest = require('next/jest')
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -80,6 +80,8 @@ const nextConfig = {
 
   env: {
     NEXT_PUBLIC_COMMIT_HASH: commitHash,
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+    NEXT_PUBLIC_APP_HOMEPAGE: pkg.homepage,
   },
 
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],

--- a/apps/web/src/components/common/Footer/index.tsx
+++ b/apps/web/src/components/common/Footer/index.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import css from './styles.module.css'
 import { AppRoutes } from '@/config/routes'
-import packageJson from '../../../../package.json'
+import { APP_VERSION, APP_HOMEPAGE } from '@/config/version'
 import ExternalLink from '../ExternalLink'
 import MUILink from '@mui/material/Link'
 import { useIsOfficialHost } from '@/hooks/useIsOfficialHost'
@@ -94,15 +94,15 @@ const Footer: React.FC<FooterProps> = ({
         )}
 
         <li>
-          <ExternalLink href={`${packageJson.homepage}/releases/tag/v${packageJson.version}`} noIcon>
+          <ExternalLink href={`${APP_HOMEPAGE}/releases/tag/v${APP_VERSION}`} noIcon>
             {versionIcon && <SvgIcon component={GitHubIcon} inheritViewBox fontSize="inherit" sx={{ mr: 0.5 }} />}v
-            {packageJson.version}
+            {APP_VERSION}
           </ExternalLink>
         </li>
 
         {!IS_PRODUCTION && COMMIT_HASH && (
           <li>
-            <ExternalLink href={`${packageJson.homepage}/commit/${COMMIT_HASH}`} noIcon>
+            <ExternalLink href={`${APP_HOMEPAGE}/commit/${COMMIT_HASH}`} noIcon>
               {COMMIT_HASH.slice(0, 7)}
             </ExternalLink>
           </li>

--- a/apps/web/src/components/settings/PushNotifications/__tests__/logic.test.ts
+++ b/apps/web/src/components/settings/PushNotifications/__tests__/logic.test.ts
@@ -3,7 +3,7 @@ import { BrowserProvider, type JsonRpcSigner, toBeHex } from 'ethers'
 
 import * as logic from '../logic'
 import * as web3 from '@/hooks/wallets/web3'
-import packageJson from '../../../../../package.json'
+import { APP_VERSION } from '@/config/version'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { MockEip1193Provider } from '@/tests/mocks/providers'
 
@@ -124,7 +124,7 @@ describe('Notifications', () => {
         buildNumber: '0',
         bundle: 'safe',
         deviceType: 'WEB',
-        version: packageJson.version,
+        version: APP_VERSION,
         timestamp: expect.any(String),
         safeRegistrations: [
           {

--- a/apps/web/src/components/settings/PushNotifications/logic.ts
+++ b/apps/web/src/components/settings/PushNotifications/logic.ts
@@ -4,7 +4,7 @@ import { getBytes, keccak256, toUtf8Bytes, type BrowserProvider } from 'ethers'
 import { getToken, getMessaging } from 'firebase/messaging'
 
 import { FIREBASE_VAPID_KEY, initializeFirebaseApp } from '@/services/push-notifications/firebase'
-import packageJson from '../../../../package.json'
+import { APP_VERSION } from '@/config/version'
 import { logError } from '@/services/exceptions'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
 import { checksumAddress } from '@safe-global/utils/utils/addresses'
@@ -123,7 +123,7 @@ export const getRegisterDevicePayload = async ({
     buildNumber: BUILD_NUMBER,
     bundle: BUNDLE,
     deviceType: DeviceType.WEB,
-    version: packageJson.version,
+    version: APP_VERSION,
     timestamp,
     safeRegistrations,
   }

--- a/apps/web/src/config/version.ts
+++ b/apps/web/src/config/version.ts
@@ -1,0 +1,10 @@
+const rawAppVersion = process.env.NEXT_PUBLIC_APP_VERSION
+const rawAppHomepage = process.env.NEXT_PUBLIC_APP_HOMEPAGE
+if (!rawAppVersion) {
+  throw new Error('Environment variable NEXT_PUBLIC_APP_VERSION is required but was not set or is empty.')
+}
+if (!rawAppHomepage) {
+  throw new Error('Environment variable NEXT_PUBLIC_APP_HOMEPAGE is required but was not set or is empty.')
+}
+export const APP_VERSION = rawAppVersion
+export const APP_HOMEPAGE = rawAppHomepage

--- a/apps/web/src/hooks/useIsOfficialHost.ts
+++ b/apps/web/src/hooks/useIsOfficialHost.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { IPFS_HOSTS, IS_OFFICIAL_HOST, OFFICIAL_HOSTS } from '@/config/constants'
-import packageJson from '../../package.json'
+import { APP_VERSION } from '@/config/version'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 
 const GITHUB_API_URL = 'https://api.github.com/repos/5afe/safe-wallet-ipfs/releases/tags'
@@ -16,7 +16,7 @@ async function getGithubRelease(version: string) {
 }
 
 async function isOfficialIpfs(): Promise<boolean> {
-  const data = await getGithubRelease(packageJson.version)
+  const data = await getGithubRelease(APP_VERSION)
   return data.body.includes(window.location.host)
 }
 

--- a/apps/web/src/services/analytics/__tests__/mixpanel.test.ts
+++ b/apps/web/src/services/analytics/__tests__/mixpanel.test.ts
@@ -9,7 +9,7 @@ jest.mock('@/config/constants', () => ({
 
 import { trackEvent, trackMixpanelEvent, MixpanelEvent } from '../index'
 import { mixpanelInit, mixpanelTrack, mixpanelSetSafeAddress } from '../mixpanel'
-import packageJson from '../../../../package.json'
+import { APP_VERSION } from '@/config/version'
 
 // Mock GTM
 jest.mock('../gtm', () => ({
@@ -60,7 +60,7 @@ describe('Mixpanel Integration', () => {
 
       // Should register initial params
       expect(mockMixpanel.register).toHaveBeenCalledWith({
-        'App Version': packageJson.version,
+        'App Version': APP_VERSION,
         'Device Type': 'desktop',
       })
     })

--- a/apps/web/src/services/analytics/gtm.ts
+++ b/apps/web/src/services/analytics/gtm.ts
@@ -10,16 +10,16 @@
 import { sendGAEvent } from '@next/third-parties/google'
 import Cookies from 'js-cookie'
 import { SAFE_APPS_GA_TRACKING_ID, GA_TRACKING_ID, IS_PRODUCTION } from '@/config/constants'
+import { APP_VERSION } from '@/config/version'
 import type { AnalyticsEvent, EventLabel, SafeAppSDKEvent } from './types'
 import { EventType, DeviceType } from './types'
 import { SAFE_APPS_SDK_CATEGORY } from './events'
 import { getAbTest } from '../tracking/abTesting'
 import type { AbTest } from '../tracking/abTesting'
 import { AppRoutes } from '@/config/routes'
-import packageJson from '../../../package.json'
 
 const commonEventParams = {
-  appVersion: packageJson.version,
+  appVersion: APP_VERSION,
   chainId: '',
   deviceType: DeviceType.DESKTOP,
   safeAddress: '',

--- a/apps/web/src/services/analytics/mixpanel.ts
+++ b/apps/web/src/services/analytics/mixpanel.ts
@@ -1,8 +1,8 @@
 import mixpanel from 'mixpanel-browser'
 import { IS_PRODUCTION, MIXPANEL_TOKEN } from '@/config/constants'
+import { APP_VERSION } from '@/config/version'
 import { DeviceType } from './types'
 import { MixpanelEventParams, ADDRESS_PROPERTIES, type MixpanelUserProperty } from './mixpanel-events'
-import packageJson from '../../../package.json'
 
 let isMixpanelInitialized = false
 
@@ -75,7 +75,7 @@ export const mixpanelInit = (): void => {
     isMixpanelInitialized = true
 
     mixpanel.register({
-      [MixpanelEventParams.APP_VERSION]: packageJson.version,
+      [MixpanelEventParams.APP_VERSION]: APP_VERSION,
       [MixpanelEventParams.DEVICE_TYPE]: DeviceType.DESKTOP,
     })
 

--- a/apps/web/src/services/beamer/index.ts
+++ b/apps/web/src/services/beamer/index.ts
@@ -1,8 +1,8 @@
 import Cookies from 'js-cookie'
 
 import { BEAMER_ID } from '@/config/constants'
+import { APP_VERSION } from '@/config/version'
 import local from '@/services/local-storage/local'
-import packageJson from '../../../package.json'
 
 export const BEAMER_SELECTOR = 'whats-new-button'
 
@@ -18,7 +18,7 @@ const isBeamerLoaded = (): boolean => !!scriptRef
 export const loadBeamer = async (shortName: string): Promise<void> => {
   if (isBeamerLoaded()) return
 
-  const BEAMER_URL = '/beamer-embed.js?v=' + packageJson.version
+  const BEAMER_URL = '/beamer-embed.js?v=' + APP_VERSION
 
   if (!BEAMER_ID) {
     console.warn('[Beamer] In order to use Beamer you need to add a `product_id`')

--- a/apps/web/src/services/sentry.ts
+++ b/apps/web/src/services/sentry.ts
@@ -1,10 +1,10 @@
 import { init, ErrorBoundary, captureException } from '@sentry/react'
 import { SENTRY_DSN } from '@/config/constants'
-import packageJson from '../../package.json'
+import { APP_VERSION } from '@/config/version'
 
 init({
   dsn: SENTRY_DSN,
-  release: `safe-wallet-web@${packageJson.version}`,
+  release: `safe-wallet-web@${APP_VERSION}`,
   sampleRate: 0.1,
   // ignore MetaMask errors we don't control
   ignoreErrors: ['Internal JSON-RPC error', 'JsonRpcEngine', 'Non-Error promise rejection captured with keys: code'],


### PR DESCRIPTION
## What it solves
Importing the package.json in the next app would lead to the package.json being distributed in the final bundle. We were only reading the version and homepage from it. So we now parse it in the nextjs config and pass those as env variables for the app to consume.


Resolves https://linear.app/safe-global/issue/WA-1270/dont-include-packagejson-in-bundle

## How this PR fixes it
- load package.json in the next.config and export env variables from there.

## How to test it
Everything should continue to work as before. I've replaces all the places where we needed the version. 

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves all runtime `package.json` reads to build-time env variables and updates consumers accordingly.
> 
> - Injects `NEXT_PUBLIC_APP_VERSION` and `NEXT_PUBLIC_APP_HOMEPAGE` in `next.config.mjs`; adds `src/config/version.ts` to validate and export `APP_VERSION`/`APP_HOMEPAGE`
> - Refactors Footer, push notifications logic/tests, `useIsOfficialHost`, analytics (GTM/Mixpanel), Beamer, and Sentry to use `APP_VERSION`/`APP_HOMEPAGE` instead of importing `package.json`
> - Test setup: `jest.config.cjs` preloads env vars from `package.json` for the test environment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7310e81062cc399caa039d856e3e5c1ebe0ff441. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->