### PR TITLE
fix(mobile): add type declaration for auto-generated storybook.requires

### DIFF
--- a/apps/mobile/.storybook/storybook.requires.d.ts
+++ b/apps/mobile/.storybook/storybook.requires.d.ts
@@ -1,0 +1,5 @@
+// Type declaration for the auto-generated storybook.requires file.
+// The actual file is created by sb-rn-get-stories / withStorybook and is gitignored.
+export declare const view: {
+  getStorybookUI: (params?: Record<string, unknown>) => () => React.JSX.Element
+}


### PR DESCRIPTION
> A ghost module, gitignored and gone,
> breaks type-check at dawn—
> a .d.ts stub sets things right.

## What it solves

Running `yarn workspace @safe-global/mobile type-check` on a fresh clone fails with "Cannot find module './storybook.requires' or its corresponding type declarations" because the auto-generated `storybook.requires.ts` is gitignored but transitively imported via `_layout.tsx → .storybook/index.ts`.

## How this PR fixes it

Adds a `storybook.requires.d.ts` type declaration file that provides the module shape as a fallback when the auto-generated `.ts` file doesn't exist. Note that `tsconfig.json` `exclude` cannot solve this because TypeScript always resolves modules referenced via imports regardless of exclude patterns.

## How to test it

1. Ensure `apps/mobile/.storybook/storybook.requires.ts` does NOT exist (it's gitignored, so a fresh clone won't have it)
2. Run `yarn workspace @safe-global/mobile type-check`
3. Verify it passes without the "Cannot find module" error

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).