### PR TITLE
refactor(tests): update ProposersList tests to use new spending limit…

### DIFF
--- a/apps/web/src/components/settings/ProposersList/index.test.tsx
+++ b/apps/web/src/components/settings/ProposersList/index.test.tsx
@@ -38,9 +38,9 @@ jest.mock('@/hooks/useChains', () => ({
   useHasFeature: jest.fn(() => true),
 }))
 
-jest.mock('@/hooks/useIsOnlySpendingLimitBeneficiary', () => ({
+jest.mock('@/features/spending-limits', () => ({
   __esModule: true,
-  default: jest.fn(() => false),
+  useIsOnlySpendingLimitBeneficiary: jest.fn(() => false),
 }))
 
 jest.mock('@/hooks/useIsWrongChain', () => ({


### PR DESCRIPTION
- Changed the mock for useIsOnlySpendingLimitBeneficiary to align with the new structure in the spending-limits feature.
- This update improves the clarity and maintainability of the test suite for the ProposersList component.

## What it solves

Resolves:

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
