### PR TITLE
fix(mobile): prevent refresh indicator from showing during polling

### DIFF
--- a/apps/mobile/src/features/Assets/components/Positions/Positions.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Positions/Positions.container.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import { RefreshControl } from 'react-native'
 import { getTokenValue } from 'tamagui'
 
@@ -22,13 +22,15 @@ export const PositionsContainer = () => {
 
   const totalFiatValue = React.useMemo(() => calculatePositionsFiatTotal(data), [data])
 
-  const onRefresh = useCallback(async () => {
-    setIsRefreshing(true)
-    try {
-      await refetch()
-    } finally {
+  useEffect(() => {
+    if (!isFetching) {
       setIsRefreshing(false)
     }
+  }, [isFetching])
+
+  const onRefresh = useCallback(() => {
+    setIsRefreshing(true)
+    refetch()
   }, [refetch])
 
   const renderItem = React.useCallback(

--- a/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
+++ b/apps/mobile/src/features/Assets/components/Tokens/Tokens.container.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { ListRenderItem, RefreshControl } from 'react-native'
 import { getTokenValue } from 'tamagui'
 
@@ -13,7 +13,16 @@ import { useTokenBalances } from './useTokenBalances'
 export function TokensContainer() {
   const { visibleItems, currency, isFetching, error, isLoading, hasItems, allFilteredByDust, refetch } =
     useTokenBalances()
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  useEffect(() => {
+    if (!isFetching) {
+      setIsRefreshing(false)
+    }
+  }, [isFetching])
+
   const onRefresh = useCallback(() => {
+    setIsRefreshing(true)
     refetch()
   }, [refetch])
 
@@ -57,7 +66,7 @@ export function TokensContainer() {
       keyExtractor={(item, index): string => item.tokenInfo.name + index}
       contentContainerStyle={{ paddingHorizontal: getTokenValue('$4'), gap: getTokenValue('$2') }}
       style={{ marginTop: getTokenValue('$4') }}
-      refreshControl={<RefreshControl refreshing={isFetching} onRefresh={onRefresh} />}
+      refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />}
     />
   )
 }


### PR DESCRIPTION
## What it solves

The token and position lists on the home screen visually "jump" (shift down then back up) every time the polling interval triggers a background refetch. This is because the `RefreshControl`'s `refreshing` prop was bound to `isFetching`, which is `true` during both user-initiated pull-to-refresh and automatic polling.

## How this PR fixes it

Introduces a separate `isRefreshing` state that's only set to `true` on manual pull-to-refresh. A `useEffect` clears it when `isFetching` becomes `false`, so the spinner stays visible for the full duration of a user-initiated refresh but never appears during background polling. The `refetch()` function returns `void` (not a promise), so the previous `await refetch()` pattern in Positions was silently broken — the spinner would disappear immediately rather than waiting for the fetch to complete.

## How to test it

1. Open the app and navigate to the home screen with tokens visible
2. Wait for a polling interval to pass (~15s) — the token list should **not** show a refresh spinner or jump
3. Pull down to refresh — the spinner should appear and stay visible until the fetch completes
4. Switch to the Positions tab and repeat steps 2-3

## Screenshots

N/A - no visual changes other than removing the unintended refresh flash

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).