### PR TITLE
fix(mobile): remove duplicate menu dots icon in contact item

### DIFF
--- a/apps/mobile/src/features/AddressBook/List/components/List/ContactItem.tsx
+++ b/apps/mobile/src/features/AddressBook/List/components/List/ContactItem.tsx
@@ -63,11 +63,6 @@ export const ContactItem: React.FC<ContactItemProps> = ({ contact, onPress, onMe
               <Identicon address={`${contact.value as Address}`} rounded size={40} />
             </View>
           }
-          rightNode={
-            <View>
-              <SafeFontIcon name={'options-horizontal'} />
-            </View>
-          }
         />
       </Pressable>
 


### PR DESCRIPTION
> Two icons bloom where one should stand,
> A mirror trick by careless hand—
> The extra fades, the menu clears,
> Three dots alone, as it appears.

## What it solves

The contact list item in the address book was showing 6 dots instead of 3 for the menu trigger. The `SafeListItem` had a `rightNode` rendering an `options-horizontal` icon, while the `MenuView` already rendered the same icon as its child.

## How this PR fixes it

Removes the duplicate `rightNode` prop from `SafeListItem` in `ContactItem.tsx`. The `MenuView` component already renders the 3-dot icon as its trigger.

## How to test it

1. Open the mobile app and navigate to the Address Book
2. Verify each contact shows exactly 3 dots for the menu trigger (not 6)
3. Tap the 3 dots and confirm the context menu opens correctly

## Screenshots

<img width="150" alt="image" src="https://github.com/user-attachments/assets/6492ba73-d5fa-4f05-b3a9-3b9b635c641e" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).