### PR TITLE
fix(web): remove @chromatic-com/cypress from cypress config

### DIFF
--- a/apps/web/cypress.config.js
+++ b/apps/web/cypress.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'cypress'
 import 'dotenv/config'
 import * as fs from 'fs'
-import { installPlugin } from '@chromatic-com/cypress'
 import { version } from './src/markdown/terms/version.js'
 
 export default defineConfig({
@@ -22,8 +21,6 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       // Set Cookie term version on the cypress env - this way we can access it in the tests
       config.env.CURRENT_COOKIE_TERMS_VERSION = version
-
-      installPlugin(on, config)
 
       on('task', {
         log(message) {

--- a/apps/web/cypress/support/e2e.js
+++ b/apps/web/cypress/support/e2e.js
@@ -28,8 +28,6 @@ import * as ls from './localstorage_data'
   However, in cypress the cookie banner state is evaluated after the banner has been dismissed not before
   which displays the terms banner even though it shouldn't so we need to globally hide it in our tests.
  */
-import '@chromatic-com/cypress/support'
-
 const beamer = JSON.parse(Cypress.env('BEAMER_DATA_E2E') || '{}')
 const productID = beamer.PRODUCT_ID
 


### PR DESCRIPTION
## Summary
- Remove `@chromatic-com/cypress` import and `installPlugin()` call from `cypress.config.js`
- Remove `@chromatic-com/cypress/support` import from `cypress/support/e2e.js`
- The `@chromatic-com/cypress` package can't be resolved at config load time, breaking all Cypress test runs with `Cannot find module '@chromatic-com/cypress'`

## Test plan
- [x] Confirmed Cypress config fails to load before fix (`Cannot find module '@chromatic-com/cypress'`)
- [x] Confirmed Cypress smoke test (`landing.cy.js`) passes after fix
- [ ] CI Cypress tests should pass again

🤖 Generated with [Claude Code](https://claude.com/claude-code)