### PR TITLE
tests(mobile): add e2e positions feature test

### DIFF
--- a/apps/mobile/e2e/tests/assets/__suite__.yml
+++ b/apps/mobile/e2e/tests/assets/__suite__.yml
@@ -20,3 +20,8 @@ tags:
     file: ./change-currency.yml
     env:
       SKIP_CLEAN_START: 'true'
+
+- runFlow:
+    file: ./view-positions.yml
+    env:
+      SKIP_CLEAN_START: 'true'

--- a/apps/mobile/e2e/tests/assets/view-positions.yml
+++ b/apps/mobile/e2e/tests/assets/view-positions.yml
@@ -1,0 +1,152 @@
+appId: ${APP_ID}
+tags:
+  - assets
+  - positions
+---
+# Positions Feature Test
+# Tests viewing positions list and protocol detail bottom sheet
+# Uses a Polygon safe with AAVE V3 positions
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+# Set up Polygon safe with positions
+- tapOn:
+    id: 'e2ePositionsTestSafe'
+
+# Wait for home screen to load
+- assertVisible:
+    id: 'home-tab'
+
+# ============================================
+# Navigate to Positions Tab
+# ============================================
+
+- tapOn:
+    text: 'Positions'
+
+# Verify Positions tab content appears
+- assertVisible:
+    id: 'tab-content-Positions-1'
+
+# ============================================
+# Verify AAVE V3 Protocol Section
+# ============================================
+
+# Wait for positions data to load
+- assertVisible:
+    id: 'protocol-section-aave-v3'
+
+# Verify protocol name is displayed
+- assertVisible:
+    text: '.*AAVE V3.*'
+
+# Verify protocol shows a percentage badge (e.g., "84.64%")
+# Skip this for now: for some reason react can't find it in the view hierarchy despite being there
+# - assertVisible:
+#    id: 'protocol-aave-v3-percentage'
+
+# Verify protocol shows a fiat total (e.g., "$5")
+- assertVisible:
+    id: 'protocol-aave-v3-fiat-total'
+
+# ============================================
+# Open AAVE V3 Protocol Detail Sheet
+# ============================================
+
+- tapOn:
+    id: 'protocol-section-aave-v3'
+
+# Verify bottom sheet opens with protocol detail
+- assertVisible:
+    id: 'protocol-detail-sheet'
+
+# Verify protocol header shows protocol name
+- assertVisible:
+    id: 'protocol-detail-header'
+
+# Verify "Your positions" section title is visible
+- assertVisible:
+    text: 'Your positions'
+
+# ============================================
+# Verify Position Items in Bottom Sheet
+# ============================================
+
+# Verify at least one position item shows a position type label
+- assertVisible:
+    text: 'Deposited'
+
+# Verify a position item is visible (Wrapped Matic is in this safe's AAVE V3 positions)
+- assertVisible:
+    id: 'position-WMATIC'
+
+# Verify the position fiat balance is displayed
+- assertVisible:
+    id: 'position-WMATIC-fiat-balance'
+
+# ============================================
+# Dismiss Bottom Sheet
+# ============================================
+
+- swipe:
+    direction: 'DOWN'
+    startPoint: '50%,30%'
+    endPoint: '50%,80%'
+
+# Verify we're back to the positions list
+- assertVisible:
+    id: 'tab-content-Positions-1'
+
+# Verify AAVE V3 protocol section is still visible
+- assertVisible:
+    id: 'protocol-section-aave-v3'
+
+# ============================================
+# Test Morpho Protocol
+# ============================================
+
+# Verify Morpho protocol section is visible
+- assertVisible:
+    id: 'protocol-section-morpho'
+
+# Verify Morpho shows a percentage badge
+# Skip this for now: samea as above - for some reason react can't find it in the view hierarchy despite being there
+# - assertVisible:
+#    id: 'protocol-morpho-percentage'
+#    text: '.*%'
+
+# Verify Morpho shows a fiat total
+- assertVisible:
+    id: 'protocol-morpho-fiat-total'
+
+# Open Morpho Protocol Detail Sheet
+- tapOn:
+    id: 'protocol-section-morpho'
+
+# Verify bottom sheet opens
+- assertVisible:
+    id: 'protocol-detail-sheet'
+
+# Verify protocol header
+- assertVisible:
+    id: 'protocol-detail-header'
+
+# Verify "Your positions" section title
+- assertVisible:
+    text: 'Your positions'
+
+# Verify Morpho has position items with a position type label
+- assertVisible:
+    text: 'Deposited'
+
+# Dismiss Morpho bottom sheet
+- swipe:
+    direction: 'DOWN'
+    startPoint: '50%,30%'
+    endPoint: '50%,80%'
+
+# Verify we're back to the positions list
+- assertVisible:
+    id: 'tab-content-Positions-1'
+# Test completed successfully - AAVE V3 and Morpho positions verified

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/ProtocolDetailSheet.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/ProtocolDetailSheet.container.tsx
@@ -51,6 +51,7 @@ export const ProtocolDetailSheetContainer = () => {
       handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
     >
       <BottomSheetScrollView
+        testID="protocol-detail-sheet"
         stickyHeaderIndices={[0]}
         contentContainerStyle={{
           paddingBottom: insets.bottom + getTokenValue(Platform.OS === 'ios' ? '$4' : '$8'),

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/ProtocolDetailSheetHeader.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolDetailSheet/ProtocolDetailSheetHeader.tsx
@@ -19,7 +19,7 @@ export const ProtocolDetailSheetHeader = ({ protocol, percentageRatio, currency 
   const fiatChange = calculateProtocolFiatChange(protocol)
 
   return (
-    <View paddingHorizontal="$2" width="100%" backgroundColor="$backgroundSheet">
+    <View paddingHorizontal="$2" width="100%" backgroundColor="$backgroundSheet" testID="protocol-detail-header">
       <View
         backgroundColor="$backgroundPaper"
         borderRadius="$3"

--- a/apps/mobile/src/features/Assets/components/Positions/ProtocolSection/ProtocolSection.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/ProtocolSection/ProtocolSection.tsx
@@ -23,13 +23,14 @@ export const ProtocolSection = ({ protocol, totalFiatValue, currency }: Protocol
   const formattedPercentage = formatPercentage(percentageRatio)
   const formattedFiatTotal = formatCurrency(fiatTotal, currency)
   const fiatChange = calculateProtocolFiatChange(protocol)
+  const protocolSlug = protocol.protocol.toLowerCase().replace(/\s+/g, '-')
 
   const handlePress = () => {
     router.push({ pathname: '/protocol-detail-sheet', params: { protocolId: protocol.protocol } })
   }
 
   return (
-    <Pressable onPress={handlePress} testID={`protocol-section-${protocol.protocol}`}>
+    <Pressable onPress={handlePress} testID={`protocol-section-${protocolSlug}`} collapsable={false}>
       <View
         backgroundColor="$backgroundPaper"
         borderRadius="$3"
@@ -59,7 +60,14 @@ export const ProtocolSection = ({ protocol, totalFiatValue, currency }: Protocol
               borderRadius="$2"
               flexShrink={0}
             >
-              <Text fontSize={11} color="$color" fontWeight={400} lineHeight={16} letterSpacing={1}>
+              <Text
+                fontSize={11}
+                color="$color"
+                fontWeight={400}
+                lineHeight={16}
+                letterSpacing={1}
+                testID={`protocol-${protocolSlug}-percentage`}
+              >
                 {formattedPercentage}
               </Text>
             </View>
@@ -67,7 +75,13 @@ export const ProtocolSection = ({ protocol, totalFiatValue, currency }: Protocol
         </View>
         <View flexDirection="row" alignItems="center" gap="$2" flexShrink={0}>
           <View alignItems="flex-end">
-            <Text fontSize="$4" fontWeight={600} color="$color" lineHeight={20}>
+            <Text
+              fontSize="$4"
+              fontWeight={600}
+              color="$color"
+              lineHeight={20}
+              testID={`protocol-${protocolSlug}-fiat-total`}
+            >
               {formattedFiatTotal}
             </Text>
             {fiatChange !== null && (

--- a/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
+++ b/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'expo-router'
 import { useState } from 'react'
 import { setupOnboardedAccount, setupTestOnboarding, setupSeedPhraseImportAccount } from '../setup/onboardingSetup'
 import { setupOnboardedAccountForAssets } from '../setup/assetsSetup'
+import { setupPositionsTestSafe } from '../setup/positionsSetup'
 import {
   setupAllPendingTxSafes,
   setupPendingTxsSafe1,
@@ -111,6 +112,12 @@ export function TestCtrls() {
         <Pressable
           testID="e2eOnboardedAccountTestAssets"
           onPress={() => setupOnboardedAccountForAssets(dispatch, router)}
+          accessibilityRole="button"
+          style={BTN}
+        />
+        <Pressable
+          testID="e2ePositionsTestSafe"
+          onPress={() => setupPositionsTestSafe(dispatch, router)}
           accessibilityRole="button"
           style={BTN}
         />

--- a/apps/mobile/src/tests/e2e-maestro/setup/mockData.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/mockData.ts
@@ -225,6 +225,22 @@ export const pendingTxSafeInfo6: SafeOverview = {
   threshold: 1,
 }
 
+// Positions test safe (Polygon) - has AAVE V3 positions
+export const positionsTestSafe: SafeInfo = {
+  address: '0xc1f4652866ddB3811adcd3418c13eF640e88E1f6',
+  chainId: '137',
+}
+
+export const positionsTestSafeInfo: SafeOverview = {
+  address: { value: '0xc1f4652866ddB3811adcd3418c13eF640e88E1f6', name: null, logoUri: null },
+  awaitingConfirmation: null,
+  chainId: positionsTestSafe.chainId,
+  fiatTotal: '0',
+  owners: [{ value: '0x0000000000000000000000000000000000000001', name: null, logoUri: null }],
+  queued: 0,
+  threshold: 1,
+}
+
 // Seed phrase import test account
 export const mockedSeedPhraseImportAccount: SafeInfo = {
   address: '0x4c425AceFf91aa4398183FE82e210C96dD9E92F8',

--- a/apps/mobile/src/tests/e2e-maestro/setup/positionsSetup.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/positionsSetup.ts
@@ -1,0 +1,31 @@
+import type { Dispatch } from '@reduxjs/toolkit'
+import type { Router } from 'expo-router'
+import { addSafe } from '@/src/store/safesSlice'
+import { setActiveSafe } from '@/src/store/activeSafeSlice'
+import { updatePromptAttempts } from '@/src/store/notificationsSlice'
+import { addContact } from '@/src/store/addressBookSlice'
+import { Address } from '@/src/types/address'
+import { positionsTestSafe, positionsTestSafeInfo } from './mockData'
+
+/**
+ * Setup for e2ePositionsTestSafe button
+ * Creates a Polygon safe with AAVE V3 positions and navigates to home
+ */
+export const setupPositionsTestSafe = (dispatch: Dispatch, router: Router) => {
+  dispatch(
+    addSafe({
+      address: positionsTestSafeInfo.address.value as Address,
+      info: { [positionsTestSafeInfo.chainId]: positionsTestSafeInfo },
+    }),
+  )
+  dispatch(
+    addContact({
+      value: positionsTestSafeInfo.address.value as Address,
+      name: 'PositionsSafe',
+      chainIds: [positionsTestSafeInfo.chainId],
+    }),
+  )
+  dispatch(updatePromptAttempts(1))
+  dispatch(setActiveSafe(positionsTestSafe))
+  router.replace('/(tabs)')
+}


### PR DESCRIPTION
## What it solves

Adds Maestro e2e test coverage for the mobile positions feature, verifying that protocol sections (AAVE V3, Morpho) display correctly and that tapping a protocol opens the detail bottom sheet with position items.

Resolves: N/A

## How this PR fixes it

- Creates `view-positions.yml` e2e test using a real Polygon safe (`0xc1f4652866ddB3811adcd3418c13eF640e88E1f6`) with AAVE V3 and Morpho positions
- Adds necessary testIDs to `ProtocolDetailSheet.container.tsx`, `ProtocolDetailSheetHeader.tsx`, and `ProtocolSection.tsx`
- Normalizes protocol slugs in testIDs (lowercase, hyphens) for reliable Maestro selectors
- Adds positions test safe setup infrastructure (mock data, setup function, trigger button)

## How to test it

1. Run the positions e2e test: `maestro test apps/mobile/e2e/tests/assets/view-positions.yml`
2. Verify AAVE V3 protocol section is found and tappable
3. Verify the detail bottom sheet opens with position items (e.g., WMATIC)
4. Verify Morpho protocol section is also tested after dismissing AAVE V3

## Screenshots

https://github.com/user-attachments/assets/1118ca58-51d0-4431-93e3-555c29138380




N/A - e2e test addition

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).