### PR TITLE
tests: wait for skeletons to disappear before visual screenshots

### DIFF
--- a/apps/web/cypress/e2e/pages/main.page.js
+++ b/apps/web/cypress/e2e/pages/main.page.js
@@ -29,6 +29,11 @@ const closeOutreachPopupBtn = 'button[aria-label="close outreach popup"]'
 
 export const noRelayAttemptsError = 'Not enough relay attempts remaining'
 
+/** Waits until all MUI Skeleton placeholders have disappeared, ensuring the page is fully rendered. Used in visual tests before Chromatic captures the screenshot. */
+export function verifySkeletonsGone(timeout = 30000) {
+  cy.get('.MuiSkeleton-root', { timeout }).should('not.exist')
+}
+
 export function checkElementBackgroundColor(element, color) {
   cy.get(element).should('have.css', 'background-color', color)
 }

--- a/apps/web/cypress/e2e/smoke/visual/create_tx_flow.cy.js
+++ b/apps/web/cypress/e2e/smoke/visual/create_tx_flow.cy.js
@@ -1,4 +1,5 @@
 import * as constants from '../../../support/constants.js'
+import * as main from '../../pages/main.page.js'
 import * as createtx from '../../pages/create_tx.pages.js'
 import * as wallet from '../../../support/utils/wallet.js'
 import { getSafes, CATEGORIES } from '../../../support/safes/safesHandler.js'
@@ -25,6 +26,7 @@ describe(
       createtx.clickOnNewtransactionBtn()
       createtx.clickOnSendTokensBtn()
       cy.contains('Recipient address', { timeout: 10000 }).should('be.visible')
+      main.verifySkeletonsGone()
     })
 
     it('[VISUAL] Screenshot send form with filled recipient and amount', () => {
@@ -34,12 +36,14 @@ describe(
       createtx.clickOnTokenselectorAndSelectSepoliaEth()
       createtx.setMaxAmount()
       cy.contains(constants.tokenNames.sepoliaEther, { timeout: 10000 }).should('be.visible')
+      main.verifySkeletonsGone()
     })
 
     it('[VISUAL] Screenshot send form validation errors for invalid address', () => {
       createtx.clickOnNewtransactionBtn()
       createtx.clickOnSendTokensBtn()
       createtx.verifyRandomStringAddress('Lorem Ipsum')
+      main.verifySkeletonsGone()
     })
   },
 )

--- a/apps/web/cypress/e2e/smoke/visual/dark_mode.cy.js
+++ b/apps/web/cypress/e2e/smoke/visual/dark_mode.cy.js
@@ -14,17 +14,20 @@ describe('[VISUAL] Dark mode screenshots', { defaultCommandTimeout: 60000, ...co
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__settings, ls.safeSettings.settings1)
     cy.visit(constants.BALANCE_URL + staticSafes.SEP_STATIC_SAFE_2)
     cy.contains(constants.tokenNames.sepoliaEther, { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 
   it('[VISUAL] Screenshot dashboard in dark mode', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__settings, ls.safeSettings.settings1)
     cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_2)
     cy.contains('Top assets', { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 
   it('[VISUAL] Screenshot settings setup page in dark mode', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__settings, ls.safeSettings.settings1)
     cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
     cy.contains('Required confirmations', { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 })

--- a/apps/web/cypress/e2e/smoke/visual/safe_apps.cy.js
+++ b/apps/web/cypress/e2e/smoke/visual/safe_apps.cy.js
@@ -1,4 +1,5 @@
 import * as constants from '../../../support/constants.js'
+import * as main from '../../pages/main.page.js'
 import * as safeapps from '../../pages/safeapps.pages.js'
 import { getSafes, CATEGORIES } from '../../../support/safes/safesHandler.js'
 
@@ -12,6 +13,7 @@ describe('[VISUAL] Safe Apps screenshots', { defaultCommandTimeout: 60000, ...co
   it('[VISUAL] Screenshot Safe Apps list', () => {
     cy.visit(constants.appsUrlGeneral + staticSafes.SEP_STATIC_SAFE_2)
     cy.get(safeapps.safeAppsList, { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 
   it('[VISUAL] Screenshot Safe Apps search filtered results', () => {
@@ -19,6 +21,7 @@ describe('[VISUAL] Safe Apps screenshots', { defaultCommandTimeout: 60000, ...co
     cy.get(safeapps.safeAppsList, { timeout: 30000 }).should('be.visible')
     safeapps.typeAppName('Transaction Builder')
     cy.contains('Transaction Builder').should('be.visible')
+    main.verifySkeletonsGone()
   })
 
   it('[VISUAL] Screenshot Safe Apps no results state', () => {
@@ -26,5 +29,6 @@ describe('[VISUAL] Safe Apps screenshots', { defaultCommandTimeout: 60000, ...co
     cy.get(safeapps.safeAppsList, { timeout: 30000 }).should('be.visible')
     safeapps.typeAppName('zzzznonexistentapp12345')
     cy.contains(/no Safe Apps found/i, { timeout: 10000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 })

--- a/apps/web/cypress/e2e/smoke/visual/settings_pages.cy.js
+++ b/apps/web/cypress/e2e/smoke/visual/settings_pages.cy.js
@@ -1,4 +1,5 @@
 import * as constants from '../../../support/constants.js'
+import * as main from '../../pages/main.page.js'
 import * as notifications from '../../pages/notifications.page.js'
 import { getSafes, CATEGORIES } from '../../../support/safes/safesHandler.js'
 
@@ -12,20 +13,24 @@ describe('[VISUAL] Settings pages screenshots', { defaultCommandTimeout: 60000, 
   it('[VISUAL] Screenshot setup page', () => {
     cy.visit(constants.setupUrl + staticSafes.SEP_STATIC_SAFE_4)
     cy.contains('Required confirmations', { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 
   it('[VISUAL] Screenshot appearance settings page', () => {
     cy.visit(constants.appearanceSettingsUrl + staticSafes.SEP_STATIC_SAFE_4)
     cy.contains('Appearance', { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 
   it('[VISUAL] Screenshot modules page', () => {
     cy.visit(constants.modulesUrl + staticSafes.SEP_STATIC_SAFE_4)
     cy.contains('Safe modules', { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 
   it('[VISUAL] Screenshot notifications settings page', () => {
     cy.visit(constants.notificationsUrl + staticSafes.SEP_STATIC_SAFE_4)
     cy.get(notifications.notificationsTitle, { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 })

--- a/apps/web/cypress/e2e/smoke/visual/tx_queue.cy.js
+++ b/apps/web/cypress/e2e/smoke/visual/tx_queue.cy.js
@@ -1,4 +1,5 @@
 import * as constants from '../../../support/constants.js'
+import * as main from '../../pages/main.page.js'
 import { getSafes, CATEGORIES } from '../../../support/safes/safesHandler.js'
 
 let staticSafes = []
@@ -18,6 +19,7 @@ describe(
       })
       cy.wait('@getQueuedTransactions')
       cy.contains('Batch', { timeout: 10000 }).should('be.visible')
+      main.verifySkeletonsGone()
     })
 
     it('[VISUAL] Screenshot expanded queued transaction details', () => {
@@ -27,6 +29,7 @@ describe(
       })
       cy.wait('@getQueuedTransactions')
       cy.contains('Batch', { timeout: 10000 }).should('be.visible').first().click()
+      main.verifySkeletonsGone()
     })
   },
 )

--- a/apps/web/cypress/e2e/smoke/visual/welcome.cy.js
+++ b/apps/web/cypress/e2e/smoke/visual/welcome.cy.js
@@ -7,11 +7,13 @@ describe('[VISUAL] Welcome page screenshots', { defaultCommandTimeout: 60000, ..
   it('[VISUAL] Screenshot welcome page', () => {
     cy.visit(constants.welcomeUrl)
     cy.contains('Own your assets onchain securely', { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 
   it('[VISUAL] Screenshot accounts page with added safes', () => {
     main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__addedSafes, ls.addedSafes.set1)
     cy.visit(constants.welcomeAccountUrl)
     cy.get(sideBar.sideSafeListItem, { timeout: 30000 }).should('be.visible')
+    main.verifySkeletonsGone()
   })
 })


### PR DESCRIPTION
## Summary
- Add `verifySkeletonsGone()` helper to `main.page.js` that waits until all MUI Skeleton elements are gone
- Call it at the end of every visual test to ensure the page is fully rendered before Chromatic captures the screenshot
- Fixes flaky visual diffs caused by async components (WalletConnect button, token lists) still loading at screenshot time

## Test plan
- [ ] Run Chromatic E2E workflow and verify screenshots no longer show skeleton/loading states
- [ ] Verify no test timeouts from waiting for skeletons that never disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)