### PR TITLE
fix(web): resolve hydration mismatch in useIsOfficialHost hook

### DIFF
--- a/apps/web/src/hooks/useIsOfficialHost.ts
+++ b/apps/web/src/hooks/useIsOfficialHost.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useState } from 'react'
 import { IPFS_HOSTS, IS_OFFICIAL_HOST, OFFICIAL_HOSTS } from '@/config/constants'
 import { APP_VERSION } from '@/config/version'
 import useAsync from '@safe-global/utils/hooks/useAsync'
@@ -25,10 +25,13 @@ function isIpfs() {
 }
 
 export const useIsOfficialHost = (): boolean => {
-  const isOfficialHost = useMemo(
-    () => IS_OFFICIAL_HOST && (typeof window === 'undefined' || OFFICIAL_HOSTS.test(window.location.host)),
-    [],
-  )
+  // Use IS_OFFICIAL_HOST as initial value to match server-side rendering
+  const [isOfficialHost, setIsOfficialHost] = useState(IS_OFFICIAL_HOST)
+
+  useEffect(() => {
+    // Update on client after hydration
+    setIsOfficialHost(IS_OFFICIAL_HOST && OFFICIAL_HOSTS.test(window.location.host))
+  }, [])
 
   const [isTrustedIpfs = false] = useAsync<boolean>(() => {
     if (isOfficialHost || !isIpfs()) return


### PR DESCRIPTION
## What it solves

Fixes a React hydration mismatch error where the `useIsOfficialHost` hook would return different values during server-side rendering vs client-side hydration, because `window` is undefined on the server.

I was running the app on a different port with OFFICIAL_HOST set to true - this would lead to different results for the useMemo since window is undefined and host match afterwards is not guaranteed to be the same as on the client. 

Resolves: N/A

## How this PR fixes it

- Replaced `useMemo` with `useState` + `useEffect` pattern for proper SSR/hydration handling
- Initial state uses `IS_OFFICIAL_HOST` constant (consistent on both server and client)
- After hydration, the `useEffect` updates the state with the actual `window.location.host` check
- This ensures the initial render matches on server and client, preventing hydration errors

## How to test it

1. Run the web app locally with `yarn workspace @safe-global/web dev`
2. Open the browser console and verify there are no hydration mismatch warnings
3. Verify the official host detection still works correctly (should return `true` on official hosts like app.safe.global)

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).