### PR TITLE
fix(web/Spaces): sanitization of nested patterns

### DIFF
--- a/apps/web/src/components/ui/input.test.ts
+++ b/apps/web/src/components/ui/input.test.ts
@@ -43,6 +43,12 @@ describe('sanitizeInputValue', () => {
     expect(sanitizeInputValue('<SCRIPT>alert(1)</SCRIPT>')).toBe('')
     expect(sanitizeInputValue('<Script>alert(1)</Script>')).toBe('')
   })
+
+  it('should handle nested patterns that reconstruct after a single pass', () => {
+    expect(sanitizeInputValue('ononclickclick="steal()"')).toBe('')
+    expect(sanitizeInputValue('<scr<script></script>ipt>alert(1)</script>')).toBe('')
+    expect(sanitizeInputValue('ononloadload="malicious()"')).toBe('')
+  })
 })
 
 describe('containsScriptInjection', () => {

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -33,7 +33,15 @@ function containsScriptInjection(value: string): boolean {
 }
 
 function sanitizeInputValue(value: string): string {
-  return value.replace(SCRIPT_TAG_REGEX, '').replace(EVENT_HANDLER_REGEX, '')
+  let previous: string
+  let sanitized = value
+  do {
+    previous = sanitized
+    SCRIPT_TAG_REGEX.lastIndex = 0
+    EVENT_HANDLER_REGEX.lastIndex = 0
+    sanitized = sanitized.replace(SCRIPT_TAG_REGEX, '').replace(EVENT_HANDLER_REGEX, '')
+  } while (sanitized !== previous)
+  return sanitized
 }
 
 function stripChainPrefix(value: string): string {


### PR DESCRIPTION
## What it solves

Incomplete sanitization allowed nested patterns like `ononclickclick` to reconstruct event handlers after a single-pass regex replace.

## How this PR fixes it

`sanitizeInputValue` now loops until the string stabilizes, so nested bypass patterns are fully stripped.

## How to test it

New unit tests in `input.test.ts` cover the nested-pattern cases.

## Checklist

- [ ] I've tested the branch on mobile 📱 N/A
- [ ] I've documented how it affects the analytics (if at all) 📊 N/A
- [x] I've written a unit/e2e test for it 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
