### PR TITLE
fix(mobile): show fallback icon for tokens without logo in send flow

### DIFF
--- a/apps/mobile/src/features/Send/components/TokenPill.tsx
+++ b/apps/mobile/src/features/Send/components/TokenPill.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Pressable } from 'react-native'
 import { Text, View } from 'tamagui'
-import { Image } from 'expo-image'
+import { TokenIcon } from '@/src/components/TokenIcon/TokenIcon'
 
 interface TokenPillProps {
   symbol: string
@@ -22,13 +22,7 @@ export function TokenPill({ symbol, logoUri, balance, onMaxPress }: TokenPillPro
       height={48}
       gap="$3"
     >
-      {logoUri && (
-        <Image
-          source={{ uri: logoUri }}
-          style={{ width: 28, height: 28, borderRadius: 14 }}
-          cachePolicy="memory-disk"
-        />
-      )}
+      <TokenIcon logoUri={logoUri} size="$7" />
       <Text fontSize={16} color="$color">
         {balance ? `${balance} ${symbol}` : symbol}
       </Text>


### PR DESCRIPTION
## What it solves

When selecting a token without a logo in the Send flow, the Select Amount page shows no icon at all instead of the default placeholder that appears on the token list.

Resolves: https://linear.app/safe-global/issue/WA-1699/token-placeholder-is-lost-on-the-select-amount-page

## How this PR fixes it

Replaces the raw `Image` component in `TokenPill` with the shared `TokenIcon` component, which already handles missing logos by rendering a fallback icon — consistent with how tokens are displayed everywhere else in the app.

## How to test it

1. Open the Send flow on mobile
2. Select a token that has no logo (shows a default placeholder icon on the token list)
3. Proceed to the Select Amount page
4. Verify the placeholder icon is now displayed next to the token symbol

## Screenshots

N/A - needs testing on device

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).