### PR TITLE
fix: adjust No Assets layout for Safes with TVL 0

### DIFF
--- a/apps/web/src/components/dashboard/Assets/index.tsx
+++ b/apps/web/src/components/dashboard/Assets/index.tsx
@@ -28,7 +28,9 @@ const MAX_ASSETS = 4
 
 const NoAssets = () => (
   <Paper elevation={0} sx={{ p: 5, textAlign: 'center' }}>
-    <NoAssetsIcon />
+    <Box display="flex" justifyContent="center">
+      <NoAssetsIcon />
+    </Box>
 
     <Typography mb={0.5} mt={3}>
       No assets yet


### PR DESCRIPTION
## What it solves

Resolves: [WA-1787](https://linear.app/safe-global/issue/WA-1787/regression-on-the-top-assets-for-safe-empty-icon-is-displaced)

Beacuse of introducing the new design system the layout of No Assets had regression.

## How this PR fixes it
Wrap the image in a `Box` for proper alignment.

## How to test it
Open a Safe with No Assets. The icon in the No Assets widget on the Home screen is aligned to the center.

## Screenshots

Before:
<img width="472" height="195" alt="image" src="https://github.com/user-attachments/assets/3fba1557-96bb-4799-84f4-642e84189f31" />

After: 
<img width="841" height="338" alt="image" src="https://github.com/user-attachments/assets/a10ae616-425d-4b58-85b6-0950008141b4" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 N/A
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 N/A

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
