### PR TITLE
feat(mobile): add BIP44 standard derivation path for Ledger signer import

### DIFF
--- a/apps/mobile/src/features/Ledger/LedgerAddresses.container.tsx
+++ b/apps/mobile/src/features/Ledger/LedgerAddresses.container.tsx
@@ -22,6 +22,7 @@ const TITLE = 'Select address to import'
 const DERIVATION_PATH_OPTIONS = [
   { id: 'ledger-live' as const, title: 'Ledger Live' },
   { id: 'legacy-ledger' as const, title: 'Legacy Ledger' },
+  { id: 'bip44' as const, title: 'BIP44 Standard' },
 ]
 
 export const LedgerAddressesContainer = () => {

--- a/apps/mobile/src/features/Ledger/hooks/useLedgerAddresses.test.ts
+++ b/apps/mobile/src/features/Ledger/hooks/useLedgerAddresses.test.ts
@@ -562,6 +562,22 @@ describe('useLedgerAddresses', () => {
       expect(resultLegacy.current.addresses).toEqual(legacyAddresses)
     })
 
+    it('should fetch addresses with bip44 derivation path', async () => {
+      const sessionId = createMockSessionId()
+      const mockAddresses = createMockAddresses(3)
+      mockLedgerDMKService.getCurrentSession.mockReturnValue(sessionId)
+      mockLedgerEthereumService.getEthereumAddresses.mockResolvedValue(mockAddresses)
+
+      const { result } = renderHook(() => useLedgerAddresses({ sessionId, derivationPathType: 'bip44' }))
+
+      await act(async () => {
+        await result.current.fetchAddresses(3)
+      })
+
+      expect(mockLedgerEthereumService.getEthereumAddresses).toHaveBeenCalledWith(sessionId, 3, 0, 'bip44')
+      expect(result.current.addresses).toEqual(mockAddresses)
+    })
+
     it('should handle errors with legacy-ledger derivation', async () => {
       const sessionId = createMockSessionId()
       const error = new Error('Ledger device error')

--- a/apps/mobile/src/features/Ledger/hooks/useLedgerAddresses.ts
+++ b/apps/mobile/src/features/Ledger/hooks/useLedgerAddresses.ts
@@ -5,7 +5,7 @@ import { ledgerEthereumService } from '@/src/services/ledger/ledger-ethereum.ser
 import logger from '@/src/utils/logger'
 import { useAddresses, type BaseAddress } from '@/src/hooks/useAddresses'
 
-export type DerivationPathType = 'ledger-live' | 'legacy-ledger'
+export type DerivationPathType = 'ledger-live' | 'legacy-ledger' | 'bip44'
 
 interface UseLedgerAddressesParams {
   sessionId?: string

--- a/apps/mobile/src/services/ledger/ledger-ethereum.service.test.ts
+++ b/apps/mobile/src/services/ledger/ledger-ethereum.service.test.ts
@@ -110,6 +110,36 @@ describe('LedgerEthereumService', () => {
       expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0")
     })
 
+    it('should use BIP44 derivation path when specified', async () => {
+      mockGetAddress.mockReturnValue({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({ status: 'completed', output: { address: '0x123' } })
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+      await service.getEthereumAddresses(mockSessionId, 1, 0, 'bip44')
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/0")
+    })
+
+    it('should use correct BIP44 path for non-zero index', async () => {
+      mockGetAddress.mockReturnValue({
+        observable: {
+          subscribe: ({ next }: { next: (state: unknown) => void }) => {
+            next({ status: 'completed', output: { address: '0x123' } })
+          },
+        },
+      })
+
+      const service = LedgerEthereumService.getInstance()
+      await service.getEthereumAddresses(mockSessionId, 1, 5, 'bip44')
+
+      expect(mockGetAddress).toHaveBeenCalledWith("44'/60'/0'/0/5")
+    })
+
     it('should continue on address fetch error', async () => {
       let callCount = 0
       mockGetAddress.mockImplementation(() => ({

--- a/apps/mobile/src/services/ledger/ledger-ethereum.service.ts
+++ b/apps/mobile/src/services/ledger/ledger-ethereum.service.ts
@@ -11,7 +11,7 @@ export interface EthereumAddress {
   index: number
 }
 
-export type DerivationPathType = 'ledger-live' | 'legacy-ledger'
+export type DerivationPathType = 'ledger-live' | 'legacy-ledger' | 'bip44'
 
 export class LedgerEthereumService {
   private static instance: LedgerEthereumService
@@ -94,7 +94,12 @@ export class LedgerEthereumService {
 
     // Derive addresses using the appropriate derivation path
     for (let i = startIndex; i < startIndex + count; i++) {
-      const fullPath = derivationPathType === 'ledger-live' ? getAccountPath(i) : `m/44'/60'/0'/${i}`
+      const fullPath =
+        derivationPathType === 'ledger-live'
+          ? getAccountPath(i)
+          : derivationPathType === 'bip44'
+            ? `m/44'/60'/0'/0/${i}`
+            : `m/44'/60'/0'/${i}`
       const path = fullPath.substring(2) // Remove "m/" prefix for Ledger SDK
 
       try {


### PR DESCRIPTION
> Two paths offered, a third was missed,
> BIP44 now completes the list.

## What it solves

The Ledger address selection screen currently offers two derivation paths: **Ledger Live** (`m/44'/60'/x'/0/0`) and **Legacy Ledger** (`m/44'/60'/0'/x`). Many Ledger devices use the **BIP44 standard** path (`m/44'/60'/0'/0/x`). Without this option, users whose accounts were derived with BIP44 cannot import their Ledger signer (unless they use the first account).

Resolves #7464

## How this PR fixes it

- Adds `'bip44'` to the `DerivationPathType` union type in both the service and hook layers
- Adds BIP44 path generation (`m/44'/60'/0'/0/${index}`) to `LedgerEthereumService.getEthereumAddresses()`
- Adds a "BIP44 Standard" option to the derivation path dropdown in `LedgerAddressesContainer`
- Signing, execution, and signer storage are path-format agnostic — no changes needed

## How to test it

1. Connect a Ledger device via the mobile app
2. Navigate to Import Signers → Ledger
3. Open the derivation path dropdown — verify "BIP44 Standard" appears as a third option
4. Select "BIP44 Standard" — addresses should derive using `m/44'/60'/0'/0/x`
5. Import an address and verify signing works correctly

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).