### PR TITLE
chore: allow dynamic redirect for email login

### DIFF
--- a/apps/web/src/features/email-auth/hooks/__tests__/useEmailLogin.test.ts
+++ b/apps/web/src/features/email-auth/hooks/__tests__/useEmailLogin.test.ts
@@ -32,13 +32,27 @@ describe('useEmailLogin', () => {
     expect(sessionStorage.getItem(EMAIL_AUTH_PENDING_KEY)).toBe('1')
   })
 
-  it('should redirect to CGW authorize endpoint', () => {
+  it('should redirect to CGW authorize endpoint with current URL as default redirect_url', () => {
     const { result } = renderHook(() => useEmailLogin())
 
     act(() => {
       result.current.loginWithRedirect()
     })
 
-    expect(window.location.href).toBe(`${GATEWAY_URL}/v1/auth/oidc/authorize`)
+    const redirectUrl = new URL(window.location.href)
+    expect(redirectUrl.origin + redirectUrl.pathname).toBe(`${GATEWAY_URL}/v1/auth/oidc/authorize`)
+    expect(redirectUrl.searchParams.get('redirect_url')).toBe('https://app.safe.global/welcome/spaces')
+  })
+
+  it('should use explicit redirect_url when provided', () => {
+    const customUrl = 'https://app.safe.global/home'
+    const { result } = renderHook(() => useEmailLogin())
+
+    act(() => {
+      result.current.loginWithRedirect(customUrl)
+    })
+
+    const redirectUrl = new URL(window.location.href)
+    expect(redirectUrl.searchParams.get('redirect_url')).toBe(customUrl)
   })
 })

--- a/apps/web/src/features/email-auth/hooks/useEmailLogin.ts
+++ b/apps/web/src/features/email-auth/hooks/useEmailLogin.ts
@@ -12,9 +12,11 @@ const AUTHORIZE_PATH = '/v1/auth/oidc/authorize'
  * automatically and would fail trying to parse the provider's HTML as JSON).
  */
 export const useEmailLogin = () => {
-  const loginWithRedirect = useCallback(() => {
+  const loginWithRedirect = useCallback((redirectUrl?: string) => {
     sessionStorage.setItem(EMAIL_AUTH_PENDING_KEY, '1')
-    window.location.href = new URL(AUTHORIZE_PATH, GATEWAY_URL).toString()
+    const url = new URL(AUTHORIZE_PATH, GATEWAY_URL)
+    url.searchParams.set('redirect_url', redirectUrl ?? window.location.href)
+    window.location.href = url.toString()
   }, [])
 
   return { loginWithRedirect }

--- a/packages/store/scripts/api-schema/schema.json
+++ b/packages/store/scripts/api-schema/schema.json
@@ -115,6 +115,99 @@
         ]
       }
     },
+    "/v1/auth/oidc/authorize": {
+      "get": {
+        "description": "Redirects the browser to OIDC provider login page with a generated state value stored in an HTTP-only cookie.",
+        "operationId": "oidcAuthAuthorizeV1",
+        "parameters": [
+          {
+            "name": "redirect_url",
+            "required": false,
+            "in": "query",
+            "description": "URL to redirect to after successful login. Must be same-origin as the configured post-login redirect URI.",
+            "schema": {
+              "example": "/settings",
+              "type": "string"
+            }
+          },
+          {
+            "name": "connection",
+            "required": false,
+            "in": "query",
+            "description": "OIDC connection name to route to a specific identity provider.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to OIDC authorize endpoint"
+          }
+        },
+        "summary": "Start OIDC authorization code flow",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/v1/auth/oidc/callback": {
+      "get": {
+        "description": "Exchanges the OIDC authorization code for user information, mints the internal JWT cookie, and redirects to the provided post-login URL or a configured default one.",
+        "operationId": "oidcAuthCallbackV1",
+        "parameters": [
+          {
+            "name": "code",
+            "required": false,
+            "in": "query",
+            "description": "Authorization code returned by the OIDC provider",
+            "schema": {
+              "example": "SplxlOBeZQQYbYS6WxSbIA",
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "required": false,
+            "in": "query",
+            "description": "State parameter returned by the OIDC provider",
+            "schema": {
+              "example": "af0ifjsldkj",
+              "type": "string"
+            }
+          },
+          {
+            "name": "error",
+            "required": false,
+            "in": "query",
+            "description": "Error parameter returned by the OIDC provider",
+            "schema": {
+              "example": "access_denied",
+              "type": "string"
+            }
+          },
+          {
+            "name": "error_description",
+            "required": false,
+            "in": "query",
+            "description": "Description of the error returned by the OIDC provider (if failed)",
+            "schema": {
+              "example": "The user has denied the request",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to the post-login URL. On error, includes error query parameter."
+          }
+        },
+        "summary": "Handle OIDC authorization callback",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
     "/v1/chains/{chainId}/safes/{safeAddress}/balances/{fiatCode}": {
       "get": {
         "description": "Retrieves token balances for a Safe on a specific chain, converted to the specified fiat currency. Includes native tokens, ERC-20 tokens, and their current market values.",

--- a/packages/store/scripts/openapi-config.ts
+++ b/packages/store/scripts/openapi-config.ts
@@ -14,7 +14,7 @@ const config: ConfigFile = {
       filterEndpoints: [/^about/],
     },
     '../src/gateway/AUTO_GENERATED/auth.ts': {
-      filterEndpoints: [/^auth/],
+      filterEndpoints: [/^(auth|oidcAuth)/],
     },
     '../src/gateway/AUTO_GENERATED/balances.ts': {
       filterEndpoints: [/^balances/],

--- a/packages/store/src/gateway/AUTO_GENERATED/auth.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/auth.ts
@@ -22,6 +22,28 @@ const injectedRtkApi = api
         query: () => ({ url: `/v1/auth/logout`, method: 'POST' }),
         invalidatesTags: ['auth'],
       }),
+      oidcAuthAuthorizeV1: build.query<OidcAuthAuthorizeV1ApiResponse, OidcAuthAuthorizeV1ApiArg>({
+        query: (queryArg) => ({
+          url: `/v1/auth/oidc/authorize`,
+          params: {
+            redirect_url: queryArg.redirectUrl,
+            connection: queryArg.connection,
+          },
+        }),
+        providesTags: ['auth'],
+      }),
+      oidcAuthCallbackV1: build.query<OidcAuthCallbackV1ApiResponse, OidcAuthCallbackV1ApiArg>({
+        query: (queryArg) => ({
+          url: `/v1/auth/oidc/callback`,
+          params: {
+            code: queryArg.code,
+            state: queryArg.state,
+            error: queryArg.error,
+            error_description: queryArg.errorDescription,
+          },
+        }),
+        providesTags: ['auth'],
+      }),
     }),
     overrideExisting: false,
   })
@@ -37,6 +59,24 @@ export type AuthVerifyV1ApiArg = {
 }
 export type AuthLogoutV1ApiResponse = unknown
 export type AuthLogoutV1ApiArg = void
+export type OidcAuthAuthorizeV1ApiResponse = unknown
+export type OidcAuthAuthorizeV1ApiArg = {
+  /** URL to redirect to after successful login. Must be same-origin as the configured post-login redirect URI. */
+  redirectUrl?: string
+  /** OIDC connection name to route to a specific identity provider. */
+  connection?: string
+}
+export type OidcAuthCallbackV1ApiResponse = unknown
+export type OidcAuthCallbackV1ApiArg = {
+  /** Authorization code returned by the OIDC provider */
+  code?: string
+  /** State parameter returned by the OIDC provider */
+  state?: string
+  /** Error parameter returned by the OIDC provider */
+  error?: string
+  /** Description of the error returned by the OIDC provider (if failed) */
+  errorDescription?: string
+}
 export type AuthNonce = {
   nonce: string
 }
@@ -51,4 +91,8 @@ export const {
   useLazyAuthGetNonceV1Query,
   useAuthVerifyV1Mutation,
   useAuthLogoutV1Mutation,
+  useOidcAuthAuthorizeV1Query,
+  useLazyOidcAuthAuthorizeV1Query,
+  useOidcAuthCallbackV1Query,
+  useLazyOidcAuthCallbackV1Query,
 } = injectedRtkApi


### PR DESCRIPTION
## What it solves

Allows to provide a dynamic redirect from Auth0 Login page

Resolves: [WA-1816](https://linear.app/safe-global/issue/WA-1816/add-dynamic-redirect-url-to-authorize-call)

## How this PR fixes it
- add an optional parameter to `loginWithRedirect()`: `redirect_url`
- after the login is complete the app will be redirected to that page
- currently its set to the current window: /welcome/spaces

## How to test it

## Screenshots

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
