### PR TITLE
feat: update the chain selector and fix the styling

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.stories.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { withMockProvider } from '@/storybook/preview'
+import { createMockStory } from '@/stories/mocks'
 import ChainSelectorBlock from '@/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock'
 
-const chains = {
+const deployedChains = {
   single: [{ chainId: '1', chainName: 'Ethereum', chainLogoUri: undefined, shortName: 'eth' }],
   multi: [
     { chainId: '1', chainName: 'Ethereum', chainLogoUri: undefined, shortName: 'eth' },
@@ -11,22 +11,31 @@ const chains = {
   ],
 }
 
+const availableChains = [
+  { chainId: '42161', chainName: 'Arbitrum', chainLogoUri: undefined, shortName: 'arb1' },
+  { chainId: '100', chainName: 'Gnosis Chain', chainLogoUri: undefined, shortName: 'gno' },
+  { chainId: '11155111', chainName: 'Sepolia', chainLogoUri: undefined, shortName: 'sep' },
+]
+
+const defaultSetup = createMockStory({
+  scenario: 'efSafe',
+  wallet: 'disconnected',
+  layout: 'paper',
+  shadcn: true,
+})
+
 /**
  * Visual stories for the SpaceChainSelector container + ChainSelectorBlock.
  * SpaceChainSelector itself is a thin hook wrapper — these stories document
- * the two visual states (single-chain and multi-chain) directly.
+ * the visual states directly via ChainSelectorBlock.
  */
 const meta = {
   title: 'Features/Spaces/SpaceChainSelector',
-  parameters: { layout: 'centered' },
-  decorators: [
-    withMockProvider(),
-    (Story) => (
-      <div className="flex items-center gap-2 px-4 pt-4 pb-0">
-        <Story />
-      </div>
-    ),
-  ],
+  parameters: {
+    layout: 'centered',
+    ...defaultSetup.parameters,
+  },
+  decorators: [defaultSetup.decorator],
   tags: ['autodocs'],
 } satisfies Meta
 
@@ -34,7 +43,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
-  <div className="self-stretch flex items-stretch shadow-[0px_4px_20px_0px_rgba(0,0,0,0.07)] rounded-lg bg-card min-w-[64px] min-h-[68px]">
+  <div className="inline-flex items-center shadow-[0px_4px_20px_0px_rgba(0,0,0,0.07)] rounded-lg bg-card min-w-[64px] min-h-[68px]">
     {children}
   </div>
 )
@@ -43,10 +52,11 @@ export const SingleChain: Story = {
   render: () => (
     <Wrapper>
       <ChainSelectorBlock
-        hasMultipleChains={false}
-        chains={chains.single}
+        deployedChains={deployedChains.single}
+        availableChains={availableChains}
         selectedChainId="1"
         onChainSelect={() => {}}
+        onAddNetwork={() => {}}
       />
     </Wrapper>
   ),
@@ -55,7 +65,27 @@ export const SingleChain: Story = {
 export const MultiChain: Story = {
   render: () => (
     <Wrapper>
-      <ChainSelectorBlock hasMultipleChains={true} chains={chains.multi} selectedChainId="1" onChainSelect={() => {}} />
+      <ChainSelectorBlock
+        deployedChains={deployedChains.multi}
+        availableChains={availableChains}
+        selectedChainId="1"
+        onChainSelect={() => {}}
+        onAddNetwork={() => {}}
+      />
+    </Wrapper>
+  ),
+}
+
+export const NoAvailableChains: Story = {
+  render: () => (
+    <Wrapper>
+      <ChainSelectorBlock
+        deployedChains={deployedChains.multi}
+        availableChains={[]}
+        selectedChainId="1"
+        onChainSelect={() => {}}
+        onAddNetwork={() => {}}
+      />
     </Wrapper>
   ),
 }

--- a/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.test.tsx
@@ -7,21 +7,24 @@ jest.mock(
   '@/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock',
   () =>
     function ChainSelectorBlock({
-      hasMultipleChains,
+      deployedChains,
       selectedChainId,
     }: {
-      hasMultipleChains: boolean
+      deployedChains: Array<{ chainId: string }>
       selectedChainId: string
     }) {
       return (
         <div
           data-testid="chain-selector-block"
-          data-has-multiple-chains={String(hasMultipleChains)}
+          data-deployed-count={String(deployedChains.length)}
           data-selected-chain-id={selectedChainId}
         />
       )
     },
 )
+jest.mock('@/features/multichain', () => ({
+  CreateSafeOnNewChain: () => <div data-testid="create-safe-on-new-chain" />,
+}))
 
 const mockUseSpaceChainSelector = useSpaceChainSelector as jest.Mock
 
@@ -30,22 +33,29 @@ const multiChain = [
   { chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' },
   { chainId: '137', chainName: 'Polygon', chainLogoUri: null, shortName: 'matic' },
 ]
+const availableChains = [{ chainId: '42161', chainName: 'Arbitrum', chainLogoUri: null, shortName: 'arb1' }]
 
 describe('SpaceChainSelector', () => {
   beforeEach(() => {
     mockUseSpaceChainSelector.mockReturnValue({
-      chains: singleChain,
+      deployedChains: singleChain,
+      availableChains,
       selectedChainId: '1',
-      hasMultipleChains: false,
+      deployedChainIds: ['1'],
+      safeAddress: '0xSafe1',
+      safeName: 'My Safe',
       handleChainChange: jest.fn(),
     })
   })
 
-  it('renders null when chains is empty', () => {
+  it('renders null when deployedChains is empty', () => {
     mockUseSpaceChainSelector.mockReturnValue({
-      chains: [],
+      deployedChains: [],
+      availableChains: [],
       selectedChainId: '1',
-      hasMultipleChains: false,
+      deployedChainIds: [],
+      safeAddress: '0xSafe1',
+      safeName: undefined,
       handleChainChange: jest.fn(),
     })
 
@@ -53,36 +63,42 @@ describe('SpaceChainSelector', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders ChainSelectorBlock when chains are present', () => {
+  it('renders ChainSelectorBlock when deployed chains are present', () => {
     render(<SpaceChainSelector />)
 
     expect(screen.getByTestId('chain-selector-block')).toBeInTheDocument()
   })
 
-  it('passes hasMultipleChains=false for a single-chain safe', () => {
+  it('passes deployed chain count to ChainSelectorBlock', () => {
     render(<SpaceChainSelector />)
 
-    expect(screen.getByTestId('chain-selector-block')).toHaveAttribute('data-has-multiple-chains', 'false')
+    expect(screen.getByTestId('chain-selector-block')).toHaveAttribute('data-deployed-count', '1')
   })
 
-  it('passes hasMultipleChains=true for a multi-chain safe', () => {
+  it('passes correct deployed count for multi-chain safe', () => {
     mockUseSpaceChainSelector.mockReturnValue({
-      chains: multiChain,
+      deployedChains: multiChain,
+      availableChains,
       selectedChainId: '1',
-      hasMultipleChains: true,
+      deployedChainIds: ['1', '137'],
+      safeAddress: '0xSafe2',
+      safeName: 'Multi Safe',
       handleChainChange: jest.fn(),
     })
 
     render(<SpaceChainSelector />)
 
-    expect(screen.getByTestId('chain-selector-block')).toHaveAttribute('data-has-multiple-chains', 'true')
+    expect(screen.getByTestId('chain-selector-block')).toHaveAttribute('data-deployed-count', '2')
   })
 
   it('passes selectedChainId to ChainSelectorBlock', () => {
     mockUseSpaceChainSelector.mockReturnValue({
-      chains: multiChain,
+      deployedChains: multiChain,
+      availableChains,
       selectedChainId: '137',
-      hasMultipleChains: true,
+      deployedChainIds: ['1', '137'],
+      safeAddress: '0xSafe2',
+      safeName: 'Multi Safe',
       handleChainChange: jest.fn(),
     })
 

--- a/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.tsx
@@ -1,19 +1,51 @@
+import { useState, useCallback } from 'react'
 import ChainSelectorBlock from '@/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock'
+import { CreateSafeOnNewChain } from '@/features/multichain'
 import { useSpaceChainSelector } from './hooks/useSpaceChainSelector'
 
 function SpaceChainSelector() {
-  const { chains, selectedChainId, hasMultipleChains, handleChainChange } = useSpaceChainSelector()
+  const {
+    deployedChains,
+    availableChains,
+    selectedChainId,
+    deployedChainIds,
+    safeAddress,
+    safeName,
+    handleChainChange,
+  } = useSpaceChainSelector()
 
-  if (!chains.length) return null
+  const [addNetworkChainId, setAddNetworkChainId] = useState<string>()
+
+  const handleAddNetwork = useCallback((chainId: string) => {
+    setAddNetworkChainId(chainId)
+  }, [])
+
+  const handleCloseDialog = useCallback(() => {
+    setAddNetworkChainId(undefined)
+  }, [])
+
+  if (!deployedChains.length) return null
 
   return (
     <div className="self-stretch sm:order-last flex items-stretch shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)] rounded-lg bg-card">
       <ChainSelectorBlock
-        hasMultipleChains={hasMultipleChains}
-        chains={chains}
+        deployedChains={deployedChains}
+        availableChains={availableChains}
         selectedChainId={selectedChainId}
         onChainSelect={handleChainChange}
+        onAddNetwork={handleAddNetwork}
       />
+
+      {addNetworkChainId && (
+        <CreateSafeOnNewChain
+          open
+          onClose={handleCloseDialog}
+          currentName={safeName}
+          safeAddress={safeAddress}
+          deployedChainIds={deployedChainIds}
+          defaultChainId={addNetworkChainId}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceChainSelector.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceChainSelector.test.ts
@@ -63,6 +63,7 @@ import { isMultiChainSafeItem } from '@/hooks/safes'
 const chainConfigs = [
   { chainId: '1', chainName: 'Ethereum', chainLogoUri: 'eth.png', shortName: 'eth' },
   { chainId: '137', chainName: 'Polygon', chainLogoUri: 'polygon.png', shortName: 'matic' },
+  { chainId: '42161', chainName: 'Arbitrum', chainLogoUri: 'arb.png', shortName: 'arb1' },
 ]
 
 const mockPush = jest.fn()
@@ -114,11 +115,11 @@ describe('useSpaceChainSelector', () => {
     setupDefaults()
   })
 
-  it('returns the chains for the current safe', () => {
+  it('returns the deployed chains for the current safe', () => {
     const { result } = renderHook(() => useSpaceChainSelector())
 
-    expect(result.current.chains).toHaveLength(1)
-    expect(result.current.chains[0]).toMatchObject({ chainId: '1', chainName: 'Ethereum', shortName: 'eth' })
+    expect(result.current.deployedChains).toHaveLength(1)
+    expect(result.current.deployedChains[0]).toMatchObject({ chainId: '1', chainName: 'Ethereum', shortName: 'eth' })
   })
 
   it('returns selectedChainId from useChainId', () => {
@@ -126,25 +127,41 @@ describe('useSpaceChainSelector', () => {
     expect(result.current.selectedChainId).toBe('1')
   })
 
-  it('returns hasMultipleChains=false for a single-chain safe', () => {
+  it('returns deployedChainIds for a single-chain safe', () => {
     const { result } = renderHook(() => useSpaceChainSelector())
-    expect(result.current.hasMultipleChains).toBe(false)
+    expect(result.current.deployedChainIds).toEqual(['1'])
   })
 
-  it('returns hasMultipleChains=true for a multi-chain safe', () => {
+  it('returns deployedChainIds for a multi-chain safe', () => {
     setupDefaults({ allSafes: [multiChainSafe], safeAddress: '0xSafe2' })
 
     const { result } = renderHook(() => useSpaceChainSelector())
-    expect(result.current.hasMultipleChains).toBe(true)
-    expect(result.current.chains).toHaveLength(2)
+    expect(result.current.deployedChainIds).toEqual(['1', '137'])
+    expect(result.current.deployedChains).toHaveLength(2)
   })
 
-  it('returns empty chains when the current safe is not found in allSafes', () => {
+  it('returns availableChains excluding deployed chains', () => {
+    setupDefaults({ allSafes: [singleChainSafe], safeAddress: '0xSafe1' })
+
+    const { result } = renderHook(() => useSpaceChainSelector())
+    expect(result.current.availableChains).toHaveLength(2)
+    expect(result.current.availableChains.map((c) => c.chainId)).toEqual(['137', '42161'])
+  })
+
+  it('returns availableChains excluding all deployed chains for multi-chain safe', () => {
+    setupDefaults({ allSafes: [multiChainSafe], safeAddress: '0xSafe2' })
+
+    const { result } = renderHook(() => useSpaceChainSelector())
+    expect(result.current.availableChains).toHaveLength(1)
+    expect(result.current.availableChains[0].chainId).toBe('42161')
+  })
+
+  it('returns empty deployedChains when the current safe is not found in allSafes', () => {
     setupDefaults({ allSafes: [], safeAddress: '0xSafe1' })
 
     const { result } = renderHook(() => useSpaceChainSelector())
-    expect(result.current.chains).toHaveLength(0)
-    expect(result.current.hasMultipleChains).toBe(false)
+    expect(result.current.deployedChains).toHaveLength(0)
+    expect(result.current.deployedChainIds).toEqual([])
   })
 
   it('navigates to the same safe on a different chain when handleChainChange is called', () => {
@@ -176,7 +193,7 @@ describe('useSpaceChainSelector', () => {
     setupDefaults({ allSafes: [singleChainSafe], safeAddress: '0xsafe1' })
 
     const { result } = renderHook(() => useSpaceChainSelector())
-    expect(result.current.chains).toHaveLength(1)
+    expect(result.current.deployedChains).toHaveLength(1)
   })
 
   it('falls back to null for chainLogoUri when chain config exists but chainLogoUri is missing', () => {
@@ -185,7 +202,7 @@ describe('useSpaceChainSelector', () => {
     })
 
     const { result } = renderHook(() => useSpaceChainSelector())
-    expect(result.current.chains[0]).toMatchObject({
+    expect(result.current.deployedChains[0]).toMatchObject({
       chainId: '1',
       chainName: 'Ethereum',
       shortName: 'eth',
@@ -195,22 +212,32 @@ describe('useSpaceChainSelector', () => {
 
   it('falls back to chainId for chainName/shortName when chain config is missing', () => {
     const unknownSafe: SafeItem = {
-      chainId: '42161',
-      address: '0xArb',
+      chainId: '99999',
+      address: '0xUnknown',
       isReadOnly: false,
       isPinned: false,
       lastVisited: 0,
-      name: 'Arb Safe',
+      name: 'Unknown Safe',
     }
-    setupDefaults({ allSafes: [unknownSafe], safeAddress: '0xArb', currentChainId: '42161' })
+    setupDefaults({ allSafes: [unknownSafe], safeAddress: '0xUnknown', currentChainId: '99999' })
 
     const { result } = renderHook(() => useSpaceChainSelector())
-    expect(result.current.chains[0]).toMatchObject({
-      chainId: '42161',
-      chainName: '42161',
-      shortName: '42161',
+    expect(result.current.deployedChains[0]).toMatchObject({
+      chainId: '99999',
+      chainName: '99999',
+      shortName: '99999',
       chainLogoUri: null,
     })
+  })
+
+  it('returns safeAddress from useSafeInfo', () => {
+    const { result } = renderHook(() => useSpaceChainSelector())
+    expect(result.current.safeAddress).toBe('0xSafe1')
+  })
+
+  it('returns safeName from the matched safe item', () => {
+    const { result } = renderHook(() => useSpaceChainSelector())
+    expect(result.current.safeName).toBe('My Safe')
   })
 
   it('fires CHAIN_SWITCHED trackEvent exactly once with correct params on chain change', () => {

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceChainSelector.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceChainSelector.ts
@@ -10,6 +10,7 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MixpanelEventParams } from '@/services/analytics/mixpanel-events'
 import { useCurrentSpaceId } from '@/features/spaces'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
 import type { ChainInfo } from '@/features/spaces/types'
 
 export function useSpaceChainSelector() {
@@ -20,10 +21,11 @@ export function useSpaceChainSelector() {
   const router = useRouter()
   const spaceId = useCurrentSpaceId()
 
-  const { chains, hasMultipleChains } = useMemo(() => {
-    const currentSafe = allSafes.find((s) => s.address.toLowerCase() === safeAddress.toLowerCase())
+  const { deployedChains, deployedChainIds, safeName } = useMemo(() => {
+    const currentSafe = allSafes.find((s) => sameAddress(s.address, safeAddress))
 
-    if (!currentSafe) return { chains: [] as ChainInfo[], hasMultipleChains: false }
+    if (!currentSafe)
+      return { deployedChains: [] as ChainInfo[], deployedChainIds: [] as string[], safeName: undefined }
 
     const chainIds = isMultiChainSafeItem(currentSafe) ? currentSafe.safes.map((s) => s.chainId) : [currentSafe.chainId]
 
@@ -37,8 +39,19 @@ export function useSpaceChainSelector() {
       }
     })
 
-    return { chains: resolvedChains, hasMultipleChains: chainIds.length > 1 }
+    return { deployedChains: resolvedChains, deployedChainIds: chainIds, safeName: currentSafe.name }
   }, [allSafes, safeAddress, chainConfigs])
+
+  const availableChains: ChainInfo[] = useMemo(() => {
+    return chainConfigs
+      .filter((c) => !deployedChainIds.includes(c.chainId))
+      .map((c) => ({
+        chainId: c.chainId,
+        chainName: c.chainName,
+        chainLogoUri: c.chainLogoUri ?? null,
+        shortName: c.shortName,
+      }))
+  }, [chainConfigs, deployedChainIds])
 
   const handleChainChange = useCallback(
     (chainId: string) => {
@@ -57,5 +70,13 @@ export function useSpaceChainSelector() {
     [chainConfigs, router, safeAddress, spaceId],
   )
 
-  return { chains, selectedChainId, hasMultipleChains, handleChainChange }
+  return {
+    deployedChains,
+    availableChains,
+    selectedChainId,
+    deployedChainIds,
+    safeAddress,
+    safeName,
+    handleChainChange,
+  }
 }

--- a/apps/web/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
+++ b/apps/web/src/features/multichain/components/CreateSafeOnNewChain/index.tsx
@@ -21,7 +21,7 @@ import ExternalLink from '@/components/common/ExternalLink'
 import { useRouter } from 'next/router'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import { type Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useCompatibleNetworks } from '@safe-global/utils/features/multichain/hooks/useCompatibleNetworks'
 import { MULTICHAIN_HELP_ARTICLE } from '@/config/constants'
 import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
@@ -44,7 +44,7 @@ const ReplaySafeDialog = ({
       chainId: chain?.chainId || '',
     },
   })
-  const { handleSubmit, formState } = formMethods
+  const { handleSubmit, formState, reset } = formMethods
   const router = useRouter()
   const addressBook = useAddressBook()
 
@@ -53,6 +53,12 @@ const ReplaySafeDialog = ({
   const { replayCounterfactualSafeDeployment } = useLoadFeature(CounterfactualFeature)
   const [creationError, setCreationError] = useState<Error>()
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (chain?.chainId) {
+      reset({ chainId: chain.chainId })
+    }
+  }, [chain?.chainId, reset])
 
   // Load some data
   const [safeCreationData, safeCreationDataError, safeCreationDataLoading] = safeCreationResult
@@ -252,12 +258,14 @@ const ReplaySafeDialog = ({
 export const CreateSafeOnNewChain = ({
   safeAddress,
   deployedChainIds,
+  defaultChainId,
   ...props
 }: Omit<
   ReplaySafeDialogProps,
   'safeCreationResult' | 'replayableChains' | 'chain' | 'isUnsupportedSafeCreationVersion'
 > & {
   deployedChainIds: string[]
+  defaultChainId?: string
 }) => {
   const { configs } = useChains()
   const deployedChains = useMemo(
@@ -276,12 +284,18 @@ export const CreateSafeOnNewChain = ({
     [allCompatibleChains, deployedChainIds],
   )
 
+  const preselectedChain = useMemo(
+    () => (defaultChainId ? replayableChains?.find((c) => c.chainId === defaultChainId) : undefined),
+    [defaultChainId, replayableChains],
+  )
+
   return (
     <ReplaySafeDialog
       safeCreationResult={safeCreationResult}
       replayableChains={replayableChains}
       safeAddress={safeAddress}
       isUnsupportedSafeCreationVersion={isUnsupportedSafeCreationVersion}
+      chain={preselectedChain}
       {...props}
     />
   )

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock.tsx
@@ -1,14 +1,17 @@
-import { ChevronDown } from 'lucide-react'
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { useState } from 'react'
+import { ChevronDown, Plus } from 'lucide-react'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Typography } from '@/components/ui/typography'
 import ChainLogo from './ChainLogo'
 import type { ChainInfo } from '@/features/spaces/types'
 
 export interface ChainSelectorBlockProps {
-  hasMultipleChains: boolean
-  chains: ChainInfo[]
+  deployedChains: ChainInfo[]
+  availableChains: ChainInfo[]
   selectedChainId: string
   onChainSelect: (chainId: string, event?: React.MouseEvent) => void
+  onAddNetwork: (chainId: string) => void
 }
 
 const handleChainTriggerKeyDown = (e: React.KeyboardEvent) => {
@@ -18,49 +21,86 @@ const handleChainTriggerKeyDown = (e: React.KeyboardEvent) => {
   }
 }
 
-function ChainSelectorBlock({ hasMultipleChains, chains, selectedChainId, onChainSelect }: ChainSelectorBlockProps) {
-  const displayChainId = selectedChainId || chains[0]?.chainId
+function ChainSelectorBlock({
+  deployedChains,
+  availableChains,
+  selectedChainId,
+  onChainSelect,
+  onAddNetwork,
+}: ChainSelectorBlockProps) {
+  const displayChainId = selectedChainId || deployedChains[0]?.chainId
+  const [open, setOpen] = useState(false)
 
-  if (hasMultipleChains) {
-    return (
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <span
-              role="button"
-              tabIndex={0}
-              className="w-16 flex items-center justify-between px-2 rounded-lg shrink-0 cursor-pointer hover:bg-muted/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              onKeyDown={handleChainTriggerKeyDown}
-            >
-              <ChainLogo chainId={displayChainId} />
-              <ChevronDown className="size-4 text-muted-foreground shrink-0" />
-            </span>
-          }
-        />
-        <DropdownMenuContent align="end" className="w-[200px] bg-card text-foreground ring-0">
-          {chains.map((chainItem) => (
-            <DropdownMenuItem
-              key={chainItem.chainId}
-              onClick={(e) => onChainSelect(chainItem.chainId, e)}
-              onSelect={(e) => {
-                e.preventDefault()
-                onChainSelect(chainItem.chainId)
-              }}
-              className="gap-4 cursor-pointer"
-            >
-              <ChainLogo chainId={chainItem.chainId} />
-              <Typography variant="paragraph-small-medium">{chainItem.chainName}</Typography>
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    )
+  const handleAddNetworkClick = (chainId: string) => {
+    setOpen(false)
+    onAddNetwork(chainId)
   }
 
   return (
-    <span className="w-16 inline-flex items-center justify-center rounded-lg shrink-0">
-      <ChainLogo chainId={chains[0]?.chainId} />
-    </span>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger
+        render={
+          <span
+            role="button"
+            tabIndex={0}
+            className="w-16 flex items-center justify-between px-2 m-1 rounded-lg shrink-0 cursor-pointer hover:bg-muted/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            onKeyDown={handleChainTriggerKeyDown}
+          >
+            <ChainLogo chainId={displayChainId} />
+            <ChevronDown className="size-4 text-muted-foreground shrink-0" />
+          </span>
+        }
+      />
+      <DropdownMenuContent align="end" sideOffset={8} className="w-[196px] bg-card text-foreground ring-0 p-1">
+        <div className="flex flex-col">
+          {deployedChains.map((chainItem) => (
+            <button
+              key={chainItem.chainId}
+              onClick={(e) => {
+                setOpen(false)
+                onChainSelect(chainItem.chainId, e)
+              }}
+              className="flex items-center gap-4 px-2 py-2 rounded-lg cursor-pointer hover:bg-muted/30 w-full text-left"
+            >
+              <ChainLogo chainId={chainItem.chainId} />
+              <Typography variant="paragraph-small-medium">{chainItem.chainName}</Typography>
+            </button>
+          ))}
+        </div>
+
+        {availableChains.length > 0 && (
+          <Accordion defaultValue={['all-networks']}>
+            <AccordionItem value="all-networks" className="border-0">
+              <AccordionTrigger className="bg-muted/50 rounded-lg pl-4 pr-2 py-2 hover:no-underline text-muted-foreground cursor-pointer">
+                <Typography variant="paragraph-small-medium" className="text-muted-foreground">
+                  All networks
+                </Typography>
+              </AccordionTrigger>
+              <AccordionContent className="pb-0">
+                <div className="flex flex-col">
+                  {availableChains.map((chainItem) => (
+                    <button
+                      key={chainItem.chainId}
+                      onClick={() => handleAddNetworkClick(chainItem.chainId)}
+                      className="flex items-center justify-between px-2 py-2 rounded-lg w-full cursor-pointer hover:bg-muted/30 text-left"
+                      aria-label={`Add ${chainItem.chainName}`}
+                    >
+                      <div className="flex items-center gap-4">
+                        <ChainLogo chainId={chainItem.chainId} />
+                        <Typography variant="paragraph-small-medium" className="text-muted-foreground">
+                          {chainItem.chainName}
+                        </Typography>
+                      </div>
+                      <Plus className="size-4 shrink-0 text-muted-foreground" />
+                    </button>
+                  ))}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeItem.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeItem.tsx
@@ -15,7 +15,12 @@ const SafeItem = ({ name, address, threshold, owners, chains, balance, isLoading
 
   return (
     <div className={cn('flex items-center gap-3 w-full', isNested && 'pl-8')}>
-      <SafeInfoDisplay name={resolvedName} address={address} chainShortName={chainShortName} className="flex-1" />
+      <SafeInfoDisplay
+        name={resolvedName}
+        address={address}
+        chainShortName={chainShortName}
+        className="flex-1 min-w-0"
+      />
       <div className="flex items-center gap-2 bg-muted rounded-full p-0.5 shrink-0">
         {chains.slice(0, 3).map((chainItem, index) => (
           <span

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
@@ -21,8 +21,6 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
     selectedItem.address,
     chainShortName,
   )
-  const isSingleChain = selectedItem.chains.length <= 1
-
   return (
     <div className="flex items-center gap-2 sm:gap-4 w-full">
       <Avatar size="sm">
@@ -46,7 +44,7 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
         balance={selectedItem.balance}
         threshold={selectedItem.threshold}
         owners={selectedItem.owners}
-        showBalanceDisplay={isSingleChain}
+        showBalanceDisplay
       />
     </div>
   )

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/utils.ts
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/utils.ts
@@ -10,13 +10,18 @@ export const getInitials = (name: string): string => {
     .slice(0, 2)
 }
 
+const MAX_NAME_LENGTH = 20
+
+export const truncateName = (name: string, maxLength = MAX_NAME_LENGTH): string =>
+  name.length > maxLength ? `${name.slice(0, maxLength)}...` : name
+
 export const getSafeDisplayInfo = (
   name: string,
   address: string,
   chainShortName?: string,
 ): { addressWithPrefix: string; displayName: string; showAddressLine: boolean } => {
   const addressWithPrefix = formatPrefixedAddress(shortenAddress(address), chainShortName || undefined)
-  const displayName = name || addressWithPrefix
+  const displayName = name ? truncateName(name) : addressWithPrefix
   const showAddressLine = Boolean(name)
   return { addressWithPrefix, displayName, showAddressLine }
 }


### PR DESCRIPTION
## What it solves
https://linear.app/safe-global/issue/WA-1721/design-qa-dropdown-safe-selector
https://linear.app/safe-global/issue/WA-1732/navigation-component-truncate-the-address-name-if-its-too-long

Updates the chain selector in the Spaces safe bar to show all available networks (not just deployed ones), allowing users to add their Safe to new networks directly from the chain selector dropdown.

## How this PR fixes it

- Refactors `ChainSelectorBlock` to distinguish between `deployedChains` and `availableChains`, showing both in the dropdown with an expandable "All networks" accordion section
- Adds a `+` button for each available (non-deployed) network that triggers the `CreateSafeOnNewChain` dialog
- Updates `useSpaceChainSelector` hook to compute `availableChains`, `deployedChainIds`, `safeAddress`, and `safeName`
- Supports `defaultChainId` prop on `CreateSafeOnNewChain` to preselect the chain chosen by the user
- Always shows the chain selector dropdown (not just for multi-chain safes)
- Always shows balance display in the trigger content regardless of chain count
- Truncates long safe names (max 20 chars) in the dropdown display
- Adds margin to hover background and closes the dropdown when a network is selected
- Fixes min-width on `SafeInfoDisplay` to prevent text overflow

## How to test it

1. Open a Space with a Safe deployed on one or more chains
2. Click the chain selector in the safe bar — verify deployed chains appear at the top, and an "All networks" accordion lists undeployed chains
3. Click a deployed chain — verify navigation switches to that chain and the dropdown closes
4. Click the `+` on an available chain — verify the "Create Safe on new chain" dialog opens with that chain preselected
5. Verify long safe names are truncated with ellipsis in the dropdown

## Screenshots
<img width="631" height="435" alt="Screenshot 2026-03-18 at 16 13 46" src="https://github.com/user-attachments/assets/3bf83986-1bbc-4d1a-8668-a8bf07252a3d" />
<img width="518" height="579" alt="Screenshot 2026-03-18 at 16 14 14" src="https://github.com/user-attachments/assets/5551191e-f64d-4bb1-8349-4aba5bf01830" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
