### PR TITLE
fix(web): restore not activated chip on multichain safes

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -30,6 +30,11 @@ function MultiChainSubItem({
       safeOverview,
     })
 
+  const hasQueuedItems =
+    !safeItem.isReadOnly &&
+    safeOverview &&
+    ((safeOverview.queued ?? 0) > 0 || (safeOverview.awaitingConfirmation ?? 0) > 0)
+
   return (
     <AccountItem.Link
       href={href}
@@ -51,6 +56,14 @@ function MultiChainSubItem({
           isActivating={isActivating}
           isReadOnly={safeItem.isReadOnly}
         />
+        {hasQueuedItems && (
+          <AccountItem.QueueActions
+            safeAddress={safeOverview.address.value}
+            chainShortName={chain?.shortName || ''}
+            queued={safeOverview.queued ?? 0}
+            awaitingConfirmation={safeOverview.awaitingConfirmation ?? 0}
+          />
+        )}
       </AccountItem.Info>
       <AccountItem.Balance fiatTotal={safeOverview?.fiatTotal} isLoading={!safeOverview && !undeployedSafe} />
     </AccountItem.Link>

--- a/apps/web/src/features/myAccounts/components/AccountItems/styles.module.css
+++ b/apps/web/src/features/myAccounts/components/AccountItems/styles.module.css
@@ -60,7 +60,7 @@
   flex-wrap: wrap;
   padding: var(--space-2);
   align-items: center;
-  gap: var(--space-1);
+  gap: var(--space-2);
   width: 100%; /* Ensure full width */
 }
 
@@ -91,6 +91,10 @@
 
 .accountItemInfoChips {
   margin-top: 2px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
 }
 
 .accountItemBalance {
@@ -119,8 +123,10 @@
 .accountItemChips {
   flex-basis: 100%;
   margin-top: var(--space-1);
-  /* padding-bottom: var(--space-1); */
-  /* padding-left: var(--space-2); */
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
 }
 
 .accountItemChips:empty {

--- a/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
@@ -32,7 +32,9 @@ export const SafeListItem = ({ safeItem, onLinkClick, isSpaceSafe = false }: Saf
   } = useSafeItemData(safeItem, { isSpaceSafe })
 
   const hasQueuedItems =
-    safeOverview && ((safeOverview.queued ?? 0) > 0 || (safeOverview.awaitingConfirmation ?? 0) > 0)
+    !safeItem.isReadOnly &&
+    safeOverview &&
+    ((safeOverview.queued ?? 0) > 0 || (safeOverview.awaitingConfirmation ?? 0) > 0)
 
   const statusChips = (
     <>


### PR DESCRIPTION
## What it solves

The "Not activated" chip was missing on multichain safe sub-items after the myAccounts feature refactor in commit c3ade5c. This made it impossible for users to see which networks had undeployed safes in their multichain accounts.

## How this PR fixes it

- Added `undeployedSafe` and `isActivating` to destructured values from `useSafeItemData` hook in `MultiChainSubItem`
- Added `AccountItem.StatusChip` as a child of `AccountItem.Info` to display:
  - "Not activated" chip when the safe is undeployed
  - "Activating account" chip when activation is in progress
  - "Read-only" chip when applicable
- Fixed the `isLoading` prop on `AccountItem.Balance` to not show loading state for undeployed safes

## How to test it

1. Open the app with a multichain safe that has at least one network not activated
2. Navigate to My Safes
3. Expand the multichain safe accordion
4. Verify the "Not activated" chip appears next to networks that haven't been deployed

## Screenshots

N/A - restoring existing functionality

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to sidebar account list rendering and styling; no auth, transaction, or data mutation logic is modified.
> 
> **Overview**
> Restores per-network status display for multichain safe sub-items by rendering `AccountItem.StatusChip` (undeployed/activating/read-only) and conditionally showing `AccountItem.QueueActions` only when the safe is not read-only.
> 
> Adjusts balance loading behavior so undeployed safes don’t show a perpetual loading state, and tweaks account item layout CSS to better accommodate chip rows (flex wrap + updated gaps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73598aef4e62c3ecb5112eb2035455dc1e18c752. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->