### PR TITLE
fix(mobile): remove background color from date header in tx history

### DIFF
--- a/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/DateHeaderItem.tsx
+++ b/apps/mobile/src/features/TxHistory/components/TxHistoryList/components/DateHeaderItem.tsx
@@ -10,7 +10,7 @@ const DateHeaderItemComponent = ({ timestamp }: DateHeaderItemProps) => {
   const dateTitle = formatWithSchema(timestamp, 'MMM d, yyyy')
 
   return (
-    <View marginTop="$2" backgroundColor="$background" paddingTop="$2">
+    <View marginTop="$2" paddingTop="$2">
       <Text fontWeight={500} color="$colorSecondary">
         {dateTitle}
       </Text>


### PR DESCRIPTION
## What it solves

Date labels in the transaction history show a visible background rectangle in light mode, making the table look messy.

Resolves: https://linear.app/safe-global/issue/WA-1540/date-has-a-background-in-the-history-the-table-looks-messy

## How this PR fixes it

Removes the explicit `backgroundColor="$background"` from the `DateHeaderItem` component. The date header now inherits its parent's background, eliminating the visual artifact in light theme.

## How to test it

1. Open the mobile app in light mode
2. Navigate to a Safe with transaction history
3. Verify date labels no longer have a visible background rectangle
4. Check dark mode as well to ensure no regression

## Screenshots

before
<img width="250" alt="image" src="https://github.com/user-attachments/assets/d37eed6f-22a3-46ec-be5d-e02dec639630" />



after
<img width="250" alt="image" src="https://github.com/user-attachments/assets/d8254cf9-8357-4ddf-a5b6-024e681fe059" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).