### PR TITLE
chore(deps): update ethers and @mui/material versions

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -84,7 +84,7 @@
     "burnt": "^0.12.2",
     "date-fns": "^4.1.0",
     "deepmerge": "^4.3.1",
-    "ethers": "^6.14.3",
+    "ethers": "6.14.3",
     "expo": "^54.0.0",
     "expo-application": "~7.0.7",
     "expo-blur": "~15.0.7",

--- a/apps/tx-builder/package.json
+++ b/apps/tx-builder/package.json
@@ -29,7 +29,7 @@
     "@safe-global/safe-gateway-typescript-sdk": "^3.22.9",
     "axios": "^1.13.6",
     "ethereum-blockies-base64": "^1.0.2",
-    "ethers": "^6.14.3",
+    "ethers": "6.14.3",
     "evm-proxy-detection": "^1.0.0",
     "localforage": "^1.10.0",
     "react": "19.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -68,7 +68,7 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.8.0",
     "@ledgerhq/device-transport-kit-web-hid": "^1.2.0",
     "@mui/icons-material": "^6.1.6",
-    "@mui/material": "^6.3.0",
+    "@mui/material": "^6.5.0",
     "@mui/x-date-pickers": "^7.23.3",
     "@next/third-parties": "^15.2.0",
     "@reduxjs/toolkit": "^2.11.0",

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                       >
                         <button
                           aria-label="Copy to clipboard"
-                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-uneijd-MuiButtonBase-root-MuiIconButton-root"
                           tabindex="0"
                           type="button"
                         >
@@ -640,7 +640,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
             data-mui-internal-clone-element="true"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-2zc3nx-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-bg329z-MuiButtonBase-root-MuiButton-root"
               data-testid="continue-sign-btn"
               disabled=""
               tabindex="-1"

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
                                     >
                                       <button
                                         aria-label="Copy to clipboard"
-                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+                                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-uneijd-MuiButtonBase-root-MuiIconButton-root"
                                         tabindex="0"
                                         type="button"
                                       >

--- a/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`SettingsChange should display the SettingsChange component with newOwne
           >
             <button
               aria-label="Copy to clipboard"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-uneijd-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="button"
             >
@@ -149,7 +149,7 @@ exports[`SettingsChange should display the SettingsChange component with newOwne
           >
             <button
               aria-label="Copy to clipboard"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-uneijd-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="button"
             >
@@ -240,7 +240,7 @@ exports[`SettingsChange should display the SettingsChange component with owner d
           >
             <button
               aria-label="Copy to clipboard"
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-xyrzjn-MuiButtonBase-root-MuiIconButton-root"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-uneijd-MuiButtonBase-root-MuiIconButton-root"
               tabindex="0"
               type="button"
             >

--- a/config/test/package.json
+++ b/config/test/package.json
@@ -6,7 +6,7 @@
     "@faker-js/faker": "^9.2.0",
     "@safe-global/store": "workspace:^",
     "@safe-global/types-kit": "^1.0.0",
-    "ethers": "^6.13.4",
+    "ethers": "6.14.3",
     "jest": "^29.7.0",
     "msw": "^2.7.3",
     "ts-jest": "29.2.5"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -17,7 +17,6 @@
     "prettier:fix": "prettier --write . --config ../../.prettierrc --ignore-path ../../.prettierignore"
   },
   "peerDependencies": {
-    "@mui/material": "^6.x",
     "tamagui": "^1.x"
   },
   "peerDependenciesMeta": {
@@ -26,6 +25,7 @@
     }
   },
   "devDependencies": {
+    "@mui/material": "^6.5.0",
     "@safe-global/test": "workspace:^",
     "@types/jest": "^29.5.14",
     "eslint": "^9.29.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,7 @@
     "@types/jest": "^29.5.14",
     "eslint": "^9.29.0",
     "eslint-config-next": "^16.0.5",
-    "ethers": "^6.14.3",
+    "ethers": "6.14.3",
     "jest": "^29.7.0",
     "prettier": "^3.6.2",
     "typescript": "~5.9.2"
@@ -32,7 +32,6 @@
   "peerDependencies": {
     "@safe-global/protocol-kit": "^5.x",
     "@safe-global/store": "*",
-    "@safe-global/types-kit": "^1.x",
-    "ethers": "^6.x"
+    "@safe-global/types-kit": "^1.x"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9990,13 +9990,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/core-downloads-tracker@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "@mui/core-downloads-tracker@npm:6.3.0"
-  checksum: 10/cdfe2b2ba66c456587c7a285c0d2179ab5e42728e6a42d3921eb335c31aeeeda610ec728d96d797e4e82b298a229c20b6a74a7a8e6636d9f026f3d3240100e42
-  languageName: node
-  linkType: hard
-
 "@mui/core-downloads-tracker@npm:^6.5.0":
   version: 6.5.0
   resolution: "@mui/core-downloads-tracker@npm:6.5.0"
@@ -10065,42 +10058,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "@mui/material@npm:6.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.26.0"
-    "@mui/core-downloads-tracker": "npm:^6.3.0"
-    "@mui/system": "npm:^6.3.0"
-    "@mui/types": "npm:^7.2.20"
-    "@mui/utils": "npm:^6.3.0"
-    "@popperjs/core": "npm:^2.11.8"
-    "@types/react-transition-group": "npm:^4.4.12"
-    clsx: "npm:^2.1.1"
-    csstype: "npm:^3.1.3"
-    prop-types: "npm:^15.8.1"
-    react-is: "npm:^19.0.0"
-    react-transition-group: "npm:^4.4.5"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@mui/material-pigment-css": ^6.3.0
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@mui/material-pigment-css":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10/e6db71b4d044c87e08d50fe7cea8c5667d0a10ea16e376aab83639029d7fbc350342b1c93f20d1f7b3b3c63f35eef09fe3dcada73f5c2f8f041887dc30d56ead
-  languageName: node
-  linkType: hard
-
 "@mui/material@npm:^6.5.0":
   version: 6.5.0
   resolution: "@mui/material@npm:6.5.0"
@@ -10137,23 +10094,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "@mui/private-theming@npm:6.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.26.0"
-    "@mui/utils": "npm:^6.3.0"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10/61b19754f1f343866c47b9fa363482ddf79dab940620350fd707d863a74e18ec54540d3b2c19c94de7bdee78c75b00c0195ddd4f0019f2ee844e5e64c8c7a275
-  languageName: node
-  linkType: hard
-
 "@mui/private-theming@npm:^6.4.9":
   version: 6.4.9
   resolution: "@mui/private-theming@npm:6.4.9"
@@ -10168,29 +10108,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/d2e6b24001e82cb3a0c6115a54610ba0ee0abea64befe7fb5567fb8753fdc40b86eb77d399b1c014b1b8425c250f7bb3ee32171bb538f19bda5ce7a0d897a102
-  languageName: node
-  linkType: hard
-
-"@mui/styled-engine@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "@mui/styled-engine@npm:6.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.26.0"
-    "@emotion/cache": "npm:^11.13.5"
-    "@emotion/serialize": "npm:^1.3.3"
-    "@emotion/sheet": "npm:^1.4.0"
-    csstype: "npm:^3.1.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@emotion/react": ^11.4.1
-    "@emotion/styled": ^11.3.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-  checksum: 10/d36545fff9a50a508bc422ce0d20ecc5c24b7e3e9d64b7aa11117b16a382e4d4dd3aa2b127a94e150482999038e0437f631386b3727cb2ecfb00a75bf28877ac
   languageName: node
   linkType: hard
 
@@ -10245,34 +10162,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/system@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "@mui/system@npm:6.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.26.0"
-    "@mui/private-theming": "npm:^6.3.0"
-    "@mui/styled-engine": "npm:^6.3.0"
-    "@mui/types": "npm:^7.2.20"
-    "@mui/utils": "npm:^6.3.0"
-    clsx: "npm:^2.1.1"
-    csstype: "npm:^3.1.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10/35e42c2182a745cb6caa476800580f536c5388064a837b0984faf4858b7537b0cc6dada11cef000100143903ea7130de306e1615f1b74cf5799c0a6ebb17e870
-  languageName: node
-  linkType: hard
-
 "@mui/types@npm:^7.2.14":
   version: 7.4.10
   resolution: "@mui/types@npm:7.4.10"
@@ -10284,18 +10173,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/7492c6aa0b55e1d3c2bcbac7d3e0a41fe684aa5927a26911d9b6bef5d1ad85e578614af5da1f61e7ea0b37318d3c595bff29ae9af6f345572ad8d23cbd2211d0
-  languageName: node
-  linkType: hard
-
-"@mui/types@npm:^7.2.20":
-  version: 7.2.20
-  resolution: "@mui/types@npm:7.2.20"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10/1e1e4ddecce8afd277f6332ba57d3473c58b581994b3768ab2afbcf9a785efc509b44c267dfeb3e100d2539da3fcf45d514d4c1aed6f2cd1f2531a1855798349
   languageName: node
   linkType: hard
 
@@ -10362,26 +10239,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/4769956cc79283f9813d2984cd92b647528e4456eaea582c60b599d2db0a132ae4a10bf03ad28e8241463cd0ec2df1d56c0c4958f7c39d998241f93fc91c3ad4
-  languageName: node
-  linkType: hard
-
-"@mui/utils@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "@mui/utils@npm:6.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.26.0"
-    "@mui/types": "npm:^7.2.20"
-    "@types/prop-types": "npm:^15.7.14"
-    clsx: "npm:^2.1.1"
-    prop-types: "npm:^15.8.1"
-    react-is: "npm:^19.0.0"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10/09d78139405d761b92b0c722b27eb40b1a1993d1e146f6c1c5f505abd0c720ae135badb4f87b586fc8cefb0113c3ce7540e63fc54a6d19842fef14f9200ff864
   languageName: node
   linkType: hard
 
@@ -13119,7 +12976,7 @@ __metadata:
     deepmerge: "npm:^4.3.1"
     eslint: "npm:^9.29.0"
     eslint-plugin-react: "npm:^7.37.1"
-    ethers: "npm:^6.14.3"
+    ethers: "npm:6.14.3"
     expo: "npm:^54.0.0"
     expo-application: "npm:~7.0.7"
     expo-blur: "npm:~15.0.7"
@@ -13327,7 +13184,7 @@ __metadata:
     "@faker-js/faker": "npm:^9.2.0"
     "@safe-global/store": "workspace:^"
     "@safe-global/types-kit": "npm:^1.0.0"
-    ethers: "npm:^6.13.4"
+    ethers: "npm:6.14.3"
     jest: "npm:^29.7.0"
     jest-transform-stub: "npm:2.0.0"
     msw: "npm:^2.7.3"
@@ -13339,6 +13196,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@safe-global/theme@workspace:packages/theme"
   dependencies:
+    "@mui/material": "npm:^6.5.0"
     "@safe-global/test": "workspace:^"
     "@types/jest": "npm:^29.5.14"
     eslint: "npm:^9.29.0"
@@ -13348,7 +13206,6 @@ __metadata:
     prettier: "npm:^3.6.2"
     typescript: "npm:~5.9.2"
   peerDependencies:
-    "@mui/material": ^6.x
     tamagui: ^1.x
   peerDependenciesMeta:
     tamagui:
@@ -13397,7 +13254,7 @@ __metadata:
     eslint-config-next: "npm:^16.0.5"
     eslint-config-prettier: "npm:^9.1.0"
     ethereum-blockies-base64: "npm:^1.0.2"
-    ethers: "npm:^6.14.3"
+    ethers: "npm:6.14.3"
     evm-proxy-detection: "npm:^1.0.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
@@ -13440,7 +13297,7 @@ __metadata:
     date-fns: "npm:^4.1.0"
     eslint: "npm:^9.29.0"
     eslint-config-next: "npm:^16.0.5"
-    ethers: "npm:^6.14.3"
+    ethers: "npm:6.14.3"
     jest: "npm:^29.7.0"
     jest-fixed-jsdom: "npm:^0.0.10"
     prettier: "npm:^3.6.2"
@@ -13450,7 +13307,6 @@ __metadata:
     "@safe-global/protocol-kit": ^5.x
     "@safe-global/store": "*"
     "@safe-global/types-kit": ^1.x
-    ethers: ^6.x
   languageName: unknown
   linkType: soft
 
@@ -13481,7 +13337,7 @@ __metadata:
     "@mdx-js/loader": "npm:^3.0.1"
     "@mdx-js/react": "npm:^3.0.1"
     "@mui/icons-material": "npm:^6.1.6"
-    "@mui/material": "npm:^6.3.0"
+    "@mui/material": "npm:^6.5.0"
     "@mui/x-date-pickers": "npm:^7.23.3"
     "@next/bundle-analyzer": "npm:^15.0.4"
     "@next/mdx": "npm:^15.0.4"
@@ -26190,7 +26046,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ethers@npm:6.14.3, ethers@npm:^6.14.3":
+"ethers@npm:6.14.3":
   version: 6.14.3
   resolution: "ethers@npm:6.14.3"
   dependencies:
@@ -26202,21 +26058,6 @@ __metadata:
     tslib: "npm:2.7.0"
     ws: "npm:8.17.1"
   checksum: 10/ce68b962f117fd651090bd8096fde708428ce23f0d044c365bc8cbf2e8f3cb70e1661ff0194364848ccac06d607d4a977f2a0c9e370b9712809c0ca6c36131f9
-  languageName: node
-  linkType: hard
-
-"ethers@npm:^6.13.4":
-  version: 6.15.0
-  resolution: "ethers@npm:6.15.0"
-  dependencies:
-    "@adraffy/ens-normalize": "npm:1.10.1"
-    "@noble/curves": "npm:1.2.0"
-    "@noble/hashes": "npm:1.3.2"
-    "@types/node": "npm:22.7.5"
-    aes-js: "npm:4.0.0-beta.5"
-    tslib: "npm:2.7.0"
-    ws: "npm:8.17.1"
-  checksum: 10/21ab1d31e1b89f62dce5611c3686e4b81e000107aff8dccdbeaa1eac2da43459d5b590efa127470208729ca99a3b5757dd690943cf60745c2393d13db6a3218a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves
This PR updates the versions of @mui/material and ethers to fix errors that appeared in another [PR](https://github.com/safe-global/safe-wallet-monorepo/pull/7077).

## How this PR fixes it
- Updated `ethers` from ^6.14.3 to 6.14.3 in multiple package.json files.
- Updated `@mui/material` from ^6.3.0 to ^6.5.0 in the web package.json and added it as a devDependency in the theme package.json.
- Removed outdated versions of `@mui/material` packages from yarn.lock.