### PR TITLE
chore(web): optimistic portfolio API loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,6 +548,7 @@ Avoid these common mistakes when contributing:
 - **RPC issues**: Check that `INFURA_TOKEN` or other RPC provider env vars are set correctly
 - **Build errors**: Check `.next` cache – sometimes `rm -rf apps/web/.next` helps
 - **Storybook issues**: Try `rm -rf node_modules/.cache/storybook`
+- **Using prod CGW locally**: The sidebar has a "Use prod CGW" toggle (bottom-left corner) to switch between staging and production Client Gateway. Enable it when testing a local build against real production data.
 
 ## Code Complexity Guidelines
 

--- a/apps/web/src/features/portfolio/hooks/__tests__/usePortfolioBalances.test.ts
+++ b/apps/web/src/features/portfolio/hooks/__tests__/usePortfolioBalances.test.ts
@@ -3,7 +3,7 @@ import usePortfolioBalances from '@/features/portfolio/hooks/usePortfolioBalance
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import * as useChains from '@/hooks/useChains'
 import * as useChainId from '@/hooks/useChainId'
-import * as useSafeAddressFromUrl from '@/hooks/useSafeAddressFromUrl'
+import * as useOptimisticSafeAddress from '@/hooks/useOptimisticSafeAddress'
 import * as store from '@/store'
 import * as portfolioQueries from '@safe-global/store/gateway/AUTO_GENERATED/portfolios'
 import * as useLoadBalances from '@/hooks/loadables/useLoadBalances'
@@ -88,8 +88,8 @@ describe('usePortfolioBalances', () => {
     })
 
     jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(mockChain)
-    jest.spyOn(useChainId, 'useRawUrlChainId').mockReturnValue(CHAIN_ID)
-    jest.spyOn(useSafeAddressFromUrl, 'useSafeAddressFromUrl').mockReturnValue(SAFE_ADDRESS)
+    jest.spyOn(useChainId, 'useOptimisticChainId').mockReturnValue(CHAIN_ID)
+    jest.spyOn(useOptimisticSafeAddress, 'useOptimisticSafeAddress').mockReturnValue(SAFE_ADDRESS)
 
     jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
       selector({
@@ -167,7 +167,7 @@ describe('usePortfolioBalances', () => {
         refetch: jest.fn(),
       } as any)
 
-      jest.spyOn(useChainId, 'useRawUrlChainId').mockReturnValue(CHAIN_ID)
+      jest.spyOn(useChainId, 'useOptimisticChainId').mockReturnValue(CHAIN_ID)
       renderHook(() => usePortfolioBalances(false))
 
       expect(portfolioQuerySpy).toHaveBeenCalledWith(

--- a/apps/web/src/features/portfolio/hooks/__tests__/usePortfolioBalances.test.ts
+++ b/apps/web/src/features/portfolio/hooks/__tests__/usePortfolioBalances.test.ts
@@ -2,6 +2,8 @@ import { renderHook, waitFor } from '@/tests/test-utils'
 import usePortfolioBalances from '@/features/portfolio/hooks/usePortfolioBalances'
 import * as useSafeInfo from '@/hooks/useSafeInfo'
 import * as useChains from '@/hooks/useChains'
+import * as useChainId from '@/hooks/useChainId'
+import * as useSafeAddressFromUrl from '@/hooks/useSafeAddressFromUrl'
 import * as store from '@/store'
 import * as portfolioQueries from '@safe-global/store/gateway/AUTO_GENERATED/portfolios'
 import * as useLoadBalances from '@/hooks/loadables/useLoadBalances'
@@ -86,6 +88,8 @@ describe('usePortfolioBalances', () => {
     })
 
     jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(mockChain)
+    jest.spyOn(useChainId, 'useRawUrlChainId').mockReturnValue(CHAIN_ID)
+    jest.spyOn(useSafeAddressFromUrl, 'useSafeAddressFromUrl').mockReturnValue(SAFE_ADDRESS)
 
     jest.spyOn(store, 'useAppSelector').mockImplementation((selector) =>
       selector({
@@ -151,6 +155,29 @@ describe('usePortfolioBalances', () => {
       expect(balances?.positions).toHaveLength(1)
       expect(error).toBeUndefined()
       expect(loading).toBe(false)
+    })
+
+    it('should optimistically fetch with early chain id when chain config is not loaded yet', async () => {
+      jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(undefined)
+
+      const portfolioQuerySpy = jest.spyOn(portfolioQueries, 'usePortfolioGetPortfolioV1Query').mockReturnValue({
+        currentData: undefined,
+        isLoading: true,
+        error: undefined,
+        refetch: jest.fn(),
+      } as any)
+
+      jest.spyOn(useChainId, 'useRawUrlChainId').mockReturnValue(CHAIN_ID)
+      renderHook(() => usePortfolioBalances(false))
+
+      expect(portfolioQuerySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: SAFE_ADDRESS,
+          chainIds: CHAIN_ID,
+          trusted: true,
+        }),
+        expect.objectContaining({ skip: false }),
+      )
     })
 
     it('should handle missing logoUri by setting empty string', async () => {

--- a/apps/web/src/features/portfolio/hooks/usePortfolioBalances.ts
+++ b/apps/web/src/features/portfolio/hooks/usePortfolioBalances.ts
@@ -4,8 +4,8 @@ import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
 import type { AsyncResult } from '@safe-global/utils/hooks/useAsync'
 import { useTxServiceBalances, useTokenListSetting, type PortfolioBalances } from '@/hooks/loadables/useLoadBalances'
-import { useRawUrlChainId } from '@/hooks/useChainId'
-import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
+import { useOptimisticChainId } from '@/hooks/useChainId'
+import { useOptimisticSafeAddress } from '@/hooks/useOptimisticSafeAddress'
 
 const transformPortfolioToBalances = (portfolio?: Portfolio): PortfolioBalances | undefined => {
   if (!portfolio) return undefined
@@ -36,8 +36,8 @@ const transformPortfolioToBalances = (portfolio?: Portfolio): PortfolioBalances 
  */
 const usePortfolioBalances = (skip = false): AsyncResult<PortfolioBalances> => {
   const currency = useAppSelector(selectCurrency)
-  const safeAddress = useSafeAddressFromUrl() // From URL directly, no API wait
-  const earlyChainId = useRawUrlChainId()
+  const safeAddress = useOptimisticSafeAddress()
+  const earlyChainId = useOptimisticChainId()
   const isTrustedTokenList = useTokenListSetting() ?? true // Optimistic: assume trusted before chain config loads
 
   const isReadyPortfolio = safeAddress && earlyChainId

--- a/apps/web/src/features/portfolio/hooks/usePortfolioBalances.ts
+++ b/apps/web/src/features/portfolio/hooks/usePortfolioBalances.ts
@@ -2,9 +2,10 @@ import { useMemo } from 'react'
 import { usePortfolioGetPortfolioV1Query, type Portfolio } from '@safe-global/store/gateway/AUTO_GENERATED/portfolios'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
-import useSafeInfo from '@/hooks/useSafeInfo'
 import type { AsyncResult } from '@safe-global/utils/hooks/useAsync'
 import { useTxServiceBalances, useTokenListSetting, type PortfolioBalances } from '@/hooks/loadables/useLoadBalances'
+import { useRawUrlChainId } from '@/hooks/useChainId'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 
 const transformPortfolioToBalances = (portfolio?: Portfolio): PortfolioBalances | undefined => {
   if (!portfolio) return undefined
@@ -35,9 +36,11 @@ const transformPortfolioToBalances = (portfolio?: Portfolio): PortfolioBalances 
  */
 const usePortfolioBalances = (skip = false): AsyncResult<PortfolioBalances> => {
   const currency = useAppSelector(selectCurrency)
-  const isTrustedTokenList = useTokenListSetting()
-  const { safe, safeAddress } = useSafeInfo()
-  const isReadyPortfolio = safeAddress && isTrustedTokenList !== undefined
+  const safeAddress = useSafeAddressFromUrl() // From URL directly, no API wait
+  const earlyChainId = useRawUrlChainId()
+  const isTrustedTokenList = useTokenListSetting() ?? true // Optimistic: assume trusted before chain config loads
+
+  const isReadyPortfolio = safeAddress && earlyChainId
 
   // Portfolio endpoint (called first)
   const {
@@ -47,12 +50,12 @@ const usePortfolioBalances = (skip = false): AsyncResult<PortfolioBalances> => {
   } = usePortfolioGetPortfolioV1Query(
     {
       address: safeAddress,
-      chainIds: safe.chainId,
+      chainIds: earlyChainId,
       fiatCode: currency,
       trusted: isTrustedTokenList,
     },
     {
-      skip: skip || !isReadyPortfolio || !safe.chainId,
+      skip: skip || !isReadyPortfolio,
     },
   )
 

--- a/apps/web/src/hooks/loadables/useLoadBalances.ts
+++ b/apps/web/src/hooks/loadables/useLoadBalances.ts
@@ -110,7 +110,7 @@ const calculateTokensFiatTotal = (items: Balances['items']): string => {
  */
 const useLoadBalances = (): AsyncResult<PortfolioBalances> => {
   const settings = useAppSelector(selectSettings)
-  const hasPortfolioFeature = useHasFeature(FEATURES.PORTFOLIO_ENDPOINT) ?? false
+  const hasPortfolioFeature = useHasFeature(FEATURES.PORTFOLIO_ENDPOINT) !== false
   const isAllTokensSelected = settings.tokenList === TOKEN_LISTS.ALL
 
   const portfolioResult = usePortfolioBalances(!hasPortfolioFeature)

--- a/apps/web/src/hooks/useChainId.ts
+++ b/apps/web/src/hooks/useChainId.ts
@@ -13,20 +13,28 @@ const getLocationQuery = (): ParsedUrlQuery => {
   return query
 }
 
-export const useUrlChainId = (): string | undefined => {
+// Shared URL parsing: extracts the chain short name from query params
+const useUrlShortName = (): string => {
   const queryParams = useParams()
-  const { configs } = useChains()
-
-  // Dynamic query params
   const query = queryParams && (queryParams.safe || queryParams.chain) ? queryParams : getLocationQuery()
   const chain = query.chain?.toString() || ''
   const safe = query.safe?.toString() || ''
-
   const { prefix } = parsePrefixedAddress(safe)
-  const shortName = prefix || chain
+  return prefix || chain
+}
 
+// Static-only chainId from URL (no API wait)
+// Enables optimistic early API calls before chains config loads
+export const useRawUrlChainId = (): string => {
+  const shortName = useUrlShortName()
+  if (!shortName) return String(DEFAULT_CHAIN_ID)
+  return chains[shortName] || String(DEFAULT_CHAIN_ID)
+}
+
+export const useUrlChainId = (): string | undefined => {
+  const shortName = useUrlShortName()
+  const { configs } = useChains()
   if (!shortName) return undefined
-
   return chains[shortName] || configs.find((item) => item.shortName === shortName)?.chainId
 }
 

--- a/apps/web/src/hooks/useChainId.ts
+++ b/apps/web/src/hooks/useChainId.ts
@@ -7,7 +7,7 @@ import useWallet from './wallets/useWallet'
 import useChains from './useChains'
 
 // Use the location object directly because Next.js's router.query is available only on mount
-const getLocationQuery = (): ParsedUrlQuery => {
+export const getLocationQuery = (): ParsedUrlQuery => {
   if (typeof location === 'undefined') return {}
   const query = parse(location.search.slice(1))
   return query
@@ -23,19 +23,23 @@ const useUrlShortName = (): string => {
   return prefix || chain
 }
 
-// Static-only chainId from URL (no API wait)
-// Enables optimistic early API calls before chains config loads
-export const useRawUrlChainId = (): string => {
-  const shortName = useUrlShortName()
-  if (!shortName) return String(DEFAULT_CHAIN_ID)
-  return chains[shortName] || String(DEFAULT_CHAIN_ID)
-}
-
 export const useUrlChainId = (): string | undefined => {
   const shortName = useUrlShortName()
   const { configs } = useChains()
   if (!shortName) return undefined
   return chains[shortName] || configs.find((item) => item.shortName === shortName)?.chainId
+}
+
+// Optimistic chainId: returns static lookup immediately, resolves to real value once chains config loads
+export const useOptimisticChainId = (): string => {
+  const shortName = useUrlShortName()
+  const resolvedChainId = useUrlChainId()
+
+  if (resolvedChainId) return resolvedChainId
+
+  // Optimistic fallback while chains config is loading
+  if (!shortName) return String(DEFAULT_CHAIN_ID)
+  return chains[shortName] || String(DEFAULT_CHAIN_ID)
 }
 
 const useWalletChainId = (): string | undefined => {

--- a/apps/web/src/hooks/useOptimisticSafeAddress.ts
+++ b/apps/web/src/hooks/useOptimisticSafeAddress.ts
@@ -1,0 +1,12 @@
+import { useParams } from 'next/navigation'
+import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
+import { getLocationQuery } from './useChainId'
+
+// Optimistic safe address: parsed directly from URL without waiting for API/router
+export const useOptimisticSafeAddress = (): string => {
+  const queryParams = useParams()
+  const query = queryParams && queryParams.safe ? queryParams : getLocationQuery()
+  const safe = query.safe?.toString() || ''
+  const { address } = parsePrefixedAddress(safe)
+  return address
+}


### PR DESCRIPTION
## Summary
- Portfolio API now fires immediately on page load by extracting `chainId` and `safeAddress` directly from the URL, instead of waiting for chains config and SafeInfo APIs to resolve first
- Eliminates the sequential waterfall: `chains config → SafeInfo → portfolio` is now `chains config ‖ SafeInfo ‖ portfolio` (all parallel)
- Adds `useRawUrlChainId()` hook for static chain lookup from URL (no API wait)
- Uses `useSafeAddressFromUrl()` instead of `useSafeInfo()` in the portfolio hook
- Optimistic `trusted=true` default when chain config hasn't loaded yet (RTK Query re-fetches if wrong)
- DRYs up URL chain parsing via shared `useUrlShortName()` internal hook

## Measurements (local build, prod CGW)

| Branch | Median Start | Median End |
|--------|-------------|------------|
| Optimistic (with optimization) | 348.8ms | 755.5ms | 
| Baseline (reverted) | 938.7ms | 1379.3ms | 
| **Delta (improvement)** | **-589.9ms** (63% earlier start) | **-623.8ms** (45% earlier completion) | 

### Key Findings

1. **Portfolio API starts 590ms earlier** with the optimization (median: 349ms vs 939ms)
2. **Portfolio API completes 624ms earlier** with the optimization (median: 756ms vs 1379ms)
3. **Portfolio API duration is 124ms faster** (median: 310ms vs 434ms) - **28.5% improvement**
4. The optimization successfully eliminates the waterfall delay by allowing the portfolio API to start immediately instead of waiting for chains config
Portfolio and SafeInfo now start at the exact same time. Portfolio complete time improved from ~1313ms median to ~1027ms.

## How to verify with Chrome DevTools

1. Recommendation: Use Chrome
2. Open the same Safe at two different staging deployments:
    - **Optimized**: https://chore_optimistic_portfolio_loading--walletweb.review.5afe.dev/balances?safe=eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6
    - **Before**: https://revert_pr_7100--walletweb.review.5afe.dev/balances?safe=eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6 
4. Open DevTools → **Network** tab on each
5. Soft refresh (`Cmd+R`):
6. Filter by **Fetch/XHR** to show only API calls
7. In the filter box, type `portfolio` to isolate the portfolio call
8. Click on `timing`
9. Observe the `Started at` value of the portfolio call in the two tabs you have open.
   - **Optimized**: Should be faster (i.e. <1s)
   - **Before**: Should be slower (i.e. >1s)

Example outpout:

Optimized:
<img width="1165" height="771" alt="Screenshot 2026-02-06 at 16 57 35" src="https://github.com/user-attachments/assets/902be027-a5d8-43e2-8b07-61312409a799" />

Before:
<img width="1166" height="806" alt="Screenshot 2026-02-06 at 16 57 56" src="https://github.com/user-attachments/assets/35854dd0-6c77-4ec1-ba17-ca0751b768a4" />


Alternatively, run this in the Console after page load to get exact timings (comparing the optimized portfolio call to another call):
```js
const r = performance.getEntriesByType('resource').filter(r => r.initiatorType === 'fetch');
const info = r.find(e => e.name.match(/\/safes\/0x[^/]+$/));
const port = r.find(e => e.name.includes('portfolio'));
console.table({
  SafeInfo: { start: Math.round(info?.startTime), end: Math.round(info?.responseEnd) },
  Portfolio: { start: Math.round(port?.startTime), end: Math.round(port?.responseEnd) },
});
```

## Test plan
- [x] Type-check passes
- [x] All 3069 tests pass (344 suites)
- [x] Lint clean (0 errors)
- [ ] Verify portfolio loads correctly on `/home`, `/balances` pages
- [ ] Verify "All tokens" mode still merges portfolio + tx service data
- [ ] Verify counterfactual (undeployed) safes still show balances
- [ ] Check DevTools Network tab confirms parallel API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)