### PR TITLE
fix: add back breadcrumbs for nested safes

### DIFF
--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -14,6 +14,8 @@ import { TxModalContext } from '@/components/tx-flow'
 import { useLoadFeature } from '@/features/__core__'
 import { BatchingFeature } from '@/features/batching'
 import { AppRoutes } from '@/config/routes'
+import Breadcrumbs from '@/components/common/Breadcrumbs'
+import { useParentSafe } from '@/hooks/useParentSafe'
 import SpaceSafeBar from '@/components/common/SpaceSafeBar'
 import { useRouterGuard } from '@/hooks/useRouterGuard'
 import { useFlowActivationGuard } from '@/hooks/useRouterGuard/activationGuards/useFlowActivationGuard'
@@ -44,6 +46,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
   const hideHeader = NO_HEADER_ROUTES.includes(pathname)
   const isOnboardingRoute = ONBOARDING_ROUTES.includes(pathname)
   const isSpaceRoute = useIsSpaceRoute()
+  const parentSafe = useParentSafe()
   const menuToggleHandler = isSidebarRoute ? setSidebarOpen : undefined
 
   useRouterGuard({ useGuard: useFlowActivationGuard })
@@ -88,6 +91,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
       >
         <div className={css.content}>
           <SafeLoadingError>
+            {!hideHeader && parentSafe && <Breadcrumbs />}
             {!hideHeader && !isSpaceRoute && pathname === AppRoutes.home && <SpaceSafeBar />}
             {isOnboardingRoute ? (
               <AnimatePresence mode="wait">


### PR DESCRIPTION
## What it solves

Resolves:
https://linear.app/safe-global/issue/QA-52/release-1850#comment-4ce798b1

## How this PR fixes it
Show breadcrumbs for nested safes

## How to test it
Go to any nested safes, the breadcrumbs is there.

## Screenshots
<img width="1048" height="439" alt="Screenshot 2026-03-20 at 12 34 19" src="https://github.com/user-attachments/assets/31cf4c0e-539c-4cf5-b62e-fc88eea5d9d5" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
