### PR TITLE
fix(web): redirect new users to create space after sign-in

### DIFF
--- a/apps/web/src/components/welcome/WelcomeLogin/hooks/__tests__/useSignInRedirect.test.ts
+++ b/apps/web/src/components/welcome/WelcomeLogin/hooks/__tests__/useSignInRedirect.test.ts
@@ -2,8 +2,6 @@ import { renderHook, act } from '@/tests/test-utils'
 import { useSignInRedirect } from '../useSignInRedirect'
 import * as router from 'next/router'
 import * as store from '@/store'
-import * as spacesQueries from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import { setLastUsedSpace } from '@/store/authSlice'
 import { AppRoutes } from '@/config/routes'
 
 // ---------------------------------------------------------------------------
@@ -24,47 +22,43 @@ jest.mock('next/router', () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-const mockTriggerSpacesQuery = jest.fn()
-const mockDispatch = jest.fn()
-
-interface SetupOptions {
-  currentSpaceId?: string | null
-  isAuthenticated?: boolean
-  reactiveSpaces?: Array<{ id: number; name: string }> | undefined
-  routerQuery?: Record<string, string>
+interface DefaultProps {
+  spacesAmount: number
+  inviteAmount: number
+  isSpacesLoading: boolean
+  error: Error | undefined
 }
 
-const setupMocks = ({
-  currentSpaceId = null,
-  isAuthenticated = true,
-  reactiveSpaces = undefined,
-  routerQuery = {},
-}: SetupOptions = {}) => {
+const defaultProps: DefaultProps = {
+  spacesAmount: 0,
+  inviteAmount: 0,
+  isSpacesLoading: false,
+  error: undefined,
+}
+
+interface SetupOptions {
+  isAuthenticated?: boolean
+  routerQuery?: Record<string, string>
+  props?: Partial<DefaultProps>
+}
+
+const setupMocks = ({ isAuthenticated = true, routerQuery = {} }: SetupOptions = {}) => {
   ;(router.useRouter as jest.Mock).mockReturnValue({
     pathname: '/welcome',
     query: routerQuery,
     push: mockPush,
   })
 
-  jest.spyOn(store, 'useAppDispatch').mockReturnValue(mockDispatch)
   jest.spyOn(store, 'useAppSelector').mockImplementation((selector) => {
     const fakeState = {
       auth: {
         sessionExpiresAt: isAuthenticated ? Date.now() + 86400000 : null,
-        lastUsedSpace: currentSpaceId,
+        lastUsedSpace: null,
         isStoreHydrated: true,
       },
     }
     return selector(fakeState as unknown as store.RootState)
   })
-
-  jest.spyOn(spacesQueries, 'useSpacesGetV1Query').mockReturnValue({
-    data: reactiveSpaces,
-  } as unknown as ReturnType<typeof spacesQueries.useSpacesGetV1Query>)
-
-  jest
-    .spyOn(spacesQueries, 'useLazySpacesGetV1Query')
-    .mockReturnValue([mockTriggerSpacesQuery] as unknown as ReturnType<typeof spacesQueries.useLazySpacesGetV1Query>)
 }
 
 // ---------------------------------------------------------------------------
@@ -76,70 +70,44 @@ describe('useSignInRedirect', () => {
     jest.clearAllMocks()
   })
 
-  it('should return redirect function and spaces data', () => {
+  it('should return setHasSignedIn and redirectLoading', () => {
     setupMocks()
 
-    const { result } = renderHook(() => useSignInRedirect())
+    const { result } = renderHook(() => useSignInRedirect(defaultProps))
 
-    expect(result.current.redirect).toBeDefined()
-    expect(typeof result.current.redirect).toBe('function')
-    expect(result.current.spaces).toBeUndefined()
-  })
-
-  it('should return reactive spaces when authenticated', () => {
-    const spaces = [{ id: 1, name: 'My Space' }]
-    setupMocks({ isAuthenticated: true, reactiveSpaces: spaces })
-
-    const { result } = renderHook(() => useSignInRedirect())
-
-    expect(result.current.spaces).toEqual(spaces)
+    expect(result.current.setHasSignedIn).toBeDefined()
+    expect(typeof result.current.setHasSignedIn).toBe('function')
+    expect(result.current.redirectLoading).toBe(false)
   })
 
   // -----------------------------------------------------------------------
-  // Redirect when user has no spaces
+  // Redirect for new users (no spaces, no invites)
   // -----------------------------------------------------------------------
 
-  describe('when user has no spaces', () => {
-    it('should redirect to create space page when spaces are empty', async () => {
+  describe('when user is new (no spaces, no invites)', () => {
+    it('should redirect to create space page after sign-in', async () => {
       setupMocks()
-      mockTriggerSpacesQuery.mockResolvedValue({ data: [] })
 
-      const { result } = renderHook(() => useSignInRedirect())
+      const { result } = renderHook(() => useSignInRedirect(defaultProps))
 
       await act(async () => {
-        await result.current.redirect()
+        result.current.setHasSignedIn(true)
       })
 
       expect(mockPush).toHaveBeenCalledWith({
         pathname: AppRoutes.welcome.createSpace,
         query: {},
       })
-    })
-
-    it('should redirect to create space page when spaces data is undefined', async () => {
-      setupMocks()
-      mockTriggerSpacesQuery.mockResolvedValue({ data: undefined })
-
-      const { result } = renderHook(() => useSignInRedirect())
-
-      await act(async () => {
-        await result.current.redirect()
-      })
-
-      expect(mockPush).toHaveBeenCalledWith({
-        pathname: AppRoutes.welcome.createSpace,
-        query: {},
-      })
+      expect(result.current.redirectLoading).toBe(true)
     })
 
     it('should preserve query parameters when redirecting to create space', async () => {
       setupMocks({ routerQuery: { chain: 'eth' } })
-      mockTriggerSpacesQuery.mockResolvedValue({ data: [] })
 
-      const { result } = renderHook(() => useSignInRedirect())
+      const { result } = renderHook(() => useSignInRedirect(defaultProps))
 
       await act(async () => {
-        await result.current.redirect()
+        result.current.setHasSignedIn(true)
       })
 
       expect(mockPush).toHaveBeenCalledWith({
@@ -150,107 +118,111 @@ describe('useSignInRedirect', () => {
   })
 
   // -----------------------------------------------------------------------
-  // Redirect when user has spaces but no last used space
+  // Redirect when spaces endpoint returns 404
   // -----------------------------------------------------------------------
 
-  describe('when user has spaces but no last used space', () => {
-    it('should redirect to the first space and set it as last used', async () => {
-      const spaces = [
-        { id: 10, name: 'First Space' },
-        { id: 20, name: 'Second Space' },
-      ]
-      setupMocks({ currentSpaceId: null })
-      mockTriggerSpacesQuery.mockResolvedValue({ data: spaces })
+  describe('when spaces endpoint returns 404', () => {
+    it('should redirect to create space page', async () => {
+      setupMocks()
+      const notFoundError = { status: 404, data: 'Not Found' } as unknown as Error
 
-      const { result } = renderHook(() => useSignInRedirect())
+      const { result } = renderHook(() => useSignInRedirect({ ...defaultProps, error: notFoundError }))
 
       await act(async () => {
-        await result.current.redirect()
+        result.current.setHasSignedIn(true)
       })
 
-      expect(mockDispatch).toHaveBeenCalledWith(setLastUsedSpace('10'))
       expect(mockPush).toHaveBeenCalledWith({
-        pathname: AppRoutes.spaces.index,
-        query: { spaceId: '10' },
+        pathname: AppRoutes.welcome.createSpace,
+        query: {},
       })
     })
   })
 
   // -----------------------------------------------------------------------
-  // Redirect when user has spaces and a valid last used space
+  // No redirect when not signed in
   // -----------------------------------------------------------------------
 
-  describe('when user has spaces and a valid last used space', () => {
-    it('should redirect to the last used space', async () => {
-      const spaces = [
-        { id: 10, name: 'First Space' },
-        { id: 20, name: 'Second Space' },
-      ]
-      setupMocks({ currentSpaceId: '20' })
-      mockTriggerSpacesQuery.mockResolvedValue({ data: spaces })
+  describe('when user has not signed in yet', () => {
+    it('should not redirect if hasSignedIn is false', () => {
+      setupMocks()
 
-      const { result } = renderHook(() => useSignInRedirect())
+      renderHook(() => useSignInRedirect(defaultProps))
 
-      await act(async () => {
-        await result.current.redirect()
-      })
-
-      expect(mockPush).toHaveBeenCalledWith({
-        pathname: AppRoutes.spaces.index,
-        query: { spaceId: '20' },
-      })
-      // Should NOT dispatch setLastUsedSpace since it is already correct
-      expect(mockDispatch).not.toHaveBeenCalledWith(setLastUsedSpace(expect.anything()))
+      expect(mockPush).not.toHaveBeenCalled()
     })
   })
 
   // -----------------------------------------------------------------------
-  // Redirect when last used space is no longer valid
+  // No redirect when user has spaces
   // -----------------------------------------------------------------------
 
-  describe('when last used space is no longer valid', () => {
-    it('should fall back to the first space and update last used', async () => {
-      const spaces = [
-        { id: 10, name: 'First Space' },
-        { id: 20, name: 'Second Space' },
-      ]
-      setupMocks({ currentSpaceId: '999' })
-      mockTriggerSpacesQuery.mockResolvedValue({ data: spaces })
+  describe('when user has existing spaces', () => {
+    it('should not redirect to create space page', async () => {
+      setupMocks()
 
-      const { result } = renderHook(() => useSignInRedirect())
+      const { result } = renderHook(() => useSignInRedirect({ ...defaultProps, spacesAmount: 2 }))
 
       await act(async () => {
-        await result.current.redirect()
+        result.current.setHasSignedIn(true)
       })
 
-      expect(mockDispatch).toHaveBeenCalledWith(setLastUsedSpace('10'))
-      expect(mockPush).toHaveBeenCalledWith({
-        pathname: AppRoutes.spaces.index,
-        query: { spaceId: '10' },
-      })
+      expect(mockPush).not.toHaveBeenCalled()
     })
   })
 
   // -----------------------------------------------------------------------
-  // Query parameter preservation
+  // No redirect when user has invites
   // -----------------------------------------------------------------------
 
-  describe('query parameter preservation', () => {
-    it('should preserve existing query parameters when redirecting to spaces', async () => {
-      const spaces = [{ id: 5, name: 'Space' }]
-      setupMocks({ currentSpaceId: null, routerQuery: { safe: 'eth:0x123' } })
-      mockTriggerSpacesQuery.mockResolvedValue({ data: spaces })
+  describe('when user has pending invites', () => {
+    it('should not redirect to create space page', async () => {
+      setupMocks()
 
-      const { result } = renderHook(() => useSignInRedirect())
+      const { result } = renderHook(() => useSignInRedirect({ ...defaultProps, inviteAmount: 1 }))
 
       await act(async () => {
-        await result.current.redirect()
+        result.current.setHasSignedIn(true)
       })
 
-      expect(mockPush).toHaveBeenCalledWith({
-        pathname: AppRoutes.spaces.index,
-        query: { safe: 'eth:0x123', spaceId: '5' },
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // No redirect on non-404 errors
+  // -----------------------------------------------------------------------
+
+  describe('when there is a non-404 error', () => {
+    it('should not redirect', async () => {
+      setupMocks()
+      const serverError = { status: 500, data: 'Server Error' } as unknown as Error
+
+      const { result } = renderHook(() => useSignInRedirect({ ...defaultProps, error: serverError }))
+
+      await act(async () => {
+        result.current.setHasSignedIn(true)
       })
+
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // No redirect while spaces are loading
+  // -----------------------------------------------------------------------
+
+  describe('when spaces are still loading', () => {
+    it('should not redirect', async () => {
+      setupMocks()
+
+      const { result } = renderHook(() => useSignInRedirect({ ...defaultProps, isSpacesLoading: true }))
+
+      await act(async () => {
+        result.current.setHasSignedIn(true)
+      })
+
+      expect(mockPush).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/web/src/components/welcome/WelcomeLogin/hooks/useSignInRedirect.ts
+++ b/apps/web/src/components/welcome/WelcomeLogin/hooks/useSignInRedirect.ts
@@ -1,42 +1,40 @@
-import { useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
-import { useAppDispatch, useAppSelector } from '@/store'
-import { isAuthenticated, lastUsedSpace, setLastUsedSpace } from '@/store/authSlice'
-import { useLazySpacesGetV1Query, useSpacesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
 
-export const useSignInRedirect = () => {
+type RtkError = FetchBaseQueryError | SerializedError
+
+interface UseSignInRedirectProps {
+  spacesAmount: number
+  inviteAmount: number
+  isSpacesLoading: boolean
+  error: RtkError | undefined
+}
+
+const hasNotFoundSpaces = (error?: RtkError) => {
+  return error && 'status' in error && error.status === 404
+}
+
+export const useSignInRedirect = ({ spacesAmount, inviteAmount, isSpacesLoading, error }: UseSignInRedirectProps) => {
+  const [hasSignedIn, setHasSignedIn] = useState(false)
   const router = useRouter()
-  const dispatch = useAppDispatch()
-  const currentSpaceId = useAppSelector(lastUsedSpace)
-  const isSiweAuthenticated = useAppSelector(isAuthenticated)
+  const [redirectLoading, setRedirectLoading] = useState(false)
+  const isUserSignedIn = useAppSelector(isAuthenticated)
 
-  // Reactive query for template UI (skipped until authenticated)
-  const { data: spaces } = useSpacesGetV1Query(undefined, { skip: !isSiweAuthenticated })
+  useEffect(() => {
+    const isNewUser = !inviteAmount && !isSpacesLoading && spacesAmount === 0 && isUserSignedIn
 
-  // Lazy query to fetch fresh spaces data at redirect time
-  const [triggerSpacesQuery] = useLazySpacesGetV1Query()
+    if (error && !hasNotFoundSpaces(error)) return
 
-  const redirect = useCallback(async () => {
-    // Fetch spaces fresh – auth cookie is now set after SIWE
-    const { data: spaces } = await triggerSpacesQuery()
-    const hasSpaces = spaces && spaces.length > 0
-
-    if (!hasSpaces) {
+    if (hasSignedIn && (isNewUser || hasNotFoundSpaces(error))) {
+      setRedirectLoading(true)
       router.push({ pathname: AppRoutes.welcome.createSpace, query: router.query })
-      return
     }
+  }, [hasSignedIn, isSpacesLoading, spacesAmount, inviteAmount, isUserSignedIn, error])
 
-    // Use last used space if the user is still a member, otherwise fall back to the first space
-    const isInLastUsedSpace = spaces.some((space) => String(space.id) === currentSpaceId)
-    const targetSpaceId = isInLastUsedSpace && currentSpaceId ? currentSpaceId : String(spaces[0].id)
-
-    if (!isInLastUsedSpace || !currentSpaceId) {
-      dispatch(setLastUsedSpace(targetSpaceId))
-    }
-
-    router.push({ pathname: AppRoutes.spaces.index, query: { ...router.query, spaceId: targetSpaceId } })
-  }, [triggerSpacesQuery, currentSpaceId, dispatch, router])
-
-  return { redirect, spaces }
+  return { setHasSignedIn, redirectLoading }
 }

--- a/apps/web/src/features/spaces/components/SignInButton/index.tsx
+++ b/apps/web/src/features/spaces/components/SignInButton/index.tsx
@@ -8,9 +8,14 @@ import { showNotification } from '@/store/notificationsSlice'
 import { logError } from '@/services/exceptions'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
 
-const SignInButton = () => {
+interface SignInButtonProps {
+  redirectLoading: boolean
+  afterSignIn: () => void
+}
+
+const SignInButton = ({ afterSignIn, redirectLoading = false }: SignInButtonProps) => {
   const dispatch = useAppDispatch()
-  const { signIn } = useSiwe()
+  const { signIn, loading } = useSiwe()
 
   const handleLogin = () => {
     trackEvent({ ...OVERVIEW_EVENTS.OPEN_ONBOARD, label: OVERVIEW_LABELS.space_list_page })
@@ -29,6 +34,7 @@ const SignInButton = () => {
       if (result) {
         const oneDayInMs = 24 * 60 * 60 * 1000
         dispatch(setAuthenticated(Date.now() + oneDayInMs))
+        afterSignIn()
       }
     } catch (error) {
       logError(ErrorCodes._640)
@@ -43,7 +49,14 @@ const SignInButton = () => {
     }
   }
 
-  return <WalletLogin onLogin={handleLogin} onContinue={handleSignIn} buttonText="Sign in with" />
+  return (
+    <WalletLogin
+      onLogin={handleLogin}
+      onContinue={handleSignIn}
+      isLoading={loading || redirectLoading}
+      buttonText="Sign in with"
+    />
+  )
 }
 
 export default SignInButton

--- a/apps/web/src/features/spaces/components/SignedOutState/index.tsx
+++ b/apps/web/src/features/spaces/components/SignedOutState/index.tsx
@@ -2,7 +2,12 @@ import { Box, Typography } from '@mui/material'
 import css from '../Dashboard/styles.module.css'
 import SignInButton from '../SignInButton'
 
-const SignedOutState = () => {
+interface SignedOutStateProps {
+  afterSignIn?: () => void
+  redirectLoading?: boolean
+}
+
+const SignedOutState = ({ afterSignIn, redirectLoading = false }: SignedOutStateProps) => {
   return (
     <Box className={css.content}>
       <Box textAlign="center" className={css.contentWrapper}>
@@ -16,7 +21,7 @@ const SignedOutState = () => {
             in to continue.
           </Typography>
 
-          <SignInButton />
+          <SignInButton afterSignIn={afterSignIn ?? (() => {})} redirectLoading={redirectLoading} />
         </Box>
       </Box>
     </Box>

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -9,7 +9,7 @@ import { Box, Button, Card, Grid2, Link, Typography } from '@mui/material'
 import { type GetSpaceResponse, useSpacesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 import SpaceListInvite from '../InviteBanner'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import css from './styles.module.css'
 import { MemberStatus } from '@/features/spaces'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -19,6 +19,7 @@ import SpaceInfoModal from '../SpaceInfoModal'
 import { filterSpacesByStatus } from '@/features/spaces/utils'
 import { AppRoutes } from '@/config/routes'
 import NextLink from 'next/link'
+import { useSignInRedirect } from '@/components/welcome/WelcomeLogin/hooks/useSignInRedirect'
 
 const AddSpaceButton = () => {
   return (
@@ -36,7 +37,7 @@ const AddSpaceButton = () => {
   )
 }
 
-const SignedOutState = () => {
+const SignedOutState = ({ afterSignIn, redirectLoading }: { afterSignIn: () => void; redirectLoading: boolean }) => {
   const wallet = useWallet()
   const [isInfoOpen, setIsInfoOpen] = useState<boolean>(false)
 
@@ -58,7 +59,7 @@ const SignedOutState = () => {
           </Link>
         </Box>
 
-        <SignInButton />
+        <SignInButton afterSignIn={afterSignIn} redirectLoading={redirectLoading} />
       </Card>
       {isInfoOpen && <SpaceInfoModal onClose={() => setIsInfoOpen(false)} showButtons={false} />}
     </>
@@ -97,10 +98,25 @@ const SpacesList = () => {
   const { AccountsNavigation } = useLoadFeature(MyAccountsFeature)
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
-  const { currentData: spaces } = useSpacesGetV1Query(undefined, { skip: !isUserSignedIn })
-
+  const {
+    currentData: spaces,
+    isFetching: isSpacesLoading,
+    error,
+  } = useSpacesGetV1Query(undefined, { skip: !isUserSignedIn })
   const pendingInvites = filterSpacesByStatus(currentUser, spaces || [], MemberStatus.INVITED)
   const activeSpaces = filterSpacesByStatus(currentUser, spaces || [], MemberStatus.ACTIVE)
+  const inviteAmount = pendingInvites?.length
+
+  const { setHasSignedIn, redirectLoading } = useSignInRedirect({
+    spacesAmount: spaces?.length || 0,
+    inviteAmount: inviteAmount || 0,
+    isSpacesLoading: isSpacesLoading || false,
+    error: error || undefined,
+  })
+
+  const afterSignIn = useCallback(() => {
+    setHasSignedIn(true)
+  }, [])
 
   return (
     <Box className={css.container}>
@@ -121,7 +137,7 @@ const SpacesList = () => {
             <SpaceListInvite key={invitingSpace.id} space={invitingSpace} />
           ))}
 
-        {isUserSignedIn ? (
+        {isUserSignedIn || (!redirectLoading && pendingInvites.length) ? (
           <Grid2 container spacing={2} flexWrap="wrap">
             {activeSpaces.length > 0 ? (
               activeSpaces.map((space) => (
@@ -134,7 +150,7 @@ const SpacesList = () => {
             )}
           </Grid2>
         ) : (
-          <SignedOutState />
+          <SignedOutState afterSignIn={afterSignIn} redirectLoading={redirectLoading} />
         )}
       </Box>
     </Box>


### PR DESCRIPTION
> New users sign in, spaces checked,
> no spaces found—redirect to create,
> reactive hooks replace lazy queries.

## What it solves
Resolves: <!-- Add Linear link here -->

After signing in on the spaces list page, new users (with no existing spaces or invites) were not being redirected to the create-space flow.

## How this PR fixes it

Refactors `useSignInRedirect` from an imperative approach (lazy query + callback) to a reactive one driven by props from `SpacesList`:
- The hook now receives `spacesAmount`, `inviteAmount`, `isSpacesLoading`, and `error` as props
- Uses a `hasSignedIn` flag (set via `afterSignIn` callback passed to `SignInButton`) to trigger the redirect effect
- Redirects to the create-space page when the user has signed in and has no spaces/invites (or the spaces endpoint returns 404)
- Shows a loading state on the sign-in button during redirect

## How to test it

1. Disconnect wallet / sign out
2. Connect a wallet that has **no spaces and no invites**
3. Navigate to the spaces list page
4. Click "Sign in with" button
5. After signing in, you should be redirected to the create-space page
6. Verify the sign-in button shows a loading state during redirect

## Screenshots
<!-- Add screenshots here -->

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).