### PR TITLE
fix: resolve correct spending limit module version per chain

### DIFF
--- a/apps/web/src/features/spending-limits/__tests__/spendingLimitDeployments.test.ts
+++ b/apps/web/src/features/spending-limits/__tests__/spendingLimitDeployments.test.ts
@@ -20,6 +20,7 @@ describe('getLatestSpendingLimitAddress', () => {
     const v011 = getAllowanceModuleDeployment({ version: '0.1.1' })
     // XDC (chainId 50) has v0.1.1
     const expectedAddress = v011?.networkAddresses['50']
+    expect(expectedAddress).toBeDefined()
 
     const result = getLatestSpendingLimitAddress('50')
 
@@ -35,10 +36,10 @@ describe('getLatestSpendingLimitAddress', () => {
       (chainId) => v010?.networkAddresses[chainId] != null,
     )
 
-    if (sharedChainId) {
-      const result = getLatestSpendingLimitAddress(sharedChainId)
-      expect(result).toBe(v011?.networkAddresses[sharedChainId])
-    }
+    expect(sharedChainId).toBeDefined()
+
+    const result = getLatestSpendingLimitAddress(sharedChainId as string)
+    expect(result).toBe(v011?.networkAddresses[sharedChainId as string])
   })
 
   it('should NOT return the v0.1.1 address for mainnet (regression test for #7494)', () => {
@@ -60,6 +61,7 @@ describe('getLatestSpendingLimitAddress', () => {
   it('should return v0.1.0 address for Sepolia (chainId 11155111)', () => {
     const v010 = getAllowanceModuleDeployment({ version: '0.1.0' })
     const expectedAddress = v010?.networkAddresses['11155111']
+    expect(expectedAddress).toBeDefined()
 
     const result = getLatestSpendingLimitAddress('11155111')
 
@@ -69,6 +71,7 @@ describe('getLatestSpendingLimitAddress', () => {
   it('should return v0.1.0 address for Base (chainId 8453)', () => {
     const v010 = getAllowanceModuleDeployment({ version: '0.1.0' })
     const expectedAddress = v010?.networkAddresses['8453']
+    expect(expectedAddress).toBeDefined()
 
     const result = getLatestSpendingLimitAddress('8453')
 

--- a/apps/web/src/features/spending-limits/__tests__/spendingLimitDeployments.test.ts
+++ b/apps/web/src/features/spending-limits/__tests__/spendingLimitDeployments.test.ts
@@ -1,0 +1,122 @@
+import { getAllowanceModuleDeployment } from '@safe-global/safe-modules-deployments'
+import {
+  getLatestSpendingLimitAddress,
+  getDeployment,
+  getDeployedSpendingLimitModuleAddress,
+} from '../services/spendingLimitDeployments'
+
+describe('getLatestSpendingLimitAddress', () => {
+  it('should return the v0.1.0 address on Ethereum mainnet (chainId 1)', () => {
+    const v010 = getAllowanceModuleDeployment({ version: '0.1.0' })
+    const expectedAddress = v010?.networkAddresses['1']
+
+    const result = getLatestSpendingLimitAddress('1')
+
+    expect(result).toBe(expectedAddress)
+    expect(result).not.toBeUndefined()
+  })
+
+  it('should return the v0.1.1 address on chains where v0.1.1 is deployed', () => {
+    const v011 = getAllowanceModuleDeployment({ version: '0.1.1' })
+    // XDC (chainId 50) has v0.1.1
+    const expectedAddress = v011?.networkAddresses['50']
+
+    const result = getLatestSpendingLimitAddress('50')
+
+    expect(result).toBe(expectedAddress)
+  })
+
+  it('should prefer v0.1.1 over v0.1.0 when both are deployed on a chain', () => {
+    const v010 = getAllowanceModuleDeployment({ version: '0.1.0' })
+    const v011 = getAllowanceModuleDeployment({ version: '0.1.1' })
+
+    // Find a chain that has both versions
+    const sharedChainId = Object.keys(v011?.networkAddresses ?? {}).find(
+      (chainId) => v010?.networkAddresses[chainId] != null,
+    )
+
+    if (sharedChainId) {
+      const result = getLatestSpendingLimitAddress(sharedChainId)
+      expect(result).toBe(v011?.networkAddresses[sharedChainId])
+    }
+  })
+
+  it('should NOT return the v0.1.1 address for mainnet (regression test for #7494)', () => {
+    const v011 = getAllowanceModuleDeployment({ version: '0.1.1' })
+    const v011Address = Object.values(v011?.networkAddresses ?? {})[0]
+
+    // Mainnet should NOT get the v0.1.1 address since v0.1.1 was never deployed there
+    const result = getLatestSpendingLimitAddress('1')
+
+    expect(result).not.toBe(v011Address)
+  })
+
+  it('should return undefined for a chain with no deployment in any version', () => {
+    const result = getLatestSpendingLimitAddress('999999')
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should return v0.1.0 address for Sepolia (chainId 11155111)', () => {
+    const v010 = getAllowanceModuleDeployment({ version: '0.1.0' })
+    const expectedAddress = v010?.networkAddresses['11155111']
+
+    const result = getLatestSpendingLimitAddress('11155111')
+
+    expect(result).toBe(expectedAddress)
+  })
+
+  it('should return v0.1.0 address for Base (chainId 8453)', () => {
+    const v010 = getAllowanceModuleDeployment({ version: '0.1.0' })
+    const expectedAddress = v010?.networkAddresses['8453']
+
+    const result = getLatestSpendingLimitAddress('8453')
+
+    expect(result).toBe(expectedAddress)
+  })
+})
+
+describe('getDeployment', () => {
+  it('should return the matching deployment when a module is enabled', () => {
+    const v010 = getAllowanceModuleDeployment({ version: '0.1.0' })
+    const mainnetAddress = v010?.networkAddresses['1']
+    const modules = [{ value: mainnetAddress! }]
+
+    const result = getDeployment('1', modules)
+
+    expect(result?.version).toBe('0.1.0')
+  })
+
+  it('should return undefined when no modules are enabled', () => {
+    const result = getDeployment('1', [])
+    expect(result).toBeUndefined()
+  })
+
+  it('should return undefined when no module matches any deployment', () => {
+    const modules = [{ value: '0x0000000000000000000000000000000000000001' }]
+
+    const result = getDeployment('1', modules)
+
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('getDeployedSpendingLimitModuleAddress', () => {
+  it('should return the deployed module address for a matching version', () => {
+    const v010 = getAllowanceModuleDeployment({ version: '0.1.0' })
+    const mainnetAddress = v010?.networkAddresses['1']
+    const modules = [{ value: mainnetAddress! }]
+
+    const result = getDeployedSpendingLimitModuleAddress('1', modules)
+
+    expect(result).toBe(mainnetAddress)
+  })
+
+  it('should return undefined when no module matches', () => {
+    const modules = [{ value: '0x0000000000000000000000000000000000000001' }]
+
+    const result = getDeployedSpendingLimitModuleAddress('1', modules)
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/apps/web/src/features/spending-limits/services/spendingLimitDeployments.ts
+++ b/apps/web/src/features/spending-limits/services/spendingLimitDeployments.ts
@@ -38,8 +38,8 @@ export const getLatestSpendingLimitAddress = (chainId: string): string | undefin
   // Unlike getDeployment (which uses CREATE2 fallback for already-enabled modules),
   // new enablements must match an explicitly registered chain to avoid enabling
   // a version that was never deployed there.
-  for (const version of [...ALL_VERSIONS].reverse()) {
-    const deployment = getAllowanceModuleDeployment({ version })
+  for (let i = ALL_VERSIONS.length - 1; i >= 0; i--) {
+    const deployment = getAllowanceModuleDeployment({ version: ALL_VERSIONS[i] })
     if (!deployment) continue
     if (deployment.networkAddresses[chainId]) return deployment.networkAddresses[chainId]
   }

--- a/apps/web/src/features/spending-limits/services/spendingLimitDeployments.ts
+++ b/apps/web/src/features/spending-limits/services/spendingLimitDeployments.ts
@@ -34,8 +34,15 @@ export const getDeployment = (chainId: string, modules: SafeState['modules']) =>
 }
 
 export const getLatestSpendingLimitAddress = (chainId: string): string | undefined => {
-  const deployment = getAllowanceModuleDeployment()
-  return getModuleAddress(deployment, chainId)
+  // Try versions from newest to oldest, picking the first that's registered on this chain.
+  // Unlike getDeployment (which uses CREATE2 fallback for already-enabled modules),
+  // new enablements must match an explicitly registered chain to avoid enabling
+  // a version that was never deployed there.
+  for (const version of [...ALL_VERSIONS].reverse()) {
+    const deployment = getAllowanceModuleDeployment({ version })
+    if (!deployment) continue
+    if (deployment.networkAddresses[chainId]) return deployment.networkAddresses[chainId]
+  }
 }
 
 export const getDeployedSpendingLimitModuleAddress = (


### PR DESCRIPTION
> Wrong module, wrong chain—
> iterate versions, pick the one
> deployed where you stand.

## What it solves

Resolves: Users enabling the Spending Limits module on major chains (Ethereum mainnet, Base, Sepolia, etc.) were getting the wrong contract address (`0xAA46724893dedD72658219405185Fb0Fc91e091C` — v0.1.1) instead of the correct one (`0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134` — v0.1.0).

Regression introduced in #7494 (commit `9de62ce56`).

## How this PR fixes it

`getLatestSpendingLimitAddress()` was calling `getAllowanceModuleDeployment()` without a version filter, which always returned v0.1.1 (the latest). v0.1.1 is only deployed on ~35 smaller chains (XDC, Shape, Boba, etc.) — **not** on Ethereum mainnet, Base, BSC, Sepolia, etc. A CREATE2 fallback (`Object.values(networkAddresses)[0]`) then returned the v0.1.1 address regardless of chain.

The fix iterates versions from newest to oldest and picks the first version whose `networkAddresses` explicitly includes the requested `chainId`. The CREATE2 fallback in `getModuleAddress()` is preserved for `getDeployment()` / `getDeployedSpendingLimitModuleAddress()` where it's appropriate for recognizing already-enabled modules.

## How to test it

1. Open the app on Ethereum mainnet (chain 1)
2. Go to Settings → Spending Limits → Enable module
3. Verify the transaction targets `0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134` (v0.1.0), not `0xAA46724893dedD72658219405185Fb0Fc91e091C` (v0.1.1)
4. Repeat on a v0.1.1 chain (e.g. XDC, chain 50) and verify it targets the v0.1.1 address

## Visual summary

```mermaid
flowchart TB
  subgraph Before_broken
    A1["getLatestSpendingLimitAddress('1')"] --> B1["getAllowanceModuleDeployment()"]
    B1 --> C1["Returns v0.1.1 (latest)"]
    C1 --> D1["networkAddresses['1'] → undefined"]
    D1 --> E1["Fallback: Object.values(...)[0]"]
    E1 --> F1["❌ 0xAA46...091C (v0.1.1, not on mainnet)"]
  end
  subgraph After_fixed
    A2["getLatestSpendingLimitAddress('1')"] --> B2["Try v0.1.1 → networkAddresses['1'] = undefined"]
    B2 --> C2["Try v0.1.0 → networkAddresses['1'] = 0xCFbF...3134"]
    C2 --> D2["✅ 0xCFbF...3134 (v0.1.0, deployed on mainnet)"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)