### PR TITLE
chore(workflows): sign version commit in web release workflow

### DIFF
--- a/.github/workflows/web-release-start.yml
+++ b/.github/workflows/web-release-start.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Commit version bump
         run: |
           git add apps/web/package.json
-          git commit -m "${{ steps.version.outputs.version }}"
+          git commit -S -m "${{ steps.version.outputs.version }}"
           git push origin release
           echo "✅ Version committed"
 


### PR DESCRIPTION
## What it solves
Updated the web release workflow to sign the version commit using GPG, enhancing the security and integrity of versioning. This change ensures that the version bump is verifiable.

Following the [example from the docs](https://github.com/crazy-max/ghaction-import-gpg/tree/v6/?tab=readme-ov-file#sign-commits) of the used package.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
