### PR TITLE
feat: add Tempo chain integration 

### DIFF
--- a/apps/web/src/components/balances/TotalAssetValue/index.tsx
+++ b/apps/web/src/components/balances/TotalAssetValue/index.tsx
@@ -5,6 +5,8 @@ import TokenAmount from '@/components/common/TokenAmount'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useVisibleBalances } from '@/hooks/useVisibleBalances'
 import { InfoTooltip } from '@/components/common/InfoTooltip'
+import { useNativeTokenDisplay } from '@/hooks/useNativeTokenDisplay'
+import { TokenType } from '@safe-global/store/gateway/types'
 
 const TotalAssetValue = ({
   fiatTotal,
@@ -22,6 +24,11 @@ const TotalAssetValue = ({
   const fontSizeValue = size === 'lg' ? '44px' : '24px'
   const { safe } = useSafeInfo()
   const { balances } = useVisibleBalances()
+  const { showUndeployedNativeValue } = useNativeTokenDisplay()
+  const shouldHideNativeTokenValue = !safe.deployed && !showUndeployedNativeValue
+  const hasOtherBalances =
+    balances.items.length > 1 ||
+    (balances.items.length === 1 && balances.items[0]?.tokenInfo.type !== TokenType.NATIVE_TOKEN)
 
   return (
     <Box>
@@ -38,6 +45,12 @@ const TotalAssetValue = ({
               </>
             ) : (
               <Skeleton variant="text" width={60} />
+            )
+          ) : shouldHideNativeTokenValue ? (
+            hasOtherBalances ? (
+              <FiatValue value={fiatTotal ?? '0'} precise />
+            ) : (
+              <FiatValue value="0" precise />
             )
           ) : (
             <TokenAmount

--- a/apps/web/src/components/common/WalletInfo/index.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.tsx
@@ -14,6 +14,7 @@ import useChainId from '@/hooks/useChainId'
 import { useAuthLogoutV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
 import { setUnauthenticated } from '@/store/authSlice'
 import { logError, Errors } from '@/services/exceptions'
+import { getNativeTokenDisplay, NATIVE_TOKEN_DISPLAY_DEFAULT } from '@safe-global/utils/utils/chains'
 
 type WalletInfoProps = {
   wallet: ConnectedWallet
@@ -40,6 +41,7 @@ export const WalletInfo = ({
   const dispatch = useAppDispatch()
   const chainInfo = useChain(wallet.chainId)
   const prefix = chainInfo?.shortName
+  const { showWalletBalance } = chainInfo ? getNativeTokenDisplay(chainInfo) : NATIVE_TOKEN_DISPLAY_DEFAULT
 
   const handleSwitchWallet = () => {
     if (onboard) {
@@ -90,22 +92,24 @@ export const WalletInfo = ({
           <Typography variant="body2">{wallet.label}</Typography>
         </Box>
 
-        <Box className={css.row}>
-          <Typography variant="body2" color="primary.light">
-            Balance
-          </Typography>
-          <Typography variant="body2" textAlign="right">
-            <WalletBalance balance={balance} />
+        {showWalletBalance && (
+          <Box className={css.row}>
+            <Typography variant="body2" color="primary.light">
+              Balance
+            </Typography>
+            <Typography variant="body2" textAlign="right">
+              <WalletBalance balance={balance} />
 
-            {currentChainId !== chainInfo?.chainId && (
-              <>
-                <Typography variant="body2" color="primary.light">
-                  ({chainInfo?.chainName || 'Unknown chain'})
-                </Typography>
-              </>
-            )}
-          </Typography>
-        </Box>
+              {currentChainId !== chainInfo?.chainId && (
+                <>
+                  <Typography variant="body2" color="primary.light">
+                    ({chainInfo?.chainName || 'Unknown chain'})
+                  </Typography>
+                </>
+              )}
+            </Typography>
+          </Box>
+        )}
       </Box>
 
       <Box display="flex" flexDirection="column" gap={2} width={1}>

--- a/apps/web/src/components/common/WalletOverview/index.tsx
+++ b/apps/web/src/components/common/WalletOverview/index.tsx
@@ -8,6 +8,7 @@ import WalletIcon from '@/components/common/WalletIcon'
 import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { useChain } from '@/hooks/useChains'
 import WalletBalance from '@/components/common/WalletBalance'
+import { getNativeTokenDisplay, NATIVE_TOKEN_DISPLAY_DEFAULT } from '@safe-global/utils/utils/chains'
 
 import css from './styles.module.css'
 
@@ -35,6 +36,7 @@ const WalletOverview = ({
 }): ReactElement => {
   const walletChain = useChain(wallet.chainId)
   const prefix = walletChain?.shortName
+  const { showWalletBalance } = walletChain ? getNativeTokenDisplay(walletChain) : NATIVE_TOKEN_DISPLAY_DEFAULT
 
   return (
     <Box className={css.container}>
@@ -56,7 +58,7 @@ const WalletOverview = ({
           )}
         </Typography>
 
-        {showBalance && (
+        {showBalance && showWalletBalance && (
           <Typography variant="caption" component="div" fontWeight="bold" display={{ xs: 'none', sm: 'block' }}>
             <WalletBalance balance={balance} />
           </Typography>

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -67,7 +67,12 @@ import { AppRoutes } from '@/config/routes'
 import type { CreateSafeResult, ReplayedSafeProps } from '@safe-global/utils/features/counterfactual/store/types'
 import { createWeb3ReadOnly } from '@/hooks/wallets/web3'
 import { updateAddressBook } from '../../logic/address-book'
-import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
+import {
+  FEATURES,
+  hasFeature,
+  getNativeTokenDisplay,
+  NATIVE_TOKEN_DISPLAY_DEFAULT,
+} from '@safe-global/utils/utils/chains'
 import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
 import { type TransactionOptions } from '@safe-global/types-kit'
 import { getTotalFeeFormatted } from '@safe-global/utils/hooks/useDefaultGasPrice'
@@ -183,6 +188,9 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
   const [submitError, setSubmitError] = useState<string>()
   const isCounterfactualEnabled = useHasFeature(FEATURES.COUNTERFACTUAL)
   const isEIP1559 = chain && hasFeature(chain, FEATURES.EIP1559)
+  const { showGasFeeEstimation, showInsufficientFundsWarning, showFeeInConfirmationText } = chain
+    ? getNativeTokenDisplay(chain)
+    : NATIVE_TOKEN_DISPLAY_DEFAULT
 
   const ownerAddresses = useMemo(() => data.owners.map((owner) => owner.address), [data.owners])
   const [minRelays] = useLeastRemainingRelays(ownerAddresses)
@@ -448,9 +456,15 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
                     mt: 2,
                   }}
                 >
-                  You will have to confirm a transaction and pay an estimated fee of{' '}
-                  <NetworkFee totalFee={totalFee} isWaived={willRelay} chain={chain} inline /> with your connected
-                  wallet
+                  {!showFeeInConfirmationText ? (
+                    'You will have to confirm a transaction with your connected wallet'
+                  ) : (
+                    <>
+                      You will have to confirm a transaction and pay an estimated fee of{' '}
+                      <NetworkFee totalFee={totalFee} isWaived={willRelay} chain={chain} inline /> with your connected
+                      wallet
+                    </>
+                  )}
                 </Typography>
               </Grid>
             )}
@@ -483,32 +497,34 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
               </Grid>
             )}
 
-            <Grid data-testid="network-fee-section" container spacing={3}>
-              <ReviewRow
-                name="Est. network fee"
-                value={
-                  <>
-                    <NetworkFee totalFee={totalFee} isWaived={willRelay} chain={chain} />
+            {showGasFeeEstimation && (
+              <Grid data-testid="network-fee-section" container spacing={3}>
+                <ReviewRow
+                  name="Est. network fee"
+                  value={
+                    <>
+                      <NetworkFee totalFee={totalFee} isWaived={willRelay} chain={chain} />
 
-                    {!willRelay && (
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          color: 'text.secondary',
-                          mt: 1,
-                        }}
-                      >
-                        You will have to confirm a transaction with your connected wallet.
-                      </Typography>
-                    )}
-                  </>
-                }
-              />
-            </Grid>
+                      {!willRelay && (
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: 'text.secondary',
+                            mt: 1,
+                          }}
+                        >
+                          You will have to confirm a transaction with your connected wallet.
+                        </Typography>
+                      )}
+                    </>
+                  }
+                />
+              </Grid>
+            )}
 
             {showNetworkWarning && <NetworkWarning action="create a Safe Account" />}
 
-            {!walletCanPay && !willRelay && (
+            {!walletCanPay && !willRelay && showInsufficientFundsWarning && (
               <ErrorMessage>
                 Your connected wallet doesn&apos;t have enough funds to execute this transaction
               </ErrorMessage>

--- a/apps/web/src/components/settings/FeeTokenPreference/index.tsx
+++ b/apps/web/src/components/settings/FeeTokenPreference/index.tsx
@@ -1,0 +1,365 @@
+import { useState, useEffect } from 'react'
+import {
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  InputAdornment,
+  MenuItem,
+  Select,
+  Typography,
+  Alert,
+  Paper,
+  Grid,
+} from '@mui/material'
+import useWallet from '@/hooks/wallets/useWallet'
+import { useWeb3ReadOnly } from '@/hooks/wallets/web3'
+import { ERC20__factory } from '@safe-global/utils/types/contracts'
+import { multicall } from '@safe-global/utils/utils/multicall'
+import { getERC20TokenInfoOnChain } from '@/utils/tokens'
+import useAsync from '@safe-global/utils/hooks/useAsync'
+import { Interface } from 'ethers'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
+import { isWalletRejection } from '@/utils/wallets'
+import { didRevert, didReprice, type EthersError } from '@/utils/ethers-utils'
+import type { Erc20Token } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
+
+// TODO: move to external source to prevent code edits
+const TEMPO_FEE_TOKENS = [
+  { name: 'PathUSD', address: '0x20c0000000000000000000000000000000000000' as `0x${string}` },
+  { name: 'AlphaUSD', address: '0x20c0000000000000000000000000000000000001' as `0x${string}` },
+  { name: 'BetaUSD', address: '0x20c0000000000000000000000000000000000002' as `0x${string}` },
+  { name: 'ThetaUSD', address: '0x20c0000000000000000000000000000000000003' as `0x${string}` },
+] as const
+
+type TokenWithBalance = Erc20Token & {
+  balance: bigint
+}
+
+// Read more: https://docs.tempo.xyz/protocol/transactions/spec-tempo-transaction#fee-payer-signature
+const FEE_PRECOMPILE_ADDRESS = '0xfeec000000000000000000000000000000000000' as `0x${string}`
+
+const FEE_PRECOMPILE_ABI = [
+  'function setUserToken(address token)',
+  'function userTokens(address user) view returns (address)',
+] as const
+
+const feePrecompile_interface = new Interface(FEE_PRECOMPILE_ABI)
+
+const FEE_TOKEN_ERRORS = {
+  FAILED_TO_FETCH_PREFERENCE: 'Failed to fetch current preference',
+  PLEASE_SELECT_TOKEN: 'Please select a token',
+  TRANSACTION_FAILED: 'Transaction failed',
+  TRANSACTION_REJECTED: 'Transaction rejected',
+  FAILED_TO_UPDATE: 'Failed to update preference. Please try again.',
+} as const
+
+const useTempoFeeTokenBalances = () => {
+  const wallet = useWallet()
+  const web3ReadOnly = useWeb3ReadOnly()
+  const walletAddress = wallet?.address
+
+  return useAsync<TokenWithBalance[]>(async () => {
+    if (!web3ReadOnly || !walletAddress) {
+      return []
+    }
+
+    const tokenAddresses = TEMPO_FEE_TOKENS.map((token) => token.address)
+
+    const tokenInfos = await getERC20TokenInfoOnChain(tokenAddresses)
+    if (!tokenInfos) {
+      return []
+    }
+
+    const erc20Interface = ERC20__factory.createInterface()
+    const balanceCalls = tokenAddresses.map((address) => ({
+      to: address,
+      data: erc20Interface.encodeFunctionData('balanceOf', [walletAddress]),
+    }))
+
+    const balanceResults = await multicall(web3ReadOnly, balanceCalls)
+
+    const balances: TokenWithBalance[] = []
+    for (let i = 0; i < TEMPO_FEE_TOKENS.length; i++) {
+      const token = TEMPO_FEE_TOKENS[i]
+      const tokenInfo = tokenInfos.find((info) => info.address.toLowerCase() === token.address.toLowerCase())
+      const balanceResult = balanceResults[i]
+
+      if (tokenInfo && balanceResult?.success) {
+        balances.push({
+          ...tokenInfo,
+          name: token.name,
+          logoUri: '',
+          type: 'ERC20',
+          balance: BigInt(balanceResult.returnData),
+        })
+      }
+    }
+
+    return balances
+  }, [web3ReadOnly, walletAddress])
+}
+
+const useTempoUserPreference = () => {
+  const wallet = useWallet()
+  const web3ReadOnly = useWeb3ReadOnly()
+  const walletAddress = wallet?.address
+
+  return useAsync<`0x${string}` | null>(
+    async () => {
+      if (!web3ReadOnly || !walletAddress) {
+        return null
+      }
+
+      try {
+        const data = feePrecompile_interface.encodeFunctionData('userTokens', [walletAddress])
+
+        const result = await web3ReadOnly.call({
+          to: FEE_PRECOMPILE_ADDRESS,
+          data,
+        })
+
+        if (result === '0x' || result === '0x0000000000000000000000000000000000000000000000000000000000000000') {
+          return null
+        }
+
+        const address = feePrecompile_interface.decodeFunctionResult('userTokens', result)[0] as string
+
+        if (address && address !== '0x0000000000000000000000000000000000000000') {
+          const normalizedAddress = address.toLowerCase() as `0x${string}`
+          const isValidToken = TEMPO_FEE_TOKENS.some((token) => token.address.toLowerCase() === normalizedAddress)
+          return isValidToken ? normalizedAddress : null
+        }
+
+        return null
+      } catch (e: unknown) {
+        const err = e as { code?: string; reason?: string }
+        const isRevert = err?.code === 'CALL_EXCEPTION' || err?.reason?.includes('reverted')
+        if (!isRevert) {
+          throw e
+        }
+        return null
+      }
+    },
+    [web3ReadOnly, walletAddress],
+    false,
+  )
+}
+
+export const FeeTokenPreference = () => {
+  const wallet = useWallet()
+  const web3ReadOnly = useWeb3ReadOnly()
+  const isEnabled = useHasFeature(FEATURES.TEMPO_GAS_TOKEN)
+  const [balances, , loadingBalances] = useTempoFeeTokenBalances()
+  const [currentPreference, preferenceError, loadingPreference] = useTempoUserPreference()
+  const [selectedToken, setSelectedToken] = useState<`0x${string}` | ''>('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string>()
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    if (wallet?.address) {
+      setSelectedToken('')
+      setError(undefined)
+      setSuccess(false)
+    }
+  }, [wallet?.address])
+
+  useEffect(() => {
+    if (currentPreference && !selectedToken) {
+      setSelectedToken(currentPreference)
+    }
+  }, [currentPreference, selectedToken])
+
+  useEffect(() => {
+    if (preferenceError) {
+      setError(FEE_TOKEN_ERRORS.FAILED_TO_FETCH_PREFERENCE)
+    }
+  }, [preferenceError])
+
+  if (!isEnabled) {
+    return null
+  }
+
+  const tokenOptions = TEMPO_FEE_TOKENS.map((token) => {
+    const tokenBalance = balances?.find((b) => b.address === token.address)
+    return {
+      ...token,
+      balance: tokenBalance?.balance ?? 0n,
+      decimals: tokenBalance?.decimals ?? 18,
+    }
+  })
+
+  const handleSave = async () => {
+    if (!selectedToken || !wallet?.address || !wallet?.provider || !web3ReadOnly) {
+      setError(FEE_TOKEN_ERRORS.PLEASE_SELECT_TOKEN)
+      return
+    }
+
+    setSaving(true)
+    setError(undefined)
+    setSuccess(false)
+
+    try {
+      const data = feePrecompile_interface.encodeFunctionData('setUserToken', [selectedToken as `0x${string}`])
+
+      const txHash = await wallet.provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from: wallet.address,
+            to: FEE_PRECOMPILE_ADDRESS,
+            data,
+            value: '0x0',
+            // @ts-ignore - feeToken override for this transaction
+            feeToken: selectedToken as `0x${string}`,
+          },
+        ],
+      })
+
+      try {
+        const receipt = await web3ReadOnly.waitForTransaction(txHash as string)
+
+        if (!receipt) {
+          setError(FEE_TOKEN_ERRORS.TRANSACTION_FAILED)
+        } else if (didRevert(receipt)) {
+          setError(FEE_TOKEN_ERRORS.TRANSACTION_FAILED)
+        } else {
+          setSuccess(true)
+        }
+      } catch (waitError: unknown) {
+        const error = waitError as EthersError
+        if (didReprice(error)) {
+          setSuccess(true)
+        } else {
+          const msg = (waitError as { message?: string })?.message
+          setError(msg || FEE_TOKEN_ERRORS.TRANSACTION_FAILED)
+        }
+      }
+    } catch (err: unknown) {
+      const castErr = err as EthersError
+      if (isWalletRejection(castErr)) {
+        setError(FEE_TOKEN_ERRORS.TRANSACTION_REJECTED)
+      } else {
+        setError(castErr?.message || FEE_TOKEN_ERRORS.FAILED_TO_UPDATE)
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const loading = loadingBalances || loadingPreference
+
+  return (
+    <Paper data-testid="fee-token-preference-section" sx={{ padding: 4, mt: 2 }}>
+      <Grid
+        container
+        direction="row"
+        spacing={3}
+        sx={{
+          justifyContent: 'space-between',
+        }}
+      >
+        <Grid item lg={4} xs={12}>
+          <Typography
+            variant="h4"
+            sx={{
+              fontWeight: 700,
+            }}
+          >
+            Fee token preference
+          </Typography>
+        </Grid>
+
+        <Grid item xs>
+          {wallet ? (
+            <Box>
+              <Typography mb={3}>
+                Select your preferred token for paying transaction fees on Tempo. This preference will be used for all
+                future transactions for the connected wallet.
+              </Typography>
+
+              {error && (
+                <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(undefined)}>
+                  {error}
+                </Alert>
+              )}
+
+              {success && (
+                <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess(false)}>
+                  Fee token preference updated successfully!
+                </Alert>
+              )}
+
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <InputLabel id="fee-token-label">Fee token</InputLabel>
+                <Select
+                  labelId="fee-token-label"
+                  label="Fee token"
+                  value={loading ? '' : selectedToken || ''}
+                  onChange={(e) => {
+                    setSelectedToken(e.target.value as `0x${string}`)
+                    setSuccess(false)
+                  }}
+                  disabled={loading || saving}
+                  startAdornment={
+                    loading ? (
+                      <InputAdornment position="start">
+                        <CircularProgress size={20} />
+                      </InputAdornment>
+                    ) : undefined
+                  }
+                >
+                  {loading && (
+                    <MenuItem disabled>
+                      <Box display="flex" alignItems="center" gap={1}>
+                        <CircularProgress size={16} />
+                        <Typography>Loading...</Typography>
+                      </Box>
+                    </MenuItem>
+                  )}
+                  {!loading &&
+                    tokenOptions.map((token) => {
+                      const balanceStr = formatVisualAmount(token.balance.toString(), token.decimals)
+
+                      return (
+                        <MenuItem key={token.address} value={token.address}>
+                          <Box display="flex" justifyContent="space-between" width="100%">
+                            <Typography>{token.name}</Typography>
+                            <Typography variant="body2" color="text.secondary">
+                              Balance: {balanceStr}
+                            </Typography>
+                          </Box>
+                        </MenuItem>
+                      )
+                    })}
+                </Select>
+              </FormControl>
+
+              <Button
+                variant="contained"
+                onClick={handleSave}
+                disabled={!selectedToken || saving || loading}
+                sx={{ minWidth: 120 }}
+              >
+                {saving ? (
+                  <>
+                    <CircularProgress size={16} sx={{ mr: 1 }} />
+                    Saving...
+                  </>
+                ) : (
+                  'Save preference'
+                )}
+              </Button>
+            </Box>
+          ) : (
+            <Typography>Please connect your wallet to configure fee token preference.</Typography>
+          )}
+        </Grid>
+      </Grid>
+    </Paper>
+  )
+}

--- a/apps/web/src/components/sidebar/SidebarHeader/SafeHeaderInfo.tsx
+++ b/apps/web/src/components/sidebar/SidebarHeader/SafeHeaderInfo.tsx
@@ -3,6 +3,8 @@ import Typography from '@mui/material/Typography'
 import Skeleton from '@mui/material/Skeleton'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { useNativeTokenDisplay } from '@/hooks/useNativeTokenDisplay'
+import { TokenType } from '@safe-global/store/gateway/types'
 import SafeIcon from '@/components/common/SafeIcon'
 import TokenAmount from '@/components/common/TokenAmount'
 import EthHashInfo from '@/components/common/EthHashInfo'
@@ -24,6 +26,11 @@ const SafeHeaderInfo = (): ReactElement => {
   const { ens } = useAddressResolver(safeAddress)
   const { SafeHeaderHnTooltip } = useLoadFeature(HypernativeFeature)
   const { isHypernativeGuard } = useIsHypernativeGuard()
+  const { showUndeployedNativeValue } = useNativeTokenDisplay()
+  const shouldHideNativeTokenValue = !safe.deployed && !showUndeployedNativeValue
+  const hasOtherBalances =
+    balances.items.length > 1 ||
+    (balances.items.length === 1 && balances.items[0]?.tokenInfo.type !== TokenType.NATIVE_TOKEN)
 
   return (
     <div data-testid="safe-header-info" className={css.safe}>
@@ -60,6 +67,12 @@ const SafeHeaderInfo = (): ReactElement => {
               </>
             ) : (
               <Skeleton variant="text" width={60} />
+            )
+          ) : shouldHideNativeTokenValue ? (
+            hasOtherBalances ? (
+              <FiatValue value={balances.fiatTotal} />
+            ) : (
+              <FiatValue value="0" />
             )
           ) : (
             <TokenAmount

--- a/apps/web/src/components/tx-flow/flows/TokenTransfer/utils.ts
+++ b/apps/web/src/components/tx-flow/flows/TokenTransfer/utils.ts
@@ -6,6 +6,8 @@ import { type Balances } from '@safe-global/store/gateway/AUTO_GENERATED/balance
 import { useTrustedTokenBalances } from '@/hooks/loadables/useTrustedTokenBalances'
 import useHiddenTokens from '@/hooks/useHiddenTokens'
 import { useMemo } from 'react'
+import { useNativeTokenDisplay } from '@/hooks/useNativeTokenDisplay'
+import { TokenType } from '@safe-global/store/gateway/types'
 
 export const useTokenAmount = (selectedToken: Balances['items'][0] | undefined) => {
   const spendingLimit = useSpendingLimit(selectedToken?.tokenInfo)
@@ -25,13 +27,18 @@ export const useVisibleTokens = () => {
   const spendingLimits = useAppSelector(selectSpendingLimits)
   const wallet = useWallet()
   const hiddenTokens = useHiddenTokens()
+  const { showNativeInBalances } = useNativeTokenDisplay()
 
   return useMemo(() => {
     if (!balances) {
       return []
     }
 
-    const items = filterHiddenTokens(balances.items, hiddenTokens)
+    let items = filterHiddenTokens(balances.items, hiddenTokens)
+
+    if (!showNativeInBalances) {
+      items = items.filter((item) => item.tokenInfo.type !== TokenType.NATIVE_TOKEN)
+    }
 
     if (isOnlySpendingLimitBeneficiary) {
       return items.filter(({ tokenInfo }) => {
@@ -42,5 +49,5 @@ export const useVisibleTokens = () => {
     }
 
     return items
-  }, [balances, hiddenTokens, isOnlySpendingLimitBeneficiary, spendingLimits, wallet?.address])
+  }, [balances, hiddenTokens, showNativeInBalances, isOnlySpendingLimitBeneficiary, spendingLimits, wallet?.address])
 }

--- a/apps/web/src/components/tx/GasParams/index.tsx
+++ b/apps/web/src/components/tx/GasParams/index.tsx
@@ -14,6 +14,7 @@ import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import WarningIcon from '@/public/images/notifications/warning.svg'
 import { useCurrentChain } from '@/hooks/useChains'
+import { getNativeTokenDisplay, NATIVE_TOKEN_DISPLAY_DEFAULT } from '@safe-global/utils/utils/chains'
 import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
 import { type AdvancedParameters } from '../AdvancedParams/types'
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
@@ -60,6 +61,11 @@ export const _GasParams = ({
   chain,
 }: GasParamsProps & { chain?: Chain }): ReactElement => {
   const { nonce, userNonce, safeTxGas, gasLimit, maxFeePerGas, maxPriorityFeePerGas } = params
+  const { showGasFeeEstimation } = chain?.features ? getNativeTokenDisplay(chain) : NATIVE_TOKEN_DISPLAY_DEFAULT
+
+  if (!showGasFeeEstimation) {
+    return <></>
+  }
 
   const onChangeExpand = (_: SyntheticEvent, expanded: boolean) => {
     trackEvent({ ...MODALS_EVENTS.ESTIMATION, label: expanded ? 'Open' : 'Close' })

--- a/apps/web/src/features/counterfactual/components/ActivateAccountFlow/index.tsx
+++ b/apps/web/src/features/counterfactual/components/ActivateAccountFlow/index.tsx
@@ -34,6 +34,7 @@ import NetworkWarning from '@/components/new-safe/create/NetworkWarning'
 import CheckWallet from '@/components/common/CheckWallet'
 import { getSafeToL2SetupDeployment } from '@safe-global/safe-deployments'
 import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
+import { useNativeTokenDisplay } from '@/hooks/useNativeTokenDisplay'
 import type { UndeployedSafe } from '@safe-global/utils/features/counterfactual/store/types'
 import type { TransactionOptions } from '@safe-global/types-kit'
 import { getTotalFeeFormatted } from '@safe-global/utils/hooks/useDefaultGasPrice'
@@ -81,6 +82,7 @@ const ActivateAccountFlow = () => {
   const wallet = useWallet()
   const { options, totalFee, walletCanPay } = useActivateAccount(undeployedSafe)
   const isWrongChain = useIsWrongChain()
+  const { showGasFeeEstimation, showInsufficientFundsWarning } = useNativeTokenDisplay()
 
   const undeployedSafeSetup = useMemo(
     () => extractCounterfactualSafeSetup(undeployedSafe, chainId),
@@ -171,7 +173,7 @@ const ActivateAccountFlow = () => {
           networks={chain ? [chain] : []}
         />
 
-        <Divider sx={{ mx: -3, mt: 2, mb: 1 }} />
+        {showGasFeeEstimation && <Divider sx={{ mx: -3, mt: 2, mb: 1 }} />}
         <Box display="flex" flexDirection="column" gap={3}>
           {canRelay && (
             <Grid container spacing={3}>
@@ -188,24 +190,26 @@ const ActivateAccountFlow = () => {
             </Grid>
           )}
 
-          <Grid data-testid="network-fee-section" container spacing={3}>
-            <ReviewRow
-              name="Est. network fee"
-              value={
-                <>
-                  <NetworkFee totalFee={totalFee} isWaived={willRelay || isWrongChain} chain={chain} />
+          {showGasFeeEstimation && (
+            <Grid data-testid="network-fee-section" container spacing={3}>
+              <ReviewRow
+                name="Est. network fee"
+                value={
+                  <>
+                    <NetworkFee totalFee={totalFee} isWaived={willRelay || isWrongChain} chain={chain} />
 
-                  {!willRelay && (
-                    <Typography variant="body2" color="text.secondary" mt={1}>
-                      {isWrongChain
-                        ? `Switch your connected wallet to ${chain?.chainName} to see the correct estimated network fee`
-                        : 'You will have to confirm a transaction with your connected wallet.'}
-                    </Typography>
-                  )}
-                </>
-              }
-            />
-          </Grid>
+                    {!willRelay && (
+                      <Typography variant="body2" color="text.secondary" mt={1}>
+                        {isWrongChain
+                          ? `Switch your connected wallet to ${chain?.chainName} to see the correct estimated network fee`
+                          : 'You will have to confirm a transaction with your connected wallet.'}
+                      </Typography>
+                    )}
+                  </>
+                }
+              />
+            </Grid>
+          )}
 
           {submitError && (
             <Box mt={1}>
@@ -213,7 +217,7 @@ const ActivateAccountFlow = () => {
             </Box>
           )}
           {isWrongChain && <NetworkWarning />}
-          {!walletCanPay && !willRelay && (
+          {!walletCanPay && !willRelay && showInsufficientFundsWarning && (
             <ErrorMessage>
               Your connected wallet doesn&apos;t have enough funds to execute this transaction
             </ErrorMessage>

--- a/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
+++ b/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
@@ -1,8 +1,10 @@
 import type { ChangeEvent, Dispatch, SetStateAction } from 'react'
 import classnames from 'classnames'
 import { useCurrentChain } from '@/hooks/useChains'
+import { useNativeTokenDisplay } from '@/hooks/useNativeTokenDisplay'
 import CheckRoundedIcon from '@mui/icons-material/CheckRounded'
 import {
+  Box,
   FormControl,
   FormControlLabel,
   List,
@@ -31,6 +33,7 @@ const PayNowPayLater = ({
   setPayMethod: Dispatch<SetStateAction<PayMethod>>
 }) => {
   const chain = useCurrentChain()
+  const { showGasFeeEstimation, showStablecoinFeeInfo } = useNativeTokenDisplay()
 
   const onChoosePayMethod = (_: ChangeEvent<HTMLInputElement>, newPayMethod: string) => {
     setPayMethod(newPayMethod as PayMethod)
@@ -46,6 +49,14 @@ const PayNowPayLater = ({
           You will need to <b>activate your account</b> separately on each network. Make sure you have funds on your
           wallet to pay the network fee.
         </ErrorMessage>
+      )}
+      {showStablecoinFeeInfo && (
+        <Box mt={2}>
+          <ErrorMessage level="info">
+            This network uses USD stablecoins for transaction fees instead of a native token. Ensure your connected
+            wallet holds a supported stablecoin to cover fees.
+          </ErrorMessage>
+        </Box>
       )}
       <List>
         {isMultiChain && (
@@ -92,15 +103,17 @@ const PayNowPayLater = ({
               label={
                 <>
                   <Typography className={css.radioTitle}>Pay now</Typography>
-                  <Typography className={css.radioSubtitle} variant="body2" color="text.secondary">
-                    {canRelay ? (
-                      'Sponsored free transaction'
-                    ) : (
-                      <>
-                        &asymp; {totalFee} {chain?.nativeCurrency.symbol}
-                      </>
-                    )}
-                  </Typography>
+                  {showGasFeeEstimation && (
+                    <Typography className={css.radioSubtitle} variant="body2" color="text.secondary">
+                      {canRelay ? (
+                        'Sponsored free transaction'
+                      ) : (
+                        <>
+                          &asymp; {totalFee} {chain?.nativeCurrency.symbol}
+                        </>
+                      )}
+                    </Typography>
+                  )}
                 </>
               }
               control={<Radio />}

--- a/apps/web/src/features/counterfactual/hooks/useCounterfactualBalances.ts
+++ b/apps/web/src/features/counterfactual/hooks/useCounterfactualBalances.ts
@@ -4,15 +4,22 @@ import type { ExtendedSafeInfo } from '@safe-global/store/slices/SafeInfo/types'
 import useAsync from '@safe-global/utils/hooks/useAsync'
 import { useCurrentChain } from '@/hooks/useChains'
 import type { Balances } from '@safe-global/store/gateway/AUTO_GENERATED/balances'
+import { getNativeTokenDisplay } from '@safe-global/utils/utils/chains'
 
 export function useCounterfactualBalances(safe: ExtendedSafeInfo) {
   const web3 = useWeb3()
   const chain = useCurrentChain()
   const safeAddress = safe.address.value
   const isCounterfactual = !safe.deployed
+  const showNativeInBalances = chain ? getNativeTokenDisplay(chain).showNativeInBalances : true
 
   return useAsync<Balances | undefined>(() => {
     if (!chain || !isCounterfactual || !safeAddress) return
+
+    if (!showNativeInBalances) {
+      return Promise.resolve(<Balances>{ fiatTotal: '0', items: [] })
+    }
+
     return getCounterfactualBalance(safeAddress, web3, chain)
-  }, [chain, safeAddress, web3, isCounterfactual])
+  }, [chain, safeAddress, web3, isCounterfactual, showNativeInBalances])
 }

--- a/apps/web/src/hooks/useNativeTokenDisplay.ts
+++ b/apps/web/src/hooks/useNativeTokenDisplay.ts
@@ -1,0 +1,11 @@
+import { useCurrentChain } from '@/hooks/useChains'
+import {
+  getNativeTokenDisplay,
+  NATIVE_TOKEN_DISPLAY_DEFAULT,
+  type NativeTokenDisplay,
+} from '@safe-global/utils/utils/chains'
+
+export const useNativeTokenDisplay = (): NativeTokenDisplay => {
+  const chain = useCurrentChain()
+  return chain ? getNativeTokenDisplay(chain) : NATIVE_TOKEN_DISPLAY_DEFAULT
+}

--- a/apps/web/src/hooks/useVisibleBalances.ts
+++ b/apps/web/src/hooks/useVisibleBalances.ts
@@ -7,6 +7,8 @@ import { useAppSelector } from '@/store'
 import { selectHideDust } from '@/store/settingsSlice'
 import { DUST_THRESHOLD } from '@/config/constants'
 import useSafeInfo from './useSafeInfo'
+import { useNativeTokenDisplay } from './useNativeTokenDisplay'
+import { TokenType } from '@safe-global/store/gateway/types'
 
 const PRECISION = 18
 
@@ -80,10 +82,16 @@ export const useVisibleBalances = (): {
   const hiddenTokens = useHiddenTokens()
   // Disable dust filtering for counterfactual safes
   const hideDust = useAppSelector(selectHideDust) && safe.deployed
+  const { showNativeInBalances } = useNativeTokenDisplay()
 
   return useMemo(() => {
-    const itemsWithoutHidden = filterHiddenTokens(data.balances.items, hiddenTokens)
-    const visibleItems = filterDustTokens(itemsWithoutHidden, hideDust)
+    let items = filterHiddenTokens(data.balances.items, hiddenTokens)
+
+    if (!showNativeInBalances) {
+      items = items.filter((item) => item.tokenInfo.type !== TokenType.NATIVE_TOKEN)
+    }
+
+    const visibleItems = filterDustTokens(items, hideDust)
 
     return {
       ...data,
@@ -97,5 +105,5 @@ export const useVisibleBalances = (): {
         positionsFiatTotal: data.balances.positionsFiatTotal,
       },
     }
-  }, [data, hiddenTokens, hideDust])
+  }, [data, hiddenTokens, hideDust, showNativeInBalances])
 }

--- a/apps/web/src/pages/settings/setup.tsx
+++ b/apps/web/src/pages/settings/setup.tsx
@@ -12,6 +12,7 @@ import { SpendingLimitsFeature } from '@/features/spending-limits'
 import { useLoadFeature } from '@/features/__core__'
 import { BRAND_NAME } from '@/config/constants'
 import { NestedSafesList } from '@/components/settings/NestedSafesList'
+import { FeeTokenPreference } from '@/components/settings/FeeTokenPreference'
 
 const Setup: NextPage = () => {
   const { safe, safeLoaded } = useSafeInfo()
@@ -84,6 +85,8 @@ const Setup: NextPage = () => {
         <SpendingLimitsSettings />
 
         <NestedSafesList />
+
+        <FeeTokenPreference />
       </main>
     </>
   )

--- a/apps/web/src/utils/__tests__/chains.test.ts
+++ b/apps/web/src/utils/__tests__/chains.test.ts
@@ -1,5 +1,11 @@
 import { getBlockExplorerLink } from '@safe-global/utils/utils/chains'
-import { FEATURES, getLatestSafeVersion, hasFeature } from '@safe-global/utils/utils/chains'
+import {
+  FEATURES,
+  getLatestSafeVersion,
+  getNativeTokenDisplay,
+  NATIVE_TOKEN_DISPLAY_DEFAULT,
+  hasFeature,
+} from '@safe-global/utils/utils/chains'
 import { CONFIG_SERVICE_CHAINS } from '@/tests/mocks/chains'
 import { chainBuilder } from '@/tests/builders/chains'
 import { getChainConfig } from '@/utils/chains'
@@ -31,6 +37,42 @@ describe('chains', () => {
           FEATURES.DOMAIN_LOOKUP,
         ),
       ).toBe(false)
+    })
+  })
+
+  describe('getNativeTokenDisplay', () => {
+    it('returns default (show everything) for chains without HIDE_NATIVE_TOKEN', () => {
+      const chain = { features: [FEATURES.ERC721, FEATURES.EIP1559] as string[] }
+      const result = getNativeTokenDisplay(chain)
+
+      expect(result).toEqual(NATIVE_TOKEN_DISPLAY_DEFAULT)
+      expect(result.showNativeInBalances).toBe(true)
+      expect(result.showGasFeeEstimation).toBe(true)
+      expect(result.showWalletBalance).toBe(true)
+      expect(result.showInsufficientFundsWarning).toBe(true)
+      expect(result.showFeeInConfirmationText).toBe(true)
+      expect(result.showUndeployedNativeValue).toBe(true)
+      expect(result.showStablecoinFeeInfo).toBe(false)
+    })
+
+    it('returns hidden config for chains with HIDE_NATIVE_TOKEN', () => {
+      const chain = { features: [FEATURES.HIDE_NATIVE_TOKEN] as string[] }
+      const result = getNativeTokenDisplay(chain)
+
+      expect(result.showNativeInBalances).toBe(false)
+      expect(result.showGasFeeEstimation).toBe(false)
+      expect(result.showWalletBalance).toBe(false)
+      expect(result.showInsufficientFundsWarning).toBe(false)
+      expect(result.showFeeInConfirmationText).toBe(false)
+      expect(result.showUndeployedNativeValue).toBe(false)
+      expect(result.showStablecoinFeeInfo).toBe(true)
+    })
+
+    it('returns default for chains with empty features', () => {
+      const chain = { features: [] as string[] }
+      const result = getNativeTokenDisplay(chain)
+
+      expect(result).toEqual(NATIVE_TOKEN_DISPLAY_DEFAULT)
     })
   })
 

--- a/packages/utils/src/utils/chains.ts
+++ b/packages/utils/src/utils/chains.ts
@@ -57,12 +57,53 @@ export enum FEATURES {
   MY_ACCOUNTS = 'MY_ACCOUNTS',
   SEND_FLOW = 'SEND_FLOW',
   BATCHING = 'BATCHING',
+  HIDE_NATIVE_TOKEN = 'HIDE_NATIVE_TOKEN',
+  TEMPO_GAS_TOKEN = 'TEMPO_GAS_TOKEN',
 }
 
 const MIN_SAFE_VERSION = '1.3.0'
 
 export const hasFeature = (chain: Pick<Chain, 'features'>, feature: FEATURES): boolean => {
   return (chain.features as string[]).includes(feature)
+}
+
+export type NativeTokenDisplay = {
+  showNativeInBalances: boolean
+  showGasFeeEstimation: boolean
+  showWalletBalance: boolean
+  showInsufficientFundsWarning: boolean
+  showFeeInConfirmationText: boolean
+  showUndeployedNativeValue: boolean
+  showStablecoinFeeInfo: boolean
+}
+
+export const NATIVE_TOKEN_DISPLAY_DEFAULT: NativeTokenDisplay = {
+  showNativeInBalances: true,
+  showGasFeeEstimation: true,
+  showWalletBalance: true,
+  showInsufficientFundsWarning: true,
+  showFeeInConfirmationText: true,
+  showUndeployedNativeValue: true,
+  showStablecoinFeeInfo: false,
+}
+
+const HIDE_NATIVE: NativeTokenDisplay = {
+  showNativeInBalances: false,
+  showGasFeeEstimation: false,
+  showWalletBalance: false,
+  showInsufficientFundsWarning: false,
+  showFeeInConfirmationText: false,
+  showUndeployedNativeValue: false,
+  showStablecoinFeeInfo: true,
+}
+
+/**
+ * Derives granular display capabilities from the HIDE_NATIVE_TOKEN chain feature.
+ * Use with components that already have a chain object.
+ * For React hooks, use useNativeTokenDisplay from apps/web/src/hooks/.
+ */
+export const getNativeTokenDisplay = (chain: Pick<Chain, 'features'>): NativeTokenDisplay => {
+  return hasFeature(chain, FEATURES.HIDE_NATIVE_TOKEN) ? HIDE_NATIVE : NATIVE_TOKEN_DISPLAY_DEFAULT
 }
 
 export const getBlockExplorerLink = (


### PR DESCRIPTION
## What it solves

Adds Tempo chain integration (hide native token + fee token preference)

## How this PR fixes it

* Add HIDE_NATIVE_TOKEN and TEMPO_GAS_TOKEN feature flags to FEATURES enum
- Hide native token balance in WalletInfo and WalletOverview when HIDE_NATIVE_TOKEN is enabled (Tempo uses ERC20 tokens for gas, not ETH)
- Show $0 instead of native token amount for undeployed Safes in TotalAssetValue and SafeHeaderInfo when HIDE_NATIVE_TOKEN is enabled
- Add FeeTokenPreference settings component guarded by TEMPO_GAS_TOKEN, allowing users to select their preferred ERC20 fee token via Tempo's fee precompile at 0xfeec...0000

* fix: suppress native token UI on chains with HIDE_NATIVE_TOKEN

On chains like Tempo where gas fees are paid in ERC20 stablecoins, the native token balance and fee estimates are meaningless. This commit hides them across the UI when HIDE_NATIVE_TOKEN is enabled:

- Fix isNativeToken guard in TotalAssetValue and SafeHeaderInfo
- Return empty balances for counterfactual Safes
- Filter native token from assets table and token transfer dropdown
- Hide estimated fee accordion in tx flow
- Hide fee displays in creation and activation flows
- Add info message about ERC20 fee tokens in creation flow

* fix: guard hasFeature call against missing chain.features in GasParams

* refactor: centralize HIDE_NATIVE_TOKEN into useNativeTokenDisplay (#7439)

* refactor: centralize HIDE_NATIVE_TOKEN checks into useNativeTokenDisplay

Replace scattered `hideNativeToken` conditionals across 12 files with a centralized hook (useNativeTokenDisplay) and utility function (getNativeTokenDisplay) that derive granular, self-documenting booleans from the HIDE_NATIVE_TOKEN chain feature flag.

Each consumer now checks a named capability (showGasFeeEstimation, showWalletBalance, showInsufficientFundsWarning, etc.) instead of reasoning about why "hide native token" affects that specific UI.

* refactor: deduplicate constants between hook and utility

Export NATIVE_TOKEN_DISPLAY_DEFAULT from chains.ts and reuse it in useNativeTokenDisplay hook and all consumer fallbacks, eliminating duplicated constant objects.

* tests: add unit tests for getNativeTokenDisplay utility

* fix: show actual fiat total for undeployed Safes with ERC20 balances

Previously, HIDE_NATIVE_TOKEN always showed $0 for undeployed Safes, breaking Zerion integration which can return ERC20 token balances for counterfactual accounts. Now checks for non-native balances first.


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
