### PR TITLE
chore: align shadcn design system with dev

### DIFF
--- a/apps/web/.storybook-vite/preview.tsx
+++ b/apps/web/.storybook-vite/preview.tsx
@@ -26,18 +26,6 @@ export { withLayout, withMockProvider } from '../.storybook/decorators'
 
 const BACKGROUND_COLORS: Record<string, string> = { light: '#ffffff', dark: '#121312' }
 
-// Wraps the story in .shadcn-scope so shadcn/ui Tailwind and CSS variables apply.
-// Required for any story that uses components from src/components/ui/ (shadcn).
-const ShadcnScopeDecorator = (Story: React.ComponentType, context: { globals?: { theme?: string } }) => {
-  const themeMode = context.globals?.theme || 'light'
-  const isDark = themeMode === 'dark'
-  return (
-    <div className={isDark ? 'shadcn-scope dark' : 'shadcn-scope'}>
-      <Story />
-    </div>
-  )
-}
-
 // Syncs data-theme attribute and background color with the theme switcher
 const ThemeSyncDecorator = (
   Story: React.ComponentType,
@@ -160,11 +148,7 @@ const preview: Preview = {
   loaders: [mswLoader],
 
   decorators: [
-    ThemeSyncDecorator,
-    // Wraps story in .shadcn-scope so shadcn/ui components get Tailwind and CSS variables
-    ShadcnScopeDecorator,
-    // Custom MUI theme decorator with emotion cache (same as real app)
-    // This ensures CSS modules can override MUI styles
+    // Conditional MUI/shadcn decorator: skip MUI for UI/ stories, wrap with ShadcnProvider instead
     (Story, context) => {
       const themeMode = (context.globals?.theme as 'light' | 'dark') || 'light'
 
@@ -187,6 +171,7 @@ const preview: Preview = {
         </CacheProvider>
       )
     },
+    ThemeSyncDecorator,
   ],
 }
 

--- a/apps/web/.storybook-vite/preview.tsx
+++ b/apps/web/.storybook-vite/preview.tsx
@@ -148,7 +148,7 @@ const preview: Preview = {
   loaders: [mswLoader],
 
   decorators: [
-    // Conditional MUI/shadcn decorator: skip MUI for UI/ stories, wrap with ShadcnProvider instead
+    // All stories get ShadcnProvider (matching the real app). UI/ stories skip MUI.
     (Story, context) => {
       const themeMode = (context.globals?.theme as 'light' | 'dark') || 'light'
 
@@ -163,12 +163,14 @@ const preview: Preview = {
       const theme = createSafeTheme(themeMode)
 
       return (
-        <CacheProvider value={emotionCache}>
-          <ThemeProvider theme={theme}>
-            <CssBaseline />
-            <Story />
-          </ThemeProvider>
-        </CacheProvider>
+        <ShadcnProvider dark={themeMode === 'dark'}>
+          <CacheProvider value={emotionCache}>
+            <ThemeProvider theme={theme}>
+              <CssBaseline />
+              <Story />
+            </ThemeProvider>
+          </CacheProvider>
+        </ShadcnProvider>
       )
     },
     ThemeSyncDecorator,

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -27,18 +27,6 @@ export { withLayout, withMockProvider } from './decorators'
 
 const BACKGROUND_COLORS: Record<string, string> = { light: '#ffffff', dark: '#121312' }
 
-// Wraps the story in .shadcn-scope so shadcn/ui Tailwind and CSS variables apply.
-// Required for any story that uses components from src/components/ui/ (shadcn).
-const ShadcnScopeDecorator = (Story: React.ComponentType, context: { globals?: { theme?: string } }) => {
-  const themeMode = context.globals?.theme || 'light'
-  const isDark = themeMode === 'dark'
-  return (
-    <div className={isDark ? 'shadcn-scope dark' : 'shadcn-scope'}>
-      <Story />
-    </div>
-  )
-}
-
 // Syncs data-theme attribute and background color with the theme switcher
 const ThemeSyncDecorator = (
   Story: React.ComponentType,
@@ -161,11 +149,7 @@ const preview: Preview = {
   loaders: [mswLoader],
 
   decorators: [
-    ThemeSyncDecorator,
-    // Wraps story in .shadcn-scope so shadcn/ui components get Tailwind and CSS variables
-    ShadcnScopeDecorator,
-    // Custom MUI theme decorator with emotion cache (same as real app)
-    // This ensures CSS modules can override MUI styles
+    // Conditional MUI/shadcn decorator: skip MUI for UI/ stories, wrap with ShadcnProvider instead
     (Story, context) => {
       const themeMode = (context.globals?.theme as 'light' | 'dark') || 'light'
 
@@ -188,6 +172,7 @@ const preview: Preview = {
         </CacheProvider>
       )
     },
+    ThemeSyncDecorator,
   ],
 }
 

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -149,7 +149,7 @@ const preview: Preview = {
   loaders: [mswLoader],
 
   decorators: [
-    // Conditional MUI/shadcn decorator: skip MUI for UI/ stories, wrap with ShadcnProvider instead
+    // All stories get ShadcnProvider (matching the real app). UI/ stories skip MUI.
     (Story, context) => {
       const themeMode = (context.globals?.theme as 'light' | 'dark') || 'light'
 
@@ -164,12 +164,14 @@ const preview: Preview = {
       const theme = createSafeTheme(themeMode)
 
       return (
-        <CacheProvider value={emotionCache}>
-          <ThemeProvider theme={theme}>
-            <CssBaseline />
-            <Story />
-          </ThemeProvider>
-        </CacheProvider>
+        <ShadcnProvider dark={themeMode === 'dark'}>
+          <CacheProvider value={emotionCache}>
+            <ThemeProvider theme={theme}>
+              <CssBaseline />
+              <Story />
+            </ThemeProvider>
+          </CacheProvider>
+        </ShadcnProvider>
       )
     },
     ThemeSyncDecorator,

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,14 +1,16 @@
-@import './vars.css';
-@import './onboard.css';
-@import './fonts.css';
-@import './shadcn.css';
-/*---break---*/
+@import url(./vars.css);
+@import url(./onboard.css);
+@import url(/fonts/fonts.css);
 /**
- * Font faces are imported from ./fonts.css instead of /fonts/fonts.css for
- * proper resolution in production builds.
- * More info on @import:
- * https://developer.mozilla.org/en-US/docs/Web/CSS/@import#description
- */
+* ^^^^^^^
+* Some IDEs show the fonts file above as not existing, but it is.
+* If you modify the path to it make sure that the file is also loaded on the
+* actual website.
+* Fun fact: if this comment block is above the @import url(/fonts/fonts.css);
+* nextjs's build will incorrectly place the @import in the middle of the file
+* and the fonts won't load. More info on @import:
+* https://developer.mozilla.org/en-US/docs/Web/CSS/@import#description
+*/
 
 html,
 body {
@@ -18,14 +20,6 @@ body {
     DM Sans,
     sans-serif;
   background-color: var(--color-background-paper);
-}
-
-body {
-  position: relative;
-}
-
-.root {
-  isolation: isolate;
 }
 
 main {

--- a/apps/web/src/styles/shadcn.css
+++ b/apps/web/src/styles/shadcn.css
@@ -45,7 +45,6 @@
   --z-overlay: 9200;
 }
 
-/* shadcn dark theme CSS variables */
 .dark.shadcn-scope,
 .shadcn-scope.dark {
   --background: #000000;
@@ -81,97 +80,48 @@
   --sidebar-ring: #404040;
 }
 
-/* Portaled content mounts outside .shadcn-scope. Mirror dark vars globally when dark theme is active. */
-:root[data-theme='dark'],
-html[data-theme='dark'],
-body[data-theme='dark'],
-:root:has(.shadcn-scope.dark),
-:root:has(.dark.shadcn-scope) {
-  --background: #000000;
-  --foreground: #fafafa;
-  --card: #171717;
-  --card-foreground: #ffffff;
-  --popover: #171717;
-  --popover-foreground: #ffffff;
-  --primary: #f5f5f5;
-  --primary-foreground: #0a0a0a;
-  --secondary: #262626;
-  --secondary-foreground: #f5f5f5;
-  --muted: #171717;
-  --muted-foreground: #a3a3a3;
-  --accent: #171717;
-  --accent-foreground: #f5f5f5;
-  --destructive: #9e4042;
-  --border: #404040;
-  --input: #ffffff0d;
-  --ring: #404040;
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --sidebar: #0a0a0a;
-  --sidebar-foreground: #d4d4d4;
-  --sidebar-primary: #fafafa;
-  --sidebar-primary-foreground: #171717;
-  --sidebar-accent: #171717;
-  --sidebar-accent-foreground: #f5f5f5;
-  --sidebar-border: #262626;
-  --sidebar-ring: #404040;
-}
-
-/* shadcn → Tailwind color mapping */
 @theme inline {
-  /* Override Tailwind's default font-sans to preserve DM Sans */
+  /* Override Tailwind's default system font stack with the Safe{Wallet} app font */
   --font-sans: 'DM Sans', sans-serif;
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-border: var(--border);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
-  --color-card: var(--card);
-  --color-foreground: var(--foreground);
   --color-background: var(--background);
-  /* Synced from Figma: xN0ennrwA6cqy3navhpLYB (2026-01-29) */
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
   --radius-2xs: 0.25rem;
-  /* 4px - Figma: 2xs */
   --radius-xs: 0.5rem;
-  /* 8px - Figma: xs, rounded-md */
   --radius-sm: 0.5rem;
-  /* 8px - Figma: absolute/radius-8 */
   --radius-md: 0.75rem;
-  /* 12px - Figma: rounded-lg, semantic/rounded-lg-xl */
   --radius-lg: 1rem;
-  /* 16px - Figma: radius, md */
   --radius-xl: 1.5rem;
-  /* 24px - Figma: rounded-xl, xl */
   --radius-2xl: 1.5rem;
-  /* 24px - Figma: rounded-xl */
   --radius-infinite: 9999px;
-  /* Figma: rounded-full, radius-infinite */
 }
 
 /*


### PR DESCRIPTION
## Summary

- Reset `globals.css` to dev's version — removes bare import workarounds, `body { position: relative }`, and `.root { isolation: isolate }`
- Reset `shadcn.css` to dev's scoped preflight version — removes the global dark theme mirror (`:root[data-theme='dark']`), the reversed `@theme inline` order, and Figma comments. Keeps popover color fix and `--z-sidebar`/`--z-overlay` vars needed by Spaces
- Reset Storybook previews (`.storybook/preview.tsx`, `.storybook-vite/preview.tsx`) to dev — removes the `ShadcnScopeDecorator` workaround and restores original decorator order

These workarounds on epicSpaces were superseded by the scoped Tailwind preflight work merged to dev in #7227.

## Test plan

- [ ] Verify shadcn components render correctly in the Spaces sidebar (light + dark)
- [ ] Verify MUI components are not affected by Tailwind resets
- [ ] Verify Storybook stories render without CSS conflicts
- [ ] Verify popover and overlay z-index behavior is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)