### PR TITLE
fix(web): remove redirect to welcome screen on wallet disconnect

### DIFF
--- a/apps/web/src/components/common/WalletInfo/index.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.tsx
@@ -14,8 +14,6 @@ import useChainId from '@/hooks/useChainId'
 import { useAuthLogoutV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
 import { setUnauthenticated } from '@/store/authSlice'
 import { logError, Errors } from '@/services/exceptions'
-import { AppRoutes } from '@/config/routes'
-import { useRouter } from 'next/router'
 
 type WalletInfoProps = {
   wallet: ConnectedWallet
@@ -30,7 +28,6 @@ export const WalletInfo = ({ wallet, balance, currentChainId, onboard, addressBo
   const [authLogout] = useAuthLogoutV1Mutation()
   const dispatch = useAppDispatch()
   const chainInfo = useChain(wallet.chainId)
-  const router = useRouter()
   const prefix = chainInfo?.shortName
 
   const handleSwitchWallet = () => {
@@ -47,8 +44,6 @@ export const WalletInfo = ({ wallet, balance, currentChainId, onboard, addressBo
     try {
       await authLogout()
       dispatch(setUnauthenticated())
-
-      router.push(AppRoutes.welcome.index)
     } catch (error) {
       logError(Errors._108, error)
     }


### PR DESCRIPTION
> Wallet disconnects, page stays put,
> no more welcome screen detour,
> user stays where they were.

## What it solves
Resolves: 


## How this PR fixes it
Removes the `router.push(AppRoutes.welcome.index)` call from `handleDisconnect` in the `WalletInfo` component. The auth logout and state cleanup still happen, but the user is no longer redirected to the welcome screen when disconnecting their wallet.

## How to test it
1. Connect a wallet
2. Navigate to any page (e.g., dashboard, transactions)
3. Open the wallet info popover and click "Disconnect"
4. Verify you stay on the current page instead of being redirected to `/welcome`

## Screenshots


## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).