### PR TITLE
chore(web): auto-export NEXT_PUBLIC secrets in build action

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -42,7 +42,7 @@ runs:
         if [ -n "$EXPORTED" ]; then
           echo "$EXPORTED" >> "$GITHUB_ENV"
           # Log exported key names (values masked)
-          echo "$EXPORTED" | grep -oP '^[A-Z_]+(?=<<)' | while read -r key; do
+          echo "$EXPORTED" | grep -oP '^[A-Z0-9_]+(?=<<)' | while read -r key; do
             echo "  Exported: $key"
           done
         else


### PR DESCRIPTION
## Summary
- Replace the manually maintained ~40-line `env:` block in the Build step with a `jq`-based step that bulk-exports all `NEXT_PUBLIC_*` secrets from the secrets JSON into `$GITHUB_ENV`
- New secrets with this prefix are now picked up automatically without editing `action.yml`
- The existing "Set environment variables" step still overrides specific keys (Infura prod/staging, Datadog env, commit hash) via last-write-wins in `$GITHUB_ENV`
- Uses heredoc delimiters (`KEY<<DELIM`) for safe handling of multi-line secret values (e.g. `NEXT_PUBLIC_FIREBASE_OPTIONS_*` JSON strings)
- Removed the old relay URL remap (`GELATO` → non-`GELATO`) — neither name is referenced in source code

## Unused env vars found

The following `NEXT_PUBLIC_*` secrets were set in the old build action but are **not referenced** anywhere in the web app source code:

| Secret | Notes |
|--------|-------|
| `NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL_PRODUCTION` | Was remapped to `NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_PRODUCTION` — neither name is used |
| `NEXT_PUBLIC_SAFE_GELATO_RELAY_SERVICE_URL_STAGING` | Was remapped to `NEXT_PUBLIC_SAFE_RELAY_SERVICE_URL_STAGING` — neither name is used |
| `NEXT_PUBLIC_SPINDL_SDK_KEY` | Not referenced in any source file |
| `NEXT_PUBLIC_INFURA_TOKEN_DEVSTAGING` | Only used indirectly — override step writes it as `NEXT_PUBLIC_INFURA_TOKEN` |
| `NEXT_PUBLIC_SAFE_APPS_INFURA_TOKEN_DEVSTAGING` | Only used indirectly — override step writes it as `NEXT_PUBLIC_SAFE_APPS_INFURA_TOKEN` |

These are harmless (Next.js only inlines vars actually referenced in source), but the GitHub secrets could be cleaned up separately.

## Test plan
- [ ] PR preview deployment works correctly (auto-triggered by `web-deploy-dev.yml`)
- [ ] Compare bundle analysis output to confirm no env vars are missing
- [ ] Verify Datadog sourcemap upload step still has access to its required env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI build-time environment variable injection for the web app; missing/mis-exported `NEXT_PUBLIC_*` values could break builds or alter runtime configuration. Touches GitHub Actions secret handling and Datadog sourcemap upload environment behavior.
> 
> **Overview**
> Simplifies the web build GitHub Action by auto-exporting all non-empty `NEXT_PUBLIC_*` entries from the provided secrets JSON into `$GITHUB_ENV` (with heredoc delimiters to support multi-line values).
> 
> Removes the manually maintained `env:` list from the `Build` step and relies on `$GITHUB_ENV` with *last-write-wins* overrides for commit hash, Datadog RUM env, and prod/staging Infura token selection. The Datadog sourcemap upload step now only sets `DATADOG_API_KEY`/`DATADOG_SITE` explicitly and consumes remaining config from the environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 790b3fbeeadd3b6e6fa4f190c08576bbb989f2f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->