### PR TITLE
chore: fix lint warnings in store package

### DIFF
--- a/packages/store/eslint.config.mjs
+++ b/packages/store/eslint.config.mjs
@@ -3,6 +3,6 @@ import baseConfig from '../../config/eslint/base.mjs'
 export default [
   ...baseConfig,
   {
-    ignores: ['**/node_modules/'],
+    ignores: ['**/node_modules/', '**/AUTO_GENERATED/'],
   },
 ]

--- a/packages/store/src/gateway/cgwClient-hooks.test.ts
+++ b/packages/store/src/gateway/cgwClient-hooks.test.ts
@@ -42,7 +42,7 @@ describe('cgwClient hooks', () => {
   })
 
   it('should call custom prepareHeadersHook and set header when fetchBaseQuery is used', async () => {
-    const mockHeaderFunction = jest.fn((headers: Headers, _url: string, _endpoint: string) => {
+    const mockHeaderFunction = jest.fn((headers: Headers) => {
       headers.set('X-Test-Header', 'test-value')
       return headers
     })

--- a/packages/store/src/gateway/cgwClient.ts
+++ b/packages/store/src/gateway/cgwClient.ts
@@ -1,4 +1,4 @@
-import { createApi, fetchBaseQuery, retry } from '@reduxjs/toolkit/query/react'
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
 import { REHYDRATE } from 'redux-persist'
 import type { UnknownAction } from '@reduxjs/toolkit'
@@ -10,7 +10,7 @@ export const CREDENTIAL_ROUTES = [
   /\/v1\/spaces/,
   /\/v1\/auth/,
   /\/v2\/register\/notifications$/,
-  /\/v2\/chains\/[^\/]+\/notifications\/devices/,
+  /\/v2\/chains\/[^/]+\/notifications\/devices/,
 ]
 
 const IS_BEHIND_IAP = process.env.NEXT_PUBLIC_IS_BEHIND_IAP === 'true'
@@ -95,7 +95,7 @@ export const dynamicBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBas
   // Check for credential override in extraOptions (this is where RTK Query passes the options)
   const forceOmitCredentials =
     extraOptions && typeof extraOptions === 'object' && 'forceOmitCredentials' in extraOptions
-      ? (extraOptions as any).forceOmitCredentials
+      ? (extraOptions as Record<string, unknown>).forceOmitCredentials
       : false
 
   const shouldIncludeCredentials = !forceOmitCredentials && isCredentialRoute(urlEnd)
@@ -119,7 +119,10 @@ export const dynamicBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBas
 export const cgwClient = createApi({
   baseQuery: dynamicBaseQuery,
   endpoints: () => ({}),
-  extractRehydrationInfo: (action: UnknownAction, { reducerPath }): CombinedState<{}, never, 'api'> | undefined => {
+  extractRehydrationInfo: (
+    action: UnknownAction,
+    { reducerPath },
+  ): CombinedState<Record<string, never>, never, 'api'> | undefined => {
     if (action.type === REHYDRATE && action.payload) {
       // Use type assertion to tell TypeScript the expected structure
       const payload = action.payload as {
@@ -127,7 +130,7 @@ export const cgwClient = createApi({
       }
 
       if (payload[reducerPath] && 'api' in payload[reducerPath]) {
-        return payload[reducerPath].api as CombinedState<{}, never, 'api'>
+        return payload[reducerPath].api as CombinedState<Record<string, never>, never, 'api'>
       }
     }
     return undefined

--- a/packages/store/src/gateway/transactions.ts
+++ b/packages/store/src/gateway/transactions.ts
@@ -7,7 +7,6 @@ import type {
   TransactionDetails,
 } from './AUTO_GENERATED/transactions'
 import { addTagTypes } from './AUTO_GENERATED/transactions'
-import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { getNextPageParam } from '../utils/infiniteQuery'
 
 // Define types needed for infinite query

--- a/packages/store/src/gateway/types.ts
+++ b/packages/store/src/gateway/types.ts
@@ -13,7 +13,6 @@ import {
   NativeStakingWithdrawTransactionInfo,
   Transaction,
   TransferTransactionInfo,
-  TransactionDetails,
   ModuleExecutionDetails,
   MultisigExecutionDetails,
 } from './AUTO_GENERATED/transactions'

--- a/packages/store/src/utils/__tests__/infiniteQuery.test.ts
+++ b/packages/store/src/utils/__tests__/infiniteQuery.test.ts
@@ -3,7 +3,7 @@ import { getNextPageParam, getPreviousPageParam } from '../infiniteQuery'
 
 describe('getNextPageParam', () => {
   it('should return undefined for null lastPage', () => {
-    expect(getNextPageParam(null as any)).toBeUndefined()
+    expect(getNextPageParam(null as unknown as Parameters<typeof getNextPageParam>[0])).toBeUndefined()
   })
 
   it('should return undefined for lastPage without next', () => {
@@ -75,7 +75,7 @@ describe('getNextPageParam', () => {
 
 describe('getPreviousPageParam', () => {
   it('should return undefined for null firstPage', () => {
-    expect(getPreviousPageParam(null as any)).toBeUndefined()
+    expect(getPreviousPageParam(null as unknown as Parameters<typeof getPreviousPageParam>[0])).toBeUndefined()
   })
 
   it('should return undefined for firstPage without previous', () => {

--- a/packages/store/src/utils/persistTransformFilter.test.ts
+++ b/packages/store/src/utils/persistTransformFilter.test.ts
@@ -114,7 +114,7 @@ describe('redux-persist-transform-filter', () => {
       const store = { a: [1, 2, 3], b: 'b' }
       const result = persistFilter(
         JSON.parse(JSON.stringify(store)) as Record<string, unknown>,
-        [{ path: 'a', filterFunction: (_item: unknown) => true }],
+        [{ path: 'a', filterFunction: () => true }],
         'blacklist',
       )
 


### PR DESCRIPTION
> Auto-generated files now ignored,
> dead imports swept away—
> store lints clean at last.

## What it solves

The store package had 14 ESLint warnings after the new ESLint setup was introduced. Auto-generated files were being linted unnecessarily, and several source files had unused imports, `any` types, useless escapes, and empty object types.

## How this PR fixes it

Adds `**/AUTO_GENERATED/` to the ESLint ignore list (2 warnings from generated code) and fixes the remaining 12 warnings: removing unused imports/params, replacing `any` with proper types, fixing a useless regex escape, and replacing `{}` empty object types with `Record<string, never>`.

## How to test it

1. Run `yarn workspace @safe-global/store lint` — should produce 0 warnings
2. Run `yarn workspace @safe-global/store type-check` — should pass cleanly
3. Run `yarn workspace @safe-global/store test` — all 64 tests should pass

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).