### PR TITLE
fix(web): allow custom Safe Apps added via URL to load

### DIFF
--- a/apps/web/src/hooks/safe-apps/useSafeAppRedirects.ts
+++ b/apps/web/src/hooks/safe-apps/useSafeAppRedirects.ts
@@ -11,13 +11,10 @@ type UseSafeAppRedirectsParams = {
   goToList: () => void
 }
 
-const isAppUnavailable = (
-  safeAppData: UseSafeAppRedirectsParams['safeAppData'],
-  chainId: string,
-  appUrl: string | undefined,
-): boolean => {
-  if (safeAppData) return !safeAppData.chainIds.includes(chainId)
-  return Boolean(appUrl)
+const isAppUnavailable = (safeAppData: UseSafeAppRedirectsParams['safeAppData'], chainId: string): boolean => {
+  // Only redirect if the app is in the remote list but doesn't support this chain.
+  // Custom apps (added via URL) have no safeAppData and should always be allowed.
+  return Boolean(safeAppData && !safeAppData.chainIds.includes(chainId))
 }
 
 const shouldRedirectToShare = (appUrl: string | undefined, isReady: boolean, safe: unknown): boolean => {
@@ -35,10 +32,10 @@ const useSafeAppRedirects = ({
   const router = useRouter()
 
   useEffect(() => {
-    if (!remoteSafeAppsLoading && isAppUnavailable(safeAppData, chainId, appUrl)) {
+    if (!remoteSafeAppsLoading && isAppUnavailable(safeAppData, chainId)) {
       goToList()
     }
-  }, [safeAppData, chainId, goToList, remoteSafeAppsLoading, appUrl])
+  }, [safeAppData, chainId, goToList, remoteSafeAppsLoading])
 
   if (shouldRedirectToShare(appUrl, router.isReady, router.query.safe)) {
     router.push({


### PR DESCRIPTION
## Summary
- Fixed `isAppUnavailable` in `useSafeAppRedirects` which incorrectly treated custom Safe Apps (added directly via URL) as unavailable, redirecting users to the apps list
- Custom apps don't exist in the remote `/safe-apps` config so `safeAppData` is `undefined`. The old logic returned `Boolean(appUrl)` in that case (always `true`), causing immediate redirect. Now returns `false` — only redirect when the app IS in the remote list but doesn't support the current chain.

## Test plan
- [ ] Open a custom Safe App via direct URL (`/apps/open?appUrl=<custom-url>&safe=<safe-address>`) — should load instead of redirecting
- [ ] Open a remote Safe App on a supported chain — should load normally
- [ ] Switch to an unsupported chain while on a remote Safe App — should redirect to apps list

🤖 Generated with [Claude Code](https://claude.com/claude-code)