### PR TITLE
chore: always upload Chromatic screenshots even on test failure

### DIFF
--- a/.github/workflows/web-chromatic-e2e.yml
+++ b/.github/workflows/web-chromatic-e2e.yml
@@ -11,7 +11,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    name: Cypress Smoke tests
+    continue-on-error: true
+    name: Cypress Visual and Smoke tests
     permissions:
       contents: read
 
@@ -36,7 +37,7 @@ jobs:
 
   chromatic:
     needs: [e2e]
-    if: always() && needs.e2e.result == 'success'
+    if: "!cancelled()"
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the e2e job so test failures don't fail the workflow
- Change chromatic job condition to `!cancelled()` so it uploads regardless of test results
- Rename job to "Cypress Visual and Smoke tests"
- Workflow success is now determined by the Chromatic upload, not test results

## Test plan
- [ ] Trigger `Web Chromatic E2E` workflow manually
- [ ] Verify Chromatic upload runs even when some tests fail
- [ ] Verify workflow shows as successful when Chromatic upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)