### PR TITLE
revert: fix: reduce safe info polling on multichain creation

### DIFF
--- a/apps/web/src/features/counterfactual/hooks/__tests__/usePendingSafeStatuses.test.ts
+++ b/apps/web/src/features/counterfactual/hooks/__tests__/usePendingSafeStatuses.test.ts
@@ -54,10 +54,9 @@ const mockIsSmartContract = jest.requireMock('@/utils/wallets').isSmartContract 
 
 describe('usePendingSafeStatuses', () => {
   const chainId = '1'
-  const currentSafeAddress = '0x1111111111111111111111111111111111111111'
-  const otherSafeAddress = '0x2222222222222222222222222222222222222222'
+  const safeAddress = '0x1111111111111111111111111111111111111111'
 
-  const setupMocks = (safeAddress: string) => {
+  const setupMocks = () => {
     mockUseChainId.mockReturnValue(chainId)
     mockUseCurrentChain.mockReturnValue({ chainId, chainName: 'Ethereum' })
     mockUseSafeInfo.mockReturnValue({
@@ -78,8 +77,8 @@ describe('usePendingSafeStatuses', () => {
     ;(pollSafeInfo as jest.Mock).mockResolvedValue(undefined)
   })
 
-  it('polls CGW only for the current safe on SUCCESS', async () => {
-    setupMocks(currentSafeAddress)
+  it('polls CGW and dispatches INDEXED on SUCCESS', async () => {
+    setupMocks()
 
     const subscriptions: Record<string, (detail: unknown) => void> = {}
     ;(safeCreationSubscribe as jest.Mock).mockImplementation((event, callback) => {
@@ -91,44 +90,16 @@ describe('usePendingSafeStatuses', () => {
 
     subscriptions[SafeCreationEvent.SUCCESS]?.({
       groupKey: 'group',
-      safeAddress: currentSafeAddress,
+      safeAddress,
       chainId,
       type: PayMethod.PayLater,
     })
 
     await waitFor(() => {
-      expect(pollSafeInfo).toHaveBeenCalledWith(chainId, currentSafeAddress)
+      expect(pollSafeInfo).toHaveBeenCalledWith(chainId, safeAddress)
       expect(safeCreationDispatch).toHaveBeenCalledWith(SafeCreationEvent.INDEXED, {
         groupKey: 'group',
-        safeAddress: currentSafeAddress,
-        chainId,
-      })
-    })
-  })
-
-  it('skips CGW polling for non-current safes on SUCCESS', async () => {
-    setupMocks(currentSafeAddress)
-
-    const subscriptions: Record<string, (detail: unknown) => void> = {}
-    ;(safeCreationSubscribe as jest.Mock).mockImplementation((event, callback) => {
-      subscriptions[event] = callback
-      return jest.fn()
-    })
-
-    renderHook(() => usePendingSafeStatus(), { initialReduxState: { undeployedSafes: {} } })
-
-    subscriptions[SafeCreationEvent.SUCCESS]?.({
-      groupKey: 'group',
-      safeAddress: otherSafeAddress,
-      chainId,
-      type: PayMethod.PayLater,
-    })
-
-    await waitFor(() => {
-      expect(pollSafeInfo).not.toHaveBeenCalled()
-      expect(safeCreationDispatch).toHaveBeenCalledWith(SafeCreationEvent.INDEXED, {
-        groupKey: 'group',
-        safeAddress: otherSafeAddress,
+        safeAddress,
         chainId,
       })
     })

--- a/apps/web/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
+++ b/apps/web/src/features/counterfactual/hooks/usePendingSafeStatuses.ts
@@ -15,7 +15,6 @@ import { CREATE_SAFE_EVENTS, trackEvent, MixpanelEventParams } from '@/services/
 import { useAppDispatch, useAppSelector } from '@/store'
 import { useEffect, useRef } from 'react'
 import { isSmartContract } from '@/utils/wallets'
-import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { gtmSetSafeAddress } from '@/services/analytics/gtm'
 import { PendingSafeStatus } from '@safe-global/utils/features/counterfactual/store/types'
 import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
@@ -149,24 +148,13 @@ const usePendingSafeStatus = (): void => {
             trackEvent(CREATE_SAFE_EVENTS.ACTIVATED_SAFE)
           }
 
-          const isCurrentSafe = creationChainId === chainId && sameAddress(detail.safeAddress, safeAddress || '')
-
-          if (isCurrentSafe) {
-            pollSafeInfo(creationChainId, detail.safeAddress).finally(() => {
-              safeCreationDispatch(SafeCreationEvent.INDEXED, {
-                groupKey: detail.groupKey,
-                safeAddress: detail.safeAddress,
-                chainId: creationChainId,
-              })
-            })
-          } else {
-            // Avoid spamming CGW when many networks are created at once.
+          pollSafeInfo(creationChainId, detail.safeAddress).finally(() => {
             safeCreationDispatch(SafeCreationEvent.INDEXED, {
               groupKey: detail.groupKey,
               safeAddress: detail.safeAddress,
               chainId: creationChainId,
             })
-          }
+          })
           return
         }
 


### PR DESCRIPTION
Revert #7080 

## Multi-Chain Safe Creation Flow
When you create a Safe on multiple networks:

1. You select multiple chains (e.g., Ethereum, Polygon, Arbitrum)
2. All of them are created as counterfactual (PayLater) - just predicting the address
3. No actual deployment happens - they all get `AWAITING_EXECUTION` status
4. The user deploys/activates them one chain at a time later

### When Does SUCCESS Fire?
The `SafeCreationEvent.SUCCESS` only fires when an actual on-chain deployment happens:
* A transaction is mined (single chain)
* A relay task completes (single chain)
You can't deploy on multiple chains simultaneously - each chain requires a separate transaction.

### The Flaw in the Optimization
The comment says "Avoid spamming CGW when many networks are created at once" - but:

1. Counterfactual creation fires `AWAITING_EXECUTION`, not `SUCCESS`
2. `SUCCESS` only fires for actual deployment, which is one chain at a time

The optimization doesn't make sense for the `SUCCESS → INDEXED` flow
So the optimization seems to be solving for a case that doesn't actually exist in the SUCCESS handler. The "many networks at once" scenario applies to counterfactual creation (AWAITING_EXECUTION), not to deployment completion (SUCCESS).


PS I believe the lazy-loading of Counterfactual safes (as part of new architecture refactoring) has actually fixed the bug that was seen with multichain flow