### PR TITLE
refactor(web): refactor uncontrolled components to controlled

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -28,6 +28,7 @@ const customJestConfig = {
     '^.+/markdown/terms/terms\\.md$': '<rootDir>/mocks/terms.md.js',
     isows: '<rootDir>/node_modules/isows/_cjs/index.js',
     '^@safe-global/utils/(.*)$': '<rootDir>/../../packages/utils/src/$1',
+    '^@safe-global/store/(.*)$': '<rootDir>/../../packages/store/src/$1',
   },
   // https://github.com/mswjs/jest-fixed-jsdom
   // without this environment it is basically impossible to run tests with msw

--- a/apps/web/src/components/common/CookieAndTermBanner/CookieBannerActions.tsx
+++ b/apps/web/src/components/common/CookieAndTermBanner/CookieBannerActions.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from 'react'
+import { Grid, Button, Typography } from '@mui/material'
+import { styles } from './constants'
+
+const CookieBannerActions = ({
+  onAccept,
+  onAcceptAll,
+}: {
+  onAccept: () => void
+  onAcceptAll: () => void
+}): ReactElement => {
+  return (
+    <Grid container sx={styles.buttonsGrid}>
+      <Grid item>
+        <Typography>
+          <Button onClick={onAccept} variant="text" size="small" color="inherit" disableElevation>
+            Save settings
+          </Button>
+        </Typography>
+      </Grid>
+
+      <Grid item>
+        <Button onClick={onAcceptAll} variant="contained" color="secondary" size="small" disableElevation>
+          Accept all
+        </Button>
+      </Grid>
+    </Grid>
+  )
+}
+
+export default CookieBannerActions

--- a/apps/web/src/components/common/CookieAndTermBanner/CookieOptionsList.tsx
+++ b/apps/web/src/components/common/CookieAndTermBanner/CookieOptionsList.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement } from 'react'
+import { Grid, Box, Typography, Checkbox, FormControlLabel } from '@mui/material'
+import { Controller, type Control } from 'react-hook-form'
+import { CookieAndTermType } from '@/store/cookiesAndTermsSlice'
+import { styles } from './constants'
+
+type CookieFormData = {
+  [CookieAndTermType.TERMS]: boolean
+  [CookieAndTermType.NECESSARY]: boolean
+  [CookieAndTermType.UPDATES]: boolean
+  [CookieAndTermType.ANALYTICS]: boolean
+}
+
+const CookieCheckbox = ({
+  label,
+  checked,
+  checkboxProps,
+}: {
+  label: string
+  checked: boolean
+  checkboxProps: React.ComponentProps<typeof Checkbox>
+}) => <FormControlLabel label={label} checked={checked} control={<Checkbox {...checkboxProps} />} sx={{ mt: '-9px' }} />
+
+const CookieOptionsList = ({ control }: { control: Control<CookieFormData> }): ReactElement => {
+  return (
+    <Grid item xs={12} sm>
+      <Box sx={styles.optionBox}>
+        <CookieCheckbox checkboxProps={{ id: 'necessary', disabled: true }} label="Necessary" checked />
+        <br />
+        <Typography variant="body2">Locally stored data for core functionality</Typography>
+      </Box>
+
+      <Box sx={styles.optionBox}>
+        <Controller
+          name={CookieAndTermType.UPDATES}
+          control={control}
+          render={({ field }) => (
+            <CookieCheckbox
+              checkboxProps={{
+                ...field,
+                checked: field.value,
+                id: 'beamer',
+              }}
+              label="Beamer"
+              checked={field.value}
+            />
+          )}
+        />
+        <br />
+        <Typography variant="body2">New features and product announcements</Typography>
+      </Box>
+
+      <Box>
+        <Controller
+          name={CookieAndTermType.ANALYTICS}
+          control={control}
+          render={({ field }) => (
+            <CookieCheckbox
+              checkboxProps={{
+                ...field,
+                checked: field.value,
+                id: 'ga',
+              }}
+              label="Analytics"
+              checked={field.value}
+            />
+          )}
+        />
+        <br />
+        <Typography variant="body2">Analytics tools to understand usage patterns.</Typography>
+      </Box>
+    </Grid>
+  )
+}
+
+export default CookieOptionsList

--- a/apps/web/src/components/common/CookieAndTermBanner/IntroText.tsx
+++ b/apps/web/src/components/common/CookieAndTermBanner/IntroText.tsx
@@ -1,0 +1,18 @@
+import type { ReactElement } from 'react'
+import { Typography } from '@mui/material'
+import ExternalLink from '../ExternalLink'
+import { AppRoutes } from '@/config/routes'
+import { styles } from './constants'
+
+const IntroText = ({ lastUpdated }: { lastUpdated: string }): ReactElement => {
+  return (
+    <Typography variant="body2" sx={styles.introText}>
+      By browsing this page, you accept our <ExternalLink href={AppRoutes.terms}>Terms & Conditions</ExternalLink> (last
+      updated {lastUpdated}) and the use of necessary cookies. By clicking &quot;Accept all&quot; you additionally agree
+      to the use of Beamer and Analytics cookies as listed below.{' '}
+      <ExternalLink href={AppRoutes.cookie}>Cookie policy</ExternalLink>
+    </Typography>
+  )
+}
+
+export default IntroText

--- a/apps/web/src/components/common/CookieAndTermBanner/WarningMessage.tsx
+++ b/apps/web/src/components/common/CookieAndTermBanner/WarningMessage.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from 'react'
+import { Typography, SvgIcon } from '@mui/material'
+import WarningIcon from '@/public/images/notifications/warning.svg'
+import { styles } from './constants'
+
+const WarningMessage = ({ message }: { message: string }): ReactElement => {
+  return (
+    <Typography align="center" variant="body2" sx={styles.warningText}>
+      <SvgIcon component={WarningIcon} inheritViewBox fontSize="small" color="error" sx={styles.warningIcon} />{' '}
+      {message}
+    </Typography>
+  )
+}
+
+export default WarningMessage

--- a/apps/web/src/components/common/CookieAndTermBanner/__tests__/index.test.tsx
+++ b/apps/web/src/components/common/CookieAndTermBanner/__tests__/index.test.tsx
@@ -1,0 +1,244 @@
+import { fireEvent, waitFor, screen, render as rtlRender } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/store'
+import SafeThemeProvider from '@/components/theme/SafeThemeProvider'
+import { ThemeProvider } from '@mui/material/styles'
+import type { Theme } from '@mui/material/styles'
+import { CookieAndTermBanner } from '../index'
+import { CookieAndTermType } from '@/store/cookiesAndTermsSlice'
+import * as metadata from '@/markdown/terms/version'
+
+// Mock next/router
+const mockPush = jest.fn()
+const mockPathname = '/home'
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: mockPathname,
+    push: mockPush,
+    query: {},
+  }),
+}))
+
+// Helper to render with Redux store
+const renderWithStore = (ui: React.ReactElement, preloadedState?: any) => {
+  const store = makeStore(preloadedState, { skipBroadcast: true })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <SafeThemeProvider mode="light">
+        {(safeTheme: Theme) => <ThemeProvider theme={safeTheme}>{children}</ThemeProvider>}
+      </SafeThemeProvider>
+    </Provider>
+  )
+  const result = rtlRender(ui, { wrapper })
+  return { ...result, store }
+}
+
+describe('CookieAndTermBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Basic rendering', () => {
+    it('should render all cookie options', () => {
+      renderWithStore(<CookieAndTermBanner />)
+
+      expect(screen.getByText('Necessary')).toBeInTheDocument()
+      expect(screen.getByText('Beamer')).toBeInTheDocument()
+      expect(screen.getByText('Analytics')).toBeInTheDocument()
+    })
+
+    it('should display intro text with terms link', () => {
+      renderWithStore(<CookieAndTermBanner />)
+
+      expect(screen.getByText(/By browsing this page, you accept our/)).toBeInTheDocument()
+      expect(screen.getByText('Terms & Conditions')).toBeInTheDocument()
+      expect(screen.getByText(/last updated/)).toBeInTheDocument()
+      expect(screen.getByText('Cookie policy')).toBeInTheDocument()
+    })
+
+    it('should display both action buttons', () => {
+      renderWithStore(<CookieAndTermBanner />)
+
+      expect(screen.getByText('Save settings')).toBeInTheDocument()
+      expect(screen.getByText('Accept all')).toBeInTheDocument()
+    })
+
+    it('should display warning message when warningKey is provided', () => {
+      renderWithStore(<CookieAndTermBanner warningKey={CookieAndTermType.UPDATES} />)
+
+      expect(
+        screen.getByText(
+          /You attempted to open the "What's new" section but need to accept the "Beamer" cookies first/,
+        ),
+      ).toBeInTheDocument()
+    })
+
+    it('should not display warning message when warningKey is not provided', () => {
+      renderWithStore(<CookieAndTermBanner />)
+
+      expect(screen.queryByText(/You attempted to open the "What's new" section/)).not.toBeInTheDocument()
+    })
+
+    it('should apply inverted class when inverted prop is true', () => {
+      const { container } = renderWithStore(<CookieAndTermBanner inverted />)
+
+      const paper = container.querySelector('[data-testid="cookies-popup"]')
+      expect(paper).toHaveClass('inverted')
+    })
+  })
+
+  describe('Cookie options state', () => {
+    it('should have necessary cookie checkbox disabled and checked', () => {
+      renderWithStore(<CookieAndTermBanner />)
+
+      const necessaryCheckbox = screen.getByRole('checkbox', { name: /Necessary/ })
+      expect(necessaryCheckbox).toBeDisabled()
+      expect(necessaryCheckbox).toBeChecked()
+    })
+
+    it('should load saved cookie preferences from store', () => {
+      const preloadedState = {
+        cookies_terms: {
+          [CookieAndTermType.TERMS]: true,
+          [CookieAndTermType.NECESSARY]: true,
+          [CookieAndTermType.UPDATES]: true,
+          [CookieAndTermType.ANALYTICS]: false,
+          termsVersion: metadata.version,
+        },
+      }
+
+      renderWithStore(<CookieAndTermBanner />, preloadedState)
+
+      const beamerCheckbox = screen.getByRole('checkbox', { name: /Beamer/ })
+      const analyticsCheckbox = screen.getByRole('checkbox', { name: /Analytics/ })
+
+      expect(beamerCheckbox).toBeChecked()
+      expect(analyticsCheckbox).not.toBeChecked()
+    })
+
+    it('should allow toggling Beamer checkbox', () => {
+      renderWithStore(<CookieAndTermBanner />)
+
+      const beamerCheckbox = screen.getByRole('checkbox', { name: /Beamer/ })
+      expect(beamerCheckbox).not.toBeChecked()
+
+      fireEvent.click(beamerCheckbox)
+      expect(beamerCheckbox).toBeChecked()
+
+      fireEvent.click(beamerCheckbox)
+      expect(beamerCheckbox).not.toBeChecked()
+    })
+
+    it('should allow toggling Analytics checkbox', () => {
+      renderWithStore(<CookieAndTermBanner />)
+
+      const analyticsCheckbox = screen.getByRole('checkbox', { name: /Analytics/ })
+      expect(analyticsCheckbox).not.toBeChecked()
+
+      fireEvent.click(analyticsCheckbox)
+      expect(analyticsCheckbox).toBeChecked()
+
+      fireEvent.click(analyticsCheckbox)
+      expect(analyticsCheckbox).not.toBeChecked()
+    })
+
+    it('should check warning cookie when warningKey is provided', () => {
+      renderWithStore(<CookieAndTermBanner warningKey={CookieAndTermType.UPDATES} />)
+
+      const beamerCheckbox = screen.getByRole('checkbox', { name: /Beamer/ })
+      expect(beamerCheckbox).toBeChecked()
+    })
+  })
+
+  describe('User interactions', () => {
+    it('should save selected cookie preferences on "Save settings" click', async () => {
+      const { store } = renderWithStore(<CookieAndTermBanner />)
+
+      const beamerCheckbox = screen.getByRole('checkbox', { name: /Beamer/ })
+      const saveButton = screen.getByText('Save settings')
+
+      // Select only Beamer
+      fireEvent.click(beamerCheckbox)
+
+      fireEvent.click(saveButton)
+
+      await waitFor(() => {
+        const state = store.getState()
+        expect(state.cookies_terms[CookieAndTermType.UPDATES]).toBe(true)
+        expect(state.cookies_terms[CookieAndTermType.ANALYTICS]).toBe(false)
+      })
+    })
+
+    it('should accept all cookies on "Accept all" click', async () => {
+      const { store } = renderWithStore(<CookieAndTermBanner />)
+
+      const acceptAllButton = screen.getByText('Accept all')
+
+      fireEvent.click(acceptAllButton)
+
+      await waitFor(() => {
+        const state = store.getState()
+        expect(state.cookies_terms[CookieAndTermType.UPDATES]).toBe(true)
+        expect(state.cookies_terms[CookieAndTermType.ANALYTICS]).toBe(true)
+      })
+    })
+
+    it('should close banner after saving settings', async () => {
+      const { store } = renderWithStore(<CookieAndTermBanner />)
+
+      const saveButton = screen.getByText('Save settings')
+
+      fireEvent.click(saveButton)
+
+      await waitFor(() => {
+        const state = store.getState()
+        expect(state.popups.cookies.open).toBe(false)
+      })
+    })
+
+    it('should close banner after accepting all', async () => {
+      const { store } = renderWithStore(<CookieAndTermBanner />)
+
+      const acceptAllButton = screen.getByText('Accept all')
+
+      fireEvent.click(acceptAllButton)
+
+      await waitFor(() => {
+        const state = store.getState()
+        expect(state.popups.cookies.open).toBe(false)
+      })
+    })
+
+    it('should save terms version when accepting settings', async () => {
+      const { store } = renderWithStore(<CookieAndTermBanner />)
+
+      const saveButton = screen.getByText('Save settings')
+
+      fireEvent.click(saveButton)
+
+      await waitFor(() => {
+        const state = store.getState()
+        expect(state.cookies_terms.termsVersion).toBe(metadata.version)
+      })
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have proper labels for all checkboxes', () => {
+      renderWithStore(<CookieAndTermBanner />)
+
+      expect(screen.getByLabelText('Necessary')).toBeInTheDocument()
+      expect(screen.getByLabelText('Beamer')).toBeInTheDocument()
+      expect(screen.getByLabelText('Analytics')).toBeInTheDocument()
+    })
+
+    it('should have descriptions for each cookie type', () => {
+      renderWithStore(<CookieAndTermBanner />)
+
+      expect(screen.getByText('Locally stored data for core functionality')).toBeInTheDocument()
+      expect(screen.getByText('New features and product announcements')).toBeInTheDocument()
+      expect(screen.getByText('Analytics tools to understand usage patterns.')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/components/common/CookieAndTermBanner/constants.ts
+++ b/apps/web/src/components/common/CookieAndTermBanner/constants.ts
@@ -1,0 +1,34 @@
+import { CookieAndTermType } from '@/store/cookiesAndTermsSlice'
+
+export const COOKIE_AND_TERM_WARNING: Record<CookieAndTermType, string> = {
+  [CookieAndTermType.TERMS]: '',
+  [CookieAndTermType.NECESSARY]: '',
+  [CookieAndTermType.UPDATES]: `You attempted to open the "What's new" section but need to accept the "Beamer" cookies first.`,
+  [CookieAndTermType.ANALYTICS]: '',
+}
+
+export const styles = {
+  warningText: {
+    mb: 2,
+    color: 'warning.background',
+  },
+  introText: {
+    mb: 2,
+  },
+  optionsGrid: {
+    alignItems: 'center',
+    gap: 4,
+  },
+  optionBox: {
+    mb: 2,
+  },
+  buttonsGrid: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    mt: 4,
+    gap: 2,
+  },
+  warningIcon: {
+    mb: -0.4,
+  },
+} as const

--- a/apps/web/src/components/common/CookieAndTermBanner/index.tsx
+++ b/apps/web/src/components/common/CookieAndTermBanner/index.tsx
@@ -1,8 +1,6 @@
 import { useEffect, type ReactElement } from 'react'
 import classnames from 'classnames'
-import type { CheckboxProps } from '@mui/material'
-import { Grid, Button, Checkbox, FormControlLabel, Typography, Paper, SvgIcon, Box } from '@mui/material'
-import WarningIcon from '@/public/images/notifications/warning.svg'
+import { Grid, Paper } from '@mui/material'
 import { useForm } from 'react-hook-form'
 import * as metadata from '@/markdown/terms/version'
 
@@ -17,25 +15,12 @@ import { selectCookieBanner, openCookieBanner, closeCookieBanner } from '@/store
 
 import css from './styles.module.css'
 import { AppRoutes } from '@/config/routes'
-import ExternalLink from '../ExternalLink'
 import { useRouter } from 'next/router'
-
-const COOKIE_AND_TERM_WARNING: Record<CookieAndTermType, string> = {
-  [CookieAndTermType.TERMS]: '',
-  [CookieAndTermType.NECESSARY]: '',
-  [CookieAndTermType.UPDATES]: `You attempted to open the "What's new" section but need to accept the "Beamer" cookies first.`,
-  [CookieAndTermType.ANALYTICS]: '',
-}
-
-const CookieCheckbox = ({
-  checkboxProps,
-  label,
-  checked,
-}: {
-  label: string
-  checked: boolean
-  checkboxProps: CheckboxProps
-}) => <FormControlLabel label={label} checked={checked} control={<Checkbox {...checkboxProps} />} sx={{ mt: '-9px' }} />
+import { COOKIE_AND_TERM_WARNING, styles } from './constants'
+import WarningMessage from './WarningMessage'
+import IntroText from './IntroText'
+import CookieOptionsList from './CookieOptionsList'
+import CookieBannerActions from './CookieBannerActions'
 
 export const CookieAndTermBanner = ({
   warningKey,
@@ -48,7 +33,7 @@ export const CookieAndTermBanner = ({
   const dispatch = useAppDispatch()
   const cookies = useAppSelector(selectCookies)
 
-  const { register, watch, getValues, setValue } = useForm({
+  const { control, getValues, setValue } = useForm({
     defaultValues: {
       [CookieAndTermType.TERMS]: true,
       [CookieAndTermType.NECESSARY]: true,
@@ -77,106 +62,17 @@ export const CookieAndTermBanner = ({
 
   return (
     <Paper data-testid="cookies-popup" className={classnames(css.container, { [css.inverted]: inverted })}>
-      {warning && (
-        <Typography
-          align="center"
-          variant="body2"
-          sx={{
-            mb: 2,
-            color: 'warning.background',
-          }}
-        >
-          <SvgIcon component={WarningIcon} inheritViewBox fontSize="small" color="error" sx={{ mb: -0.4 }} /> {warning}
-        </Typography>
-      )}
+      {warning && <WarningMessage message={warning} />}
       <form>
-        <Grid
-          container
-          sx={{
-            alignItems: 'center',
-          }}
-        >
+        <Grid container sx={{ alignItems: 'center' }}>
           <Grid item xs>
-            <Typography
-              variant="body2"
-              sx={{
-                mb: 2,
-              }}
-            >
-              By browsing this page, you accept our{' '}
-              <ExternalLink href={AppRoutes.terms}>Terms & Conditions</ExternalLink> (last updated{' '}
-              {metadata.lastUpdated}) and the use of necessary cookies. By clicking &quot;Accept all&quot; you
-              additionally agree to the use of Beamer and Analytics cookies as listed below.{' '}
-              <ExternalLink href={AppRoutes.cookie}>Cookie policy</ExternalLink>
-            </Typography>
+            <IntroText lastUpdated={metadata.lastUpdated} />
 
-            <Grid
-              container
-              sx={{
-                alignItems: 'center',
-                gap: 4,
-              }}
-            >
-              <Grid item xs={12} sm>
-                <Box
-                  sx={{
-                    mb: 2,
-                  }}
-                >
-                  <CookieCheckbox checkboxProps={{ id: 'necessary', disabled: true }} label="Necessary" checked />
-                  <br />
-                  <Typography variant="body2">Locally stored data for core functionality</Typography>
-                </Box>
-
-                <Box
-                  sx={{
-                    mb: 2,
-                  }}
-                >
-                  <CookieCheckbox
-                    checkboxProps={{ ...register(CookieAndTermType.UPDATES), id: 'beamer' }}
-                    label="Beamer"
-                    checked={watch(CookieAndTermType.UPDATES)}
-                  />
-                  <br />
-                  <Typography variant="body2">New features and product announcements</Typography>
-                </Box>
-
-                <Box>
-                  <CookieCheckbox
-                    checkboxProps={{ ...register(CookieAndTermType.ANALYTICS), id: 'ga' }}
-                    label="Analytics"
-                    checked={watch(CookieAndTermType.ANALYTICS)}
-                  />
-                  <br />
-                  <Typography variant="body2">Analytics tools to understand usage patterns.</Typography>
-                </Box>
-              </Grid>
+            <Grid container sx={styles.optionsGrid}>
+              <CookieOptionsList control={control} />
             </Grid>
 
-            <Grid
-              container
-              sx={{
-                alignItems: 'center',
-                justifyContent: 'center',
-                mt: 4,
-                gap: 2,
-              }}
-            >
-              <Grid item>
-                <Typography>
-                  <Button onClick={handleAccept} variant="text" size="small" color="inherit" disableElevation>
-                    Save settings
-                  </Button>
-                </Typography>
-              </Grid>
-
-              <Grid item>
-                <Button onClick={handleAcceptAll} variant="contained" color="secondary" size="small" disableElevation>
-                  Accept all
-                </Button>
-              </Grid>
-            </Grid>
+            <CookieBannerActions onAccept={handleAccept} onAcceptAll={handleAcceptAll} />
           </Grid>
         </Grid>
       </form>

--- a/apps/web/src/components/settings/EnvironmentVariables/RpcProviderSection.tsx
+++ b/apps/web/src/components/settings/EnvironmentVariables/RpcProviderSection.tsx
@@ -1,0 +1,69 @@
+import { Controller, useFormContext } from 'react-hook-form'
+import { TextField, Typography, InputAdornment, Tooltip, IconButton, SvgIcon } from '@mui/material'
+import RotateLeftIcon from '@mui/icons-material/RotateLeft'
+import { useCurrentChain } from '@/hooks/useChains'
+import InfoIcon from '@/public/images/notifications/info.svg'
+import { EnvVariablesField } from './index'
+
+type RpcProviderSectionProps = {
+  onReset: () => void
+  showResetButton: boolean
+}
+
+const RpcProviderSection = ({ onReset, showResetButton }: RpcProviderSectionProps) => {
+  const chain = useCurrentChain()
+  const { control } = useFormContext()
+
+  return (
+    <>
+      <Typography
+        sx={{
+          fontWeight: 700,
+          mb: 2,
+          mt: 3,
+        }}
+      >
+        RPC provider
+        <Tooltip placement="top" arrow title="Any provider that implements the Ethereum JSON-RPC standard can be used.">
+          <span>
+            <SvgIcon
+              component={InfoIcon}
+              inheritViewBox
+              fontSize="small"
+              color="border"
+              sx={{ verticalAlign: 'middle', ml: 0.5 }}
+            />
+          </span>
+        </Tooltip>
+      </Typography>
+
+      <Controller
+        name={EnvVariablesField.rpc}
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            value={field.value || ''}
+            variant="outlined"
+            type="url"
+            placeholder={chain?.rpcUri.value}
+            InputProps={{
+              endAdornment: showResetButton ? (
+                <InputAdornment position="end">
+                  <Tooltip title="Reset to default value">
+                    <IconButton onClick={onReset} size="small" color="primary">
+                      <RotateLeftIcon />
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ) : null,
+            }}
+            fullWidth
+          />
+        )}
+      />
+    </>
+  )
+}
+
+export default RpcProviderSection

--- a/apps/web/src/components/settings/EnvironmentVariables/TenderlySection.tsx
+++ b/apps/web/src/components/settings/EnvironmentVariables/TenderlySection.tsx
@@ -1,0 +1,128 @@
+import { Controller, useFormContext } from 'react-hook-form'
+import { TextField, Typography, Grid, InputAdornment, Tooltip, IconButton, SvgIcon } from '@mui/material'
+import RotateLeftIcon from '@mui/icons-material/RotateLeft'
+import InfoIcon from '@/public/images/notifications/info.svg'
+import ExternalLink from '@/components/common/ExternalLink'
+import { TENDERLY_SIMULATE_ENDPOINT_URL } from '@safe-global/utils/config/constants'
+import { EnvVariablesField } from './index'
+
+type TenderlySectionProps = {
+  onResetUrl: () => void
+  onResetToken: () => void
+  showResetUrlButton: boolean
+  showResetTokenButton: boolean
+}
+
+const TenderlySection = ({
+  onResetUrl,
+  onResetToken,
+  showResetUrlButton,
+  showResetTokenButton,
+}: TenderlySectionProps) => {
+  const { control } = useFormContext()
+
+  return (
+    <>
+      <Typography
+        sx={{
+          fontWeight: 700,
+          mb: 2,
+          mt: 3,
+        }}
+      >
+        Tenderly
+        <Tooltip
+          placement="top"
+          arrow
+          title={
+            <>
+              You can use your own Tenderly project to keep track of all your transaction simulations.{' '}
+              <ExternalLink
+                color="secondary"
+                href="https://docs.tenderly.co/simulations-and-forks/simulation-api/configuration-of-api-access"
+              >
+                Read more
+              </ExternalLink>
+            </>
+          }
+        >
+          <span>
+            <SvgIcon
+              component={InfoIcon}
+              inheritViewBox
+              fontSize="small"
+              color="border"
+              sx={{ verticalAlign: 'middle', ml: 0.5 }}
+            />
+          </span>
+        </Tooltip>
+      </Typography>
+
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          <Controller
+            name={EnvVariablesField.tenderlyURL}
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value || ''}
+                type="url"
+                variant="outlined"
+                label="Tenderly API URL"
+                placeholder={TENDERLY_SIMULATE_ENDPOINT_URL}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                InputProps={{
+                  endAdornment: showResetUrlButton ? (
+                    <InputAdornment position="end">
+                      <Tooltip title="Reset to default value">
+                        <IconButton onClick={onResetUrl} size="small" color="primary">
+                          <RotateLeftIcon />
+                        </IconButton>
+                      </Tooltip>
+                    </InputAdornment>
+                  ) : null,
+                }}
+                fullWidth
+              />
+            )}
+          />
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <Controller
+            name={EnvVariablesField.tenderlyToken}
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                value={field.value || ''}
+                variant="outlined"
+                label="Tenderly access token"
+                InputLabelProps={{
+                  shrink: true,
+                }}
+                InputProps={{
+                  endAdornment: showResetTokenButton ? (
+                    <InputAdornment position="end">
+                      <Tooltip title="Reset to default value">
+                        <IconButton onClick={onResetToken} size="small" color="primary">
+                          <RotateLeftIcon />
+                        </IconButton>
+                      </Tooltip>
+                    </InputAdornment>
+                  ) : null,
+                }}
+                fullWidth
+              />
+            )}
+          />
+        </Grid>
+      </Grid>
+    </>
+  )
+}
+
+export default TenderlySection

--- a/apps/web/src/components/settings/EnvironmentVariables/__tests__/index.test.tsx
+++ b/apps/web/src/components/settings/EnvironmentVariables/__tests__/index.test.tsx
@@ -1,0 +1,263 @@
+import { fireEvent, waitFor, screen, render as rtlRender } from '@testing-library/react'
+import { render } from '@/tests/test-utils'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/store'
+import type { RootState } from '@/store'
+import { initialState as settingsInitialState } from '@/store/settingsSlice'
+import EnvironmentVariables from '..'
+import { faker } from '@faker-js/faker'
+import { chainBuilder } from '@/tests/builders/chains'
+import * as analytics from '@/services/analytics'
+import SafeThemeProvider from '@/components/theme/SafeThemeProvider'
+import { ThemeProvider } from '@mui/material/styles'
+import type { Theme } from '@mui/material/styles'
+
+// Mock chain data
+const mockChain = chainBuilder()
+  .with({ chainId: '1', shortName: 'eth' })
+  .with({ rpcUri: { authentication: 'NO_AUTHENTICATION', value: 'https://mainnet.infura.io/v3/' } })
+  .build()
+
+// Mock hooks
+jest.mock('@/hooks/useChainId', () => ({
+  __esModule: true,
+  default: jest.fn(() => '1'),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  useCurrentChain: jest.fn(() => mockChain),
+}))
+
+// Mock analytics
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+  SETTINGS_EVENTS: {
+    ENV_VARIABLES: {
+      SAVE: { category: 'settings', action: 'env_variables_save' },
+    },
+  },
+}))
+
+// Helper function to render with store access
+const renderWithStore = (ui: React.ReactElement, initialReduxState?: Partial<RootState>) => {
+  const store = makeStore(initialReduxState, { skipBroadcast: true })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <SafeThemeProvider mode="light">
+        {(safeTheme: Theme) => <ThemeProvider theme={safeTheme}>{children}</ThemeProvider>}
+      </SafeThemeProvider>
+    </Provider>
+  )
+  const result = rtlRender(ui, { wrapper })
+  return { ...result, store }
+}
+
+describe('EnvironmentVariables', () => {
+  const mockRpcUrl = faker.internet.url()
+  const mockTenderlyUrl = faker.internet.url()
+  const mockTenderlyToken = faker.string.alphanumeric(32)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Mock location.reload
+    delete (window as any).location
+    window.location = { reload: jest.fn() } as any
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should render with empty initial values', () => {
+    render(<EnvironmentVariables />, {
+      initialReduxState: {
+        settings: {
+          ...settingsInitialState,
+          env: {
+            rpc: {},
+            tenderly: { url: '', accessToken: '' },
+          },
+        },
+      },
+    })
+
+    // Check placeholder text is visible
+    expect(screen.getByPlaceholderText(mockChain.rpcUri.value)).toBeInTheDocument()
+  })
+
+  it('should render with existing Redux values', () => {
+    render(<EnvironmentVariables />, {
+      initialReduxState: {
+        settings: {
+          ...settingsInitialState,
+          env: {
+            rpc: { '1': mockRpcUrl },
+            tenderly: { url: mockTenderlyUrl, accessToken: mockTenderlyToken },
+          },
+        },
+      },
+    })
+
+    const rpcInput = screen.getByPlaceholderText(mockChain.rpcUri.value) as HTMLInputElement
+    const tenderlyUrlInput = screen.getByLabelText('Tenderly API URL') as HTMLInputElement
+    const tenderlyTokenInput = screen.getByLabelText('Tenderly access token') as HTMLInputElement
+
+    expect(rpcInput).toHaveValue(mockRpcUrl)
+    expect(tenderlyUrlInput).toHaveValue(mockTenderlyUrl)
+    expect(tenderlyTokenInput).toHaveValue(mockTenderlyToken)
+  })
+
+  it('should allow user to input RPC URL', async () => {
+    render(<EnvironmentVariables />, {
+      initialReduxState: {
+        settings: {
+          ...settingsInitialState,
+          env: { rpc: {}, tenderly: { url: '', accessToken: '' } },
+        },
+      },
+    })
+
+    const rpcInput = screen.getByPlaceholderText(mockChain.rpcUri.value) as HTMLInputElement
+
+    fireEvent.change(rpcInput, { target: { value: mockRpcUrl } })
+
+    await waitFor(() => {
+      expect(rpcInput).toHaveValue(mockRpcUrl)
+    })
+  })
+
+  it('should show reset button when value is entered', async () => {
+    render(<EnvironmentVariables />, {
+      initialReduxState: {
+        settings: {
+          ...settingsInitialState,
+          env: { rpc: {}, tenderly: { url: '', accessToken: '' } },
+        },
+      },
+    })
+
+    const rpcInput = screen.getByPlaceholderText(mockChain.rpcUri.value) as HTMLInputElement
+
+    // Initially no reset button
+    expect(screen.queryAllByLabelText('Reset to default value')).toHaveLength(0)
+
+    // Enter value
+    fireEvent.change(rpcInput, { target: { value: mockRpcUrl } })
+
+    // Reset button should appear
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Reset to default value').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('should clear input when reset button is clicked', async () => {
+    render(<EnvironmentVariables />, {
+      initialReduxState: {
+        settings: {
+          ...settingsInitialState,
+          env: { rpc: { '1': mockRpcUrl }, tenderly: { url: '', accessToken: '' } },
+        },
+      },
+    })
+
+    const rpcInput = screen.getByPlaceholderText(mockChain.rpcUri.value) as HTMLInputElement
+    expect(rpcInput).toHaveValue(mockRpcUrl)
+
+    // Click reset button
+    const resetButtons = screen.getAllByLabelText('Reset to default value')
+    fireEvent.click(resetButtons[0])
+
+    await waitFor(() => {
+      expect(rpcInput).toHaveValue('')
+    })
+  })
+
+  it('should save settings and reload page on submit', async () => {
+    const { store } = renderWithStore(<EnvironmentVariables />, {
+      settings: {
+        ...settingsInitialState,
+        env: { rpc: {}, tenderly: { url: '', accessToken: '' } },
+      },
+    })
+
+    // Fill in values
+    const rpcInput = screen.getByPlaceholderText(mockChain.rpcUri.value) as HTMLInputElement
+    const tenderlyUrlInput = screen.getByLabelText('Tenderly API URL') as HTMLInputElement
+    const tenderlyTokenInput = screen.getByLabelText('Tenderly access token') as HTMLInputElement
+
+    fireEvent.change(rpcInput, { target: { value: mockRpcUrl } })
+    fireEvent.change(tenderlyUrlInput, { target: { value: mockTenderlyUrl } })
+    fireEvent.change(tenderlyTokenInput, { target: { value: mockTenderlyToken } })
+
+    // Submit form
+    const saveButton = screen.getByText('Save')
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      // Check Redux state was updated
+      const state = store.getState()
+      expect(state.settings.env.rpc['1']).toBe(mockRpcUrl)
+      expect(state.settings.env.tenderly.url).toBe(mockTenderlyUrl)
+      expect(state.settings.env.tenderly.accessToken).toBe(mockTenderlyToken)
+
+      // Check that location.reload was called
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+  })
+
+  it('should track analytics event on save', async () => {
+    render(<EnvironmentVariables />, {
+      initialReduxState: {
+        settings: {
+          ...settingsInitialState,
+          env: { rpc: {}, tenderly: { url: '', accessToken: '' } },
+        },
+      },
+    })
+
+    const saveButton = screen.getByText('Save')
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(analytics.trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'settings',
+          action: 'env_variables_save',
+        }),
+      )
+    })
+  })
+
+  it('should allow clearing all inputs', async () => {
+    render(<EnvironmentVariables />, {
+      initialReduxState: {
+        settings: {
+          ...settingsInitialState,
+          env: {
+            rpc: { '1': mockRpcUrl },
+            tenderly: { url: mockTenderlyUrl, accessToken: mockTenderlyToken },
+          },
+        },
+      },
+    })
+
+    const rpcInput = screen.getByPlaceholderText(mockChain.rpcUri.value) as HTMLInputElement
+    const tenderlyUrlInput = screen.getByLabelText('Tenderly API URL') as HTMLInputElement
+    const tenderlyTokenInput = screen.getByLabelText('Tenderly access token') as HTMLInputElement
+
+    // All inputs should have values
+    expect(rpcInput).toHaveValue(mockRpcUrl)
+    expect(tenderlyUrlInput).toHaveValue(mockTenderlyUrl)
+    expect(tenderlyTokenInput).toHaveValue(mockTenderlyToken)
+
+    // Click all reset buttons
+    const resetButtons = screen.getAllByLabelText('Reset to default value')
+    resetButtons.forEach((button) => fireEvent.click(button))
+
+    await waitFor(() => {
+      expect(rpcInput).toHaveValue('')
+      expect(tenderlyUrlInput).toHaveValue('')
+      expect(tenderlyTokenInput).toHaveValue('')
+    })
+  })
+})

--- a/apps/web/src/components/settings/EnvironmentVariables/index.tsx
+++ b/apps/web/src/components/settings/EnvironmentVariables/index.tsx
@@ -1,15 +1,11 @@
 import { useForm, FormProvider } from 'react-hook-form'
-import { Paper, Grid, Typography, TextField, Button, Tooltip, IconButton, SvgIcon } from '@mui/material'
-import InputAdornment from '@mui/material/InputAdornment'
-import RotateLeftIcon from '@mui/icons-material/RotateLeft'
+import { Paper, Grid, Typography, Button } from '@mui/material'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectSettings, setRpc, setTenderly } from '@/store/settingsSlice'
 import useChainId from '@/hooks/useChainId'
-import { useCurrentChain } from '@/hooks/useChains'
 import { SETTINGS_EVENTS, trackEvent } from '@/services/analytics'
-import InfoIcon from '@/public/images/notifications/info.svg'
-import ExternalLink from '@/components/common/ExternalLink'
-import { TENDERLY_SIMULATE_ENDPOINT_URL } from '@safe-global/utils/config/constants'
+import RpcProviderSection from './RpcProviderSection'
+import TenderlySection from './TenderlySection'
 
 export enum EnvVariablesField {
   rpc = 'rpc',
@@ -25,7 +21,6 @@ export type EnvVariablesFormData = {
 
 const EnvironmentVariables = () => {
   const chainId = useChainId()
-  const chain = useCurrentChain()
   const settings = useAppSelector(selectSettings)
   const dispatch = useAppDispatch()
 
@@ -38,7 +33,7 @@ const EnvironmentVariables = () => {
     },
   })
 
-  const { register, handleSubmit, setValue, watch } = formMethods
+  const { handleSubmit, setValue, watch } = formMethods
 
   const rpc = watch(EnvVariablesField.rpc)
   const tenderlyURL = watch(EnvVariablesField.tenderlyURL)
@@ -64,9 +59,9 @@ const EnvironmentVariables = () => {
     location.reload()
   })
 
-  const onReset = (name: EnvVariablesField) => {
-    setValue(name, '')
-  }
+  const onResetRpc = () => setValue(EnvVariablesField.rpc, '')
+  const onResetTenderlyUrl = () => setValue(EnvVariablesField.tenderlyURL, '')
+  const onResetTenderlyToken = () => setValue(EnvVariablesField.tenderlyToken, '')
 
   return (
     <Paper sx={{ padding: 4 }}>
@@ -101,142 +96,14 @@ const EnvironmentVariables = () => {
 
           <FormProvider {...formMethods}>
             <form onSubmit={onSubmit}>
-              <Typography
-                sx={{
-                  fontWeight: 700,
-                  mb: 2,
-                  mt: 3,
-                }}
-              >
-                RPC provider
-                <Tooltip
-                  placement="top"
-                  arrow
-                  title="Any provider that implements the Ethereum JSON-RPC standard can be used."
-                >
-                  <span>
-                    <SvgIcon
-                      component={InfoIcon}
-                      inheritViewBox
-                      fontSize="small"
-                      color="border"
-                      sx={{ verticalAlign: 'middle', ml: 0.5 }}
-                    />
-                  </span>
-                </Tooltip>
-              </Typography>
+              <RpcProviderSection onReset={onResetRpc} showResetButton={!!rpc} />
 
-              <TextField
-                {...register(EnvVariablesField.rpc)}
-                variant="outlined"
-                type="url"
-                placeholder={chain?.rpcUri.value}
-                InputProps={{
-                  endAdornment: rpc ? (
-                    <InputAdornment position="end">
-                      <Tooltip title="Reset to default value">
-                        <IconButton onClick={() => onReset(EnvVariablesField.rpc)} size="small" color="primary">
-                          <RotateLeftIcon />
-                        </IconButton>
-                      </Tooltip>
-                    </InputAdornment>
-                  ) : null,
-                }}
-                fullWidth
+              <TenderlySection
+                onResetUrl={onResetTenderlyUrl}
+                onResetToken={onResetTenderlyToken}
+                showResetUrlButton={!!tenderlyURL}
+                showResetTokenButton={!!tenderlyToken}
               />
-
-              <Typography
-                sx={{
-                  fontWeight: 700,
-                  mb: 2,
-                  mt: 3,
-                }}
-              >
-                Tenderly
-                <Tooltip
-                  placement="top"
-                  arrow
-                  title={
-                    <>
-                      You can use your own Tenderly project to keep track of all your transaction simulations.{' '}
-                      <ExternalLink
-                        color="secondary"
-                        href="https://docs.tenderly.co/simulations-and-forks/simulation-api/configuration-of-api-access"
-                      >
-                        Read more
-                      </ExternalLink>
-                    </>
-                  }
-                >
-                  <span>
-                    <SvgIcon
-                      component={InfoIcon}
-                      inheritViewBox
-                      fontSize="small"
-                      color="border"
-                      sx={{ verticalAlign: 'middle', ml: 0.5 }}
-                    />
-                  </span>
-                </Tooltip>
-              </Typography>
-
-              <Grid container spacing={2}>
-                <Grid item xs={12} md={6}>
-                  <TextField
-                    {...register(EnvVariablesField.tenderlyURL)}
-                    type="url"
-                    variant="outlined"
-                    label="Tenderly API URL"
-                    placeholder={TENDERLY_SIMULATE_ENDPOINT_URL}
-                    InputLabelProps={{
-                      shrink: true,
-                    }}
-                    InputProps={{
-                      endAdornment: tenderlyURL ? (
-                        <InputAdornment position="end">
-                          <Tooltip title="Reset to default value">
-                            <IconButton
-                              onClick={() => onReset(EnvVariablesField.tenderlyURL)}
-                              size="small"
-                              color="primary"
-                            >
-                              <RotateLeftIcon />
-                            </IconButton>
-                          </Tooltip>
-                        </InputAdornment>
-                      ) : null,
-                    }}
-                    fullWidth
-                  />
-                </Grid>
-
-                <Grid item xs={12} md={6}>
-                  <TextField
-                    {...register(EnvVariablesField.tenderlyToken)}
-                    variant="outlined"
-                    label="Tenderly access token"
-                    InputLabelProps={{
-                      shrink: true,
-                    }}
-                    InputProps={{
-                      endAdornment: tenderlyToken ? (
-                        <InputAdornment position="end">
-                          <Tooltip title="Reset to default value">
-                            <IconButton
-                              onClick={() => onReset(EnvVariablesField.tenderlyToken)}
-                              size="small"
-                              color="primary"
-                            >
-                              <RotateLeftIcon />
-                            </IconButton>
-                          </Tooltip>
-                        </InputAdornment>
-                      ) : null,
-                    }}
-                    fullWidth
-                  />
-                </Grid>
-              </Grid>
 
               <Button type="submit" variant="contained" color="primary" sx={{ mt: 2 }}>
                 Save

--- a/apps/web/src/features/spaces/components/SpaceSettings/ErrorAlert.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/ErrorAlert.tsx
@@ -1,0 +1,16 @@
+import { Alert } from '@mui/material'
+import type { ReactElement } from 'react'
+
+const ErrorAlert = ({ error }: { error?: string }): ReactElement | null => {
+  if (!error) {
+    return null
+  }
+
+  return (
+    <Alert severity="error" sx={{ mt: 2 }}>
+      {error}
+    </Alert>
+  )
+}
+
+export default ErrorAlert

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, waitFor, screen, render as rtlRender } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/store'
+import SafeThemeProvider from '@/components/theme/SafeThemeProvider'
+import { ThemeProvider } from '@mui/material/styles'
+import type { Theme } from '@mui/material/styles'
+import UpdateSpaceForm from '../UpdateSpaceForm'
+
+// Import the real type
+import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+// Mock the hooks
+const mockUpdateSpace = jest.fn()
+const mockUseIsAdmin = jest.fn()
+
+jest.mock('@/features/spaces/hooks/useSpaceMembers', () => ({
+  useIsAdmin: jest.fn(() => mockUseIsAdmin()),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useSpacesUpdateV1Mutation: jest.fn(() => [mockUpdateSpace]),
+}))
+
+// Helper to render with Redux store
+const renderWithStore = (ui: React.ReactElement) => {
+  const store = makeStore(undefined, { skipBroadcast: true })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <SafeThemeProvider mode="light">
+        {(safeTheme: Theme) => <ThemeProvider theme={safeTheme}>{children}</ThemeProvider>}
+      </SafeThemeProvider>
+    </Provider>
+  )
+  const result = rtlRender(ui, { wrapper })
+  return { ...result, store }
+}
+
+describe('UpdateSpaceForm', () => {
+  const mockSpace: GetSpaceResponse = {
+    id: 123,
+    name: 'Test Space',
+    status: 'ACTIVE',
+    members: [],
+  }
+
+  // Helper functions to reduce code duplication
+  const setupForm = (space: GetSpaceResponse | undefined, isAdmin: boolean) => {
+    mockUseIsAdmin.mockReturnValue(isAdmin)
+    return renderWithStore(<UpdateSpaceForm space={space} />)
+  }
+
+  const getFormElements = () => ({
+    input: screen.getByLabelText('Space name') as HTMLInputElement,
+    saveButton: screen.getByTestId('space-save-button'),
+  })
+
+  const changeSpaceName = (newName: string) => {
+    const { input } = getFormElements()
+    fireEvent.change(input, { target: { value: newName } })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUpdateSpace.mockReset()
+    mockUseIsAdmin.mockReset()
+  })
+
+  it('should render with space data', () => {
+    setupForm(mockSpace, true)
+
+    const { input } = getFormElements()
+    expect(input).toHaveValue('Test Space')
+  })
+
+  it('should render empty when no space is provided', () => {
+    setupForm(undefined, false)
+
+    const { input } = getFormElements()
+    expect(input).toHaveValue('')
+  })
+
+  it('should allow user to change space name', async () => {
+    setupForm(mockSpace, true)
+
+    changeSpaceName('Updated Space Name')
+
+    await waitFor(() => {
+      const { input } = getFormElements()
+      expect(input).toHaveValue('Updated Space Name')
+    })
+  })
+
+  it('should disable save button when name is unchanged', () => {
+    setupForm(mockSpace, true)
+
+    const { saveButton } = getFormElements()
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('should enable save button when name is changed and user is admin', async () => {
+    setupForm(mockSpace, true)
+
+    changeSpaceName('New Name')
+
+    await waitFor(() => {
+      const { saveButton } = getFormElements()
+      expect(saveButton).not.toBeDisabled()
+    })
+  })
+
+  it('should disable save button when user is not admin', () => {
+    setupForm(mockSpace, false)
+
+    changeSpaceName('New Name')
+
+    const { saveButton } = getFormElements()
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('should call updateSpace mutation on submit', async () => {
+    mockUpdateSpace.mockResolvedValue({})
+    setupForm(mockSpace, true)
+
+    changeSpaceName('New Space Name')
+
+    const { saveButton } = getFormElements()
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(mockUpdateSpace).toHaveBeenCalledWith({
+        id: 123,
+        updateSpaceDto: { name: 'New Space Name' },
+      })
+    })
+  })
+
+  it('should show success notification on successful update', async () => {
+    mockUpdateSpace.mockResolvedValue({})
+    const { store } = setupForm(mockSpace, true)
+
+    changeSpaceName('New Space Name')
+
+    const { saveButton } = getFormElements()
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      const state = store.getState()
+      const notifications = state.notifications
+      expect(notifications.length).toBeGreaterThan(0)
+      const lastNotification = notifications[notifications.length - 1]
+      expect(lastNotification.message).toBe('Updated space name')
+      expect(lastNotification.variant).toBe('success')
+      expect(lastNotification.groupKey).toBe('space-update-name')
+    })
+  })
+
+  it('should display error message when update fails', async () => {
+    mockUpdateSpace.mockRejectedValue(new Error('Network error'))
+    setupForm(mockSpace, true)
+
+    changeSpaceName('New Space Name')
+
+    const { saveButton } = getFormElements()
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Error updating the space. Please try again.')).toBeInTheDocument()
+    })
+  })
+
+  it('should not call updateSpace when space is undefined', async () => {
+    setupForm(undefined, true)
+
+    changeSpaceName('Some Name')
+
+    const { saveButton } = getFormElements()
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(mockUpdateSpace).not.toHaveBeenCalled()
+    })
+  })
+
+  it('should clear error message when user retries after error', async () => {
+    mockUpdateSpace.mockRejectedValueOnce(new Error('Network error')).mockResolvedValueOnce({})
+    setupForm(mockSpace, true)
+
+    // First attempt fails
+    changeSpaceName('New Name')
+    const { saveButton } = getFormElements()
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Error updating the space. Please try again.')).toBeInTheDocument()
+    })
+
+    // Second attempt succeeds
+    changeSpaceName('Another Name')
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Error updating the space. Please try again.')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
+++ b/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+import { useAppDispatch } from '@/store'
+import { showNotification } from '@/store/notificationsSlice'
+import { type GetSpaceResponse, useSpacesUpdateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+export type UpdateSpaceFormData = {
+  name: string
+}
+
+export const useUpdateSpace = (space: GetSpaceResponse | undefined) => {
+  const [error, setError] = useState<string>()
+  const dispatch = useAppDispatch()
+  const [updateSpace] = useSpacesUpdateV1Mutation()
+
+  const handleUpdate = async (data: UpdateSpaceFormData) => {
+    setError(undefined)
+
+    if (!space) {
+      return
+    }
+
+    try {
+      await updateSpace({ id: space.id, updateSpaceDto: { name: data.name } })
+
+      dispatch(
+        showNotification({
+          variant: 'success',
+          message: 'Updated space name',
+          groupKey: 'space-update-name',
+        }),
+      )
+    } catch (e) {
+      console.error(e)
+      setError('Error updating the space. Please try again.')
+    }
+  }
+
+  return { handleUpdate, error }
+}

--- a/apps/web/src/features/tx-notes/components/TxNoteInput/__tests__/index.test.tsx
+++ b/apps/web/src/features/tx-notes/components/TxNoteInput/__tests__/index.test.tsx
@@ -1,0 +1,197 @@
+import { fireEvent, waitFor, screen } from '@testing-library/react'
+import { render } from '@/tests/test-utils'
+import TxNoteInput from '..'
+import * as analytics from '@/services/analytics'
+
+// Mock analytics
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+  MODALS_EVENTS: {
+    SUBMIT_TX_NOTE: { category: 'modals', action: 'submit_tx_note' },
+  },
+}))
+
+describe('TxNoteInput', () => {
+  const mockOnChange = jest.fn()
+
+  // Helper functions to reduce code duplication
+  const setupInput = () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+    return screen.getByLabelText('Optional') as HTMLInputElement
+  }
+
+  const changeAndBlur = (input: HTMLInputElement, value: string) => {
+    fireEvent.change(input, { target: { value } })
+    fireEvent.blur(input)
+  }
+
+  const expectTrackEventCalls = async (count: number) => {
+    await waitFor(() => {
+      expect(analytics.trackEvent).toHaveBeenCalledTimes(count)
+    })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render with default empty value', () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+
+    const input = screen.getByLabelText('Optional') as HTMLInputElement
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveValue('')
+    expect(screen.getByText('0/60')).toBeInTheDocument()
+  })
+
+  it('should display note heading and privacy warning', () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+
+    expect(screen.getByText('Note')).toBeInTheDocument()
+    expect(screen.getByTestId('tx-note-alert')).toHaveTextContent(
+      'Notes are publicly visible. Do not share any private or sensitive details.',
+    )
+  })
+
+  it('should call onChange when user types', async () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+
+    const input = screen.getByLabelText('Optional') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: 'Test note' } })
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith('Test note')
+      expect(input).toHaveValue('Test note')
+    })
+  })
+
+  it('should update character counter as user types', async () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+
+    const input = screen.getByLabelText('Optional') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: 'Hello' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('5/60')).toBeInTheDocument()
+    })
+
+    fireEvent.change(input, { target: { value: 'Hello World' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('11/60')).toBeInTheDocument()
+    })
+  })
+
+  it('should enforce maximum length of 60 characters', async () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+
+    const input = screen.getByLabelText('Optional') as HTMLInputElement
+    const longText = 'a'.repeat(100) // Try to enter 100 characters
+
+    fireEvent.change(input, { target: { value: longText } })
+
+    await waitFor(() => {
+      expect(input).toHaveValue('a'.repeat(60))
+      expect(mockOnChange).toHaveBeenCalledWith('a'.repeat(60))
+      expect(screen.getByText('60/60')).toBeInTheDocument()
+    })
+  })
+
+  it('should not track analytics on focus without changes', () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+
+    const input = screen.getByLabelText('Optional') as HTMLInputElement
+
+    fireEvent.focus(input)
+    fireEvent.blur(input)
+
+    expect(analytics.trackEvent).not.toHaveBeenCalled()
+  })
+
+  it('should not track analytics when note is empty on blur', async () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+
+    const input = screen.getByLabelText('Optional') as HTMLInputElement
+
+    // Type and then clear
+    fireEvent.change(input, { target: { value: 'Test' } })
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(analytics.trackEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  it('should track analytics when note is changed and non-empty on blur', async () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+
+    const input = screen.getByLabelText('Optional') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: 'Test note' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(analytics.trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'modals',
+          action: 'submit_tx_note',
+        }),
+      )
+    })
+  })
+
+  it('should reset isDirty state on focus', async () => {
+    const input = setupInput()
+
+    // First change and blur
+    changeAndBlur(input, 'First note')
+    await expectTrackEventCalls(1)
+
+    // Focus again (should reset isDirty)
+    fireEvent.focus(input)
+
+    // Blur without changes (should not track again)
+    fireEvent.blur(input)
+
+    await expectTrackEventCalls(1) // Still 1, not 2
+  })
+
+  it('should track analytics again after refocusing and making new changes', async () => {
+    const input = setupInput()
+
+    // First change and blur
+    changeAndBlur(input, 'First')
+    await expectTrackEventCalls(1)
+
+    // Focus and make another change
+    fireEvent.focus(input)
+    changeAndBlur(input, 'First Second')
+
+    await expectTrackEventCalls(2)
+  })
+
+  it('should allow clearing the input', async () => {
+    render(<TxNoteInput onChange={mockOnChange} />)
+
+    const input = screen.getByLabelText('Optional') as HTMLInputElement
+
+    // Add text
+    fireEvent.change(input, { target: { value: 'Some text' } })
+
+    await waitFor(() => {
+      expect(input).toHaveValue('Some text')
+    })
+
+    // Clear it
+    fireEvent.change(input, { target: { value: '' } })
+
+    await waitFor(() => {
+      expect(input).toHaveValue('')
+      expect(mockOnChange).toHaveBeenCalledWith('')
+      expect(screen.getByText('0/60')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/features/tx-notes/components/TxNoteInput/index.tsx
+++ b/apps/web/src/features/tx-notes/components/TxNoteInput/index.tsx
@@ -1,26 +1,21 @@
 import { useCallback } from 'react'
 import { InputAdornment, Stack, TextField, Typography } from '@mui/material'
 import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
-import { useForm } from 'react-hook-form'
+import { Controller, useForm } from 'react-hook-form'
 
 const MAX_NOTE_LENGTH = 60
 
 export default function TxNoteInput({ onChange }: { onChange: (note: string) => void }) {
   const {
-    register,
+    control,
     watch,
     reset,
     formState: { isDirty },
-  } = useForm<{ note: string }>()
+  } = useForm<{ note: string }>({
+    defaultValues: { note: '' },
+  })
 
   const note = watch('note') || ''
-
-  const onInput = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(e.target.value.slice(0, MAX_NOTE_LENGTH))
-    },
-    [onChange],
-  )
 
   const onFocus = useCallback(() => {
     // Reset the isDirty state when the user focuses on the input
@@ -41,26 +36,40 @@ export default function TxNoteInput({ onChange }: { onChange: (note: string) => 
         <Typography variant="h5">Note</Typography>
       </Stack>
 
-      <TextField
-        data-testid="tx-note-textfield"
-        label="Optional"
-        fullWidth
-        slotProps={{
-          htmlInput: { maxLength: MAX_NOTE_LENGTH },
-          input: {
-            endAdornment: (
-              <InputAdornment position="end">
-                <Typography variant="caption" mt={3}>
-                  {note.length}/{MAX_NOTE_LENGTH}
-                </Typography>
-              </InputAdornment>
-            ),
-          },
-        }}
-        {...register('note')}
-        onInput={onInput}
-        onBlur={onBlur}
-        onFocus={onFocus}
+      <Controller
+        name="note"
+        control={control}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            data-testid="tx-note-textfield"
+            label="Optional"
+            fullWidth
+            value={field.value || ''}
+            onChange={(e) => {
+              const limitedValue = e.target.value.slice(0, MAX_NOTE_LENGTH)
+              field.onChange(limitedValue)
+              onChange(limitedValue)
+            }}
+            onFocus={onFocus}
+            onBlur={() => {
+              field.onBlur()
+              onBlur()
+            }}
+            slotProps={{
+              htmlInput: { maxLength: MAX_NOTE_LENGTH },
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <Typography variant="caption" mt={3}>
+                      {note.length}/{MAX_NOTE_LENGTH}
+                    </Typography>
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+        )}
       />
 
       <Typography data-testid="tx-note-alert" variant="body2" color="text.secondary">


### PR DESCRIPTION
## What it solves

Uncontrolled component sometimes has some ui issues with the MUI.
Resolves:  https://linear.app/safe-global/issue/WA-1401/track-work-for-github-issue-safe-wallet-monorepo-1369

## How this PR fixes it
Refactor `TxNoteInput`, `UpdateSpaceForm`, `EnvironmentVariables`, `CookieAndTermBanner` from uncontrolled input to controlled component.

The Analytics is not affected.

## How to test it
1. TxNoteInput: token transfer page, change threshold page, add signers page, remove signers page, change threshold page, confirm transaction page.
2. UpdateSpaceForm: rename space popup, space setting page.
3. EnvironmentVariables: Environment variables tab for the settings page. 
4. CookieAndTermBanner: when user first time enter into the app, settings page without safe wallet address.

## Screenshots
1. TxNoteInput:
<img width="510" height="717" alt="Screenshot 2026-02-09 at 14 24 59" src="https://github.com/user-attachments/assets/7117deed-53f2-4ed0-b23f-0c2377c45b39" />
2. UpdateSpaceForm:
<img width="862" height="518" alt="Screenshot 2026-02-09 at 14 26 15" src="https://github.com/user-attachments/assets/8438864f-1b07-4723-92e0-8ac07cdd3aec" />
3. EnvironmentVariables: 
<img width="1222" height="492" alt="Screenshot 2026-02-09 at 15 34 24" src="https://github.com/user-attachments/assets/f28c2c52-75a1-4ce5-9ba5-fa1c79bedd61" />
4. CookieAndTermBanner:
<img width="1475" height="508" alt="Screenshot 2026-02-09 at 15 35 25" src="https://github.com/user-attachments/assets/f243bca1-144f-4414-ae07-12d31fe11756" />



## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple user-facing forms and consent flows; while largely a refactor, controlled-input rewiring can subtly change input state, validation, and submission timing across several surfaces.
> 
> **Overview**
> Refactors several MUI form inputs from uncontrolled `register` usage to controlled `Controller`/`useFormContext` patterns to avoid UI sync issues, including `TxNoteInput`, `UpdateSpaceForm`, `EnvironmentVariables`, and `CookieAndTermBanner`.
> 
> As part of the refactor, larger components are split into focused subcomponents/hooks (e.g. `useUpdateSpace`, `RpcProviderSection`, `TenderlySection`, cookie banner parts), submit/reset/disable logic is tightened (e.g. prevent double-submit while submitting), and new unit tests are added to cover the controlled behavior, persistence, and interactions. Jest config is updated to map the `@safe-global/store` alias for tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 787c942fd62ad0af3a26bf0cd5892055435a3003. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->