### PR TITLE
chore: fix lint warnings in theme package

### DIFF
--- a/packages/theme/src/generators/mui.ts
+++ b/packages/theme/src/generators/mui.ts
@@ -284,7 +284,7 @@ export function generateMuiTheme(mode: PaletteMode): Theme {
       MuiChip: {
         styleOverrides: {
           colorSuccess: ({ theme }) => ({ backgroundColor: theme.palette.secondary.light, height: '24px' }),
-          //@ts-ignore this is not detected even though it is declared in web app
+          //@ts-expect-error this is not detected even though it is declared in web app
           sizeTiny: {
             fontSize: '11px',
             height: 'auto',
@@ -312,7 +312,7 @@ export function generateMuiTheme(mode: PaletteMode): Theme {
             '& .MuiAlert-icon': { color: theme.palette.warning.main },
             '&.MuiPaper-root': { backgroundColor: theme.palette.warning.background },
           }),
-          // @ts-ignore - custom color variant
+          // @ts-expect-error - custom color variant
           standardBackground: ({ theme }) => ({
             '& .MuiAlert-icon': { color: theme.palette.text.primary },
             '&.MuiPaper-root': { backgroundColor: theme.palette.background.main },
@@ -452,7 +452,7 @@ export function generateMuiTheme(mode: PaletteMode): Theme {
               boxSizing: 'border-box',
             },
           }),
-          sizeSmall: ({ theme }) => ({
+          sizeSmall: () => ({
             width: 22,
             height: 13,
             padding: 0,


### PR DESCRIPTION
> Swap ts-ignore for ts-expect-error,
> drop a param that's never read,
> the linter rests quiet.

## What it solves

The `@safe-global/theme` package had 3 lint warnings: two `@ts-ignore` directives that should use `@ts-expect-error`, and an unused `theme` parameter.

## How this PR fixes it

- Replaced `@ts-ignore` with `@ts-expect-error` (preferred per `@typescript-eslint/ban-ts-comment`)
- Removed unused `theme` parameter from the `sizeSmall` switch style callback

## How to test it

1. Run `yarn workspace @safe-global/theme lint` — should pass with 0 warnings
2. Run `yarn workspace @safe-global/theme type-check` — should pass

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).