### PR TITLE
fix(web/Spaces): Storybook fixes after Shadcn merge

### DIFF
--- a/apps/web/.storybook-vite/preview.tsx
+++ b/apps/web/.storybook-vite/preview.tsx
@@ -59,7 +59,7 @@ const ThemeSyncDecorator = (
   )
 }
 
-const isShadcnStory = (title: string | undefined) => title?.startsWith('UI/')
+const isShadcnStory = (title: string | undefined) => title?.startsWith('UI/') || title?.startsWith('Features/Spaces/')
 
 /** Safe{Wallet} viewport presets for responsive testing */
 const SAFE_VIEWPORTS = {

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -60,7 +60,7 @@ const ThemeSyncDecorator = (
   )
 }
 
-const isShadcnStory = (title: string | undefined) => title?.startsWith('UI/')
+const isShadcnStory = (title: string | undefined) => title?.startsWith('UI/') || title?.startsWith('Features/Spaces/')
 
 /** Safe{Wallet} viewport presets for responsive testing */
 const SAFE_VIEWPORTS = {


### PR DESCRIPTION
Adds the new Shadcn wrapper for portaled components in the Storybook.

Extend `isShadcnStory` bool with `Features/Spaces/` so those stories use the Shadcn-only branch and dropdowns render with the correct border and background. This fix mitigates UI problems with stories that are outside the `/ui` folder.