### PR TITLE
chore: fix Argos CI by not passing --group/--tag without --record

### DIFF
--- a/.github/actions/cypress/action.yml
+++ b/.github/actions/cypress/action.yml
@@ -62,11 +62,11 @@ runs:
     - uses: cypress-io/github-action@v6
       with:
         spec: ${{ inputs.spec }}
-        group: ${{ inputs.group }}
-        parallel: ${{ inputs.parallel == 'true' }}
+        group: ${{ inputs.record == 'true' && inputs.group || '' }}
+        parallel: ${{ inputs.record == 'true' && inputs.parallel == 'true' }}
         browser: chrome
         record: ${{ inputs.record == 'true' }}
-        tag: ${{ inputs.tag }}
+        tag: ${{ inputs.record == 'true' && inputs.tag || '' }}
         config: baseUrl=http://localhost:8080
         install: false
         start: yarn workspace @safe-global/web serve


### PR DESCRIPTION
## Summary
- Cypress rejects `--group` and `--tag` flags when `--record` is `false`
- The Argos E2E workflow passes `record: 'false'` but the shared cypress action was always forwarding `group` and `tag` to `cypress-io/github-action`, causing all 5 shards to fail immediately
- Now `group`, `tag`, and `parallel` are only passed when `record` is enabled

## Test plan
- [ ] Re-run the Argos E2E workflow and verify all shards complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)