### PR TITLE
feat(mobile): redesign signer badges and list layout in settings

### DIFF
--- a/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
+++ b/apps/mobile/src/components/SafeListItem/SafeListItem.tsx
@@ -72,10 +72,10 @@ export function SafeListItem({
       {...(pressStyle ? { pressStyle } : {})}
     >
       <View flexDirection="row" width="100%" alignItems="center" justifyContent="space-between" gap={8}>
-        <View flexDirection="row" flexShrink={1} flex={1} alignItems="center" gap={12}>
+        <View flexDirection="row" maxWidth={rightNode ? '55%' : '100%'} alignItems="center" gap={12}>
           {leftNode}
 
-          <View flexShrink={1}>
+          <View>
             {type && (
               <View flexDirection="row" alignItems="center" gap={4}>
                 {icon && (
@@ -112,7 +112,7 @@ export function SafeListItem({
             <SafeFontIcon name="chevron-right" size={16} />
           </View>
         ) : rightNode ? (
-          <View flexShrink={0} alignItems="flex-end">
+          <View flexShrink={1} alignItems="flex-end">
             {rightNode}
           </View>
         ) : null}

--- a/apps/mobile/src/components/SafeListItem/__snapshots__/SafeListItem.test.tsx.snap
+++ b/apps/mobile/src/components/SafeListItem/__snapshots__/SafeListItem.test.tsx.snap
@@ -46,10 +46,9 @@ exports[`SafeListItem should render a list item with a custom label template 1`]
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "100%",
             }
           }
         >
@@ -63,13 +62,7 @@ exports[`SafeListItem should render a list item with a custom label template 1`]
           >
             Left node
           </Text>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <View
               style={
                 {
@@ -182,10 +175,9 @@ exports[`SafeListItem should render bottomContent with proper styling and layout
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "100%",
             }
           }
         >
@@ -199,13 +191,7 @@ exports[`SafeListItem should render bottomContent with proper styling and layout
           >
             Left node
           </Text>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <Text
               ellipsizeMode="tail"
               numberOfLines={1}

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxDepositCard/__snapshots__/StakingTxDepositCard.test.tsx.snap
@@ -55,10 +55,9 @@ exports[`StakingTxDepositCard renders correctly 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "55%",
             }
           }
         >
@@ -131,13 +130,7 @@ exports[`StakingTxDepositCard renders correctly 1`] = `
               />
             </View>
           </View>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <View
               style={
                 {
@@ -206,7 +199,7 @@ exports[`StakingTxDepositCard renders correctly 1`] = `
           style={
             {
               "alignItems": "flex-end",
-              "flexShrink": 0,
+              "flexShrink": 1,
             }
           }
         >

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxExitCard/__snapshots__/StakingTxExitCard.test.tsx.snap
@@ -55,10 +55,9 @@ exports[`StakingTxExitCard matches snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "55%",
             }
           }
         >
@@ -131,13 +130,7 @@ exports[`StakingTxExitCard matches snapshot 1`] = `
               />
             </View>
           </View>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <View
               style={
                 {
@@ -206,7 +199,7 @@ exports[`StakingTxExitCard matches snapshot 1`] = `
           style={
             {
               "alignItems": "flex-end",
-              "flexShrink": 0,
+              "flexShrink": 1,
             }
           }
         >

--- a/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/StakingTxWithdrawCard/__snapshots__/StakingTxWithdrawCard.test.tsx.snap
@@ -55,10 +55,9 @@ exports[`StakingTxWithdrawCard matches snapshot 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "55%",
             }
           }
         >
@@ -131,13 +130,7 @@ exports[`StakingTxWithdrawCard matches snapshot 1`] = `
               />
             </View>
           </View>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <View
               style={
                 {
@@ -206,7 +199,7 @@ exports[`StakingTxWithdrawCard matches snapshot 1`] = `
           style={
             {
               "alignItems": "flex-end",
-              "flexShrink": 0,
+              "flexShrink": 1,
             }
           }
         >

--- a/apps/mobile/src/components/transactions-list/Card/TxBatchCard/__snapshots__/TxBatchCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxBatchCard/__snapshots__/TxBatchCard.test.tsx.snap
@@ -55,10 +55,9 @@ exports[`TxBatchCard should render the default markup 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "100%",
             }
           }
         >
@@ -99,13 +98,7 @@ exports[`TxBatchCard should render the default markup 1`] = `
               
             </Text>
           </View>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <View
               style={
                 {

--- a/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/__snapshots__/TxSettingCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/TxSettingsCard/__snapshots__/TxSettingCard.test.tsx.snap
@@ -55,10 +55,9 @@ exports[`TxSettingCard should render the default markup 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "100%",
             }
           }
         >
@@ -99,13 +98,7 @@ exports[`TxSettingCard should render the default markup 1`] = `
               
             </Text>
           </View>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <View
               style={
                 {

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/__snapshots__/VaultTxDepositCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxDepositCard/__snapshots__/VaultTxDepositCard.test.tsx.snap
@@ -46,10 +46,9 @@ exports[`VaultTxDepositCard renders correctly 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "55%",
             }
           }
         >
@@ -122,13 +121,7 @@ exports[`VaultTxDepositCard renders correctly 1`] = `
               />
             </View>
           </View>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <View
               style={
                 {
@@ -197,7 +190,7 @@ exports[`VaultTxDepositCard renders correctly 1`] = `
           style={
             {
               "alignItems": "flex-end",
-              "flexShrink": 0,
+              "flexShrink": 1,
             }
           }
         >

--- a/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/__snapshots__/VaultTxRedeemCard.test.tsx.snap
+++ b/apps/mobile/src/components/transactions-list/Card/VaultTxRedeemCard/__snapshots__/VaultTxRedeemCard.test.tsx.snap
@@ -46,10 +46,9 @@ exports[`VaultTxRedeemCard renders correctly 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "55%",
             }
           }
         >
@@ -122,13 +121,7 @@ exports[`VaultTxRedeemCard renders correctly 1`] = `
               />
             </View>
           </View>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <View
               style={
                 {
@@ -197,7 +190,7 @@ exports[`VaultTxRedeemCard renders correctly 1`] = `
           style={
             {
               "alignItems": "flex-end",
-              "flexShrink": 0,
+              "flexShrink": 1,
             }
           }
         >

--- a/apps/mobile/src/features/Assets/components/Positions/PositionItem/__snapshots__/PositionItem.test.tsx.snap
+++ b/apps/mobile/src/features/Assets/components/Positions/PositionItem/__snapshots__/PositionItem.test.tsx.snap
@@ -52,10 +52,9 @@ exports[`PositionItem renders correctly 1`] = `
           style={
             {
               "alignItems": "center",
-              "flex": 1,
               "flexDirection": "row",
-              "flexShrink": 1,
               "gap": 12,
+              "maxWidth": "55%",
             }
           }
         >
@@ -128,13 +127,7 @@ exports[`PositionItem renders correctly 1`] = `
               />
             </View>
           </View>
-          <View
-            style={
-              {
-                "flexShrink": 1,
-              }
-            }
-          >
+          <View>
             <View>
               <Text
                 style={
@@ -203,7 +196,7 @@ exports[`PositionItem renders correctly 1`] = `
           style={
             {
               "alignItems": "flex-end",
-              "flexShrink": 0,
+              "flexShrink": 1,
             }
           }
         >


### PR DESCRIPTION
> Badges gain status, icons, and props,
> signers shift from absolute to flex,
> tests rewrite with purpose.

## What it solves

The signer list in settings used absolute positioning for badges and menus, causing layout issues. The WalletConnectBadge component lacked flexibility — it only supported a binary `withStatus` toggle and couldn't display wallet icons on the error screen or in non-WC signer contexts.

## How this PR fixes it

Replaces `withStatus` boolean with explicit `status`, `skipStatus`, and `walletIcon` props on `WalletConnectBadge`, backed by a `statusConfig` lookup for connected/disconnected/error states. The badge now auto-derives status from signer type and connection state when no explicit status is given, and accepts a `walletIcon` prop as fallback when the signer isn't in the store yet.

The signers list moves badges and the menu into `SignersCard.rightNode` using flexbox instead of absolute positioning. The error screen now shows the actual wallet icon (passed via route params) instead of a generic error badge.

WalletConnectBadge tests were rewritten from 7 shallow smoke tests to 9 focused behavioral tests covering null guards, icon resolution priority, status derivation, image error handling, and skipStatus. useWalletConnect tests were extended with 9 new cases for route params, fallbacks, guard conditions, and unmount cancellation.

## Screenshots

<img width="150" alt="simulator_screenshot_501329C9-29CC-47CC-B1B9-82CAACD18A23" src="https://github.com/user-attachments/assets/2f7c3960-c794-4e91-9dd8-640f47f19803" />
<img width="150" alt="simulator_screenshot_1CB8FB14-4CD0-48D1-AE08-A5E1961823B1" src="https://github.com/user-attachments/assets/76f56ad4-1f84-4514-b18b-c72a333b35aa" />
<img width="150" alt="simulator_screenshot_025B461C-D24C-4CC7-8F89-8FB2129D8E2E" src="https://github.com/user-attachments/assets/627591a4-0e41-4100-bd42-d4443b4bba61" />


## How to test it

1. Open the signers list in Settings — verify WC signers show wallet icons (no status dot), imported signers show "Imported" badge, and the overflow menu is aligned
2. Connect a WalletConnect signer that is NOT an owner — verify the error screen shows the wallet icon with an error status badge
3. Connect a WalletConnect signer that IS an owner — verify navigation to the name-signer screen works

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    A1[withStatus: boolean] --> B1[connected or disconnected]
    C1[Absolute positioned badges]
  end
  subgraph After
    A2[status / skipStatus / walletIcon props] --> B2[connected / disconnected / error]
    C2[Flexbox rightNode layout]
    D2[Error screen shows wallet icon]
  end
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).