### PR TITLE
fix(web): infinite skeleton banner

### DIFF
--- a/apps/web/src/features/targetedFeatures/hooks/__tests__/useIsOutreachSafe.test.ts
+++ b/apps/web/src/features/targetedFeatures/hooks/__tests__/useIsOutreachSafe.test.ts
@@ -30,7 +30,6 @@ describe('useIsOutreachSafe', () => {
         address: safeInfo.address.value,
       },
       isLoading: false,
-      isFetching: false,
       refetch: jest.fn(),
     })
 
@@ -56,7 +55,6 @@ describe('useIsOutreachSafe', () => {
       data: undefined,
       error: new Error('Safe not targeted'),
       isLoading: false,
-      isFetching: false,
       refetch: jest.fn(),
     })
 
@@ -81,7 +79,6 @@ describe('useIsOutreachSafe', () => {
     jest.spyOn(targetedMessages, 'useTargetedMessagingGetTargetedSafeV1Query').mockReturnValue({
       data: undefined, // Yet to be fetched
       isLoading: false,
-      isFetching: false,
       refetch: jest.fn(),
     })
 
@@ -110,7 +107,6 @@ describe('useIsOutreachSafe', () => {
         address: safeInfo.address.value,
       },
       isLoading: false,
-      isFetching: false,
       refetch: jest.fn(),
     })
 
@@ -139,7 +135,6 @@ describe('useIsOutreachSafe', () => {
         address: otherAddress,
       },
       isLoading: false,
-      isFetching: false,
       refetch: jest.fn(),
     })
 
@@ -166,7 +161,6 @@ describe('useIsOutreachSafe', () => {
         data: undefined,
         error: { status: 404, data: { detail: 'Not found' } },
         isLoading: false,
-        isFetching: false,
         refetch: jest.fn(),
       })
 
@@ -192,7 +186,6 @@ describe('useIsOutreachSafe', () => {
         data: undefined,
         error: { status: 500, data: { detail: 'Internal server error' } },
         isLoading: false,
-        isFetching: false,
         refetch: jest.fn(),
       })
 
@@ -218,7 +211,6 @@ describe('useIsOutreachSafe', () => {
         data: undefined,
         error: { status: 'FETCH_ERROR', error: 'Network request failed' },
         isLoading: false,
-        isFetching: false,
         refetch: jest.fn(),
       })
 
@@ -244,7 +236,6 @@ describe('useIsOutreachSafe', () => {
       jest.spyOn(targetedMessages, 'useTargetedMessagingGetTargetedSafeV1Query').mockReturnValue({
         data: undefined,
         isLoading: true,
-        isFetching: false,
         refetch: jest.fn(),
       })
 
@@ -270,7 +261,6 @@ describe('useIsOutreachSafe', () => {
     jest.spyOn(targetedMessages, 'useTargetedMessagingGetTargetedSafeV1Query').mockReturnValue({
       data: undefined,
       isLoading: false,
-      isFetching: false,
       refetch: jest.fn(),
     })
 

--- a/apps/web/src/features/targetedFeatures/hooks/useIsOutreachSafe.ts
+++ b/apps/web/src/features/targetedFeatures/hooks/useIsOutreachSafe.ts
@@ -13,7 +13,7 @@ export function useIsOutreachSafe(outreachId: number, options?: { skip?: boolean
   const isSafeUnavailable = !safe.address.value
   const shouldSkip = options?.skip || isSafeUnavailable
 
-  const { data, isLoading, isFetching } = useTargetedMessagingGetTargetedSafeV1Query(
+  const { data, isLoading } = useTargetedMessagingGetTargetedSafeV1Query(
     {
       outreachId,
       chainId: safe.chainId,
@@ -23,7 +23,10 @@ export function useIsOutreachSafe(outreachId: number, options?: { skip?: boolean
   )
 
   const isTargeted = data?.outreachId === outreachId && sameAddress(data.address, safe.address.value)
-  const loading = isSafeUnavailable || (!options?.skip && (isLoading || isFetching))
+  // Only report loading during the initial fetch (isLoading), not during background refetches (isFetching)
+  // This prevents showing skeleton indefinitely for non-targeted Safes during background refetches
+  // Once the initial query completes (isLoading becomes false), we have a definitive answer
+  const loading = isSafeUnavailable ? false : !options?.skip && isLoading
 
   return { isTargeted, loading }
 }


### PR DESCRIPTION
## What it solves

- Banner skeleton was shown due to infinite fetching of targeted safe

Resolves:

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
