### PR TITLE
Fix overflow and truncation in SafeListItem and TxSafeAppCard

### DIFF
--- a/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
+++ b/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
@@ -72,16 +72,16 @@ export function SafeListItem({
       {...(pressStyle ? { pressStyle } : {})}
     >
       <View flexDirection="row" width="100%" alignItems="center" justifyContent="space-between">
-        <View flexDirection="row" maxWidth={rightNode ? '55%' : '100%'} alignItems="center" gap={12}>
+        <View flexDirection="row" flex={1} minWidth={0} alignItems="center" gap={12}>
           {leftNode}
 
-          <View>
+          <View flex={1} minWidth={0}>
             {type && (
               <View flexDirection="row" alignItems="center" gap={4}>
                 {icon && (
                   <SafeFontIcon testID={`safe-list-${icon}-icon`} name={icon} size={10} color="$colorSecondary" />
                 )}
-                <Text fontSize="$2" lineHeight={20} color="$colorSecondary">
+                <Text fontSize="$2" lineHeight={20} color="$colorSecondary" numberOfLines={1} ellipsizeMode="tail">
                   {type}
                 </Text>
               </View>
@@ -111,9 +111,11 @@ export function SafeListItem({
 
             <SafeFontIcon name="chevron-right" size={16} />
           </View>
-        ) : (
-          rightNode
-        )}
+        ) : rightNode ? (
+          <View alignItems="flex-end" flexShrink={1} minWidth={0} marginLeft="$2">
+            {rightNode}
+          </View>
+        ) : null}
       </View>
 
       {bottomContent && (

--- a/apps/mobile/src/components/transactions-list/Card/TxSafeAppCard/TxSafeAppCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/TxSafeAppCard/TxSafeAppCard.tsx
@@ -25,7 +25,11 @@ export function TxSafeAppCard({ safeAppInfo, txInfo, ...rest }: TxSafeAppCardPro
           accessibilityLabel={safeAppInfo.name}
         />
       }
-      rightNode={<Text>{txInfo.methodName}</Text>}
+      rightNode={
+        <Text numberOfLines={1} ellipsizeMode="tail" textAlign="right">
+          {txInfo.methodName}
+        </Text>
+      }
       {...rest}
     />
   )


### PR DESCRIPTION
### Motivation

- Prevent label and type text from overflowing their containers and ensure right-side nodes do not cause layout breakage in list items.
- Make method names in `TxSafeAppCard` truncate cleanly when they are too long for the available space.

### Description

- Reworked `SafeListItem` layout to use flexible sizing by replacing the previous `maxWidth` with `flex={1}` and adding `minWidth={0}` so children can properly shrink and ellipsize.
- Added `numberOfLines={1}` and `ellipsizeMode="tail"` to the type `Text` element so the type label truncates instead of overflowing.
- Wrapped `rightNode` in a container with `alignItems="flex-end"`, `flexShrink={1}`, `minWidth={0}` and `marginLeft="$2"` so trailing content is aligned and constrained without breaking the row layout; fall back to `null` when `rightNode` is not present.
- Updated `TxSafeAppCard` to render its `rightNode` `Text` with `numberOfLines={1}`, `ellipsizeMode="tail"`, and `textAlign="right"` to ensure method names truncate properly.

### Testing

- Ran TypeScript type checking via `yarn build` with no type errors reported.
- Ran unit/component tests via `yarn test` and existing Jest tests passed successfully.
- Verified the changes in the running mobile app UI to confirm truncation and layout behavior (no automated failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a6e154eee8832899df63afc2463d6d)