### PR TITLE
chore: update Claude Code Review workflow for improved functionality

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          model: 'claude-sonnet-4-5-20250929'
+          model: 'claude-opus-4-6'
           direct_prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices


### PR DESCRIPTION
## What it solves
This PR updates Claude workflow

## How this PR fixes it
- Removed automatic PR review triggers, now only runs on manual trigger or when @claude is mentioned.
- Updated action to use anthropics/claude-code-action@v1 and specified model arguments for better performance.
- Cleaned up commented-out sections for clarity and maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only changes a GitHub Actions workflow; impact is limited to when the Claude review job runs and which model/action versions it uses.
> 
> **Overview**
> Updates the `Claude Code Review` GitHub Actions workflow to run **only** on manual dispatch or when `@claude review` is mentioned in issue/review comments, removing the previous (commented) automatic PR-trigger setup.
> 
> Adjusts the workflow configuration by switching `actions/checkout` to `@v5`, explicitly setting the Claude model to `claude-opus-4-6`, and trimming optional commented configuration to simplify maintenance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec7d42645cf05fe5223a204c496884e2026d4ab8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->