### PR TITLE
fix(web): UI fixes for the Calendly widget

### DIFF
--- a/apps/web/src/features/hypernative/components/HnSignupFlow/HnCalendlyStep.tsx
+++ b/apps/web/src/features/hypernative/components/HnSignupFlow/HnCalendlyStep.tsx
@@ -71,13 +71,6 @@ const HnCalendlyStep = ({ calendlyUrl, onBookingScheduled }: HnCalendlyStepProps
   return (
     <HnSignupLayout contentClassName={css.calendlyColumn}>
       <div className={css.calendlyWrapper}>
-        {!isSecondStep && !hasError && (
-          <div className={css.calendlyHeader}>
-            <Typography variant="h2" className={css.calendlyTitle}>
-              Get connected to the right expert
-            </Typography>
-          </div>
-        )}
         {hasError ? (
           <Box className={css.errorContainer}>
             <Typography variant="h3" className={css.errorTitle}>
@@ -112,15 +105,7 @@ const HnCalendlyStep = ({ calendlyUrl, onBookingScheduled }: HnCalendlyStepProps
             {showSkeleton && (
               <div className={css.calendlySkeletonOverlay}>
                 <Skeleton variant="rounded" width="100%" height="40px" sx={{ mb: 2, bgcolor: SKELETON_COLOR }} />
-                <br />
-                <Skeleton
-                  variant="rounded"
-                  sx={{
-                    width: { sm: '100%', md: '160px' },
-                    bgcolor: SKELETON_COLOR,
-                  }}
-                  height="40px"
-                />
+                <Skeleton variant="rounded" width="100%" height="40px" sx={{ bgcolor: SKELETON_COLOR }} />
               </div>
             )}
             <div

--- a/apps/web/src/features/hypernative/components/HnSignupFlow/styles.module.css
+++ b/apps/web/src/features/hypernative/components/HnSignupFlow/styles.module.css
@@ -32,51 +32,11 @@
 }
 
 .calendlyWrapper {
-  margin: 0 auto;
   width: 100%;
   height: 100%;
   display: flex;
   flex-direction: column;
   position: relative;
-}
-
-.calendlyHeader {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1000;
-  padding: var(--space-4);
-  background: var(--color-static-primary);
-  pointer-events: none;
-  visibility: visible;
-  opacity: 1;
-}
-
-.calendlyTitle {
-  padding: var(--space-3) var(--space-1);
-  font-weight: 700;
-  font-size: 24px;
-  color: var(--color-static-main);
-}
-
-@media (max-width: 400px) {
-  .calendlyHeader {
-    padding: var(--space-4);
-  }
-
-  .calendlyTitle {
-    font-size: 14px;
-    padding: 0;
-  }
-}
-
-/* Hardcoded values to make the new header hide Calendly branding on different screen sizes*/
-@media (min-width: 401px) and (max-width: 919px) {
-  .calendlyTitle {
-    font-size: 16px;
-    padding-block: var(--space-1);
-  }
 }
 
 .calendlyWidget {
@@ -94,7 +54,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  padding-top: 150px;
+  padding-top: var(--space-12);
   padding-inline: var(--space-5);
   z-index: 999;
   background-color: var(--color-static-primary);
@@ -103,11 +63,9 @@
 
 @media (min-width: 920px) {
   .calendlyWidget {
-    min-width: 660px;
-    height: 700px;
-    /* Compensate for the custom header + customized CSS for the desktop version: */
-    margin-top: calc(-1 * var(--space-9));
-    margin-left: -16px;
+    width: 100%;
+    height: 100%;
+    margin-top: 0;
   }
 }
 


### PR DESCRIPTION
## What it solves

Resolves: [WA-1602](https://linear.app/safe-global/issue/WA-1602/guardian-banner-see-how-it-works-modal-ui-broken)

## How this PR fixes it
Adjusts UI for the Calendly widget.
Removed the "Get connected to the right expert" title as it caused a lot of UI customization. If Calendly changes their widget UI, layout on our side will not be in place again.

## How to test it
Click on the HN banner -> check if the layout of the Calendly widget is not cropped.

## Screenshots
<img width="992" height="706" alt="image" src="https://github.com/user-attachments/assets/9b51f927-42bc-4e4e-9765-e0f66c6db202" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 - n/a
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
