### PR TITLE
fix: delete the z-index

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
@@ -40,7 +40,7 @@ function SafeSelectorDropdown({ items, selectedItemId, onItemSelect, isError, on
       >
         <SelectTrigger
           className={cn(
-            '-m-4 flex-1 border-0 shadow-none bg-transparent dark:bg-transparent py-0 pl-6 hover:bg-transparent dark:hover:bg-transparent data-[state=open]:bg-transparent [&_[data-slot=select-value]]:pr-0 relative z-10',
+            '-m-4 flex-1 border-0 shadow-none bg-transparent dark:bg-transparent py-0 pl-6 hover:bg-transparent dark:hover:bg-transparent data-[state=open]:bg-transparent [&_[data-slot=select-value]]:pr-0 relative',
             variants.triggerClass,
           )}
           size="default"


### PR DESCRIPTION
## What it solves

Resolves:
https://linear.app/safe-global/issue/WA-1790/safe-selector-is-broken-on-the-recovery-screen

## How this PR fixes it
delete the z-index the hide it behind the modal

## How to test it
go to recovery account 

## Screenshots
<img width="1044" height="681" alt="Screenshot 2026-03-19 at 15 18 50" src="https://github.com/user-attachments/assets/2327e23a-612e-4488-817e-020309ec40c0" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
