### PR TITLE
fix(web): race condition in navigation

### DIFF
--- a/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
+++ b/apps/web/src/components/sidebar/SidebarNavigation/index.tsx
@@ -40,7 +40,7 @@ const customSidebarEvents: { [key: string]: { event: any; label: string } } = {
   [AppRoutes.earn]: { event: EARN_EVENTS.OPEN_EARN_PAGE, label: EARN_LABELS.sidebar },
 }
 
-const Navigation = (): ReactElement => {
+const Navigation = (): ReactElement | null => {
   const chain = useCurrentChain()
   const router = useRouter()
   const { safe } = useSafeInfo()
@@ -63,6 +63,10 @@ const Navigation = (): ReactElement => {
       ? visibleNavItems
       : visibleNavItems.filter((item) => !UNDEPLOYED_SAFE_BLOCKED_ROUTES.includes(item.href))
   }, [safe.deployed, visibleNavItems])
+
+  if (!router.isReady) {
+    return null
+  }
 
   const getBadge = (item: NavItem) => {
     // Indicate whether the current Safe needs an upgrade


### PR DESCRIPTION
## What it solves
In our cypress tests there was a race condition. The test was loading the balance page and then looking for the bridge sidebar button and immediately pressing it. Unfortunately the router was not yet ready and the app was navigating to bridge?safe= -> the safe address was dropped from the request.

## How this PR fixes it
doesn't navigate if the safe is the router is not yet ready

## How to test it
run cypress tests locally use sidebar_9.js -> the visit bridge test should pass

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
