### PR TITLE
fix: trust CGW recommended version for chains not in safe-deployments

### DIFF
--- a/apps/web/src/utils/__tests__/chains.test.ts
+++ b/apps/web/src/utils/__tests__/chains.test.ts
@@ -144,6 +144,14 @@ describe('chains', () => {
           ),
         ).toEqual('1.4.1')
       })
+
+      it('should trust recommendedMasterCopyVersion for chains not in safe-deployments', () => {
+        expect(
+          getLatestSafeVersion(
+            chainBuilder().with({ chainId: '25363', recommendedMasterCopyVersion: '1.4.1' }).build(),
+          ),
+        ).toEqual('1.4.1')
+      })
     })
   })
 })

--- a/apps/web/src/utils/__tests__/chains.test.ts
+++ b/apps/web/src/utils/__tests__/chains.test.ts
@@ -10,6 +10,7 @@ import { CONFIG_SERVICE_CHAINS } from '@/tests/mocks/chains'
 import { chainBuilder } from '@/tests/builders/chains'
 import { getChainConfig } from '@/utils/chains'
 import { makeStore, setStoreInstance } from '@/store'
+import * as safeDeployments from '@safe-global/safe-deployments'
 
 describe('chains', () => {
   beforeAll(() => {
@@ -145,11 +146,21 @@ describe('chains', () => {
         ).toEqual('1.4.1')
       })
 
-      it('should trust recommendedMasterCopyVersion for chains not in safe-deployments', () => {
+      it('should trust recommendedMasterCopyVersion when chain is not in safe-deployments', () => {
+        jest.spyOn(safeDeployments, 'getSafeSingletonDeployment').mockReturnValue(undefined)
+
         expect(
           getLatestSafeVersion(
-            chainBuilder().with({ chainId: '25363', recommendedMasterCopyVersion: '1.4.1' }).build(),
+            chainBuilder().with({ chainId: '99999', recommendedMasterCopyVersion: '1.4.1' }).build(),
           ),
+        ).toEqual('1.4.1')
+      })
+
+      it('should fall back to LATEST_SAFE_VERSION when chain is not in safe-deployments and recommendedMasterCopyVersion is null', () => {
+        jest.spyOn(safeDeployments, 'getSafeSingletonDeployment').mockReturnValue(undefined)
+
+        expect(
+          getLatestSafeVersion(chainBuilder().with({ chainId: '99999', recommendedMasterCopyVersion: null }).build()),
         ).toEqual('1.4.1')
       })
     })

--- a/packages/utils/src/utils/chains.ts
+++ b/packages/utils/src/utils/chains.ts
@@ -117,23 +117,23 @@ export const getBlockExplorerLink = (
     return getExplorerLink(address, chain.blockExplorerUriTemplate)
   }
 }
-/** This version is used if a network does not have the LATEST_SAFE_VERSION deployed yet */
-const FALLBACK_SAFE_VERSION = '1.3.0' as const
 export const getLatestSafeVersion = (
   chain: Pick<Chain, 'recommendedMasterCopyVersion' | 'chainId'> | undefined,
 ): SafeVersion => {
-  const latestSafeVersion = chain?.recommendedMasterCopyVersion || LATEST_SAFE_VERSION
+  const recommendedVersion = chain?.recommendedMasterCopyVersion || LATEST_SAFE_VERSION
 
-  // Without version filter it will always return the LATEST_SAFE_VERSION constant to avoid automatically updating to the newest version if the deployments change
-  const latestDeploymentVersion = (getSafeSingletonDeployment({ network: chain?.chainId, released: true })?.version ??
-    FALLBACK_SAFE_VERSION) as SafeVersion
+  // For chains registered in safe-deployments, cap at the latest deployed version
+  // to avoid using a version that isn't actually deployed on-chain yet.
+  const deployedVersion = getSafeSingletonDeployment({ network: chain?.chainId, released: true })?.version
 
-  // The version needs to be smaller or equal to the
-  if (semverSatisfies(latestDeploymentVersion, `<=${latestSafeVersion}`)) {
-    return latestDeploymentVersion
-  } else {
-    return latestSafeVersion as SafeVersion
+  if (deployedVersion) {
+    return (
+      semverSatisfies(deployedVersion, `<=${recommendedVersion}`) ? deployedVersion : recommendedVersion
+    ) as SafeVersion
   }
+
+  // For chains not in safe-deployments, trust the CGW's recommended version directly
+  return recommendedVersion as SafeVersion
 }
 
 export const isNonCriticalUpdate = (version?: string | null) => {


### PR DESCRIPTION
> When deployments don't know your chain,
> the fallback dragged you back to 1.3.
> Now CGW speaks, the code believes,
> and 1.4.1 is what you'll receive.

## What it solves

Resolves: Safe creation on new chains (e.g. Fluent) defaults to version 1.3.0 instead of the CGW-configured 1.4.1, causing "SDK not initialized" errors because the chain-agnostic SDK init path only covers `>=1.4.1`.

## How this PR fixes it

`getLatestSafeVersion()` used `getSafeSingletonDeployment({ network: chainId })` to determine the latest deployed version. For chains not registered in the `safe-deployments` npm package, this returned `undefined`, falling back to a hardcoded `1.3.0`.

Now, when the per-chain lookup returns nothing, we trust the CGW's `recommendedMasterCopyVersion` directly instead of falling back to 1.3.0. For registered chains, behavior is unchanged — we still cap at the latest deployed version.

## How to test it

1. Open a Safe on a chain not in `safe-deployments` (e.g. Fluent, chain 25363) on staging
2. Create a new Safe — it should be created with version 1.4.1 (not 1.3.0)
3. The SDK should initialize successfully without "SDK not initialized" errors
4. Verify existing chains (Ethereum, Polygon, etc.) still create Safes with the correct version

## Visual summary

```mermaid
flowchart TB
    A[getLatestSafeVersion] --> B{safe-deployments\nhas chain?}
    B -->|Yes| C[Cap at deployed version\nvs recommended]
    B -->|No - Before| D[❌ Fallback to 1.3.0]
    B -->|No - After| E[✅ Trust CGW\nrecommendedMasterCopyVersion]
    D --> F[Safe created with 1.3.0\nSDK init fails]
    E --> G[Safe created with 1.4.1\nChain-agnostic path works]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).