### PR TITLE
fix(web): restore mastercopy warnings in Action Required panel (WA-1514)

### DIFF
--- a/apps/web/src/components/dashboard/index.tsx
+++ b/apps/web/src/components/dashboard/index.tsx
@@ -10,7 +10,11 @@ import ExplorePossibleWidget from '@/components/dashboard/ExplorePossibleWidget'
 import { useIsRecoverySupported } from '@/features/recovery/hooks/useIsRecoverySupported'
 import { useHasFeature } from '@/hooks/useChains'
 import css from './styles.module.css'
-import { InconsistentSignerSetupWarning, UnsupportedMastercopyWarning } from '@/features/multichain'
+import {
+  InconsistentSignerSetupWarning,
+  OutdatedMastercopyWarning,
+  UnsupportedMastercopyWarning,
+} from '@/features/multichain'
 import { MyAccountsFeature } from '@/features/myAccounts'
 import { ActionRequiredPanel } from './ActionRequiredPanel'
 import { FEATURES } from '@safe-global/utils/utils/chains'
@@ -124,6 +128,7 @@ const Dashboard = (): ReactElement => {
           <ActionRequiredPanel>
             {supportsRecovery && <RecoveryHeader />}
             <InconsistentSignerSetupWarning />
+            <OutdatedMastercopyWarning />
             <UnsupportedMastercopyWarning />
             <NonPinnedWarning />
           </ActionRequiredPanel>

--- a/apps/web/src/features/multichain/components/OutdatedMastercopyWarning/OutdatedMastercopyWarning.test.tsx
+++ b/apps/web/src/features/multichain/components/OutdatedMastercopyWarning/OutdatedMastercopyWarning.test.tsx
@@ -1,0 +1,99 @@
+import { screen } from '@testing-library/react'
+import { render } from '@/tests/test-utils'
+import { OutdatedMastercopyWarning } from './OutdatedMastercopyWarning'
+import { ImplementationVersionState } from '@safe-global/store/gateway/types'
+import { MasterCopyDeployer } from '@/hooks/useMasterCopies'
+
+jest.mock('@/hooks/useSafeInfo')
+jest.mock('@/hooks/useMasterCopies', () => ({
+  ...jest.requireActual('@/hooks/useMasterCopies'),
+  useMasterCopies: jest.fn(),
+}))
+jest.mock('@/hooks/useChains')
+jest.mock('@/hooks/useIsSafeOwner')
+jest.mock('@/components/tx-flow/flows', () => ({
+  UpdateSafeFlow: () => null,
+}))
+
+const mockUseSafeInfo = jest.requireMock('@/hooks/useSafeInfo').default as jest.Mock
+const mockUseMasterCopies = jest.requireMock('@/hooks/useMasterCopies').useMasterCopies as jest.Mock
+const mockUseCurrentChain = jest.requireMock('@/hooks/useChains').useCurrentChain as jest.Mock
+const mockUseIsSafeOwner = jest.requireMock('@/hooks/useIsSafeOwner').default as jest.Mock
+
+const MOCK_ADDRESS = '0x3E5c63644E683549055b9Be8653de26E0B4CD36E'
+
+const gnosisMasterCopy = {
+  address: MOCK_ADDRESS,
+  version: '1.1.1',
+  deployer: MasterCopyDeployer.GNOSIS,
+  deployerRepoUrl: 'https://github.com/gnosis/safe-contracts/releases',
+}
+
+const defaultSafe = {
+  implementation: { value: MOCK_ADDRESS },
+  implementationVersionState: ImplementationVersionState.OUTDATED,
+  version: '1.1.1',
+}
+
+describe('OutdatedMastercopyWarning', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseSafeInfo.mockReturnValue({ safe: defaultSafe })
+    mockUseMasterCopies.mockReturnValue([[gnosisMasterCopy], undefined, false])
+    mockUseCurrentChain.mockReturnValue({ recommendedMasterCopyVersion: '1.4.1' })
+    mockUseIsSafeOwner.mockReturnValue(true)
+  })
+
+  it('returns null when UP_TO_DATE', () => {
+    mockUseSafeInfo.mockReturnValue({
+      safe: { ...defaultSafe, implementationVersionState: ImplementationVersionState.UP_TO_DATE },
+    })
+
+    const { container } = render(<OutdatedMastercopyWarning />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('returns null when OUTDATED but version is non-critical (>= 1.3.0)', () => {
+    mockUseSafeInfo.mockReturnValue({
+      safe: { ...defaultSafe, version: '1.3.0', implementationVersionState: ImplementationVersionState.OUTDATED },
+    })
+    mockUseMasterCopies.mockReturnValue([[{ ...gnosisMasterCopy, version: '1.3.0' }], undefined, false])
+
+    const { container } = render(<OutdatedMastercopyWarning />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('returns null when OUTDATED and critical but deployer is not GNOSIS', () => {
+    mockUseMasterCopies.mockReturnValue([
+      [{ ...gnosisMasterCopy, deployer: MasterCopyDeployer.CIRCLES }],
+      undefined,
+      false,
+    ])
+
+    const { container } = render(<OutdatedMastercopyWarning />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders ActionCard with info severity and correct copy when all conditions met', () => {
+    render(<OutdatedMastercopyWarning />)
+
+    expect(screen.getByTestId('action-card')).toBeInTheDocument()
+    expect(screen.getByText(/New Safe version is available/)).toBeInTheDocument()
+    expect(screen.getByText(/Update now to take advantage of new features/)).toBeInTheDocument()
+  })
+
+  it('renders Update CTA for owners', () => {
+    render(<OutdatedMastercopyWarning />)
+
+    expect(screen.getByText('Update')).toBeInTheDocument()
+  })
+
+  it('omits Update CTA for non-owners', () => {
+    mockUseIsSafeOwner.mockReturnValue(false)
+
+    render(<OutdatedMastercopyWarning />)
+
+    expect(screen.queryByText('Update')).not.toBeInTheDocument()
+    expect(screen.getByTestId('action-card')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/multichain/components/OutdatedMastercopyWarning/OutdatedMastercopyWarning.tsx
+++ b/apps/web/src/features/multichain/components/OutdatedMastercopyWarning/OutdatedMastercopyWarning.tsx
@@ -1,0 +1,41 @@
+import { TxModalContext } from '@/components/tx-flow'
+import { UpdateSafeFlow } from '@/components/tx-flow/flows'
+import { ActionCard } from '@/components/common/ActionCard'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { MasterCopyDeployer, useMasterCopies } from '@/hooks/useMasterCopies'
+import { useCurrentChain } from '@/hooks/useChains'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import { useCallback, useContext, useMemo } from 'react'
+import { ImplementationVersionState } from '@safe-global/store/gateway/types'
+import { getLatestSafeVersion, isNonCriticalUpdate } from '@safe-global/utils/utils/chains'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { ATTENTION_PANEL_EVENTS } from '@/services/analytics/events/attention-panel'
+
+export const OutdatedMastercopyWarning = () => {
+  const { safe } = useSafeInfo()
+  const [masterCopies] = useMasterCopies()
+  const currentChain = useCurrentChain()
+  const isOwner = useIsSafeOwner()
+  const { setTxFlow } = useContext(TxModalContext)
+  const openUpdateModal = useCallback(() => setTxFlow(<UpdateSafeFlow />), [setTxFlow])
+
+  const safeMasterCopy = useMemo(() => {
+    return masterCopies?.find((mc) => sameAddress(mc.address, safe.implementation.value))
+  }, [masterCopies, safe.implementation.value])
+
+  if (safe.implementationVersionState !== ImplementationVersionState.OUTDATED) return null
+  if (isNonCriticalUpdate(safe.version)) return null
+  if (safeMasterCopy?.deployer !== MasterCopyDeployer.GNOSIS) return null
+
+  const latestSafeVersion = getLatestSafeVersion(currentChain)
+
+  return (
+    <ActionCard
+      severity="info"
+      title={`New Safe version is available - ${latestSafeVersion}. `}
+      content="Update now to take advantage of new features and the highest security standards available. You will need to confirm this update just like any other transaction."
+      action={isOwner ? { label: 'Update', onClick: openUpdateModal } : undefined}
+      trackingEvent={ATTENTION_PANEL_EVENTS.UPDATE_OUTDATED_MASTERCOPY}
+    />
+  )
+}

--- a/apps/web/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
+++ b/apps/web/src/features/multichain/components/SignerSetupWarning/InconsistentSignerSetupWarning.tsx
@@ -77,8 +77,8 @@ export const InconsistentSignerSetupWarning = () => {
   return (
     <ActionCard
       severity="warning"
-      title="Different signers across chains "
-      content="can break approvals and risk losing control of this Safe."
+      title="You have different signers across different networks."
+      content="This could break approvals and you may risk losing control of this Safe. First, switch to the affected network and review the signer setup for this Safe."
       action={{ label: 'Review signers', onClick: handleReviewSigners }}
       trackingEvent={ATTENTION_PANEL_EVENTS.REVIEW_SIGNERS}
     />

--- a/apps/web/src/features/multichain/components/UnsupportedMastercopyWarning/UnsupportedMasterCopyWarning.tsx
+++ b/apps/web/src/features/multichain/components/UnsupportedMastercopyWarning/UnsupportedMasterCopyWarning.tsx
@@ -37,13 +37,17 @@ export const UnsupportedMastercopyWarning = () => {
   return (
     <ActionCard
       severity="warning"
-      title="This Safe is running an outdated version "
-      content="and may miss security fixes and improvements."
+      title="This Safe is running an unsupported version "
+      content={
+        canMigrate
+          ? 'and may miss security fixes and improvements. You should migrate it to a compatible version.'
+          : 'and may miss security fixes and improvements. You must use our CLI tool to migrate.'
+      }
       action={
         canMigrate
-          ? { label: 'Update version', onClick: openUpgradeModal }
+          ? { label: 'Migrate', onClick: openUpgradeModal }
           : {
-              label: 'Use CLI',
+              label: 'Get CLI',
               href: CLI_LINK,
               target: '_blank',
               rel: 'noopener noreferrer',

--- a/apps/web/src/features/multichain/index.ts
+++ b/apps/web/src/features/multichain/index.ts
@@ -53,6 +53,12 @@ const UnsupportedMastercopyWarning = dynamic(() =>
   })),
 )
 
+const OutdatedMastercopyWarning = dynamic(() =>
+  import('./components/OutdatedMastercopyWarning/OutdatedMastercopyWarning').then((mod) => ({
+    default: mod.OutdatedMastercopyWarning,
+  })),
+)
+
 export {
   CreateSafeOnNewChain,
   CreateSafeOnSpecificChain,
@@ -62,4 +68,5 @@ export {
   InconsistentSignerSetupWarning,
   ChainIndicatorList,
   UnsupportedMastercopyWarning,
+  OutdatedMastercopyWarning,
 }

--- a/apps/web/src/services/analytics/events/attention-panel.ts
+++ b/apps/web/src/services/analytics/events/attention-panel.ts
@@ -6,8 +6,15 @@ export const ATTENTION_PANEL_EVENTS = {
     action: 'Migrate unsupported mastercopy',
     category: ATTENTION_PANEL_CATEGORY,
   },
+
   GET_CLI_MASTERCOPY: {
     action: 'Get CLI for unsupported mastercopy',
+    category: ATTENTION_PANEL_CATEGORY,
+  },
+
+  // Outdated Mastercopy
+  UPDATE_OUTDATED_MASTERCOPY: {
+    action: 'Update outdated mastercopy',
     category: ATTENTION_PANEL_CATEGORY,
   },
 


### PR DESCRIPTION
## Summary

- Cherry-picks the mastercopy warnings fix onto the `release` branch
- Restores `OutdatedMastercopyWarning` component display in the Action Required panel

## Test plan

- [ ] Verify outdated mastercopy warning appears in the Action Required panel for affected Safes
- [ ] Confirm no regression in the multichain/Action Required panel flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)