### PR TITLE
refactor(mobile): restructure home screen header and balance layout

### DIFF
--- a/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
+++ b/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
@@ -15,19 +15,19 @@ interface AssetsHeaderProps {
 export function AssetsHeader({ amount, isLoading, onPendingTransactionsPress, hasMore }: AssetsHeaderProps) {
   return (
     <StyledAssetsHeader>
-      <BalanceContainer />
-
       <ReadOnlyContainer />
 
-      <View marginTop="$4">
-        {amount > 0 && (
+      <BalanceContainer />
+
+      {amount > 0 && (
+        <View marginTop="$4">
           <PendingTransactions
             isLoading={isLoading}
             onPress={onPendingTransactionsPress}
             number={`${amount}${hasMore ? '+' : ''}`}
           />
-        )}
-      </View>
+        </View>
+      )}
     </StyledAssetsHeader>
   )
 }

--- a/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
+++ b/apps/mobile/src/features/Assets/components/AssetsHeader/AssetsHeader.tsx
@@ -15,7 +15,11 @@ interface AssetsHeaderProps {
 export function AssetsHeader({ amount, isLoading, onPendingTransactionsPress, hasMore }: AssetsHeaderProps) {
   return (
     <StyledAssetsHeader>
-      <View marginBottom="$8" marginTop="$4">
+      <BalanceContainer />
+
+      <ReadOnlyContainer />
+
+      <View marginTop="$4">
         {amount > 0 && (
           <PendingTransactions
             isLoading={isLoading}
@@ -24,10 +28,6 @@ export function AssetsHeader({ amount, isLoading, onPendingTransactionsPress, ha
           />
         )}
       </View>
-
-      <BalanceContainer />
-
-      <ReadOnlyContainer />
     </StyledAssetsHeader>
   )
 }

--- a/apps/mobile/src/features/Assets/components/Balance/Balance.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/Balance.container.tsx
@@ -1,22 +1,14 @@
-import { getChainsByIds, selectChainById } from '@/src/store/chains'
 import { Balance } from './Balance'
 import { makeSafeId } from '@/src/utils/formatters'
-import { RootState } from '@/src/store'
-import { selectSafeChains } from '@/src/store/safesSlice'
 import { useAppSelector } from '@/src/store/hooks'
-import React, { useCallback } from 'react'
-import { useSelector } from 'react-redux'
+import React from 'react'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
-import { useCopyAndDispatchToast } from '@/src/hooks/useCopyAndDispatchToast'
 import { selectCurrency } from '@/src/store/settingsSlice'
 import { POLLING_INTERVAL } from '@/src/config/constants'
 import { useSafeOverviewsQuery } from '@/src/hooks/services/useSafeOverviewsQuery'
 
 export function BalanceContainer() {
   const activeSafe = useDefinedActiveSafe()
-  const chainsIds = useAppSelector((state: RootState) => selectSafeChains(state, activeSafe.address))
-  const activeSafeChains = useAppSelector((state: RootState) => getChainsByIds(state, chainsIds))
-  const copy = useCopyAndDispatchToast()
   const currency = useAppSelector(selectCurrency)
   const { data, isLoading } = useSafeOverviewsQuery(
     {
@@ -29,22 +21,7 @@ export function BalanceContainer() {
       pollingInterval: POLLING_INTERVAL,
     },
   )
-  const activeChain = useSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
   const balance = data?.find((chain) => chain.chainId === activeSafe.chainId)
 
-  const onPressAddressCopy = useCallback(() => {
-    copy(activeSafe.address)
-  }, [activeSafe.address])
-
-  return (
-    <Balance
-      chainName={activeChain?.chainName}
-      chains={activeSafeChains}
-      isLoading={isLoading}
-      activeChainId={activeSafe.chainId}
-      safeAddress={activeSafe.address}
-      balanceAmount={balance?.fiatTotal || ''}
-      onPressAddressCopy={onPressAddressCopy}
-    />
-  )
+  return <Balance isLoading={isLoading} balanceAmount={balance?.fiatTotal || ''} />
 }

--- a/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
@@ -1,70 +1,25 @@
 import React from 'react'
-import { View, XStack, Text } from 'tamagui'
+import { View } from 'tamagui'
 
-import { DropdownLabel } from '@/src/components/Dropdown'
 import { Fiat } from '@/src/components/Fiat'
-import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-
-import { ChainsDisplay } from '@/src/components/ChainsDisplay'
-import { useRouter } from 'expo-router'
-import { TouchableOpacity } from 'react-native'
-import { shortenAddress } from '@safe-global/utils/utils/formatters'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Skeleton } from 'moti/skeleton'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectCurrency } from '@/src/store/settingsSlice'
 import { useTheme } from '@/src/theme/hooks/useTheme'
 
 interface BalanceProps {
-  activeChainId: string
-  safeAddress: string
   isLoading: boolean
-  chains: Chain[]
   balanceAmount: string
-  chainName: string
-  onPressAddressCopy: () => void
 }
 
-export function Balance({
-  activeChainId,
-  chains,
-  isLoading,
-  balanceAmount,
-  chainName,
-  safeAddress,
-  onPressAddressCopy,
-}: BalanceProps) {
-  const router = useRouter()
+export function Balance({ isLoading, balanceAmount }: BalanceProps) {
   const { colorScheme } = useTheme()
   const currency = useAppSelector(selectCurrency)
 
   const showSkeleton = isLoading || !balanceAmount
 
   return (
-    <View marginBottom="$4">
-      {activeChainId && (
-        <XStack paddingBottom={'$4'} gap={'$1'} alignItems={'center'}>
-          <DropdownLabel
-            label={chainName}
-            leftNode={<ChainsDisplay activeChainId={activeChainId} chains={chains} max={1} />}
-            onPress={() => {
-              router.push('/networks-sheet')
-            }}
-            labelProps={{ fontWeight: 600, fontSize: '$4' }}
-            displayDropDownIcon={chains.length > 1}
-          />
-          <TouchableOpacity onPress={onPressAddressCopy}>
-            <XStack alignItems={'center'} paddingLeft={'$1'}>
-              <Text color={'$colorSecondary'} fontSize={'$4'}>
-                {shortenAddress(safeAddress)}
-              </Text>
-              <View paddingLeft={'$1'}>
-                <SafeFontIcon name={'copy'} size={13} color={'$colorSecondary'} />
-              </View>
-            </XStack>
-          </TouchableOpacity>
-        </XStack>
-      )}
+    <View>
       <Skeleton.Group show={showSkeleton}>
         <Skeleton colorMode={colorScheme} width={220}>
           <Fiat value={balanceAmount} currency={currency} precise />

--- a/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/Balance.tsx
@@ -19,7 +19,7 @@ export function Balance({ isLoading, balanceAmount }: BalanceProps) {
   const showSkeleton = isLoading || !balanceAmount
 
   return (
-    <View>
+    <View alignItems="center">
       <Skeleton.Group show={showSkeleton}>
         <Skeleton colorMode={colorScheme} width={220}>
           <Fiat value={balanceAmount} currency={currency} precise />

--- a/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
+++ b/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
@@ -1,21 +1,22 @@
 import React from 'react'
 import { Pressable } from 'react-native'
-import { Theme, XStack, getTokenValue } from 'tamagui'
+import { Text, Theme, View, XStack, getTokenValue } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Identicon } from '@/src/components/Identicon'
 import { BadgeWrapper } from '@/src/components/BadgeWrapper'
 import { ThresholdBadge } from '@/src/components/ThresholdBadge'
 
 import { shortenAddress } from '@/src/utils/formatters'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useAppSelector } from '@/src/store/hooks'
-import { Link, useRouter } from 'expo-router'
+import { useRouter } from 'expo-router'
 import { DropdownLabel } from '@/src/components/Dropdown/DropdownLabel'
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { selectContactByAddress } from '@/src/store/addressBookSlice'
 import { selectSafeInfo } from '@/src/store/safesSlice'
 import { RootState } from '@/src/store'
 import { useTheme } from '@/src/theme/hooks/useTheme'
+import { selectChainById } from '@/src/store/chains'
+import { Logo } from '@/src/components/Logo'
 
 const dropdownLabelProps = {
   fontSize: '$5',
@@ -31,6 +32,7 @@ export const Navbar = () => {
 
   const activeSafeInfo = useAppSelector((state: RootState) => selectSafeInfo(state, activeSafe.address))
   const chainSafe = activeSafeInfo ? activeSafeInfo[activeSafe.chainId] : undefined
+  const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
 
   return (
     <Theme name="navbar">
@@ -42,36 +44,40 @@ export const Navbar = () => {
         paddingBottom={'$2'}
         backgroundColor={isDark ? '$background' : '$backgroundFocus'}
       >
-        <DropdownLabel
-          label={contact ? contact.name : shortenAddress(activeSafe.address)}
-          labelProps={dropdownLabelProps}
-          leftNode={
-            <BadgeWrapper
-              badge={
-                <ThresholdBadge
-                  threshold={chainSafe?.threshold ?? 0}
-                  ownersCount={chainSafe?.owners.length ?? 0}
-                  size={18}
-                  fontSize={8}
-                  isLoading={!chainSafe}
-                  testID="threshold-info-badge"
-                />
-              }
-              testID="threshold-info-badge-wrapper"
-            >
-              <Identicon address={activeSafe.address} size={30} />
-            </BadgeWrapper>
-          }
-          onPress={() => {
-            router.push('/accounts-sheet')
-          }}
-          hitSlop={4}
-        />
-        <Link href={'/share'} asChild>
-          <Pressable hitSlop={10}>
-            <SafeFontIcon name="qr-code-1" size={16} />
-          </Pressable>
-        </Link>
+        <View>
+          <DropdownLabel
+            label={contact ? contact.name : shortenAddress(activeSafe.address)}
+            labelProps={dropdownLabelProps}
+            leftNode={
+              <BadgeWrapper
+                badge={
+                  <ThresholdBadge
+                    threshold={chainSafe?.threshold ?? 0}
+                    ownersCount={chainSafe?.owners.length ?? 0}
+                    size={18}
+                    fontSize={8}
+                    isLoading={!chainSafe}
+                    testID="threshold-info-badge"
+                  />
+                }
+                testID="threshold-info-badge-wrapper"
+              >
+                <Identicon address={activeSafe.address} size={30} />
+              </BadgeWrapper>
+            }
+            onPress={() => {
+              router.push('/accounts-sheet')
+            }}
+            hitSlop={4}
+          />
+          <Text color={'$colorSecondary'} fontSize={'$3'} paddingLeft={'$10'}>
+            {shortenAddress(activeSafe.address)}
+          </Text>
+        </View>
+
+        <Pressable hitSlop={10} onPress={() => router.push('/networks-sheet')}>
+          <Logo logoUri={activeChain?.chainLogoUri} accessibilityLabel={activeChain?.chainName} size="$8" />
+        </Pressable>
       </XStack>
     </Theme>
   )

--- a/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
+++ b/apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx
@@ -70,9 +70,11 @@ export const Navbar = () => {
             }}
             hitSlop={4}
           />
-          <Text color={'$colorSecondary'} fontSize={'$3'} paddingLeft={'$10'}>
-            {shortenAddress(activeSafe.address)}
-          </Text>
+          {contact && (
+            <Text color={'$colorSecondary'} fontSize={'$3'} paddingLeft={'$10'}>
+              {shortenAddress(activeSafe.address)}
+            </Text>
+          )}
         </View>
 
         <Pressable hitSlop={10} onPress={() => router.push('/networks-sheet')}>


### PR DESCRIPTION
## What it solves

Restructures the mobile home screen header and balance area to match the updated Figma designs (Positions file, nodes 14175:3862, 14175:4426, 14175:7814, 14179:3488).

## How this PR fixes it

**Navbar changes:**
- Added shortened Safe address as a secondary line below the Safe name
- Replaced the QR code share button with the active chain's logo icon
- Chain logo taps navigate to the networks sheet for switching chains

**Balance changes:**
- Removed the chain selector dropdown (moved to header as chain logo)
- Removed the address display and copy button (address moved to header)
- Simplified to show only the fiat total balance with skeleton loading

**Files changed:**
- `apps/mobile/src/features/Assets/components/Navbar/Navbar.tsx`
- `apps/mobile/src/features/Assets/components/Balance/Balance.tsx`
- `apps/mobile/src/features/Assets/components/Balance/Balance.container.tsx`

Net result: **-62 lines** (44 added, 106 removed)

## How to test it

1. Open the mobile app on the Home tab
2. Verify the header shows: identicon with threshold badge, Safe name with dropdown arrow, shortened address below, and chain logo on the right
3. Tap the Safe name area — should open the accounts sheet
4. Tap the chain logo — should open the networks sheet
5. Verify the balance area shows only the fiat total (no chain selector, no address)
6. Check both light and dark modes render correctly
7. Verify skeleton loading states work

## Screenshots

Manual verification needed on iOS/Android simulator.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

No analytics impact. No new tests needed — existing tests pass and changes are presentational.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

---
[![Safe Engineering](https://img.shields.io/badge/Safe-Engineering-12ff80)](https://github.com/5afe/safe-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)