### PR TITLE
fix(e2e): fixMultichainTooltip

### DIFF
--- a/apps/web/cypress/e2e/pages/sidebar.pages.js
+++ b/apps/web/cypress/e2e/pages/sidebar.pages.js
@@ -45,6 +45,7 @@ const groupBalance = '[data-testid="group-balance"]'
 const groupAddress = '[data-testid="group-address"]'
 const groupSafeIcon = '[data-testid="group-safe-icon"]'
 const multichainTooltip = '[data-testid="multichain-tooltip"]'
+const tooltipTrigger = '[data-slot="tooltip-trigger"]'
 const networkInput = '[id="network-input"]'
 const networkOption = 'li[role="option"]'
 const showAllNetworks = '[data-testid="show-all-networks"]'
@@ -446,7 +447,7 @@ export function clickOnMultichainItemOptionsBtn(index) {
 }
 
 export function checkMultichainTooltipExists(index) {
-  cy.get(multichainItemSummary).eq(index).find(chainLogo).eq(0).realHover()
+  cy.get(multichainItemSummary).eq(index).find(tooltipTrigger).eq(0).focus()
   cy.get(multichainTooltip).should('exist')
 }
 

--- a/apps/web/src/features/myAccounts/components/AccountItem/AccountItemChainBadge.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/AccountItemChainBadge.tsx
@@ -19,7 +19,7 @@ function AccountItemChainBadge({ chainId, safes, className, imageSize = 24 }: Ac
     return (
       <div className={cn('flex shrink-0 justify-end', className)}>
         <Tooltip>
-          <TooltipTrigger render={<span />} className="flex items-center">
+          <TooltipTrigger render={<span />} tabIndex={0} className="flex items-center">
             <NetworkLogosList networks={safes} showHasMore />
           </TooltipTrigger>
           <TooltipContent>


### PR DESCRIPTION
## What it solves
The test is not able to open the multichain tooltip after migration to shadCN

Resolves: https://linear.app/safe-global/issue/WA-1817/fix-multichain-tooltio-after-latest-updates-for-spaces

## How this PR fixes it

## How to test it
Run the test locally

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
