### PR TITLE
chore(ci): revert smoke workflow spec-splitting and recording changes

### DIFF
--- a/.github/workflows/web-e2e-smoke.yml
+++ b/.github/workflows/web-e2e-smoke.yml
@@ -35,31 +35,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Split specs across containers
-        id: specs
-        shell: bash
-        run: |
-          mapfile -t all_specs < <(ls apps/web/cypress/e2e/smoke/*.cy.js | sort)
-          total=${#all_specs[@]}
-          container=${{ matrix.containers }}
-          num_containers=5
-          selected=()
-          for (( i=0; i<total; i++ )); do
-            if (( (i % num_containers) + 1 == container )); then
-              # Convert absolute path to relative from apps/web/
-              spec="${all_specs[$i]#apps/web/}"
-              selected+=("$spec")
-            fi
-          done
-          echo "specs=$(IFS=,; echo "${selected[*]}")" >> "$GITHUB_OUTPUT"
-
       - uses: ./.github/actions/cypress
         with:
           secrets: ${{ toJSON(secrets) }}
-          spec: ${{ steps.specs.outputs.specs }}
+          spec: cypress/e2e/smoke/*.cy.js
           group: 'Smoke tests'
           tag: 'smoke'
-          record: 'false'
 
   notify:
     if: failure() && github.event_name == 'push'


### PR DESCRIPTION
> Specs unsplit, Cloud restored,
> the smoke workflow heals—
> a revert, nothing more.

## What it solves

Reverts unintended CI changes introduced in e6d1678 (#7525) that disabled Cypress Cloud recording and added manual spec splitting to the smoke workflow.

## How this PR fixes it

Restores `.github/workflows/web-e2e-smoke.yml` to its previous state:
- Removes the manual bash spec-splitting step
- Restores the original `spec: cypress/e2e/smoke/*.cy.js` glob
- Re-enables Cypress Cloud recording (removes `record: 'false'`)

## How to test it

- Verify the smoke workflow runs correctly on this PR
- Confirm Cypress Cloud recording works again

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A (CI-only change)
- [ ] I've documented how it affects the analytics (if at all) 📊 — N/A
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — N/A

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)