### PR TITLE
chore: require visual summary in PR descriptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,8 @@ Resolves:
 
 ## How to test it
 
-## Screenshots
+## Visual summary
+<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->
 
 ## Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,6 +320,40 @@ The repo provides automated verification:
 
 9. **PR description**: Always use the GitHub PR template (`.github/PULL_REQUEST_TEMPLATE.md`). Fill out all sections — "What it solves", "How this PR fixes it", "How to test it", and the checklist.
 
+10. **PR visual summary (required)**: Every PR must include a visual in the `## Visual summary` section. This is mandatory, not optional.
+
+    - **Architecture/logic changes** → Mermaid diagram (flowchart, sequence, or class diagram) showing what changed
+    - **UI changes** → Screenshot of the result (use Chrome DevTools MCP if the app is running, or describe how to capture manually)
+    - **Both** if the PR includes UI + logic changes
+
+    Mermaid diagrams are rendered natively by GitHub. Example:
+
+    ````markdown
+    ```mermaid
+    flowchart LR
+      A[useSafeInfo hook] --> B[New validation logic]
+      B --> C{Is owner?}
+      C -->|Yes| D[Show actions]
+      C -->|No| E[Show read-only]
+    ```
+    ````
+
+    For refactors, use a before/after diagram:
+
+    ````markdown
+    ```mermaid
+    flowchart TB
+      subgraph Before
+        A1[Component A] --> B1[Inline logic]
+        A1 --> C1[Inline logic]
+      end
+      subgraph After
+        A2[Component A] --> H[useSharedHook]
+        H --> B2[Extracted service]
+      end
+    ```
+    ````
+
 **Environment Variables** – Web apps use `NEXT_PUBLIC_*` prefix, mobile apps use `EXPO_PUBLIC_*` prefix for environment variables. In shared packages, check for both prefixes.
 
 ## Testing Guidelines


### PR DESCRIPTION
> A picture speaks a thousand diffs,
> now every PR must show its face —
> Mermaid or screenshot, no more blanks.

## What it solves

AI-authored PRs often lack visual context, making them harder to review. The existing `## Screenshots` section in the PR template was optional and frequently left empty.

## How this PR fixes it

- Renames `## Screenshots` to `## Visual summary` in the PR template with guidance comment
- Adds rule #10 in AGENTS.md making visual summaries mandatory for all PRs
- Provides concrete Mermaid diagram examples (flowchart + before/after refactor pattern)
- Covers three scenarios: architecture/logic changes (Mermaid), UI changes (screenshots), and combined

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    A[PR template] --> B["## Screenshots (optional, empty)"]
  end
  subgraph After
    C[PR template] --> D["## Visual summary (required, guided)"]
    E[AGENTS.md] --> F["Rule #10: mandatory visual + examples"]
  end
```

## How to test it

- Open a new PR and verify the template shows `## Visual summary` with the guidance comment
- Check that AGENTS.md rule #10 renders correctly with Mermaid examples

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>