### PR TITLE
fix(web/Spaces): API CTA text; background color in dark mode

### DIFF
--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -27,7 +27,7 @@
 
 /* Spaces: use black background in dark mode (matches shadcn --background) */
 [data-theme='dark'] .mainSpace {
-  background-color: var(--color-background-main);
+  background-color: var(--background);
 }
 
 /* Spaces: reduce left padding when the sidebar is collapsed to icon mode */

--- a/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar.tsx
@@ -42,7 +42,7 @@ export const ApiCtaSidebar = (): ReactElement => {
 
   return (
     <div
-      className="flex flex-col gap-2 rounded-[8px] bg-secondary p-5 group-data-[collapsible=icon]:hidden"
+      className="flex flex-col gap-2 rounded-[8px] bg-secondary p-3 group-data-[collapsible=icon]:hidden"
       data-testid="api-cta-sidebar"
     >
       <div className="flex w-full items-start justify-between">
@@ -64,7 +64,7 @@ export const ApiCtaSidebar = (): ReactElement => {
       </div>
 
       <Typography variant="paragraph-small" color="muted" className="leading-snug">
-        Start building with our new Safe API
+        Authenticated access, predictable quotas, and webhooks for teams that rely on Safe as critical infrastructure.
       </Typography>
 
       <Button
@@ -73,7 +73,7 @@ export const ApiCtaSidebar = (): ReactElement => {
         className="w-auto self-start !bg-background hover:!bg-muted"
         render={<a href={API_DOCS_URL} target="_blank" rel="noopener noreferrer" />}
       >
-        Try the API
+        Get API key
       </Button>
     </div>
   )

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarTopBar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarTopBar.tsx
@@ -48,7 +48,10 @@ export const SidebarTopBar = (): ReactElement => {
         />
       </button>
       <SidebarTrigger
-        className="shrink-0 cursor-pointer text-sidebar-foreground/65 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+        className={cn(
+          'shrink-0 cursor-pointer text-sidebar-foreground/65 hover:text-sidebar-foreground hover:bg-sidebar-accent',
+          isCollapsed && 'mt-2',
+        )}
         data-testid="sidebar-trigger"
       />
     </div>

--- a/apps/web/src/features/spaces/components/Sidebar/__tests__/ApiCtaSidebar.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/__tests__/ApiCtaSidebar.test.tsx
@@ -72,13 +72,17 @@ describe('ApiCtaSidebar', () => {
     it('renders the description', () => {
       render(<ApiCtaSidebar />)
 
-      expect(screen.getByText('Start building with our new Safe API')).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          'Authenticated access, predictable quotas, and webhooks for teams that rely on Safe as critical infrastructure.',
+        ),
+      ).toBeInTheDocument()
     })
 
     it('renders the CTA link with correct attributes', () => {
       render(<ApiCtaSidebar />)
 
-      const link = screen.getByRole('link', { name: /Try the API/i })
+      const link = screen.getByRole('link', { name: /Get API key/i })
       expect(link).toHaveAttribute('href', 'https://developer.safe.global/login')
       expect(link).toHaveAttribute('target', '_blank')
       expect(link).toHaveAttribute('rel', 'noopener noreferrer')


### PR DESCRIPTION
> Black background returns to dark spaces,
> sidebar trigger gets room to breathe,
> test learns the button's new name.

## What it solves

Minor UI regressions in the Spaces layout (dark mode background, sidebar toggle spacing) and a stale test.

## How this PR fixes it

- Restore `var(--background)` (`#000000`) as the dark mode background for Spaces
- Fix `ApiCtaSidebar` test: update CTA link assertion from "Try the API" to "Get API key" to match the current component copy

## How to test it

1. Enable dark mode, navigate to `/spaces?spaceId=...` — background should be pure black
2. Verify the API CTA text is "Authenticated access, predictable quotas, and webhooks for teams that rely on Safe as critical infrastructure." and the CTA button text is "Get API key".

## Screenshots
<img width="1487" height="698" alt="image" src="https://github.com/user-attachments/assets/9bdf6326-29ca-46ae-9589-659061f8c050" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 N/A
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
