### PR TITLE
fix(mobile): add bottomInset to nonce modal footer for Android safe area

### DIFF
--- a/apps/mobile/src/features/Send/components/NonceBottomSheet.tsx
+++ b/apps/mobile/src/features/Send/components/NonceBottomSheet.tsx
@@ -101,12 +101,12 @@ function QueuedNonceRow({
 function useRenderFooter(insets: { bottom: number }, onAddCustomNonce: () => void, onLayout: (height: number) => void) {
   return useCallback(
     (props: BottomSheetFooterProps) => (
-      <BottomSheetFooter animatedFooterPosition={props.animatedFooterPosition}>
+      <BottomSheetFooter animatedFooterPosition={props.animatedFooterPosition} bottomInset={insets.bottom}>
         <View
           onLayout={(e) => onLayout(e.nativeEvent.layout.height)}
           backgroundColor="$backgroundSheet"
           paddingTop="$2"
-          paddingBottom={insets.bottom + 16}
+          paddingBottom={insets.bottom + 8}
           marginBottom={-insets.bottom}
         >
           <View height={1} backgroundColor="$borderLight" marginBottom="$2" />


### PR DESCRIPTION
> Nonce floats beneath the bar,
> Android hides what should be seen—
> One prop lifts it clear.

## What it solves

On Android phones with a dynamic navigation bar, the "Add new nonce" button in the recommended nonce bottom sheet was hidden behind the system navigation bar, making it untappable.

Resolves: https://linear.app/safe-global/issue/WA-1468/add-new-send-and-receive-button

## How this PR fixes it

Added `bottomInset={insets.bottom}` to the `BottomSheetFooter` in `NonceBottomSheet`, matching the pattern already used in `SafeBottomSheet` (which renders `MyAccountsFooter` correctly on Android). This is the standard way `@gorhom/bottom-sheet` accounts for the system navigation bar when positioning sticky footers.

## How to test it

1. Open the app on an Android device/emulator with a dynamic navigation bar (software navigation buttons)
2. Navigate to the Send flow and reach the nonce selection step
3. Open the recommended nonce bottom sheet
4. Verify the "Add new nonce" button is fully visible and tappable above the navigation bar
5. Also verify on iOS that the sheet still looks correct (no regression)

## Screenshots

<img width="150" alt="image" src="https://github.com/user-attachments/assets/10c367d2-5863-41af-98c4-cfeac093a08d" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).