### PR TITLE
fix(e2e): hard code chrome version

### DIFF
--- a/.github/actions/cypress/action.yml
+++ b/.github/actions/cypress/action.yml
@@ -47,11 +47,11 @@ runs:
   steps:
     - uses: ./.github/actions/yarn
 
-    - name: Install Latest stable Chrome Version
-      shell: bash
-      run: |
-        curl -O 'https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb'
-        sudo apt-get install ./google-chrome-stable_current_amd64.deb
+    - name: Install Chrome
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: '134'
+      id: setup-chrome
 
     - uses: ./.github/actions/build
       with:
@@ -64,7 +64,7 @@ runs:
         spec: ${{ inputs.spec }}
         group: ${{ inputs.record == 'true' && inputs.group || '' }}
         parallel: ${{ inputs.record == 'true' && inputs.parallel == 'true' }}
-        browser: chrome
+        browser: ${{ steps.setup-chrome.outputs.chrome-path }}
         record: ${{ inputs.record == 'true' }}
         tag: ${{ inputs.record == 'true' && inputs.tag || '' }}
         config: baseUrl=http://localhost:8080


### PR DESCRIPTION
## What it solves
The smoke and regression runs on the Github are failing , because of the updating Chrome version .
Resolves: https://linear.app/safe-global/issue/WA-1850/fixe2e-hard-code-chrome-version

## How this PR fixes it
The chrome version is fixed 
## How to test it

## Visual summary
<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
