### PR TITLE
fix: add missing shadcn CSS to Vite Storybook

### DIFF
--- a/apps/web/.storybook-vite/preview.tsx
+++ b/apps/web/.storybook-vite/preview.tsx
@@ -8,6 +8,7 @@ import createEmotionCache from '../src/utils/createEmotionCache'
 import { initialize, mswLoader } from 'msw-storybook-addon'
 
 import '../src/styles/globals.css'
+import '../src/styles/shadcn.css'
 
 // Create emotion cache once for Storybook (same as real app)
 // This ensures MUI styles are injected first, allowing CSS modules to override them
@@ -23,6 +24,18 @@ initialize({
 export { withLayout, withMockProvider } from '../.storybook/decorators'
 
 const BACKGROUND_COLORS: Record<string, string> = { light: '#ffffff', dark: '#121312' }
+
+// Wraps the story in .shadcn-scope so shadcn/ui Tailwind and CSS variables apply.
+// Required for any story that uses components from src/components/ui/ (shadcn).
+const ShadcnScopeDecorator = (Story: React.ComponentType, context: { globals?: { theme?: string } }) => {
+  const themeMode = context.globals?.theme || 'light'
+  const isDark = themeMode === 'dark'
+  return (
+    <div className={isDark ? 'shadcn-scope dark' : 'shadcn-scope'}>
+      <Story />
+    </div>
+  )
+}
 
 // Syncs data-theme attribute and background color with the theme switcher
 const ThemeSyncDecorator = (
@@ -143,6 +156,9 @@ const preview: Preview = {
   loaders: [mswLoader],
 
   decorators: [
+    ThemeSyncDecorator,
+    // Wraps story in .shadcn-scope so shadcn/ui components get Tailwind and CSS variables
+    ShadcnScopeDecorator,
     // Custom MUI theme decorator with emotion cache (same as real app)
     // This ensures CSS modules can override MUI styles
     (Story, context) => {
@@ -158,7 +174,6 @@ const preview: Preview = {
         </CacheProvider>
       )
     },
-    ThemeSyncDecorator,
   ],
 }
 

--- a/apps/web/src/features/spaces/components/Sidebar/SafeSidebar.stories.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SafeSidebar.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+import { EnhancedSidebar } from './index'
+
+const meta = {
+  title: 'Features/Spaces/SafeSidebar',
+  component: EnhancedSidebar,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/home',
+        query: {
+          safe: 'eth:0x1234567890123456789012345678901234567890',
+        },
+      },
+    },
+  },
+  decorators: [
+    () => (
+      <SidebarProvider defaultOpen>
+        <div className="flex min-h-screen w-full">
+          <EnhancedSidebar isSpacesRoute={false} />
+          <SidebarInset>
+            <header className="flex h-14 items-center gap-2 border-b px-4">
+              <span className="font-semibold">Example Safe Content Area</span>
+            </header>
+            <main className="flex-1 p-4">
+              <div className="rounded-lg border bg-card p-6">
+                <h2 className="text-2xl font-bold mb-4">Example Safe Overview</h2>
+                <p className="text-muted-foreground">
+                  Example content area for the Safe view - not a part of the sidebar.
+                </p>
+              </div>
+            </main>
+          </SidebarInset>
+        </div>
+      </SidebarProvider>
+    ),
+  ],
+} satisfies Meta<typeof EnhancedSidebar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/spaces/components/Sidebar/SafeSidebarWrapper.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SafeSidebarWrapper.tsx
@@ -1,0 +1,85 @@
+import type { ReactElement } from 'react'
+import {
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from '@/components/ui/sidebar'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { icons, safeMainNavigation, safeDefiGroup } from './config'
+import css from './styles.module.css'
+
+export const SafeSidebarWrapper = (): ReactElement => {
+  return (
+    <SidebarContent>
+      {/* Back to Space */}
+      <SidebarGroup>
+        <div className="flex gap-1 items-center w-full">
+          <button
+            type="button"
+            className={'flex items-center justify-center size-5 shrink-0 ' + css.sidebarInteractive}
+          >
+            <icons.ChevronLeft className="size-5" />
+          </button>
+          <div className="flex gap-3 items-center min-h-[36px] px-3 py-2 flex-1 rounded-md">
+            <Avatar className="size-6 rounded-md">
+              <AvatarFallback className="rounded-md bg-primary text-primary-foreground text-xs">A</AvatarFallback>
+            </Avatar>
+            <div className="flex flex-col gap-0.5 leading-none">
+              <span className="font-semibold text-sm">Acme Inc</span>
+              <span className="text-xs text-muted-foreground">Space</span>
+            </div>
+          </div>
+        </div>
+      </SidebarGroup>
+
+      {/* Main Navigation */}
+      <SidebarGroup>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {safeMainNavigation.map((item) => (
+              <SidebarMenuItem key={item.href} className="relative">
+                <SidebarMenuButton isActive={item.isActive} tooltip={item.label} className={css.sidebarInteractive}>
+                  <item.icon />
+                  <span>{item.label}</span>
+                </SidebarMenuButton>
+                {item.badge !== undefined && item.badge > 0 && (
+                  <>
+                    <span
+                      className={
+                        css.transactionsBadge + ' absolute right-1 top-1/2 -translate-y-1/2 text-xs font-medium'
+                      }
+                    >
+                      {item.badge}
+                    </span>
+                    <span className={css.transactionsBadgeDot} aria-hidden />
+                  </>
+                )}
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+
+      {/* Defi Group */}
+      <SidebarGroup>
+        <SidebarGroupLabel>{safeDefiGroup.label}</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {safeDefiGroup.items.map((item) => (
+              <SidebarMenuItem key={item.href}>
+                <SidebarMenuButton tooltip={item.label} className={css.sidebarInteractive}>
+                  <item.icon />
+                  <span>{item.label}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    </SidebarContent>
+  )
+}

--- a/apps/web/src/features/spaces/components/Sidebar/SafeSidebarWrapper.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SafeSidebarWrapper.tsx
@@ -15,25 +15,22 @@ import css from './styles.module.css'
 export const SafeSidebarWrapper = (): ReactElement => {
   return (
     <SidebarContent>
-      {/* Back to Space */}
+      {/* Back to Space - same structure as SpacesSidebar so collapsed state shows Acme "A" */}
       <SidebarGroup>
-        <div className="flex gap-1 items-center w-full">
-          <button
-            type="button"
-            className={'flex items-center justify-center size-5 shrink-0 ' + css.sidebarInteractive}
-          >
-            <icons.ChevronLeft className="size-5" />
-          </button>
-          <div className="flex gap-3 items-center min-h-[36px] px-3 py-2 flex-1 rounded-md">
-            <Avatar className="size-6 rounded-md">
-              <AvatarFallback className="rounded-md bg-primary text-primary-foreground text-xs">A</AvatarFallback>
-            </Avatar>
-            <div className="flex flex-col gap-0.5 leading-none">
-              <span className="font-semibold text-sm">Acme Inc</span>
-              <span className="text-xs text-muted-foreground">Space</span>
-            </div>
-          </div>
-        </div>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" tooltip="Back to Space" className={css.backToSpace}>
+              <Avatar className={css.spaceSelectorAvatar + ' rounded-md'}>
+                <AvatarFallback className="rounded-md bg-primary text-primary-foreground">A</AvatarFallback>
+              </Avatar>
+              <div className={css.spaceSelectorText}>
+                <span className={css.spaceSelectorName}>Acme Inc</span>
+                <span className={css.spaceSelectorSubtitle}>Space</span>
+              </div>
+              <icons.ChevronLeft className="ml-auto size-4 shrink-0" />
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
       </SidebarGroup>
 
       {/* Main Navigation */}

--- a/apps/web/src/features/spaces/components/Sidebar/SafeSidebarWrapper.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SafeSidebarWrapper.tsx
@@ -48,13 +48,7 @@ export const SafeSidebarWrapper = (): ReactElement => {
                 </SidebarMenuButton>
                 {item.badge !== undefined && item.badge > 0 && (
                   <>
-                    <span
-                      className={
-                        css.transactionsBadge + ' absolute right-1 top-1/2 -translate-y-1/2 text-xs font-medium'
-                      }
-                    >
-                      {item.badge}
-                    </span>
+                    <span className={css.transactionsBadge}>{item.badge}</span>
                     <span className={css.transactionsBadgeDot} aria-hidden />
                   </>
                 )}

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter.tsx
@@ -1,0 +1,29 @@
+import type { ReactElement } from 'react'
+import {
+  SidebarFooter,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarMenuAction,
+} from '@/components/ui/sidebar'
+import { icons } from './config'
+import css from './styles.module.css'
+
+export const SidebarCommonFooter = (): ReactElement => {
+  return (
+    <SidebarFooter>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton tooltip="Help" className={css.sidebarInteractive}>
+            <icons.CircleHelp />
+            <span>Help</span>
+          </SidebarMenuButton>
+          <SidebarMenuAction showOnHover className={css.sidebarInteractive}>
+            <icons.EllipsisVertical />
+            <span className="sr-only">More options</span>
+          </SidebarMenuAction>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarFooter>
+  )
+}

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarMapper.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarMapper.tsx
@@ -1,0 +1,11 @@
+import type { ReactElement } from 'react'
+import { SpacesSidebarWrapper } from './SpacesSidebarWrapper'
+import { SafeSidebarWrapper } from './SafeSidebarWrapper'
+
+interface SidebarMapperProps {
+  isSpacesRoute?: boolean
+}
+
+export const SidebarMapper = ({ isSpacesRoute = false }: SidebarMapperProps): ReactElement => {
+  return isSpacesRoute ? <SpacesSidebarWrapper /> : <SafeSidebarWrapper />
+}

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarTopBar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarTopBar.tsx
@@ -14,10 +14,10 @@ export const SidebarTopBar = (): ReactElement => {
           : 'flex items-center justify-between w-full'
       }
     >
-      <div className="relative shrink-0 size-6 flex items-center justify-center">
+      <div className="relative shrink-0 size-6 flex items-center justify-center cursor-pointer">
         <Image src="/images/logo-no-text.svg" alt="Safe" width={24} height={24} className="size-6" />
       </div>
-      <SidebarTrigger className="shrink-0" />
+      <SidebarTrigger className="shrink-0 cursor-pointer" />
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarTopBar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarTopBar.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react'
+import Image from 'next/image'
+import { SidebarTrigger, useSidebar } from '@/components/ui/sidebar'
+
+export const SidebarTopBar = (): ReactElement => {
+  const { state } = useSidebar()
+  const isCollapsed = state === 'collapsed'
+
+  return (
+    <div
+      className={
+        isCollapsed
+          ? 'flex flex-col items-center justify-center gap-2 w-full'
+          : 'flex items-center justify-between w-full'
+      }
+    >
+      <div className="relative shrink-0 size-6 flex items-center justify-center">
+        <Image src="/images/logo-no-text.svg" alt="Safe" width={24} height={24} className="size-6" />
+      </div>
+      <SidebarTrigger className="shrink-0" />
+    </div>
+  )
+}

--- a/apps/web/src/features/spaces/components/Sidebar/SpacesSidebar.stories.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SpacesSidebar.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar'
+import { EnhancedSidebar } from './index'
+
+const meta = {
+  title: 'Features/Spaces/SpacesSidebar',
+  component: EnhancedSidebar,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/spaces',
+      },
+    },
+  },
+  decorators: [
+    () => (
+      <SidebarProvider defaultOpen>
+        <div className="flex min-h-screen w-full">
+          <EnhancedSidebar isSpacesRoute />
+          <SidebarInset>
+            <header className="flex h-14 items-center gap-2 border-b px-4">
+              <span className="font-semibold">Example Spaces Content Area</span>
+            </header>
+            <main className="flex-1 p-4">
+              <div className="rounded-lg border bg-card p-6">
+                <h2 className="text-2xl font-bold mb-4">Example Spaces Dashboard</h2>
+                <p className="text-muted-foreground">
+                  Example content area for the Spaces view - not a part of the sidebar.
+                </p>
+              </div>
+            </main>
+          </SidebarInset>
+        </div>
+      </SidebarProvider>
+    ),
+  ],
+} satisfies Meta<typeof EnhancedSidebar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/spaces/components/Sidebar/SpacesSidebarWrapper.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SpacesSidebarWrapper.tsx
@@ -46,13 +46,7 @@ export const SpacesSidebarWrapper = (): ReactElement => {
                 </SidebarMenuButton>
                 {item.badge !== undefined && item.badge > 0 && (
                   <>
-                    <span
-                      className={
-                        css.transactionsBadge + ' absolute right-2 top-1/2 -translate-y-1/2 text-xs font-medium'
-                      }
-                    >
-                      {item.badge}
-                    </span>
+                    <span className={css.transactionsBadge}>{item.badge}</span>
                     <span className={css.transactionsBadgeDot} aria-hidden />
                   </>
                 )}

--- a/apps/web/src/features/spaces/components/Sidebar/SpacesSidebarWrapper.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SpacesSidebarWrapper.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
 import {
   SidebarContent,
   SidebarGroup,
@@ -16,7 +16,6 @@ import css from './styles.module.css'
 export const SpacesSidebarWrapper = (): ReactElement => {
   return (
     <SidebarContent>
-      {/* Space Selector (Figma: 7524-14116) */}
       <SidebarGroup>
         <SidebarMenu>
           <SidebarMenuItem>
@@ -28,7 +27,10 @@ export const SpacesSidebarWrapper = (): ReactElement => {
                 <span className={css.spaceSelectorName}>Acme Inc</span>
                 <span className={css.spaceSelectorSubtitle}>Space</span>
               </div>
-              <ChevronDown className="ml-auto size-4 shrink-0" />
+              <div className="ml-auto flex flex-col items-center shrink-0 -space-y-1">
+                <ChevronUp className="size-4" />
+                <ChevronDown className="size-4" />
+              </div>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/apps/web/src/features/spaces/components/Sidebar/SpacesSidebarWrapper.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SpacesSidebarWrapper.tsx
@@ -1,0 +1,83 @@
+import type { ReactElement } from 'react'
+import { ChevronDown } from 'lucide-react'
+import {
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from '@/components/ui/sidebar'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
+import { spacesMainNavigation, spacesSetupGroup } from './config'
+import css from './styles.module.css'
+
+export const SpacesSidebarWrapper = (): ReactElement => {
+  return (
+    <SidebarContent>
+      {/* Space Selector (Figma: 7524-14116) */}
+      <SidebarGroup>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" className={css.spaceSelector}>
+              <Avatar className={css.spaceSelectorAvatar + ' rounded-md'}>
+                <AvatarFallback className="rounded-md bg-primary text-primary-foreground">A</AvatarFallback>
+              </Avatar>
+              <div className={css.spaceSelectorText}>
+                <span className={css.spaceSelectorName}>Acme Inc</span>
+                <span className={css.spaceSelectorSubtitle}>Space</span>
+              </div>
+              <ChevronDown className="ml-auto size-4 shrink-0" />
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroup>
+
+      {/* Main Navigation */}
+      <SidebarGroup>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {spacesMainNavigation.map((item) => (
+              <SidebarMenuItem key={item.href} className="relative">
+                <SidebarMenuButton isActive={item.isActive} tooltip={item.label} className={css.sidebarInteractive}>
+                  <item.icon />
+                  <span>{item.label}</span>
+                </SidebarMenuButton>
+                {item.badge !== undefined && item.badge > 0 && (
+                  <>
+                    <span
+                      className={
+                        css.transactionsBadge + ' absolute right-2 top-1/2 -translate-y-1/2 text-xs font-medium'
+                      }
+                    >
+                      {item.badge}
+                    </span>
+                    <span className={css.transactionsBadgeDot} aria-hidden />
+                  </>
+                )}
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+
+      {/* Setup Group */}
+      <SidebarGroup>
+        <SidebarGroupLabel>{spacesSetupGroup.label}</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {spacesSetupGroup.items.map((item) => (
+              <SidebarMenuItem key={item.href}>
+                <SidebarMenuButton tooltip={item.label} className={css.sidebarInteractive}>
+                  <item.icon />
+                  <span>{item.label}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    </SidebarContent>
+  )
+}

--- a/apps/web/src/features/spaces/components/Sidebar/config.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/config.tsx
@@ -1,0 +1,128 @@
+import {
+  House,
+  ArrowRightLeft,
+  WalletCards,
+  BookUser,
+  UsersRound,
+  Shield,
+  Settings,
+  Wallet,
+  Coins,
+  LayoutGrid,
+  Repeat2,
+  Orbit,
+  Database,
+  TrendingUp,
+  CircleHelp,
+  ChevronLeft,
+  PanelRight,
+  EllipsisVertical,
+} from 'lucide-react'
+import type { SidebarItemConfig, SidebarGroupConfig } from './types'
+
+// Spaces Sidebar Navigation
+export const spacesMainNavigation: SidebarItemConfig[] = [
+  {
+    icon: House,
+    label: 'Home',
+    href: '/spaces',
+    isActive: true,
+  },
+  {
+    icon: ArrowRightLeft,
+    label: 'Transactions',
+    href: '/spaces/transactions',
+    badge: 1,
+  },
+  {
+    icon: WalletCards,
+    label: 'Accounts',
+    href: '/spaces/safe-accounts',
+  },
+  {
+    icon: BookUser,
+    label: 'Address book',
+    href: '/spaces/address-book',
+  },
+]
+
+export const spacesSetupGroup: SidebarGroupConfig = {
+  label: 'Setup',
+  items: [
+    {
+      icon: UsersRound,
+      label: 'Team',
+      href: '/spaces/members',
+    },
+    {
+      icon: Shield,
+      label: 'Security',
+      href: '/spaces/security',
+    },
+    {
+      icon: Settings,
+      label: 'Settings',
+      href: '/spaces/settings',
+    },
+  ],
+}
+
+// Safe Sidebar Navigation
+export const safeMainNavigation: SidebarItemConfig[] = [
+  {
+    icon: Wallet,
+    label: 'Overview',
+    href: '/home',
+    isActive: true,
+  },
+  {
+    icon: ArrowRightLeft,
+    label: 'Transactions',
+    href: '/transactions',
+    badge: 1,
+  },
+  {
+    icon: Coins,
+    label: 'Assets',
+    href: '/balances',
+  },
+  {
+    icon: LayoutGrid,
+    label: 'Apps',
+    href: '/apps',
+  },
+]
+
+export const safeDefiGroup: SidebarGroupConfig = {
+  label: 'Defi',
+  items: [
+    {
+      icon: Repeat2,
+      label: 'Swap',
+      href: '/swap',
+    },
+    {
+      icon: Orbit,
+      label: 'Bridge',
+      href: '/bridge',
+    },
+    {
+      icon: Database,
+      label: 'Earn',
+      href: '/earn',
+    },
+    {
+      icon: TrendingUp,
+      label: 'Stake',
+      href: '/stake',
+    },
+  ],
+}
+
+// Export icons for use in other components
+export const icons = {
+  CircleHelp,
+  ChevronLeft,
+  PanelRight,
+  EllipsisVertical,
+}

--- a/apps/web/src/features/spaces/components/Sidebar/config/index.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/config/index.tsx
@@ -18,9 +18,8 @@ import {
   PanelRight,
   EllipsisVertical,
 } from 'lucide-react'
-import type { SidebarItemConfig, SidebarGroupConfig } from './types'
+import type { SidebarItemConfig, SidebarGroupConfig } from '../types'
 
-// Spaces Sidebar Navigation
 export const spacesMainNavigation: SidebarItemConfig[] = [
   {
     icon: House,
@@ -67,7 +66,6 @@ export const spacesSetupGroup: SidebarGroupConfig = {
   ],
 }
 
-// Safe Sidebar Navigation
 export const safeMainNavigation: SidebarItemConfig[] = [
   {
     icon: Wallet,
@@ -119,7 +117,6 @@ export const safeDefiGroup: SidebarGroupConfig = {
   ],
 }
 
-// Export icons for use in other components
 export const icons = {
   CircleHelp,
   ChevronLeft,

--- a/apps/web/src/features/spaces/components/Sidebar/index.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/index.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react'
+import { Sidebar, SidebarHeader } from '@/components/ui/sidebar'
+import { SidebarTopBar } from './SidebarTopBar'
+import { SidebarMapper } from './SidebarMapper'
+import { SidebarCommonFooter } from './SidebarCommonFooter'
+
+interface EnhancedSidebarProps {
+  isSpacesRoute?: boolean
+}
+
+export const EnhancedSidebar = ({ isSpacesRoute = false }: EnhancedSidebarProps): ReactElement => {
+  return (
+    <Sidebar collapsible="icon" variant="sidebar">
+      <SidebarHeader>
+        <SidebarTopBar />
+      </SidebarHeader>
+
+      <SidebarMapper isSpacesRoute={isSpacesRoute} />
+
+      <SidebarCommonFooter />
+    </Sidebar>
+  )
+}

--- a/apps/web/src/features/spaces/components/Sidebar/styles.module.css
+++ b/apps/web/src/features/spaces/components/Sidebar/styles.module.css
@@ -22,6 +22,17 @@
   cursor: pointer;
 }
 
+.backToSpace {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
 .spaceSelectorAvatar {
   width: 32px;
   height: 32px;

--- a/apps/web/src/features/spaces/components/Sidebar/styles.module.css
+++ b/apps/web/src/features/spaces/components/Sidebar/styles.module.css
@@ -1,6 +1,3 @@
-/* Custom styles for the Enhanced Sidebar */
-
-/* Match Figma spacing and sizing */
 .sidebarContainer {
   width: var(--sidebar-width, 16rem);
 }
@@ -9,12 +6,10 @@
   width: var(--sidebar-width-icon, 3rem);
 }
 
-/* Cursor pointer for all interactive sidebar elements */
 .sidebarInteractive {
   cursor: pointer;
 }
 
-/* Space selector styling (Figma: node 7524-14116) */
 .spaceSelector {
   display: flex;
   align-items: center;
@@ -55,15 +50,18 @@
   color: #737373;
 }
 
-/* Transactions badge (expanded only): circle with number – hidden on small/collapsed sidebar */
 .transactionsBadge {
+  position: absolute;
+  right: 0.25rem;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   align-items: center;
   justify-content: center;
   min-width: 20px;
   height: 20px;
   padding: 0 6px;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 500;
   line-height: 16px;
   color: #166534;
@@ -75,7 +73,6 @@
   display: none;
 }
 
-/* Green dot for collapsed sidebar when N tx > 0 – upper-right of icon, no overlap */
 .transactionsBadgeDot {
   display: none;
   position: absolute;
@@ -93,7 +90,6 @@
   display: block;
 }
 
-/* Navigation item styling */
 .navItem {
   gap: 12px;
   padding: 8px 12px;
@@ -104,7 +100,6 @@
   background-color: var(--sidebar-accent);
 }
 
-/* Group label styling */
 .groupLabel {
   color: var(--sidebar-muted, #737373);
   font-size: 12px;
@@ -112,7 +107,6 @@
   padding: 8px 12px;
 }
 
-/* Badge styling */
 .badge {
   background-color: var(--green-400, #4ade80);
   border: 1px solid var(--white, white);
@@ -121,7 +115,6 @@
   height: 8px;
 }
 
-/* Typography */
 .textSmall {
   font-size: 14px;
   line-height: 20px;
@@ -146,7 +139,6 @@
   font-weight: 600;
 }
 
-/* Back button in Safe view */
 .backButton {
   display: flex;
   align-items: center;

--- a/apps/web/src/features/spaces/components/Sidebar/styles.module.css
+++ b/apps/web/src/features/spaces/components/Sidebar/styles.module.css
@@ -1,0 +1,158 @@
+/* Custom styles for the Enhanced Sidebar */
+
+/* Match Figma spacing and sizing */
+.sidebarContainer {
+  width: var(--sidebar-width, 16rem);
+}
+
+.sidebarCollapsed {
+  width: var(--sidebar-width-icon, 3rem);
+}
+
+/* Cursor pointer for all interactive sidebar elements */
+.sidebarInteractive {
+  cursor: pointer;
+}
+
+/* Space selector styling (Figma: node 7524-14116) */
+.spaceSelector {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background-color: #f5f5f5;
+  cursor: pointer;
+}
+
+.spaceSelectorAvatar {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+
+.spaceSelectorText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.spaceSelectorName {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+  color: #171717;
+}
+
+.spaceSelectorSubtitle {
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+  color: #737373;
+}
+
+/* Transactions badge (expanded only): circle with number – hidden on small/collapsed sidebar */
+.transactionsBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  color: #166534;
+  background-color: #dcfce7;
+  border-radius: 12px;
+}
+
+:global(.group[data-collapsible='icon']) .transactionsBadge {
+  display: none;
+}
+
+/* Green dot for collapsed sidebar when N tx > 0 – upper-right of icon, no overlap */
+.transactionsBadgeDot {
+  display: none;
+  position: absolute;
+  top: 4px;
+  right: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #22c55e;
+  flex-shrink: 0;
+  pointer-events: none;
+}
+
+:global(.group[data-collapsible='icon']) .transactionsBadgeDot {
+  display: block;
+}
+
+/* Navigation item styling */
+.navItem {
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: var(--rounded-md, 8px);
+}
+
+.navItemActive {
+  background-color: var(--sidebar-accent);
+}
+
+/* Group label styling */
+.groupLabel {
+  color: var(--sidebar-muted, #737373);
+  font-size: 12px;
+  line-height: 16px;
+  padding: 8px 12px;
+}
+
+/* Badge styling */
+.badge {
+  background-color: var(--green-400, #4ade80);
+  border: 1px solid var(--white, white);
+  border-radius: var(--rounded-lg, 12px);
+  width: 8px;
+  height: 8px;
+}
+
+/* Typography */
+.textSmall {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+}
+
+.textSmallBold {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 600;
+}
+
+.textMini {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+}
+
+.textMiniBold {
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 600;
+}
+
+/* Back button in Safe view */
+.backButton {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.backButton:hover {
+  opacity: 0.8;
+}

--- a/apps/web/src/features/spaces/components/Sidebar/types.ts
+++ b/apps/web/src/features/spaces/components/Sidebar/types.ts
@@ -1,0 +1,18 @@
+import type { LucideIcon } from 'lucide-react'
+
+export interface SidebarItemConfig {
+  icon: LucideIcon
+  label: string
+  href: string
+  badge?: number
+  isActive?: boolean
+}
+
+export interface SidebarGroupConfig {
+  label: string
+  items: SidebarItemConfig[]
+}
+
+export interface SidebarWrapperProps {
+  // Common props for both wrappers if needed in the future
+}


### PR DESCRIPTION
## Summary

- Adds missing `shadcn.css` import to `.storybook-vite/preview.tsx`
- Adds `ShadcnScopeDecorator` to wrap stories in `.shadcn-scope` (matching regular Storybook)

Without these, shadcn/ui components in Vite Storybook (port 6007) render completely unstyled.

## Test plan

- [x] Verify `http://localhost:6007/?path=/story/features-spaces-safesidebar--default` renders correctly
- [x] Confirmed output matches regular Storybook on port 6006

🤖 Generated with [Claude Code](https://claude.com/claude-code)