### PR TITLE
fix: restore pending transaction badge shape and position

### DIFF
--- a/apps/web/src/components/dashboard/ActionRequiredPanel/styles.module.css
+++ b/apps/web/src/components/dashboard/ActionRequiredPanel/styles.module.css
@@ -9,13 +9,8 @@
   align-items: center;
 }
 
-/* Badge alignment to match PendingTxsList */
-.headerText :global .MuiBadge-root {
+.headerText > span {
   margin-left: var(--space-1);
-}
-
-.headerText :global .MuiBadge-badge {
-  position: relative;
 }
 
 .chevron {

--- a/apps/web/src/components/dashboard/PendingTxs/styles.module.css
+++ b/apps/web/src/components/dashboard/PendingTxs/styles.module.css
@@ -16,12 +16,8 @@
   grid-template-columns: 1fr 170px;
 }
 
-.pendingTxHeader :global .MuiBadge-root {
+.pendingTxHeader > span {
   margin-left: var(--space-1);
-}
-
-.pendingTxHeader :global .MuiBadge-badge {
-  position: relative;
 }
 
 .innerContainer {

--- a/apps/web/src/components/sidebar/SidebarList/index.tsx
+++ b/apps/web/src/components/sidebar/SidebarList/index.tsx
@@ -95,13 +95,16 @@ export const SidebarListItemCounter = ({
         backgroundColor: variant === 'warning' ? 'warning.light' : 'background.main',
         border: variant === 'subtle' ? '1px solid' : undefined,
         borderColor: variant === 'subtle' ? 'background.main' : undefined,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        verticalAlign: 'middle',
         fontWeight: 700,
         fontSize: 11,
-        lineHeight: '20px',
         minWidth: 20,
+        height: 20,
         px: 0.5,
         borderRadius: '10px',
-        textAlign: 'center',
         ml: 3,
       }}
     >


### PR DESCRIPTION
## Summary

- Replaced dead `.MuiBadge-*` CSS selectors in `PendingTxsList` and `ActionRequiredPanel` with `> span` targeting, after `SidebarListItemCounter` was changed from MUI `Badge` to `Box` in #7313
- Fixed badge circularity by adding `display: inline-flex`, explicit `height: 20`, and `verticalAlign: middle` to ensure proper shape and vertical centering in Typography contexts

Fixes WA-1725