### PR TITLE
fix(mobile): remove duplicate self-send warning in send flow

### DIFF
--- a/apps/mobile/src/features/Send/components/RecipientInput.tsx
+++ b/apps/mobile/src/features/Send/components/RecipientInput.tsx
@@ -233,7 +233,8 @@ export function RecipientInput({
         hasAddress &&
         validationState !== 'unknown' &&
         validationState !== 'invalid' &&
-        validationState !== 'known-other-chain' && (
+        validationState !== 'known-other-chain' &&
+        validationState !== 'self-send' && (
           <RecipientValidationBadge state={validationState} contactName={contactName} />
         )}
     </View>


### PR DESCRIPTION
> Warning doubled, glaring bright,
> One label was already right—
> The badge bowed out,
> Removed all doubt,
> Now one calm message holds the light.

## What it solves

When sending to your own Safe address, the "Sending to your own Safe" warning appeared twice — once as a label above the input and again as a validation badge below it.

Resolves: https://linear.app/safe-global/issue/WA-1468/add-new-send-and-receive-button#comment-9bc75386

## How this PR fixes it

The `RecipientValidationBadge` was not excluded for the `self-send` state, unlike other states (`unknown`, `invalid`, `known-other-chain`) that already had their own label. Added `self-send` to the exclusion list so only the `RecipientLabel` above the input shows the warning.

## How to test it

1. Open the Send flow in the mobile app
2. Paste or enter the same address as the current Safe
3. Verify "Sending to your own Safe" appears only once (as a label above the input)
4. Verify other validation states (unknown, known, suspicious) still display correctly

## Screenshots

N/A - bug fix for duplicate UI element

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).