### PR TITLE
fix(web/Spaces): Import btn and Contacts UI in the Address Book

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/index.tsx
@@ -1,5 +1,5 @@
 import ImportIcon from '@/public/images/common/import.svg'
-import { Button } from '@mui/material'
+import { Button, SvgIcon } from '@mui/material'
 import { useState } from 'react'
 import ImportAddressBookDialog from './ImportAddressBookDialog'
 
@@ -8,7 +8,12 @@ const ImportAddressBook = () => {
 
   return (
     <>
-      <Button variant="text" size="small" startIcon={<ImportIcon />} onClick={() => setOpen(true)}>
+      <Button
+        variant="outlined"
+        size="small"
+        startIcon={<SvgIcon component={ImportIcon} inheritViewBox fontSize="small" color="primary" />}
+        onClick={() => setOpen(true)}
+      >
         Import
       </Button>
       {open && <ImportAddressBookDialog handleClose={() => setOpen(false)} />}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -31,18 +31,20 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
         content: (
           <Stack direction="row" spacing={1} alignItems="center">
             <Identicon address={entry.address} size={32} />
-            <Stack direction="column" spacing={0.5}>
-              <EthHashInfo
-                showAvatar={false}
-                address={entry.address}
-                name={entry.name}
-                shortAddress={false}
-                showPrefix={false}
-                addressBookNameSource={ContactSource.space}
-                hasExplorer
-                showCopyButton
-              />
-            </Stack>
+            <Box sx={{ '& .ethHashInfo-name': { fontWeight: 700 } }}>
+              <Stack direction="column" spacing={0.5}>
+                <EthHashInfo
+                  showAvatar={false}
+                  address={entry.address}
+                  name={entry.name}
+                  shortAddress={false}
+                  showPrefix={false}
+                  addressBookNameSource={ContactSource.space}
+                  hasExplorer
+                  showCopyButton
+                />
+              </Stack>
+            </Box>
           </Stack>
         ),
       },


### PR DESCRIPTION
## What it solves

The Import button in the Address book lost its visibility during MUI -> Shadcn migration.
The contact names' font weight was not bold.

## How this PR fixes it
Adjusts the SVG icon and Import button styles; makes the contacts font bold.

## How to test it
Open Spaces Address Book: the Import button (including SVG) should be outlined; the imported contacts' font should be bold.

## Visual summary
Screenshots:
Before:
<img width="283" height="69" alt="image" src="https://github.com/user-attachments/assets/b5911b8a-0de9-4885-a399-a9017f32f667" />
<img width="265" height="191" alt="image" src="https://github.com/user-attachments/assets/a1d7c428-968d-4957-8dd1-a958f68a861e" />


After:
<img width="286" height="79" alt="image" src="https://github.com/user-attachments/assets/7038ee26-7e18-4eb1-bd34-78249ec98975" />
<img width="215" height="161" alt="image" src="https://github.com/user-attachments/assets/da1a862a-101b-4ac7-88ff-033e7e9096f0" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 N/A
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 N/A

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
