### PR TITLE
fix(web): prevent double redirect on first client-side navigation

### DIFF
--- a/apps/web/src/hooks/useRouterGuard/__tests__/useRouterGuard.test.ts
+++ b/apps/web/src/hooks/useRouterGuard/__tests__/useRouterGuard.test.ts
@@ -86,4 +86,42 @@ describe('useRouterGuard', () => {
       expect(mockReplace).toHaveBeenCalledWith('/welcome/create-space')
     })
   })
+
+  it('should discard stale guard results when activationGuard changes', async () => {
+    // First guard: slow, will resolve after the second one is set up
+    let resolveFirst: (value: { success: boolean }) => void
+    const firstGuard = jest.fn(
+      () => new Promise<{ success: boolean }>((resolve) => {
+        resolveFirst = resolve
+      }),
+    )
+
+    // Second guard: resolves immediately with success
+    const secondGuard = jest.fn().mockResolvedValue({ success: true })
+
+    let currentGuard = firstGuard
+    const useGuard: UseGuard = () => ({ activationGuard: currentGuard })
+
+    const { rerender } = renderHook(() => useRouterGuard({ useGuard }))
+
+    // Switch to second guard and rerender — this cancels the first evaluation
+    currentGuard = secondGuard
+    rerender()
+
+    // Second guard resolves immediately
+    await waitFor(() => {
+      expect(secondGuard).toHaveBeenCalled()
+    })
+
+    // Now resolve the stale first guard with a redirect
+    resolveFirst!({ success: false })
+
+    // Wait a tick for the stale promise handler to run
+    await waitFor(() => {
+      expect(firstGuard).toHaveBeenCalled()
+    })
+
+    // The stale redirect should NOT have been applied
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/hooks/useRouterGuard/__tests__/useRouterGuard.test.ts
+++ b/apps/web/src/hooks/useRouterGuard/__tests__/useRouterGuard.test.ts
@@ -91,9 +91,10 @@ describe('useRouterGuard', () => {
     // First guard: slow, will resolve after the second one is set up
     let resolveFirst: (value: { success: boolean }) => void
     const firstGuard = jest.fn(
-      () => new Promise<{ success: boolean }>((resolve) => {
-        resolveFirst = resolve
-      }),
+      () =>
+        new Promise<{ success: boolean }>((resolve) => {
+          resolveFirst = resolve
+        }),
     )
 
     // Second guard: resolves immediately with success

--- a/apps/web/src/hooks/useRouterGuard/activationGuards/useFlowActivationGuard.ts
+++ b/apps/web/src/hooks/useRouterGuard/activationGuards/useFlowActivationGuard.ts
@@ -117,7 +117,7 @@ export const useFlowActivationGuard: UseGuard = () => {
       },
       guardRules,
     )
-  }, [pathname, query, isReady, isWalletReady, isSiweAuthenticated, isStoreHydrated, fetchSpaces])
+  }, [pathname, query, isReady, isWalletReady, isSiweAuthenticated, isSpaceRoute, fetchSpaces])
 
   return {
     activationGuard,

--- a/apps/web/src/hooks/useRouterGuard/index.ts
+++ b/apps/web/src/hooks/useRouterGuard/index.ts
@@ -1,6 +1,6 @@
 import { AppRoutes } from '@/config/routes'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import ExternalStore from '@safe-global/utils/services/ExternalStore'
 
 export type ActivationGuard = () => Promise<{ success: boolean; redirectTo?: string }>
@@ -24,26 +24,37 @@ interface useRouterGuardProps {
 
 export const useRouterGuard = ({ useGuard }: useRouterGuardProps) => {
   const router = useRouter()
+  const routerRef = useRef(router)
+  routerRef.current = router
+
   const { activationGuard } = useGuard()
   const isCheckingAccess = useIsCheckingAccess()
 
   useEffect(() => {
+    let cancelled = false
+
     const checkAccess = async () => {
       setIsCheckingAccess(true)
 
       const { success, redirectTo } = await activationGuard()
+
+      if (cancelled) return
 
       if (success) {
         setIsCheckingAccess(false)
       } else {
         // we do not want to set isCheckingAccess to false here because we want
         // the checking access to be reseted only after the redirect is done
-        router.replace(redirectTo ?? AppRoutes.welcome.index)
+        routerRef.current.replace(redirectTo ?? AppRoutes.welcome.index)
       }
     }
 
     checkAccess()
-  }, [activationGuard, router])
+
+    return () => {
+      cancelled = true
+    }
+  }, [activationGuard])
 
   return { isCheckingAccess }
 }

--- a/apps/web/src/hooks/useRouterGuard/index.ts
+++ b/apps/web/src/hooks/useRouterGuard/index.ts
@@ -44,7 +44,7 @@ export const useRouterGuard = ({ useGuard }: useRouterGuardProps) => {
         setIsCheckingAccess(false)
       } else {
         // we do not want to set isCheckingAccess to false here because we want
-        // the checking access to be reseted only after the redirect is done
+        // the checking access to be reset only after the redirect is done
         routerRef.current.replace(redirectTo ?? AppRoutes.welcome.index)
       }
     }


### PR DESCRIPTION
> A stale guard whispers "redirect,"
> but the fresh one says "stay put" —
> now cancelled flags keep order.

## What it solves

First client-side navigation causes a visible bounce: the app navigates to the target route, redirects back, then redirects to the target again. This only happens once (not on subsequent navigations to the same route).

## How this PR fixes it

**Root cause:** `useRouterGuard` runs an async guard evaluation (`await fetchSpaces()`) on every route change. On the first navigation, `fetchSpaces` makes a real network request (no RTK Query cache yet). During this await, if `activationGuard` deps change, a second evaluation starts — but the first (stale) evaluation isn't cancelled, and its `router.replace()` call causes the incorrect redirect. On subsequent navigations, cached data resolves instantly, closing the race window.

**Fixes applied:**

1. **Cancellation flag in `useRouterGuard`** — The async effect now uses a `cancelled` flag via the cleanup function. When deps change and the effect re-fires, the previous evaluation's result is discarded.

2. **Router ref instead of dep** — `router` was in the effect's dependency array, causing redundant triggers (it changes on every navigation independently of `activationGuard`). Replaced with a `useRef` so the effect only re-runs when `activationGuard` changes.

3. **Fixed missing `isSpaceRoute` dep in `useFlowActivationGuard`** — `isSpaceRoute` was used inside the `useCallback` but missing from the dependency array, causing stale closure values. Replaced redundant `isStoreHydrated` (already captured via `isWalletReady`) with the missing `isSpaceRoute`.

## How to test it

1. Open the app in the browser
2. Navigate to any route via a link
3. Verify the navigation happens cleanly without any bounce-back redirect
4. Repeat with different routes — no double redirects on first or subsequent navigations

## Visual summary

```mermaid
sequenceDiagram
    participant User
    participant Effect as useRouterGuard effect
    participant Guard as activationGuard
    participant Router

    Note over Effect: Before fix
    User->>Router: Navigate to /spaces
    Router->>Effect: deps change → fire
    Effect->>Guard: await guard_v1()
    Note over Guard: fetchSpaces (network)...
    Router->>Effect: deps change again → fire
    Effect->>Guard: await guard_v2()
    Guard-->>Effect: guard_v1 resolves (stale)
    Effect->>Router: router.replace(/welcome) ❌
    Guard-->>Effect: guard_v2 resolves (correct)
    Effect->>Router: setIsCheckingAccess(false)
    Note over Router: Bounce: /spaces → /welcome → /spaces

    Note over Effect: After fix
    User->>Router: Navigate to /spaces
    Router->>Effect: deps change → fire
    Effect->>Guard: await guard_v1()
    Note over Guard: fetchSpaces (network)...
    Router->>Effect: deps change → cleanup cancels v1, fire v2
    Effect->>Guard: await guard_v2()
    Guard-->>Effect: guard_v1 resolves → cancelled ✓ (ignored)
    Guard-->>Effect: guard_v2 resolves (correct)
    Effect->>Router: setIsCheckingAccess(false) ✅
    Note over Router: Clean navigation to /spaces
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).