### PR TITLE
chore: pin app version for visual regression builds

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -81,7 +81,7 @@ const nextConfig = {
 
   env: {
     NEXT_PUBLIC_COMMIT_HASH: commitHash,
-    NEXT_PUBLIC_APP_VERSION: pkg.version,
+    NEXT_PUBLIC_APP_VERSION: process.env.VISUAL_REGRESSION_BUILD === 'true' ? 'vistest' : pkg.version,
     NEXT_PUBLIC_APP_HOMEPAGE: pkg.homepage,
   },
 


### PR DESCRIPTION
## Summary
- Pins `NEXT_PUBLIC_APP_VERSION` to `vistest` when `VISUAL_REGRESSION_BUILD=true`, preventing release version bumps from causing false Chromatic diffs
- Complements the commit hash pinning added in #7199

## Test plan
- [ ] Verify local build with `VISUAL_REGRESSION_BUILD=true` shows `vistest` in footer
- [ ] Verify normal build still shows package.json version

🤖 Generated with [Claude Code](https://claude.com/claude-code)