### PR TITLE
fix(mobile): add cross-chain recipient warning in send flow

### DIFF
--- a/apps/mobile/src/features/Send/SelectRecipient.container.tsx
+++ b/apps/mobile/src/features/Send/SelectRecipient.container.tsx
@@ -9,8 +9,12 @@ import { RecipientInput } from './components/RecipientInput'
 import { RecipientSections } from './components/RecipientSections'
 import { AddToAddressBookModal } from './components/AddToAddressBookModal'
 import { SuspiciousAddressComparison } from './components/SuspiciousAddressComparison'
+import { KnownOtherChainWarning } from './components/KnownOtherChainWarning'
 import { useRecipientValidation } from './hooks/useRecipientValidation'
 import { useRecipientSearch } from './hooks/useRecipientSearch'
+import { useAppSelector } from '@/src/store/hooks'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { selectChainById } from '@/src/store/chains'
 import { IconName } from '@/src/types/iconTypes'
 
 function IconRow({
@@ -49,6 +53,9 @@ export function SelectRecipientContainer() {
   const router = useRouter()
   const { bottom } = useSafeAreaInsets()
   const { scannedAddress } = useLocalSearchParams<{ scannedAddress?: string }>()
+  const activeSafe = useDefinedActiveSafe()
+  const chain = useAppSelector((state) => selectChainById(state, activeSafe.chainId))
+  const chainName = chain?.chainName ?? 'this network'
   const [address, setAddress] = useState('')
   const [recipientName, setRecipientName] = useState<string>()
   const [showAddContact, setShowAddContact] = useState(false)
@@ -68,10 +75,18 @@ export function SelectRecipientContainer() {
     setRecipientName(undefined)
   }, [])
 
-  const handleSelect = useCallback((selectedAddress: string, name?: string) => {
-    setAddress(selectedAddress)
-    setRecipientName(name)
-  }, [])
+  const handleSelect = useCallback(
+    (selectedAddress: string, name?: string) => {
+      router.push({
+        pathname: '/(send)/token',
+        params: {
+          recipientAddress: selectedAddress.trim(),
+          ...(name ? { recipientName: name } : {}),
+        },
+      })
+    },
+    [router],
+  )
 
   const handleClear = useCallback(() => {
     setAddress('')
@@ -115,6 +130,7 @@ export function SelectRecipientContainer() {
     setShowAddContact(false)
   }, [])
   const isSuspicious = validation.state === 'suspicious'
+  const isKnownOtherChain = validation.state === 'known-other-chain'
   const isSelected = !!displayName
   const hasAddress = validation.state !== 'empty' && validation.state !== 'typing'
   const showBrowseOptions = !isSelected && !hasAddress
@@ -148,7 +164,16 @@ export function SelectRecipientContainer() {
                 validationState={validation.state}
                 contactName={validation.contactName}
                 selectedName={displayName}
+                chainName={chainName}
               />
+
+              {isKnownOtherChain && validation.contactAddress && (
+                <KnownOtherChainWarning
+                  contactAddress={validation.contactAddress}
+                  chainId={activeSafe.chainId}
+                  chainName={chainName}
+                />
+              )}
 
               {showAddToAddressBook && (
                 <IconRow

--- a/apps/mobile/src/features/Send/components/KnownOtherChainWarning.tsx
+++ b/apps/mobile/src/features/Send/components/KnownOtherChainWarning.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback } from 'react'
+import { Alert, Pressable } from 'react-native'
+import { Text, View } from 'tamagui'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { useAppDispatch } from '@/src/store/hooks'
+import { mergeContactChainIds } from '@/src/store/addressBookSlice'
+
+interface KnownOtherChainWarningProps {
+  contactAddress: string
+  chainId: string
+  chainName: string
+}
+
+export function KnownOtherChainWarning({ contactAddress, chainId, chainName }: KnownOtherChainWarningProps) {
+  const dispatch = useAppDispatch()
+
+  const handleUpdateAddressBook = useCallback(() => {
+    Alert.alert(
+      'Update address book',
+      `Add ${chainName} to this contact's networks?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Update',
+          onPress: () => {
+            dispatch(mergeContactChainIds({ value: contactAddress, chainIds: [chainId] }))
+          },
+        },
+      ],
+      { cancelable: true },
+    )
+  }, [dispatch, contactAddress, chainId, chainName])
+
+  return (
+    <View gap="$4" paddingTop="$2">
+      <View gap="$2">
+        <Text fontSize={20} fontWeight="600" color="$color">
+          Unknown recipient on this network
+        </Text>
+        <Text fontSize="$5" color="$colorSecondary" lineHeight={22}>
+          This address is already saved in your address book, but for a different network. Are you sure you want to send
+          funds on {chainName}?
+        </Text>
+      </View>
+
+      <Pressable onPress={handleUpdateAddressBook} testID="update-address-book">
+        <View flexDirection="row" alignItems="center" gap="$3" paddingVertical="$3" paddingRight="$3">
+          <View
+            width={40}
+            height={40}
+            borderRadius={20}
+            backgroundColor="$backgroundSkeleton"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <SafeFontIcon name="send-to-user" size={24} color="$color" />
+          </View>
+          <Text fontSize="$5" color="$color">
+            Update address book
+          </Text>
+        </View>
+      </Pressable>
+    </View>
+  )
+}

--- a/apps/mobile/src/features/Send/components/RecipientInput.tsx
+++ b/apps/mobile/src/features/Send/components/RecipientInput.tsx
@@ -16,6 +16,7 @@ interface RecipientInputProps {
   validationState: RecipientValidationState
   contactName?: string
   selectedName?: string
+  chainName?: string
 }
 
 const borderColors: Record<RecipientValidationState, string> = {
@@ -26,6 +27,7 @@ const borderColors: Record<RecipientValidationState, string> = {
   invalid: '$error',
   'self-send': '$warning',
   suspicious: '$warning',
+  'known-other-chain': '$warning',
 }
 
 const labelConfig: Partial<
@@ -46,17 +48,31 @@ const labelConfig: Partial<
     textColor: '$color',
     text: 'Suspicious recipient',
   },
+  'known-other-chain': {
+    icon: 'alert',
+    iconColor: '$warning',
+    textColor: '$color',
+    text: 'Unknown recipient on this network',
+  },
 }
 
-function RecipientLabel({ validationState }: { validationState: RecipientValidationState }) {
+function RecipientLabel({
+  validationState,
+  chainName,
+}: {
+  validationState: RecipientValidationState
+  chainName?: string
+}) {
   const label = labelConfig[validationState]
 
   if (label) {
+    const text = validationState === 'known-other-chain' && chainName ? `Unknown recipient on ${chainName}` : label.text
+
     return (
       <>
         <SafeFontIcon name={label.icon as 'check'} size={16} color={label.iconColor} />
         <Text fontSize="$4" color={label.textColor}>
-          {label.text}
+          {text}
         </Text>
       </>
     )
@@ -171,6 +187,7 @@ export function RecipientInput({
   validationState,
   contactName,
   selectedName,
+  chainName,
 }: RecipientInputProps) {
   const handlePaste = useCallback(async () => {
     const text = await Clipboard.getString()
@@ -186,7 +203,7 @@ export function RecipientInput({
   return (
     <View gap="$2">
       <View flexDirection="row" alignItems="center" gap="$1" paddingLeft={4}>
-        <RecipientLabel validationState={validationState} />
+        <RecipientLabel validationState={validationState} chainName={chainName} />
       </View>
       <View
         flexDirection="row"
@@ -212,9 +229,13 @@ export function RecipientInput({
           />
         )}
       </View>
-      {!isSelected && hasAddress && validationState !== 'unknown' && validationState !== 'invalid' && (
-        <RecipientValidationBadge state={validationState} contactName={contactName} />
-      )}
+      {!isSelected &&
+        hasAddress &&
+        validationState !== 'unknown' &&
+        validationState !== 'invalid' &&
+        validationState !== 'known-other-chain' && (
+          <RecipientValidationBadge state={validationState} contactName={contactName} />
+        )}
     </View>
   )
 }

--- a/apps/mobile/src/features/Send/components/RecipientValidationBadge.tsx
+++ b/apps/mobile/src/features/Send/components/RecipientValidationBadge.tsx
@@ -27,6 +27,12 @@ const stateConfig: Record<
     icon: 'alert',
     label: 'Suspicious recipient',
   },
+  'known-other-chain': {
+    color: '$warning',
+    bg: '$warningBackground',
+    icon: 'alert',
+    label: 'Known on another network',
+  },
 }
 
 export function RecipientValidationBadge({ state, contactName }: RecipientValidationBadgeProps) {

--- a/apps/mobile/src/features/Send/hooks/useRecipientSearch.ts
+++ b/apps/mobile/src/features/Send/hooks/useRecipientSearch.ts
@@ -94,13 +94,13 @@ export function useRecipientSearch(query: string): {
     const contactsByAddress = buildChainFilteredContactNames(contacts, activeSafe.chainId)
     const safeOptions = buildSafeOptions(allSafes, activeSafe.chainId, namesByAddress)
 
-    // Exclude all Safe addresses (including the active one) from other sections
-    const allSafeAddresses = new Set(Object.keys(allSafes).map((a) => a.toLowerCase()))
-    allSafeAddresses.add(activeSafe.address.toLowerCase())
-    const signerOptions = buildSignerOptions(signersMap, allSafeAddresses, contactsByAddress)
+    // Exclude Safes shown in "My Safe accounts" + the active Safe from other sections
+    const shownSafeAddresses = new Set(safeOptions.map((s) => s.address.toLowerCase()))
+    shownSafeAddresses.add(activeSafe.address.toLowerCase())
+    const signerOptions = buildSignerOptions(signersMap, shownSafeAddresses, contactsByAddress)
 
     const signerAddresses = new Set(signerOptions.map((s) => s.address.toLowerCase()))
-    const allExcluded = new Set([...allSafeAddresses, ...signerAddresses])
+    const allExcluded = new Set([...shownSafeAddresses, ...signerAddresses])
     const contactOptions = buildContactOptions(contacts, activeSafe.chainId, allExcluded)
 
     return { safeOptions, signerOptions, contactOptions }

--- a/apps/mobile/src/features/Send/hooks/useRecipientValidation.ts
+++ b/apps/mobile/src/features/Send/hooks/useRecipientValidation.ts
@@ -10,11 +10,20 @@ import { selectSigners } from '@/src/store/signersSlice'
 import { selectAllSafes } from '@/src/store/safesSlice'
 import { useSuspiciousAddressDetection, type SuspiciousAddressMatch } from './useSuspiciousAddressDetection'
 
-export type RecipientValidationState = 'empty' | 'typing' | 'known' | 'unknown' | 'invalid' | 'self-send' | 'suspicious'
+export type RecipientValidationState =
+  | 'empty'
+  | 'typing'
+  | 'known'
+  | 'unknown'
+  | 'invalid'
+  | 'self-send'
+  | 'suspicious'
+  | 'known-other-chain'
 
 export interface RecipientValidationResult {
   state: RecipientValidationState
   contactName?: string
+  contactAddress?: string
   isValid: boolean
   canContinue: boolean
   suspiciousMatch?: SuspiciousAddressMatch
@@ -84,6 +93,24 @@ const UNKNOWN_RESULT: RecipientValidationResult = {
   canContinue: true,
 }
 
+function resolveCrossChainContact(
+  trimmed: string,
+  contacts: Record<string, Contact>,
+  chainId: string,
+): { contactName: string; contactAddress: string } | undefined {
+  const contact = findContact(contacts, trimmed)
+  if (!contact) {
+    return undefined
+  }
+  if (contact.chainIds.length === 0) {
+    return undefined
+  }
+  if (contact.chainIds.includes(chainId)) {
+    return undefined
+  }
+  return { contactName: contact.name, contactAddress: contact.value }
+}
+
 function resolveAddressState(trimmed: string, ctx: AddressContext): RecipientValidationResult {
   return resolveIncompleteAddress(trimmed) ?? resolveKnownAddress(trimmed, ctx) ?? UNKNOWN_RESULT
 }
@@ -104,7 +131,13 @@ export function useRecipientValidation(address: string): RecipientValidationResu
     }
   }, [addressBookState.contacts])
 
-  const ownedSafes = useMemo(() => Object.keys(allSafes), [allSafes])
+  const ownedSafes = useMemo(
+    () =>
+      Object.entries(allSafes)
+        .filter(([, chainMap]) => activeSafe.chainId in chainMap)
+        .map(([addr]) => addr),
+    [allSafes, activeSafe.chainId],
+  )
 
   const trimmed = address.trim()
   const isValidAddress = trimmed.length >= 42 && isAddress(trimmed)
@@ -121,17 +154,38 @@ export function useRecipientValidation(address: string): RecipientValidationResu
       signers,
     })
 
-    if (baseResult.state === 'unknown' && suspiciousDetection.isSuspicious) {
-      return {
-        ...baseResult,
-        state: 'suspicious',
-        canContinue: false,
-        suspiciousMatch: suspiciousDetection.match,
+    if (baseResult.state === 'unknown') {
+      const crossChain = resolveCrossChainContact(trimmed, addressBookState.contacts, activeSafe.chainId)
+      if (crossChain) {
+        return {
+          state: 'known-other-chain',
+          contactName: crossChain.contactName,
+          contactAddress: crossChain.contactAddress,
+          isValid: true,
+          canContinue: true,
+        }
+      }
+
+      if (suspiciousDetection.isSuspicious) {
+        return {
+          ...baseResult,
+          state: 'suspicious',
+          canContinue: false,
+          suspiciousMatch: suspiciousDetection.match,
+        }
       }
     }
 
     return baseResult
-  }, [trimmed, activeSafe.address, addressBookCheck, addressBookState.contacts, signers, suspiciousDetection])
+  }, [
+    trimmed,
+    activeSafe.address,
+    activeSafe.chainId,
+    addressBookCheck,
+    addressBookState.contacts,
+    signers,
+    suspiciousDetection,
+  ])
 
   return result
 }


### PR DESCRIPTION
> Chains diverge in silence—
> an address drifts between worlds,
> warning lights the bridge.

## What it solves

When pasting an address that exists in the address book but for a different chain (e.g., a Sepolia Safe pasted on mainnet), the send flow incorrectly showed "Known recipient" with a green tick. Additionally, tapping known recipients from the list required an unnecessary confirmation step before reaching token selection.

## How this PR fixes it

Two bugs were chain-filtering related: `ownedSafes` in validation and `allSafeAddresses` in the recipient search both included all chains instead of the current one. This caused cross-chain Safes to be both falsely validated as "known" AND hidden from the address book list (excluded as "a Safe" but not shown in "My Safe accounts" since it's not on the current chain).

The new `'known-other-chain'` validation state detects when a pasted address is in the address book but not for the active chain, showing a warning with an "Update address book" action that merges the current chain into the contact via `mergeContactChainIds`. After updating, the validation auto-transitions to "Known recipient".

Known recipients tapped from the list now skip the confirmation step and navigate directly to token selection.

## How to test it

1. Have a Safe on Sepolia saved in the address book
2. Switch to mainnet and open the Send flow
3. Paste the Sepolia Safe's address — should show orange "Unknown recipient on Ethereum" warning with explanation text and "Update address book" button
4. Tap "Update address book" → confirm in the alert → should transition to green "Known recipient"
5. Clear and verify: tap a known recipient from the list → should navigate directly to token selection (no intermediate confirmation)
6. Verify fully unknown addresses still show "Unknown recipient" with "Add to address book"

## Screenshots

https://github.com/user-attachments/assets/009707e3-d675-4a06-8fe7-eb3bbfbef36e


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).