### PR TITLE
fix(safe-creation): pass activateReplayedSafe to createNewSafe for Pay Now

### DIFF
--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -4,6 +4,7 @@ import {
   safeCreationDispatch,
   SafeCreationEvent,
   replayCounterfactualSafeDeployment,
+  activateReplayedSafe,
 } from '@/features/counterfactual/services'
 import { PayNowPayLater } from '@/features/counterfactual/components'
 import { CF_TX_GROUP_KEY } from '@/features/counterfactual'
@@ -364,6 +365,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
             onSubmitCallback(undefined, txHash)
           },
           true,
+          activateReplayedSafe,
         )
       }
     } catch (_err) {


### PR DESCRIPTION
## What it solves

Safe creation with "Pay now" + wallet payment fails silently with "Error creating the Safe Account" because the `activateReplayedSafe` function is not passed to `createNewSafe`.

This bug was introduced in #7024 (counterfactual v3 migration) and partially fixed in #7051, but that fix only addressed `ActivateAccountFlow` and missed `ReviewStep`.

## How this PR fixes it

Applies the same fix from #7051 to `ReviewStep`: imports `activateReplayedSafe` from counterfactual services and passes it as the 7th parameter to `createNewSafe`.

Note: Sponsored/relay Safe creation was unaffected because it uses `relaySafeCreation` which doesn't require this parameter.

## How to test it

1. Go to create a new Safe
2. Select "Pay now" 
3. Ensure you don't have relay credits OR select wallet payment instead of sponsored
4. Click "Create account" - MetaMask should now open (previously it would fail silently)

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).