### PR TITLE
chore: fix PR preview URLs by using DNS-safe branch name sanitization

### DIFF
--- a/.github/actions/branch-slug/action.yml
+++ b/.github/actions/branch-slug/action.yml
@@ -1,0 +1,25 @@
+name: 'Branch Slug'
+
+description: 'Sanitize branch name into a DNS-safe slug for preview subdomains'
+
+inputs:
+  max-length:
+    description: 'Max slug length (default 50, keeps branch--walletweb under 63-char DNS limit)'
+    required: false
+    default: '50'
+
+outputs:
+  slug:
+    description: 'DNS-safe branch slug'
+    value: ${{ steps.slugify.outputs.slug }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Slugify branch name
+      id: slugify
+      shell: bash
+      run: |
+        raw="$(echo "$GITHUB_HEAD_REF" | sed 's|refs/heads/||')"
+        safe="$(echo "$raw" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | sed 's/[A-Z]/\L&/g' | cut -c1-${{ inputs.max-length }} | sed 's/-$//')"
+        echo "slug=$safe" >> $GITHUB_OUTPUT

--- a/.github/workflows/tx-builder-deploy.yml
+++ b/.github/workflows/tx-builder-deploy.yml
@@ -62,14 +62,7 @@ jobs:
 
       - name: Extract branch name
         id: extract_branch
-        shell: bash
-        ## Sanitize for DNS subdomain: hyphens instead of underscores,
-        ## truncate to 50 chars so branch--tx-builder stays under the
-        ## 63-char DNS label limit.
-        run: |
-          raw="$(echo "$GITHUB_HEAD_REF" | sed 's|refs/heads/||')"
-          safe="$(echo "$raw" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | sed 's/[A-Z]/\L&/g' | cut -c1-50 | sed 's/-$//')"
-          echo "branch=$safe" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/branch-slug
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -79,7 +72,7 @@ jobs:
 
       - name: Deploy to S3
         env:
-          BUCKET: s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/tx-builder/${{ steps.extract_branch.outputs.branch }}
+          BUCKET: s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/tx-builder/${{ steps.extract_branch.outputs.slug }}
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: aws s3 sync ./build $BUCKET --delete
 
@@ -93,7 +86,7 @@ jobs:
             ✅ Deploy successful!
 
             **Preview URL:**
-            https://${{ steps.extract_branch.outputs.branch }}--tx-builder.review.5afe.dev/
+            https://${{ steps.extract_branch.outputs.slug }}--tx-builder.review.5afe.dev/
           message-failure: |
             ## tx-builder Preview
             ❌ Deploy failed!

--- a/.github/workflows/tx-builder-deploy.yml
+++ b/.github/workflows/tx-builder-deploy.yml
@@ -63,7 +63,13 @@ jobs:
       - name: Extract branch name
         id: extract_branch
         shell: bash
-        run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/[^a-z0-9]/_/ig' | sed 's/[A-Z]/\L&/g')" >> $GITHUB_OUTPUT
+        ## Sanitize for DNS subdomain: hyphens instead of underscores,
+        ## truncate to 50 chars so branch--tx-builder stays under the
+        ## 63-char DNS label limit.
+        run: |
+          raw="$(echo "$GITHUB_HEAD_REF" | sed 's|refs/heads/||')"
+          safe="$(echo "$raw" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | sed 's/[A-Z]/\L&/g' | cut -c1-50 | sed 's/-$//')"
+          echo "branch=$safe" >> $GITHUB_OUTPUT
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -79,9 +79,13 @@ jobs:
       # Extract branch name
       - name: Extract branch name
         shell: bash
-        ## Cut off "refs/heads/", only allow alphanumeric characters and convert to lower case,
-        ## e.g. "refs/heads/features/hello-1.2.0" -> "features_hello_1_2_0"
-        run: echo "branch=$(echo $GITHUB_HEAD_REF | sed 's/refs\/heads\///' | sed 's/[^a-z0-9]/_/ig' | sed 's/[A-Z]/\L&/g')" >> $GITHUB_OUTPUT
+        ## Sanitize for DNS subdomain: replace non-alphanumeric with hyphens,
+        ## collapse runs, strip edges, lowercase, truncate to 63 chars (DNS limit).
+        ## e.g. "refs/heads/features/hello-1.2.0" -> "features-hello-1-2-0"
+        run: |
+          raw="$(echo "$GITHUB_HEAD_REF" | sed 's|refs/heads/||')"
+          safe="$(echo "$raw" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | sed 's/[A-Z]/\L&/g' | cut -c1-63 | sed 's/-$//')"
+          echo "branch=$safe" >> $GITHUB_OUTPUT
         id: extract_branch
 
       # Deploy to S3

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -78,22 +78,14 @@ jobs:
 
       # Extract branch name
       - name: Extract branch name
-        shell: bash
-        ## Sanitize for DNS subdomain: replace non-alphanumeric with hyphens,
-        ## collapse runs, strip edges, lowercase.
-        ## Truncate to 50 chars so the full label (branch--walletweb) stays under
-        ## the 63-char DNS limit.
-        run: |
-          raw="$(echo "$GITHUB_HEAD_REF" | sed 's|refs/heads/||')"
-          safe="$(echo "$raw" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | sed 's/[A-Z]/\L&/g' | cut -c1-50 | sed 's/-$//')"
-          echo "branch=$safe" >> $GITHUB_OUTPUT
         id: extract_branch
+        uses: ./.github/actions/branch-slug
 
       # Deploy to S3
       - name: Deploy PR branch
         if: github.event.number
         env:
-          BUCKET: s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/walletweb/${{ steps.extract_branch.outputs.branch }}
+          BUCKET: s3://${{ secrets.AWS_REVIEW_BUCKET_NAME }}/walletweb/${{ steps.extract_branch.outputs.slug }}
         working-directory: apps/web
         run: bash  ./scripts/github/s3_upload.sh
 
@@ -108,10 +100,10 @@ jobs:
             ✅  Deploy successful!
 
             **Website:**
-            https://${{ steps.extract_branch.outputs.branch }}--walletweb.review.5afe.dev/home?safe=eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6
+            https://${{ steps.extract_branch.outputs.slug }}--walletweb.review.5afe.dev/home?safe=eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6
 
             **Storybook:**
-            https://${{ steps.extract_branch.outputs.branch }}--walletweb.review.5afe.dev/storybook/
+            https://${{ steps.extract_branch.outputs.slug }}--walletweb.review.5afe.dev/storybook/
           message-failure: |
             ## Branch preview
             ❌  Deploy failed!

--- a/.github/workflows/web-deploy-dev.yml
+++ b/.github/workflows/web-deploy-dev.yml
@@ -80,11 +80,12 @@ jobs:
       - name: Extract branch name
         shell: bash
         ## Sanitize for DNS subdomain: replace non-alphanumeric with hyphens,
-        ## collapse runs, strip edges, lowercase, truncate to 63 chars (DNS limit).
-        ## e.g. "refs/heads/features/hello-1.2.0" -> "features-hello-1-2-0"
+        ## collapse runs, strip edges, lowercase.
+        ## Truncate to 50 chars so the full label (branch--walletweb) stays under
+        ## the 63-char DNS limit.
         run: |
           raw="$(echo "$GITHUB_HEAD_REF" | sed 's|refs/heads/||')"
-          safe="$(echo "$raw" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | sed 's/[A-Z]/\L&/g' | cut -c1-63 | sed 's/-$//')"
+          safe="$(echo "$raw" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | sed 's/[A-Z]/\L&/g' | cut -c1-50 | sed 's/-$//')"
           echo "branch=$safe" >> $GITHUB_OUTPUT
         id: extract_branch
 


### PR DESCRIPTION
> Hyphens where underscores once broke the chain,
> sixty-three chars keep DNS sane.

## What it solves

PR preview URLs frequently break when branch names contain slashes or hyphens. The branch name sanitizer converts all special characters to underscores, but underscores are **invalid in DNS labels** — they break SSL certificate validation and some DNS resolvers. Long branch names also exceed the 63-character DNS label limit.

**This PR itself uses a slash/hyphen-heavy branch name** (`danield/chore-fix-pr-preview-urls-dns-safe-branch-sanitization`) to verify the fix works.

## How this PR fixes it

Updated the branch name extraction step in `web-deploy-dev.yml`:
- Replace non-alphanumeric characters with **hyphens** instead of underscores (DNS-valid)
- Collapse consecutive hyphens and strip leading/trailing ones
- Truncate to **63 characters** (DNS label maximum)

Before: `danield/feat-my-feature` → `danield_feat_my_feature` (invalid DNS)
After: `danield/feat-my-feature` → `danield-feat-my-feature` (valid DNS)

## How to test it

1. Check that this PR's own preview URL works (the branch name has `/` and `-`)
2. The preview comment should show a working `https://danield-chore-fix-pr-preview-urls-dns-safe-branch-sanitization--walletweb.review.5afe.dev/...` link

## Visual summary

N/A - CI/CD change only

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).