### PR TITLE
fix(mobile): use dismissTo for recipient navigation on amount screen

### DIFF
--- a/apps/mobile/src/features/Send/EnterAmount.container.tsx
+++ b/apps/mobile/src/features/Send/EnterAmount.container.tsx
@@ -144,7 +144,7 @@ export function EnterAmountContainer() {
           recipientAddress={recipientAddress}
           recipientName={recipientName}
           displayNonce={nonce.displayNonce}
-          onRecipientPress={() => router.navigate('/(send)/recipient')}
+          onRecipientPress={() => router.dismissTo('/(send)/recipient')}
           onNoncePress={nonce.handleOpenNonceSheet}
         />
 


### PR DESCRIPTION
## What it solves

Tapping the recipient on the amount input screen pushes a new recipient screen onto the navigation stack instead of navigating back to the existing one.

Resolves: https://linear.app/safe-global/issue/WA-1468/add-new-send-and-receive-button

## How this PR fixes it

Replaces `router.navigate('/(send)/recipient')` with `router.dismissTo('/(send)/recipient')` so the navigation pops back through the stack (amount → token → recipient) instead of pushing a duplicate screen. This is consistent with how the token screen already handles recipient press via `router.back()`.

## How to test it

1. Open the mobile app and navigate to the Send flow
2. Select a recipient, then select a token to reach the amount input screen
3. Tap the recipient area at the top of the amount screen
4. Verify it navigates **back** to the recipient screen (not a new push)

## Screenshots

N/A

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).