### PR TITLE
fix(web): infinite loading positions

### DIFF
--- a/apps/web/src/features/positions/index.tsx
+++ b/apps/web/src/features/positions/index.tsx
@@ -17,7 +17,7 @@ const Positions = () => {
   const { data: protocols, error, isLoading } = usePositions()
   const portfolio = useLoadFeature(PortfolioFeature)
 
-  if (isLoading || (!error && !protocols)) {
+  if (isLoading) {
     return <PositionsSkeleton />
   }
 

--- a/packages/utils/src/hooks/__tests__/useTotalBalances.test.ts
+++ b/packages/utils/src/hooks/__tests__/useTotalBalances.test.ts
@@ -195,7 +195,7 @@ describe('useTotalBalances', () => {
       expect(item?.fiatBalance24hChange).toBe('0.05')
     })
 
-    it('should fallback to tx service when portfolio returns empty', () => {
+    it('should fallback to tx service when portfolio returns empty data', () => {
       const { result } = setupAndRender(portfolioParams, {
         portfolio: { currentData: createMockEmptyPortfolio() },
         txService: { currentData: createMockTxServiceBalances() },
@@ -203,15 +203,18 @@ describe('useTotalBalances', () => {
 
       expect(result.current.data?.fiatTotal).toBe('1000')
       expect(result.current.data?.tokensFiatTotal).toBe('1000')
+      expect(result.current.data?.positions).toEqual([])
+      expect(result.current.data?.positionsFiatTotal).toBe('0')
     })
 
-    it('should fallback to tx service when portfolio errors', () => {
+    it('should fallback to tx service when portfolio errors with positions unknown', () => {
       const { result } = setupAndRender(portfolioParams, {
         portfolio: { error: new Error('Portfolio error') },
         txService: { currentData: createMockTxServiceBalances() },
       })
 
       expect(result.current.data?.fiatTotal).toBe('1000')
+      expect(result.current.data?.positions).toBeUndefined()
     })
 
     it('should use counterfactual balances on fallback for undeployed safe', () => {
@@ -231,6 +234,8 @@ describe('useTotalBalances', () => {
       )
 
       expect(result.current.data?.fiatTotal).toBe('500')
+      expect(result.current.data?.positions).toEqual([])
+      expect(result.current.data?.positionsFiatTotal).toBe('0')
     })
 
     it('should handle loading state', () => {

--- a/packages/utils/src/hooks/useTotalBalances.ts
+++ b/packages/utils/src/hooks/useTotalBalances.ts
@@ -150,6 +150,7 @@ interface AggregateParams {
   hasPortfolioFeature: boolean
   isAllTokensSelected: boolean
   needsPortfolioFallback: boolean
+  isPortfolioEmpty: boolean
   isCounterfactual: boolean
   txService: TxServiceState
   counterfactual: CounterfactualState
@@ -164,7 +165,13 @@ const aggregateBalances = (p: AggregateParams): TotalBalancesResult => {
   const useTxServiceOnly = !p.hasPortfolioFeature || (p.needsPortfolioFallback && !p.isAllTokensSelected)
 
   if (useTxServiceOnly) {
-    return buildTxServiceResult(p.txService, p.counterfactual, p.isCounterfactual, p.shared)
+    const result = buildTxServiceResult(p.txService, p.counterfactual, p.isCounterfactual, p.shared)
+
+    if (result.data && p.isPortfolioEmpty) {
+      return { ...result, data: { ...result.data, positions: [], positionsFiatTotal: '0' } }
+    }
+
+    return result
   }
 
   if (!p.isAllTokensSelected) {
@@ -254,6 +261,7 @@ const useTotalBalances = (params: UseTotalBalancesParams): TotalBalancesResult =
       hasPortfolioFeature: params.hasPortfolioFeature,
       isAllTokensSelected: params.isAllTokensSelected,
       needsPortfolioFallback: !!needsPortfolioFallback,
+      isPortfolioEmpty: !!isPortfolioEmpty,
       isCounterfactual,
       txService: { balances: txServiceBalances, error: txServiceError, loading: txServiceLoading },
       counterfactual: { data: cfData, error: cfError, loading: cfLoading },
@@ -265,6 +273,7 @@ const useTotalBalances = (params: UseTotalBalancesParams): TotalBalancesResult =
     params.hasPortfolioFeature,
     params.isAllTokensSelected,
     needsPortfolioFallback,
+    isPortfolioEmpty,
     isCounterfactual,
     cfData,
     cfError,


### PR DESCRIPTION
## What it solves

Resolves: [Linear Issue](https://linear.app/safe-global/issue/WA-1536/infinite-loading-of-positions-for-new-safes)

When opening a Safe with no funds, the Positions tab showed an infinite loading skeleton instead of the empty state.

### Root cause: 
When the portfolio API returns empty data, isPortfolioEmpty triggers a tx-service fallback. That fallback sets positions: undefined — discarding the knowledge that positions were already confirmed empty. The component then treats undefined as "still loading" indefinitely.

### Fix:
Data layer (useTotalBalances.ts): Pass isPortfolioEmpty into aggregateBalances. When the portfolio confirmed empty, overlay positions: [] on the fallback result instead of letting it be undefined. Error fallbacks remain undefined (positions unknown).
UI layer (positions/index.tsx): Remove !protocols from the skeleton condition — isLoading alone drives the skeleton. !protocols now only shows the unavailable state for genuine cases (error or feature disabled on chain).
Tests: Updated to assert positions: [] on empty-portfolio fallback and positions: undefined on error fallback.

### Replaces [this PR](https://github.com/safe-global/safe-wallet-monorepo/pull/7280)