### PR TITLE
fix(mobile): add identicon, copy, and explorer link to send recipient display

### DIFF
--- a/apps/mobile/src/features/Send/components/RecipientDisplay.tsx
+++ b/apps/mobile/src/features/Send/components/RecipientDisplay.tsx
@@ -1,6 +1,16 @@
 import React from 'react'
+import { Linking, TouchableOpacity } from 'react-native'
 import { Text, View } from 'tamagui'
 import { shortenAddress } from '@/src/utils/formatters'
+import { Identicon } from '@/src/components/Identicon/Identicon'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { useCopyAndDispatchToast } from '@/src/hooks/useCopyAndDispatchToast'
+import { useAppSelector } from '@/src/store/hooks'
+import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
+import { selectChainById } from '@/src/store/chains'
+import { getExplorerLink } from '@safe-global/utils/utils/gateway'
+import type { Address } from '@/src/types/address'
+import type { RootState } from '@/src/store'
 
 interface RecipientDisplayProps {
   address: string
@@ -8,22 +18,46 @@ interface RecipientDisplayProps {
 }
 
 export function RecipientDisplay({ name, address }: RecipientDisplayProps) {
-  if (name) {
-    return (
-      <View gap={2}>
-        <Text fontSize="$4" fontWeight={600} color="$color">
-          {name}
-        </Text>
-        <Text fontSize="$3" color="$colorSecondary">
-          {shortenAddress(address, 4)}
-        </Text>
-      </View>
-    )
+  const activeSafe = useDefinedActiveSafe()
+  const activeChain = useAppSelector((state: RootState) => selectChainById(state, activeSafe.chainId))
+  const copyAddress = useCopyAndDispatchToast()
+
+  const handleOpenExplorer = () => {
+    const link = getExplorerLink(address, activeChain.blockExplorerUriTemplate)
+    Linking.openURL(link.href)
   }
 
   return (
-    <Text fontSize="$4" color="$color">
-      {shortenAddress(address, 6)}
-    </Text>
+    <View flexDirection="row" alignItems="center" gap="$3" flex={1}>
+      <Identicon address={address as Address} size={32} />
+      <TouchableOpacity onPress={() => copyAddress(address)} style={{ flex: 1 }} testID="copy-address">
+        <View gap={2}>
+          {name ? (
+            <>
+              <Text
+                fontSize="$4"
+                fontWeight={600}
+                color="$color"
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                testID="recipient-name"
+              >
+                {name}
+              </Text>
+              <Text fontSize="$3" color="$colorSecondary">
+                {shortenAddress(address, 4)}
+              </Text>
+            </>
+          ) : (
+            <Text fontSize="$4" color="$color">
+              {shortenAddress(address, 6)}
+            </Text>
+          )}
+        </View>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={handleOpenExplorer} hitSlop={8} testID="explorer-link-button">
+        <SafeFontIcon name="external-link" size={24} color="$colorSecondary" />
+      </TouchableOpacity>
+    </View>
   )
 }


### PR DESCRIPTION
> A blockie blooms beside the name,
> tap once to copy, tap the flame—
> the explorer opens wide its gate,
> to show the chain address's fate.

## What it solves

The recipient display on the token selection and amount input screens in the send flow was showing only plain text (name + shortened address) with no visual identity or quick actions for the recipient address.

Resolves: https://linear.app/safe-global/issue/WA-1706
## How this PR fixes it

Enhances the `RecipientDisplay` component to show an identicon (blockie) for visual identification, makes the address tappable to copy to clipboard (with toast feedback), and adds an external-link icon to open the address on the chain's block explorer.

## How to test it

1. Open the mobile app, navigate to a Safe, and start a send flow
2. Select a recipient (try both a named contact and an unknown address)
3. On the **token selection** screen, verify the recipient row shows: identicon, name/address, and an external-link icon
4. Tap the address text — confirm it copies to clipboard with a toast
5. Tap the external-link icon — confirm it opens the block explorer for that address
6. Proceed to the **amount input** screen and verify the same behavior on the recipient header

## Screenshots

N/A - will add after testing on device

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).