### PR TITLE
fix(mobile): remove Coming Soon placeholders and fix icon colors

### DIFF
--- a/apps/mobile/src/app/(tabs)/transactions.tsx
+++ b/apps/mobile/src/app/(tabs)/transactions.tsx
@@ -1,39 +1,5 @@
-import { SafeTab } from '@/src/components/SafeTab'
-import React from 'react'
 import { TxHistoryContainer } from '@/src/features/TxHistory'
-import { ComingSoon } from '@/src/components/ComingSoon/ComingSoon'
-import { useNavigation } from 'expo-router'
-import TransactionHeader from '@/src/features/TxHistory/components/TransactionHeader'
-import { Platform } from 'react-native'
-
-const tabItems = [
-  {
-    label: 'History',
-    testID: 'history-tab-content',
-    title: 'Transactions',
-    Component: TxHistoryContainer,
-  },
-  {
-    label: `Messages`,
-    testID: 'messages-tab-content',
-    title: 'Messages',
-    Component: ComingSoon,
-  },
-]
 
 export default function TransactionScreen() {
-  const navigation = useNavigation()
-
-  const onIndexChange = (index: number) => {
-    navigation.setOptions({
-      headerTitle: () => <TransactionHeader title={tabItems[index].title} />,
-    })
-  }
-  return (
-    <SafeTab
-      items={tabItems}
-      containerStyle={{ marginTop: Platform.OS === 'ios' ? 8 : 0 }}
-      onIndexChange={onIndexChange}
-    />
-  )
+  return <TxHistoryContainer />
 }

--- a/apps/mobile/src/features/AddressBook/List/hooks/useContactActions.test.ts
+++ b/apps/mobile/src/features/AddressBook/List/hooks/useContactActions.test.ts
@@ -7,6 +7,9 @@ jest.mock('tamagui', () => ({
     color: {
       get: () => '#000000',
     },
+    error: {
+      get: () => '#FF5F72',
+    },
   }),
 }))
 
@@ -42,10 +45,10 @@ describe('useContactActions', () => {
       expect(result.current[1].attributes).toEqual({ destructive: true })
     })
 
-    it('should set delete image color to red', () => {
+    it('should set delete image color to error theme color', () => {
       const { result } = renderHook(() => useContactActions())
 
-      expect(result.current[1].imageColor).toBe('red')
+      expect(result.current[1].imageColor).toBe('#FF5F72')
     })
   })
 

--- a/apps/mobile/src/features/AddressBook/List/hooks/useContactActions.ts
+++ b/apps/mobile/src/features/AddressBook/List/hooks/useContactActions.ts
@@ -5,7 +5,7 @@ import { useTheme } from 'tamagui'
 export const useContactActions = () => {
   const theme = useTheme()
   const color = theme.color?.get()
-  const colorError = 'red'
+  const colorError = theme.error?.get() || '#FF5F72'
 
   const actions = useMemo(
     () => [

--- a/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
+++ b/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, Pressable } from 'react-native'
+import { Pressable } from 'react-native'
 import { Theme, XStack, getTokenValue } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Identicon } from '@/src/components/Identicon'
@@ -11,7 +11,6 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useAppSelector } from '@/src/store/hooks'
 import { Link, useRouter } from 'expo-router'
 import { DropdownLabel } from '@/src/components/Dropdown/DropdownLabel'
-import { selectAppNotificationStatus } from '@/src/store/notificationsSlice'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { selectContactByAddress } from '@/src/store/addressBookSlice'
 import { selectSafeInfo } from '@/src/store/safesSlice'
@@ -28,16 +27,7 @@ export const Navbar = () => {
   const router = useRouter()
   const activeSafe = useDefinedActiveSafe()
   const contact = useAppSelector(selectContactByAddress(activeSafe.address))
-  const isAppNotificationEnabled = useAppSelector(selectAppNotificationStatus)
   const { isDark } = useTheme()
-
-  const handleNotificationAccess = () => {
-    if (!isAppNotificationEnabled) {
-      router.navigate('/notifications-opt-in')
-    } else {
-      router.navigate('/notifications-center')
-    }
-  }
 
   const activeSafeInfo = useAppSelector((state: RootState) => selectSafeInfo(state, activeSafe.address))
   const chainSafe = activeSafeInfo ? activeSafeInfo[activeSafe.chainId] : undefined
@@ -77,23 +67,11 @@ export const Navbar = () => {
           }}
           hitSlop={4}
         />
-        <View
-          style={{
-            flexDirection: 'row',
-            gap: 18,
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <Link href={'/share'} asChild>
-            <Pressable hitSlop={10}>
-              <SafeFontIcon name="qr-code-1" size={16} />
-            </Pressable>
-          </Link>
-          <Pressable onPressIn={handleNotificationAccess} hitSlop={8}>
-            <SafeFontIcon name="bell" size={20} />
+        <Link href={'/share'} asChild>
+          <Pressable hitSlop={10}>
+            <SafeFontIcon name="qr-code-1" size={16} />
           </Pressable>
-        </View>
+        </Link>
       </XStack>
     </Theme>
   )

--- a/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
+++ b/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
@@ -124,13 +124,6 @@ export const AppSettingsContainer = () => {
           ),
           disabled: false,
         },
-        {
-          label: 'Change passcode',
-          leftIcon: 'lock',
-          onPress: () => console.log('change passcode'),
-          disabled: true,
-          tag: 'Coming soon',
-        },
       ],
     },
     {

--- a/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
@@ -28,7 +28,7 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
   const copyAndDispatchToast = useCopyAndDispatchToast()
   const theme = useTheme()
   const color = theme.color?.get()
-  const colorError = 'red'
+  const colorError = theme.error?.get() || '#FF5F72'
 
   if (!safeAddress) {
     return null

--- a/apps/mobile/src/features/TxHistory/TxHistory.container.test.tsx
+++ b/apps/mobile/src/features/TxHistory/TxHistory.container.test.tsx
@@ -16,9 +16,9 @@ jest.mock('@/src/store/hooks/activeSafe', () => ({
   useDefinedActiveSafe: () => mockSafeState.safe,
 }))
 
-jest.mock('react-native-collapsible-tab-view', () => {
+jest.mock('@shopify/flash-list', () => {
   const { FlatList } = require('react-native')
-  return { Tabs: { FlashList: FlatList } }
+  return { FlashList: FlatList }
 })
 
 const sender = faker.finance.ethereumAddress()

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.test.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.test.tsx
@@ -3,10 +3,9 @@ import { render, screen, fireEvent } from '@/src/tests/test-utils'
 import { TxHistoryList } from './TxHistoryList'
 import { HistoryTransactionItems } from '@safe-global/store/gateway/types'
 
-// Mock react-native-collapsible-tab-view to use regular FlatList
-jest.mock('react-native-collapsible-tab-view', () => {
+jest.mock('@shopify/flash-list', () => {
   const { FlatList } = require('react-native')
-  return { Tabs: { FlashList: FlatList } }
+  return { FlashList: FlatList }
 })
 
 describe('TxHistoryList', () => {

--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/TxHistoryList.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useCallback } from 'react'
 import { View, getTokenValue } from 'tamagui'
-import { Tabs } from 'react-native-collapsible-tab-view'
+import { FlashList } from '@shopify/flash-list'
 import { RefreshControl } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
@@ -111,7 +111,7 @@ export function TxHistoryList({
 
   return (
     <View position="relative" flex={1}>
-      <Tabs.FlashList
+      <FlashList
         testID="tx-history-list"
         data={groupedTransactions}
         renderItem={renderItem}


### PR DESCRIPTION
## What it solves

Resolves [WA-1384](https://linear.app/safe-global/issue/WA-1384/adhoc-fixes-for-upcoming-release) — Adhoc fixes for upcoming mobile release.

## How this PR fixes it

1. **Removed notification bell icon** from home tab navbar (Assets Navbar) — removes the bell icon and notification handler code
2. **Removed "Change passcode"** Coming Soon item from Settings > Security section
3. **Removed "Messages" tab** from Transactions screen — replaced SafeTab with direct TxHistoryContainer rendering since only one tab remains (header title already set by _layout.tsx)
4. **Fixed hardcoded error colors** — replaced `'red'` (#FF0000) with theme error token (#FF5F72) in SettingsMenu and useContactActions for design system consistency
5. **Cleaned up** unused imports (View, ComingSoon, SafeTab, Platform, selectAppNotificationStatus)
6. **Fixed wrong icon colors" - the icon colors when using the react-native-menu were wrong. If the users OS was set to dark mode, but out app would be set to light it would inherit the wrong colors for the icons. 

## How to test it

- Open the Home tab → verify bell icon is gone, only QR code icon remains
- Open Transactions tab → verify single history view without tab bar
- Open Account > Settings (gear icon) → verify no "Change passcode" item in Security section
- Open Account > three-dots menu → verify "Remove account" uses the correct error color (#FF5F72)
- Open Address Book > long-press contact → verify "Delete contact" uses the correct error color
- Test in both light and dark modes

## Screenshots

Mobile-only change — screenshots from device testing needed.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---
[![Safe Engineering](https://img.shields.io/badge/Safe-Engineering-12ff80)](https://github.com/5afe/safe-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)