### PR TITLE
fix(web): add missing setSafeMessageHash to TxNonce test context

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
@@ -20,6 +20,8 @@ const defaultSafeTxContext: SafeTxContextParams = {
   setSafeTx: jest.fn(),
   safeMessage: undefined,
   setSafeMessage: jest.fn(),
+  safeMessageHash: undefined,
+  setSafeMessageHash: jest.fn(),
   safeTxError: undefined,
   setSafeTxError: jest.fn(),
   nonce: 5,


### PR DESCRIPTION
> Merge order left a gap,
> new type field meets old test mock—
> one line seals the crack.

## What it solves

Fixes the type-check failure on `dev` introduced by the merge ordering of PR #7409 and PR #7420.

PR #7409 added `setSafeMessageHash` as a required property to `SafeTxContextParams`. PR #7420 (merged earlier the same day) introduced a new `TxNonce.test.tsx` file that constructs a `SafeTxContextParams` object. Since #7409's CI ran before #7420 was merged, the test file didn't exist on the PR branch, so no type error was caught. After both merged, the combined codebase has a type mismatch.

## How this PR fixes it

Adds the missing `safeMessageHash` and `setSafeMessageHash` properties to the `defaultSafeTxContext` mock in `TxNonce.test.tsx`.

## How to test it

```bash
yarn workspace @safe-global/web type-check
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).