### PR TITLE
refactor(tx-builder): migrate to Sourcify API v2

### DIFF
--- a/apps/tx-builder/src/lib/getAbi.test.ts
+++ b/apps/tx-builder/src/lib/getAbi.test.ts
@@ -1,0 +1,192 @@
+import axios from 'axios'
+import getAbi from './getAbi'
+import { ChainInfo } from '@safe-global/safe-apps-sdk'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+const mockChainInfo: ChainInfo = {
+  chainName: 'Ethereum',
+  chainId: '1',
+  shortName: 'eth',
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+    logoUri: '',
+  },
+  blockExplorerUriTemplate: {
+    address: '',
+    txHash: '',
+    api: '',
+  },
+}
+
+const mockAbi = [
+  {
+    inputs: [{ name: 'to', type: 'address' }],
+    name: 'transfer',
+    payable: false,
+  },
+]
+
+describe('getAbi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Sourcify v2 API', () => {
+    it('should return ABI from Sourcify with exact_match status', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: {
+          abi: mockAbi,
+          match: 'exact_match',
+          chainId: '1',
+          address: '0x123',
+        },
+      })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toEqual(mockAbi)
+      expect(mockedAxios.get).toHaveBeenCalledWith('https://sourcify.dev/server/v2/contract/1/0x123?fields=abi', {
+        timeout: 10000,
+      })
+    })
+
+    it('should return ABI from Sourcify with match status (partial match)', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: {
+          abi: mockAbi,
+          match: 'match',
+          chainId: '1',
+          address: '0x123',
+        },
+      })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toEqual(mockAbi)
+    })
+
+    it('should return ABI even when match is null', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: {
+          abi: mockAbi,
+          match: null,
+          chainId: '1',
+          address: '0x123',
+        },
+      })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toEqual(mockAbi)
+    })
+
+    it('should return empty array when ABI is empty', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: {
+          abi: [],
+          match: 'exact_match',
+          chainId: '1',
+          address: '0x123',
+        },
+      })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('fallback to Gateway', () => {
+    it('should fallback to Gateway when Sourcify returns 404', async () => {
+      mockedAxios.get.mockRejectedValueOnce({ response: { status: 404 } }).mockResolvedValueOnce({
+        data: {
+          contractAbi: { abi: mockAbi },
+        },
+      })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toEqual(mockAbi)
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2)
+      expect(mockedAxios.get).toHaveBeenLastCalledWith('https://safe-client.safe.global/v1/chains/1/contracts/0x123', {
+        timeout: 10000,
+      })
+    })
+
+    it('should fallback to Gateway when Sourcify returns 500', async () => {
+      mockedAxios.get.mockRejectedValueOnce({ response: { status: 500 } }).mockResolvedValueOnce({
+        data: {
+          contractAbi: { abi: mockAbi },
+        },
+      })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toEqual(mockAbi)
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2)
+    })
+
+    it('should fallback to Gateway when Sourcify times out', async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error('timeout')).mockResolvedValueOnce({
+        data: {
+          contractAbi: { abi: mockAbi },
+        },
+      })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toEqual(mockAbi)
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2)
+    })
+
+    it('should fallback when Sourcify response has no ABI field', async () => {
+      mockedAxios.get
+        .mockResolvedValueOnce({
+          data: {
+            match: 'exact_match',
+            chainId: '1',
+            address: '0x123',
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            contractAbi: { abi: mockAbi },
+          },
+        })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toEqual(mockAbi)
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('both providers fail', () => {
+    it('should return null when both Sourcify and Gateway fail', async () => {
+      mockedAxios.get
+        .mockRejectedValueOnce({ response: { status: 404 } })
+        .mockRejectedValueOnce({ response: { status: 404 } })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toBeNull()
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2)
+    })
+
+    it('should return null when Gateway has no contractAbi', async () => {
+      mockedAxios.get.mockRejectedValueOnce({ response: { status: 404 } }).mockResolvedValueOnce({
+        data: {
+          name: 'Some Contract',
+        },
+      })
+
+      const result = await getAbi('0x123', mockChainInfo)
+
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/apps/tx-builder/src/mocks/handlers.ts
+++ b/apps/tx-builder/src/mocks/handlers.ts
@@ -1,6 +1,19 @@
 import { http, HttpResponse } from 'msw'
 
 export const handlers = [
+  http.get('https://sourcify.dev/server/v2/contract/:chainId/:address', ({ params }) => {
+    return HttpResponse.json({
+      abi: [],
+      matchId: '1',
+      creationMatch: 'exact_match',
+      runtimeMatch: 'exact_match',
+      match: 'exact_match',
+      verifiedAt: '2024-01-01T00:00:00Z',
+      chainId: params.chainId,
+      address: params.address,
+    })
+  }),
+
   http.get('*/v1/chains/:chainId/contracts/:address', ({ params }) => {
     return HttpResponse.json({
       address: params.address,


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/WA-1358/update-tx-builder-sourcify-api

The TX Builder currently uses Sourcify's deprecated File API (`/server/files/{chainId}/{address}`), which risks sudden breaking changes or API removal.

## How this PR fixes it

Migrates to the new Sourcify API v2 endpoint:

- Updates endpoint to `/server/v2/contract/{chainId}/{address}?fields=abi`
- Simplifies response parsing - ABI is now returned directly instead of parsing `metadata.json`
- Accepts both `exact_match` and `match` verification statuses for better contract resolution
- Maintains Gateway API fallback for reliability

## How to test it

1. Open TX Builder in development mode
2. Enter a verified contract address (e.g., USDC on mainnet: `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`)
3. Verify ABI loads and methods are displayed
4. Enter an unverified contract address
5. Verify graceful fallback (no error, allows manual ABI entry)

## Screenshots

N/A - no UI changes

## Checklist

- [x] I've tested the branch on mobile 📱 (N/A - TX Builder is web-only)
- [x] I've documented how it affects the analytics (if at all) 📊 (No analytics impact)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).