### PR TITLE
chore: set Chromatic env variables for correct git metadata

### DIFF
--- a/.github/workflows/web-chromatic-e2e.yml
+++ b/.github/workflows/web-chromatic-e2e.yml
@@ -2,11 +2,6 @@ name: Web Chromatic E2E
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - 'apps/web/**'
-      - 'packages/**'
-      - '.github/workflows/web-chromatic-e2e.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Sets `CHROMATIC_SHA`, `CHROMATIC_BRANCH`, and `CHROMATIC_SLUG` env vars in the Chromatic E2E workflow
- Ensures Chromatic correctly associates screenshots with the source branch commit (not the temporary merge commit GitHub Actions creates for `pull_request` events)
- See: https://www.chromatic.com/docs/faq/environment-variables/

## Changes
- `.github/workflows/web-chromatic-e2e.yml` — added env vars to the `chromatic` job + temporary `pull_request` trigger for testing

## Test plan
- [ ] Verify the Chromatic E2E workflow runs on this PR
- [ ] Check Chromatic dashboard shows correct branch/commit association
- [ ] Remove `pull_request` trigger before merging (revert to `workflow_dispatch` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)