### PR TITLE
fix(counterfactual): pass activateReplayedSafe to createNewSafe for wallet activation

### DIFF
--- a/apps/web/src/features/counterfactual/components/ActivateAccountFlow/index.tsx
+++ b/apps/web/src/features/counterfactual/components/ActivateAccountFlow/index.tsx
@@ -8,7 +8,11 @@ import ErrorMessage from '@/components/tx/ErrorMessage'
 import { ExecutionMethod, ExecutionMethodSelector } from '@/components/tx/ExecutionMethodSelector'
 import { safeCreationDispatch, SafeCreationEvent } from '../../services/safeCreationEvents'
 import { selectUndeployedSafe } from '../../store/undeployedSafesSlice'
-import { extractCounterfactualSafeSetup, isPredictedSafeProps } from '../../services/safeDeployment'
+import {
+  extractCounterfactualSafeSetup,
+  isPredictedSafeProps,
+  activateReplayedSafe,
+} from '../../services/safeDeployment'
 import { CF_TX_GROUP_KEY } from '../../constants'
 import useChainId from '@/hooks/useChainId'
 import { useCurrentChain } from '@/hooks/useChains'
@@ -138,6 +142,7 @@ const ActivateAccountFlow = () => {
           options,
           onSubmit,
           isMultichainSafe ? true : undefined,
+          activateReplayedSafe,
         )
       }
     } catch (_err) {


### PR DESCRIPTION
Resolves https://linear.app/safe-global/issue/WA-1353/migrate-counterfactual-feature-to-new-feature-architecture

## Summary
- Fixed counterfactual Safe activation with connected wallet paying for gas
- After the v3 feature architecture migration, the `activateReplayedSafe` parameter was missing when calling `createNewSafe`

## Root Cause
The `createNewSafe` function requires an `activateReplayedSafe` parameter (added during the v3 migration to support lazy-loading) for handling "replayed" safes. Without it, activation fails with:
```
Error: activateReplayedSafe function is required for replayed safes
```

Sponsored gas activation was unaffected because it uses `relaySafeCreation` which doesn't require this parameter.

## Test plan
- [ ] Create a counterfactual Safe
- [ ] Try to activate it using "Pay Now" with connected wallet (not relay/sponsored)
- [ ] Verify the activation transaction is sent successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)