### PR TITLE
fix(web): make nested safes popover responsive on mobile

### DIFF
--- a/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesPopover/index.tsx
@@ -294,6 +294,12 @@ export function NestedSafesPopover({
             display: 'flex',
             flexDirection: 'column',
             overflow: 'hidden',
+            '@media (max-width: 599.95px)': {
+              top: '16px !important',
+              left: '16px !important',
+              height: 'calc(100vh - 32px)',
+              maxHeight: 'none',
+            },
           },
         },
       }}
@@ -324,7 +330,8 @@ export function NestedSafesPopover({
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
-          maxHeight: 'calc(100vh - 250px)',
+          flex: '1 1 auto',
+          minHeight: 0,
         }}
       >
         {showIntroScreen ? (


### PR DESCRIPTION
## Summary
- On mobile screens (<600px), the Nested Safes popover now stretches to full viewport height (minus 16px margin) with inner scroll
- Overrides MUI Popover's anchor-based positioning on mobile to pin the popup at the top of the viewport
- Inner content area uses flex-grow instead of a fixed `maxHeight`, allowing it to fill available space

Fixes https://linear.app/safe-global/issue/WA-1423/nested-safes-modal-is-not-mobile-responsive

## Test plan
- [ ] Open the Nested Safes popover on a mobile viewport (e.g. iPhone SE 375x667)
- [ ] Verify the popover stretches to near full screen height with margin
- [ ] Verify the content scrolls when it overflows
- [ ] Verify manage mode and intro screen also stretch correctly
- [ ] Verify desktop behavior is unchanged (popover anchored to button, sized by content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)