### PR TITLE
feat: add ENS name for welcome accounts page

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
@@ -87,6 +87,15 @@ describe('NamedAddressInfo', () => {
 
     expect(result.queryByText('This Safe Account')).not.toBeInTheDocument()
   })
+
+  it('should skip contract lookup when noContractName is true', () => {
+    const address = faker.finance.ethereumAddress()
+    render(<NamedAddressInfo address={address} noContractName />)
+
+    expect(useGetContractQueryMock.mock.calls.every(([, opts]: unknown[]) => (opts as { skip: boolean }).skip)).toBe(
+      true,
+    )
+  })
 })
 
 describe('useAddressName', () => {
@@ -260,6 +269,44 @@ describe('useAddressName', () => {
       name: 'This Safe Account',
       logoUri: undefined,
       isUnverifiedContract: false,
+    })
+  })
+
+  describe('noContractName', () => {
+    it('should skip contract lookup when noContractName is true', () => {
+      const { result } = renderHook(() => useAddressName(address, undefined, undefined, true))
+
+      expect(result.current).toEqual({
+        name: undefined,
+        logoUri: undefined,
+        isUnverifiedContract: false,
+      })
+      expect(useGetContractQueryMock.mock.calls.every(([, opts]: unknown[]) => (opts as { skip: boolean }).skip)).toBe(
+        true,
+      )
+    })
+
+    it('should still use provided name when noContractName is true', () => {
+      const { result } = renderHook(() => useAddressName(address, 'Address Book Name', undefined, true))
+
+      expect(result.current).toEqual({
+        name: 'Address Book Name',
+        logoUri: undefined,
+        isUnverifiedContract: false,
+      })
+      expect(useGetContractQueryMock.mock.calls.every(([, opts]: unknown[]) => (opts as { skip: boolean }).skip)).toBe(
+        true,
+      )
+    })
+
+    it('should still show "This Safe Account" when noContractName is true', () => {
+      const { result } = renderHook(() => useAddressName(safeAddress, undefined, undefined, true))
+
+      expect(result.current).toEqual({
+        name: 'This Safe Account',
+        logoUri: undefined,
+        isUnverifiedContract: false,
+      })
     })
   })
 })

--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -22,19 +22,24 @@ const useIsUnverifiedContract = (contract?: { contractAbi?: object | null } | nu
   return !!contract && !contract.contractAbi
 }
 
-export function useAddressName(address?: string, name?: string | null, customAvatar?: string | null) {
+export function useAddressName(
+  address?: string,
+  name?: string | null,
+  customAvatar?: string | null,
+  noContractName?: boolean,
+) {
   const chainId = useChainId()
   const safeAddress = useSafeAddress()
   const displayName = sameAddress(address, safeAddress) ? THIS_SAFE_ACCOUNT : name
-  const shouldSkipContractCheck = !!displayName || !address || !isAddress(address)
-  const isContract = useIsContractAddress(shouldSkipContractCheck ? undefined : address)
+  const shouldFetchContract = !noContractName && !displayName && address && isAddress(address)
+  const isContract = useIsContractAddress(shouldFetchContract ? address : undefined)
 
-  const shouldSkipContractData = shouldSkipContractCheck || !isContract
+  const shouldFetchContractData = shouldFetchContract && isContract
   const { data: contract } = useGetContractQuery(
     { chainId, contractAddress: address as string },
-    { skip: shouldSkipContractData },
+    { skip: !shouldFetchContractData },
   )
-  const contractData = shouldSkipContractData ? undefined : contract
+  const contractData = shouldFetchContractData ? contract : undefined
   const nonEnsName = displayName || contractData?.displayName || contractData?.name
 
   const { ens: ensName } = useAddressResolver(nonEnsName ? undefined : address)
@@ -51,10 +56,22 @@ export function useAddressName(address?: string, name?: string | null, customAva
   )
 }
 
-const NamedAddressInfo = ({ address, name, customAvatar, ...props }: EthHashInfoProps) => {
-  const { name: finalName, logoUri: finalAvatar } = useAddressName(address, name, customAvatar)
+type NamedAddressInfoProps = EthHashInfoProps & {
+  showName?: boolean
+  noContractName?: boolean
+}
 
-  return <EthHashInfo address={address} name={finalName} customAvatar={finalAvatar} {...props} />
+const NamedAddressInfo = ({
+  address,
+  name,
+  customAvatar,
+  noContractName,
+  showName,
+  ...props
+}: NamedAddressInfoProps) => {
+  const { name: finalName, logoUri: finalAvatar } = useAddressName(address, name, customAvatar, noContractName)
+
+  return <EthHashInfo address={address} name={finalName} customAvatar={finalAvatar} showName={showName} {...props} />
 }
 
 export default memo(NamedAddressInfo)

--- a/apps/web/src/features/myAccounts/components/AccountItem/AccountItemInfo.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/AccountItemInfo.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { Typography } from '@mui/material'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import NamedAddressInfo from '@/components/common/NamedAddressInfo'
 import { type ContactSource } from '@/hooks/useAllAddressBooks'
 import css from '../AccountItems/styles.module.css'
 
@@ -58,9 +58,10 @@ function AccountItemInfo({
             {chainName}
           </Typography>
         ) : (
-          <EthHashInfo
+          <NamedAddressInfo
             address={address}
             name={name}
+            noContractName
             showName={addressBookNameSource ? !!name : true}
             shortAddress={!fullAddress}
             chainId={chainId}


### PR DESCRIPTION
## What it solves

Resolves:
https://linear.app/safe-global/issue/WA-1624/show-saved-name-fallback-to-ens-name

Safe accounts on `/welcome/accounts` only display address book names. If a Safe has an ENS name but no address book entry, users see a raw truncated address with no way to identify it.

## How this PR fixes it

Replaces `EthHashInfo` with `NamedAddressInfo` in `AccountItemInfo`, passing `noContractName` to skip the contract name lookup (Safe accounts are contracts themselves, so querying their contract name is not useful).

When no address book name exists, `NamedAddressInfo` falls back to ENS reverse resolution via the existing `useAddressResolver` hook.

**Name resolution priority:** Address book name → ENS name → truncated address


## How to test it

1. Connect your wallet to **Ethereum Mainnet**
2. Go to `/welcome/accounts`
3. Ensure you have a Safe that has an ENS name but **no** address book name
4. The Safe should display its ENS name above the truncated address
5. Add an address book name for that Safe — the address book name should take priority over the ENS name

## Screenshots

https://github.com/user-attachments/assets/38bb1a16-cba0-4f3f-bb6c-e1e02061f1fa



## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 -> not affected
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
