### PR TITLE
fix(mobile): fix infinite pull-to-refresh spinner in All tokens mode

### DIFF
--- a/packages/utils/src/hooks/__tests__/useTotalBalances.test.ts
+++ b/packages/utils/src/hooks/__tests__/useTotalBalances.test.ts
@@ -290,6 +290,17 @@ describe('useTotalBalances', () => {
       expect(result.current.loading).toBe(true)
     })
 
+    it('should propagate isFetching in merged mode', () => {
+      const { result } = setupAndRender(allTokensParams, {
+        portfolio: { currentData: createMockPortfolio(), isFetching: true },
+        txService: { currentData: createMockTxServiceBalances() },
+      })
+
+      expect(result.current.isFetching).toBe(true)
+      expect(result.current.loading).toBe(false)
+      expect(result.current.data).toBeDefined()
+    })
+
     it('should show error when either source errors', () => {
       const mockPortfolio = createMockPortfolio()
 

--- a/packages/utils/src/hooks/useTotalBalances.ts
+++ b/packages/utils/src/hooks/useTotalBalances.ts
@@ -143,7 +143,7 @@ const buildMergedResult = (opts: {
     isAllTokensMode: true,
   }
 
-  return { data: mergedBalances, error: undefined, loading: false, isFetching: false, refetch: shared.refetch }
+  return { data: mergedBalances, error: undefined, loading: false, ...shared }
 }
 
 interface AggregateParams {


### PR DESCRIPTION
## What it solves

Pull-to-refresh on the tokens list spins indefinitely when the user has "Show all tokens" enabled.

## How this PR fixes it

`buildMergedResult` (the code path used in "All tokens" mode) hardcoded `isFetching: false` in its success return. This meant the `useEffect` in `Tokens.container.tsx` that resets the refresh spinner never detected the `true → false` transition after a refetch, so `isRefreshing` stayed `true` forever. Fixed by spreading `shared` (which carries the reactive `isFetching` value) instead of hardcoding it.

## How to test it

1. Open the mobile app and navigate to the Assets/Tokens tab
2. Go to Settings and enable "Show all tokens"
3. Pull down to refresh the token list
4. Verify the spinner stops after data loads (previously it spun forever)

## Screenshots

N/A - no UI changes

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).