### PR TITLE
fix(mobile): show correct tx type labels in nonce list

### DIFF
--- a/apps/mobile/src/features/Send/components/NonceBottomSheet.tsx
+++ b/apps/mobile/src/features/Send/components/NonceBottomSheet.tsx
@@ -38,19 +38,18 @@ function RecommendedNonceRow({
       <View
         flexDirection="row"
         alignItems="center"
-        height={64}
+        paddingVertical="$1"
         paddingHorizontal="$3"
         borderRadius={8}
         backgroundColor={isSelected ? '$borderLight' : undefined}
+        gap="$1"
       >
-        <Text fontSize="$4" fontWeight={600} color="$color" width={40}>
+        <Text fontSize="$4" fontWeight={600} color="$color" width={40} textAlign="right">
           {nonce}
         </Text>
-        <View flex={1}>
-          <Text fontSize="$4" fontWeight={600} color="$color">
-            New transaction
-          </Text>
-        </View>
+        <Text fontSize="$4" color="$colorSecondary">
+          New transaction
+        </Text>
       </View>
     </Pressable>
   )
@@ -82,19 +81,18 @@ function QueuedNonceRow({
       <View
         flexDirection="row"
         alignItems="center"
-        height={64}
+        paddingVertical="$3"
         paddingHorizontal="$3"
         borderRadius={8}
         backgroundColor={isSelected ? '$borderLight' : undefined}
+        gap="$1"
       >
-        <Text fontSize="$4" fontWeight={600} color="$color" width={40}>
+        <Text fontSize="$4" fontWeight={600} color="$color" width={40} textAlign="right" fontVariant={['tabular-nums']}>
           {item.nonce}
         </Text>
-        <View flex={1}>
-          <Text fontSize="$4" fontWeight={600} color="$color">
-            {item.label}
-          </Text>
-        </View>
+        <Text fontSize="$4" color="$colorSecondary">
+          {item.label}
+        </Text>
       </View>
     </Pressable>
   )
@@ -107,14 +105,21 @@ function useRenderFooter(insets: { bottom: number }, onAddCustomNonce: () => voi
         <View
           onLayout={(e) => onLayout(e.nativeEvent.layout.height)}
           backgroundColor="$backgroundSheet"
-          paddingHorizontal="$4"
           paddingTop="$2"
           paddingBottom={insets.bottom + 16}
           marginBottom={-insets.bottom}
         >
           <View height={1} backgroundColor="$borderLight" marginBottom="$2" />
           <Pressable onPress={onAddCustomNonce} testID="nonce-add-custom">
-            <View flexDirection="row" alignItems="center" height={64} paddingHorizontal="$3" borderRadius={8} gap="$3">
+            <View
+              flexDirection="row"
+              alignItems="center"
+              marginHorizontal="$4"
+              paddingVertical="$1"
+              paddingHorizontal="$3"
+              borderRadius={8}
+              gap="$3"
+            >
               <View
                 width={40}
                 height={40}
@@ -193,7 +198,7 @@ export const NonceBottomSheet = forwardRef<BottomSheetModal, NonceBottomSheetPro
           <H5 fontWeight={700}>Recommended nonce</H5>
         </View>
 
-        <View paddingHorizontal="$4" gap="$4">
+        <View paddingHorizontal="$4">
           {recommendedNonce !== undefined && (
             <RecommendedNonceRow
               nonce={recommendedNonce}
@@ -214,7 +219,7 @@ export const NonceBottomSheet = forwardRef<BottomSheetModal, NonceBottomSheetPro
           ))}
 
           {isFetchingMore && (
-            <View height={64} alignItems="center" justifyContent="center">
+            <View paddingVertical="$2" alignItems="center" justifyContent="center">
               <Loader size={24} color="$color" />
             </View>
           )}

--- a/apps/mobile/src/features/Send/hooks/useNonce.ts
+++ b/apps/mobile/src/features/Send/hooks/useNonce.ts
@@ -6,6 +6,7 @@ import type {
   QueuedItemPage,
   TransactionQueuedItem,
 } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { getTransactionType } from '@/src/hooks/useTransactionType'
 
 interface QueuedNonceItem {
   nonce: number
@@ -40,7 +41,7 @@ function resolveTransactionNonce(txItem: TransactionQueuedItem, fallbackNonce: n
 }
 
 function buildQueuedNonceItem(txItem: TransactionQueuedItem, nonce: number): QueuedNonceItem {
-  return { nonce, label: extractTxLabel(txItem.transaction.txInfo) }
+  return { nonce, label: extractTxLabel(txItem) }
 }
 
 function collectQueuedNonces(items: QueuedItem[]): QueuedNonceItem[] {
@@ -124,23 +125,15 @@ export function useNonce(chainId: string, safeAddress: string): UseNonceResult {
   }
 }
 
-function extractTxLabel(
-  txInfo: {
-    type: string
-    methodName?: string | null
-    humanDescription?: string | null
-  } & Record<string, unknown>,
-): string {
-  switch (txInfo.type) {
-    case 'Transfer':
-      return 'Send transaction'
-    case 'SettingsChange':
-      return 'Settings change'
-    case 'Custom':
-      return (txInfo.methodName as string) ?? 'Contract interaction'
-    case 'MultiSend':
-      return 'Batch transaction'
-    default:
-      return txInfo.humanDescription ?? 'Transaction'
+function extractTxLabel(txItem: TransactionQueuedItem): string {
+  const { transaction } = txItem
+  const txInfo = transaction.txInfo as { humanDescription?: string | null }
+  if (txInfo.humanDescription) {
+    return txInfo.humanDescription
   }
+  const { text } = getTransactionType(transaction)
+  if (text.toLowerCase().endsWith('transaction')) {
+    return text
+  }
+  return `${text} transaction`
 }


### PR DESCRIPTION
## What it solves

The nonce selection bottom sheet in the Send flow showed generic "Transaction" for all queued transactions instead of specific types like "Swap order", "Bridge", "Batch", etc. The styling also diverged from Figma — wrong colors, font weights, and excessive vertical spacing.

Resolves: https://linear.app/safe-global/issue/WA-1703

## How this PR fixes it

- Replaced the manual `extractTxLabel` switch-case with the existing `getTransactionType` utility (same approach as web's `TxNonce`), which handles all tx types including swaps, bridges, TWAP orders, staking, etc.
- Guards against double "transaction" suffix since some types (e.g. "Bridge transaction") already include it.
- Updated row styling to match Figma: nonce number is white/semibold, label is gray/regular weight. Nonce column is fixed-width and right-aligned with tabular numerals for consistent alignment.
- Replaced hardcoded `height` values with `paddingVertical` using Tamagui spacing tokens.
- Made the footer divider full-width per Figma.

## How to test it

1. Open a Safe with queued transactions
2. Start the Send flow and reach the step with the Nonce field
3. Tap the Nonce field to open the nonce selection bottom sheet
4. Verify that each queued tx shows the correct type (e.g. "Swap order transaction", "Bridge transaction", "Batch transaction") instead of generic "Transaction"
5. Verify styling: nonce numbers are white/bold, labels are gray, numbers are right-aligned, spacing is compact

## Screenshots
<img width="150" alt="image" src="https://github.com/user-attachments/assets/a3fad2ff-eec3-40d7-af0b-e90f6cf945b7" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).