### PR TITLE
fix(web/Spaces): Storybook tests: chore: update snapshots

### DIFF
--- a/apps/web/src/components/common/EthHashInfo/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/components/common/EthHashInfo/__snapshots__/index.stories.test.tsx.snap
@@ -2,47 +2,51 @@
 
 exports[`./index.stories Default 1`] = `
 <div
-  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+  class="shadcn-scope"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
-    style="--Paper-shadow: none;"
+    style="background-color: rgb(255, 255, 255); padding: 1rem;"
   >
     <div
-      class="container"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
+      style="--Paper-shadow: none;"
     >
       <div
-        class="avatarContainer"
-        style="width: 40px; height: 40px;"
+        class="container"
       >
         <div
-          class="icon"
-          style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjg1IDUyJSAzMyUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg1NiA1NiUgMTclKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsM2gxdjFoLTF6TTUsM2gxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTAsNmgxdjFoLTF6TTcsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDEzOCA3NyUgNDIlKSIgZD0iTTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6Ii8+PC9zdmc+); width: 40px; height: 40px;"
-        />
-      </div>
-      <div
-        class="MuiBox-root mui-style-1lchl8k"
-      >
-        <div
-          class="addressContainer"
+          class="avatarContainer"
+          style="width: 40px; height: 40px;"
         >
           <div
-            class="MuiBox-root mui-style-b5p5gz"
+            class="icon"
+            style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjg1IDUyJSAzMyUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCg1NiA1NiUgMTclKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTMsMGgxdjFoLTF6TTQsMGgxdjFoLTF6TTIsMWgxdjFoLTF6TTUsMWgxdjFoLTF6TTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsM2gxdjFoLTF6TTUsM2gxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTEsNGgxdjFoLTF6TTYsNGgxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTAsNWgxdjFoLTF6TTcsNWgxdjFoLTF6TTEsNWgxdjFoLTF6TTYsNWgxdjFoLTF6TTAsNmgxdjFoLTF6TTcsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDEzOCA3NyUgNDIlKSIgZD0iTTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6Ii8+PC9zdmc+); width: 40px; height: 40px;"
+          />
+        </div>
+        <div
+          class="MuiBox-root mui-style-1lchl8k"
+        >
+          <div
+            class="addressContainer"
           >
-            <span
-              aria-label="Copy to clipboard"
-              class=""
-              data-mui-internal-clone-element="true"
-              style="cursor: pointer;"
+            <div
+              class="MuiBox-root mui-style-b5p5gz"
             >
-              <b>
-                rin
-                :
-              </b>
-              <span>
-                0xd9Db...9552
+              <span
+                aria-label="Copy to clipboard"
+                class=""
+                data-mui-internal-clone-element="true"
+                style="cursor: pointer;"
+              >
+                <b>
+                  rin
+                  :
+                </b>
+                <span>
+                  0xd9Db...9552
+                </span>
               </span>
-            </span>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/common/EthHashInfo/index.stories.tsx
+++ b/apps/web/src/components/common/EthHashInfo/index.stories.tsx
@@ -3,6 +3,7 @@ import EthHashInfo from './index'
 import { Paper } from '@mui/material'
 
 import { StoreDecorator } from '@/stories/storeDecorator'
+import { RouterDecorator } from '@/stories/routerDecorator'
 
 const meta = {
   component: EthHashInfo,
@@ -14,9 +15,11 @@ const meta = {
     (Story) => {
       return (
         <StoreDecorator initialState={{}}>
-          <Paper sx={{ padding: 2 }}>
-            <Story />
-          </Paper>
+          <RouterDecorator>
+            <Paper sx={{ padding: 2 }}>
+              <Story />
+            </Paper>
+          </RouterDecorator>
         </StoreDecorator>
       )
     },

--- a/apps/web/src/components/tx/confirmation-views/SettingsChange/SettingsChange.stories.tsx
+++ b/apps/web/src/components/tx/confirmation-views/SettingsChange/SettingsChange.stories.tsx
@@ -3,6 +3,7 @@ import type { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERAT
 import type { Meta, StoryObj } from '@storybook/react'
 import { Paper } from '@mui/material'
 import { StoreDecorator } from '@/stories/storeDecorator'
+import { RouterDecorator } from '@/stories/routerDecorator'
 import { ownerAddress, txInfo } from './mockData'
 import SettingsChange from '.'
 
@@ -15,9 +16,11 @@ const meta = {
     (Story) => {
       return (
         <StoreDecorator initialState={{}}>
-          <Paper sx={{ padding: 2 }}>
-            <Story />
-          </Paper>
+          <RouterDecorator>
+            <Paper sx={{ padding: 2 }}>
+              <Story />
+            </Paper>
+          </RouterDecorator>
         </StoreDecorator>
       )
     },

--- a/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.stories.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.stories.test.tsx.snap
@@ -2,259 +2,267 @@
 
 exports[`./SettingsChange.stories AddOwner 1`] = `
 <div
-  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+  class="shadcn-scope"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
-    style="--Paper-shadow: none;"
+    style="background-color: rgb(255, 255, 255); padding: 1rem;"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 container mui-style-zpxm0u-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
       style="--Paper-shadow: none;"
     >
-      <p
-        class="MuiTypography-root MuiTypography-body1 mui-style-1950vt0-MuiTypography-root"
-      >
-        <mock-icon
-          aria-hidden=""
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1hr8a3z-MuiSvgIcon-root"
-          focusable="false"
-        />
-        Add owner
-      </p>
       <div
-        class="container"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 container mui-style-zpxm0u-MuiPaper-root"
+        style="--Paper-shadow: none;"
       >
-        <div
-          class="avatarContainer"
-          style="width: 32px; height: 32px;"
+        <p
+          class="MuiTypography-root MuiTypography-body1 mui-style-1950vt0-MuiTypography-root"
         >
-          <div
-            class="icon"
-            style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMzI1IDQ4JSAyMiUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgyNDAgOTklIDQ5JSkiIGQ9Ik0xLDBoMXYxaC0xek02LDBoMXYxaC0xek0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0zLDBoMXYxaC0xek00LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0wLDJoMXYxaC0xek03LDJoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0xLDRoMXYxaC0xek02LDRoMXYxaC0xek0xLDVoMXYxaC0xek02LDVoMXYxaC0xek0yLDVoMXYxaC0xek01LDVoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgxNTUgOTUlIDU5JSkiIGQ9Ik0xLDFoMXYxaC0xek02LDFoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0zLDJoMXYxaC0xek00LDJoMXYxaC0xek0xLDdoMXYxaC0xek02LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 32px; height: 32px;"
+          <mock-icon
+            aria-hidden=""
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1hr8a3z-MuiSvgIcon-root"
+            focusable="false"
           />
-        </div>
+          Add owner
+        </p>
         <div
-          class="MuiBox-root mui-style-1lchl8k"
+          class="container"
         >
           <div
-            class="ethHashInfo-name MuiBox-root mui-style-171onha"
-            title="Nevinha"
+            class="avatarContainer"
+            style="width: 32px; height: 32px;"
           >
             <div
-              class="MuiBox-root mui-style-1o4wo1x"
-            >
-              Nevinha
-            </div>
+              class="icon"
+              style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMzI1IDQ4JSAyMiUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgyNDAgOTklIDQ5JSkiIGQ9Ik0xLDBoMXYxaC0xek02LDBoMXYxaC0xek0yLDBoMXYxaC0xek01LDBoMXYxaC0xek0zLDBoMXYxaC0xek00LDBoMXYxaC0xek0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0wLDJoMXYxaC0xek03LDJoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0yLDJoMXYxaC0xek01LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0xLDRoMXYxaC0xek02LDRoMXYxaC0xek0xLDVoMXYxaC0xek02LDVoMXYxaC0xek0yLDVoMXYxaC0xek01LDVoMXYxaC0xek0yLDdoMXYxaC0xek01LDdoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCgxNTUgOTUlIDU5JSkiIGQ9Ik0xLDFoMXYxaC0xek02LDFoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0zLDJoMXYxaC0xek00LDJoMXYxaC0xek0xLDdoMXYxaC0xek02LDdoMXYxaC0xeiIvPjwvc3ZnPg==); width: 32px; height: 32px;"
+            />
           </div>
           <div
-            class="addressContainer"
+            class="MuiBox-root mui-style-1lchl8k"
           >
             <div
-              class="MuiBox-root mui-style-b5p5gz"
+              class="ethHashInfo-name MuiBox-root mui-style-171onha"
+              title="Nevinha"
             >
+              <div
+                class="MuiBox-root mui-style-1o4wo1x"
+              >
+                Nevinha
+              </div>
+            </div>
+            <div
+              class="addressContainer"
+            >
+              <div
+                class="MuiBox-root mui-style-b5p5gz"
+              >
+                <span
+                  aria-label="Copy to clipboard"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                  style="cursor: pointer;"
+                >
+                  <b>
+                    rin
+                    :
+                  </b>
+                  <span>
+                    0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+                  </span>
+                </span>
+              </div>
               <span
                 aria-label="Copy to clipboard"
                 class=""
                 data-mui-internal-clone-element="true"
                 style="cursor: pointer;"
               >
-                <b>
-                  rin
-                  :
-                </b>
-                <span>
-                  0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
-                </span>
+                <button
+                  aria-label="Copy to clipboard"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <mock-icon
+                    aria-hidden=""
+                    class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-gvpe62-MuiSvgIcon-root"
+                    data-testid="copy-btn-icon"
+                    focusable="false"
+                  />
+                </button>
               </span>
-            </div>
-            <span
-              aria-label="Copy to clipboard"
-              class=""
-              data-mui-internal-clone-element="true"
-              style="cursor: pointer;"
-            >
-              <button
-                aria-label="Copy to clipboard"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="MuiBox-root mui-style-yjghm1"
               >
-                <mock-icon
-                  aria-hidden=""
-                  class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-gvpe62-MuiSvgIcon-root"
-                  data-testid="copy-btn-icon"
-                  focusable="false"
-                />
-              </button>
-            </span>
-            <div
-              class="MuiBox-root mui-style-yjghm1"
-            >
-              <a
-                aria-label="View on rinkeby.etherscan.io"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                data-mui-internal-clone-element="true"
-                data-testid="explorer-btn"
-                href="https://rinkeby.etherscan.io/address/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
-                rel="noreferrer"
-                tabindex="0"
-                target="_blank"
-              >
-                <mock-icon
-                  aria-hidden=""
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                  focusable="false"
-                />
-              </a>
+                <a
+                  aria-label="View on rinkeby.etherscan.io"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="explorer-btn"
+                  href="https://rinkeby.etherscan.io/address/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                  rel="noreferrer"
+                  tabindex="0"
+                  target="_blank"
+                >
+                  <mock-icon
+                    aria-hidden=""
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                    focusable="false"
+                  />
+                </a>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <hr
-      class="MuiDivider-root MuiDivider-fullWidth nestedDivider mui-style-1facvfi-MuiDivider-root"
-    />
-    <div
-      class="MuiBox-root mui-style-0"
-    >
-      <p
-        class="MuiTypography-root MuiTypography-body2 mui-style-17vdyq3-MuiTypography-root"
+      <hr
+        class="MuiDivider-root MuiDivider-fullWidth nestedDivider mui-style-1facvfi-MuiDivider-root"
+      />
+      <div
+        class="MuiBox-root mui-style-0"
       >
-        Any transaction requires the confirmation of:
-      </p>
-      <p
-        class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
-      >
-        <b>
-          1
-        </b>
-         out of
-         
-        <b>
-          1
-           signer
-        </b>
-      </p>
+        <p
+          class="MuiTypography-root MuiTypography-body2 mui-style-17vdyq3-MuiTypography-root"
+        >
+          Any transaction requires the confirmation of:
+        </p>
+        <p
+          class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+        >
+          <b>
+            1
+          </b>
+           out of
+           
+          <b>
+            1
+             signer
+          </b>
+        </p>
+      </div>
+      <hr
+        class="MuiDivider-root MuiDivider-fullWidth nestedDivider mui-style-1facvfi-MuiDivider-root"
+      />
     </div>
-    <hr
-      class="MuiDivider-root MuiDivider-fullWidth nestedDivider mui-style-1facvfi-MuiDivider-root"
-    />
   </div>
 </div>
 `;
 
 exports[`./SettingsChange.stories SwapOwner 1`] = `
 <div
-  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+  class="shadcn-scope"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
-    style="--Paper-shadow: none;"
+    style="background-color: rgb(255, 255, 255); padding: 1rem;"
   >
     <div
-      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1nt2i3f-MuiPaper-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
       style="--Paper-shadow: none;"
     >
-      <p
-        class="MuiTypography-root MuiTypography-body1 mui-style-qzqzle-MuiTypography-root"
-      >
-        <mock-icon
-          aria-hidden=""
-          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1hr8a3z-MuiSvgIcon-root"
-          focusable="false"
-        />
-        Previous signer
-      </p>
       <div
-        class="container"
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1nt2i3f-MuiPaper-root"
+        style="--Paper-shadow: none;"
       >
-        <div
-          class="avatarContainer"
-          style="width: 40px; height: 40px;"
+        <p
+          class="MuiTypography-root MuiTypography-body1 mui-style-qzqzle-MuiTypography-root"
         >
-          <span
-            class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse mui-style-143xw5x-MuiSkeleton-root"
-            style="width: 40px; height: 40px;"
+          <mock-icon
+            aria-hidden=""
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1hr8a3z-MuiSvgIcon-root"
+            focusable="false"
           />
-        </div>
+          Previous signer
+        </p>
         <div
-          class="MuiBox-root mui-style-1lchl8k"
+          class="container"
         >
           <div
-            class="ethHashInfo-name MuiBox-root mui-style-171onha"
-            title="Bob"
+            class="avatarContainer"
+            style="width: 40px; height: 40px;"
           >
-            <div
-              class="MuiBox-root mui-style-1o4wo1x"
-            >
-              Bob
-            </div>
+            <span
+              class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse mui-style-143xw5x-MuiSkeleton-root"
+              style="width: 40px; height: 40px;"
+            />
           </div>
           <div
-            class="addressContainer"
+            class="MuiBox-root mui-style-1lchl8k"
           >
             <div
-              class="MuiBox-root mui-style-b5p5gz"
+              class="ethHashInfo-name MuiBox-root mui-style-171onha"
+              title="Bob"
             >
+              <div
+                class="MuiBox-root mui-style-1o4wo1x"
+              >
+                Bob
+              </div>
+            </div>
+            <div
+              class="addressContainer"
+            >
+              <div
+                class="MuiBox-root mui-style-b5p5gz"
+              >
+                <span
+                  aria-label="Copy to clipboard"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                  style="cursor: pointer;"
+                >
+                  <span>
+                    0x00000000
+                  </span>
+                </span>
+              </div>
               <span
                 aria-label="Copy to clipboard"
                 class=""
                 data-mui-internal-clone-element="true"
                 style="cursor: pointer;"
               >
-                <span>
-                  0x00000000
-                </span>
+                <button
+                  aria-label="Copy to clipboard"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <mock-icon
+                    aria-hidden=""
+                    class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-gvpe62-MuiSvgIcon-root"
+                    data-testid="copy-btn-icon"
+                    focusable="false"
+                  />
+                </button>
               </span>
-            </div>
-            <span
-              aria-label="Copy to clipboard"
-              class=""
-              data-mui-internal-clone-element="true"
-              style="cursor: pointer;"
-            >
-              <button
-                aria-label="Copy to clipboard"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                tabindex="0"
-                type="button"
+              <div
+                class="MuiBox-root mui-style-yjghm1"
               >
-                <mock-icon
-                  aria-hidden=""
-                  class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-gvpe62-MuiSvgIcon-root"
-                  data-testid="copy-btn-icon"
-                  focusable="false"
-                />
-              </button>
-            </span>
-            <div
-              class="MuiBox-root mui-style-yjghm1"
-            >
-              <a
-                aria-label="View on rinkeby.etherscan.io"
-                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                data-mui-internal-clone-element="true"
-                data-testid="explorer-btn"
-                href="https://rinkeby.etherscan.io/address/0x00000000"
-                rel="noreferrer"
-                tabindex="0"
-                target="_blank"
-              >
-                <mock-icon
-                  aria-hidden=""
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                  focusable="false"
-                />
-              </a>
+                <a
+                  aria-label="View on rinkeby.etherscan.io"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  data-testid="explorer-btn"
+                  href="https://rinkeby.etherscan.io/address/0x00000000"
+                  rel="noreferrer"
+                  tabindex="0"
+                  target="_blank"
+                >
+                  <mock-icon
+                    aria-hidden=""
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                    focusable="false"
+                  />
+                </a>
+              </div>
             </div>
           </div>
         </div>
       </div>
+      <hr
+        class="MuiDivider-root MuiDivider-fullWidth nestedDivider mui-style-1facvfi-MuiDivider-root"
+      />
     </div>
-    <hr
-      class="MuiDivider-root MuiDivider-fullWidth nestedDivider mui-style-1facvfi-MuiDivider-root"
-    />
   </div>
 </div>
 `;

--- a/apps/web/src/features/safe-shield/SafeShield.stories.tsx
+++ b/apps/web/src/features/safe-shield/SafeShield.stories.tsx
@@ -9,6 +9,7 @@ import {
 import { ThreatAnalysisBuilder } from '@safe-global/utils/features/safe-shield/builders/threat-analysis.builder'
 import { faker } from '@faker-js/faker'
 import { StoreDecorator } from '@/stories/storeDecorator'
+import { RouterDecorator } from '@/stories/routerDecorator'
 
 // Seed faker for deterministic visual regression tests
 faker.seed(456)
@@ -19,11 +20,13 @@ const meta: Meta<typeof SafeShieldDisplay> = {
   decorators: [
     (Story, context) => (
       <StoreDecorator initialState={{}} context={context}>
-        <Paper sx={{ padding: 2, backgroundColor: 'background.main' }}>
-          <Box sx={{ width: 320 }}>
-            <Story />
-          </Box>
-        </Paper>
+        <RouterDecorator>
+          <Paper sx={{ padding: 2, backgroundColor: 'background.main' }}>
+            <Box sx={{ width: 320 }}>
+              <Story />
+            </Box>
+          </Paper>
+        </RouterDecorator>
       </StoreDecorator>
     ),
   ],

--- a/apps/web/src/features/safe-shield/__snapshots__/SafeShield.stories.test.tsx.snap
+++ b/apps/web/src/features/safe-shield/__snapshots__/SafeShield.stories.test.tsx.snap
@@ -3363,821 +3363,197 @@ exports[`./SafeShield.stories ModulesChange 1`] = `
 
 exports[`./SafeShield.stories MultipleCounterparties 1`] = `
 <div
-  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+  class="shadcn-scope"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-wf13l-MuiPaper-root"
-    style="--Paper-shadow: none;"
+    style="background-color: rgb(255, 255, 255); padding: 1rem;"
   >
     <div
-      class="MuiBox-root mui-style-1hjq20a"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-wf13l-MuiPaper-root"
+      style="--Paper-shadow: none;"
     >
       <div
-        class="MuiStack-root mui-style-hwnj0i-MuiStack-root"
-        data-testid="safe-shield-widget"
+        class="MuiBox-root mui-style-1hjq20a"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root mui-style-1294j3-MuiPaper-root-MuiCard-root"
-          style="--Paper-shadow: none;"
+          class="MuiStack-root mui-style-hwnj0i-MuiStack-root"
+          data-testid="safe-shield-widget"
         >
           <div
-            class="MuiBox-root mui-style-2w7gpf"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root mui-style-1294j3-MuiPaper-root-MuiCard-root"
+            style="--Paper-shadow: none;"
           >
             <div
-              class="MuiStack-root mui-style-1gfvvrg-MuiStack-root"
-              data-testid="safe-shield-status"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-overline mui-style-1jydjdd-MuiTypography-root"
-              >
-                Risk detected
-              </span>
-            </div>
-          </div>
-          <div
-            class="MuiBox-root mui-style-1hpqev5"
-          >
-            <div
-              class="MuiBox-root mui-style-1l5zt4q"
+              class="MuiBox-root mui-style-2w7gpf"
             >
               <div
-                class="MuiBox-root mui-style-xhak29"
+                class="MuiStack-root mui-style-1gfvvrg-MuiStack-root"
+                data-testid="safe-shield-status"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-overline mui-style-1jydjdd-MuiTypography-root"
+                >
+                  Risk detected
+                </span>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root mui-style-1hpqev5"
+            >
+              <div
+                class="MuiBox-root mui-style-1l5zt4q"
               >
                 <div
-                  class="MuiBox-root mui-style-12i4uqz"
-                  data-testid="recipient-analysis-group-card"
+                  class="MuiBox-root mui-style-xhak29"
                 >
                   <div
-                    class="MuiStack-root mui-style-es2900-MuiStack-root"
+                    class="MuiBox-root mui-style-12i4uqz"
+                    data-testid="recipient-analysis-group-card"
                   >
                     <div
-                      class="MuiStack-root mui-style-1rlitzi-MuiStack-root"
-                    >
-                      <mock-icon
-                        aria-hidden=""
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-1e3jf0k-MuiSvgIcon-root"
-                        focusable="false"
-                      />
-                      <p
-                        class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                      >
-                        Incompatible Safe version
-                      </p>
-                    </div>
-                    <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1fkg3qi-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-118obxm-MuiSvgIcon-root"
-                        data-testid="KeyboardArrowDownIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                      class="MuiStack-root mui-style-es2900-MuiStack-root"
                     >
                       <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                        class="MuiStack-root mui-style-1rlitzi-MuiStack-root"
                       >
-                        <div
-                          class="MuiBox-root mui-style-v1dotw"
+                        <mock-icon
+                          aria-hidden=""
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-1e3jf0k-MuiSvgIcon-root"
+                          focusable="false"
+                        />
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
                         >
-                          <div
-                            class="MuiStack-root mui-style-hwnj0i-MuiStack-root"
-                          >
-                            <div
-                              class="MuiBox-root mui-style-6io5aq"
-                            >
-                              <div
-                                class="MuiBox-root mui-style-fnkd19"
-                              >
-                                <div
-                                  class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                                  >
-                                    1 Safe account cannot be created on the destination chain. You will not be able to claim ownership of the same address. Funds sent may be inaccessible.
-                                  </p>
-                                  <div
-                                    class="MuiBox-root mui-style-u2tihl"
-                                  >
-                                    <div
-                                      aria-label="Show all"
-                                      class="MuiBox-root mui-style-1ari483"
-                                      role="button"
-                                    >
-                                      <span
-                                        class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
-                                      >
-                                        Show all
-                                      </span>
-                                      <div
-                                        class="MuiBox-root mui-style-1xmxy86"
-                                      />
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
-                                        data-testid="ExpandMoreIcon"
-                                        focusable="false"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <path
-                                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                                        />
-                                      </svg>
-                                    </div>
-                                    <div
-                                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                                      style="min-height: 0px;"
-                                    >
-                                      <div
-                                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
-                                      >
-                                        <div
-                                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
-                                        >
-                                          <div
-                                            class="MuiBox-root mui-style-1821gv5"
-                                          >
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
-                                              >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
-                                                  >
-                                                    0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                                                      data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
-                                                    >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="MuiBox-root mui-style-6io5aq"
-                            >
-                              <div
-                                class="MuiBox-root mui-style-1f9z19n"
-                              >
-                                <div
-                                  class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                                  >
-                                    1 address has few transactions.
-                                  </p>
-                                  <div
-                                    class="MuiBox-root mui-style-u2tihl"
-                                  >
-                                    <div
-                                      aria-label="Show all"
-                                      class="MuiBox-root mui-style-1ari483"
-                                      role="button"
-                                    >
-                                      <span
-                                        class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
-                                      >
-                                        Show all
-                                      </span>
-                                      <div
-                                        class="MuiBox-root mui-style-1xmxy86"
-                                      />
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
-                                        data-testid="ExpandMoreIcon"
-                                        focusable="false"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <path
-                                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                                        />
-                                      </svg>
-                                    </div>
-                                    <div
-                                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                                      style="min-height: 0px;"
-                                    >
-                                      <div
-                                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
-                                      >
-                                        <div
-                                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
-                                        >
-                                          <div
-                                            class="MuiBox-root mui-style-1821gv5"
-                                          >
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
-                                              >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
-                                                  >
-                                                    0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                                                      data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
-                                                    >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="MuiBox-root mui-style-6io5aq"
-                            >
-                              <div
-                                class="MuiBox-root mui-style-1f9z19n"
-                              >
-                                <div
-                                  class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                                  >
-                                    You are interacting with 2 addresses for the first time.
-                                  </p>
-                                  <div
-                                    class="MuiBox-root mui-style-u2tihl"
-                                  >
-                                    <div
-                                      aria-label="Show all"
-                                      class="MuiBox-root mui-style-1ari483"
-                                      role="button"
-                                    >
-                                      <span
-                                        class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
-                                      >
-                                        Show all
-                                      </span>
-                                      <div
-                                        class="MuiBox-root mui-style-1xmxy86"
-                                      />
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
-                                        data-testid="ExpandMoreIcon"
-                                        focusable="false"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <path
-                                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                                        />
-                                      </svg>
-                                    </div>
-                                    <div
-                                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                                      style="min-height: 0px;"
-                                    >
-                                      <div
-                                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
-                                      >
-                                        <div
-                                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
-                                        >
-                                          <div
-                                            class="MuiBox-root mui-style-1821gv5"
-                                          >
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
-                                              >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
-                                                  >
-                                                    0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                                                      data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
-                                                    >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
-                                              </div>
-                                            </div>
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
-                                              >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
-                                                  >
-                                                    0x75a4a3378eb9be1d6cd40847aa7fac5d66b99cfe
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                                                      data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0x75a4a3378eb9be1d6cd40847aa7fac5d66b99cfe"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
-                                                    >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                            <div
-                              class="MuiBox-root mui-style-6io5aq"
-                            >
-                              <div
-                                class="MuiBox-root mui-style-1f9z19n"
-                              >
-                                <div
-                                  class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
-                                >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                                  >
-                                    2 addresses are in your address book or a Safe you own.
-                                  </p>
-                                  <div
-                                    class="MuiBox-root mui-style-u2tihl"
-                                  >
-                                    <div
-                                      aria-label="Show all"
-                                      class="MuiBox-root mui-style-1ari483"
-                                      role="button"
-                                    >
-                                      <span
-                                        class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
-                                      >
-                                        Show all
-                                      </span>
-                                      <div
-                                        class="MuiBox-root mui-style-1xmxy86"
-                                      />
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
-                                        data-testid="ExpandMoreIcon"
-                                        focusable="false"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <path
-                                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                                        />
-                                      </svg>
-                                    </div>
-                                    <div
-                                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                                      style="min-height: 0px;"
-                                    >
-                                      <div
-                                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
-                                      >
-                                        <div
-                                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
-                                        >
-                                          <div
-                                            class="MuiBox-root mui-style-1821gv5"
-                                          >
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
-                                              >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
-                                                  >
-                                                    0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                                                      data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
-                                                    >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
-                                              </div>
-                                            </div>
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
-                                              >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
-                                                  >
-                                                    0x9648b1e4ad3eecbae513afb45e7ea8b2918e91ff
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                                                      data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0x9648b1e4ad3eecbae513afb45e7ea8b2918e91ff"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
-                                                    >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
-                                              </div>
-                                            </div>
-                                          </div>
-                                        </div>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
+                          Incompatible Safe version
+                        </p>
                       </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  class="MuiBox-root mui-style-7yf5bk"
-                  data-testid="contract-analysis-group-card"
-                >
-                  <div
-                    class="MuiStack-root mui-style-es2900-MuiStack-root"
-                  >
-                    <div
-                      class="MuiStack-root mui-style-1rlitzi-MuiStack-root"
-                    >
-                      <mock-icon
-                        aria-hidden=""
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-zluq22-MuiSvgIcon-root"
-                        focusable="false"
-                      />
-                      <p
-                        class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1fkg3qi-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
                       >
-                        Unofficial fallback handler
-                      </p>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-118obxm-MuiSvgIcon-root"
+                          data-testid="KeyboardArrowDownIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
+                          />
+                        </svg>
+                      </button>
                     </div>
-                    <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1fkg3qi-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-118obxm-MuiSvgIcon-root"
-                        data-testid="KeyboardArrowDownIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
                     <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                      style="min-height: 0px;"
                     >
                       <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
                       >
                         <div
-                          class="MuiBox-root mui-style-v1dotw"
+                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
                         >
                           <div
-                            class="MuiStack-root mui-style-hwnj0i-MuiStack-root"
+                            class="MuiBox-root mui-style-v1dotw"
                           >
                             <div
-                              class="MuiBox-root mui-style-6io5aq"
+                              class="MuiStack-root mui-style-hwnj0i-MuiStack-root"
                             >
                               <div
-                                class="MuiBox-root mui-style-jgusbz"
+                                class="MuiBox-root mui-style-6io5aq"
                               >
                                 <div
-                                  class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
+                                  class="MuiBox-root mui-style-fnkd19"
                                 >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+                                  <div
+                                    class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
                                   >
-                                    Verify the 
-                                    <a
-                                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways mui-style-ioipc8-MuiTypography-root-MuiLink-root"
-                                      href="https://help.safe.global/en/articles/40838-what-is-a-fallback-handler-and-how-does-it-relate-to-safe"
-                                      rel="noreferrer noopener"
-                                      target="_blank"
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
                                     >
-                                      <span
-                                        class="MuiBox-root mui-style-u9xrjn"
+                                      1 Safe account cannot be created on the destination chain. You will not be able to claim ownership of the same address. Funds sent may be inaccessible.
+                                    </p>
+                                    <div
+                                      class="MuiBox-root mui-style-u2tihl"
+                                    >
+                                      <div
+                                        aria-label="Show all"
+                                        class="MuiBox-root mui-style-1ari483"
+                                        role="button"
                                       >
-                                        fallback handler
+                                        <span
+                                          class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
+                                        >
+                                          Show all
+                                        </span>
+                                        <div
+                                          class="MuiBox-root mui-style-1xmxy86"
+                                        />
                                         <svg
                                           aria-hidden="true"
-                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall external-link-icon mui-style-tqxw8e-MuiSvgIcon-root"
-                                          data-testid="OpenInNewRoundedIcon"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
+                                          data-testid="ExpandMoreIcon"
                                           focusable="false"
                                           viewBox="0 0 24 24"
                                         >
                                           <path
-                                            d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                            d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
                                           />
                                         </svg>
-                                      </span>
-                                    </a>
-                                     is trusted and secure before proceeding.
-                                  </p>
-                                  <div
-                                    class="MuiBox-root mui-style-u2tihl"
-                                  >
-                                    <div
-                                      aria-label="Show all"
-                                      class="MuiBox-root mui-style-1ari483"
-                                      role="button"
-                                    >
-                                      <span
-                                        class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
-                                      >
-                                        Show all
-                                      </span>
+                                      </div>
                                       <div
-                                        class="MuiBox-root mui-style-1xmxy86"
-                                      />
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
-                                        data-testid="ExpandMoreIcon"
-                                        focusable="false"
-                                        viewBox="0 0 24 24"
-                                      >
-                                        <path
-                                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                                        />
-                                      </svg>
-                                    </div>
-                                    <div
-                                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                                      style="min-height: 0px;"
-                                    >
-                                      <div
-                                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                                        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                                        style="min-height: 0px;"
                                       >
                                         <div
-                                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                                          class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
                                         >
                                           <div
-                                            class="MuiBox-root mui-style-1821gv5"
+                                            class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
                                           >
                                             <div
-                                              class="MuiBox-root mui-style-i7v45s"
+                                              class="MuiBox-root mui-style-1821gv5"
                                             >
                                               <div
-                                                class="MuiAvatar-root MuiAvatar-circular mui-style-asrpj2-MuiAvatar-root"
-                                                style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
+                                                class="MuiBox-root mui-style-i7v45s"
                                               >
-                                                <img
-                                                  class="MuiAvatar-img mui-style-1su80sj-MuiAvatar-img"
-                                                  src="/images/transactions/custom.svg"
-                                                />
-                                              </div>
-                                              <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
-                                              >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
                                                 >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
                                                   >
-                                                    0xfafa1beaddbcd913f4de0ed3557a1f3d026de0a6
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
                                                       data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0xfafa1beaddbcd913f4de0ed3557a1f3d026de0a6"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
                                                     >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
-                                              </div>
-                                            </div>
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <div
-                                                class="MuiAvatar-root MuiAvatar-circular mui-style-asrpj2-MuiAvatar-root"
-                                                style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
-                                              >
-                                                <img
-                                                  class="MuiAvatar-img mui-style-1su80sj-MuiAvatar-img"
-                                                  src="/images/transactions/custom.svg"
-                                                />
-                                              </div>
-                                              <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
-                                              >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
-                                                  >
-                                                    0xfafa1beaddbcd913f4de0ed3557a1f3d026de0a6
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                                                      data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0xfafa1beaddbcd913f4de0ed3557a1f3d026de0a6"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
+                                                      0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
                                                     >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
                                               </div>
                                             </div>
                                           </div>
@@ -4187,170 +3563,99 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                   </div>
                                 </div>
                               </div>
-                            </div>
-                            <div
-                              class="MuiBox-root mui-style-6io5aq"
-                            >
                               <div
-                                class="MuiBox-root mui-style-1f9z19n"
+                                class="MuiBox-root mui-style-6io5aq"
                               >
                                 <div
-                                  class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
+                                  class="MuiBox-root mui-style-1f9z19n"
                                 >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                                  >
-                                    This transaction calls a smart contract that will be able to modify your Safe account. 
-                                    <a
-                                      class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways mui-style-r9pq5a-MuiTypography-root-MuiLink-root"
-                                      href="https://help.safe.global/en/articles/40794-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction"
-                                      rel="noreferrer noopener"
-                                      target="_blank"
-                                    >
-                                      <span
-                                        class="MuiBox-root mui-style-u9xrjn"
-                                      >
-                                        Learn more
-                                      </span>
-                                    </a>
-                                  </p>
                                   <div
-                                    class="MuiBox-root mui-style-u2tihl"
+                                    class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
                                   >
-                                    <div
-                                      aria-label="Show all"
-                                      class="MuiBox-root mui-style-1ari483"
-                                      role="button"
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
                                     >
-                                      <span
-                                        class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
-                                      >
-                                        Show all
-                                      </span>
+                                      1 address has few transactions.
+                                    </p>
+                                    <div
+                                      class="MuiBox-root mui-style-u2tihl"
+                                    >
                                       <div
-                                        class="MuiBox-root mui-style-1xmxy86"
-                                      />
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
-                                        data-testid="ExpandMoreIcon"
-                                        focusable="false"
-                                        viewBox="0 0 24 24"
+                                        aria-label="Show all"
+                                        class="MuiBox-root mui-style-1ari483"
+                                        role="button"
                                       >
-                                        <path
-                                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                        <span
+                                          class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
+                                        >
+                                          Show all
+                                        </span>
+                                        <div
+                                          class="MuiBox-root mui-style-1xmxy86"
                                         />
-                                      </svg>
-                                    </div>
-                                    <div
-                                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                                      style="min-height: 0px;"
-                                    >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
+                                          data-testid="ExpandMoreIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                          />
+                                        </svg>
+                                      </div>
                                       <div
-                                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                                        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                                        style="min-height: 0px;"
                                       >
                                         <div
-                                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                                          class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
                                         >
                                           <div
-                                            class="MuiBox-root mui-style-1821gv5"
+                                            class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
                                           >
                                             <div
-                                              class="MuiBox-root mui-style-i7v45s"
+                                              class="MuiBox-root mui-style-1821gv5"
                                             >
-                                              <img
-                                                alt=""
-                                                src="https://placehold.co/160"
-                                                style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
-                                              />
                                               <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                class="MuiBox-root mui-style-i7v45s"
                                               >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
                                                 >
-                                                  Balancer
-                                                </p>
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
                                                   >
-                                                    0x53bbddda3398c3facefe325073bc424fcb946d7a
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
                                                       data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0x53bbddda3398c3facefe325073bc424fcb946d7a"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
                                                     >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
-                                              </div>
-                                            </div>
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <img
-                                                alt=""
-                                                src="https://placehold.co/160"
-                                                style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
-                                              />
-                                              <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
-                                              >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
-                                                >
-                                                  Balancer
-                                                </p>
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
-                                                  >
-                                                    0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                                                      data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
+                                                      0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
                                                     >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
                                               </div>
                                             </div>
                                           </div>
@@ -4360,158 +3665,138 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                   </div>
                                 </div>
                               </div>
-                            </div>
-                            <div
-                              class="MuiBox-root mui-style-6io5aq"
-                            >
                               <div
-                                class="MuiBox-root mui-style-1f9z19n"
+                                class="MuiBox-root mui-style-6io5aq"
                               >
                                 <div
-                                  class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
+                                  class="MuiBox-root mui-style-1f9z19n"
                                 >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                                  >
-                                    All these contracts are verified.
-                                  </p>
                                   <div
-                                    class="MuiBox-root mui-style-u2tihl"
+                                    class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
                                   >
-                                    <div
-                                      aria-label="Show all"
-                                      class="MuiBox-root mui-style-1ari483"
-                                      role="button"
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
                                     >
-                                      <span
-                                        class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
-                                      >
-                                        Show all
-                                      </span>
+                                      You are interacting with 2 addresses for the first time.
+                                    </p>
+                                    <div
+                                      class="MuiBox-root mui-style-u2tihl"
+                                    >
                                       <div
-                                        class="MuiBox-root mui-style-1xmxy86"
-                                      />
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
-                                        data-testid="ExpandMoreIcon"
-                                        focusable="false"
-                                        viewBox="0 0 24 24"
+                                        aria-label="Show all"
+                                        class="MuiBox-root mui-style-1ari483"
+                                        role="button"
                                       >
-                                        <path
-                                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                        <span
+                                          class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
+                                        >
+                                          Show all
+                                        </span>
+                                        <div
+                                          class="MuiBox-root mui-style-1xmxy86"
                                         />
-                                      </svg>
-                                    </div>
-                                    <div
-                                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                                      style="min-height: 0px;"
-                                    >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
+                                          data-testid="ExpandMoreIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                          />
+                                        </svg>
+                                      </div>
                                       <div
-                                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                                        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                                        style="min-height: 0px;"
                                       >
                                         <div
-                                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                                          class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
                                         >
                                           <div
-                                            class="MuiBox-root mui-style-1821gv5"
+                                            class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
                                           >
                                             <div
-                                              class="MuiBox-root mui-style-i7v45s"
+                                              class="MuiBox-root mui-style-1821gv5"
                                             >
-                                              <img
-                                                alt=""
-                                                src="https://placehold.co/160"
-                                                style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
-                                              />
                                               <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                class="MuiBox-root mui-style-i7v45s"
                                               >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
                                                 >
-                                                  Balancer
-                                                </p>
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
                                                   >
-                                                    0x53bbddda3398c3facefe325073bc424fcb946d7a
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
                                                       data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0x53bbddda3398c3facefe325073bc424fcb946d7a"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
                                                     >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
+                                                      0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
                                               </div>
-                                            </div>
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <img
-                                                alt=""
-                                                src="https://placehold.co/160"
-                                                style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
-                                              />
                                               <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                class="MuiBox-root mui-style-i7v45s"
                                               >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
                                                 >
-                                                  Balancer
-                                                </p>
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
                                                   >
-                                                    0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
                                                       data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
                                                     >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
+                                                      0x75a4a3378eb9be1d6cd40847aa7fac5d66b99cfe
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0x75a4a3378eb9be1d6cd40847aa7fac5d66b99cfe"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
                                               </div>
                                             </div>
                                           </div>
@@ -4521,158 +3806,138 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                                   </div>
                                 </div>
                               </div>
-                            </div>
-                            <div
-                              class="MuiBox-root mui-style-6io5aq"
-                            >
                               <div
-                                class="MuiBox-root mui-style-1f9z19n"
+                                class="MuiBox-root mui-style-6io5aq"
                               >
                                 <div
-                                  class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
+                                  class="MuiBox-root mui-style-1f9z19n"
                                 >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                                  >
-                                    You have interacted with all these contracts before.
-                                  </p>
                                   <div
-                                    class="MuiBox-root mui-style-u2tihl"
+                                    class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
                                   >
-                                    <div
-                                      aria-label="Show all"
-                                      class="MuiBox-root mui-style-1ari483"
-                                      role="button"
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
                                     >
-                                      <span
-                                        class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
-                                      >
-                                        Show all
-                                      </span>
+                                      2 addresses are in your address book or a Safe you own.
+                                    </p>
+                                    <div
+                                      class="MuiBox-root mui-style-u2tihl"
+                                    >
                                       <div
-                                        class="MuiBox-root mui-style-1xmxy86"
-                                      />
-                                      <svg
-                                        aria-hidden="true"
-                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
-                                        data-testid="ExpandMoreIcon"
-                                        focusable="false"
-                                        viewBox="0 0 24 24"
+                                        aria-label="Show all"
+                                        class="MuiBox-root mui-style-1ari483"
+                                        role="button"
                                       >
-                                        <path
-                                          d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                        <span
+                                          class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
+                                        >
+                                          Show all
+                                        </span>
+                                        <div
+                                          class="MuiBox-root mui-style-1xmxy86"
                                         />
-                                      </svg>
-                                    </div>
-                                    <div
-                                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                                      style="min-height: 0px;"
-                                    >
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
+                                          data-testid="ExpandMoreIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                          />
+                                        </svg>
+                                      </div>
                                       <div
-                                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                                        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                                        style="min-height: 0px;"
                                       >
                                         <div
-                                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                                          class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
                                         >
                                           <div
-                                            class="MuiBox-root mui-style-1821gv5"
+                                            class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
                                           >
                                             <div
-                                              class="MuiBox-root mui-style-i7v45s"
+                                              class="MuiBox-root mui-style-1821gv5"
                                             >
-                                              <img
-                                                alt=""
-                                                src="https://placehold.co/160"
-                                                style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
-                                              />
                                               <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                class="MuiBox-root mui-style-i7v45s"
                                               >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
                                                 >
-                                                  Balancer
-                                                </p>
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
                                                   >
-                                                    0x53bbddda3398c3facefe325073bc424fcb946d7a
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
                                                       data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0x53bbddda3398c3facefe325073bc424fcb946d7a"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
                                                     >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
+                                                      0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0xce3d3d0e8b0a22cdfffbb275d1acb1d8f180834b"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
                                               </div>
-                                            </div>
-                                            <div
-                                              class="MuiBox-root mui-style-i7v45s"
-                                            >
-                                              <img
-                                                alt=""
-                                                src="https://placehold.co/160"
-                                                style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
-                                              />
                                               <div
-                                                class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                class="MuiBox-root mui-style-i7v45s"
                                               >
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
                                                 >
-                                                  Balancer
-                                                </p>
-                                                <p
-                                                  class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
-                                                >
-                                                  <span
-                                                    aria-label="Copy address"
-                                                    class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
-                                                    data-mui-internal-clone-element="true"
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
                                                   >
-                                                    0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2
-                                                  </span>
-                                                  <span
-                                                    class="MuiBox-root mui-style-yjghm1"
-                                                  >
-                                                    <a
-                                                      aria-label=""
-                                                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
                                                       data-mui-internal-clone-element="true"
-                                                      data-testid="explorer-btn"
-                                                      href="https://etherscan.io/address/0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2"
-                                                      rel="noreferrer"
-                                                      tabindex="0"
-                                                      target="_blank"
                                                     >
-                                                      <mock-icon
-                                                        aria-hidden=""
-                                                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                                                        focusable="false"
-                                                      />
-                                                    </a>
-                                                  </span>
-                                                </p>
+                                                      0x9648b1e4ad3eecbae513afb45e7ea8b2918e91ff
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0x9648b1e4ad3eecbae513afb45e7ea8b2918e91ff"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
                                               </div>
                                             </div>
                                           </div>
@@ -4688,90 +3953,829 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
                       </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  class="MuiBox-root mui-style-l9pt9e"
-                  data-testid="threat-analysis-group-card"
-                >
                   <div
-                    class="MuiStack-root mui-style-es2900-MuiStack-root"
+                    class="MuiBox-root mui-style-7yf5bk"
+                    data-testid="contract-analysis-group-card"
                   >
                     <div
-                      class="MuiStack-root mui-style-1rlitzi-MuiStack-root"
-                    >
-                      <mock-icon
-                        aria-hidden=""
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-zluq22-MuiSvgIcon-root"
-                        focusable="false"
-                      />
-                      <p
-                        class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                      >
-                        Moderate threat detected
-                      </p>
-                    </div>
-                    <button
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1fkg3qi-MuiButtonBase-root-MuiIconButton-root"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-118obxm-MuiSvgIcon-root"
-                        data-testid="KeyboardArrowDownIcon"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                  <div
-                    class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
-                    style="min-height: 0px;"
-                  >
-                    <div
-                      class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                      class="MuiStack-root mui-style-es2900-MuiStack-root"
                     >
                       <div
-                        class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                        class="MuiStack-root mui-style-1rlitzi-MuiStack-root"
+                      >
+                        <mock-icon
+                          aria-hidden=""
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-zluq22-MuiSvgIcon-root"
+                          focusable="false"
+                        />
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+                        >
+                          Unofficial fallback handler
+                        </p>
+                      </div>
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1fkg3qi-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-118obxm-MuiSvgIcon-root"
+                          data-testid="KeyboardArrowDownIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                      style="min-height: 0px;"
+                    >
+                      <div
+                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
                       >
                         <div
-                          class="MuiBox-root mui-style-v1dotw"
+                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
                         >
                           <div
-                            class="MuiStack-root mui-style-hwnj0i-MuiStack-root"
+                            class="MuiBox-root mui-style-v1dotw"
                           >
                             <div
-                              class="MuiBox-root mui-style-6io5aq"
+                              class="MuiStack-root mui-style-hwnj0i-MuiStack-root"
                             >
                               <div
-                                class="MuiBox-root mui-style-1f9z19n"
+                                class="MuiBox-root mui-style-6io5aq"
                               >
                                 <div
-                                  class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
+                                  class="MuiBox-root mui-style-jgusbz"
                                 >
-                                  <p
-                                    class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-                                  >
-                                    The transaction {reason_phrase} {classification_phrase}. Cancel this transaction.
-                                  </p>
                                   <div
-                                    class="MuiBox-root mui-style-1821gv5"
+                                    class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
                                   >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+                                    >
+                                      Verify the 
+                                      <a
+                                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways mui-style-ioipc8-MuiTypography-root-MuiLink-root"
+                                        href="https://help.safe.global/en/articles/40838-what-is-a-fallback-handler-and-how-does-it-relate-to-safe"
+                                        rel="noreferrer noopener"
+                                        target="_blank"
+                                      >
+                                        <span
+                                          class="MuiBox-root mui-style-u9xrjn"
+                                        >
+                                          fallback handler
+                                          <svg
+                                            aria-hidden="true"
+                                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall external-link-icon mui-style-tqxw8e-MuiSvgIcon-root"
+                                            data-testid="OpenInNewRoundedIcon"
+                                            focusable="false"
+                                            viewBox="0 0 24 24"
+                                          >
+                                            <path
+                                              d="M18 19H6c-.55 0-1-.45-1-1V6c0-.55.45-1 1-1h5c.55 0 1-.45 1-1s-.45-1-1-1H5c-1.11 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-6c0-.55-.45-1-1-1s-1 .45-1 1v5c0 .55-.45 1-1 1M14 4c0 .55.45 1 1 1h2.59l-9.13 9.13c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0L19 6.41V9c0 .55.45 1 1 1s1-.45 1-1V4c0-.55-.45-1-1-1h-5c-.55 0-1 .45-1 1"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </a>
+                                       is trusted and secure before proceeding.
+                                    </p>
                                     <div
-                                      class="MuiBox-root mui-style-1ygviyr"
+                                      class="MuiBox-root mui-style-u2tihl"
                                     >
                                       <div
-                                        class="MuiBox-root mui-style-jnhdwv"
+                                        aria-label="Show all"
+                                        class="MuiBox-root mui-style-1ari483"
+                                        role="button"
                                       >
-                                        <p
-                                          class="MuiTypography-root MuiTypography-body2 mui-style-1lbkc8c-MuiTypography-root"
+                                        <span
+                                          class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
                                         >
-                                          Bulleted list from validation.features, grouped by Malicious first, then Warnings.
-                                        </p>
+                                          Show all
+                                        </span>
+                                        <div
+                                          class="MuiBox-root mui-style-1xmxy86"
+                                        />
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
+                                          data-testid="ExpandMoreIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                          />
+                                        </svg>
+                                      </div>
+                                      <div
+                                        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                                        style="min-height: 0px;"
+                                      >
+                                        <div
+                                          class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                                        >
+                                          <div
+                                            class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                                          >
+                                            <div
+                                              class="MuiBox-root mui-style-1821gv5"
+                                            >
+                                              <div
+                                                class="MuiBox-root mui-style-i7v45s"
+                                              >
+                                                <div
+                                                  class="MuiAvatar-root MuiAvatar-circular mui-style-asrpj2-MuiAvatar-root"
+                                                  style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
+                                                >
+                                                  <img
+                                                    class="MuiAvatar-img mui-style-1su80sj-MuiAvatar-img"
+                                                    src="/images/transactions/custom.svg"
+                                                  />
+                                                </div>
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                >
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
+                                                  >
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
+                                                      data-mui-internal-clone-element="true"
+                                                    >
+                                                      0xfafa1beaddbcd913f4de0ed3557a1f3d026de0a6
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0xfafa1beaddbcd913f4de0ed3557a1f3d026de0a6"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
+                                              </div>
+                                              <div
+                                                class="MuiBox-root mui-style-i7v45s"
+                                              >
+                                                <div
+                                                  class="MuiAvatar-root MuiAvatar-circular mui-style-asrpj2-MuiAvatar-root"
+                                                  style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
+                                                >
+                                                  <img
+                                                    class="MuiAvatar-img mui-style-1su80sj-MuiAvatar-img"
+                                                    src="/images/transactions/custom.svg"
+                                                  />
+                                                </div>
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                >
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
+                                                  >
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
+                                                      data-mui-internal-clone-element="true"
+                                                    >
+                                                      0xfafa1beaddbcd913f4de0ed3557a1f3d026de0a6
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0xfafa1beaddbcd913f4de0ed3557a1f3d026de0a6"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="MuiBox-root mui-style-6io5aq"
+                              >
+                                <div
+                                  class="MuiBox-root mui-style-1f9z19n"
+                                >
+                                  <div
+                                    class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+                                    >
+                                      This transaction calls a smart contract that will be able to modify your Safe account. 
+                                      <a
+                                        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways mui-style-r9pq5a-MuiTypography-root-MuiLink-root"
+                                        href="https://help.safe.global/en/articles/40794-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction"
+                                        rel="noreferrer noopener"
+                                        target="_blank"
+                                      >
+                                        <span
+                                          class="MuiBox-root mui-style-u9xrjn"
+                                        >
+                                          Learn more
+                                        </span>
+                                      </a>
+                                    </p>
+                                    <div
+                                      class="MuiBox-root mui-style-u2tihl"
+                                    >
+                                      <div
+                                        aria-label="Show all"
+                                        class="MuiBox-root mui-style-1ari483"
+                                        role="button"
+                                      >
+                                        <span
+                                          class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
+                                        >
+                                          Show all
+                                        </span>
+                                        <div
+                                          class="MuiBox-root mui-style-1xmxy86"
+                                        />
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
+                                          data-testid="ExpandMoreIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                          />
+                                        </svg>
+                                      </div>
+                                      <div
+                                        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                                        style="min-height: 0px;"
+                                      >
+                                        <div
+                                          class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                                        >
+                                          <div
+                                            class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                                          >
+                                            <div
+                                              class="MuiBox-root mui-style-1821gv5"
+                                            >
+                                              <div
+                                                class="MuiBox-root mui-style-i7v45s"
+                                              >
+                                                <img
+                                                  alt=""
+                                                  src="https://placehold.co/160"
+                                                  style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
+                                                />
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                >
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                  >
+                                                    Balancer
+                                                  </p>
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
+                                                  >
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
+                                                      data-mui-internal-clone-element="true"
+                                                    >
+                                                      0x53bbddda3398c3facefe325073bc424fcb946d7a
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0x53bbddda3398c3facefe325073bc424fcb946d7a"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
+                                              </div>
+                                              <div
+                                                class="MuiBox-root mui-style-i7v45s"
+                                              >
+                                                <img
+                                                  alt=""
+                                                  src="https://placehold.co/160"
+                                                  style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
+                                                />
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                >
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                  >
+                                                    Balancer
+                                                  </p>
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
+                                                  >
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
+                                                      data-mui-internal-clone-element="true"
+                                                    >
+                                                      0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="MuiBox-root mui-style-6io5aq"
+                              >
+                                <div
+                                  class="MuiBox-root mui-style-1f9z19n"
+                                >
+                                  <div
+                                    class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+                                    >
+                                      All these contracts are verified.
+                                    </p>
+                                    <div
+                                      class="MuiBox-root mui-style-u2tihl"
+                                    >
+                                      <div
+                                        aria-label="Show all"
+                                        class="MuiBox-root mui-style-1ari483"
+                                        role="button"
+                                      >
+                                        <span
+                                          class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
+                                        >
+                                          Show all
+                                        </span>
+                                        <div
+                                          class="MuiBox-root mui-style-1xmxy86"
+                                        />
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
+                                          data-testid="ExpandMoreIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                          />
+                                        </svg>
+                                      </div>
+                                      <div
+                                        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                                        style="min-height: 0px;"
+                                      >
+                                        <div
+                                          class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                                        >
+                                          <div
+                                            class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                                          >
+                                            <div
+                                              class="MuiBox-root mui-style-1821gv5"
+                                            >
+                                              <div
+                                                class="MuiBox-root mui-style-i7v45s"
+                                              >
+                                                <img
+                                                  alt=""
+                                                  src="https://placehold.co/160"
+                                                  style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
+                                                />
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                >
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                  >
+                                                    Balancer
+                                                  </p>
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
+                                                  >
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
+                                                      data-mui-internal-clone-element="true"
+                                                    >
+                                                      0x53bbddda3398c3facefe325073bc424fcb946d7a
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0x53bbddda3398c3facefe325073bc424fcb946d7a"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
+                                              </div>
+                                              <div
+                                                class="MuiBox-root mui-style-i7v45s"
+                                              >
+                                                <img
+                                                  alt=""
+                                                  src="https://placehold.co/160"
+                                                  style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
+                                                />
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                >
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                  >
+                                                    Balancer
+                                                  </p>
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
+                                                  >
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
+                                                      data-mui-internal-clone-element="true"
+                                                    >
+                                                      0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                              <div
+                                class="MuiBox-root mui-style-6io5aq"
+                              >
+                                <div
+                                  class="MuiBox-root mui-style-1f9z19n"
+                                >
+                                  <div
+                                    class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+                                    >
+                                      You have interacted with all these contracts before.
+                                    </p>
+                                    <div
+                                      class="MuiBox-root mui-style-u2tihl"
+                                    >
+                                      <div
+                                        aria-label="Show all"
+                                        class="MuiBox-root mui-style-1ari483"
+                                        role="button"
+                                      >
+                                        <span
+                                          class="MuiTypography-root MuiTypography-body2 mui-style-1kookhh-MuiTypography-root"
+                                        >
+                                          Show all
+                                        </span>
+                                        <div
+                                          class="MuiBox-root mui-style-1xmxy86"
+                                        />
+                                        <svg
+                                          aria-hidden="true"
+                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-1e55ibv-MuiSvgIcon-root"
+                                          data-testid="ExpandMoreIcon"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                                          />
+                                        </svg>
+                                      </div>
+                                      <div
+                                        class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                                        style="min-height: 0px;"
+                                      >
+                                        <div
+                                          class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                                        >
+                                          <div
+                                            class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                                          >
+                                            <div
+                                              class="MuiBox-root mui-style-1821gv5"
+                                            >
+                                              <div
+                                                class="MuiBox-root mui-style-i7v45s"
+                                              >
+                                                <img
+                                                  alt=""
+                                                  src="https://placehold.co/160"
+                                                  style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
+                                                />
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                >
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                  >
+                                                    Balancer
+                                                  </p>
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
+                                                  >
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
+                                                      data-mui-internal-clone-element="true"
+                                                    >
+                                                      0x53bbddda3398c3facefe325073bc424fcb946d7a
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0x53bbddda3398c3facefe325073bc424fcb946d7a"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
+                                              </div>
+                                              <div
+                                                class="MuiBox-root mui-style-i7v45s"
+                                              >
+                                                <img
+                                                  alt=""
+                                                  src="https://placehold.co/160"
+                                                  style="border-radius: 50%; padding-top: 2px; width: 16px; height: 16px;"
+                                                />
+                                                <div
+                                                  class="MuiStack-root mui-style-j3ygch-MuiStack-root"
+                                                >
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-6jietn-MuiTypography-root"
+                                                  >
+                                                    Balancer
+                                                  </p>
+                                                  <p
+                                                    class="MuiTypography-root MuiTypography-body2 mui-style-vt8sx8-MuiTypography-root"
+                                                  >
+                                                    <span
+                                                      aria-label="Copy address"
+                                                      class="MuiTypography-root MuiTypography-body2 mui-style-5w23lj-MuiTypography-root"
+                                                      data-mui-internal-clone-element="true"
+                                                    >
+                                                      0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2
+                                                    </span>
+                                                    <span
+                                                      class="MuiBox-root mui-style-yjghm1"
+                                                    >
+                                                      <a
+                                                        aria-label=""
+                                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                                                        data-mui-internal-clone-element="true"
+                                                        data-testid="explorer-btn"
+                                                        href="https://etherscan.io/address/0xcf00af6ed21dbbd45c8f46ca1c9be8f6ebb0a4a2"
+                                                        rel="noreferrer"
+                                                        tabindex="0"
+                                                        target="_blank"
+                                                      >
+                                                        <mock-icon
+                                                          aria-hidden=""
+                                                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                                                          focusable="false"
+                                                        />
+                                                      </a>
+                                                    </span>
+                                                  </p>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiBox-root mui-style-l9pt9e"
+                    data-testid="threat-analysis-group-card"
+                  >
+                    <div
+                      class="MuiStack-root mui-style-es2900-MuiStack-root"
+                    >
+                      <div
+                        class="MuiStack-root mui-style-1rlitzi-MuiStack-root"
+                      >
+                        <mock-icon
+                          aria-hidden=""
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-zluq22-MuiSvgIcon-root"
+                          focusable="false"
+                        />
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+                        >
+                          Moderate threat detected
+                        </p>
+                      </div>
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1fkg3qi-MuiButtonBase-root-MuiIconButton-root"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-118obxm-MuiSvgIcon-root"
+                          data-testid="KeyboardArrowDownIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M7.41 8.59 12 13.17l4.59-4.58L18 10l-6 6-6-6z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <div
+                      class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden mui-style-cwrbtg-MuiCollapse-root"
+                      style="min-height: 0px;"
+                    >
+                      <div
+                        class="MuiCollapse-wrapper MuiCollapse-vertical mui-style-1x6hinx-MuiCollapse-wrapper"
+                      >
+                        <div
+                          class="MuiCollapse-wrapperInner MuiCollapse-vertical mui-style-1i4ywhz-MuiCollapse-wrapperInner"
+                        >
+                          <div
+                            class="MuiBox-root mui-style-v1dotw"
+                          >
+                            <div
+                              class="MuiStack-root mui-style-hwnj0i-MuiStack-root"
+                            >
+                              <div
+                                class="MuiBox-root mui-style-6io5aq"
+                              >
+                                <div
+                                  class="MuiBox-root mui-style-1f9z19n"
+                                >
+                                  <div
+                                    class="MuiStack-root mui-style-1ucnu3w-MuiStack-root"
+                                  >
+                                    <p
+                                      class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+                                    >
+                                      The transaction {reason_phrase} {classification_phrase}. Cancel this transaction.
+                                    </p>
+                                    <div
+                                      class="MuiBox-root mui-style-1821gv5"
+                                    >
+                                      <div
+                                        class="MuiBox-root mui-style-1ygviyr"
+                                      >
+                                        <div
+                                          class="MuiBox-root mui-style-jnhdwv"
+                                        >
+                                          <p
+                                            class="MuiTypography-root MuiTypography-body2 mui-style-1lbkc8c-MuiTypography-root"
+                                          >
+                                            Bulleted list from validation.features, grouped by Malicious first, then Warnings.
+                                          </p>
+                                        </div>
                                       </div>
                                     </div>
                                   </div>
@@ -4787,26 +4791,26 @@ exports[`./SafeShield.stories MultipleCounterparties 1`] = `
               </div>
             </div>
           </div>
-        </div>
-        <div
-          class="MuiStack-root mui-style-10778a5-MuiStack-root"
-        >
-          <a
-            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways mui-style-r9pq5a-MuiTypography-root-MuiLink-root"
-            href="https://help.safe.global/en/articles/461021-understanding-safe-shield-transaction-checks"
-            rel="noreferrer noopener"
-            target="_blank"
+          <div
+            class="MuiStack-root mui-style-10778a5-MuiStack-root"
           >
-            <span
-              class="MuiBox-root mui-style-u9xrjn"
+            <a
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways mui-style-r9pq5a-MuiTypography-root-MuiLink-root"
+              href="https://help.safe.global/en/articles/461021-understanding-safe-shield-transaction-checks"
+              rel="noreferrer noopener"
+              target="_blank"
             >
-              <mock-icon
-                aria-hidden=""
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-6s60fs-MuiSvgIcon-root"
-                focusable="false"
-              />
-            </span>
-          </a>
+              <span
+                class="MuiBox-root mui-style-u9xrjn"
+              >
+                <mock-icon
+                  aria-hidden=""
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium mui-style-6s60fs-MuiSvgIcon-root"
+                  focusable="false"
+                />
+              </span>
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/features/swap/components/SwapOrderConfirmationView/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/features/swap/components/SwapOrderConfirmationView/__snapshots__/index.stories.test.tsx.snap
@@ -2,43 +2,46 @@
 
 exports[`./index.stories CustomRecipient 1`] = `
 <div
-  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+  class="shadcn-scope"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
-    style="--Paper-shadow: none;"
+    style="background-color: rgb(255, 255, 255); padding: 1rem;"
   >
     <div
-      class="MuiStack-root mui-style-1qh2y1i-MuiStack-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
+      style="--Paper-shadow: none;"
     >
-      <p
-        class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
-      >
-        <b>
-          Order details
-        </b>
-      </p>
       <div
-        class="amount"
+        class="MuiStack-root mui-style-1qh2y1i-MuiStack-root"
       >
+        <p
+          class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+        >
+          <b>
+            Order details
+          </b>
+        </p>
         <div
-          class="MuiStack-root mui-style-niqf4j-MuiStack-root"
+          class="amount"
         >
           <div
-            class="MuiStack-root mui-style-p24gtu-MuiStack-root"
+            class="MuiStack-root mui-style-niqf4j-MuiStack-root"
           >
             <div
-              class="MuiBox-root mui-style-wvnvdm"
+              class="MuiStack-root mui-style-p24gtu-MuiStack-root"
             >
               <div
-                class="MuiBox-root mui-style-olq4e8"
+                class="MuiBox-root mui-style-wvnvdm"
               >
-                <iframe
-                  height="40"
-                  loading="lazy"
-                  referrerpolicy="strict-origin"
-                  sandbox="allow-scripts"
-                  srcdoc="
+                <div
+                  class="MuiBox-root mui-style-olq4e8"
+                >
+                  <iframe
+                    height="40"
+                    loading="lazy"
+                    referrerpolicy="strict-origin"
+                    sandbox="allow-scripts"
+                    srcdoc="
     <body style="margin: 0; overflow: hidden; display: flex; align-items: center; justify-content: center;">
       <img src="https://safe-transaction-assets.staging.5afe.dev/tokens/logos/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.png" alt="Safe App logo" height="40" width="auto" style="border-radius: 100%;" />
       <script>
@@ -49,71 +52,71 @@ exports[`./index.stories CustomRecipient 1`] = `
       </script>
     </body>
   "
-                  style="pointer-events: none; border: 0px; display: block;"
-                  tabindex="-1"
-                  title="USDC"
-                  width="40"
-                />
+                    style="pointer-events: none; border: 0px; display: block;"
+                    tabindex="-1"
+                    title="USDC"
+                    width="40"
+                  />
+                </div>
               </div>
-            </div>
-            <div
-              class="MuiBox-root mui-style-1rr4qq7"
-              data-testid="block-label"
-            >
-              <p
-                class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-              >
-                Sell
-              </p>
               <div
-                class="MuiTypography-root MuiTypography-h4 mui-style-csh7nj-MuiTypography-root"
+                class="MuiBox-root mui-style-1rr4qq7"
+                data-testid="block-label"
               >
-                <span
-                  aria-label="10 USDC"
-                  class="container"
-                  data-mui-internal-clone-element="true"
+                <p
+                  class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
                 >
-                  <b
-                    class="tokenText"
+                  Sell
+                </p>
+                <div
+                  class="MuiTypography-root MuiTypography-h4 mui-style-csh7nj-MuiTypography-root"
+                >
+                  <span
+                    aria-label="10 USDC"
+                    class="container"
+                    data-mui-internal-clone-element="true"
                   >
-                    10
-                     
-                    USDC
-                  </b>
-                </span>
+                    <b
+                      class="tokenText"
+                    >
+                      10
+                       
+                      USDC
+                    </b>
+                  </span>
+                </div>
+              </div>
+              <div
+                class="MuiStack-root mui-style-1nxlmhd-MuiStack-root"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-15tzxj8-MuiSvgIcon-root-MuiSvgIcon-root"
+                  data-testid="EastRoundedIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M14.29 5.71c-.39.39-.39 1.02 0 1.41L18.17 11H3c-.55 0-1 .45-1 1s.45 1 1 1h15.18l-3.88 3.88c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0l5.59-5.59c.39-.39.39-1.02 0-1.41l-5.6-5.58c-.38-.39-1.02-.39-1.41 0"
+                  />
+                </svg>
               </div>
             </div>
             <div
-              class="MuiStack-root mui-style-1nxlmhd-MuiStack-root"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-15tzxj8-MuiSvgIcon-root-MuiSvgIcon-root"
-                data-testid="EastRoundedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M14.29 5.71c-.39.39-.39 1.02 0 1.41L18.17 11H3c-.55 0-1 .45-1 1s.45 1 1 1h15.18l-3.88 3.88c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0l5.59-5.59c.39-.39.39-1.02 0-1.41l-5.6-5.58c-.38-.39-1.02-.39-1.41 0"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            class="MuiStack-root mui-style-p24gtu-MuiStack-root"
-          >
-            <div
-              class="MuiBox-root mui-style-wvnvdm"
+              class="MuiStack-root mui-style-p24gtu-MuiStack-root"
             >
               <div
-                class="MuiBox-root mui-style-olq4e8"
+                class="MuiBox-root mui-style-wvnvdm"
               >
-                <iframe
-                  height="40"
-                  loading="lazy"
-                  referrerpolicy="strict-origin"
-                  sandbox="allow-scripts"
-                  srcdoc="
+                <div
+                  class="MuiBox-root mui-style-olq4e8"
+                >
+                  <iframe
+                    height="40"
+                    loading="lazy"
+                    referrerpolicy="strict-origin"
+                    sandbox="allow-scripts"
+                    srcdoc="
     <body style="margin: 0; overflow: hidden; display: flex; align-items: center; justify-content: center;">
       <img src="https://safe-transaction-assets.staging.5afe.dev/tokens/logos/0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14.png" alt="Safe App logo" height="40" width="auto" style="border-radius: 100%;" />
       <script>
@@ -124,404 +127,405 @@ exports[`./index.stories CustomRecipient 1`] = `
       </script>
     </body>
   "
-                  style="pointer-events: none; border: 0px; display: block;"
-                  tabindex="-1"
-                  title="NPR"
-                  width="40"
-                />
+                    style="pointer-events: none; border: 0px; display: block;"
+                    tabindex="-1"
+                    title="NPR"
+                    width="40"
+                  />
+                </div>
               </div>
-            </div>
-            <div
-              class="MuiBox-root mui-style-1rr4qq7"
-              data-testid="block-label"
-            >
-              <p
-                class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-              >
-                For at least
-              </p>
               <div
-                class="MuiTypography-root MuiTypography-h4 mui-style-csh7nj-MuiTypography-root"
+                class="MuiBox-root mui-style-1rr4qq7"
+                data-testid="block-label"
               >
-                <span
-                  aria-label="0 NPR"
-                  class="container"
-                  data-mui-internal-clone-element="true"
+                <p
+                  class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
                 >
-                  <b
-                    class="tokenText"
+                  For at least
+                </p>
+                <div
+                  class="MuiTypography-root MuiTypography-h4 mui-style-csh7nj-MuiTypography-root"
+                >
+                  <span
+                    aria-label="0 NPR"
+                    class="container"
+                    data-mui-internal-clone-element="true"
                   >
-                    0
-                     
-                    NPR
-                  </b>
-                </span>
+                    <b
+                      class="tokenText"
+                    >
+                      0
+                       
+                      NPR
+                    </b>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid="limit-price"
-      >
         <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Limit price
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid="limit-price"
         >
           <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
           >
-            1 
-            NPR
-             = 
-            0
-             
-            USDC
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Limit price
+            </span>
           </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid=""
-      >
-        <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Expiry
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
-        >
           <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
-          >
-            Dec 24, 2024 - 12:54:40 AM
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid="order-id"
-      >
-        <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Order ID
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
-        >
-          <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
           >
             <div
-              class="MuiStack-root mui-style-m69qwo-MuiStack-root"
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
             >
-              <span>
-                170e4a48
-              </span>
+              1 
+              NPR
+               = 
+              0
+               
+              USDC
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid=""
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Expiry
+            </span>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
+          >
+            <div
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            >
+              Dec 24, 2024 - 12:54:40 AM
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid="order-id"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Order ID
+            </span>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
+          >
+            <div
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            >
+              <div
+                class="MuiStack-root mui-style-m69qwo-MuiStack-root"
+              >
+                <span>
+                  170e4a48
+                </span>
+                <span
+                  aria-label="Copy to clipboard"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                  style="cursor: pointer;"
+                >
+                  <button
+                    aria-label="Copy to clipboard"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <mock-icon
+                      aria-hidden=""
+                      class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-gvpe62-MuiSvgIcon-root"
+                      data-testid="copy-btn-icon"
+                      focusable="false"
+                    />
+                  </button>
+                </span>
+                <div
+                  class="MuiBox-root mui-style-yjghm1"
+                >
+                  <a
+                    aria-label=""
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    data-testid="explorer-btn"
+                    href="https://explorer.cow.fi/orders/0x03a5d561ad2452d719a0d075573f4bed68217c696b52f151122c30e3e4426f1b05e6b5eb1d0e6aabab082057d5bb91f2ee6d11be66223d88"
+                    rel="noreferrer"
+                    tabindex="0"
+                    target="_blank"
+                  >
+                    <mock-icon
+                      aria-hidden=""
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                      focusable="false"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid="widget-fee"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Widget fee
+               
               <span
-                aria-label="Copy to clipboard"
                 class=""
                 data-mui-internal-clone-element="true"
-                style="cursor: pointer;"
               >
-                <button
-                  aria-label="Copy to clipboard"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                  tabindex="0"
-                  type="button"
-                >
-                  <mock-icon
-                    aria-hidden=""
-                    class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-gvpe62-MuiSvgIcon-root"
-                    data-testid="copy-btn-icon"
-                    focusable="false"
-                  />
-                </button>
+                <mock-icon
+                  aria-hidden=""
+                  class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-1nezs5b-MuiSvgIcon-root"
+                  focusable="false"
+                />
               </span>
-              <div
-                class="MuiBox-root mui-style-yjghm1"
-              >
-                <a
-                  aria-label=""
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  data-testid="explorer-btn"
-                  href="https://explorer.cow.fi/orders/0x03a5d561ad2452d719a0d075573f4bed68217c696b52f151122c30e3e4426f1b05e6b5eb1d0e6aabab082057d5bb91f2ee6d11be66223d88"
-                  rel="noreferrer"
-                  tabindex="0"
-                  target="_blank"
-                >
-                  <mock-icon
-                    aria-hidden=""
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                    focusable="false"
-                  />
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid="widget-fee"
-      >
-        <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Widget fee
-             
-            <span
-              class=""
-              data-mui-internal-clone-element="true"
-            >
-              <mock-icon
-                aria-hidden=""
-                class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-1nezs5b-MuiSvgIcon-root"
-                focusable="false"
-              />
             </span>
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
-        >
-          <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
-          >
-            0.5
-             %
           </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid="interact-wth"
-      >
-        <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Interact with
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
-        >
           <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
           >
             <div
-              class="container"
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            >
+              0.5
+               %
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid="interact-wth"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Interact with
+            </span>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
+          >
+            <div
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
             >
               <div
-                class="avatarContainer"
-                style="width: 24px; height: 24px;"
+                class="container"
               >
                 <div
-                  class="icon"
-                  style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjUwIDg5JSA3NSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNDggNjglIDMxJSkiIGQ9Ik0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0yLDFoMXYxaC0xek01LDFoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0wLDJoMXYxaC0xek03LDJoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0xLDRoMXYxaC0xek02LDRoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xek0zLDZoMXYxaC0xek00LDZoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCg3NiA2OSUgNjclKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6Ii8+PC9zdmc+); width: 24px; height: 24px;"
-                />
-              </div>
-              <div
-                class="inline MuiBox-root mui-style-1lchl8k"
-              >
-                <div
-                  class="addressContainer inline"
+                  class="avatarContainer"
+                  style="width: 24px; height: 24px;"
                 >
                   <div
-                    class="MuiBox-root mui-style-b5p5gz"
-                  >
-                    <span
-                      aria-label="Copy to clipboard"
-                      class=""
-                      data-mui-internal-clone-element="true"
-                      style="cursor: pointer;"
-                    >
-                      <b>
-                        rin
-                        :
-                      </b>
-                      <span>
-                        0x9008D19f58AAbD9eD0D60971565AA8510560ab41
-                      </span>
-                    </span>
-                  </div>
+                    class="icon"
+                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjUwIDg5JSA3NSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNDggNjglIDMxJSkiIGQ9Ik0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0yLDFoMXYxaC0xek01LDFoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0wLDJoMXYxaC0xek03LDJoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0xLDRoMXYxaC0xek02LDRoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xek0zLDZoMXYxaC0xek00LDZoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCg3NiA2OSUgNjclKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6Ii8+PC9zdmc+); width: 24px; height: 24px;"
+                  />
+                </div>
+                <div
+                  class="inline MuiBox-root mui-style-1lchl8k"
+                >
                   <div
-                    class="MuiBox-root mui-style-yjghm1"
+                    class="addressContainer inline"
                   >
-                    <a
-                      aria-label="View on rinkeby.etherscan.io"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                      data-mui-internal-clone-element="true"
-                      data-testid="explorer-btn"
-                      href="https://rinkeby.etherscan.io/address/0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
-                      rel="noreferrer"
-                      tabindex="0"
-                      target="_blank"
+                    <div
+                      class="MuiBox-root mui-style-b5p5gz"
                     >
-                      <mock-icon
-                        aria-hidden=""
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                        focusable="false"
-                      />
-                    </a>
+                      <span
+                        aria-label="Copy to clipboard"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                        style="cursor: pointer;"
+                      >
+                        <b>
+                          rin
+                          :
+                        </b>
+                        <span>
+                          0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="MuiBox-root mui-style-yjghm1"
+                    >
+                      <a
+                        aria-label="View on rinkeby.etherscan.io"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        data-testid="explorer-btn"
+                        href="https://rinkeby.etherscan.io/address/0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
+                        rel="noreferrer"
+                        tabindex="0"
+                        target="_blank"
+                      >
+                        <mock-icon
+                          aria-hidden=""
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                          focusable="false"
+                        />
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid="recipient"
-      >
         <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Recipient
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid="recipient"
         >
           <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Recipient
+            </span>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
           >
             <div
-              class="container"
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
             >
               <div
-                class="avatarContainer"
-                style="width: 24px; height: 24px;"
+                class="container"
               >
                 <div
-                  class="icon"
-                  style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMTc0IDcwJSA2MCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgyNSA4MSUgNDAlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsM2gxdjFoLTF6TTUsM2gxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTAsNmgxdjFoLTF6TTcsNmgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDIwOSA5MCUgMjclKSIgZD0iTTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsN2gxdjFoLTF6TTYsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 24px; height: 24px;"
-                />
-              </div>
-              <div
-                class="MuiBox-root mui-style-1lchl8k"
-              >
-                <div
-                  class="addressContainer"
+                  class="avatarContainer"
+                  style="width: 24px; height: 24px;"
                 >
                   <div
-                    class="MuiBox-root mui-style-b5p5gz"
-                  >
-                    <span
-                      aria-label="Copy to clipboard"
-                      class=""
-                      data-mui-internal-clone-element="true"
-                      style="cursor: pointer;"
-                    >
-                      <b>
-                        rin
-                        :
-                      </b>
-                      <span>
-                        0x1234...7890
-                      </span>
-                    </span>
-                  </div>
+                    class="icon"
+                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMTc0IDcwJSA2MCUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgyNSA4MSUgNDAlKSIgZD0iTTAsMGgxdjFoLTF6TTcsMGgxdjFoLTF6TTAsMWgxdjFoLTF6TTcsMWgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTMsMWgxdjFoLTF6TTQsMWgxdjFoLTF6TTMsMmgxdjFoLTF6TTQsMmgxdjFoLTF6TTAsM2gxdjFoLTF6TTcsM2gxdjFoLTF6TTIsM2gxdjFoLTF6TTUsM2gxdjFoLTF6TTMsM2gxdjFoLTF6TTQsM2gxdjFoLTF6TTIsNGgxdjFoLTF6TTUsNGgxdjFoLTF6TTMsNGgxdjFoLTF6TTQsNGgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6TTAsNmgxdjFoLTF6TTcsNmgxdjFoLTF6TTEsNmgxdjFoLTF6TTYsNmgxdjFoLTF6TTMsNmgxdjFoLTF6TTQsNmgxdjFoLTF6TTMsN2gxdjFoLTF6TTQsN2gxdjFoLTF6Ii8+PHBhdGggZmlsbD0iaHNsKDIwOSA5MCUgMjclKSIgZD0iTTEsMmgxdjFoLTF6TTYsMmgxdjFoLTF6TTIsMmgxdjFoLTF6TTUsMmgxdjFoLTF6TTEsM2gxdjFoLTF6TTYsM2gxdjFoLTF6TTAsNGgxdjFoLTF6TTcsNGgxdjFoLTF6TTEsN2gxdjFoLTF6TTYsN2gxdjFoLTF6Ii8+PC9zdmc+); width: 24px; height: 24px;"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root mui-style-1lchl8k"
+                >
                   <div
-                    class="MuiBox-root mui-style-yjghm1"
+                    class="addressContainer"
                   >
-                    <a
-                      aria-label="View on rinkeby.etherscan.io"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                      data-mui-internal-clone-element="true"
-                      data-testid="explorer-btn"
-                      href="https://rinkeby.etherscan.io/address/0x1234567890123456789012345678901234567890"
-                      rel="noreferrer"
-                      tabindex="0"
-                      target="_blank"
+                    <div
+                      class="MuiBox-root mui-style-b5p5gz"
                     >
-                      <mock-icon
-                        aria-hidden=""
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                        focusable="false"
-                      />
-                    </a>
+                      <span
+                        aria-label="Copy to clipboard"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                        style="cursor: pointer;"
+                      >
+                        <b>
+                          rin
+                          :
+                        </b>
+                        <span>
+                          0x1234...7890
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="MuiBox-root mui-style-yjghm1"
+                    >
+                      <a
+                        aria-label="View on rinkeby.etherscan.io"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        data-testid="explorer-btn"
+                        href="https://rinkeby.etherscan.io/address/0x1234567890123456789012345678901234567890"
+                        rel="noreferrer"
+                        tabindex="0"
+                        target="_blank"
+                      >
+                        <mock-icon
+                          aria-hidden=""
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                          focusable="false"
+                        />
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div>
-        <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard mui-style-1wi6bbj-MuiPaper-root-MuiAlert-root"
-          data-testid="recipient-alert"
-          role="alert"
-          style="--Paper-shadow: none;"
-        >
+        <div>
           <div
-            class="MuiAlert-icon mui-style-vab54s-MuiAlert-icon"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAlert-root MuiAlert-colorWarning MuiAlert-standardWarning MuiAlert-standard mui-style-1wi6bbj-MuiPaper-root-MuiAlert-root"
+            data-testid="recipient-alert"
+            role="alert"
+            style="--Paper-shadow: none;"
           >
-            mock-icon
-          </div>
-          <div
-            class="MuiAlert-message mui-style-zioonp-MuiAlert-message"
-          >
-            <p
-              class="MuiTypography-root MuiTypography-body2 mui-style-17vdyq3-MuiTypography-root"
+            <div
+              class="MuiAlert-icon mui-style-vab54s-MuiAlert-icon"
             >
-              <span
-                class="MuiTypography-root MuiTypography-body1 mui-style-w5uidf-MuiTypography-root"
+              mock-icon
+            </div>
+            <div
+              class="MuiAlert-message mui-style-zioonp-MuiAlert-message"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body2 mui-style-17vdyq3-MuiTypography-root"
               >
-                Order recipient address differs from order owner.
-              </span>
-               
-              Double check the address to prevent fund loss.
-            </p>
+                <span
+                  class="MuiTypography-root MuiTypography-body1 mui-style-w5uidf-MuiTypography-root"
+                >
+                  Order recipient address differs from order owner.
+                </span>
+                 
+                Double check the address to prevent fund loss.
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -532,43 +536,46 @@ exports[`./index.stories CustomRecipient 1`] = `
 
 exports[`./index.stories Default 1`] = `
 <div
-  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+  class="shadcn-scope"
 >
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
-    style="--Paper-shadow: none;"
+    style="background-color: rgb(255, 255, 255); padding: 1rem;"
   >
     <div
-      class="MuiStack-root mui-style-1qh2y1i-MuiStack-root"
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-1xulk7h-MuiPaper-root"
+      style="--Paper-shadow: none;"
     >
-      <p
-        class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
-      >
-        <b>
-          Order details
-        </b>
-      </p>
       <div
-        class="amount"
+        class="MuiStack-root mui-style-1qh2y1i-MuiStack-root"
       >
+        <p
+          class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+        >
+          <b>
+            Order details
+          </b>
+        </p>
         <div
-          class="MuiStack-root mui-style-niqf4j-MuiStack-root"
+          class="amount"
         >
           <div
-            class="MuiStack-root mui-style-p24gtu-MuiStack-root"
+            class="MuiStack-root mui-style-niqf4j-MuiStack-root"
           >
             <div
-              class="MuiBox-root mui-style-wvnvdm"
+              class="MuiStack-root mui-style-p24gtu-MuiStack-root"
             >
               <div
-                class="MuiBox-root mui-style-olq4e8"
+                class="MuiBox-root mui-style-wvnvdm"
               >
-                <iframe
-                  height="40"
-                  loading="lazy"
-                  referrerpolicy="strict-origin"
-                  sandbox="allow-scripts"
-                  srcdoc="
+                <div
+                  class="MuiBox-root mui-style-olq4e8"
+                >
+                  <iframe
+                    height="40"
+                    loading="lazy"
+                    referrerpolicy="strict-origin"
+                    sandbox="allow-scripts"
+                    srcdoc="
     <body style="margin: 0; overflow: hidden; display: flex; align-items: center; justify-content: center;">
       <img src="https://safe-transaction-assets.staging.5afe.dev/tokens/logos/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.png" alt="Safe App logo" height="40" width="auto" style="border-radius: 100%;" />
       <script>
@@ -579,71 +586,71 @@ exports[`./index.stories Default 1`] = `
       </script>
     </body>
   "
-                  style="pointer-events: none; border: 0px; display: block;"
-                  tabindex="-1"
-                  title="USDC"
-                  width="40"
-                />
+                    style="pointer-events: none; border: 0px; display: block;"
+                    tabindex="-1"
+                    title="USDC"
+                    width="40"
+                  />
+                </div>
               </div>
-            </div>
-            <div
-              class="MuiBox-root mui-style-1rr4qq7"
-              data-testid="block-label"
-            >
-              <p
-                class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-              >
-                Sell
-              </p>
               <div
-                class="MuiTypography-root MuiTypography-h4 mui-style-csh7nj-MuiTypography-root"
+                class="MuiBox-root mui-style-1rr4qq7"
+                data-testid="block-label"
               >
-                <span
-                  aria-label="10 USDC"
-                  class="container"
-                  data-mui-internal-clone-element="true"
+                <p
+                  class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
                 >
-                  <b
-                    class="tokenText"
+                  Sell
+                </p>
+                <div
+                  class="MuiTypography-root MuiTypography-h4 mui-style-csh7nj-MuiTypography-root"
+                >
+                  <span
+                    aria-label="10 USDC"
+                    class="container"
+                    data-mui-internal-clone-element="true"
                   >
-                    10
-                     
-                    USDC
-                  </b>
-                </span>
+                    <b
+                      class="tokenText"
+                    >
+                      10
+                       
+                      USDC
+                    </b>
+                  </span>
+                </div>
+              </div>
+              <div
+                class="MuiStack-root mui-style-1nxlmhd-MuiStack-root"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-15tzxj8-MuiSvgIcon-root-MuiSvgIcon-root"
+                  data-testid="EastRoundedIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M14.29 5.71c-.39.39-.39 1.02 0 1.41L18.17 11H3c-.55 0-1 .45-1 1s.45 1 1 1h15.18l-3.88 3.88c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0l5.59-5.59c.39-.39.39-1.02 0-1.41l-5.6-5.58c-.38-.39-1.02-.39-1.41 0"
+                  />
+                </svg>
               </div>
             </div>
             <div
-              class="MuiStack-root mui-style-1nxlmhd-MuiStack-root"
-            >
-              <svg
-                aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-15tzxj8-MuiSvgIcon-root-MuiSvgIcon-root"
-                data-testid="EastRoundedIcon"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M14.29 5.71c-.39.39-.39 1.02 0 1.41L18.17 11H3c-.55 0-1 .45-1 1s.45 1 1 1h15.18l-3.88 3.88c-.39.39-.39 1.02 0 1.41s1.02.39 1.41 0l5.59-5.59c.39-.39.39-1.02 0-1.41l-5.6-5.58c-.38-.39-1.02-.39-1.41 0"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            class="MuiStack-root mui-style-p24gtu-MuiStack-root"
-          >
-            <div
-              class="MuiBox-root mui-style-wvnvdm"
+              class="MuiStack-root mui-style-p24gtu-MuiStack-root"
             >
               <div
-                class="MuiBox-root mui-style-olq4e8"
+                class="MuiBox-root mui-style-wvnvdm"
               >
-                <iframe
-                  height="40"
-                  loading="lazy"
-                  referrerpolicy="strict-origin"
-                  sandbox="allow-scripts"
-                  srcdoc="
+                <div
+                  class="MuiBox-root mui-style-olq4e8"
+                >
+                  <iframe
+                    height="40"
+                    loading="lazy"
+                    referrerpolicy="strict-origin"
+                    sandbox="allow-scripts"
+                    srcdoc="
     <body style="margin: 0; overflow: hidden; display: flex; align-items: center; justify-content: center;">
       <img src="https://safe-transaction-assets.staging.5afe.dev/tokens/logos/0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14.png" alt="Safe App logo" height="40" width="auto" style="border-radius: 100%;" />
       <script>
@@ -654,287 +661,288 @@ exports[`./index.stories Default 1`] = `
       </script>
     </body>
   "
-                  style="pointer-events: none; border: 0px; display: block;"
-                  tabindex="-1"
-                  title="NPR"
-                  width="40"
-                />
+                    style="pointer-events: none; border: 0px; display: block;"
+                    tabindex="-1"
+                    title="NPR"
+                    width="40"
+                  />
+                </div>
               </div>
-            </div>
-            <div
-              class="MuiBox-root mui-style-1rr4qq7"
-              data-testid="block-label"
-            >
-              <p
-                class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-              >
-                For at least
-              </p>
               <div
-                class="MuiTypography-root MuiTypography-h4 mui-style-csh7nj-MuiTypography-root"
+                class="MuiBox-root mui-style-1rr4qq7"
+                data-testid="block-label"
               >
-                <span
-                  aria-label="0 NPR"
-                  class="container"
-                  data-mui-internal-clone-element="true"
+                <p
+                  class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
                 >
-                  <b
-                    class="tokenText"
+                  For at least
+                </p>
+                <div
+                  class="MuiTypography-root MuiTypography-h4 mui-style-csh7nj-MuiTypography-root"
+                >
+                  <span
+                    aria-label="0 NPR"
+                    class="container"
+                    data-mui-internal-clone-element="true"
                   >
-                    0
-                     
-                    NPR
-                  </b>
-                </span>
+                    <b
+                      class="tokenText"
+                    >
+                      0
+                       
+                      NPR
+                    </b>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid="limit-price"
-      >
         <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Limit price
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid="limit-price"
         >
           <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
           >
-            1 
-            NPR
-             = 
-            0
-             
-            USDC
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Limit price
+            </span>
           </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid=""
-      >
-        <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Expiry
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
-        >
           <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
-          >
-            Dec 24, 2024 - 12:54:40 AM
-          </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid="order-id"
-      >
-        <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Order ID
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
-        >
-          <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
           >
             <div
-              class="MuiStack-root mui-style-m69qwo-MuiStack-root"
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
             >
-              <span>
-                170e4a48
-              </span>
+              1 
+              NPR
+               = 
+              0
+               
+              USDC
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid=""
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Expiry
+            </span>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
+          >
+            <div
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            >
+              Dec 24, 2024 - 12:54:40 AM
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid="order-id"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Order ID
+            </span>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
+          >
+            <div
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            >
+              <div
+                class="MuiStack-root mui-style-m69qwo-MuiStack-root"
+              >
+                <span>
+                  170e4a48
+                </span>
+                <span
+                  aria-label="Copy to clipboard"
+                  class=""
+                  data-mui-internal-clone-element="true"
+                  style="cursor: pointer;"
+                >
+                  <button
+                    aria-label="Copy to clipboard"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <mock-icon
+                      aria-hidden=""
+                      class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-gvpe62-MuiSvgIcon-root"
+                      data-testid="copy-btn-icon"
+                      focusable="false"
+                    />
+                  </button>
+                </span>
+                <div
+                  class="MuiBox-root mui-style-yjghm1"
+                >
+                  <a
+                    aria-label=""
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    data-testid="explorer-btn"
+                    href="https://explorer.cow.fi/orders/0x03a5d561ad2452d719a0d075573f4bed68217c696b52f151122c30e3e4426f1b05e6b5eb1d0e6aabab082057d5bb91f2ee6d11be66223d88"
+                    rel="noreferrer"
+                    tabindex="0"
+                    target="_blank"
+                  >
+                    <mock-icon
+                      aria-hidden=""
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                      focusable="false"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid="widget-fee"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+            >
+              Widget fee
+               
               <span
-                aria-label="Copy to clipboard"
                 class=""
                 data-mui-internal-clone-element="true"
-                style="cursor: pointer;"
               >
-                <button
-                  aria-label="Copy to clipboard"
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
-                  tabindex="0"
-                  type="button"
-                >
-                  <mock-icon
-                    aria-hidden=""
-                    class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-gvpe62-MuiSvgIcon-root"
-                    data-testid="copy-btn-icon"
-                    focusable="false"
-                  />
-                </button>
+                <mock-icon
+                  aria-hidden=""
+                  class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-1nezs5b-MuiSvgIcon-root"
+                  focusable="false"
+                />
               </span>
-              <div
-                class="MuiBox-root mui-style-yjghm1"
-              >
-                <a
-                  aria-label=""
-                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                  data-mui-internal-clone-element="true"
-                  data-testid="explorer-btn"
-                  href="https://explorer.cow.fi/orders/0x03a5d561ad2452d719a0d075573f4bed68217c696b52f151122c30e3e4426f1b05e6b5eb1d0e6aabab082057d5bb91f2ee6d11be66223d88"
-                  rel="noreferrer"
-                  tabindex="0"
-                  target="_blank"
-                >
-                  <mock-icon
-                    aria-hidden=""
-                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                    focusable="false"
-                  />
-                </a>
-              </div>
+            </span>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
+          >
+            <div
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            >
+              0.5
+               %
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid="widget-fee"
-      >
         <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
+          class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
+          data-testid="interact-wth"
         >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
+          <div
+            class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
+            data-testid="tx-row-title"
+            style="word-break: break-word;"
           >
-            Widget fee
-             
             <span
-              class=""
-              data-mui-internal-clone-element="true"
+              class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
             >
-              <mock-icon
-                aria-hidden=""
-                class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall mui-style-1nezs5b-MuiSvgIcon-root"
-                focusable="false"
-              />
+              Interact with
             </span>
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
-        >
-          <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
-          >
-            0.5
-             %
           </div>
-        </div>
-      </div>
-      <div
-        class="MuiGrid-root MuiGrid-container mui-style-1yff1ei-MuiGrid-root"
-        data-testid="interact-wth"
-      >
-        <div
-          class="MuiGrid-root MuiGrid-item mui-style-ezmk0c-MuiGrid-root"
-          data-testid="tx-row-title"
-          style="word-break: break-word;"
-        >
-          <span
-            class="MuiTypography-root MuiTypography-body2 mui-style-1ew0eu5-MuiTypography-root"
-          >
-            Interact with
-          </span>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
-          data-testid="tx-data-row"
-        >
           <div
-            class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true mui-style-1vd824g-MuiGrid-root"
+            data-testid="tx-data-row"
           >
             <div
-              class="container"
+              class="MuiTypography-root MuiTypography-body1 mui-style-v6lhhw-MuiTypography-root"
             >
               <div
-                class="avatarContainer"
-                style="width: 24px; height: 24px;"
+                class="container"
               >
                 <div
-                  class="icon"
-                  style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjUwIDg5JSA3NSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNDggNjglIDMxJSkiIGQ9Ik0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0yLDFoMXYxaC0xek01LDFoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0wLDJoMXYxaC0xek03LDJoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0xLDRoMXYxaC0xek02LDRoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xek0zLDZoMXYxaC0xek00LDZoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCg3NiA2OSUgNjclKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6Ii8+PC9zdmc+); width: 24px; height: 24px;"
-                />
-              </div>
-              <div
-                class="inline MuiBox-root mui-style-1lchl8k"
-              >
-                <div
-                  class="addressContainer inline"
+                  class="avatarContainer"
+                  style="width: 24px; height: 24px;"
                 >
                   <div
-                    class="MuiBox-root mui-style-b5p5gz"
-                  >
-                    <span
-                      aria-label="Copy to clipboard"
-                      class=""
-                      data-mui-internal-clone-element="true"
-                      style="cursor: pointer;"
-                    >
-                      <b>
-                        rin
-                        :
-                      </b>
-                      <span>
-                        0x9008D19f58AAbD9eD0D60971565AA8510560ab41
-                      </span>
-                    </span>
-                  </div>
+                    class="icon"
+                    style="background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4IDgiIHNoYXBlLXJlbmRlcmluZz0ib3B0aW1pemVTcGVlZCIgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0Ij48cGF0aCBmaWxsPSJoc2woMjUwIDg5JSA3NSUpIiBkPSJNMCwwSDhWOEgweiIvPjxwYXRoIGZpbGw9ImhzbCgzNDggNjglIDMxJSkiIGQ9Ik0wLDFoMXYxaC0xek03LDFoMXYxaC0xek0yLDFoMXYxaC0xek01LDFoMXYxaC0xek0zLDFoMXYxaC0xek00LDFoMXYxaC0xek0wLDJoMXYxaC0xek03LDJoMXYxaC0xek0xLDJoMXYxaC0xek02LDJoMXYxaC0xek0xLDNoMXYxaC0xek02LDNoMXYxaC0xek0yLDNoMXYxaC0xek01LDNoMXYxaC0xek0xLDRoMXYxaC0xek02LDRoMXYxaC0xek0zLDRoMXYxaC0xek00LDRoMXYxaC0xek0wLDVoMXYxaC0xek03LDVoMXYxaC0xek0zLDVoMXYxaC0xek00LDVoMXYxaC0xek0xLDZoMXYxaC0xek02LDZoMXYxaC0xek0zLDZoMXYxaC0xek00LDZoMXYxaC0xek0zLDdoMXYxaC0xek00LDdoMXYxaC0xeiIvPjxwYXRoIGZpbGw9ImhzbCg3NiA2OSUgNjclKSIgZD0iTTEsMGgxdjFoLTF6TTYsMGgxdjFoLTF6TTEsMWgxdjFoLTF6TTYsMWgxdjFoLTF6TTIsNWgxdjFoLTF6TTUsNWgxdjFoLTF6Ii8+PC9zdmc+); width: 24px; height: 24px;"
+                  />
+                </div>
+                <div
+                  class="inline MuiBox-root mui-style-1lchl8k"
+                >
                   <div
-                    class="MuiBox-root mui-style-yjghm1"
+                    class="addressContainer inline"
                   >
-                    <a
-                      aria-label="View on rinkeby.etherscan.io"
-                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
-                      data-mui-internal-clone-element="true"
-                      data-testid="explorer-btn"
-                      href="https://rinkeby.etherscan.io/address/0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
-                      rel="noreferrer"
-                      tabindex="0"
-                      target="_blank"
+                    <div
+                      class="MuiBox-root mui-style-b5p5gz"
                     >
-                      <mock-icon
-                        aria-hidden=""
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
-                        focusable="false"
-                      />
-                    </a>
+                      <span
+                        aria-label="Copy to clipboard"
+                        class=""
+                        data-mui-internal-clone-element="true"
+                        style="cursor: pointer;"
+                      >
+                        <b>
+                          rin
+                          :
+                        </b>
+                        <span>
+                          0x9008D19f58AAbD9eD0D60971565AA8510560ab41
+                        </span>
+                      </span>
+                    </div>
+                    <div
+                      class="MuiBox-root mui-style-yjghm1"
+                    >
+                      <a
+                        aria-label="View on rinkeby.etherscan.io"
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall mui-style-1vbp2rr-MuiButtonBase-root-MuiIconButton-root"
+                        data-mui-internal-clone-element="true"
+                        data-testid="explorer-btn"
+                        href="https://rinkeby.etherscan.io/address/0x9008D19f58AAbD9eD0D60971565AA8510560ab41"
+                        rel="noreferrer"
+                        tabindex="0"
+                        target="_blank"
+                      >
+                        <mock-icon
+                          aria-hidden=""
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall mui-style-tqxw8e-MuiSvgIcon-root"
+                          focusable="false"
+                        />
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/apps/web/src/features/swap/components/SwapOrderConfirmationView/index.stories.tsx
+++ b/apps/web/src/features/swap/components/SwapOrderConfirmationView/index.stories.tsx
@@ -4,6 +4,7 @@ import CowOrderConfirmationView from './index'
 import { Paper } from '@mui/material'
 import { swapOrderConfirmationViewBuilder } from '@/features/swap/helpers/swapOrderBuilder'
 import { StoreDecorator } from '@/stories/storeDecorator'
+import { RouterDecorator } from '@/stories/routerDecorator'
 
 // Fixed settlement contract address for deterministic tests
 const FIXED_SETTLEMENT_CONTRACT = '0x9008D19f58AAbD9eD0D60971565AA8510560ab41'
@@ -34,9 +35,11 @@ const meta = {
     (Story) => {
       return (
         <StoreDecorator initialState={{}}>
-          <Paper sx={{ padding: 2 }}>
-            <Story />
-          </Paper>
+          <RouterDecorator>
+            <Paper sx={{ padding: 2 }}>
+              <Story />
+            </Paper>
+          </RouterDecorator>
         </StoreDecorator>
       )
     },


### PR DESCRIPTION
## What it solves

The Storybook tests were failing after the latest merge and update to the Feature architecture. The affected stories were missing a router mock decorator.

## How this PR fixes it
- Adds router mocking to the failing stories.
- Updates snapshots.

## How to test it
Run `yarn test:storybook`. The tests should be passing.

## Checklist

- [ ] I've tested the branch on mobile 📱 N/A
- [ ] I've documented how it affects the analytics (if at all) 📊 N/A
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
