### PR TITLE
fix: add auto-generated schema.json to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -31,6 +31,9 @@ apps/web/src/config/__generated__/
 # Utils package
 packages/utils/src/types/contracts/**/*
 
+# Store package (auto-generated from CGW API)
+packages/store/scripts/api-schema/schema.json
+
 # Expo plugins
 expo-plugins/notification-service-ios/dist
 


### PR DESCRIPTION
## Summary
- Add `packages/store/scripts/api-schema/schema.json` to `.prettierignore`
- The file is auto-generated by `fetch-schema.ts` using `JSON.stringify(data, null, 2)`, which formats single-element arrays across 3 lines. Prettier with `printWidth: 120` collapses these, causing a conflict: running `yarn prettier:fix` from root reformats the file, but CI's `store-codegen-check` then fails because the codegen regenerates the unformatted version.
- This matches the existing pattern for other auto-generated files (e.g., `packages/utils/src/types/contracts/**/*`)

## Test plan
- [x] `yarn prettier --check .` passes from repo root
- [x] `yarn workspace @safe-global/web prettier` still passes
- [x] `yarn workspace @safe-global/store prettier` no longer flags schema.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)