### PR TITLE
chore(ci): use dedicated IAM role for tx-builder deploys

### DIFF
--- a/.github/workflows/tx-builder-deploy.yml
+++ b/.github/workflows/tx-builder-deploy.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-to-assume: ${{ secrets.TX_BUILDER_AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy to staging
@@ -170,7 +170,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-to-assume: ${{ secrets.TX_BUILDER_AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Deploy to production S3


### PR DESCRIPTION
## What it solves
Switch from shared AWS_ROLE to TX_BUILDER_AWS_ROLE in staging and
production deploy jobs. PR preview keeps using the shared role since
it pushes to the shared review bucket.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
