### PR TITLE
fix(mobile): use app theme for native context menu instead of device theme

### DIFF
--- a/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
+++ b/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
@@ -77,7 +77,6 @@ export const AppSettingsContainer = () => {
           type: 'floating-menu',
           rightNode: (
             <FloatingMenu
-              themeVariant={themePreference}
               onPressAction={({ nativeEvent }) => {
                 const mode = nativeEvent.event as 'auto' | 'dark' | 'light'
                 setThemePreference(mode)

--- a/apps/mobile/src/features/Settings/components/FloatingMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/FloatingMenu.tsx
@@ -1,17 +1,23 @@
 import React from 'react'
 import { Pressable } from 'react-native'
 import { MenuAction, MenuView, NativeActionEvent } from '@react-native-menu/menu'
-import { ThemePreference } from '@/src/types/theme'
+import { useTheme } from '@/src/theme/hooks/useTheme'
 
 type FloatingMenuProps = {
   onPressAction: (event: NativeActionEvent) => void
   actions: MenuAction[]
   children: React.ReactNode
-  themeVariant?: ThemePreference
 }
-export const FloatingMenu = ({ onPressAction, actions, children, themeVariant }: FloatingMenuProps) => {
+export const FloatingMenu = ({ onPressAction, actions, children }: FloatingMenuProps) => {
+  const { themePreference } = useTheme()
+
   return (
-    <MenuView themeVariant={themeVariant} onPressAction={onPressAction} actions={actions} shouldOpenOnLongPress={false}>
+    <MenuView
+      themeVariant={themePreference}
+      onPressAction={onPressAction}
+      actions={actions}
+      shouldOpenOnLongPress={false}
+    >
       <Pressable testID={'settings-screen-header-more-settings-button'}>{children}</Pressable>
     </MenuView>
   )

--- a/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
@@ -28,7 +28,11 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
   const copyAndDispatchToast = useCopyAndDispatchToast()
   const theme = useTheme()
   const color = theme.color.get()
-  const colorError = theme.error.get() || '#FF5F72'
+  // hardcoded to the iOS red
+  // when we set danger to a button, it automatically sets a color that the OS selects
+  // titleColor only works on android and not on iOS
+  // that's why I'm hardcoding the iOS value of the danger text here
+  const colorError = 'rgb(255,66,69)'
 
   if (!safeAddress) {
     return null
@@ -180,6 +184,7 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
             {
               id: 'remove',
               title: 'Remove account',
+              titleColor: colorError,
               attributes: {
                 destructive: true,
               },


### PR DESCRIPTION
## What it solves

When the user's app theme is set to light but the device is in dark mode, the native context menu (FloatingMenu) renders with a dark background (from device theme) while the icon colors are derived from the app's light theme — resulting in dark icons on a dark background.

Resolves: https://linear.app/safe-global/issue/WA-1384/adhoc-fixes-for-upcoming-release

## How this PR fixes it

Moved `themeVariant` resolution into `FloatingMenu` itself via `useTheme()` hook, so the native `MenuView` always matches the app's theme preference. This fixes the bug for all 3 callers (SettingsMenu, AppSettings, LedgerAddresses) at once and prevents future callers from forgetting to pass it. Also hardcodes the iOS destructive action color to match the native red.

## How to test it

1. Set the app theme to **light** in App Settings
2. Set device to **dark mode**
3. Go to Settings and tap the "..." menu
4. Verify the menu background is light and icons are visible (not dark-on-dark)
5. Repeat with app theme set to **dark** and device in **light mode** — menu should be dark

## Screenshots

N/A - requires device testing

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).