### PR TITLE
fix: align icon and text in API sidebar nav item

### DIFF
--- a/apps/web/src/components/sidebar/SidebarList/index.tsx
+++ b/apps/web/src/components/sidebar/SidebarList/index.tsx
@@ -6,6 +6,7 @@ import ListItemText, { type ListItemTextProps } from '@mui/material/ListItemText
 import Link from 'next/link'
 import type { LinkProps } from 'next/link'
 import Badge from '@mui/material/Badge'
+import Box from '@mui/material/Box'
 
 import css from './styles.module.css'
 
@@ -87,21 +88,23 @@ export const SidebarListItemCounter = ({
   variant?: 'warning' | 'subtle'
 }): ReactElement | null =>
   count ? (
-    <Badge
+    <Box
+      component="span"
       sx={{
-        '& .MuiBadge-badge': {
-          color: variant === 'warning' ? 'static.main' : 'text.primary',
-          backgroundColor: variant === 'warning' ? 'warning.light' : 'background.main',
-          border: variant === 'subtle' ? '1px solid' : undefined,
-          borderColor: variant === 'subtle' ? 'background.main' : undefined,
-          transform: 'none',
-          fontWeight: 'bold',
-          padding: '0 4px',
-          fontSize: '11px',
-        },
+        color: variant === 'warning' ? 'static.main' : 'text.primary',
+        backgroundColor: variant === 'warning' ? 'warning.light' : 'background.main',
+        border: variant === 'subtle' ? '1px solid' : undefined,
+        borderColor: variant === 'subtle' ? 'background.main' : undefined,
+        fontWeight: 700,
+        fontSize: 11,
+        lineHeight: '20px',
+        minWidth: 20,
+        px: 0.5,
+        borderRadius: '10px',
+        textAlign: 'center',
         ml: 3,
       }}
-      variant="standard"
-      badgeContent={count}
-    />
+    >
+      {count}
+    </Box>
   ) : null


### PR DESCRIPTION
## Summary
- Fixes vertical misalignment between the icon and text label in sidebar nav items with tags (e.g. the API promo card with the "New" chip)
- Adds `alignItems: 'center'` to `SidebarListItemText` Typography so the text and tag are vertically centered, matching the icon's alignment

Fixes WA-1641

## Test plan
- [ ] Verify the API sidebar item icon and "API" text are vertically aligned
- [ ] Verify other sidebar items (Home, Assets, Transactions, etc.) still look correct
- [ ] Check the Transactions queue counter alignment when there are queued txs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes: adjusts MUI typography layout and replaces the counter badge rendering, which could slightly affect spacing/appearance but not behavior or data flow.
> 
> **Overview**
> Fixes sidebar nav item alignment by updating `SidebarListItemText` typography to `alignItems: 'center'`, vertically centering labels/tags relative to the icon.
> 
> Replaces `SidebarListItemCounter` from a MUI `Badge` to a styled `Box`-based pill, shifting the counter’s styling and layout (size, padding, border radius, line height) while keeping the same `count`/`variant` API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b811e69ddf86bd45e071c7e720351834378f418. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->