### PR TITLE
fix: preserve ethers exports in ledger execution test

### DIFF
--- a/apps/mobile/src/services/ledger/ledger-execution.service.test.ts
+++ b/apps/mobile/src/services/ledger/ledger-execution.service.test.ts
@@ -57,16 +57,22 @@ jest.mock('@safe-global/protocol-kit/dist/src/utils', () => ({
   generatePreValidatedSignature: (owner: string) => ({ signer: owner, data: '0xPreValidated' }),
 }))
 
-jest.mock('ethers', () => ({
-  Transaction: {
-    from: jest.fn().mockImplementation((data) => ({
-      ...data,
-      unsignedSerialized: '0x1234',
-      serialized: '0x5678',
-      signature: null,
-    })),
-  },
-}))
+jest.mock('ethers', () => {
+  const actual = jest.requireActual('ethers')
+
+  return {
+    ...actual,
+    Transaction: {
+      ...actual.Transaction,
+      from: jest.fn().mockImplementation((data) => ({
+        ...data,
+        unsignedSerialized: '0x1234',
+        serialized: '0x5678',
+        signature: null,
+      })),
+    },
+  }
+})
 
 jest.mock('@/src/utils/logger', () => ({
   __esModule: true,


### PR DESCRIPTION
> Mocked modules shared one name,
> Two versions blurred the test boundary,
> Real exports now remain.

## What it solves

Fixes a mobile ledger unit test regression caused by a full `ethers` mock replacing exports needed by shared `@safe-global/test` factories after dependency standardization.

Resolves: N/A

## How this PR fixes it

The test now partially mocks `ethers` and preserves the real module exports via `jest.requireActual`, while still overriding `Transaction.from`. This keeps the ledger execution test isolated without breaking shared helpers that import `getAddress`.

## How to test it

1. Run `yarn workspace @safe-global/mobile test src/services/ledger/ledger-execution.service.test.ts --runInBand --watchman=false`.
2. Confirm the suite passes and the previous `getAddress is not a function` failure is gone.
3. Optionally compare the mock shape in `ledger-execution.service.test.ts` and verify only `Transaction.from` is overridden.

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
