### PR TITLE
feat: add dashboard header component

### DIFF
--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -24,7 +24,7 @@ import { cn } from '@/utils/cn'
  */
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "cursor-pointer focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
   {
     variants: {
       variant: {

--- a/apps/web/src/features/spaces/components/Dashboard/DashboardHeader.stories.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/DashboardHeader.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { DashboardHeader } from './DashboardHeader'
+
+const meta = {
+  title: 'Features/Spaces/DashboardHeader',
+  component: DashboardHeader,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-muted p-6 min-w-[1000px] min-h-[200px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof DashboardHeader>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    value: '$123,456.01',
+    onSend: () => {},
+    onReceive: () => {},
+    onSwap: () => {},
+    onBuildTransaction: () => {},
+    onCustomize: () => {},
+  },
+}

--- a/apps/web/src/features/spaces/components/Dashboard/DashboardHeader.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/DashboardHeader.tsx
@@ -1,0 +1,44 @@
+import { TotalValueElement } from '@/features/spaces/components/TotalValueElement'
+
+import { HeaderActions } from './HeaderActions'
+
+/**
+ * DashboardHeader
+ *
+ * Dashboard header with Total value display and primary action buttons.
+ * Part of Spaces Enterprise workspace design.
+ * Figma: https://www.figma.com/design/5z9yzEgPAhCMGIumIwvXQY/Enterprise-workspace?node-id=7524-19551
+ */
+
+interface DashboardHeaderProps {
+  value: string
+  onSend?: () => void
+  onReceive?: () => void
+  onSwap?: () => void
+  onBuildTransaction?: () => void
+  onCustomize?: () => void
+}
+
+const DashboardHeader = ({
+  value,
+  onSend,
+  onReceive,
+  onSwap,
+  onBuildTransaction,
+  onCustomize,
+}: DashboardHeaderProps) => {
+  return (
+    <div className="flex flex-col gap-6">
+      <TotalValueElement value={value} />
+      <HeaderActions
+        onSend={onSend}
+        onReceive={onReceive}
+        onSwap={onSwap}
+        onBuildTransaction={onBuildTransaction}
+        onCustomize={onCustomize}
+      />
+    </div>
+  )
+}
+
+export { DashboardHeader }

--- a/apps/web/src/features/spaces/components/Dashboard/HeaderActions.stories.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/HeaderActions.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { HeaderActions } from './HeaderActions'
+
+const meta = {
+  title: 'Features/Spaces/HeaderActions',
+  component: HeaderActions,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-muted p-6 min-w-[1000px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HeaderActions>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onSend: () => {},
+    onReceive: () => {},
+    onSwap: () => {},
+    onBuildTransaction: () => {},
+    onCustomize: () => {},
+  },
+}

--- a/apps/web/src/features/spaces/components/Dashboard/HeaderActions.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/HeaderActions.tsx
@@ -1,0 +1,51 @@
+import { ArrowDownLeft, Repeat, ArrowUpRight, MoreVertical, SquareDashedBottomCode } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+/**
+ * HeaderActions
+ *
+ * Action button group for dashboard header: Send, Receive, Swap, Build transaction, Customize.
+ * Part of Spaces Enterprise workspace design.
+ *
+ */
+
+interface HeaderActionsProps {
+  onSend?: () => void
+  onReceive?: () => void
+  onSwap?: () => void
+  onBuildTransaction?: () => void
+  onCustomize?: () => void
+}
+
+const HeaderActions = ({ onSend, onReceive, onSwap, onBuildTransaction, onCustomize }: HeaderActionsProps) => {
+  const outlineClassName = 'bg-transparent border-[#d4d4d4] hover:bg-muted/50'
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-2">
+        <Button variant="default" onClick={onSend}>
+          <ArrowUpRight className="size-4 text-[#4ade80]" />
+          Send
+        </Button>
+        <Button variant="outline" className={outlineClassName} onClick={onReceive}>
+          <ArrowDownLeft className="size-4" />
+          Receive
+        </Button>
+        <Button variant="outline" className={outlineClassName} onClick={onSwap}>
+          <Repeat className="size-4" />
+          Swap
+        </Button>
+        <Button variant="outline" className={outlineClassName} onClick={onBuildTransaction}>
+          <SquareDashedBottomCode className="size-4" />
+          Build transaction
+        </Button>
+      </div>
+      <Button variant="ghost" size="sm" className="text-muted-foreground" onClick={onCustomize}>
+        <MoreVertical className="size-4 text-foreground" />
+        Customize
+      </Button>
+    </div>
+  )
+}
+
+export { HeaderActions }

--- a/apps/web/src/features/spaces/components/TotalValueElement/TotalValueElement.stories.tsx
+++ b/apps/web/src/features/spaces/components/TotalValueElement/TotalValueElement.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Card, CardContent } from '@/components/ui/card'
+import { TotalValueElement } from './TotalValueElement'
+
+const meta = {
+  title: 'Features/Spaces/TotalValueElement',
+  component: TotalValueElement,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-muted p-6 min-h-[200px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TotalValueElement>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    value: '$123,456.01',
+  },
+}
+
+export const InCard: Story = {
+  decorators: [
+    (Story) => (
+      <Card className="w-[320px]">
+        <CardContent className="pt-6">
+          <Story />
+        </CardContent>
+      </Card>
+    ),
+  ],
+  args: {
+    value: '$123,456.01',
+  },
+}

--- a/apps/web/src/features/spaces/components/TotalValueElement/TotalValueElement.tsx
+++ b/apps/web/src/features/spaces/components/TotalValueElement/TotalValueElement.tsx
@@ -1,0 +1,22 @@
+/**
+ * TotalValueElement
+ *
+ * Presentational component displaying a "Total value" label with a formatted monetary amount.
+ * Part of Spaces feature design.
+ * Figma: https://www.figma.com/design/5z9yzEgPAhCMGIumIwvXQY/Enterprise-workspace?node-id=7506-30004
+ */
+
+interface TotalValueElementProps {
+  value: string
+}
+
+const TotalValueElement = ({ value }: TotalValueElementProps) => {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-medium text-muted-foreground">Total value</span>
+      <span className="font-medium leading-[1] tracking-tight text-foreground text-[30px]">{value}</span>
+    </div>
+  )
+}
+
+export { TotalValueElement }

--- a/apps/web/src/features/spaces/components/TotalValueElement/index.ts
+++ b/apps/web/src/features/spaces/components/TotalValueElement/index.ts
@@ -1,0 +1,1 @@
+export { TotalValueElement } from './TotalValueElement'


### PR DESCRIPTION
## What it solves
Resolves: https://linear.app/safe-global/issue/WA-1442/story-for-the-total-value-cta-btns
- Introduces the dashboard header UI for the Spaces Enterprise workspace
- Extracts total value display and action buttons into reusable components for easier maintenance and Storybook use

## How this PR fixes it

- **TotalValueElement**: Displays "Total value" label with amount (fixed 30px font size)
- **HeaderActions**: Button group for Send, Receive, Swap, Build transaction, Customize
- **DashboardHeader**: Composes TotalValueElement + HeaderActions as the dashboard top section

## How to test it

1. Run `yarn workspace @safe-global/web storybook`
2. Open `Components/Spaces/TotalValueElement`, `Components/Spaces/HeaderActions`, and `Components/Spaces/DashboardHeader`
3. Switch between light and dark themes to verify styling

## Screenshots
<img width="994" height="165" alt="Screenshot 2026-02-17 at 16 22 25" src="https://github.com/user-attachments/assets/e36de0a3-4b6d-4701-978a-1d9121aad55b" />

## Checklist

- [ ] I've tested the branch on mobile -> not related to mobile
- [ ] I've documented how it affects the analytics (if at all) -> not affected
- [ ] I've written a unit/e2e test for it (if applicable) -> not applicable

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
