### PR TITLE
docs: use repo-relative app README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Safe{Wallet} monorepo
 
-🌐 [Safe{Wallet} web app](/apps/web/README.md) ・ 📱 [Safe{Wallet} mobile app](/apps/mobile/README.md)
+🌐 [Safe{Wallet} web app](./apps/web/README.md) ・ 📱 [Safe{Wallet} mobile app](./apps/mobile/README.md)
 
 ## Overview
 
@@ -12,8 +12,8 @@ This repository houses both web and mobile applications along with shared packag
 
 ### Key components
 
-- **apps/web** - Next.js web application ([detailed documentation](/apps/web/README.md))
-- **apps/mobile** - Expo/React Native mobile application ([detailed documentation](/apps/mobile/README.md))
+- **apps/web** - Next.js web application ([detailed documentation](./apps/web/README.md))
+- **apps/mobile** - Expo/React Native mobile application ([detailed documentation](./apps/mobile/README.md))
 - **packages/store** - Shared Redux store used by both platforms
 - **packages/utils** - Shared utilities and TypeScript types
 - **config/** - Shared configuration files
@@ -22,8 +22,8 @@ This repository houses both web and mobile applications along with shared packag
 >
 > For detailed setup instructions and platform-specific development guides, please refer to the dedicated README files:
 >
-> - **[Web App Documentation](/apps/web/README.md)** - Complete guide for the Next.js web application
-> - **[Mobile App Documentation](/apps/mobile/README.md)** - Complete guide for the mobile application, including iOS/Android setup
+> - **[Web App Documentation](./apps/web/README.md)** - Complete guide for the Next.js web application
+> - **[Mobile App Documentation](./apps/mobile/README.md)** - Complete guide for the mobile application, including iOS/Android setup
 
 ## Getting started
 
@@ -88,8 +88,8 @@ yarn workspace @safe-global/web storybook
 >
 > For comprehensive setup instructions, environment variables, testing, and platform-specific workflows, see:
 >
-> - **[Web App README](/apps/web/README.md)** - Environment setup, Cypress E2E tests, Storybook, and more
-> - **[Mobile App README](/apps/mobile/README.md)** - iOS/Android setup, Maestro E2E tests, Expo configuration, and more
+> - **[Web App README](./apps/web/README.md)** - Environment setup, Cypress E2E tests, Storybook, and more
+> - **[Mobile App README](./apps/mobile/README.md)** - iOS/Android setup, Maestro E2E tests, Expo configuration, and more
 
 ## Monorepo commands
 


### PR DESCRIPTION
## What it solves

Resolves broken root-README links to the web and mobile app documentation when the file is viewed in the GitHub repository context.

## How this PR fixes it

Replaces root-style `/apps/...` links in `README.md` with repo-relative `./apps/...` links so they resolve to files in this repository instead of `github.com/apps/...`.

## How to test it

1. Open the root `README.md` in the GitHub repository view.
2. Confirm each web/mobile app documentation link now resolves to:
   - `apps/web/README.md`
   - `apps/mobile/README.md`
3. Verify the previous root-style targets would have resolved to 404s outside the repository context.

## Visual summary

```mermaid
flowchart LR
  A[Root README link] --> B[/apps/web/README.md]
  B --> C[GitHub root path outside repo]
  C --> D[404]
  A --> E[./apps/web/README.md]
  E --> F[Repo-local README target]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).