### PR TITLE
fix(mobile): populate recipient field when rescanning same QR address

### DIFF
--- a/apps/mobile/src/features/Send/ScanQrSend.container.tsx
+++ b/apps/mobile/src/features/Send/ScanQrSend.container.tsx
@@ -74,7 +74,7 @@ export function ScanQrSendContainer() {
       setIsCameraActive(false)
       router.dismissTo({
         pathname: '/(send)/recipient',
-        params: { scannedAddress: address },
+        params: { scannedAddress: address, scanTimestamp: Date.now().toString() },
       })
     },
     [router],

--- a/apps/mobile/src/features/Send/SelectRecipient.container.tsx
+++ b/apps/mobile/src/features/Send/SelectRecipient.container.tsx
@@ -52,7 +52,7 @@ function IconRow({
 export function SelectRecipientContainer() {
   const router = useRouter()
   const { bottom } = useSafeAreaInsets()
-  const { scannedAddress } = useLocalSearchParams<{ scannedAddress?: string }>()
+  const { scannedAddress, scanTimestamp } = useLocalSearchParams<{ scannedAddress?: string; scanTimestamp?: string }>()
   const activeSafe = useDefinedActiveSafe()
   const chain = useAppSelector((state) => selectChainById(state, activeSafe.chainId))
   const chainName = chain?.chainName ?? 'this network'
@@ -65,7 +65,7 @@ export function SelectRecipientContainer() {
       setAddress(scannedAddress)
       setRecipientName(undefined)
     }
-  }, [scannedAddress])
+  }, [scannedAddress, scanTimestamp])
 
   const validation = useRecipientValidation(address)
   const searchResults = useRecipientSearch(address)


### PR DESCRIPTION
> The scanner blinks, forgets the code,
> Same address, different epoch's load,
> A timestamp breaks the loop.

## What it solves

When a user scans a QR code address, clears the recipient field, and rescans the **same** address, the field is not populated. Scanning a different address works fine.

Resolves: https://linear.app/safe-global/issue/WA-1468/add-new-send-and-receive-button#comment-9bc75386

## How this PR fixes it

The `useEffect` in `SelectRecipientContainer` only depended on `scannedAddress`, so rescanning the same address produced no state change and the effect was skipped. A `scanTimestamp` param is now passed alongside `scannedAddress` on every scan, ensuring the effect always re-triggers.

## How to test it

1. Open the send flow and tap "Scan QR code"
2. Scan any valid Ethereum address QR — verify the recipient field is populated
3. Clear the address field and tap "Scan QR code" again
4. Scan the **same** QR code — verify the recipient field is populated again

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).