### PR TITLE
fix(web/Spaces): restore NftsFeature export

### DIFF
--- a/apps/web/src/features/nfts/index.ts
+++ b/apps/web/src/features/nfts/index.ts
@@ -1,3 +1,9 @@
+import { createFeatureHandle } from '@/features/__core__'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import type { NftsContract } from './contract'
+
+export const NftsFeature = createFeatureHandle<NftsContract>('nfts', FEATURES.ERC721)
+
 export type { NftsContract } from './contract'
 
 export { default as NftsPage } from './components/NftsPage'


### PR DESCRIPTION
## What it solves

The epicSpaces branch dropped NftsFeature from nfts/index.ts as part of the spaces dashboard work (cdab94ddf). The dev branch then added a feature flag integration test that expects all features — including nfts — to export a createFeatureHandle handle.

After merging this fix, it will be possible to merge `dev` branch into epicSpaces with all tests passing.

## How this PR fixes it

Restores the three lines to match the most recent dev exactly.
Merging dev into epicSpaces brought the test without the export it depends on.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
