### PR TITLE
refactor(web/Spaces): remove code duplications; Onboarding pages follow Feature Architecture; tracking fixes

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/__tests__/NavItem.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/__tests__/NavItem.test.tsx
@@ -90,6 +90,19 @@ describe('NavItem', () => {
     expect(screen.getByText('You need to activate your Safe first.')).toBeInTheDocument()
   })
 
+  it('uses per-label test id when isSpacesVariant', () => {
+    render(<NavItem item={baseItem} isSpacesVariant />)
+
+    expect(screen.getByTestId('sidebar-item-home')).toBeInTheDocument()
+  })
+
+  it('does not show Safe activation tooltip when disabled and isSpacesVariant', () => {
+    const disabledItem = { ...baseItem, disabled: true }
+    render(<NavItem item={disabledItem} isSpacesVariant />)
+
+    expect(screen.queryByText('You need to activate your Safe first.')).not.toBeInTheDocument()
+  })
+
   it('sets data-active attribute when isActive is true', () => {
     const activeItem = { ...baseItem, isActive: true }
     render(<NavItem item={activeItem} />)

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem.tsx
@@ -3,36 +3,55 @@ import Link from 'next/link'
 import { SidebarMenuItem, SidebarMenuButton } from '@/components/ui/sidebar'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import type { ResolvedSidebarItem } from '../types'
+import { getSidebarItemTestId } from '../utils'
 import css from '../styles.module.css'
 
 const getBadgeAriaLabel = (label: string, count: number): string =>
   `${count} ${label} ${count === 1 ? 'notification' : 'notifications'}`
 
-export const NavItem = ({ item }: { item: ResolvedSidebarItem }): ReactElement => (
-  <SidebarMenuItem className="relative">
+interface NavItemProps {
+  item: ResolvedSidebarItem
+  /** Spaces sidebar: per-label test ids; no tooltip wrapper so disabled state reaches the DOM. */
+  isSpacesVariant?: boolean
+}
+
+export const NavItem = ({ item, isSpacesVariant = false }: NavItemProps): ReactElement => {
+  const dataTestId = isSpacesVariant ? getSidebarItemTestId(item.label) : 'sidebar-list-item'
+
+  const menuButton = (
+    <SidebarMenuButton
+      size="lg"
+      isActive={item.isActive}
+      disabled={item.disabled}
+      className={`h-9 gap-3 ${css.sidebarInteractive} ${css.sidebarNavItem}`}
+      render={!item.disabled ? <Link href={item.link} /> : undefined}
+      data-testid={dataTestId}
+    >
+      <item.icon />
+      <span>{item.label}</span>
+    </SidebarMenuButton>
+  )
+
+  const interactive = isSpacesVariant ? (
+    menuButton
+  ) : (
     <Tooltip>
-      <TooltipTrigger className="block w-full">
-        <SidebarMenuButton
-          size="lg"
-          isActive={item.isActive}
-          disabled={item.disabled}
-          className={`h-9 gap-3 ${css.sidebarInteractive} ${css.sidebarNavItem}`}
-          render={!item.disabled ? <Link href={item.link} /> : undefined}
-          data-testid="sidebar-list-item"
-        >
-          <item.icon />
-          <span>{item.label}</span>
-        </SidebarMenuButton>
-      </TooltipTrigger>
+      <TooltipTrigger className="block w-full">{menuButton}</TooltipTrigger>
       {item.disabled && <TooltipContent side="right">You need to activate your Safe first.</TooltipContent>}
     </Tooltip>
-    {item.badge !== undefined && item.badge > 0 && (
-      <>
-        <span className={css.transactionsBadge} aria-label={getBadgeAriaLabel(item.label, item.badge)}>
-          {item.badge}
-        </span>
-        <span className={css.transactionsBadgeDot} aria-hidden />
-      </>
-    )}
-  </SidebarMenuItem>
-)
+  )
+
+  return (
+    <SidebarMenuItem className="relative">
+      {interactive}
+      {item.badge !== undefined && item.badge > 0 && (
+        <>
+          <span className={css.transactionsBadge} aria-label={getBadgeAriaLabel(item.label, item.badge)}>
+            {item.badge}
+          </span>
+          <span className={css.transactionsBadgeDot} aria-hidden />
+        </>
+      )}
+    </SidebarMenuItem>
+  )
+}

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarVariant.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarVariant.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from 'react'
-import Link from 'next/link'
 import {
   SidebarContent,
   SidebarGroup,
@@ -7,45 +6,16 @@ import {
   SidebarGroupContent,
   SidebarMenu,
   SidebarMenuItem,
-  SidebarMenuButton,
 } from '@/components/ui/sidebar'
 import css from '../styles.module.css'
 import type { SpaceSelectorProps, ResolvedSidebarItem, ResolvedSidebarGroup } from '../types'
-import { getSidebarItemTestId } from '../utils'
+import { NavItem } from './NavItem'
 import { SpaceSelectorDropdown } from './SpaceSelectorDropdown'
 
 interface SpacesSidebarVariantProps extends SpaceSelectorProps {
   mainNavItems: ResolvedSidebarItem[]
   setupGroup: ResolvedSidebarGroup
 }
-
-const getBadgeAriaLabel = (label: string, count: number): string =>
-  `${count} ${label} ${count === 1 ? 'notification' : 'notifications'}`
-
-const NavItem = ({ item }: { item: ResolvedSidebarItem }): ReactElement => (
-  <SidebarMenuItem key={item.href} className="relative">
-    <SidebarMenuButton
-      size="lg"
-      isActive={item.isActive}
-      disabled={item.disabled}
-      data-testid={getSidebarItemTestId(item.label)}
-      className={`h-9 gap-3 ${css.sidebarInteractive} ${css.sidebarNavItem}`}
-      // No tooltip: when set, TooltipTrigger is used and does not forward disabled to the DOM.
-      render={!item.disabled ? <Link href={item.link} /> : undefined}
-    >
-      <item.icon />
-      <span>{item.label}</span>
-    </SidebarMenuButton>
-    {item.badge !== undefined && item.badge > 0 && (
-      <>
-        <span className={css.transactionsBadge} aria-label={getBadgeAriaLabel(item.label, item.badge)}>
-          {item.badge}
-        </span>
-        <span className={css.transactionsBadgeDot} aria-hidden />
-      </>
-    )}
-  </SidebarMenuItem>
-)
 
 export const SpacesSidebarVariant = ({
   selectedSpace,
@@ -68,7 +38,7 @@ export const SpacesSidebarVariant = ({
         <SidebarGroupContent>
           <SidebarMenu className="gap-0">
             {mainNavItems.map((item) => (
-              <NavItem key={item.href} item={item} />
+              <NavItem key={item.href} item={item} isSpacesVariant />
             ))}
           </SidebarMenu>
         </SidebarGroupContent>
@@ -80,7 +50,7 @@ export const SpacesSidebarVariant = ({
         <SidebarGroupContent>
           <SidebarMenu className="gap-0">
             {setupGroup.items.map((item) => (
-              <NavItem key={item.href} item={item} />
+              <NavItem key={item.href} item={item} isSpacesVariant />
             ))}
           </SidebarMenu>
         </SidebarGroupContent>

--- a/apps/web/src/features/spaces/contract.ts
+++ b/apps/web/src/features/spaces/contract.ts
@@ -28,6 +28,9 @@ import type SpaceMembersPage from './components/Members/Page'
 import type SpaceSafeAccountsPage from './components/SafeAccounts/Page'
 import type SpaceAddressBookPage from './components/SpaceAddressBook/Page'
 import type SpaceSettingsPage from './components/SpaceSettings/Page'
+import type CreateSpaceOnboarding from './components/CreateSpaceOnboarding'
+import type SelectSafesOnboarding from './components/SelectSafesOnboarding'
+import type InviteMembersOnboarding from './components/InviteMembersOnboarding'
 
 // Utility services
 import type { isUnauthorized, filterSpacesByStatus, getNonDeclinedSpaces } from './utils'
@@ -59,6 +62,11 @@ export interface SpacesContract {
   SpaceSafeAccountsPage: typeof SpaceSafeAccountsPage
   SpaceAddressBookPage: typeof SpaceAddressBookPage
   SpaceSettingsPage: typeof SpaceSettingsPage
+
+  // Onboarding page components (PascalCase) - stub renders null
+  CreateSpaceOnboarding: typeof CreateSpaceOnboarding
+  SelectSafesOnboarding: typeof SelectSafesOnboarding
+  InviteMembersOnboarding: typeof InviteMembersOnboarding
 
   // Services (camelCase) - undefined when not ready
   isUnauthorized: typeof isUnauthorized

--- a/apps/web/src/features/spaces/feature.ts
+++ b/apps/web/src/features/spaces/feature.ts
@@ -32,6 +32,9 @@ import SpaceMembersPage from './components/Members/Page'
 import SpaceSafeAccountsPage from './components/SafeAccounts/Page'
 import SpaceAddressBookPage from './components/SpaceAddressBook/Page'
 import SpaceSettingsPage from './components/SpaceSettings/Page'
+import CreateSpaceOnboarding from './components/CreateSpaceOnboarding'
+import SelectSafesOnboarding from './components/SelectSafesOnboarding'
+import InviteMembersOnboarding from './components/InviteMembersOnboarding'
 
 // Service imports
 import { isUnauthorized, filterSpacesByStatus, getNonDeclinedSpaces } from './utils'
@@ -55,6 +58,11 @@ const feature: SpacesContract = {
   SpaceSafeContextMenu,
   SendTransactionButton,
   PendingTxWidget,
+
+  // Onboarding page components
+  CreateSpaceOnboarding,
+  SelectSafesOnboarding,
+  InviteMembersOnboarding,
 
   // Page components
   SpaceDashboardPage,

--- a/apps/web/src/features/spaces/hooks/__tests__/useTrackSpace.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useTrackSpace.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import useTrackSpace from '../useTrackSpace'
+import type { AllSafeItems } from '@/hooks/safes'
+import type { Member } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('@/services/analytics/events/spaces', () => ({
+  SPACE_EVENTS: {
+    TOTAL_SAFE_ACCOUNTS: { action: 'Total safes added to space', category: 'spaces' },
+    TOTAL_ACTIVE_MEMBERS: { action: 'Total active members in space', category: 'spaces' },
+  },
+}))
+
+const mockTrackEvent = trackEvent as jest.Mock
+
+describe('useTrackSpace', () => {
+  const safes = [{ id: '1' }, { id: '2' }] as unknown as AllSafeItems
+  const members = [{ id: 'm1' }, { id: 'm2' }, { id: 'm3' }] as unknown as Member[]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('tracks total safe accounts on mount', () => {
+    renderHook(() => useTrackSpace(safes, members))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      ...SPACE_EVENTS.TOTAL_SAFE_ACCOUNTS,
+      label: safes.length,
+    })
+  })
+
+  it('tracks total active members on mount', () => {
+    renderHook(() => useTrackSpace(safes, members))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      ...SPACE_EVENTS.TOTAL_ACTIVE_MEMBERS,
+      label: members.length,
+    })
+  })
+
+  it('tracks each event only once per instance even if deps change', () => {
+    const { rerender } = renderHook(({ s, m }: { s: AllSafeItems; m: Member[] }) => useTrackSpace(s, m), {
+      initialProps: { s: safes, m: members },
+    })
+
+    const updatedSafes = [...safes, { id: '3' }] as unknown as AllSafeItems
+    const updatedMembers = [...members, { id: 'm4' }] as unknown as Member[]
+
+    rerender({ s: updatedSafes, m: updatedMembers })
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(2)
+  })
+
+  it('tracks independently per instance (no shared module state)', () => {
+    renderHook(() => useTrackSpace(safes, members))
+    renderHook(() => useTrackSpace(safes, members))
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(4)
+  })
+})

--- a/apps/web/src/features/spaces/hooks/useTrackSpace.ts
+++ b/apps/web/src/features/spaces/hooks/useTrackSpace.ts
@@ -1,25 +1,25 @@
 import type { AllSafeItems } from '@/hooks/safes'
 import type { Member } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 
-let isTotalSafesTracked = false
-let isTotalMembersTracked = false
-
 const useTrackSpace = (safes: AllSafeItems, activeMembers: Member[]) => {
+  const isTotalSafesTracked = useRef(false)
+  const isTotalMembersTracked = useRef(false)
+
   useEffect(() => {
-    if (isTotalSafesTracked) return
+    if (isTotalSafesTracked.current) return
 
     trackEvent({ ...SPACE_EVENTS.TOTAL_SAFE_ACCOUNTS, label: safes.length })
-    isTotalSafesTracked = true
+    isTotalSafesTracked.current = true
   }, [safes.length])
 
   useEffect(() => {
-    if (isTotalMembersTracked) return
+    if (isTotalMembersTracked.current) return
 
     trackEvent({ ...SPACE_EVENTS.TOTAL_ACTIVE_MEMBERS, label: activeMembers.length })
-    isTotalMembersTracked = true
+    isTotalMembersTracked.current = true
   }, [activeMembers.length])
 }
 

--- a/apps/web/src/pages/spaces/create-space.tsx
+++ b/apps/web/src/pages/spaces/create-space.tsx
@@ -1,9 +1,11 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { BRAND_NAME } from '@/config/constants'
-import CreateSpaceOnboarding from '@/features/spaces/components/CreateSpaceOnboarding'
+import { SpacesFeature } from '@/features/spaces'
+import { useLoadFeature } from '@/features/__core__'
 
 const CreateSpacePage: NextPage = () => {
+  const { CreateSpaceOnboarding } = useLoadFeature(SpacesFeature)
   return (
     <>
       <Head>

--- a/apps/web/src/pages/welcome/create-space.tsx
+++ b/apps/web/src/pages/welcome/create-space.tsx
@@ -1,9 +1,11 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { BRAND_NAME } from '@/config/constants'
-import CreateSpaceOnboarding from '@/features/spaces/components/CreateSpaceOnboarding'
+import { SpacesFeature } from '@/features/spaces'
+import { useLoadFeature } from '@/features/__core__'
 
 const CreateSpacePage: NextPage = () => {
+  const { CreateSpaceOnboarding } = useLoadFeature(SpacesFeature)
   return (
     <>
       <Head>

--- a/apps/web/src/pages/welcome/invite-members.tsx
+++ b/apps/web/src/pages/welcome/invite-members.tsx
@@ -1,9 +1,11 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { BRAND_NAME } from '@/config/constants'
-import InviteMembersOnboarding from '@/features/spaces/components/InviteMembersOnboarding'
+import { SpacesFeature } from '@/features/spaces'
+import { useLoadFeature } from '@/features/__core__'
 
 const InviteMembersPage: NextPage = () => {
+  const { InviteMembersOnboarding } = useLoadFeature(SpacesFeature)
   return (
     <>
       <Head>

--- a/apps/web/src/pages/welcome/select-safes.tsx
+++ b/apps/web/src/pages/welcome/select-safes.tsx
@@ -1,9 +1,11 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { BRAND_NAME } from '@/config/constants'
-import SelectSafesOnboarding from '@/features/spaces/components/SelectSafesOnboarding'
+import { SpacesFeature } from '@/features/spaces'
+import { useLoadFeature } from '@/features/__core__'
 
 const SelectSafesPage: NextPage = () => {
+  const { SelectSafesOnboarding } = useLoadFeature(SpacesFeature)
   return (
     <>
       <Head>


### PR DESCRIPTION
> Nav rows share one `NavItem`, Spaces toggles tooltips and test ids.
> Onboarding routes lift into the spaces feature contract—three pages, one pattern.

## What it solves

- Removes duplicated code (moves it to  `NavItem` from `SpacesSidebarVariant`)
- Aligns onboarding-related pages with the feature architecture (lazy-loaded contract + feature bundle)
- Fixes a bug in `useTrackSpace`: tracking total Safe accounts and total members per Space was calculated wrongly 

## How this PR fixes it

- **Sidebar:** `SpacesSidebarVariant` imports shared `NavItem` and uses `isSpacesVariant` for Spaces-specific behavior.
- **Feature architecture — onboarding:** Onboarding pages are moved under the features architecture.
- Fixes the bug in `useTrackSpace`: Replaces the module-level let variables with useRef so each component instance has its own tracking state
- Adds missing tests for the tracking hook

## How to test it

- Open a Space: sidebar main + setup groups render correctly
- Regression: Safe sidebar nav still shows the activation tooltip for disabled items where applicable.
- Go through the Spaces Onboarding flow; all 3 pages load and behave as before (no broken imports / 404s).
- All unit tests should pass.

## Visual summary
```mermaid
flowchart LR
  subgraph Contract
    C[SpacesContract] --> E1[Entry 1]
    C --> E2[Entry 2]
    C --> E3[Entry 3]
  end
  subgraph After
    SSV2[SpacesSidebarVariant] --> NI[NavItem]
    NI --> |isSpacesVariant| Spaces[Spaces test ids / no tooltip]
    NI --> |default| Safe[Safe tooltip + list item test id]
  end
    subgraph Before
    SSV[SpacesSidebarVariant] --> Dup[Inline NavItem duplicate]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
