### PR TITLE
fix(web): asset widget clipped values when swap is disabled

### DIFF
--- a/apps/web/src/components/dashboard/Assets/Assets.stories.tsx
+++ b/apps/web/src/components/dashboard/Assets/Assets.stories.tsx
@@ -28,7 +28,24 @@ type Story = StoryObj<typeof meta>
 /**
  * Swap enabled (Send + Swap). Values translated 80px right; hover to reveal buttons.
  */
-export const WithSwap: Story = {}
+export const WithSwap: Story = (() => {
+  const setup = createMockStory({
+    scenario: 'efSafe',
+    wallet: 'owner',
+    layout: 'none',
+  })
+  return {
+    parameters: { ...setup.parameters },
+    decorators: [
+      setup.decorator,
+      (Story) => (
+        <div style={{ padding: 24, overflow: 'hidden' }}>
+          <Story />
+        </div>
+      ),
+    ],
+  }
+})()
 
 /**
  * AssetsWidget with whale portfolio data.
@@ -102,7 +119,7 @@ export const DiversePortfolio: Story = (() => {
 })()
 
 /**
- * Swap disabled (Send only). BUG: 80px translate over-crops the value.
+ * Swap disabled (Send only). Values translated 44px right; hover to reveal button.
  */
 export const WithoutSwap: Story = (() => {
   const setup = createMockStory({
@@ -113,6 +130,13 @@ export const WithoutSwap: Story = (() => {
   })
   return {
     parameters: { ...setup.parameters },
-    decorators: [setup.decorator],
+    decorators: [
+      setup.decorator,
+      (Story) => (
+        <div style={{ padding: 24, overflow: 'hidden' }}>
+          <Story />
+        </div>
+      ),
+    ],
   }
 })()

--- a/apps/web/src/components/dashboard/Assets/Assets.stories.tsx
+++ b/apps/web/src/components/dashboard/Assets/Assets.stories.tsx
@@ -26,13 +26,9 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 /**
- * Default AssetsWidget showing top 4 assets from EF Safe.
- * Displays token icons, names, balances, and fiat values.
- *
- * Note: Values are translated 80px right and reveal action buttons on hover.
- * Hover over a row to see the full values and action buttons.
+ * Swap enabled (Send + Swap). Values translated 80px right; hover to reveal buttons.
  */
-export const Default: Story = {}
+export const WithSwap: Story = {}
 
 /**
  * AssetsWidget with whale portfolio data.
@@ -92,9 +88,6 @@ export const Loading: Story = (() => {
 
 /**
  * Safe Token holder with diverse portfolio (25 tokens).
- *
- * Note: Values are translated 80px right and reveal action buttons on hover.
- * Hover over a row to see the full values and action buttons.
  */
 export const DiversePortfolio: Story = (() => {
   const setup = createMockStory({
@@ -109,13 +102,9 @@ export const DiversePortfolio: Story = (() => {
 })()
 
 /**
- * AssetsWidget without swap feature enabled.
- * Demonstrates how the widget looks on chains that don't support native swaps.
- *
- * Note: Without the swap button, values may appear clipped on hover due to
- * the translateX animation having fewer buttons to offset.
+ * Swap disabled (Send only). BUG: 80px translate over-crops the value.
  */
-export const WithoutSwapFeature: Story = (() => {
+export const WithoutSwap: Story = (() => {
   const setup = createMockStory({
     scenario: 'efSafe',
     wallet: 'owner',

--- a/apps/web/src/components/dashboard/Assets/index.tsx
+++ b/apps/web/src/components/dashboard/Assets/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { type CSSProperties, useMemo } from 'react'
 import { Box, Skeleton, Typography, Paper, Stack, Divider } from '@mui/material'
 import useBalances from '@/hooks/useBalances'
 import TokenAmount from '@/components/common/TokenAmount'
@@ -44,6 +44,9 @@ const AssetsSkeleton = () => (
   </WidgetCard>
 )
 
+const TRANSLATE_SWAP_ENABLED = 80
+const TRANSLATE_SWAP_DISABLED = 44
+
 const AssetRow = ({
   item,
   chainId,
@@ -60,6 +63,8 @@ const AssetRow = ({
   const stake = useLoadFeature(StakeFeature)
   const { SwapButton } = useLoadFeature(SwapFeature)
 
+  const translateOffset = showSwap ? TRANSLATE_SWAP_ENABLED : TRANSLATE_SWAP_DISABLED
+
   return (
     <Box className={css.container} key={item.tokenInfo.address}>
       <Stack direction="row" gap={1.5} alignItems="center">
@@ -72,7 +77,7 @@ const AssetRow = ({
         </Box>
       </Stack>
 
-      <Box className={css.valueContainer}>
+      <Box className={css.valueContainer} style={{ '--buttons-width': `${translateOffset}px` } as CSSProperties}>
         <Box className={css.valueContent}>
           <FiatBalance balanceItem={item} />
           <FiatChange balanceItem={item} inline />

--- a/apps/web/src/components/dashboard/Assets/styles.module.css
+++ b/apps/web/src/components/dashboard/Assets/styles.module.css
@@ -23,9 +23,8 @@
   justify-content: flex-end;
   gap: 16px;
   flex: 1;
-  /* 80px = width of action buttons container (up to 3 buttons × 28px + gaps)
-     This slides content right to hide buttons, revealing them on hover */
-  transform: translateX(80px);
+  /* --buttons-width: 80px when swap enabled, 44px when disabled (tweak as needed) */
+  transform: translateX(var(--buttons-width, 80px));
   transition: transform 0.2s ease-out;
 }
 

--- a/apps/web/src/stories/mocks/createMockStory.tsx
+++ b/apps/web/src/stories/mocks/createMockStory.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
 import type { Decorator, StoryContext } from '@storybook/react'
 import { SAFE_ADDRESSES } from '../../../../../config/test/msw/fixtures'
+import { cgwClient } from '@safe-global/store/gateway/cgwClient'
+import { chainsAdapter, chainsInitialState } from '@safe-global/store/gateway'
+import { CONFIG_SERVICE_KEY } from '@/config/constants'
 import { MockContextProvider } from './MockContextProvider'
 import { resolveWallet } from './wallets'
 import { createHandlers, getFixtureData } from './handlers'
 import { createInitialState } from './defaults'
+import { createChainData } from './chains'
 import type { MockStoryConfig, MockStoryResult } from './types'
 
 /**
@@ -86,6 +90,41 @@ export function createMockStory(config: MockStoryConfig = {}): MockStoryResult {
     handlers: customHandlers,
   })
 
+  const chainData = createChainData(features)
+  const chainsPreload = {
+    queries: {
+      [`getChainsConfigV2("${CONFIG_SERVICE_KEY}")`]: {
+        status: 'fulfilled' as const,
+        endpointName: 'getChainsConfigV2' as const,
+        requestId: `mock-chains-${Date.now()}`,
+        originalArgs: CONFIG_SERVICE_KEY,
+        startedTimeStamp: Date.now(),
+        data: chainsAdapter.setAll(chainsInitialState, [chainData]),
+        fulfilledTimeStamp: Date.now(),
+        error: undefined,
+      },
+    },
+    mutations: {},
+    provided: { tags: {}, keys: {} },
+    subscriptions: {},
+    config: {
+      online: true,
+      focused: true,
+      middlewareRegistered: false,
+      refetchOnFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMountOrArgChange: false,
+      keepUnusedDataFor: 60,
+      reducerPath: cgwClient.reducerPath,
+      invalidationBehavior: 'delayed',
+    },
+  }
+
+  const storeOverridesWithChains = {
+    ...storeOverrides,
+    [cgwClient.reducerPath]: chainsPreload,
+  }
+
   // Create decorator function
   const decorator: Decorator = (Story, context: StoryContext) => {
     const isDarkMode = context.globals?.theme === 'dark'
@@ -97,7 +136,7 @@ export function createMockStory(config: MockStoryConfig = {}): MockStoryResult {
     const initialState = createInitialState({
       safeData,
       isDarkMode,
-      overrides: storeOverrides,
+      overrides: storeOverridesWithChains,
       isAuthenticated,
     })
 
@@ -118,7 +157,7 @@ export function createMockStory(config: MockStoryConfig = {}): MockStoryResult {
   const initialState = createInitialState({
     safeData,
     isDarkMode: false,
-    overrides: storeOverrides,
+    overrides: storeOverridesWithChains,
     isAuthenticated,
   })
 

--- a/apps/web/src/stories/mocks/handlers.ts
+++ b/apps/web/src/stories/mocks/handlers.ts
@@ -18,11 +18,14 @@ import type { FeatureFlags, MockStoryConfig } from './types'
 
 /**
  * Core chain configuration handlers
+ * Web app uses /v2/chains (getChainsConfigV2); mobile may use /v1/chains
  */
 export function coreHandlers(chainData: Chain): RequestHandler[] {
+  const chainsPageData = createChainsPageData(chainData)
   return [
     http.get(/\/v1\/chains\/\d+$/, () => HttpResponse.json(chainData)),
-    http.get(/\/v1\/chains$/, () => HttpResponse.json(createChainsPageData(chainData))),
+    http.get(/\/v1\/chains$/, () => HttpResponse.json(chainsPageData)),
+    http.get(/\/v2\/chains(?:\?|$)/, () => HttpResponse.json(chainsPageData)),
   ]
 }
 


### PR DESCRIPTION
> Swap button gone, translate too wide,
> values clipped off the right-hand side—
> a CSS var now sets the shift,
> no more layout drift.

## Summary
- Fix Assets widget values being clipped/cropped on chains without native swaps enabled (WA-1371)
- Use a CSS custom property (`--buttons-width`) to dynamically set `translateX` based on whether swap is available (80px with swap, 44px without)
- Add `/v2/chains` MSW handler and RTK Query chains preload to `createMockStory` so feature flags work correctly in Storybook
- Update Assets stories to demonstrate both swap-enabled and swap-disabled states

## Test plan
- [ ] On a chain with swaps enabled, asset rows show Send + Swap buttons on hover with no clipping
- [ ] On a chain without swaps, asset rows show only Send button and values are fully visible
- [ ] Storybook `WithSwap` and `WithoutSwap` stories render correctly
- [ ] No visual regressions on other dashboard widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)