### PR TITLE
fix(web): auto-reconnect for Ambire Wallet on page refresh

### DIFF
--- a/apps/web/src/utils/wallets.ts
+++ b/apps/web/src/utils/wallets.ts
@@ -82,7 +82,7 @@ export const isSmartContractWallet = memoize(
 export const isWalletUnlocked = async (walletName: string): Promise<boolean | undefined> => {
   if ([PRIVATE_KEY_MODULE_LABEL, WALLETCONNECT].includes(walletName)) return true
 
-  const METAMASK_LIKE = ['MetaMask', 'Rabby Wallet', 'Zerion']
+  const METAMASK_LIKE = ['MetaMask', 'Rabby Wallet', 'Zerion', 'Ambire']
 
   // Only MetaMask exposes a method to check if the wallet is unlocked
   if (METAMASK_LIKE.includes(walletName)) {


### PR DESCRIPTION
## What it solves

Safe does not automatically reconnect to Ambire Wallet after a web page refresh.
This results in the wallet appearing disconnected even though the provider is
available and previously authorized.

## How this PR fixes it

Ambire Wallet behaves like other MetaMask-compatible providers (e.g. MetaMask,
Rabby, Zerion) and exposes the same method (**window.ethereum._metamask.isUnlocked()**)

This PR adds `Ambire` to the `METAMASK_LIKE` wallet list so it follows the same
auto-reconnect logic already used for MetaMask-like wallets.

No new logic is introduced — this only enables existing behavior for Ambire.

## How to test it

1. Connect Safe to Ambire Wallet
2. Refresh the page
3. Observe that the Ambire Wallet reconnects automatically

## Screenshots

N/A

## Checklist

- [x] I've tested the branch locally
- [ ] I've tested the branch on mobile (not applicable — changes affect web app only)
- [ ] I've written a unit/e2e test (not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treats Ambire Wallet as MetaMask‑compatible for unlock detection to enable auto‑reconnect after refresh.
> 
> - Adds `Ambire` to `METAMASK_LIKE` in `apps/web/src/utils/wallets.ts`, so `isWalletUnlocked` uses `window.ethereum._metamask.isUnlocked()` for Ambire
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fec388071e18f4ce24a1149990231befa5a2c75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->