### PR TITLE
fix(web): grid layout in transaction summary

### DIFF
--- a/apps/web/src/components/transactions/TxSummary/index.tsx
+++ b/apps/web/src/components/transactions/TxSummary/index.tsx
@@ -60,6 +60,7 @@ const TxSummary = ({ item, isConflictGroup, isBulkGroup }: TxSummaryProps): Reac
         [css.conflictGroup]: isConflictGroup,
         [css.bulkGroup]: isBulkGroup,
         [css.untrusted]: !isTrusted || isImitationTransaction,
+        [css.withAssessment]: showAssessment,
       })}
       id={tx.id}
     >

--- a/apps/web/src/components/transactions/TxSummary/styles.module.css
+++ b/apps/web/src/components/transactions/TxSummary/styles.module.css
@@ -4,8 +4,7 @@
   --grid-info: minmax(170px, 3fr);
   --grid-date: minmax(170px, 3fr);
   --grid-confirmations: minmax(100px, 1fr);
-  --grid-assessment: minmax(80px, 1.5fr);
-
+  --grid-assessment: 0;
   --grid-status: minmax(100px, 1fr);
   --grid-actions: minmax(100px, 1fr);
 
@@ -18,6 +17,11 @@
     var(--grid-nonce) var(--grid-type) var(--grid-info) var(--grid-date) var(--grid-confirmations)
     var(--grid-assessment) var(--grid-status) var(--grid-actions);
   grid-template-areas: 'nonce type info date confirmations assessment status actions';
+}
+
+.gridContainer.withAssessment {
+  --grid-confirmations: minmax(90px, 1fr);
+  --grid-assessment: minmax(80px, 1.5fr);
 }
 
 .gridContainer > * {


### PR DESCRIPTION
## What it solves

Resolves: [WA-1424](https://linear.app/safe-global/issue/WA-1424/mac-13-buttons-positions-is-wrong-in-the-queue-table)
Fixes the layout for tx entries in the queue.

## How this PR fixes it
- Updated TxSummary component to conditionally apply styles for assessment display.
- Modified CSS grid settings to accommodate the assessment section when visible, enhancing layout responsiveness.

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
