### PR TITLE
fix(e2e): update tests for the 1.85 release

### DIFF
--- a/apps/web/cypress/e2e/pages/sidebar.pages.js
+++ b/apps/web/cypress/e2e/pages/sidebar.pages.js
@@ -446,7 +446,7 @@ export function clickOnMultichainItemOptionsBtn(index) {
 }
 
 export function checkMultichainTooltipExists(index) {
-  cy.get(multichainItemSummary).eq(index).find(chainLogo).eq(0).trigger('mouseover', { force: true })
+  cy.get(multichainItemSummary).eq(index).find(chainLogo).eq(0).realHover()
   cy.get(multichainTooltip).should('exist')
 }
 

--- a/apps/web/cypress/e2e/regression/twaps_integration.cy.js
+++ b/apps/web/cypress/e2e/regression/twaps_integration.cy.js
@@ -179,7 +179,7 @@ describe('TWAP tests', { defaultCommandTimeout: 30000 }, () => {
     })
     //formData.sellPart = formData.sellPart.replace('249.9962', '250') add only till the bug on the CowSwap side is fixed
     cy.get('@twapFormData').then((formData) => {
-      formData.sellPart = formData.sellPart.replace('249.9962', '250')
+      formData.sellPart = formData.sellPart.replace(/249\.\d+/, '250')
       swaps.checkTwapValuesInReviewScreen(formData)
       cy.get('[data-testid="slippage"] [data-testid="tx-data-row"]').invoke('text').should('match', slippage)
       cy.get('[data-testid="widget-fee"] [data-testid="tx-data-row"]').invoke('text').should('match', widgetFee)


### PR DESCRIPTION
## What it solves
There are 2 failing tests:
1. Twap - the amount is dinamic , not a static
2. Multichain tooltip 

Resolves:

## How this PR fixes it

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
