### PR TITLE
fix(mobile): use primary theme color for active tab bar indicator

### DIFF
--- a/apps/mobile/src/components/SafeTab/SafeTabBar.tsx
+++ b/apps/mobile/src/components/SafeTab/SafeTabBar.tsx
@@ -21,7 +21,7 @@ export const SafeTabBar = ({
 
   const activeButtonStyle = {
     paddingBottom: 8,
-    borderBottomColor: theme.color?.get(),
+    borderBottomColor: theme.primary?.get(),
     borderBottomWidth: 2,
   }
 


### PR DESCRIPTION
## What it solves
                                                                                                                
  Fixes the active tab bar indicator in the mobile app using the wrong theme color. The `borderBottomColor` was set to `theme.color`
  (generic text color) instead of `theme.primary`, making the active tab indicator inconsistent with the app's primary color scheme.  
   
  ## How this PR fixes it                                                                                                             
                  
  Updates `SafeTabBar.tsx` to use `theme.primary` instead of `theme.color` for the `borderBottomColor` of the active tab indicator,
  ensuring it matches the app's primary brand color across both light and dark themes.

  ## How to test it

  1. Open the mobile app
  2. Navigate to a screen with the SafeTabBar (e.g., Assets tab)
  3. Verify the active tab's bottom border uses the primary color
  4. Switch between light and dark themes and confirm the indicator color is correct in both

  ## Screenshots
<img width="551" height="1037" alt="Screenshot 2026-02-09 at 10 16 29" src="https://github.com/user-attachments/assets/f523b460-7568-45a9-af83-d7def2379dfd" />


  ## Checklist

  - [x] I've tested the branch on mobile 📱
  - [ ] I've documented how it affects the analytics (if at all) 📊
  - [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

  ---

  ## CLA signature

  With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License
  Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to the tab indicator color; minimal behavioral impact and no security/data implications.
> 
> **Overview**
> Updates the mobile `SafeTabBar` active tab underline to use the theme’s `primary` color instead of the generic `color`, aligning the active indicator with the app’s primary branding across themes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27e901981ac2f55f7db7fc1c1dcf064cc8913be5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->