### PR TITLE
demo: increase font size for visual regression testing

### DIFF
--- a/apps/web/src/components/balances/TotalAssetValue/index.tsx
+++ b/apps/web/src/components/balances/TotalAssetValue/index.tsx
@@ -19,7 +19,7 @@ const TotalAssetValue = ({
   size?: 'md' | 'lg'
   action?: ReactNode
 }) => {
-  const fontSizeValue = size === 'lg' ? '44px' : '24px'
+  const fontSizeValue = size === 'lg' ? '48px' : '24px'
   const { safe } = useSafeInfo()
   const { balances } = useVisibleBalances()
 


### PR DESCRIPTION
## Summary

This PR demonstrates Chromatic visual regression testing by making a small visual change to the total asset value component.

## Changes

- Increased the large font size for `TotalAssetValue` component from 44px to 48px

## Test Plan

- [x] All tests pass
- [x] Type-check passes
- [x] Lint passes
- [ ] Visual regression snapshots will be captured by Chromatic

## Related

This PR is created against `fix/chromatic-pr-review` to demonstrate the visual regression testing workflow with Chromatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)