### PR TITLE
fix(mobile): prevent crash when pressing account item in edit mode

### DIFF
--- a/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.tsx
+++ b/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.tsx
@@ -34,6 +34,7 @@ export function AccountItem({ account, drag, chains, isDragging, activeAccount, 
   const isActive = activeAccount === account.address.value
   const contact = useAppSelector(selectContactByAddress(account.address.value))
   const handleChainSelect = () => {
+    if (isEdit) return
     onSelect(account.address.value)
   }
 
@@ -56,12 +57,7 @@ export function AccountItem({ account, drag, chains, isDragging, activeAccount, 
   }, [account.address.value, deleteSafe])
 
   return (
-    <TouchableOpacity
-      style={styles.container}
-      disabled={isDragging}
-      onLongPress={drag}
-      onPress={isEdit ? undefined : handleChainSelect}
-    >
+    <TouchableOpacity style={styles.container} disabled={isDragging} onLongPress={drag} onPress={handleChainSelect}>
       <View
         testID="account-item-wrapper"
         backgroundColor={isActive && !isEdit ? '$borderLight' : '$backgroundTransparent'}

--- a/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.tsx
+++ b/apps/mobile/src/features/AccountsSheet/AccountItem/AccountItem.tsx
@@ -34,7 +34,9 @@ export function AccountItem({ account, drag, chains, isDragging, activeAccount, 
   const isActive = activeAccount === account.address.value
   const contact = useAppSelector(selectContactByAddress(account.address.value))
   const handleChainSelect = () => {
-    if (isEdit) return
+    if (isEdit) {
+      return
+    }
     onSelect(account.address.value)
   }
 


### PR DESCRIPTION
> Tap an account in edit mode,
> undefined tries to run—
> guard the handler, crash undone.

## What it solves

Pressing an account item in the "My accounts" sheet while in edit mode crashes the app with "undefined is not a function". The `onPress` handler was set to `undefined` when editing, but the `react-native-draggable-flatlist` gesture handler invokes it without null-checking.

## How this PR fixes it

Instead of conditionally passing `undefined` to `onPress`, `handleChainSelect` is now always passed as the handler but early-returns when `isEdit` is true. This keeps `onPress` as a valid function at all times while preserving the same behavior (no navigation in edit mode, drag via long-press still works).

## How to test it

1. Open the app and navigate to the "My accounts" bottom sheet
2. Tap "Edit" to enter edit mode
3. Tap on an account item (not the delete icon) — should do nothing, no crash
4. Tap "Done", then tap an account item — should navigate to that account as before

## Screenshots

N/A - no UI changes, bug fix only

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).