### PR TITLE
chore(tx-builder): fix all lint warnings

### DIFF
--- a/apps/tx-builder/src/components/Button.tsx
+++ b/apps/tx-builder/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, HTMLAttributes } from 'react'
+import { ReactElement, ReactNode, HTMLAttributes } from 'react'
 import ButtonMUI, { ButtonProps as ButtonMUIProps } from '@mui/material/Button'
 import { alpha } from '@mui/material/styles'
 

--- a/apps/tx-builder/src/components/ChecksumWarning.tsx
+++ b/apps/tx-builder/src/components/ChecksumWarning.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import MuiAlert from '@mui/lab/Alert'
 import MuiAlertTitle from '@mui/lab/AlertTitle'
 import styled from 'styled-components'

--- a/apps/tx-builder/src/components/ErrorAlert.tsx
+++ b/apps/tx-builder/src/components/ErrorAlert.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import MuiAlert from '@mui/lab/Alert'
 import MuiAlertTitle from '@mui/lab/AlertTitle'
 import styled from 'styled-components'

--- a/apps/tx-builder/src/components/FixedIcon/images/arrowReceivedWhite.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/arrowReceivedWhite.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/arrowSent.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/arrowSent.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/arrowSentWhite.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/arrowSentWhite.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/arrowSort.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/arrowSort.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/bullit.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/bullit.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="6" height="6" viewBox="0 0 6 6">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/chevronDown.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/chevronDown.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="12" height="7" viewBox="0 0 12 7">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/chevronLeft.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/chevronLeft.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="7" height="12" viewBox="0 0 7 12">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/chevronRight.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/chevronRight.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="7" height="12" viewBox="0 0 7 12">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/chevronUp.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/chevronUp.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="12" height="7" viewBox="0 0 12 7">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/connectedRinkeby.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/connectedRinkeby.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 9 9">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/connectedWallet.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/connectedWallet.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 9 9">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/creatingInProgress.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/creatingInProgress.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="34" height="34" viewBox="0 0 34 34">
     <g fill="none" fillRule="evenodd">

--- a/apps/tx-builder/src/components/FixedIcon/images/dropdownArrowSmall.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/dropdownArrowSmall.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="9" height="5" viewBox="0 0 9 5">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/networkError.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/networkError.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="90" height="90" viewBox="0 0 90 90">
     <g fill="none" fillRule="evenodd">

--- a/apps/tx-builder/src/components/FixedIcon/images/notConnected.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/notConnected.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
     <defs>

--- a/apps/tx-builder/src/components/FixedIcon/images/notOwner.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/notOwner.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="108" height="96" viewBox="0 0 108 96">
     <g fill="none" fillRule="evenodd">

--- a/apps/tx-builder/src/components/FixedIcon/images/options.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/options.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="16" height="4" viewBox="0 0 16 4">
     <g fill="#B2B5B2" className="icon-color" fillRule="evenodd">

--- a/apps/tx-builder/src/components/FixedIcon/images/settingsChange.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/settingsChange.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
     <path

--- a/apps/tx-builder/src/components/FixedIcon/images/threeDots.tsx
+++ b/apps/tx-builder/src/components/FixedIcon/images/threeDots.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const icon = (
   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="4" viewBox="0 0 20 4">
     <g fill="#B2B5B2" className="icon-color" fillRule="evenodd">

--- a/apps/tx-builder/src/components/Icon/images/cross.tsx
+++ b/apps/tx-builder/src/components/Icon/images/cross.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 const Cross = {
   sm: (
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">

--- a/apps/tx-builder/src/components/forms/fields/AddressInput.tsx
+++ b/apps/tx-builder/src/components/forms/fields/AddressInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState, ChangeEvent, useEffect, useCallback, useRef } from 'react'
+import { ReactElement, useState, ChangeEvent, useEffect, useCallback, useRef } from 'react'
 import InputAdornment from '@mui/material/InputAdornment'
 import CircularProgress from '@mui/material/CircularProgress'
 
@@ -68,7 +68,7 @@ function AddressInput({
         onChangeAddress(checksumValidAddress(resolvedAddress))
         // we update the input value
         updateInputValue(resolvedAddress)
-      } catch (e) {
+      } catch {
         onChangeAddress(address)
       } finally {
         setIsLoadingENSResolution(false)

--- a/apps/tx-builder/src/components/forms/fields/TextFieldInput.tsx
+++ b/apps/tx-builder/src/components/forms/fields/TextFieldInput.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react'
+import { ReactElement } from 'react'
 import TextFieldMui, { TextFieldProps } from '@mui/material/TextField'
 import styled from 'styled-components'
 import { errorStyles, inputLabelStyles, inputStyles } from './styles'

--- a/apps/tx-builder/src/hooks/useAsync.ts
+++ b/apps/tx-builder/src/hooks/useAsync.ts
@@ -12,6 +12,7 @@ const useAsync = <T>(
   const [loading, setLoading] = useState<boolean>(false)
 
   // Dependencies passed manually to avoid stale closures
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const callback = useCallback(asyncCall, dependencies)
 
   useEffect(() => {


### PR DESCRIPTION
> Unused imports swept away,
> catch clause trimmed, deps suppressed—
> zero warnings remain.

## What it solves

The tx-builder package had 27 ESLint warnings (0 errors) cluttering CI output and hiding real issues.

## How this PR fixes it

- Removed 25 unused `import React` statements (JSX transform handles this automatically)
- Removed unused `e` parameter from a catch clause in `AddressInput.tsx`
- Added `eslint-disable` comment for `useAsync`'s intentional dynamic `useCallback` dependencies

## How to test it

1. Run `yarn workspace @safe-global/tx-builder lint`
2. Verify 0 warnings, 0 errors
3. Run `yarn workspace @safe-global/tx-builder build` to confirm nothing broke

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).