### PR TITLE
tests(web): fix flaky visual tests and add spaces welcome screenshot

### DIFF
--- a/apps/web/cypress/COVERAGE.md
+++ b/apps/web/cypress/COVERAGE.md
@@ -2,7 +2,7 @@
 
 > **Maintenance:** This file is manually maintained. Update it when adding, removing, or changing visual test files in `e2e/visual/`. Cross-reference with `.storybook/COVERAGE.md` for component-level gaps.
 
-**64 tests** across **33 test files** — each test captures an Argos screenshot automatically.
+**65 tests** across **33 test files** — each test captures an Argos screenshot automatically.
 
 Screenshots are captured via a global `afterEach` hook in `cypress/support/e2e.js`.
 
@@ -47,6 +47,7 @@ Screenshots are captured via a global `afterEach` hook in `cypress/support/e2e.j
 | `/imprint`                        | legal_pages.cy.js            | 1     | No               | No      |
 | `/cookie`                         | legal_pages.cy.js            | 1     | No               | No      |
 | `/safe-labs-terms`                | legal_pages.cy.js            | 1     | No               | No      |
+| `/welcome/spaces`                 | spaces.cy.js                 | 1     | Yes (auth + API) | No      |
 | `/spaces` (dashboard)             | spaces.cy.js                 | 1     | Yes (auth + API) | No      |
 | `/spaces/settings`                | spaces.cy.js                 | 1     | Yes (auth + API) | No      |
 | `/spaces/members`                 | spaces.cy.js                 | 1     | Yes (auth + API) | No      |

--- a/apps/web/cypress/e2e/visual/bridge.cy.js
+++ b/apps/web/cypress/e2e/visual/bridge.cy.js
@@ -15,7 +15,6 @@ describe('[VISUAL] Bridge page screenshots', { defaultCommandTimeout: 60000, ...
   })
 
   it('[VISUAL] Screenshot bridge page', () => {
-    main.enableChainFeature(constants.chainFeatures.bridge)
     cy.visit(constants.bridgeUrl + staticSafes.SEP_STATIC_SAFE_2)
     main.awaitVisualStability()
   })

--- a/apps/web/cypress/e2e/visual/earn.cy.js
+++ b/apps/web/cypress/e2e/visual/earn.cy.js
@@ -15,7 +15,6 @@ describe('[VISUAL] Earn page screenshots', { defaultCommandTimeout: 60000, ...co
   })
 
   it('[VISUAL] Screenshot earn page', () => {
-    main.enableChainFeature(constants.chainFeatures.earn)
     cy.visit(constants.earnUrl + staticSafes.SEP_STATIC_SAFE_2)
     main.awaitVisualStability()
   })

--- a/apps/web/cypress/e2e/visual/positions.cy.js
+++ b/apps/web/cypress/e2e/visual/positions.cy.js
@@ -15,7 +15,6 @@ describe('[VISUAL] Positions page screenshots', { defaultCommandTimeout: 60000, 
   })
 
   it('[VISUAL] Screenshot DeFi positions page', () => {
-    main.enableChainFeature(constants.chainFeatures.positions)
     cy.visit(constants.positionsUrl + staticSafes.SEP_STATIC_SAFE_2)
     main.awaitVisualStability()
   })

--- a/apps/web/cypress/e2e/visual/spaces.cy.js
+++ b/apps/web/cypress/e2e/visual/spaces.cy.js
@@ -5,7 +5,9 @@ import { mockVisualTestApis } from '../../support/visual-mocks.js'
 const SPACE_ID = '1'
 
 function setupSpacesAuth() {
-  main.enableChainFeature(constants.chainFeatures.spaces)
+  // Note: SPACES feature flag is already present in the chains fixture (all.json).
+  // Do NOT call enableChainFeature here — it uses req.continue() which bypasses
+  // the fixture mock and hits the real staging server, causing flaky failures.
 
   main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__auth, {
     sessionExpiresAt: Date.now() + 24 * 60 * 60 * 1000,
@@ -32,6 +34,11 @@ describe('[VISUAL] Spaces page screenshots', { defaultCommandTimeout: 60000, ...
   beforeEach(() => {
     mockVisualTestApis()
     setupSpacesAuth()
+  })
+
+  it('[VISUAL] Screenshot spaces welcome page', () => {
+    cy.visit(constants.spacesUrl)
+    main.awaitVisualStability()
   })
 
   it('[VISUAL] Screenshot spaces dashboard page', () => {

--- a/apps/web/cypress/e2e/visual/stake.cy.js
+++ b/apps/web/cypress/e2e/visual/stake.cy.js
@@ -15,7 +15,6 @@ describe('[VISUAL] Stake page screenshots', { defaultCommandTimeout: 60000, ...c
   })
 
   it('[VISUAL] Screenshot stake page', () => {
-    main.enableChainFeature(constants.chainFeatures.staking)
     cy.visit(constants.stakingUrl + staticSafes.SEP_STATIC_SAFE_2)
     main.awaitVisualStability()
   })

--- a/apps/web/cypress/e2e/visual/swap.cy.js
+++ b/apps/web/cypress/e2e/visual/swap.cy.js
@@ -15,7 +15,6 @@ describe('[VISUAL] Swap page screenshots', { defaultCommandTimeout: 60000, ...co
   })
 
   it('[VISUAL] Screenshot swap page', () => {
-    main.enableChainFeature(constants.chainFeatures.nativeSwaps)
     cy.visit(constants.swapUrl + staticSafes.SEP_STATIC_SAFE_2)
     main.awaitVisualStability()
   })


### PR DESCRIPTION
> Fixtures mock the chain flags just fine,
> enableChainFeature breaks the line—
> stripped the calls, tests stay stable,
> welcome page joins the screenshot table.

## Summary
- Remove `enableChainFeature()` calls from visual tests (bridge, earn, positions, spaces, stake, swap) — the feature flags are already in the chains fixture (`all.json`), and `enableChainFeature` uses `req.continue()` which bypasses fixture mocks and hits the real staging server, causing flaky failures
- Add visual test coverage for the `/welcome/spaces` page
- Update `COVERAGE.md` (64 → 65 tests)

## Test plan
- [ ] Visual tests pass in CI without flaky failures from staging API calls
- [ ] New `/welcome/spaces` screenshot is captured by Argos
- [ ] Existing visual tests remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)