### PR TITLE
feat(web): add ident icon and full address display for safe onboarding

### DIFF
--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCard.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCard.tsx
@@ -5,7 +5,7 @@ import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import { Checkbox } from '@/components/ui/checkbox'
 import { AccountItem } from '@/features/myAccounts/components/AccountItem'
 import useSafeCardData from '../hooks/useSafeCardData'
-import SafeAvatar from './SafeAvatar'
+import Identicon from '@/components/common/Identicon'
 import { Badge } from '@/components/ui/badge'
 import { TriangleAlert } from 'lucide-react'
 import FiatBalance from './FiatBalance'
@@ -124,21 +124,35 @@ const SafeCardLayout = ({
     </div>
 
     <div className="flex min-w-0 flex-1 items-center gap-4">
-      <SafeAvatar name={name} address={address} />
+      <Identicon address={address} />
 
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <span className="truncate text-base font-medium text-foreground">{name || shortenAddress(address)}</span>
-        <span className="text-xs text-muted-foreground">{shortenAddress(address)}</span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
         {isSimilar && (
-          <Badge variant="warning">
+          <Badge variant="warning" className="self-start -ml-px">
             <TriangleAlert data-icon="inline-start" />
             High similarity
           </Badge>
         )}
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-base font-medium text-foreground">{name || shortenAddress(address)}</span>
+          <div className="ml-auto shrink-0 pl-4">
+            <AccountItem.ChainBadge safes={safes} />
+          </div>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {isSimilar ? (
+            <>
+              {address.slice(0, 2)}
+              <b>{address.slice(2, 6)}</b>
+              {address.slice(6, -4)}
+              <b>{address.slice(-4)}</b>
+            </>
+          ) : (
+            address
+          )}
+        </span>
       </div>
     </div>
-
-    <AccountItem.ChainBadge safes={safes} />
 
     <div className="flex shrink-0 flex-col min-w-16 items-end gap-2">
       <FiatBalance value={fiatValue} />

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCard.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCard.test.tsx
@@ -16,9 +16,9 @@ jest.mock('../../hooks/useSafeCardData', () => ({
   }),
 }))
 
-jest.mock('../SafeAvatar', () => ({
+jest.mock('@/components/common/Identicon', () => ({
   __esModule: true,
-  default: ({ address }: { address: string }) => <div data-testid={`avatar-${address}`} />,
+  default: ({ address }: { address: string }) => <div data-testid={`identicon-${address}`} />,
 }))
 
 jest.mock('../FiatBalance', () => ({
@@ -71,6 +71,41 @@ describe('SafeCard', () => {
     expect(screen.getByText('Test Safe')).toBeInTheDocument()
     expect(screen.getByTestId('fiat-balance')).toHaveTextContent('1000')
     expect(screen.getByTestId('threshold-badge')).toHaveTextContent('2/3')
+  })
+
+  it('shows full address as subtitle', () => {
+    const address = '0xabc1234567890def'
+    render(
+      <FormWrapper>
+        <SafeCard safe={buildSafe(address)} />
+      </FormWrapper>,
+    )
+
+    expect(screen.getByText(address)).toBeInTheDocument()
+  })
+
+  it('bolds first and last 4 chars of address when isSimilar', () => {
+    const address = '0xABCDEF1234567890abcdef'
+    const { container } = render(
+      <FormWrapper>
+        <SafeCard safe={buildSafe(address)} isSimilar />
+      </FormWrapper>,
+    )
+
+    const boldElements = container.querySelectorAll('b')
+    expect(boldElements).toHaveLength(2)
+    expect(boldElements[0].textContent).toBe(address.slice(2, 6))
+    expect(boldElements[1].textContent).toBe(address.slice(-4))
+  })
+
+  it('does not bold address when not similar', () => {
+    const { container } = render(
+      <FormWrapper>
+        <SafeCard safe={buildSafe('0xabc123')} />
+      </FormWrapper>,
+    )
+
+    expect(container.querySelectorAll('b')).toHaveLength(0)
   })
 
   it('does not show similarity badge when isSimilar is false', () => {


### PR DESCRIPTION
## What it solves
https://linear.app/safe-global/issue/WA-1714/add-trusted-safes-to-the-onboarding
Improves the visual design and usability of `SafeCard` in the onboarding flow, making it easier to identify and compare Safe addresses — especially when similar addresses are detected.

## How this PR fixes it

- **Identicon avatar**: replaced the initials-based `SafeAvatar` with `Identicon`, consistent with the sidebar and account dropdown
- **Full address display**: subtitle now shows the full address instead of a truncated version
- **Bold highlighting for similar addresses**: when a Safe is flagged as similar, the first and last 4 significant characters of the address are bolded (matching the pattern used in the "Manage trusted Safes" dialog)

## How to test it

1. Go to the Spaces onboarding flow and reach the "Select Safes" step
2. Verify each Safe card shows an Identicon (not initials)
3. Verify the full address is displayed as the subtitle
4. Trigger a similar address scenario — confirm the "High similarity" badge appears above the name, and the address has bold first/last 4 chars

## Screenshots
<img width="844" height="826" alt="Screenshot 2026-03-12 at 13 53 50" src="https://github.com/user-attachments/assets/79ad6cd4-8ffb-4a63-bb83-accc3d3bbf05" />
<img width="676" height="803" alt="Screenshot 2026-03-12 at 13 54 00" src="https://github.com/user-attachments/assets/da2c8c50-7c24-4904-91ef-8b14912a3053" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

