### PR TITLE
fix: handle unset RUN_TESTS_ON_PUSH in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -22,7 +22,7 @@ if [ "$initial_status" != "$post_lint_status" ]; then
 fi
 
 # Check if the user wants to run tests on push
-if [ "$RUN_TESTS_ON_PUSH" == "true" ]; then
+if [ "${RUN_TESTS_ON_PUSH:-}" == "true" ]; then
   echo "Running tests..."
   if ! yarn test; then
     echo "===================================="


### PR DESCRIPTION
## Summary
- `set -euo pipefail` in the pre-push hook crashes when `RUN_TESTS_ON_PUSH` is not set (the `u` flag treats unset variables as errors)
- Uses `${RUN_TESTS_ON_PUSH:-}` to default to empty string, unblocking everyone's `git push`

## Test plan
- [ ] Run `git push` without `RUN_TESTS_ON_PUSH` set — should no longer crash
- [ ] Run `RUN_TESTS_ON_PUSH=true git push` — should still run tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)