### PR TITLE
chore: make PR poem instructions focus on technical summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,12 +289,12 @@ See `apps/web/docs/feature-architecture.md` for the complete guide including pro
 
 7. **Pull requests**: fill out the PR template and ensure all checks pass.
 
-8. **PR poem**: Include a short poem at the very top of each PR description that summarizes the changes. Each poem must use a randomly chosen style (e.g., haiku, sonnet, limerick, free verse, tanka, villanelle) and a randomly chosen genre/movement (e.g., symbolism, futurism, post-modernism, romanticism, surrealism, imagism). The poem should be wrapped in a blockquote:
+8. **PR poem**: Include a short technical poem at the very top of each PR description that acts as a concise summary of what the PR actually changes. The poem should prioritize clarity over artistry — a reader should understand the gist of the PR from the poem alone. Use a randomly chosen short form (e.g., haiku, limerick, free verse, tanka) and keep it to 2–4 lines. Wrap in a blockquote:
 
    ```markdown
-   > Cache key dissolves slow,
-   > Redux dreams in melted clocks,
-   > State rehydrates whole.
+   > Strip Sentry SDK and config,
+   > no more error tracking calls,
+   > bundle shrinks, tests pass clean.
    ```
 
 **Environment Variables** – Web apps use `NEXT_PUBLIC_*` prefix, mobile apps use `EXPO_PUBLIC_*` prefix for environment variables. In shared packages, check for both prefixes.


### PR DESCRIPTION
> Rewrite the poem rule—
> clarity over art now,
> summaries that speak plain.

## Summary
- Update PR poem instructions in AGENTS.md to prioritize technical clarity over artistic style
- Poems should act as concise summaries so readers understand the PR's gist at a glance
- Replace surrealist example with a concrete technical summary example

## Test plan
- [ ] Review the updated AGENTS.md instructions for clarity
- [ ] Verify the example poem demonstrates a real technical summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)