### PR TITLE
fix(web): storybook not rendering

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -2,8 +2,17 @@
 import { createRequire } from 'node:module'
 import type { StorybookConfig } from '@storybook/nextjs'
 import path from 'path'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
 
 const require = createRequire(import.meta.url)
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const packageJsonPath = path.join(__dirname, '../package.json')
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+
+process.env.NEXT_PUBLIC_APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version
+process.env.NEXT_PUBLIC_APP_HOMEPAGE = process.env.NEXT_PUBLIC_APP_HOMEPAGE || packageJson.homepage
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -70,6 +79,8 @@ const config: StorybookConfig = {
   env: (config) => ({
     ...config,
     NEXT_PUBLIC_HUBSPOT_CONFIG: process.env.NEXT_PUBLIC_HUBSPOT_CONFIG ?? '',
+    NEXT_PUBLIC_APP_VERSION: process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version,
+    NEXT_PUBLIC_APP_HOMEPAGE: process.env.NEXT_PUBLIC_APP_HOMEPAGE || packageJson.homepage,
   }),
 
   typescript: {


### PR DESCRIPTION

## What it solves
In https://github.com/safe-global/safe-wallet-monorepo/pull/6979 we changed the way we use version from package.json. It was necessary to pass the version to the storybook config as well.


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
