### PR TITLE
feat(web): add ENS resolution to accounts list items

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -51,7 +51,7 @@ export function useAddressName(address?: string, name?: string | null, customAva
   )
 }
 
-const NamedAddressInfo = ({ address, name, customAvatar, ...props }: EthHashInfoProps) => {
+const NamedAddressInfo = ({ address, name, customAvatar, ...props }: EthHashInfoProps & { showName?: boolean }) => {
   const { name: finalName, logoUri: finalAvatar } = useAddressName(address, name, customAvatar)
 
   return <EthHashInfo address={address} name={finalName} customAvatar={finalAvatar} {...props} />

--- a/apps/web/src/features/myAccounts/components/AccountItem/AccountItemInfo.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/AccountItemInfo.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { Typography } from '@mui/material'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import NamedAddressInfo from '@/components/common/NamedAddressInfo'
 import { type ContactSource } from '@/hooks/useAllAddressBooks'
 import css from '../AccountItems/styles.module.css'
 
@@ -43,7 +43,7 @@ function AccountItemInfo({
             {chainName}
           </Typography>
         ) : (
-          <EthHashInfo
+          <NamedAddressInfo
             address={address}
             name={name}
             showName={addressBookNameSource ? !!name : true}


### PR DESCRIPTION
## What it solves

In the spirit of better integrating ENS as a core component for better UX and as a user who feels this pain, here is a PR that adds ENS names for Safe accounts on the welcome/accounts page (`/welcome/accounts`).

Related: https://x.com/austingriffith/status/1961450319411646535

<img width="467" height="258" alt="image" src="https://github.com/user-attachments/assets/39240aef-f841-4e64-829f-30414895803e" />

## How this PR fixes it

Adds ENS resolution to `SafeListItem` and `MultiAccountItem` using the existing `useAddressResolver` hook — the same pattern already used in `SafeHeaderInfo`.

- **`SafeListItem`**: Resolves ENS for single-chain Safe items when no address book name exists
- **`MultiAccountItem`**: Resolves ENS for multi-chain Safe group headers when no name is set

ENS resolution is skipped when an address book name already exists, keeping the priority chain consistent: address book name > ENS name > shortened address.

> **Future improvement:** A more scalable approach would be to integrate ENS resolution directly into the shared `EthHashInfo` component, so every address display across the app gets ENS names automatically. This was intentionally scoped to a targeted fix to reduce risk.

## How to test it

1. Navigate to `/welcome/accounts`
2. Safe accounts with ENS names should now display their ENS name instead of the shortened address

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).