### PR TITLE
fix(web): guard against undefined curatedNestedSafes in Storybook

### DIFF
--- a/.codemod/spaces.config.json
+++ b/.codemod/spaces.config.json
@@ -95,13 +95,7 @@
       "filterSpacesByStatus",
       "getNonDeclinedSpaces"
     ],
-    "types": [
-      "AuthState",
-      "LoadingState",
-      "SignedOutState",
-      "UnauthorizedState",
-      "mapSpaceContactsToAddressBookState"
-    ],
+    "types": ["AuthState", "LoadingState", "SignedOutState", "UnauthorizedState", "mapSpaceContactsToAddressBookState"],
     "constants": []
   },
   "structure": {

--- a/apps/web/src/store/settingsSlice.ts
+++ b/apps/web/src/store/settingsSlice.ts
@@ -245,7 +245,7 @@ export const selectCuratedAddresses = createSelector(
 export const selectIsCuratedNestedSafe = createSelector(
   [selectSettings, (_, safeAddress: string) => safeAddress],
   (settings, safeAddress): boolean => {
-    if (!safeAddress) return false
+    if (!safeAddress || !settings.curatedNestedSafes) return false
     const normalizedAddress = safeAddress.toLowerCase()
     return Object.values(settings.curatedNestedSafes).some((curation) =>
       curation?.selectedAddresses?.some((addr) => addr.toLowerCase() === normalizedAddress),


### PR DESCRIPTION
## Summary
- Add a null/undefined guard on `settings.curatedNestedSafes` in `selectIsCuratedNestedSafe` selector (`settingsSlice.ts`)
- Fixes `TypeError: Cannot convert undefined or null to object` when `Object.values()` is called on an uninitialized `curatedNestedSafes` field (e.g., in Storybook where the Redux store isn't fully populated)

## Test plan
- [ ] Run `yarn workspace @safe-global/web storybook` and verify UI/ stories still render correctly
- [ ] Check a Spaces story in dark mode — shadcn variables should apply
- [ ] Check a regular MUI story (e.g. Components/) — MUI should still work, no visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)