### PR TITLE
feat: Allow proposers to export CSV

### DIFF
--- a/apps/web/src/components/common/OnlyOwnerOrProposer/index.test.tsx
+++ b/apps/web/src/components/common/OnlyOwnerOrProposer/index.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@/tests/test-utils'
+import OnlyOwnerOrProposer from './index'
+import useIsSafeOwner from '@/hooks/useIsSafeOwner'
+import useWallet from '@/hooks/wallets/useWallet'
+import { useIsWalletProposer } from '@/hooks/useProposers'
+
+jest.mock('@/hooks/useIsSafeOwner')
+jest.mock('@/hooks/wallets/useWallet')
+jest.mock('@/hooks/useProposers', () => ({ useIsWalletProposer: jest.fn() }))
+jest.mock('../ConnectWallet/useConnectWallet', () => jest.fn(() => jest.fn()))
+
+const mockUseWallet = useWallet as jest.MockedFunction<typeof useWallet>
+const mockUseIsSafeOwner = useIsSafeOwner as jest.MockedFunction<typeof useIsSafeOwner>
+const mockUseIsWalletProposer = useIsWalletProposer as jest.MockedFunction<typeof useIsWalletProposer>
+
+describe('OnlyOwnerOrProposer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render children with true when wallet is owner', () => {
+    mockUseWallet.mockReturnValue({ address: '0x1234' } as ReturnType<typeof useWallet>)
+    mockUseIsSafeOwner.mockReturnValue(true)
+    mockUseIsWalletProposer.mockReturnValue(false)
+
+    const { getByText } = render(
+      <OnlyOwnerOrProposer>{(isOk) => <button disabled={!isOk}>Action</button>}</OnlyOwnerOrProposer>,
+    )
+
+    expect(getByText('Action')).not.toBeDisabled()
+  })
+
+  it('should render children with true when wallet is proposer but not owner', () => {
+    mockUseWallet.mockReturnValue({ address: '0x1234' } as ReturnType<typeof useWallet>)
+    mockUseIsSafeOwner.mockReturnValue(false)
+    mockUseIsWalletProposer.mockReturnValue(true)
+
+    const { getByText } = render(
+      <OnlyOwnerOrProposer>{(isOk) => <button disabled={!isOk}>Action</button>}</OnlyOwnerOrProposer>,
+    )
+
+    expect(getByText('Action')).not.toBeDisabled()
+  })
+
+  it('should render children with false when wallet is neither owner nor proposer', () => {
+    mockUseWallet.mockReturnValue({ address: '0x1234' } as ReturnType<typeof useWallet>)
+    mockUseIsSafeOwner.mockReturnValue(false)
+    mockUseIsWalletProposer.mockReturnValue(false)
+
+    const { getByText } = render(
+      <OnlyOwnerOrProposer>{(isOk) => <button disabled={!isOk}>Action</button>}</OnlyOwnerOrProposer>,
+    )
+
+    expect(getByText('Action')).toBeDisabled()
+  })
+
+  it('should render children with false when wallet is not connected', () => {
+    mockUseWallet.mockReturnValue(null)
+    mockUseIsSafeOwner.mockReturnValue(false)
+    mockUseIsWalletProposer.mockReturnValue(false)
+
+    const { getByText } = render(
+      <OnlyOwnerOrProposer>{(isOk) => <button disabled={!isOk}>Action</button>}</OnlyOwnerOrProposer>,
+    )
+
+    expect(getByText('Action')).toBeDisabled()
+  })
+})

--- a/apps/web/src/components/common/OnlyOwnerOrProposer/index.tsx
+++ b/apps/web/src/components/common/OnlyOwnerOrProposer/index.tsx
@@ -1,22 +1,24 @@
 import { useMemo, type ReactElement } from 'react'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import useWallet from '@/hooks/wallets/useWallet'
+import { useIsWalletProposer } from '@/hooks/useProposers'
 import useConnectWallet from '../ConnectWallet/useConnectWallet'
 import { Tooltip, type TooltipProps } from '@mui/material'
 
-type CheckWalletProps = {
+type OnlyOwnerOrProposerProps = {
   children: (ok: boolean) => ReactElement
   placement?: TooltipProps['placement']
 }
 
 enum Message {
   WalletNotConnected = 'Please connect your wallet',
-  NotSafeOwner = 'Your connected wallet is not a signer of this Safe Account',
+  NotSafeOwnerOrProposer = 'Your connected wallet is not a signer or proposer of this Safe Account',
 }
 
-const OnlyOwner = ({ children, placement = 'bottom' }: CheckWalletProps): ReactElement => {
+const OnlyOwnerOrProposer = ({ children, placement = 'bottom' }: OnlyOwnerOrProposerProps): ReactElement => {
   const wallet = useWallet()
   const isSafeOwner = useIsSafeOwner()
+  const isProposer = useIsWalletProposer()
   const connectWallet = useConnectWallet()
 
   const message = useMemo(() => {
@@ -24,10 +26,10 @@ const OnlyOwner = ({ children, placement = 'bottom' }: CheckWalletProps): ReactE
       return Message.WalletNotConnected
     }
 
-    if (!isSafeOwner) {
-      return Message.NotSafeOwner
+    if (!isSafeOwner && !isProposer) {
+      return Message.NotSafeOwnerOrProposer
     }
-  }, [isSafeOwner, wallet])
+  }, [isSafeOwner, isProposer, wallet])
 
   if (!message) return children(true)
 
@@ -38,4 +40,4 @@ const OnlyOwner = ({ children, placement = 'bottom' }: CheckWalletProps): ReactE
   )
 }
 
-export default OnlyOwner
+export default OnlyOwnerOrProposer

--- a/apps/web/src/components/transactions/CsvTxExportButton/__tests__/index.test.tsx
+++ b/apps/web/src/components/transactions/CsvTxExportButton/__tests__/index.test.tsx
@@ -10,9 +10,10 @@ jest.mock('@/services/analytics', () =>
   ).createAnalyticsMock(),
 )
 
-jest.mock('@/components/common/OnlyOwner', () => {
-  return function MockOnlyOwner({ children }: { children: (isOk: boolean) => React.ReactNode }) {
-    return <>{children(true)}</>
+let mockIsOwnerOrProposer = true
+jest.mock('@/components/common/OnlyOwnerOrProposer', () => {
+  return function MockOnlyOwnerOrProposer({ children }: { children: (isOk: boolean) => React.ReactNode }) {
+    return <>{children(mockIsOwnerOrProposer)}</>
   }
 })
 
@@ -21,6 +22,7 @@ const mockTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>
 describe('CsvTxExportButton', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockIsOwnerOrProposer = true
 
     jest.spyOn(csvExportQueries, 'useCsvExportGetExportStatusV1Query').mockImplementation(() => ({
       data: undefined,
@@ -62,5 +64,13 @@ describe('CsvTxExportButton', () => {
     fireEvent.click(exportButton)
 
     expect(screen.getByText("Transaction history filters won't apply here.")).toBeInTheDocument()
+  })
+
+  it('should disable export button when user is not owner or proposer', () => {
+    mockIsOwnerOrProposer = false
+
+    const { getByText } = render(<CsvTxExportButton hasActiveFilter={false} />)
+
+    expect(getByText('Export')).toBeDisabled()
   })
 })

--- a/apps/web/src/components/transactions/CsvTxExportButton/index.tsx
+++ b/apps/web/src/components/transactions/CsvTxExportButton/index.tsx
@@ -9,7 +9,7 @@ import { showNotification } from '@/store/notificationsSlice'
 import { OnboardingTooltip } from '@/components/common/OnboardingTooltip'
 import { Chip } from '@/components/common/Chip'
 import { useDarkMode } from '@/hooks/useDarkMode'
-import OnlyOwner from '@/components/common/OnlyOwner'
+import OnlyOwnerOrProposer from '@/components/common/OnlyOwnerOrProposer'
 import { trackEvent } from '@/services/analytics'
 import { TX_LIST_EVENTS } from '@/services/analytics/events/txList'
 
@@ -142,7 +142,7 @@ const CsvTxExportButton = ({ hasActiveFilter }: CsvTxExportProps): ReactElement 
         }
       >
         <div>
-          <OnlyOwner placement="top">
+          <OnlyOwnerOrProposer placement="top">
             {(isOk) => (
               <Button
                 variant="outlined"
@@ -160,7 +160,7 @@ const CsvTxExportButton = ({ hasActiveFilter }: CsvTxExportProps): ReactElement 
                 {exportJobId ? 'Exporting' : 'Export'}
               </Button>
             )}
-          </OnlyOwner>
+          </OnlyOwnerOrProposer>
         </div>
       </OnboardingTooltip>
 


### PR DESCRIPTION
## What it solves

Resolves: [WA-1684](https://linear.app/safe-global/issue/WA-1684/csv-download-unavailable-for-proposer-only-role)

## How this PR fixes it
Extend the CSV export functionality to proposers. Now both signers and proposers are allowed to export TX history

## How to test it
* export CSV as owner - works as before
* export CSV as proposer - allowed and works the same way as for owner
* not proposer/owner - button is disabled


## Visual summary
<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
