### PR TITLE
Update storybook snapshots for chain logo min-width

### DIFF
--- a/apps/web/src/components/common/ChainIndicator/__snapshots__/ChainIndicator.stories.test.tsx.snap
+++ b/apps/web/src/components/common/ChainIndicator/__snapshots__/ChainIndicator.stories.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`./ChainIndicator.stories Default 1`] = `
           height="24"
           loading="lazy"
           src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+          style="min-width: 24px;"
           width="24"
         />
         <div
@@ -72,6 +73,7 @@ exports[`./ChainIndicator.stories Inline 1`] = `
           height="24"
           loading="lazy"
           src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+          style="min-width: 24px;"
           width="24"
         />
         <div
@@ -109,6 +111,7 @@ exports[`./ChainIndicator.stories LargeImage 1`] = `
           height="36"
           loading="lazy"
           src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+          style="min-width: 36px;"
           width="36"
         />
         <div
@@ -177,6 +180,7 @@ exports[`./ChainIndicator.stories OnlyLogo 1`] = `
           height="24"
           loading="lazy"
           src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+          style="min-width: 24px;"
           width="24"
         />
       </span>
@@ -205,6 +209,7 @@ exports[`./ChainIndicator.stories Responsive 1`] = `
           height="24"
           loading="lazy"
           src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+          style="min-width: 24px;"
           width="24"
         />
         <div
@@ -242,6 +247,7 @@ exports[`./ChainIndicator.stories SmallImage 1`] = `
           height="16"
           loading="lazy"
           src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+          style="min-width: 16px;"
           width="16"
         />
         <div
@@ -314,6 +320,7 @@ exports[`./ChainIndicator.stories WithFiatValue 1`] = `
           height="24"
           loading="lazy"
           src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+          style="min-width: 24px;"
           width="24"
         />
         <div

--- a/apps/web/src/components/common/TokenIcon/__snapshots__/TokenIcon.stories.test.tsx.snap
+++ b/apps/web/src/components/common/TokenIcon/__snapshots__/TokenIcon.stories.test.tsx.snap
@@ -259,6 +259,7 @@ exports[`./TokenIcon.stories WithChainIndicator 1`] = `
             height="17.333342000000002"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+            style="min-width: 17.333342000000002px;"
             width="17.333342000000002"
           />
         </span>

--- a/apps/web/src/features/multichain/components/NetworkLogosList/__snapshots__/NetworkLogosList.stories.test.tsx.snap
+++ b/apps/web/src/features/multichain/components/NetworkLogosList/__snapshots__/NetworkLogosList.stories.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`./NetworkLogosList.stories FourNetworks 1`] = `
             height="24"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+            style="min-width: 24px;"
             width="24"
           />
         </span>
@@ -35,6 +36,7 @@ exports[`./NetworkLogosList.stories FourNetworks 1`] = `
             height="24"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/137/chain_logo.png"
+            style="min-width: 24px;"
             width="24"
           />
         </span>
@@ -87,6 +89,7 @@ exports[`./NetworkLogosList.stories ManyNetworksWithHasMore 1`] = `
             height="24"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+            style="min-width: 24px;"
             width="24"
           />
         </span>
@@ -99,6 +102,7 @@ exports[`./NetworkLogosList.stories ManyNetworksWithHasMore 1`] = `
             height="24"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/137/chain_logo.png"
+            style="min-width: 24px;"
             width="24"
           />
         </span>
@@ -157,6 +161,7 @@ exports[`./NetworkLogosList.stories ManyNetworksWithoutHasMore 1`] = `
             height="24"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+            style="min-width: 24px;"
             width="24"
           />
         </span>
@@ -169,6 +174,7 @@ exports[`./NetworkLogosList.stories ManyNetworksWithoutHasMore 1`] = `
             height="24"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/137/chain_logo.png"
+            style="min-width: 24px;"
             width="24"
           />
         </span>
@@ -231,6 +237,7 @@ exports[`./NetworkLogosList.stories SingleNetwork 1`] = `
             height="24"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+            style="min-width: 24px;"
             width="24"
           />
         </span>
@@ -263,6 +270,7 @@ exports[`./NetworkLogosList.stories TwoNetworks 1`] = `
             height="24"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/1/chain_logo.png"
+            style="min-width: 24px;"
             width="24"
           />
         </span>
@@ -275,6 +283,7 @@ exports[`./NetworkLogosList.stories TwoNetworks 1`] = `
             height="24"
             loading="lazy"
             src="https://safe-transaction-assets.staging.5afe.dev/chains/137/chain_logo.png"
+            style="min-width: 24px;"
             width="24"
           />
         </span>


### PR DESCRIPTION
## Summary
- Updated Storybook snapshots for `ChainIndicator`, `TokenIcon`, and `NetworkLogosList` components to reflect the new `min-width` style on chain/network logo images.

## Test plan
- [x] Snapshot files updated to match current component output
- [ ] Verify Storybook stories render correctly
- [ ] Confirm CI snapshot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)