### PR TITLE
fix(web/Spaces): main header redirect

### DIFF
--- a/apps/web/src/components/common/Header/index.test.tsx
+++ b/apps/web/src/components/common/Header/index.test.tsx
@@ -8,7 +8,6 @@ import { render } from '@/tests/test-utils'
 import { faker } from '@faker-js/faker'
 import { screen, fireEvent } from '@testing-library/react'
 import { AppRoutes } from '@/config/routes'
-import { useRouter } from 'next/router'
 
 jest.mock(
   '@/components/common/SafeTokenWidget',
@@ -37,41 +36,9 @@ jest.mock('@/hooks/useIsOfficialHost', () => ({
 
 const mockUseLoadFeature = contracts.useLoadFeature as jest.Mock
 
-const mockRouter = (pathname: string, query: Record<string, string> = {}): ReturnType<typeof useRouter> =>
-  ({ pathname, query }) as unknown as ReturnType<typeof useRouter>
-
 describe('getLogoLink', () => {
-  const safeAddress = faker.finance.ethereumAddress()
-  const spaceId = 'space-1'
-
-  it('redirects to /welcome/accounts when on home page with a safe', () => {
-    const router = mockRouter(AppRoutes.home, { safe: safeAddress })
-    expect(getLogoLink(router)).toEqual(AppRoutes.welcome.accounts)
-  })
-
-  it('redirects to /welcome/accounts when on home page with a safe and a spaceId', () => {
-    const router = mockRouter(AppRoutes.home, { safe: safeAddress })
-    expect(getLogoLink(router, spaceId)).toEqual(AppRoutes.welcome.accounts)
-  })
-
-  it('redirects to home with safe when not on home page and safe is in query', () => {
-    const router = mockRouter(AppRoutes.transactions.history, { safe: safeAddress })
-    expect(getLogoLink(router)).toEqual({ pathname: AppRoutes.home, query: { safe: safeAddress } })
-  })
-
-  it('redirects to spaces when spaceId is set and no safe in query', () => {
-    const router = mockRouter(AppRoutes.welcome.accounts)
-    expect(getLogoLink(router, spaceId)).toEqual({ pathname: AppRoutes.spaces.index, query: { spaceId } })
-  })
-
-  it('redirects to /welcome/accounts when on welcome index with no safe or spaceId', () => {
-    const router = mockRouter(AppRoutes.welcome.index)
-    expect(getLogoLink(router)).toEqual(AppRoutes.welcome.accounts)
-  })
-
-  it('redirects to /welcome when already on /welcome/accounts with no safe or spaceId', () => {
-    const router = mockRouter(AppRoutes.welcome.accounts)
-    expect(getLogoLink(router)).toEqual(AppRoutes.welcome.index)
+  it('always redirects to /welcome/accounts', () => {
+    expect(getLogoLink()).toEqual(AppRoutes.welcome.accounts)
   })
 })
 

--- a/apps/web/src/components/common/Header/index.tsx
+++ b/apps/web/src/components/common/Header/index.tsx
@@ -25,25 +25,14 @@ import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
 import { useSafeTokenEnabled } from '@/hooks/useSafeTokenEnabled'
 import { useIsOfficialHost } from '@/hooks/useIsOfficialHost'
 import { BRAND_LOGO, BRAND_NAME } from '@/config/constants'
-import { useAppSelector } from '@/store'
-import { lastUsedSpace } from '@/store/authSlice'
 
 type HeaderProps = {
   onMenuToggle?: Dispatch<SetStateAction<boolean>>
   onBatchToggle?: Dispatch<SetStateAction<boolean>>
 }
 
-export function getLogoLink(router: ReturnType<typeof useRouter>, spaceId?: string | null): Url {
-  if (router.query.safe) {
-    if (router.pathname === AppRoutes.home) {
-      return AppRoutes.welcome.accounts
-    }
-    return { pathname: AppRoutes.home, query: { safe: router.query.safe } }
-  }
-  if (spaceId) {
-    return { pathname: AppRoutes.spaces.index, query: { spaceId } }
-  }
-  return router.pathname === AppRoutes.welcome.accounts ? AppRoutes.welcome.index : AppRoutes.welcome.accounts
+export function getLogoLink(): Url {
+  return AppRoutes.welcome.accounts
 }
 
 const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
@@ -55,10 +44,8 @@ const Header = ({ onMenuToggle, onBatchToggle }: HeaderProps): ReactElement => {
   const { BatchIndicator } = useLoadFeature(BatchingFeature)
   const { WalletConnectWidget } = useLoadFeature(WalletConnectFeature)
   const isOfficialHost = useIsOfficialHost()
-  const spaceId = useAppSelector(lastUsedSpace)
 
-  // If on the home page, the logo should link back to the space (if any), else to accounts
-  const logoHref = getLogoLink(router, spaceId)
+  const logoHref = getLogoLink()
 
   const handleMenuToggle = () => {
     if (onMenuToggle) {

--- a/apps/web/src/components/terms/safe-labs-terms.tsx
+++ b/apps/web/src/components/terms/safe-labs-terms.tsx
@@ -31,7 +31,7 @@ const SafeLabsTerms = () => {
 
   const canAccept = acceptTerms && acknowledgeLiability
 
-  const logoHref = getLogoLink(router)
+  const logoHref = getLogoLink()
 
   const handleAcceptAndContinue = () => {
     trackEvent({ ...TERMS_EVENTS.ACCEPT_SAFE_LABS_TERMS, label: requestDataTransfer }, { requestDataTransfer })


### PR DESCRIPTION
## What it solves
Resolves: [WA-1789](https://linear.app/safe-global/issue/WA-1789/broken-navigation-for-the-logo-after-space-was-deleted)
The logo in the main header was always redirecting to the Spaces on click.

## How this PR fixes it

Always redirects to `/welcome/accounts` on logo click in the header.

## How to test it
Open the app:
- On the Safe level: logo click redirects to `/welcome/accounts`
- On the Space level: logo click redirects to `/welcome/accounts`

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
