### PR TITLE
chore: run Argos E2E only on manual trigger

### DIFF
--- a/.github/workflows/web-argos-e2e.yml
+++ b/.github/workflows/web-argos-e2e.yml
@@ -2,10 +2,6 @@ name: Web Argos E2E
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - 'apps/web/**'
-      - 'packages/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Removes pull_request trigger from Argos workflow. Argos visual regression tests now run only via workflow_dispatch (manual trigger from Actions tab).

Made with [Cursor](https://cursor.com)