### PR TITLE
fix(mobile): raise Android minSdkVersion to API 34 (Android 14)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -142,6 +142,7 @@ const config: ExpoConfig = {
           forceStaticLinking: ['RNFBApp'],
         },
         android: {
+          minSdkVersion: 34,
           extraMavenRepos: ['../../../../node_modules/@notifee/react-native/android/libs'],
         },
       },


### PR DESCRIPTION
> Raise the floor, trim the old,
> Android 14 takes hold.

## What it solves

Android officially supports only the last three major versions. Our minimum SDK was at the Expo default (API 24 / Android 7.0), which is far below the current support window. This raises it to API 34 (Android 14) to match Android's own compatibility policy.

Resolves: https://linear.app/safe-global/issue/WA-1589

## How this PR fixes it

Adds `minSdkVersion: 34` to the `expo-build-properties` Android config in `app.config.ts`. This is picked up by Expo prebuild to set the native Android project's minimum SDK.

## How to test it

1. Run `npx expo prebuild --platform android --clean`
2. Open `android/build.gradle` and verify `minSdkVersion` is `34`
3. Build the Android app and confirm it targets API 34+

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).