### PR TITLE
refactor(web): migrate ledger to feature architecture

### DIFF
--- a/apps/web/src/components/tx-flow/TxFlow.tsx
+++ b/apps/web/src/components/tx-flow/TxFlow.tsx
@@ -10,7 +10,8 @@ import { TxNote, SignerSelect, BalanceChanges, RiskConfirmation } from './featur
 import { Batching, ComboSubmit, Counterfactual, Execute, ExecuteThroughRole, Propose, Sign } from './actions'
 import { SlotProvider } from './slots'
 import { useTrackTimeSpent } from '@/components/tx/shared/tracking'
-import LedgerHashComparison from '@/features/ledger'
+import { useLoadFeature } from '@/features/__core__'
+import { LedgerFeature } from '@/features/ledger'
 import { SafeShieldProvider } from '@/features/safe-shield/SafeShieldContext'
 
 type SubmitCallbackProps = { txId?: string; isExecuted?: boolean }
@@ -53,6 +54,7 @@ export const TxFlow = <T extends unknown>({
   eventCategory,
   ...txLayoutProps
 }: TxFlowProps<T>) => {
+  const { LedgerHashComparison } = useLoadFeature(LedgerFeature)
   const { step, data, nextStep, prevStep } = useTxStepper(initialData, eventCategory)
 
   const childrenArray = Array.isArray(children) ? children : [children]

--- a/apps/web/src/features/ledger/contract.ts
+++ b/apps/web/src/features/ledger/contract.ts
@@ -1,0 +1,5 @@
+import type LedgerHashComparison from './components/LedgerHashComparison'
+
+export interface LedgerContract {
+  LedgerHashComparison: typeof LedgerHashComparison
+}

--- a/apps/web/src/features/ledger/feature.ts
+++ b/apps/web/src/features/ledger/feature.ts
@@ -1,0 +1,8 @@
+import type { LedgerContract } from './contract'
+import LedgerHashComparison from './components/LedgerHashComparison'
+
+const feature: LedgerContract = {
+  LedgerHashComparison,
+}
+
+export default feature

--- a/apps/web/src/features/ledger/index.ts
+++ b/apps/web/src/features/ledger/index.ts
@@ -1,15 +1,16 @@
-import dynamic from 'next/dynamic'
+import type { FeatureHandle } from '@/features/__core__'
+import type { LedgerContract } from './contract'
+
+// Ledger is a core feature - always enabled, not gated by a CGW feature flag.
+// We still use the feature architecture for lazy loading and code organization.
+export const LedgerFeature: FeatureHandle<LedgerContract> = {
+  name: 'ledger',
+  useIsEnabled: () => true,
+  load: () => import(/* webpackMode: "lazy" */ './feature') as Promise<{ default: LedgerContract }>,
+}
 
 // Type exports
 export type { TransactionHash, LedgerHashState, ShowHashFunction, HideHashFunction } from './types'
 
-// Store function exports
+// Store function exports (not lazy-loaded)
 export { showLedgerHashComparison, hideLedgerHashComparison } from './store'
-
-// Lazy-loaded component (default export)
-const LedgerHashComparison = dynamic(
-  () => import('./components/LedgerHashComparison').then((mod) => ({ default: mod.default })),
-  { ssr: false },
-)
-
-export default LedgerHashComparison


### PR DESCRIPTION
## Summary
- migrate `features/ledger` from `next/dynamic` default export to Feature Architecture
- add `LedgerContract` and lazy `feature.ts` implementation for `LedgerHashComparison`
- expose `LedgerFeature` as always-enabled `FeatureHandle` and keep store/type named exports
- switch `TxFlow` to load `LedgerHashComparison` via `useLoadFeature(LedgerFeature)`

## Validation
- yarn workspace @safe-global/web type-check
- yarn workspace @safe-global/web lint
- yarn workspace @safe-global/web test --testPathPattern=features/ledger
- yarn workspace @safe-global/web test --testPathPattern=components/tx-flow

## Notes
- `yarn prettier:fix` is currently blocked by an existing parse error in `apps/web/storybook-static/beamer-embed.css` (unrelated to this change).
