### PR TITLE
feat: add minimal age exception for @safe-global/ packages

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,3 +12,6 @@ nodeLinker: node-modules
 # This prevents the installation of npm packages if
 # they are updated within the last 24 hours
 npmMinimalAgeGate: 1440
+# Allow in-house @safe-global packages to bypass the age gate
+npmPreapprovedPackages:
+  - '@safe-global/*'


### PR DESCRIPTION
## What it solves

Allows @safe-global/ owned packages to be published before the minimalAge threshold.

## How this PR fixes it

Sets an exception only to @safe-global/ packages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Yarn config to let in-house packages bypass the npm minimal-age gate.
> 
> - Adds `npmPreapprovedPackages` in `.yarnrc.yml` with `@safe-global/*` to skip the `npmMinimalAgeGate` delay for those packages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f452ada1125bbcf7a5376b5ba745db38f2b77be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->