### PR TITLE
feat: add local safe name to space account

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountsWidget/AccountItemContent.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/AccountItemContent.tsx
@@ -5,7 +5,6 @@ import type { Account } from './types'
 import Identicon from '@/components/common/Identicon'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import { Avatar } from '@/components/ui/avatar'
-import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
 
 interface AccountItemContentProps {
   account: Account
@@ -13,9 +12,6 @@ interface AccountItemContentProps {
 }
 
 const AccountItemContent = ({ account, children }: AccountItemContentProps): ReactElement => {
-  const chainId = account.safes[0]?.chainId ?? ''
-  const displayName = useSafeDisplayName(account.address, chainId, account.name) || shortenAddress(account.address)
-
   return (
     <>
       <div className="flex min-w-0 flex-1 items-center gap-4">
@@ -23,7 +19,7 @@ const AccountItemContent = ({ account, children }: AccountItemContentProps): Rea
           <Identicon address={account.address} size={40} />
         </Avatar>
         <div className="flex min-w-0 flex-col gap-0.5 text-left">
-          <Typography variant="paragraph-bold">{displayName}</Typography>
+          <Typography variant="paragraph-bold">{account.name}</Typography>
           <Typography variant="paragraph-mini" color="muted">
             {shortenAddress(account.address, 4)}
           </Typography>

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/AccountWidgetItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/AccountWidgetItem.tsx
@@ -8,7 +8,6 @@ import { AccountItem } from '../AccountItem'
 import type { Account } from './types'
 import Identicon from '@/components/common/Identicon'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
-import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
 
 interface AccountWidgetItemProps {
   account: Account
@@ -17,14 +16,11 @@ interface AccountWidgetItemProps {
 }
 
 const AccountWidgetItem = ({ account, loading = false, onItemClick }: AccountWidgetItemProps): ReactElement => {
-  const chainId = account.safes[0]?.chainId ?? ''
-  const displayName = useSafeDisplayName(account.address, chainId, account.name) || shortenAddress(account.address)
-
   return (
     <WidgetItem
       href={account.href}
       onClick={onItemClick ? () => onItemClick(account.address) : undefined}
-      label={<Typography variant="paragraph-bold">{displayName}</Typography>}
+      label={<Typography variant="paragraph-bold">{account.name}</Typography>}
       info={
         <Typography variant="paragraph-mini" color="muted">
           {shortenAddress(account.address, 4)}

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
@@ -12,14 +12,6 @@ jest.mock('@/services/analytics', () => ({
   trackEvent: jest.fn(),
 }))
 
-const mockUseSafeDisplayName = jest.fn(
-  (_address: string, _chainId: string, preferredName?: string) => preferredName || '',
-)
-
-jest.mock('@/hooks/useSafeDisplayName', () => ({
-  useSafeDisplayName: (...args: [string, string, string?]) => mockUseSafeDisplayName(...args),
-}))
-
 const mockSafeItem = (chainId: string, address: string): SafeItem => ({
   chainId,
   address,
@@ -299,7 +291,7 @@ describe('AccountsWidget', () => {
   })
 })
 
-describe('AccountsWidget – display name fallback', () => {
+describe('AccountsWidget – display name', () => {
   const address = '0x1234567890abcdef1234567890abcdef12345678'
 
   const makeAccount = (name: string): Account => ({
@@ -311,39 +303,15 @@ describe('AccountsWidget – display name fallback', () => {
     owners: '1/1',
   })
 
-  beforeEach(() => {
-    mockUseSafeDisplayName.mockClear()
+  it('displays the resolved name from account.name', () => {
+    render(<AccountsWidget accounts={[makeAccount('My Safe')]} />)
+
+    expect(screen.getByText('My Safe')).toBeInTheDocument()
   })
 
-  it('displays cloud name when available', () => {
-    mockUseSafeDisplayName.mockReturnValue('Cloud Name')
-
-    render(<AccountsWidget accounts={[makeAccount('Cloud Name')]} />)
-
-    expect(screen.getByText('Cloud Name')).toBeInTheDocument()
-  })
-
-  it('displays local name when cloud name is empty', () => {
-    mockUseSafeDisplayName.mockReturnValue('Local Name')
-
-    render(<AccountsWidget accounts={[makeAccount('')]} />)
-
-    expect(screen.getByText('Local Name')).toBeInTheDocument()
-  })
-
-  it('displays shortened address when both cloud and local names are empty', () => {
-    mockUseSafeDisplayName.mockReturnValue('')
-
-    render(<AccountsWidget accounts={[makeAccount('')]} />)
+  it('displays shortened address when name is a short address', () => {
+    render(<AccountsWidget accounts={[makeAccount('0x1234...5678')]} />)
 
     expect(screen.getAllByText('0x1234...5678')).toHaveLength(2)
-  })
-
-  it('calls useSafeDisplayName with address, chainId, and preferred name', () => {
-    mockUseSafeDisplayName.mockReturnValue('Cloud Name')
-
-    render(<AccountsWidget accounts={[makeAccount('Cloud Name')]} />)
-
-    expect(mockUseSafeDisplayName).toHaveBeenCalledWith(address, '1', 'Cloud Name')
   })
 })

--- a/apps/web/src/features/myAccounts/hooks/useSpaceAccountsData.ts
+++ b/apps/web/src/features/myAccounts/hooks/useSpaceAccountsData.ts
@@ -3,6 +3,7 @@ import useChains from '@/hooks/useChains'
 import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
+import { type AddressBookState, selectAllAddressBooks } from '@/store/addressBookSlice'
 import useWallet from '@/hooks/wallets/useWallet'
 import {
   isMultiChainSafeItem,
@@ -15,9 +16,18 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { skipToken } from '@reduxjs/toolkit/query'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import { AppRoutes } from '@/config/routes'
 import type { Account, SubAccount } from '../components/AccountsWidget/types'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
+
+const getLocalName = (address: string, safes: SafeItem[], localAddressBooks: AddressBookState): string => {
+  for (const safe of safes) {
+    const name = localAddressBooks[safe.chainId]?.[address]
+    if (name) return name
+  }
+  return ''
+}
 
 const getSafeHref = (chain: Chain | undefined, address: string): string => {
   const shortName = chain?.shortName ?? ''
@@ -28,6 +38,7 @@ const formatMultichainAccount = (
   safe: MultiChainSafeItem,
   chainMap: Map<string, Chain>,
   overviews: SafeOverview[] | undefined,
+  localAddressBooks: AddressBookState,
 ): Account => {
   const safeOverviews =
     overviews?.filter(
@@ -37,7 +48,7 @@ const formatMultichainAccount = (
   const totalFiat = safeOverviews.reduce((sum, overview) => sum + parseFloat(overview.fiatTotal || '0'), 0)
   const firstOverview = safeOverviews[0]
   const firstChain = chainMap.get(safe.safes[0]?.chainId)
-  const name = safe.name || ''
+  const name = safe.name || getLocalName(safe.address, safe.safes, localAddressBooks) || shortenAddress(safe.address)
 
   const subAccounts: SubAccount[] = safe.safes.map((s) => {
     const chain = chainMap.get(s.chainId)
@@ -64,11 +75,12 @@ const formatSingleSafe = (
   safe: SafeItem,
   chainMap: Map<string, Chain>,
   overviews: SafeOverview[] | undefined,
+  localAddressBooks: AddressBookState,
 ): Account => {
   const chain = chainMap.get(safe.chainId)
   const overview = overviews?.find((o) => sameAddress(o.address.value, safe.address) && o.chainId === safe.chainId)
 
-  const name = safe.name || ''
+  const name = safe.name || localAddressBooks[safe.chainId]?.[safe.address] || shortenAddress(safe.address)
 
   return {
     name,
@@ -84,6 +96,7 @@ const useSpaceAccountsData = (safes: AllSafeItems) => {
   const { configs: chains } = useChains()
   const currency = useAppSelector(selectCurrency)
   const wallet = useWallet()
+  const localAddressBooks = useAppSelector(selectAllAddressBooks)
 
   const flatSafes = useMemo(() => flattenSafeItems(safes), [safes])
 
@@ -101,12 +114,12 @@ const useSpaceAccountsData = (safes: AllSafeItems) => {
 
     return safes.map((safe): Account => {
       if (isMultiChainSafeItem(safe)) {
-        return formatMultichainAccount(safe, chainMap, overviews)
+        return formatMultichainAccount(safe, chainMap, overviews, localAddressBooks)
       }
 
-      return formatSingleSafe(safe, chainMap, overviews)
+      return formatSingleSafe(safe, chainMap, overviews, localAddressBooks)
     })
-  }, [safes, overviews, chains])
+  }, [safes, overviews, chains, localAddressBooks])
 
   return { accounts, isLoading: isFetching, error: error ? getRtkQueryErrorMessage(error) : undefined, refetch }
 }


### PR DESCRIPTION
## What it solves
https://linear.app/safe-global/issue/WA-1793/fix-displaying-account-name-no-displaying-address-twice
In the Space Dashboard's Accounts widget, Safe accounts without a cloud (Space address book) name only showed a shortened address. Users who had named these Safes in their local address book expected to see those names as a fallback.

## How this PR fixes it

- **`Dashboard/Page.tsx`**: Changed `AddressBookSourceProvider` source from `"spaceOnly"` to `"merged"`, allowing `useAddressBookItem` to resolve local address book names.
- **`useSpaceAccountsData.ts`**: Removed the `shortenAddress` fallback at the data layer (`safe.name || shortenAddress(...)` → `safe.name || ''`), delegating name resolution to the rendering layer.
- **`AccountWidgetItem.tsx` / `AccountItemContent.tsx`**: Added `useSafeDisplayName` hook to resolve display names with the priority: **cloud name → local name → shortened address**.
- **`AccountsWidget.test.tsx`**: Added 4 tests covering the name fallback behavior.

**Name priority**: Space address book (cloud) > Local address book > Shortened address

## How to test it

1. Open a Space Dashboard (`/spaces?spaceId=<id>`)
2. Ensure one of the Safes in the Space has a **local** address book name but **no** Space (cloud) name
3. Verify the Accounts widget shows the local name instead of just the shortened address
4. Verify Safes with a cloud name still show the cloud name (cloud takes priority)
5. Verify Safes with neither name show the shortened address

## Screenshots
<img width="1511" height="712" alt="Screenshot 2026-03-19 at 17 49 51" src="https://github.com/user-attachments/assets/6284213b-0299-4b67-8833-d13d17f774a4" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

