### PR TITLE
fix(web): fix PageLayout CSS module purity error and space dashboard …

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
+++ b/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
@@ -59,7 +59,7 @@ const NotificationsPopover = forwardRef<NotificationsPopoverRef>((_props, ref): 
       onClose={handleClose}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-      sx={{ '& > .MuiPaper-root': { top: 'var(--header-height) !important' } }}
+      sx={{ mt: 1 }}
       transitionDuration={0}
     >
       <Paper className={notificationCss.popoverContainer}>

--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -56,7 +56,11 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
 
   return (
     <>
-      {!hideHeader && isSpaceRoute && <Topbar onMenuToggle={menuToggleHandler} />}
+      {!hideHeader && isSpaceRoute && (
+        <div className={css.topbar}>
+          <Topbar onMenuToggle={menuToggleHandler} />
+        </div>
+      )}
 
       {!hideHeader && !isSpaceRoute && (
         <header className={css.header}>

--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -1,3 +1,16 @@
+@reference '../../../styles/shadcn.css';
+
+.topbar {
+  @apply absolute top-0 right-0 z-[1];
+}
+
+.mainSpace {
+  /* we need it in order to have higher importance than the .main class */
+  && {
+    @apply pt-14;
+  }
+}
+
 .header {
   position: fixed;
   left: 0;

--- a/apps/web/src/features/spaces/components/HeaderNavigation/HeaderNavigation.tsx
+++ b/apps/web/src/features/spaces/components/HeaderNavigation/HeaderNavigation.tsx
@@ -73,7 +73,7 @@ export function HeaderNavigation({
 
         {messages > 0 && (
           <span
-            className="absolute -right-0.5 -top-0.5 z-10 flex size-2 items-center justify-center rounded-full border border-white bg-[#4ADE80]"
+            className="absolute z-10 flex items-center justify-center rounded-full border-[3px] border-secondary bg-[var(--color-success-main)] w-[10px] h-[10px] top-[9px] right-[10px]"
             aria-label={`${messages} unread messages`}
           />
         )}

--- a/apps/web/src/features/wallet/components/WalletPopover/index.tsx
+++ b/apps/web/src/features/wallet/components/WalletPopover/index.tsx
@@ -21,7 +21,7 @@ const WalletPopover = ({ wallet, open, anchorEl, onClose }: WalletPopoverProps):
       onClose={onClose}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       transformOrigin={{ vertical: 'top', horizontal: 'center' }}
-      sx={{ '& > .MuiPaper-root': { top: 'var(--header-height) !important' } }}
+      sx={{ mt: 1 }}
       transitionDuration={0}
     >
       <Paper className={walletCss.popoverContainer}>


### PR DESCRIPTION
> Popover pushed down, dot refined—
> header overlap no more,
> theme vars align.

## What it solves

Resolves: The wallet and notifications popovers overlap/cut the elements below the header trigger buttons. The notification unread circle also used hardcoded colors instead of theme variables.

## How this PR fixes it

- **Popover positioning**: Removed the forced `top: var(--header-height) !important` override from both `WalletPopover` and `NotificationsPopover`. This override conflicted with the current header layout (which uses Tailwind classes). Replaced it with `mt: 1` (8px margin) so MUI's anchor-based positioning places the popover naturally below the trigger button with a small gap.
- **Notification dot styling**: Updated the unread notification circle in `HeaderNavigation` with the requested dimensions (`10×10px`, `3px` border, `top: 9px`, `right: 10px`) and replaced hardcoded colors with theme classes (`border-secondary`, `bg-[var(--color-success-main)]`).

## How to test it

1. Connect a wallet and click the wallet button in the header — the popover should appear below the button without overlapping the header or cutting content beneath it.
2. Trigger a notification (e.g. submit a transaction) and click the bell icon — the notifications popover should also appear below the button with proper spacing.
3. With unread notifications present, verify the green dot on the bell icon is correctly positioned and sized.
4. Toggle dark mode and confirm the dot border and background colors adapt correctly.

## Screenshots



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
