### PR TITLE
fix(mobile): set native value for Polygon MRC20 payable transfer

### DIFF
--- a/apps/mobile/src/features/Send/services/tokenTransferParams.test.ts
+++ b/apps/mobile/src/features/Send/services/tokenTransferParams.test.ts
@@ -3,6 +3,7 @@ import { Interface } from 'ethers'
 import { generateChecksummedAddress } from '@safe-global/test'
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const POLYGON_MRC20 = '0x0000000000000000000000000000000000001010'
 
 describe('tokenTransferParams', () => {
   describe('createTokenTransferParams', () => {
@@ -69,6 +70,20 @@ describe('tokenTransferParams', () => {
 
       expect(result.value).toBe('1000000000000000')
     })
+
+    it('sets value equal to amount for Polygon MRC20 (0x...1010)', () => {
+      const recipient = generateChecksummedAddress()
+      const result = createTokenTransferParams(recipient, '5', 18, POLYGON_MRC20)
+
+      expect(result.to).toBe(POLYGON_MRC20)
+      expect(result.value).toBe('5000000000000000000')
+      expect(result.data).not.toBe('0x')
+
+      const iface = new Interface(['function transfer(address to, uint256 value)'])
+      const decoded = iface.decodeFunctionData('transfer', result.data)
+      expect(decoded[0]).toBe(recipient)
+      expect(decoded[1].toString()).toBe('5000000000000000000')
+    })
   })
 
   describe('createErc20TransferParams', () => {
@@ -81,6 +96,15 @@ describe('tokenTransferParams', () => {
       expect(result.value).toBe('0')
       expect(result.data).toBeDefined()
       expect(result.data.startsWith('0xa9059cbb')).toBe(true) // transfer selector
+    })
+
+    it('sets value for Polygon MRC20 payable native wrapper', () => {
+      const recipient = generateChecksummedAddress()
+      const result = createErc20TransferParams(recipient, POLYGON_MRC20, '5000000000000000000')
+
+      expect(result.to).toBe(POLYGON_MRC20)
+      expect(result.value).toBe('5000000000000000000')
+      expect(result.data.startsWith('0xa9059cbb')).toBe(true)
     })
   })
 

--- a/apps/mobile/src/features/Send/services/tokenTransferParams.ts
+++ b/apps/mobile/src/features/Send/services/tokenTransferParams.ts
@@ -5,6 +5,9 @@ import { safeParseUnits } from '@safe-global/utils/utils/formatters'
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
+// Polygon native token wrapper (MRC20) — its payable transfer() requires msg.value == amount
+const POLYGON_MRC20 = '0x0000000000000000000000000000000000001010'
+
 const encodeErc20TransferData = (to: string, value: string): string => {
   const erc20Abi = ['function transfer(address to, uint256 value)']
   const iface = new Interface(erc20Abi)
@@ -16,9 +19,11 @@ export const createErc20TransferParams = (
   tokenAddress: string,
   value: string,
 ): MetaTransactionData => {
+  const isPayableNativeWrapper = sameAddress(tokenAddress, POLYGON_MRC20)
+
   return {
     to: tokenAddress,
-    value: '0',
+    value: isPayableNativeWrapper ? value : '0',
     data: encodeErc20TransferData(recipient, value),
   }
 }


### PR DESCRIPTION
> In Polygon's wrapped halls of code,
> A transfer paid, yet nothing flowed—
> The value null, the contract mute,
> Now msg.value bears the fruit.

## What it solves

When sending POL on Polygon via the ERC-20 contract at `0x0000...1010` (returned by Zerion as token source), the transaction silently fails because the MRC20 contract's `transfer()` function is payable and requires `msg.value == amount`. Our transaction builder was setting `value: "0"`, so the contract returned `false` with no balance change.

Resolves: https://linear.app/safe-global/issue/WA-1712/balance-change-is-missing-when-zerion-is-used-on-polygon-pol-token

## How this PR fixes it

The Polygon MRC20 contract at `0x0000...1010` is a special native token wrapper — its `transfer(address, uint256)` is `payable` and checks `if (msg.value != value) { return false; }`. When building ERC-20 transfer params, we now detect this specific contract address and set the Safe transaction's `value` field equal to the transfer amount, so `msg.value` matches what the contract expects.

This is scoped to `0x0000...1010` only — no other ERC-20 has this payable transfer pattern.

## How to test it

1. Open the mobile app on Polygon with "Show all tokens" **off** (Zerion source — POL at `0x0000...1010`)
2. Initiate a send of POL to any recipient
3. On the confirm transaction page, verify the "balance change" section from Blockaid now shows the expected balance change
4. Verify the crafted transaction has both `value` and `data` fields set (value matches the transfer amount)

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).