### PR TITLE
fix: revert monospace font for addresses

### DIFF
--- a/apps/web/src/components/sidebar/NestedSafesList/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesList/index.tsx
@@ -75,7 +75,6 @@ function NestedSafeItem({
           chainId={safeItem.chainId}
           fullAddress
           highlight4bytes={showSimilarityWarning}
-          monospace
         />
         <AccountItem.Group>
           <AccountItem.Balance fiatTotal={safeOverview?.fiatTotal} isLoading={!safeOverview} />

--- a/apps/web/src/features/myAccounts/components/SafeSelectionModal/SafeSelectionItem.tsx
+++ b/apps/web/src/features/myAccounts/components/SafeSelectionModal/SafeSelectionItem.tsx
@@ -64,7 +64,6 @@ const SafeSelectionItem = ({ safe, onToggle }: SafeSelectionItemProps) => {
         fullAddress
         showCopyButton
         hasExplorer
-        monospace
         highlight4bytes={!!safe.similarityGroup}
       >
         {!isMobile && statusChips}


### PR DESCRIPTION
## What it solves

Resolves: [WA-1426](https://linear.app/safe-global/issue/WA-1426/manage-trusted-safes-wrong-shrift-for-the-single-chain-safe)

## How this PR fixes it
- Reverts using the monospace for addresses in 'Manage safes' popup

## How to test it
- font should be consistent everywhere

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentational change that only affects address typography in two UI components; no business logic or data flow changes.
> 
> **Overview**
> Removes the `monospace` prop from `AccountItem.Info` when rendering full Safe addresses in the nested safes sidebar list and the “Manage Safes” selection modal, restoring the default font styling for addresses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44e876e09136b189fc4fad0c2234c67172bd50eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->