### PR TITLE
tests: wait for hydrated safe param before clicking pending tx link

### DIFF
--- a/apps/web/cypress/e2e/pages/dashboard.pages.js
+++ b/apps/web/cypress/e2e/pages/dashboard.pages.js
@@ -24,6 +24,11 @@ export const assetsWidget = '[data-testid="assets-widget"]'
 const singleTxDetailsHeader = '[data-testid="tx-details"]'
 
 export function clickOnTxByIndex(index) {
+  // Wait for hydration to set the correct safe query param in the link href
+  cy.get(pendingTxItem)
+    .eq(index)
+    .should('have.attr', 'href')
+    .and('match', /safe=.{3,}/)
   cy.get(pendingTxItem).eq(index).click()
   cy.get(singleTxDetailsHeader).should('be.visible')
 }

--- a/apps/web/cypress/e2e/regression/dashboard.cy.js
+++ b/apps/web/cypress/e2e/regression/dashboard.cy.js
@@ -22,6 +22,7 @@ describe('Dashboard tests', { defaultCommandTimeout: 60000 }, () => {
     cy.intercept('GET', constants.queuedEndpoint).as('getQueuedTransactions')
     cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_2)
     cy.wait('@getQueuedTransactions')
+    cy.get(dashboard.pendingTxWidget).should('be.visible')
   })
 
   it('Verify clicking on View All button directs to list of all queued txs', () => {


### PR DESCRIPTION
## Summary
- Fix dashboard Cypress regression test that fails with `Expected to find element: [data-testid="transaction-item"], but never found it`
- After pre-fetched chains (#7122), `PendingTxListItem` renders during SSG hydration when `router.query` is still empty. The `useSafeQueryParam` hook falls back to `location.search`, but during SSR the links are rendered with `safe=''`. If Cypress clicks the link before React flushes the hydrated href, navigation goes to `/transactions/tx?safe=` which causes `SingleTx` to skip its API query
- Add href assertion in `clickOnTxByIndex()` to wait for the link to contain a valid `safe` param before clicking
- Wait for the pending tx widget to be visible in `beforeEach` to ensure full hydration

## Test plan
- [ ] Run `cypress/e2e/regression/dashboard.cy.js` — "Verify clicking on any tx takes the user to Transactions > Queue tab" should pass
- [ ] All other dashboard tests should remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)