### PR TITLE
fix: show safe cloud name per chain for safe selector trigger

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.test.tsx
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react'
+import SafeSelectorTriggerContent from './SafeSelectorTriggerContent'
+import type { SafeItemData } from '../types'
+
+const mockUseSafeDisplayName = jest.fn()
+
+jest.mock('@/hooks/useSafeDisplayName', () => ({
+  useSafeDisplayName: (...args: unknown[]) => mockUseSafeDisplayName(...args),
+}))
+
+jest.mock('./SafeBalanceBlock', () => {
+  const Mock = () => <div data-testid="safe-balance-block" />
+  Mock.displayName = 'SafeBalanceBlock'
+  return { __esModule: true, default: Mock }
+})
+
+const createItem = (overrides: Partial<SafeItemData> = {}): SafeItemData => ({
+  id: '1:0xabc',
+  name: 'Space AB Name',
+  address: '0xabc',
+  threshold: 1,
+  owners: 2,
+  balance: '100',
+  chains: [
+    { chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' },
+    { chainId: '137', chainName: 'Polygon', chainLogoUri: null, shortName: 'matic' },
+  ],
+  ...overrides,
+})
+
+describe('SafeSelectorTriggerContent', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockUseSafeDisplayName.mockReturnValue('')
+  })
+
+  it('resolves name per chain without using the cross-chain item name', () => {
+    const item = createItem({ name: 'Name from Ethereum' })
+
+    render(<SafeSelectorTriggerContent selectedItem={item} selectedChainId="137" />)
+
+    expect(mockUseSafeDisplayName).toHaveBeenCalledWith('0xabc', '137')
+    expect(mockUseSafeDisplayName).not.toHaveBeenCalledWith('0xabc', '137', expect.anything())
+  })
+
+  it('displays the chain-specific resolved name', () => {
+    mockUseSafeDisplayName.mockReturnValue('Polygon Name')
+    const item = createItem()
+
+    const { getByText } = render(<SafeSelectorTriggerContent selectedItem={item} selectedChainId="137" />)
+
+    expect(getByText('Polygon Name')).toBeInTheDocument()
+  })
+
+  it('displays the address when no name exists for the current chain', () => {
+    mockUseSafeDisplayName.mockReturnValue('')
+    const item = createItem({ name: 'Name from Ethereum' })
+
+    const { getByText } = render(<SafeSelectorTriggerContent selectedItem={item} selectedChainId="137" />)
+
+    // When no name is resolved, getSafeDisplayInfo falls back to prefixed address
+    expect(getByText(/0xabc/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
@@ -15,7 +15,7 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
   const selectedChain = selectedItem.chains.find((c) => c.chainId === selectedChainId) ?? selectedItem.chains[0]
   const chainShortName = selectedChain?.shortName ?? ''
 
-  const resolvedName = useSafeDisplayName(selectedItem.address, selectedChainId, selectedItem.name)
+  const resolvedName = useSafeDisplayName(selectedItem.address, selectedChainId)
   const { addressWithPrefix, displayName, showAddressLine } = getSafeDisplayInfo(
     resolvedName,
     selectedItem.address,


### PR DESCRIPTION
## What it solves

Resolves:
https://linear.app/safe-global/issue/QA-52/release-1850#comment-4fac094b

## How this PR fixes it
show safe cloud name per chain for safe selector trigger

## How to test it
Add a multichain safe to the space

add the same safe ( only one network - Ethereum as an example ) with a name to the address book

go to the safe above but on diff from the Ethereum network

## Screenshots
<img width="949" height="318" alt="Screenshot 2026-03-23 at 14 12 31" src="https://github.com/user-attachments/assets/7589a475-d445-485e-ad52-94d7e5c7b8c2" />
<img width="901" height="268" alt="Screenshot 2026-03-23 at 14 43 54" src="https://github.com/user-attachments/assets/c22f3f81-4cd3-46fe-a89b-964a20130758" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
