### PR TITLE
fix(mobile): use Reanimated for smooth SafeTab transitions

### DIFF
--- a/apps/mobile/src/components/SafeTab/SafeTab.tsx
+++ b/apps/mobile/src/components/SafeTab/SafeTab.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react'
+import React, { ReactElement } from 'react'
 import { TabBarProps, Tabs } from 'react-native-collapsible-tab-view'
 import { safeTabItem } from './types'
 import { SafeTabBar } from './SafeTabBar'
@@ -25,8 +25,6 @@ export function SafeTab<T extends object>({
   onIndexChange,
   rightNode,
 }: SafeTabProps<T>) {
-  const [activeTab, setActiveTab] = useState(items[0].label)
-
   return (
     <Theme name={'tab'}>
       <Tabs.Container
@@ -34,10 +32,7 @@ export function SafeTab<T extends object>({
         renderHeader={renderHeader}
         headerContainerStyle={headerContainerStyle}
         headerHeight={headerHeight}
-        renderTabBar={(props) => (
-          <SafeTabBar activeTab={activeTab} setActiveTab={setActiveTab} rightNode={rightNode?.(activeTab)} {...props} />
-        )}
-        onTabChange={(event) => setActiveTab(event.tabName)}
+        renderTabBar={(props) => <SafeTabBar rightNode={rightNode} {...props} />}
         onIndexChange={onIndexChange}
         initialTabName={items[0].label}
       >

--- a/apps/mobile/src/components/SafeTab/SafeTabBar.tsx
+++ b/apps/mobile/src/components/SafeTab/SafeTabBar.tsx
@@ -1,38 +1,78 @@
 import React from 'react'
 import { TabBarProps } from 'react-native-collapsible-tab-view'
 import { TabName } from 'react-native-collapsible-tab-view/lib/typescript/src/types'
-import { TouchableOpacity } from 'react-native-gesture-handler'
-import { View, Text, useTheme } from 'tamagui'
+import { Pressable } from 'react-native'
+import { View, useTheme } from 'tamagui'
+import Animated, { SharedValue, useAnimatedStyle } from 'react-native-reanimated'
 
 interface SafeTabBarProps {
-  setActiveTab: (name: string) => void
-  activeTab: string
-  rightNode?: React.ReactNode
+  rightNode?: (tabName: string) => React.ReactNode
+}
+
+const TabItem = ({
+  name,
+  index,
+  indexDecimal,
+  onPress,
+  activeColor,
+  inactiveColor,
+  activeBorderColor,
+}: {
+  name: string
+  index: number
+  indexDecimal: SharedValue<number>
+  onPress: (name: string) => void
+  activeColor: string
+  inactiveColor: string
+  activeBorderColor: string
+}) => {
+  const textStyle = useAnimatedStyle(() => ({
+    color: Math.abs(index - indexDecimal.value) < 0.5 ? activeColor : inactiveColor,
+  }))
+
+  const borderStyle = useAnimatedStyle(() => ({
+    borderBottomColor: Math.abs(index - indexDecimal.value) < 0.5 ? activeBorderColor : 'transparent',
+  }))
+
+  return (
+    <Pressable onPress={() => onPress(name)}>
+      <Animated.View style={[tabItemStyle, borderStyle]}>
+        <Animated.Text style={[tabItemTextStyle, textStyle]}>{name}</Animated.Text>
+      </Animated.View>
+    </Pressable>
+  )
+}
+
+const RightNodeItem = ({
+  index,
+  indexDecimal,
+  children,
+}: {
+  index: number
+  indexDecimal: SharedValue<number>
+  children: React.ReactNode
+}) => {
+  const style = useAnimatedStyle(() => ({
+    opacity: Math.abs(index - indexDecimal.value) < 0.5 ? 1 : 0,
+  }))
+
+  return <Animated.View style={style}>{children}</Animated.View>
 }
 
 export const SafeTabBar = ({
   tabNames,
+  indexDecimal,
   onTabPress,
-  activeTab,
-  setActiveTab,
   rightNode,
 }: TabBarProps<TabName> & SafeTabBarProps) => {
   const theme = useTheme()
+  const activeColor = theme.color?.get() ?? '#000'
+  const inactiveColor = theme.colorSecondary?.get() ?? '#999'
+  const activeBorderColor = theme.primary?.get() ?? '#000'
 
-  const activeButtonStyle = {
-    paddingBottom: 8,
-    borderBottomColor: theme.primary?.get(),
-    borderBottomWidth: 2,
-  }
-
-  const handleTabPressed = (name: string) => () => {
-    onTabPress(name)
-    setActiveTab(name)
-  }
-
-  const isActiveTab = (name: string) => {
-    return activeTab === name
-  }
+  const rightNodes = rightNode
+    ? tabNames.map((name, i) => ({ index: i, node: rightNode(name) })).filter(({ node }) => node != null)
+    : []
 
   return (
     <View
@@ -46,15 +86,39 @@ export const SafeTabBar = ({
       justifyContent="space-between"
     >
       <View flexDirection="row" gap="$6">
-        {tabNames.map((name) => (
-          <TouchableOpacity style={isActiveTab(name) && activeButtonStyle} onPress={handleTabPressed(name)} key={name}>
-            <Text color={isActiveTab(name) ? '$color' : '$colorSecondary'} fontSize="$6" fontWeight={700}>
-              {name}
-            </Text>
-          </TouchableOpacity>
+        {tabNames.map((name, i) => (
+          <TabItem
+            key={name}
+            name={name}
+            index={i}
+            indexDecimal={indexDecimal}
+            onPress={onTabPress}
+            activeColor={activeColor}
+            inactiveColor={inactiveColor}
+            activeBorderColor={activeBorderColor}
+          />
         ))}
       </View>
-      {rightNode && <View paddingBottom="$2">{rightNode}</View>}
+      {rightNodes.length > 0 && (
+        <View paddingBottom="$2">
+          {rightNodes.map(({ index: tabIndex, node }) => (
+            <RightNodeItem key={tabIndex} index={tabIndex} indexDecimal={indexDecimal}>
+              {node}
+            </RightNodeItem>
+          ))}
+        </View>
+      )}
     </View>
   )
+}
+
+const tabItemStyle = {
+  paddingBottom: 8,
+  borderBottomWidth: 2,
+}
+
+const tabItemTextStyle = {
+  fontSize: 18,
+  fontWeight: '700' as const,
+  fontFamily: 'DMSans-Bold',
 }


### PR DESCRIPTION
## What it solves

Tab switching in SafeTab felt janky because it relied on React state (`useState`) to track the active tab, causing re-renders on every tab change.

Resolves: https://linear.app/safe-global/issue/WA-1251/positions-on-mobile#comment-ca2fa62c

## How this PR fixes it

Replaces the React state-driven active tab tracking with Reanimated's `indexDecimal` shared value that the collapsible tab library already provides. Tab indicator color, text color, and right node visibility now animate on the UI thread via `useAnimatedStyle`, avoiding JS thread re-renders entirely. Also switches from `TouchableOpacity` (gesture handler) to `Pressable` (React Native) for simpler press handling.

## How to test it

1. Open the mobile app and navigate to a screen with SafeTab (e.g., positions)
2. Swipe between tabs — the tab indicator and text color should animate smoothly
3. Tap on tab labels — should switch instantly without flicker
4. Verify the right node (if present) fades in/out correctly per tab

## Screenshots
before

https://github.com/user-attachments/assets/307b639f-46d8-4fc4-9df6-257dc7959775

after

https://github.com/user-attachments/assets/05ffd839-b11a-4b61-8aae-e34d6483ec55



N/A - mobile UI, same visual result but smoother animation

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).