### PR TITLE
chore: migrate relay status polling logic to BE

### DIFF
--- a/apps/mobile/src/store/middleware/__tests__/pendingTxs.test.ts
+++ b/apps/mobile/src/store/middleware/__tests__/pendingTxs.test.ts
@@ -17,11 +17,23 @@ jest.mock('@safe-global/utils/services/SimpleTxWatcher', () => ({
 jest.mock('@safe-global/utils/services/RelayTxWatcher', () => ({
   RelayTxWatcher: {
     getInstance: jest.fn(() => ({
-      watchTaskId: jest.fn(() => Promise.resolve({ transactionHash: '0xabc123' })),
+      watchTaskId: jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          receipt: {
+            transactionHash: '0xabc123',
+          },
+        }),
+      ),
       stopWatchingTaskId: jest.fn(),
     })),
   },
   TIMEOUT_ERROR_CODE: 'TIMEOUT',
+}))
+
+jest.mock('@safe-global/store/gateway/cgwClient', () => ({
+  ...jest.requireActual('@safe-global/store/gateway/cgwClient'),
+  getBaseUrl: jest.fn(() => 'https://test-cgw.example.com'),
 }))
 
 jest.mock('@safe-global/utils/services/SimplePoller', () => ({

--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -28,6 +28,7 @@ const customJestConfig = {
     '^.+/markdown/terms/terms\\.md$': '<rootDir>/mocks/terms.md.js',
     isows: '<rootDir>/node_modules/isows/_cjs/index.js',
     '^@safe-global/utils/(.*)$': '<rootDir>/../../packages/utils/src/$1',
+    '^@safe-global/store/(.*)$': '<rootDir>/../../packages/store/src/$1',
   },
   // https://github.com/mswjs/jest-fixed-jsdom
   // without this environment it is basically impossible to run tests with msw


### PR DESCRIPTION
## What it solves

Resolve: https://linear.app/safe-global/issue/WA-1451/migrate-from-gelatonetworkrelay-sdk-to-gelatocloudgasless

Migrates Gelato Relay task status polling from direct Gelato API calls to the new backend (CGW) proxy endpoint. 

The old Gelato Legacy REST API (`https://relay.gelato.digital/tasks/status/{taskId}`) is being deprecated, and the new Gelato Turbo Relayer API requires an API key. 

The backend now proxies these requests, so the frontend must poll through the CGW instead of calling Gelato directly.

## How this PR fixes it

### Shared package (`packages/utils`)
- **`RelayTxWatcher.ts`**: Updated the shared relay status watcher to use the CGW proxy endpoint (`GET {baseUrl}/v1/chains/{chainId}/relay/status/{taskId}`) instead of the direct Gelato URL. Replaced the old string-based `TaskState` enum with a new numeric `RelayStatus` enum (100=Pending, 110=Submitted, 200=Included, 400=Rejected, 500=Reverted) and updated response types (`RelayTaskStatus`, `RelayTaskReceipt`) to match the new backend schema.

### Web app (`apps/web`)
- **`txMonitor.ts`**: Removed the local `TaskState` enum, `getRelayTxStatus` function, and Gelato URL. Now imports `getRelayTxStatus` and `RelayStatus` from the shared package. Updated `waitForRelayedTx` to pass `baseUrl` and `chainId` to the shared function, and extracts `txHash` from `receipt.transactionHash`.
- **`safeDeployment.ts`**: Updated `checkSafeActionViaRelay` (counterfactual Safe activation via relay) to use the shared `getRelayTxStatus` with the new response format.

### Mobile app (`apps/mobile`)
- **`pendingTxs.ts`**: Updated `startRelayWatcher` to obtain `baseUrl` via `getBaseUrl()` and pass it along with `chainId` to `RelayTxWatcher.watchTaskId()`. Updated response handling to extract `txHash` from `receipt.transactionHash`.

### Tests
- Updated all related unit tests for both web (`txMonitor.test.ts`) and mobile (`pendingTxs.test.ts`) to mock the new `getRelayTxStatus` and `getBaseUrl` dependencies with the new response format.
- Added `@safe-global/store` module name mapping to `apps/web/jest.config.cjs`.

## How to test it

1. **Web - Relay transaction**: On a chain with RELAYING feature enabled (e.g., Sepolia), execute a transaction using the "Sponsored by..." relay option. Verify the transaction status polling works correctly and the transaction completes successfully.
2. **Web - Counterfactual Safe activation via relay**: Create a counterfactual Safe, then activate it using the relay (sponsored) option. Verify the activation polling works and the Safe becomes deployed.
3. **Mobile - Relay transaction**: Execute a relay transaction on mobile and verify it completes and transitions through INDEXING → SUCCESS states.
4. **Browser Dev Tools Network tab**: Confirm that status polling requests go to `{CGW_BASE_URL}/v1/chains/{chainId}/relay/status/{taskId}` instead of `https://relay.gelato.digital/tasks/status/{taskId}`.

## Screenshots

N/A - No UI changes, backend API migration only.

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 -> Not affect analytics
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction status polling/relay completion handling in both web and mobile; failures or mismapped statuses could cause stuck/incorrect tx states, though the change is largely a backend-endpoint and response-shape migration with updated tests.
> 
> **Overview**
> Relay transaction monitoring now polls the CGW proxy endpoint (via `getBaseUrl()` + `getRelayTxStatus(baseUrl, chainId, taskId)`) instead of calling Gelato directly, and updates status handling to the new numeric `RelayStatus`/`receipt.transactionHash` response shape.
> 
> This refactors the shared `RelayTxWatcher` API (new URL builder, new types, terminal-status logic, and updated `watchTaskId` signature), updates web flows (`waitForRelayedTx`, counterfactual safe deployment relay checks) and mobile pending-tx relay watcher to pass `chainId`/`baseUrl` and to fail fast when CGW is not configured, and adjusts Jest config/tests/mocks accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69a68712333cabc6e695649b11c166f69bb74f2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->