### PR TITLE
chore(web): enforce unit test coverage thresholds

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -41,6 +41,14 @@ const customJestConfig = {
     customExportConditions: ['node'],
   },
   coveragePathIgnorePatterns: ['/node_modules/', '/src/tests/', '/src/types/contracts/'],
+  coverageThreshold: {
+    global: {
+      branches: 56,
+      functions: 62,
+      lines: 78,
+      statements: 76,
+    },
+  },
   // Exclude storybook snapshot tests from main test run - they have their own CI workflow
   testPathIgnorePatterns: ['/node_modules/', '/.next/', '\\.stories\\.test\\.tsx$'],
 }


### PR DESCRIPTION
> Coverage gates now guard the keep,
> no silent regressions while we sleep.

## Summary

- Add global `coverageThreshold` to `jest.config.cjs` to prevent test coverage from silently regressing
- Thresholds set ~2 points below current measured coverage to allow flexibility while catching drops:
  - **Branches**: 56% (current: 58.32%)
  - **Functions**: 62% (current: 64.39%)
  - **Lines**: 78% (current: 80.20%)
  - **Statements**: 76% (current: 78.76%)
- CI will now fail if any `--coverage` run drops below these levels

## Test plan

- [x] Ran full test suite with `--coverage` — all 391 suites pass, thresholds met
- [ ] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)