### PR TITLE
fix(web): No mobile delegates in web UI

### DIFF
--- a/apps/web/src/components/settings/ProposersList/index.tsx
+++ b/apps/web/src/components/settings/ProposersList/index.tsx
@@ -46,39 +46,41 @@ const ProposersList = () => {
   const rows = useMemo(() => {
     if (!proposers.data) return []
 
-    return proposers.data.results.map((proposer) => {
-      return {
-        cells: {
-          proposer: {
-            rawValue: proposer.delegate,
-            content: (
-              <NamedAddressInfo
-                address={proposer.delegate}
-                showCopyButton
-                hasExplorer
-                name={proposer.label || undefined}
-                shortAddress
-              />
-            ),
-          },
+    return proposers.data.results
+      .filter((proposer) => proposer.label !== 'Mobile App Delegate')
+      .map((proposer) => {
+        return {
+          cells: {
+            proposer: {
+              rawValue: proposer.delegate,
+              content: (
+                <NamedAddressInfo
+                  address={proposer.delegate}
+                  showCopyButton
+                  hasExplorer
+                  name={proposer.label || undefined}
+                  shortAddress
+                />
+              ),
+            },
 
-          creator: {
-            rawValue: proposer.delegator,
-            content: <EthHashInfo address={proposer.delegator} showCopyButton hasExplorer shortAddress />,
+            creator: {
+              rawValue: proposer.delegator,
+              content: <EthHashInfo address={proposer.delegator} showCopyButton hasExplorer shortAddress />,
+            },
+            actions: {
+              rawValue: '',
+              sticky: true,
+              content: isEnabled && (
+                <div className={tableCss.actions}>
+                  <EditProposerDialog proposer={proposer} />
+                  <DeleteProposerDialog proposer={proposer} />
+                </div>
+              ),
+            },
           },
-          actions: {
-            rawValue: '',
-            sticky: true,
-            content: isEnabled && (
-              <div className={tableCss.actions}>
-                <EditProposerDialog proposer={proposer} />
-                <DeleteProposerDialog proposer={proposer} />
-              </div>
-            ),
-          },
-        },
-      }
-    })
+        }
+      })
   }, [isEnabled, proposers.data])
 
   if (!proposers.data?.results) return null


### PR DESCRIPTION
## What it solves

Mobile delegates were shown in the web UI - they should not be shown.
Resolves:[ WA-1419](https://linear.app/safe-global/issue/WA-1429/mobile-delegate-is-displayed-on-the-web-ui)

## How this PR fixes it
Filters out mobile delegates.

## How to test it
Go to a Safe with mobile delegates -> Settings -> Proposers: Mobile delegates should not be shown.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
