### PR TITLE
feat(web): make sidebar account header fully clickable to open safe picker

### DIFF
--- a/apps/web/cypress/e2e/pages/sidebar.pages.js
+++ b/apps/web/cypress/e2e/pages/sidebar.pages.js
@@ -372,7 +372,7 @@ export function verifyAccountListSafeData(data) {
 }
 
 export function clickOnOpenSidebarBtn() {
-  cy.get(openSafesIcon).click()
+  cy.get(sidebarSafeHeader).click()
 }
 
 // Expands all safes in the sidebar

--- a/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/index.tsx
+++ b/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/index.tsx
@@ -20,13 +20,7 @@ const EnvHintButton = () => {
   return (
     <Link href={{ pathname: AppRoutes.settings.environmentVariables, query: router.query }} passHref legacyBehavior>
       <Tooltip title="Default environment has been changed" placement="top" arrow>
-        <IconButton
-          className={css.button}
-          size="small"
-          color="warning"
-          sx={{ justifySelf: 'flex-end', marginLeft: { sm: '0', md: 'auto' } }}
-          disableRipple
-        >
+        <IconButton className={css.button} size="small" color="warning" disableRipple>
           <SvgIcon component={AlertIcon} inheritViewBox fontSize="small" />
         </IconButton>
       </Tooltip>

--- a/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/styles.module.css
+++ b/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/styles.module.css
@@ -4,4 +4,5 @@
   width: 32px;
   height: 32px;
   background: var(--color-warning-background);
+  flex-shrink: 0;
 }

--- a/apps/web/src/components/sidebar/NestedSafesButton/index.tsx
+++ b/apps/web/src/components/sidebar/NestedSafesButton/index.tsx
@@ -53,8 +53,8 @@ export function NestedSafesButton({
           <IconButton
             className={headerCss.iconButton}
             sx={{
-              width: 'auto !important',
               minWidth: '32px !important',
+              flexShrink: 0,
               backgroundColor: anchorEl ? '#f2fecd !important' : undefined,
             }}
             onClick={onClick}

--- a/apps/web/src/components/sidebar/Sidebar/index.tsx
+++ b/apps/web/src/components/sidebar/Sidebar/index.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useState, type ReactElement } from 'react'
 import { Box, Divider, Drawer } from '@mui/material'
-import ChevronRight from '@mui/icons-material/ChevronRight'
 
 import ChainIndicator from '@/components/common/ChainIndicator'
 import SidebarHeader from '@/components/sidebar/SidebarHeader'
@@ -34,13 +33,8 @@ const Sidebar = (): ReactElement => {
       <div className={css.scroll}>
         <ChainIndicator showLogo={false} onlyLogo />
 
-        {/* Open the safes list */}
-        <button data-testid="open-safes-icon" className={css.drawerButton} onClick={onDrawerToggle}>
-          <ChevronRight />
-        </button>
-
         {/* Address, balance, copy button, etc */}
-        <SidebarHeader />
+        <SidebarHeader onDrawerToggle={onDrawerToggle} />
 
         {/* Nav menu */}
         <SidebarNavigation />

--- a/apps/web/src/components/sidebar/Sidebar/styles.module.css
+++ b/apps/web/src/components/sidebar/Sidebar/styles.module.css
@@ -72,10 +72,4 @@
   .drawer {
     max-width: 90vw;
   }
-
-  .drawerButton {
-    width: 60px;
-    height: 60px;
-    margin-top: 44px;
-  }
 }

--- a/apps/web/src/components/sidebar/SidebarHeader/SafeHeaderInfo.test.tsx
+++ b/apps/web/src/components/sidebar/SidebarHeader/SafeHeaderInfo.test.tsx
@@ -81,7 +81,7 @@ describe('SafeHeaderInfo', () => {
         resolving: false,
       })
 
-      const { container } = render(<SafeHeaderInfo />)
+      const { container } = render(<SafeHeaderInfo onDrawerToggle={jest.fn()} />)
 
       // Check that the shield icon is rendered
       // The HypernativeTooltip wraps the SvgIcon in a span with display: flex
@@ -106,7 +106,7 @@ describe('SafeHeaderInfo', () => {
         resolving: false,
       })
 
-      const { container } = render(<SafeHeaderInfo />)
+      const { container } = render(<SafeHeaderInfo onDrawerToggle={jest.fn()} />)
 
       const tooltipSpans = Array.from(container.querySelectorAll('span')).filter((span) => {
         const styles = window.getComputedStyle(span)
@@ -129,7 +129,7 @@ describe('SafeHeaderInfo', () => {
         resolving: false,
       })
 
-      const { container } = render(<SafeHeaderInfo />)
+      const { container } = render(<SafeHeaderInfo onDrawerToggle={jest.fn()} />)
 
       // When isHypernativeGuard is false, the shield icon should not be rendered
       const tooltipSpans = Array.from(container.querySelectorAll('span')).filter((span) => {

--- a/apps/web/src/components/sidebar/SidebarHeader/SafeHeaderInfo.tsx
+++ b/apps/web/src/components/sidebar/SidebarHeader/SafeHeaderInfo.tsx
@@ -1,6 +1,8 @@
 import { type ReactElement } from 'react'
 import Typography from '@mui/material/Typography'
 import Skeleton from '@mui/material/Skeleton'
+import { SvgIcon } from '@mui/material'
+import ChevronRight from '@mui/icons-material/KeyboardArrowRight'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
 import SafeIcon from '@/components/common/SafeIcon'
@@ -16,7 +18,11 @@ import { useLoadFeature } from '@/features/__core__'
 
 import css from './styles.module.css'
 
-const SafeHeaderInfo = (): ReactElement => {
+type SafeHeaderInfoProps = {
+  onDrawerToggle: () => void
+}
+
+const SafeHeaderInfo = ({ onDrawerToggle }: SafeHeaderInfoProps): ReactElement => {
   const { balances } = useVisibleBalances()
   const safeAddress = useSafeAddress()
   const { safe } = useSafeInfo()
@@ -26,51 +32,62 @@ const SafeHeaderInfo = (): ReactElement => {
   const { isHypernativeGuard } = useIsHypernativeGuard()
 
   return (
-    <div data-testid="safe-header-info" className={css.safe}>
-      <div data-testid="safe-icon">
-        {safeAddress ? (
-          <SafeIcon address={safeAddress} threshold={threshold} owners={owners?.length} />
-        ) : (
-          <Skeleton variant="circular" width={40} height={40} />
-        )}
-      </div>
-
-      <div className={css.address}>
-        {safeAddress ? (
-          <EthHashInfo
-            address={safeAddress}
-            shortAddress
-            showAvatar={false}
-            name={ens}
-            badgeTooltip={isHypernativeGuard ? <SafeHeaderHnTooltip /> : undefined}
-          />
-        ) : (
-          <Typography variant="body2">
-            <Skeleton variant="text" width={86} />
-            <Skeleton variant="text" width={120} />
-          </Typography>
-        )}
-
-        <Typography data-testid="currency-section" variant="body2" fontWeight={700}>
-          {safe.deployed ? (
-            balances.fiatTotal ? (
-              <>
-                <FiatValue value={balances.fiatTotal} />
-                {balances.isAllTokensMode && <InfoTooltip title="Total based on default tokens and positions." />}
-              </>
-            ) : (
-              <Skeleton variant="text" width={60} />
-            )
+    <button
+      className={css.safeHeaderButton}
+      onClick={onDrawerToggle}
+      aria-label="Open account list"
+      data-testid="safe-header-info"
+    >
+      <div className={css.safe}>
+        <div data-testid="safe-icon">
+          {safeAddress ? (
+            <SafeIcon address={safeAddress} threshold={threshold} owners={owners?.length} />
           ) : (
-            <TokenAmount
-              value={balances.items[0]?.balance}
-              decimals={balances.items[0]?.tokenInfo.decimals}
-              tokenSymbol={balances.items[0]?.tokenInfo.symbol}
-            />
+            <Skeleton variant="circular" width={40} height={40} />
           )}
-        </Typography>
+        </div>
+
+        <div className={css.address}>
+          {safeAddress ? (
+            <EthHashInfo
+              address={safeAddress}
+              shortAddress
+              showAvatar={false}
+              name={ens}
+              badgeTooltip={isHypernativeGuard ? <SafeHeaderHnTooltip /> : undefined}
+              hasExplorer={false}
+              copyAddress={false}
+            />
+          ) : (
+            <Typography variant="body2">
+              <Skeleton variant="text" width={86} />
+              <Skeleton variant="text" width={120} />
+            </Typography>
+          )}
+
+          <Typography data-testid="currency-section" variant="body2" fontWeight={700}>
+            {safe.deployed ? (
+              balances.fiatTotal ? (
+                <>
+                  <FiatValue value={balances.fiatTotal} />
+                  {balances.isAllTokensMode && <InfoTooltip title="Total based on default tokens and positions." />}
+                </>
+              ) : (
+                <Skeleton variant="text" width={60} />
+              )
+            ) : (
+              <TokenAmount
+                value={balances.items[0]?.balance}
+                decimals={balances.items[0]?.tokenInfo.decimals}
+                tokenSymbol={balances.items[0]?.tokenInfo.symbol}
+              />
+            )}
+          </Typography>
+        </div>
       </div>
-    </div>
+
+      <SvgIcon className={css.chevron} component={ChevronRight} fontSize="small" />
+    </button>
   )
 }
 

--- a/apps/web/src/components/sidebar/SidebarHeader/index.tsx
+++ b/apps/web/src/components/sidebar/SidebarHeader/index.tsx
@@ -16,8 +16,8 @@ import CopyIconBold from '@/public/images/sidebar/copy-bold.svg'
 import LinkIconBold from '@/public/images/sidebar/link-bold.svg'
 
 import { selectSettings } from '@/store/settingsSlice'
-import { useCurrentChain } from '@/hooks/useChains'
-import { getBlockExplorerLink } from '@safe-global/utils/utils/chains'
+import { useCurrentChain, useHasFeature } from '@/hooks/useChains'
+import { getBlockExplorerLink, FEATURES } from '@safe-global/utils/utils/chains'
 import QrCodeButton from '../QrCodeButton'
 import Track from '@/components/common/Track'
 import { MixpanelEventParams } from '@/services/analytics/mixpanel-events'
@@ -39,6 +39,8 @@ const SafeHeader = ({ onDrawerToggle }: SidebarHeaderProps): ReactElement => {
   const chain = useCurrentChain()
   const settings = useAppSelector(selectSettings)
   const { CounterfactualStatusButton } = useLoadFeature(CounterfactualFeature)
+
+  const shouldShowNestedSafes = useHasFeature(FEATURES.NESTED_SAFES) && safe.deployed
 
   const addressCopyText = settings.shortName.copy && chain ? `${chain.shortName}:${safeAddress}` : safeAddress
 
@@ -82,13 +84,15 @@ const SafeHeader = ({ onDrawerToggle }: SidebarHeaderProps): ReactElement => {
             <ExplorerButton {...blockExplorerLink} className={css.iconButton} icon={LinkIconBold} />
           </Track>
 
-          <Track
-            {...NESTED_SAFE_EVENTS.OPEN_LIST}
-            label={NESTED_SAFE_LABELS.header}
-            mixpanelParams={{ [MixpanelEventParams.SIDEBAR_ELEMENT]: 'Nested Safes' }}
-          >
-            <NestedSafesButton chainId={safe.chainId} safeAddress={safe.address.value} />
-          </Track>
+          {shouldShowNestedSafes && (
+            <Track
+              {...NESTED_SAFE_EVENTS.OPEN_LIST}
+              label={NESTED_SAFE_LABELS.header}
+              mixpanelParams={{ [MixpanelEventParams.SIDEBAR_ELEMENT]: 'Nested Safes' }}
+            >
+              <NestedSafesButton chainId={safe.chainId} safeAddress={safe.address.value} />
+            </Track>
+          )}
 
           <CounterfactualStatusButton />
 

--- a/apps/web/src/components/sidebar/SidebarHeader/index.tsx
+++ b/apps/web/src/components/sidebar/SidebarHeader/index.tsx
@@ -3,10 +3,12 @@ import { useLoadFeature } from '@/features/__core__'
 import { type ReactElement } from 'react'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
+import { SvgIcon } from '@mui/material'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
 import NewTxButton from '@/components/sidebar/NewTxButton'
 import { useAppSelector } from '@/store'
+import { OVERVIEW_EVENTS } from '@/services/analytics'
 
 import css from './styles.module.css'
 import QrIconBold from '@/public/images/sidebar/qr-bold.svg'
@@ -18,10 +20,8 @@ import { useCurrentChain } from '@/hooks/useChains'
 import { getBlockExplorerLink } from '@safe-global/utils/utils/chains'
 import QrCodeButton from '../QrCodeButton'
 import Track from '@/components/common/Track'
-import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
 import { MixpanelEventParams } from '@/services/analytics/mixpanel-events'
 import { NESTED_SAFE_EVENTS, NESTED_SAFE_LABELS } from '@/services/analytics/events/nested-safes'
-import { SvgIcon } from '@mui/material'
 import EnvHintButton from '@/components/settings/EnvironmentVariables/EnvHintButton'
 import useSafeAddress from '@/hooks/useSafeAddress'
 import ExplorerButton from '@/components/common/ExplorerButton'
@@ -29,7 +29,11 @@ import CopyTooltip from '@/components/common/CopyTooltip'
 import { NestedSafesButton } from '@/components/sidebar/NestedSafesButton'
 import SafeHeaderInfo from './SafeHeaderInfo'
 
-const SafeHeader = (): ReactElement => {
+type SidebarHeaderProps = {
+  onDrawerToggle: () => void
+}
+
+const SafeHeader = ({ onDrawerToggle }: SidebarHeaderProps): ReactElement => {
   const safeAddress = useSafeAddress()
   const { safe } = useSafeInfo()
   const chain = useCurrentChain()
@@ -43,7 +47,7 @@ const SafeHeader = (): ReactElement => {
   return (
     <div className={css.container}>
       <div className={css.info}>
-        <SafeHeaderInfo />
+        <SafeHeaderInfo onDrawerToggle={onDrawerToggle} />
 
         <div className={css.iconButtons}>
           <Track
@@ -92,7 +96,9 @@ const SafeHeader = (): ReactElement => {
         </div>
       </div>
 
-      <NewTxButton />
+      <div className={css.newTxButtonWrapper}>
+        <NewTxButton />
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/sidebar/SidebarHeader/styles.module.css
+++ b/apps/web/src/components/sidebar/SidebarHeader/styles.module.css
@@ -1,9 +1,31 @@
 .container {
-  padding: var(--space-2) var(--space-1) 0;
+  padding: var(--space-2) 0 0;
 }
 
 .info {
   padding: 0 var(--space-1);
+}
+
+/* Safe Header Dropdown Trigger */
+.safeHeaderButton {
+  width: 100%;
+  padding: var(--space-1);
+  border-radius: 8px;
+  transition: background-color 0.2s;
+  display: flex;
+  align-items: center;
+  text-align: left;
+  background-color: var(--color-background-main);
+  border: none;
+  cursor: pointer;
+}
+
+.safeHeaderButton:hover:not(:disabled) {
+  background-color: var(--color-background-light);
+}
+
+.safeHeaderButton:disabled {
+  cursor: default;
 }
 
 .safe {
@@ -11,6 +33,15 @@
   gap: 12px;
   text-align: left;
   align-items: center;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.chevron {
+  display: flex;
+  align-items: center;
+  color: var(--color-text-secondary);
 }
 
 .iconButtons {
@@ -18,7 +49,8 @@
   margin-bottom: 16px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
+  width: 100%;
 }
 
 .iconButton {
@@ -28,6 +60,7 @@
   background-color: var(--color-background-main);
   width: 32px;
   height: 32px;
+  flex-shrink: 0;
 }
 
 .iconButton:hover {
@@ -35,8 +68,13 @@
 }
 
 .address {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   white-space: nowrap;
   font-size: 14px;
+}
+
+.newTxButtonWrapper {
+  padding: 0 var(--space-1);
 }

--- a/apps/web/src/features/counterfactual/components/CounterfactualStatusButton/styles.module.css
+++ b/apps/web/src/features/counterfactual/components/CounterfactualStatusButton/styles.module.css
@@ -4,8 +4,7 @@
   width: 32px;
   height: 32px;
   background: var(--color-warning-background);
-  justify-self: flex-end;
-  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .statusButton.processing {

--- a/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountListFilters/index.tsx
@@ -1,21 +1,38 @@
 import { useAppDispatch, useAppSelector } from '@/store'
 import { type OrderByOption, selectOrderByPreference, setOrderByPreference } from '@/store/orderByPreferenceSlice'
 import debounce from 'lodash/debounce'
-import { type Dispatch, type SetStateAction, useCallback } from 'react'
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react'
 import OrderByButton from '../OrderByButton'
 import css from '../../styles.module.css'
 import SearchIcon from '@/public/images/common/search.svg'
-import { Box, InputAdornment, Paper, SvgIcon, TextField } from '@mui/material'
+import { Box, IconButton, InputAdornment, Paper, SvgIcon, TextField } from '@mui/material'
+import ClearIcon from '@mui/icons-material/Clear'
 
-const AccountListFilters = ({ setSearchQuery }: { setSearchQuery: Dispatch<SetStateAction<string>> }) => {
+type AccountListFiltersProps = {
+  setSearchQuery: Dispatch<SetStateAction<string>>
+  showClearButton?: boolean
+}
+
+const AccountListFilters = ({ setSearchQuery, showClearButton = true }: AccountListFiltersProps) => {
   const dispatch = useAppDispatch()
   const { orderBy } = useAppSelector(selectOrderByPreference)
+  const [internalValue, setInternalValue] = useState('')
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleSearch = useCallback(debounce(setSearchQuery, 300), [])
 
   const handleOrderByChange = (orderBy: OrderByOption) => {
     dispatch(setOrderByPreference({ orderBy }))
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInternalValue(e.target.value)
+    handleSearch(e.target.value)
+  }
+
+  const handleClear = () => {
+    setInternalValue('')
+    setSearchQuery('')
   }
 
   return (
@@ -27,9 +44,8 @@ const AccountListFilters = ({ setSearchQuery }: { setSearchQuery: Dispatch<SetSt
           aria-label="Search Safe list by name"
           variant="filled"
           hiddenLabel
-          onChange={(e) => {
-            handleSearch(e.target.value)
-          }}
+          value={internalValue}
+          onChange={handleChange}
           className={css.search}
           InputProps={{
             startAdornment: (
@@ -46,6 +62,14 @@ const AccountListFilters = ({ setSearchQuery }: { setSearchQuery: Dispatch<SetSt
                 />
               </InputAdornment>
             ),
+            endAdornment:
+              showClearButton && internalValue ? (
+                <InputAdornment position="end">
+                  <IconButton size="small" onClick={handleClear} edge="end">
+                    <ClearIcon fontSize="small" />
+                  </IconButton>
+                </InputAdornment>
+              ) : null,
             disableUnderline: true,
           }}
           fullWidth


### PR DESCRIPTION
## Summary
- Converts the Safe account header in the sidebar into a single `<button>` that opens the account list, replacing the separate standalone chevron button
- Adds a chevron indicator icon and disables inline copy/explorer from the header row (still available via the icon buttons below)
- Cleans up icon button row flex alignment across sidebar action buttons (`EnvHintButton`, `CounterfactualStatusButton`, `NestedSafesButton`)
- Removes duplicate feature-flag gate for `NestedSafesButton` — it self-gates internally
- Adds a clear button to the account list search field

Closes [WA-1205](https://linear.app/safe-global/issue/WA-1205/make-the-whole-account-header-in-the-sidebar-clickable)

## Test plan
- [ ] Click the account header in the sidebar → account picker opens
- [ ] Hover state on the header button is visible
- [ ] Long account name truncates to a single line with ellipsis
- [ ] Icon buttons (QR, Copy, Explorer, Nested Safes) still function correctly
- [ ] `EnvHintButton` and `CounterfactualStatusButton` display correctly when present
- [ ] Account list search clear button appears when text is entered and clears on click
- [ ] E2E smoke tests pass (`clickOnOpenSidebarBtn` now clicks `safe-header-info`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)