### PR TITLE
fix(ci): build expo plugins after cached yarn install

### DIFF
--- a/.github/workflows/mobile-dev-release.yml
+++ b/.github/workflows/mobile-dev-release.yml
@@ -7,10 +7,12 @@ on:
     paths:
       - apps/mobile/**
       - packages/**
+      - expo-plugins/**
   pull_request:
     paths:
       - apps/mobile/**
       - packages/**
+      - expo-plugins/**
 
 jobs:
   build:

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - apps/mobile/**
       - packages/**
+      - expo-plugins/**
 
 jobs:
   build:


### PR DESCRIPTION
> Cache hit skips install,
> postinstall never fires —
> build the plugin first.

## What it solves

After #7469 switched mobile workflows to the shared `yarn` composite action, EAS builds fail with `Cannot find module './dist/plugin/withNotifee.js'`. The shared action skips `yarn install --immutable` on cache hits, which means the `notification-service-ios` plugin's `postinstall` build script never runs and its `dist/` directory is missing.

## How this PR fixes it

Adds an explicit `yarn workspace @safe-global/notification-service-ios build` step in the two EAS build workflows (`mobile-dev-release` and `mobile-e2e`) after the yarn action. This ensures the expo plugin is always compiled regardless of cache state.

## How to test it

1. Merge and verify the `mobile-dev-release` workflow triggers successfully on the next push to `dev`
2. The EAS build should start without the `Cannot find module` error

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).