### PR TITLE
fix: resolve spaces dashboard refresh issue

### DIFF
--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -26,6 +26,15 @@ import { useLoadFeature } from '@/features/__core__'
 import AddAccounts from '@/features/spaces/components/AddAccounts'
 import { useRouter } from 'next/router'
 import AggregatedBalance from './AggregatedBalances'
+import SafeWidget from '../SafeWidget'
+
+const AddActionsAction = () => {
+  return (
+    <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
+      <AddAccounts />
+    </Track>
+  )
+}
 
 const ViewAllLink = ({ url }: { url: LinkProps['href'] }) => {
   return (
@@ -49,7 +58,7 @@ const ViewAllLink = ({ url }: { url: LinkProps['href'] }) => {
 const DASHBOARD_LIST_DISPLAY_LIMIT = 3
 
 const SpaceDashboard = () => {
-  const { AccountsWidget } = useLoadFeature(MyAccountsFeature)
+  const { AccountsWidget, $isReady } = useLoadFeature(MyAccountsFeature)
   const { allSafes: safes } = useSpaceSafes()
   const safeItems = flattenSafeItems(safes)
   const spaceId = useCurrentSpaceId()
@@ -84,17 +93,19 @@ const SpaceDashboard = () => {
 
           <Grid container spacing={3}>
             <Grid data-testid="dashboard-safe-list" size={{ xs: 12, md: 6 }}>
-              <AccountsWidget
-                accounts={accounts}
-                loading={isOverviewLoading}
-                remainingCount={remainingCount > 0 ? remainingCount : undefined}
-                onViewAll={handleViewAll}
-                action={
-                  <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-                    <AddAccounts />
-                  </Track>
-                }
-              />
+              {$isReady ? (
+                <AccountsWidget
+                  accounts={accounts}
+                  loading={isOverviewLoading}
+                  remainingCount={remainingCount > 0 ? remainingCount : undefined}
+                  onViewAll={handleViewAll}
+                  action={<AddActionsAction />}
+                />
+              ) : (
+                <SafeWidget title="Accounts" action={<AddActionsAction />}>
+                  <div className="animate-pulse rounded-lg bg-muted" />
+                </SafeWidget>
+              )}
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
               <Card sx={{ p: 2 }}>

--- a/apps/web/src/hooks/useRouterGuard/activationGuards/__tests__/useFlowActivationGuard.test.ts
+++ b/apps/web/src/hooks/useRouterGuard/activationGuards/__tests__/useFlowActivationGuard.test.ts
@@ -163,7 +163,7 @@ describe('useFlowActivationGuard', () => {
   // -----------------------------------------------------------------------
 
   describe('not connected or not authenticated', () => {
-    it('should redirect to welcome when wallet is not connected', async () => {
+    it('should allow access when wallet is not connected but SIWE authenticated', async () => {
       setupMocks({
         pathname: '/home',
         wallet: null,
@@ -175,7 +175,7 @@ describe('useFlowActivationGuard', () => {
       const { result } = renderHook(() => useFlowActivationGuard())
       const guardResult = await result.current.activationGuard()
 
-      expect(guardResult).toEqual({ success: false, redirectTo: AppRoutes.welcome.index })
+      expect(guardResult).toEqual({ success: true })
     })
 
     it('should redirect to welcome when not authenticated via SIWE', async () => {

--- a/apps/web/src/hooks/useRouterGuard/activationGuards/useFlowActivationGuard.ts
+++ b/apps/web/src/hooks/useRouterGuard/activationGuards/useFlowActivationGuard.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 import { useRouter } from 'next/router'
 import { type UseGuard } from '..'
 import { AppRoutes } from '@/config/routes'
-import useWallet from '@/hooks/wallets/useWallet'
 import { useWalletContext } from '@/hooks/wallets/useWallet'
 import { useAppSelector } from '@/store'
 import { isAuthenticated, selectIsStoreHydrated } from '@/store/authSlice'
@@ -49,10 +48,8 @@ const guardRules: GuardRule[] = [
 
   // Not connected or not signed in with SIWE → welcome
   {
-    match: ({ isConnected, isSiweAuthenticated }) => {
-      const shouldRedirect = !isConnected || !isSiweAuthenticated
-      console.log('## data', { isConnected, isSiweAuthenticated })
-      console.log('## shouldRedirect Not connected or not signed in with SIWE → welcome', shouldRedirect)
+    match: ({ isSiweAuthenticated }) => {
+      const shouldRedirect = !isSiweAuthenticated
       return shouldRedirect
     },
     action: () => redirect(AppRoutes.welcome.index),
@@ -62,7 +59,6 @@ const guardRules: GuardRule[] = [
   {
     match: ({ hasSpaces, isOnboardingRoute }) => {
       const shouldRedirect = !hasSpaces && !isOnboardingRoute
-      console.log('## shouldRedirect Authenticated but has no spaces → onboarding', shouldRedirect)
       return shouldRedirect
     },
     action: () => redirect(AppRoutes.welcome.createSpace),
@@ -73,10 +69,6 @@ const guardRules: GuardRule[] = [
     match: ({ hasSpaces, isOnboardingRoute, query }) => {
       // query paramerters are only available on the client side
       const shouldRedirect = hasSpaces && isOnboardingRoute && !query.spaceId
-      console.log(
-        '## shouldRedirect Authenticated with spaces but navigating to onboarding without a spaceId → spaces create page',
-        shouldRedirect,
-      )
       return shouldRedirect
     },
     action: () => redirect(AppRoutes.spaces.createSpace),
@@ -85,7 +77,6 @@ const guardRules: GuardRule[] = [
   {
     match: ({ isWalletReady, isPartOfSpaceUrl, isOnboardingRoute, isPublicRoute }) => {
       const shouldRedirect = isWalletReady && !isPartOfSpaceUrl && !isOnboardingRoute && !isPublicRoute
-      console.log('## redirecting in the Has spaces but no valid space selected → welcome', shouldRedirect)
       return shouldRedirect
     },
     action: () => redirect(AppRoutes.welcome.index),
@@ -98,7 +89,6 @@ const guardRules: GuardRule[] = [
 
 export const useFlowActivationGuard: UseGuard = () => {
   const { pathname, query } = useRouter()
-  const wallet = useWallet()
   const walletContext = useWalletContext()
   const isStoreHydrated = useAppSelector(selectIsStoreHydrated)
   const isWalletReady = (walletContext?.isReady ?? false) && isStoreHydrated
@@ -126,14 +116,13 @@ export const useFlowActivationGuard: UseGuard = () => {
         isPublicRoute: PUBLIC_ROUTES.some((route) => route.startsWith(pathname)),
         isOnboardingRoute: ONBOARDING_ROUTES.some((route) => pathname.startsWith(route)),
         isWalletReady,
-        isConnected: !!wallet,
         isSiweAuthenticated,
         hasSpaces,
         isPartOfSpaceUrl,
       },
       guardRules,
     )
-  }, [pathname, query, wallet, isWalletReady, isSiweAuthenticated, fetchSpaces])
+  }, [pathname, query, isWalletReady, isSiweAuthenticated, fetchSpaces])
 
   return {
     activationGuard,

--- a/apps/web/src/hooks/useRouterGuard/index.ts
+++ b/apps/web/src/hooks/useRouterGuard/index.ts
@@ -38,7 +38,6 @@ export const useRouterGuard = ({ useGuard }: useRouterGuardProps) => {
       } else {
         // we do not want to set isCheckingAccess to false here because we want
         // the checking access to be reseted only after the redirect is done
-        console.log('## caiu no redirect', redirectTo)
         router.replace(redirectTo ?? AppRoutes.welcome.index)
       }
     }

--- a/apps/web/src/hooks/useRouterGuard/types.ts
+++ b/apps/web/src/hooks/useRouterGuard/types.ts
@@ -19,7 +19,6 @@ export interface GuardContext {
   isPublicRoute: boolean
   isOnboardingRoute: boolean
   isWalletReady: boolean
-  isConnected: boolean
   isSiweAuthenticated: boolean
   hasSpaces: boolean
   isPartOfSpaceUrl: boolean

--- a/apps/web/src/hooks/wallets/useOnboard.ts
+++ b/apps/web/src/hooks/wallets/useOnboard.ts
@@ -156,7 +156,7 @@ const connectLastWallet = async (onboard: OnboardAPI) => {
     const isUnlocked = await isWalletUnlocked(lastWalletLabel)
 
     if (isUnlocked !== false) {
-      connectWallet(onboard, {
+      await connectWallet(onboard, {
         autoSelect: { label: lastWalletLabel, disableModals: isUnlocked === true },
       })
     }
@@ -194,6 +194,7 @@ export const useInitOnboard = () => {
     enableWallets().then(async () => {
       // Reconnect last wallet and mark wallet provider as ready
       await connectLastWallet(onboard)
+
       setWalletReady(true)
     })
   }, [chain, onboard])
@@ -205,6 +206,7 @@ export const useInitOnboard = () => {
 
     const walletSubscription = onboard.state.select('wallets').subscribe((wallets) => {
       const newWallet = getConnectedWallet(wallets)
+
       if (newWallet) {
         if (newWallet.label !== lastConnectedWallet) {
           lastConnectedWallet = newWallet.label


### PR DESCRIPTION
## Summary

- **Await wallet reconnection on page load** (`useOnboard.ts`): `connectLastWallet` was not awaited, causing `walletReady` to be set to `true` before the wallet was actually connected, which triggered premature router guard redirects on refresh
- **Simplify router guard authentication check**: Removed redundant `isConnected` check from the flow activation guard — only SIWE authentication status is needed to determine access, since wallet connection is now properly awaited
- **Add AccountsWidget loading state** (`Dashboard/index.tsx`): Show a SafeWidget skeleton fallback while `MyAccountsFeature` is loading via `$isReady`
- **Remove debug console.log statements** from router guard files

## Test plan
- [ ] Run `yarn workspace @safe-global/web storybook` and verify UI/ stories still render correctly
- [ ] Check a Spaces story in dark mode — shadcn variables should apply
- [ ] Check a regular MUI story (e.g. Components/) — MUI should still work, no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)