### PR TITLE
chore(web): improve Storybook webpack performance

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "serve": "sh -c 'npx -y serve out -p ${REVERSE_PROXY_UI_PORT:=8080}'",
     "static-serve": "yarn build && yarn serve",
     "storybook": "storybook dev -p 6006",
+    "storybook:full": "cross-env STORYBOOK_LAZY=false storybook dev -p 6006",
     "build-storybook": "storybook build --quiet",
     "test:storybook": "cross-env NODE_ENV=test TZ=UTC jest --testMatch '**/*.stories.test.tsx' --testPathIgnorePatterns='/node_modules/' --testPathIgnorePatterns='/.next/'",
     "test:storybook:ci": "cross-env NODE_ENV=test TZ=UTC yarn test:storybook --ci --silent --coverage=false --watchAll=false",


### PR DESCRIPTION
## Summary
- Enable webpack filesystem caching for faster subsequent builds
- Enable lazy compilation in dev mode (stories compiled on demand)
- Switch to `react-docgen` for faster startup (vs `react-docgen-typescript`)
- Disable telemetry for cleaner output
- Add `storybook:full` script for full compilation mode (no lazy loading)

## Commands
- `yarn storybook` - fast startup with lazy compilation (default)
- `yarn storybook:full` - full compilation upfront

## Test plan
- [x] Verified Storybook starts successfully
- [x] Verified type-check passes
- [x] Verified lint passes (0 errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Storybook/webpack configuration and developer scripts; primary risk is slower or broken Storybook builds if caching/lazy compilation interacts poorly with certain stories.
> 
> **Overview**
> Improves Storybook performance in `apps/web` by enabling webpack **filesystem caching** and (non-production) **lazy compilation** gated by `STORYBOOK_LAZY`.
> 
> Disables Storybook telemetry and switches TypeScript doc generation from `react-docgen-typescript` (with custom options) to `react-docgen` for faster startup. Adds a `storybook:full` script to run Storybook with lazy compilation disabled (`STORYBOOK_LAZY=false`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8bc96d94a59c8df3e9be27ae3c348a9b1f7d04f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->