### PR TITLE
Add Web full regression e2e on dev merges

### DIFF
--- a/.github/workflows/web-e2e-full-ondemand.yml
+++ b/.github/workflows/web-e2e-full-ondemand.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * 1-5'
+  pull_request_target:
+    branches:
+      - dev
+    types: [closed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,6 +15,7 @@ concurrency:
 
 jobs:
   e2e:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 40
     name: Cypress Full Regression on demand tests
@@ -20,6 +25,8 @@ jobs:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.ref }}
 
       - uses: ./.github/actions/cypress
         with:
@@ -63,3 +70,28 @@ jobs:
           -f "apps/web/reports/junit-report.xml"; then
             echo -e "\e[41;32mTestRail upload failed. Pipeline will continue, please check the upload process.\e[0m"
           fi
+
+  notify:
+    if: failure() && github.event_name == 'pull_request_target'
+    needs: [e2e]
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_DEV_ALERT }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "❌ Web full regression tests failed on ${{ github.event.pull_request.base.ref }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*❌ Web Full Regression Tests (E2E) Failed*\n• Branch: `${{ github.event.pull_request.base.ref }}`\n• Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.pull_request.merge_commit_sha }}|${{ github.event.pull_request.merge_commit_sha }}>\n• Author: ${{ github.actor }}\n• <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
Summary
- add `pull_request_target` trigger to `.github/workflows/web-e2e-full-ondemand.yml` so full regression runs only when a PR merges into `dev`
- gate the Cypress job to the merge commit, keep manual/cron runs unchanged, and align checkout behavior with the smoke rules outlined in the plan
- add Slack notification job that fires only on merged PR failures and mirrors the existing smoke test payload/webhook setup

Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions triggers and checkout ref selection, which can alter when/what code gets tested and may affect CI signal on `dev` merges; otherwise scoped to workflow configuration and Slack notifications.
> 
> **Overview**
> Runs the `web-e2e-full-ondemand` Cypress full regression workflow automatically when PRs into `dev` are closed *and merged* via a new `pull_request_target` trigger, while preserving existing manual (`workflow_dispatch`) and scheduled runs.
> 
> Updates the `e2e` job to gate execution on `merged == true` for PR events and to `checkout` the PR `merge_commit_sha` when triggered by `pull_request_target` (falling back to `github.ref` otherwise). Adds a separate `notify` job that posts a Slack alert (via `SLACK_WEBHOOK_DEV_ALERT`) only when these merge-triggered runs fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e48b488132ff12b19f6225d7681f1d5513a44a7a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->