### PR TITLE
fix(web): spaces dashboard viewport and notification fixes

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
+++ b/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
@@ -57,9 +57,8 @@ const NotificationsPopover = forwardRef<NotificationsPopoverRef>((_props, ref): 
       open={open}
       anchorEl={anchorEl}
       onClose={handleClose}
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-      transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-      sx={{ '& > .MuiPaper-root': { top: 'var(--header-height) !important' } }}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       transitionDuration={0}
     >
       <Paper className={notificationCss.popoverContainer}>

--- a/apps/web/src/components/common/Header/Topbar/index.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.tsx
@@ -34,7 +34,7 @@ const Topbar = ({ onMenuToggle }: TopbarProps): ReactElement => {
   return (
     <>
       <header
-        className={`flex items-center p-6 pb-0 bg-secondary -mb-10 dark:bg-background ${showMenuButton ? 'justify-between' : 'justify-end'}`}
+        className={`flex items-center p-6 pb-0 bg-secondary dark:bg-background ${showMenuButton ? 'justify-between' : 'justify-end'}`}
       >
         {showMenuButton ? (
           <Button

--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -54,11 +54,58 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
     setFullWidth(!isSidebarVisible)
   }, [isSidebarVisible, setFullWidth])
 
+  const mainContent = (
+    <div
+      className={classnames(css.main, {
+        [css.mainNoSidebar]: !isSidebarVisible || !isSidebarRoute,
+        [css.mainAnimated]: isSidebarRoute && isAnimated,
+        [css.mainNoHeader]: hideHeader,
+        [css.mainSpace]: isSpaceRoute,
+      })}
+    >
+      <div className={css.content}>
+        <SafeLoadingError>
+          {!hideHeader && !isSpaceRoute && <SpaceSafeBar />}
+          {isOnboardingRoute ? (
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={pathname}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.6, delay: 0.2, ease: 'easeInOut' }}
+              >
+                {children}
+              </motion.div>
+            </AnimatePresence>
+          ) : (
+            children
+          )}
+        </SafeLoadingError>
+      </div>
+
+      <BatchSidebar isOpen={isBatchOpen} onToggle={setBatchOpen} />
+
+      {!isSafeLabsTermsPage && <Footer />}
+    </div>
+  )
+
+  if (isSpaceRoute) {
+    return (
+      <div className={css.spaceLayout}>
+        {isSidebarRoute ? <SideDrawer isOpen={isSidebarVisible} onToggle={setSidebarOpen} /> : null}
+
+        <div className={css.spaceMain}>
+          {!hideHeader && <Topbar onMenuToggle={menuToggleHandler} />}
+          {mainContent}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <>
-      {!hideHeader && isSpaceRoute && <Topbar onMenuToggle={menuToggleHandler} />}
-
-      {!hideHeader && !isSpaceRoute && (
+      {!hideHeader && (
         <header className={css.header}>
           <Header onMenuToggle={menuToggleHandler} onBatchToggle={setBatchOpen} />
         </header>
@@ -66,39 +113,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
 
       {isSidebarRoute ? <SideDrawer isOpen={isSidebarVisible} onToggle={setSidebarOpen} /> : null}
 
-      <div
-        className={classnames(css.main, {
-          [css.mainNoSidebar]: !isSidebarVisible || !isSidebarRoute,
-          [css.mainAnimated]: isSidebarRoute && isAnimated,
-          [css.mainNoHeader]: hideHeader,
-          [css.mainSpace]: isSpaceRoute,
-        })}
-      >
-        <div className={css.content}>
-          <SafeLoadingError>
-            {!hideHeader && !isSpaceRoute && <SpaceSafeBar />}
-            {isOnboardingRoute ? (
-              <AnimatePresence mode="wait">
-                <motion.div
-                  key={pathname}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.6, delay: 0.2, ease: 'easeInOut' }}
-                >
-                  {children}
-                </motion.div>
-              </AnimatePresence>
-            ) : (
-              children
-            )}
-          </SafeLoadingError>
-        </div>
-
-        <BatchSidebar isOpen={isBatchOpen} onToggle={setBatchOpen} />
-
-        {!isSafeLabsTermsPage && <Footer />}
-      </div>
+      {mainContent}
     </>
   )
 }

--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -25,6 +25,29 @@
   padding-left: 0;
 }
 
+/* Spaces: full-viewport flex layout */
+.spaceLayout {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.spaceMain {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.mainSpace {
+  flex: 1;
+  min-height: 0;
+  padding-top: 0;
+  padding-left: 0;
+  overflow: hidden;
+}
+
 /* Spaces: use black background in dark mode (matches shadcn --background) */
 [data-theme='dark'] .mainSpace {
   background-color: #000000;
@@ -36,10 +59,15 @@
 
 .content {
   flex: 1;
+  min-height: 0;
   position: relative;
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
+}
+
+.mainSpace .content {
+  overflow-y: auto;
 }
 
 .content main {

--- a/apps/web/src/features/spaces/components/HeaderNavigation/HeaderNavigation.tsx
+++ b/apps/web/src/features/spaces/components/HeaderNavigation/HeaderNavigation.tsx
@@ -60,24 +60,22 @@ export function HeaderNavigation({
         </Button>
       )}
 
-      <div className="relative">
-        <Button
-          variant="secondary"
-          size="icon-lg"
-          onClick={onNotificationsClick}
-          className="cursor-pointer shrink-0 rounded-sm dark:bg-card"
-          aria-label="Notifications"
-        >
-          <Bell className="size-5 text-muted-foreground" />
-        </Button>
+      <Button
+        variant="secondary"
+        size="icon-lg"
+        onClick={onNotificationsClick}
+        className="relative cursor-pointer shrink-0 rounded-sm dark:bg-card"
+        aria-label="Notifications"
+      >
+        <Bell className="size-5 text-muted-foreground" />
 
         {messages > 0 && (
           <span
-            className="absolute -right-0.5 -top-0.5 z-10 flex size-2 items-center justify-center rounded-full border border-white bg-[#4ADE80]"
+            className="absolute right-1.5 top-1.5 z-10 flex size-2 items-center justify-center rounded-full bg-[#4ADE80]"
             aria-label={`${messages} unread messages`}
           />
         )}
-      </div>
+      </Button>
 
       <Button
         variant="secondary"


### PR DESCRIPTION
> Page fits the viewport now,
> sidebar no longer clipped,
> the bell dot finds its home.

## What it solves
Resolves: [WA-1680](https://linear.app/safe-global/issue/WA-1680/2-space-dashboard)

## How this PR fixes it

**1. Whole surface scrollable / sidebar cut off:**
- Introduced a `spaceLayout` flex container (`height: 100vh; overflow: hidden`) that wraps the sidebar and main content side by side
- The sidebar sits naturally in the flex row, and the main content area (`spaceMain`) fills the remaining space as a flex column
- Dashboard content scrolls inside `.content` via `overflow-y: auto`, while the page itself stays viewport-sized

**2. Widget/notification popover cutting elements below:**
- Removed `-mb-10` from the Topbar header, which was causing the header to overlap content below it
- Fixed the notifications popover anchor origin from forcing `top: var(--header-height) !important` to using proper anchor-relative positioning (`vertical: 'bottom', horizontal: 'right'`)

**3. Notification dot outside the grey container:**
- Moved the unread indicator dot from an outer wrapper `div` into the `Button` component itself
- Repositioned from `absolute -right-0.5 -top-0.5` (outside the button) to `absolute right-1.5 top-1.5` (inside the button's grey container)
- Removed the `border border-white` since the dot now sits inside the button background

## How to test it

1. Navigate to a Space dashboard → verify the page fits the viewport without horizontal/vertical scrolling of the entire surface
2. Check that the sidebar is fully visible and not cut off
3. Click the notification bell → verify the popover opens below the bell, not overlapping the header
4. Check the notification dot (when there are unread messages) → it should be inside the grey bell button container

## Screenshots


## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).