### PR TITLE
feat: show ens name in welcome accounts list

### DIFF
--- a/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.test.tsx
@@ -262,4 +262,39 @@ describe('useAddressName', () => {
       isUnverifiedContract: false,
     })
   })
+
+  describe('noContractName', () => {
+    it('should skip contract lookup when noContractName is true', () => {
+      const { result } = renderHook(() => useAddressName(address, undefined, undefined, true))
+
+      expect(result.current).toEqual({
+        name: undefined,
+        logoUri: undefined,
+        isUnverifiedContract: false,
+      })
+      expect(useGetContractQueryMock.mock.calls.every(([, opts]: unknown[]) => (opts as { skip: boolean }).skip)).toBe(
+        true,
+      )
+    })
+
+    it('should still use provided name when noContractName is true', () => {
+      const { result } = renderHook(() => useAddressName(address, 'Address Book Name', undefined, true))
+
+      expect(result.current).toEqual({
+        name: 'Address Book Name',
+        logoUri: undefined,
+        isUnverifiedContract: false,
+      })
+    })
+
+    it('should still show "This Safe Account" when noContractName is true', () => {
+      const { result } = renderHook(() => useAddressName(safeAddress, undefined, undefined, true))
+
+      expect(result.current).toEqual({
+        name: 'This Safe Account',
+        logoUri: undefined,
+        isUnverifiedContract: false,
+      })
+    })
+  })
 })

--- a/apps/web/src/components/common/NamedAddressInfo/index.tsx
+++ b/apps/web/src/components/common/NamedAddressInfo/index.tsx
@@ -22,11 +22,16 @@ const useIsUnverifiedContract = (contract?: { contractAbi?: object | null } | nu
   return !!contract && !contract.contractAbi
 }
 
-export function useAddressName(address?: string, name?: string | null, customAvatar?: string | null) {
+export function useAddressName(
+  address?: string,
+  name?: string | null,
+  customAvatar?: string | null,
+  noContractName?: boolean,
+) {
   const chainId = useChainId()
   const safeAddress = useSafeAddress()
   const displayName = sameAddress(address, safeAddress) ? THIS_SAFE_ACCOUNT : name
-  const shouldSkipContractCheck = !!displayName || !address || !isAddress(address)
+  const shouldSkipContractCheck = noContractName || !!displayName || !address || !isAddress(address)
   const isContract = useIsContractAddress(shouldSkipContractCheck ? undefined : address)
 
   const shouldSkipContractData = shouldSkipContractCheck || !isContract
@@ -51,10 +56,22 @@ export function useAddressName(address?: string, name?: string | null, customAva
   )
 }
 
-const NamedAddressInfo = ({ address, name, customAvatar, ...props }: EthHashInfoProps) => {
-  const { name: finalName, logoUri: finalAvatar } = useAddressName(address, name, customAvatar)
+type NamedAddressInfoProps = EthHashInfoProps & {
+  showName?: boolean
+  noContractName?: boolean
+}
 
-  return <EthHashInfo address={address} name={finalName} customAvatar={finalAvatar} {...props} />
+const NamedAddressInfo = ({
+  address,
+  name,
+  customAvatar,
+  noContractName,
+  showName,
+  ...props
+}: NamedAddressInfoProps) => {
+  const { name: finalName, logoUri: finalAvatar } = useAddressName(address, name, customAvatar, noContractName)
+
+  return <EthHashInfo address={address} name={finalName} customAvatar={finalAvatar} showName={showName} {...props} />
 }
 
 export default memo(NamedAddressInfo)

--- a/apps/web/src/features/myAccounts/components/AccountItem/AccountItemInfo.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/AccountItemInfo.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { Typography } from '@mui/material'
-import EthHashInfo from '@/components/common/EthHashInfo'
+import NamedAddressInfo from '@/components/common/NamedAddressInfo'
 import { type ContactSource } from '@/hooks/useAllAddressBooks'
 import css from '../AccountItems/styles.module.css'
 
@@ -58,9 +58,10 @@ function AccountItemInfo({
             {chainName}
           </Typography>
         ) : (
-          <EthHashInfo
+          <NamedAddressInfo
             address={address}
             name={name}
+            noContractName
             showName={addressBookNameSource ? !!name : true}
             shortAddress={!fullAddress}
             chainId={chainId}

--- a/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItems/MultiAccountItem.tsx
@@ -2,6 +2,7 @@ import type { SafeListProps } from '../SafesList'
 import { AccountItem } from '../AccountItem'
 import { useSafeItemData } from '../../hooks/useSafeItemData'
 import { useMultiAccountItemData } from '../../hooks/useMultiAccountItemData'
+import { useEnsName } from '../../hooks/useAccountEnsNames'
 import { SpacesFeature } from '@/features/spaces'
 import { useLoadFeature } from '@/features/__core__'
 import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
@@ -79,6 +80,7 @@ type MultiAccountItemProps = {
 
 const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = false }: MultiAccountItemProps) => {
   const spaces = useLoadFeature(SpacesFeature)
+  const ensName = useEnsName(multiSafeAccountItem.address)
   const {
     address,
     name,
@@ -133,7 +135,7 @@ const MultiAccountItem = ({ onLinkClick, multiSafeAccountItem, isSpaceSafe = fal
               <AccountItem.Info
                 address={address}
                 chainId={sortedSafes[0]?.chainId ?? '1'}
-                name={multiSafeAccountItem.name}
+                name={multiSafeAccountItem.name || ensName}
                 showPrefix={false}
                 addressBookNameSource={isSpaceSafe ? ContactSource.space : undefined}
                 data-testid="group-address"

--- a/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesList/SafeListItem.tsx
@@ -1,6 +1,7 @@
 import { useMediaQuery, useTheme } from '@mui/material'
 import { AccountItem } from '../AccountItem'
 import { useSafeItemData } from '../../hooks/useSafeItemData'
+import { useEnsName } from '../../hooks/useAccountEnsNames'
 import css from '../AccountItems/styles.module.css'
 import type { SafeItem } from '@/hooks/safes'
 import { SpacesFeature } from '@/features/spaces'
@@ -31,6 +32,9 @@ export const SafeListItem = ({ safeItem, onLinkClick, isSpaceSafe = false }: Saf
     elementRef,
     trackingLabel,
   } = useSafeItemData(safeItem, { isSpaceSafe })
+
+  const ensName = useEnsName(safeItem.address)
+  const displayName = isSpaceSafe ? safeItem.name : name || ensName
 
   const hasQueuedItems =
     !safeItem.isReadOnly &&
@@ -69,7 +73,7 @@ export const SafeListItem = ({ safeItem, onLinkClick, isSpaceSafe = false }: Saf
         threshold={threshold}
         owners={owners.length}
       />
-      <AccountItem.Info address={safeItem.address} chainId={safeItem.chainId} name={isSpaceSafe ? safeItem.name : name}>
+      <AccountItem.Info address={safeItem.address} chainId={safeItem.chainId} name={displayName}>
         {!isMobile && statusChips}
       </AccountItem.Info>
       <AccountItem.ChainBadge chainId={safeItem.chainId} />

--- a/apps/web/src/features/myAccounts/components/SafesList/index.tsx
+++ b/apps/web/src/features/myAccounts/components/SafesList/index.tsx
@@ -1,6 +1,7 @@
 import { type SafeItem, type AllSafeItems, type MultiChainSafeItem, isMultiChainSafeItem } from '@/hooks/safes'
 import MultiAccountItem from '../AccountItems/MultiAccountItem'
 import { SafeListItem } from './SafeListItem'
+import { EnsNamesProvider } from '../../hooks/useAccountEnsNames'
 
 export type SafeListProps = {
   safes?: AllSafeItems
@@ -25,7 +26,13 @@ const SafesList = ({ safes, onLinkClick, isSpaceSafe = false }: SafeListProps) =
     return null
   }
 
-  return safes.map((item) => <div key={item.address}>{renderSafeItem(item, onLinkClick, isSpaceSafe)}</div>)
+  return (
+    <EnsNamesProvider safes={safes}>
+      {safes.map((item) => (
+        <div key={item.address}>{renderSafeItem(item, onLinkClick, isSpaceSafe)}</div>
+      ))}
+    </EnsNamesProvider>
+  )
 }
 
 export default SafesList

--- a/apps/web/src/features/myAccounts/hooks/useAccountEnsNames.tsx
+++ b/apps/web/src/features/myAccounts/hooks/useAccountEnsNames.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { skipToken } from '@reduxjs/toolkit/query'
+import { useGetBatchEnsNamesQuery } from '@/store/api/gateway'
+import { type AllSafeItems, isMultiChainSafeItem } from '@/hooks/safes'
+import { selectAllAddressBooks } from '@/store/addressBookSlice'
+import { useAppSelector } from '@/store'
+
+type EnsNamesMap = Record<string, string | null>
+
+const EnsNamesContext = createContext<EnsNamesMap>({})
+
+/**
+ * Collect unique addresses from safe items that don't have an address book name.
+ * Only these addresses need ENS resolution.
+ */
+function getAddressesNeedingEns(safes: AllSafeItems, addressBooks: Record<string, Record<string, string>>): string[] {
+  const seen = new Set<string>()
+
+  for (const item of safes) {
+    const address = item.address
+    if (seen.has(address)) continue
+
+    // Check if any chain's address book has a name for this address
+    const hasAddressBookName = isMultiChainSafeItem(item)
+      ? item.safes.some((s) => addressBooks[s.chainId]?.[address])
+      : !!addressBooks[item.chainId]?.[address]
+
+    if (!hasAddressBookName) {
+      seen.add(address)
+    }
+  }
+
+  return Array.from(seen)
+}
+
+/**
+ * Provider that fetches ENS names for all safe items in batch.
+ * Wrap the accounts list with this provider.
+ */
+export function EnsNamesProvider({ safes, children }: { safes: AllSafeItems; children: ReactNode }) {
+  const addressBooks = useAppSelector(selectAllAddressBooks)
+
+  const addresses = useMemo(() => getAddressesNeedingEns(safes, addressBooks), [safes, addressBooks])
+
+  // Sort to keep a stable cache key for RTK Query
+  const sortedAddresses = useMemo(() => [...addresses].sort(), [addresses])
+
+  const { data: ensNames } = useGetBatchEnsNamesQuery(sortedAddresses.length > 0 ? sortedAddresses : skipToken)
+
+  const value = ensNames ?? {}
+
+  return <EnsNamesContext.Provider value={value}>{children}</EnsNamesContext.Provider>
+}
+
+/**
+ * Look up the ENS name for an address from the batch query results.
+ * Returns the ENS name string, or undefined if not resolved.
+ */
+export function useEnsName(address: string): string | undefined {
+  const ensNames = useContext(EnsNamesContext)
+  return ensNames[address] ?? undefined
+}

--- a/apps/web/src/services/ens/batchLookup.test.ts
+++ b/apps/web/src/services/ens/batchLookup.test.ts
@@ -1,0 +1,103 @@
+import type { AbstractProvider } from 'ethers'
+import { batchLookupAddresses } from './batchLookup'
+import * as multicallModule from '@safe-global/utils/utils/multicall'
+
+jest.mock('@safe-global/utils/utils/multicall')
+jest.mock('../exceptions', () => ({ logError: jest.fn() }))
+
+const multicallMock = jest.mocked(multicallModule.multicall)
+const mockProvider = {} as AbstractProvider
+
+// The Universal Resolver's reverse() returns (name, resolvedAddress, reverseResolver, resolver)
+// We need to encode this ABI response for tests
+function encodeReverseResult(name: string, resolvedAddress: string): string {
+  const { Interface } = jest.requireActual('ethers')
+  const iface = new Interface([
+    'function reverse(bytes) view returns (string name, address resolvedAddress, address reverseResolver, address resolver)',
+  ])
+  return iface.encodeFunctionResult('reverse', [
+    name,
+    resolvedAddress,
+    '0x0000000000000000000000000000000000000000',
+    '0x0000000000000000000000000000000000000000',
+  ])
+}
+
+describe('batchLookupAddresses', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return empty record for empty input', async () => {
+    const result = await batchLookupAddresses(mockProvider, [])
+    expect(result).toEqual({})
+    expect(multicallMock).not.toHaveBeenCalled()
+  })
+
+  it('should resolve ENS names for multiple addresses', async () => {
+    const addr1 = '0x1234567890123456789012345678901234567890'
+    const addr2 = '0xABCDEF0123456789ABCDEF0123456789ABCDEF01'
+
+    multicallMock.mockResolvedValue([
+      { success: true, returnData: encodeReverseResult('alice.eth', addr1) },
+      { success: true, returnData: encodeReverseResult('bob.eth', addr2.toLowerCase()) },
+    ])
+
+    const result = await batchLookupAddresses(mockProvider, [addr1, addr2])
+
+    expect(result).toEqual({
+      [addr1]: 'alice.eth',
+      [addr2]: 'bob.eth',
+    })
+    expect(multicallMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return null for addresses without ENS names', async () => {
+    const addr = '0x1234567890123456789012345678901234567890'
+
+    multicallMock.mockResolvedValue([{ success: false, returnData: '0x' }])
+
+    const result = await batchLookupAddresses(mockProvider, [addr])
+
+    expect(result).toEqual({ [addr]: null })
+  })
+
+  it('should return null when forward verification fails', async () => {
+    const addr = '0x1234567890123456789012345678901234567890'
+    const differentAddr = '0x0000000000000000000000000000000000000001'
+
+    multicallMock.mockResolvedValue([{ success: true, returnData: encodeReverseResult('fake.eth', differentAddr) }])
+
+    const result = await batchLookupAddresses(mockProvider, [addr])
+
+    expect(result).toEqual({ [addr]: null })
+  })
+
+  it('should return null for all addresses on multicall failure', async () => {
+    const addr1 = '0x1234567890123456789012345678901234567890'
+    const addr2 = '0xABCDEF0123456789ABCDEF0123456789ABCDEF01'
+
+    multicallMock.mockRejectedValue(new Error('RPC error'))
+
+    const result = await batchLookupAddresses(mockProvider, [addr1, addr2])
+
+    expect(result).toEqual({ [addr1]: null, [addr2]: null })
+  })
+
+  it('should handle mixed results', async () => {
+    const addr1 = '0x1234567890123456789012345678901234567890'
+    const addr2 = '0xABCDEF0123456789ABCDEF0123456789ABCDEF01'
+
+    multicallMock.mockResolvedValue([
+      { success: true, returnData: encodeReverseResult('alice.eth', addr1) },
+      { success: false, returnData: '0x' },
+    ])
+
+    const result = await batchLookupAddresses(mockProvider, [addr1, addr2])
+
+    expect(result).toEqual({
+      [addr1]: 'alice.eth',
+      [addr2]: null,
+    })
+  })
+})

--- a/apps/web/src/services/ens/batchLookup.ts
+++ b/apps/web/src/services/ens/batchLookup.ts
@@ -1,0 +1,98 @@
+import { Interface, type AbstractProvider } from 'ethers'
+import { multicall } from '@safe-global/utils/utils/multicall'
+import { logError } from '../exceptions'
+import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
+
+// ENS Universal Resolver on Ethereum mainnet
+// Handles both reverse resolution and forward verification in a single call
+const UNIVERSAL_RESOLVER = '0xce01f8eee7E479C928F8919abD53E553a36CeF67'
+
+const UNIVERSAL_RESOLVER_ABI = [
+  'function reverse(bytes reverseName) view returns (string name, address resolvedAddress, address reverseResolver, address resolver)',
+]
+
+const iface = new Interface(UNIVERSAL_RESOLVER_ABI)
+
+/**
+ * DNS-encode a domain name (e.g. "abc123.addr.reverse" → length-prefixed labels + 0x00)
+ * This follows the DNS wire format required by the ENS Universal Resolver.
+ */
+function dnsEncodeName(name: string): Uint8Array {
+  const labels = name.split('.')
+  const parts: number[] = []
+
+  for (const label of labels) {
+    const bytes = new TextEncoder().encode(label)
+    parts.push(bytes.length, ...bytes)
+  }
+  parts.push(0)
+
+  return new Uint8Array(parts)
+}
+
+/**
+ * Build the reverse name for an address.
+ * E.g. 0xABcD... → "abcd....addr.reverse"
+ */
+function toReverseName(address: string): Uint8Array {
+  const name = `${address.slice(2).toLowerCase()}.addr.reverse`
+  return dnsEncodeName(name)
+}
+
+/**
+ * Batch-resolve ENS reverse names for multiple addresses using multicall.
+ *
+ * Returns a record mapping each input address to its ENS name (or null if none).
+ * Uses the ENS Universal Resolver which performs both reverse resolution
+ * and forward verification in a single call.
+ */
+export async function batchLookupAddresses(
+  provider: AbstractProvider,
+  addresses: string[],
+): Promise<Record<string, string | null>> {
+  const result: Record<string, string | null> = {}
+
+  if (addresses.length === 0) return result
+
+  const calls = addresses.map((address) => ({
+    to: UNIVERSAL_RESOLVER,
+    data: iface.encodeFunctionData('reverse', [toReverseName(address)]),
+  }))
+
+  try {
+    const responses = await multicall(provider, calls)
+
+    for (let i = 0; i < addresses.length; i++) {
+      const address = addresses[i]
+      const response = responses[i]
+
+      if (!response.success || response.returnData === '0x') {
+        result[address] = null
+        continue
+      }
+
+      try {
+        const [name, resolvedAddress] = iface.decodeFunctionResult('reverse', response.returnData)
+
+        // Verify the forward resolution matches the original address
+        if (name && resolvedAddress.toLowerCase() === address.toLowerCase()) {
+          result[address] = name
+        } else {
+          result[address] = null
+        }
+      } catch {
+        result[address] = null
+      }
+    }
+  } catch (e) {
+    const err = e as Error
+    logError(ErrorCodes._101, err.message)
+
+    // On failure, mark all as null so they're still cached
+    for (const address of addresses) {
+      result[address] = null
+    }
+  }
+
+  return result
+}

--- a/apps/web/src/store/api/gateway/ensNames.ts
+++ b/apps/web/src/store/api/gateway/ensNames.ts
@@ -1,0 +1,46 @@
+import { type EndpointBuilder } from '@reduxjs/toolkit/query/react'
+import type { JsonRpcProvider } from 'ethers'
+
+import { batchLookupAddresses } from '@/services/ens/batchLookup'
+import { asError } from '@safe-global/utils/services/exceptions/utils'
+
+type EnsNamesResult = Record<string, string | null>
+
+/**
+ * Module-level cache for the mainnet provider.
+ * Lazily created on first use to keep ethers out of the main bundle.
+ */
+let mainnetProviderPromise: Promise<JsonRpcProvider> | null = null
+
+function getMainnetProvider(): Promise<JsonRpcProvider> {
+  if (!mainnetProviderPromise) {
+    mainnetProviderPromise = (async () => {
+      const { INFURA_TOKEN } = await import('@safe-global/utils/config/constants')
+      const { JsonRpcProvider } = await import('ethers')
+      return new JsonRpcProvider(`https://mainnet.infura.io/v3/${INFURA_TOKEN}`, 1, {
+        staticNetwork: true,
+      })
+    })()
+  }
+  return mainnetProviderPromise
+}
+
+export const ensNameEndpoints = (builder: EndpointBuilder<any, 'Submissions', 'gatewayApi'>) => ({
+  getBatchEnsNames: builder.query<EnsNamesResult, string[]>({
+    async queryFn(addresses) {
+      if (addresses.length === 0) {
+        return { data: {} }
+      }
+
+      try {
+        const provider = await getMainnetProvider()
+        const result = await batchLookupAddresses(provider, addresses)
+        return { data: result }
+      } catch (error) {
+        return { error: { status: 'CUSTOM_ERROR', error: asError(error).message } }
+      }
+    },
+    // Cache for 1 hour — ENS names rarely change
+    keepUnusedDataFor: 3600,
+  }),
+})

--- a/apps/web/src/store/api/gateway/index.ts
+++ b/apps/web/src/store/api/gateway/index.ts
@@ -2,6 +2,7 @@ import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react'
 
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 import { safeOverviewEndpoints } from './safeOverviews'
+import { ensNameEndpoints } from './ensNames'
 
 async function _buildQueryFn<T>(fn: () => Promise<T>) {
   try {
@@ -21,7 +22,8 @@ export const gatewayApi = createApi({
   tagTypes: ['Submissions'],
   endpoints: (builder) => ({
     ...safeOverviewEndpoints(builder),
+    ...ensNameEndpoints(builder),
   }),
 })
 
-export const { useGetSafeOverviewQuery, useGetMultipleSafeOverviewsQuery } = gatewayApi
+export const { useGetSafeOverviewQuery, useGetMultipleSafeOverviewsQuery, useGetBatchEnsNamesQuery } = gatewayApi


### PR DESCRIPTION
## What it solves
https://linear.app/safe-global/issue/WA-1624/show-saved-name-fallback-to-ens-name
Safe accounts on `/welcome/accounts` only display address book names. If a Safe has an ENS name but no address book entry, users see a raw truncated address with no way to identify it.

Additionally, the existing `useAddressResolver` hook has two problems that prevented simply reusing it here:
1. It depends on the global chain context — on the accounts page (no safe selected), it defaults to Sepolia in dev, where ENS doesn't work
2. It has no negative-result cache — addresses without ENS names are re-fetched on every mount, risking Infura rate limits

## How this PR fixes it

Introduces batch ENS reverse resolution for the accounts page using three layers:

1. **`services/ens/batchLookup.ts`** — Batch-resolves ENS names by multicalling the ENS Universal Resolver on mainnet. All addresses are resolved in a single RPC request instead of one per address. Includes forward verification to prevent spoofed reverse records.

2. **`store/api/gateway/ensNames.ts`** — RTK Query endpoint (`getBatchEnsNames`) that wraps the batch service with a dedicated mainnet provider (independent of the current chain). Results are cached for 1 hour, including `null` for addresses without ENS names, eliminating redundant RPC calls.

3. **`features/myAccounts/hooks/useAccountEnsNames.tsx`** — React Context provider + `useEnsName` hook. The provider collects addresses that lack an address book name, triggers a single batch query, and makes results available to child components via context.

4. **`AccountItemInfo`** now uses `NamedAddressInfo` with `noContractName` (skips contract name lookup, since Safe accounts are contracts themselves). `SafeListItem` and `MultiAccountItem` use `useEnsName` as a fallback when no address book name exists.

**Name resolution priority:** Address book name → ENS name → truncated address

## How to test it

1. Go to `/welcome/accounts`
2. Ensure you have a Safe whose owner address has an ENS name (e.g., add a Safe owned by a known ENS address) but **no** address book entry for that Safe
3. The Safe should display its ENS name next to the truncated address
4. Navigate away and back — the ENS name should appear immediately (cached)
5. Add an address book name for that Safe — the address book name should take priority over the ENS name

## Screenshots
<img width="1501" height="675" alt="Screenshot 2026-03-25 at 10 37 50" src="https://github.com/user-attachments/assets/2c95869c-df4d-4755-aa9e-c27b8c59cf22" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
