### PR TITLE
fix(mobile): fix keyboard not appearing for nonce input on Android

### DIFF
--- a/apps/mobile/src/features/Send/components/CustomNonceModal.tsx
+++ b/apps/mobile/src/features/Send/components/CustomNonceModal.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect, useState } from 'react'
-import { TextInput, StyleSheet } from 'react-native'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { TextInput, StyleSheet, Platform } from 'react-native'
 import { Text, useTheme } from 'tamagui'
 import { DialogModal } from './DialogModal'
 
@@ -40,10 +40,18 @@ function validateNonce(value: string, currentNonce: number): string | undefined 
 export function CustomNonceModal({ visible, defaultNonce, currentNonce, onSave, onCancel }: CustomNonceModalProps) {
   const theme = useTheme()
   const [value, setValue] = useState(defaultNonce)
+  const inputRef = useRef<TextInput>(null)
 
   useEffect(() => {
     if (visible) {
       setValue(defaultNonce)
+
+      // On Android, autoFocus inside a Modal doesn't reliably open the keyboard.
+      // Manually focusing after a short delay ensures the keyboard appears.
+      if (Platform.OS === 'android') {
+        const timer = setTimeout(() => inputRef.current?.focus(), 200)
+        return () => clearTimeout(timer)
+      }
     }
   }, [visible, defaultNonce])
 
@@ -66,11 +74,12 @@ export function CustomNonceModal({ visible, defaultNonce, currentNonce, onSave, 
   return (
     <DialogModal visible={visible} title="New nonce" onCancel={onCancel} onSave={handleSave} saveDisabled={!isValid}>
       <TextInput
+        ref={inputRef}
         style={[styles.input, { color: String(theme.color.get()) }]}
         value={value}
         onChangeText={handleChangeText}
         keyboardType="number-pad"
-        autoFocus
+        autoFocus={Platform.OS === 'ios'}
         selectTextOnFocus
         testID="custom-nonce-input"
       />


### PR DESCRIPTION
## What it solves

On Android, when the user taps "Add new nonce" in the send flow, the custom nonce modal opens but the keyboard doesn't automatically appear — forcing the user to manually tap the input field. This works fine on iOS.

Resolves: https://linear.app/safe-global/issue/WA-1711/add-nonce-issues

## How this PR fixes it

On Android, `autoFocus` inside a transparent `Modal` fires before the modal window has fully acquired focus, leaving the `TextInput` in a "focused but no keyboard" state. The fix disables `autoFocus` on Android and instead uses a delayed manual `.focus()` call (200ms) after the modal becomes visible, which reliably triggers the keyboard. iOS continues to use `autoFocus` as before.

## How to test it

1. Open the app on an **Android** device/emulator
2. Start a send flow and proceed to the amount screen
3. Tap the nonce selector, then tap "Add new nonce"
4. Verify the keyboard appears automatically when the custom nonce modal opens
5. Repeat on **iOS** to confirm no regression

## Screenshots

N/A

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).