### PR TITLE
chore(ci): use dedicated S3 bucket for tx-builder deploys

### DIFF
--- a/.github/workflows/tx-builder-deploy.yml
+++ b/.github/workflows/tx-builder-deploy.yml
@@ -87,7 +87,7 @@ jobs:
             ✅ Deploy successful!
 
             **Preview URL:**
-            https://${{ steps.extract_branch.outputs.branch }}--tx-builder.review.5afe.dev/tx-builder/
+            https://${{ steps.extract_branch.outputs.branch }}--tx-builder.review.5afe.dev/
           message-failure: |
             ## tx-builder Preview
             ❌ Deploy failed!
@@ -120,7 +120,7 @@ jobs:
 
       - name: Deploy to staging
         env:
-          BUCKET: s3://${{ secrets.TX_BUILDER_AWS_STAGING_BUCKET_NAME }}/current/tx-builder
+          BUCKET: s3://${{ secrets.TX_BUILDER_AWS_STAGING_BUCKET_NAME }}/current
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: aws s3 sync ./build $BUCKET --delete
 

--- a/apps/tx-builder/vite.config.ts
+++ b/apps/tx-builder/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       include: '**/*.svg',
     }),
   ],
-  base: '/tx-builder/',
+  base: '/',
   build: {
     outDir: 'build',
     sourcemap: true,


### PR DESCRIPTION
## What it solves

The tx-builder was moved from the safe-react-apps repo to this monorepo. The deploy workflow currently shares the `AWS_STAGING_BUCKET_NAME` secret with the web app, which will conflict once we point it at a dedicated tx-builder S3 bucket (being set up in a separate safe-devstaging PR).

## How this PR fixes it

Renames the secret reference from `AWS_STAGING_BUCKET_NAME` to `TX_BUILDER_AWS_STAGING_BUCKET_NAME` in both the staging deploy and production release jobs. A corresponding GitHub secret needs to be created pointing to the new `safe-staging-tx-builder` bucket.

## How to test it

1. Verify the workflow YAML parses correctly (CI will validate this)
2. Trigger a staging deploy by pushing to `dev` and confirm it uploads to the correct bucket

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).