### PR TITLE
chore: disable address book actions for oidc user

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
@@ -21,7 +21,7 @@ export type ContactField = {
   networks: Chain[]
 }
 
-const AddContact = () => {
+const AddContact = ({ disabled }: { disabled?: boolean }) => {
   const [open, setOpen] = useState(false)
   const [error, setError] = useState<string>()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -98,7 +98,7 @@ const AddContact = () => {
 
   return (
     <>
-      <Button variant="contained" size="small" startIcon={<PlusIcon />} onClick={handleOpen}>
+      <Button variant="contained" size="small" startIcon={<PlusIcon />} onClick={handleOpen} disabled={disabled}>
         Add contact
       </Button>
       <ModalDialog open={open} onClose={handleClose} dialogTitle="Add contact" hideChainIndicator>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/index.tsx
@@ -3,12 +3,12 @@ import { Button } from '@mui/material'
 import { useState } from 'react'
 import ImportAddressBookDialog from './ImportAddressBookDialog'
 
-const ImportAddressBook = () => {
+const ImportAddressBook = ({ disabled }: { disabled?: boolean }) => {
   const [open, setOpen] = useState(false)
 
   return (
     <>
-      <Button variant="text" size="small" startIcon={<ImportIcon />} onClick={() => setOpen(true)}>
+      <Button variant="text" size="small" startIcon={<ImportIcon />} onClick={() => setOpen(true)} disabled={disabled}>
         Import
       </Button>
       {open && <ImportAddressBookDialog handleClose={() => setOpen(false)} />}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -18,9 +18,10 @@ const headCells = [
 
 type SpaceAddressBookTableProps = {
   entries: SpaceAddressBookItemDto[]
+  hasWallet: boolean
 }
 
-function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
+function SpaceAddressBookTable({ entries, hasWallet }: SpaceAddressBookTableProps) {
   const chains = useChains()
 
   const rows = entries.map((entry) => ({
@@ -77,11 +78,7 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
       actions: {
         rawValue: '',
         sticky: true,
-        content: (
-          <div className={tableCss.actions}>
-            <SpaceAddressBookActions entry={entry} />
-          </div>
-        ),
+        content: <div className={tableCss.actions}>{hasWallet && <SpaceAddressBookActions entry={entry} />}</div>,
       },
     },
   }))

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import SpaceAddressBookTable from '../SpaceAddressBookTable'
+import { Builder } from '@/tests/Builder'
+import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { faker } from '@faker-js/faker'
+
+jest.mock('@/hooks/useChains', () => () => ({ configs: [] }))
+jest.mock('@/components/common/EthHashInfo', () => {
+  const EthHashInfo = () => <span data-testid="eth-hash-info" />
+  return EthHashInfo
+})
+jest.mock('@/components/common/Identicon', () => {
+  const Identicon = () => <span data-testid="identicon" />
+  return Identicon
+})
+jest.mock('@/features/multichain', () => ({
+  NetworkLogosList: () => <span data-testid="network-logos" />,
+}))
+jest.mock('@/components/common/ChainIndicator', () => {
+  const ChainIndicator = () => <span data-testid="chain-indicator" />
+  return ChainIndicator
+})
+jest.mock('../SpaceAddressBookActions', () => {
+  const SpaceAddressBookActions = () => <div data-testid="actions" />
+  return SpaceAddressBookActions
+})
+
+const entryBuilder = () =>
+  Builder.new<SpaceAddressBookItemDto>().with({
+    name: faker.person.fullName(),
+    address: faker.finance.ethereumAddress(),
+    chainIds: [faker.helpers.arrayElement(['1', '5', '100', '137'])],
+    createdBy: faker.finance.ethereumAddress(),
+    lastUpdatedBy: faker.finance.ethereumAddress(),
+  })
+
+describe('SpaceAddressBookTable', () => {
+  it('renders actions when hasWallet is true', () => {
+    render(<SpaceAddressBookTable entries={[entryBuilder().build()]} hasWallet={true} />)
+
+    expect(screen.getByTestId('actions')).toBeInTheDocument()
+  })
+
+  it('does not render actions when hasWallet is false', () => {
+    render(<SpaceAddressBookTable entries={[entryBuilder().build()]} hasWallet={false} />)
+
+    expect(screen.queryByTestId('actions')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/index.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/index.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react'
+import SpaceAddressBook from '../index'
+import { useIsAdmin, useIsInvited, useAddressBookSearch, useGetSpaceAddressBook } from '@/features/spaces'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { useAppSelector } from '@/store'
+import { Builder } from '@/tests/Builder'
+import type { UserWithWallets, UserWallet } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { faker } from '@faker-js/faker'
+
+jest.mock('@/store')
+jest.mock('@/features/spaces', () => ({
+  useIsAdmin: jest.fn(),
+  useIsInvited: jest.fn(() => false),
+  useAddressBookSearch: jest.fn(() => []),
+  useGetSpaceAddressBook: jest.fn(() => []),
+}))
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/users', () => ({
+  useUsersGetWithWalletsV1Query: jest.fn(),
+}))
+jest.mock('../../InviteBanner/PreviewInvite', () => {
+  const PreviewInvite = () => null
+  return PreviewInvite
+})
+jest.mock('../../SearchInput', () => {
+  const SearchInput = ({ onSearch }: { onSearch: (q: string) => void }) => (
+    <input data-testid="search" onChange={(e) => onSearch(e.target.value)} />
+  )
+  return SearchInput
+})
+jest.mock('../SpaceAddressBookTable', () => {
+  const SpaceAddressBookTable = () => <div data-testid="table" />
+  return SpaceAddressBookTable
+})
+jest.mock('../EmptyAddressBook', () => {
+  const EmptyAddressBook = () => <div data-testid="empty" />
+  return EmptyAddressBook
+})
+jest.mock('../AddContact', () => {
+  const AddContact = ({ disabled }: { disabled?: boolean }) => <button disabled={disabled}>Add contact</button>
+  return AddContact
+})
+jest.mock('../Import', () => {
+  const ImportAddressBook = ({ disabled }: { disabled?: boolean }) => <button disabled={disabled}>Import</button>
+  return ImportAddressBook
+})
+
+const walletBuilder = () =>
+  Builder.new<UserWallet>().with({
+    id: faker.number.int(),
+    address: faker.finance.ethereumAddress(),
+  })
+
+const userBuilder = () =>
+  Builder.new<UserWithWallets>().with({
+    id: faker.number.int(),
+    status: 1,
+    wallets: [],
+  })
+
+const mockUserQuery = (user: UserWithWallets | undefined) => {
+  ;(useUsersGetWithWalletsV1Query as jest.Mock).mockReturnValue({ currentData: user })
+}
+
+describe('SpaceAddressBook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useAppSelector as jest.Mock).mockReturnValue(true)
+    ;(useIsInvited as jest.Mock).mockReturnValue(false)
+    ;(useGetSpaceAddressBook as jest.Mock).mockReturnValue([])
+    ;(useAddressBookSearch as jest.Mock).mockReturnValue([])
+  })
+
+  it('hides action buttons for non-admin users', () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(false)
+    mockUserQuery(
+      userBuilder()
+        .with({ wallets: [walletBuilder().build()] })
+        .build(),
+    )
+
+    render(<SpaceAddressBook />)
+
+    expect(screen.queryByText('Import')).not.toBeInTheDocument()
+    expect(screen.queryByText('Add contact')).not.toBeInTheDocument()
+  })
+
+  it('shows enabled action buttons for SIWE admin', () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(true)
+    mockUserQuery(
+      userBuilder()
+        .with({ wallets: [walletBuilder().build()] })
+        .build(),
+    )
+
+    render(<SpaceAddressBook />)
+
+    expect(screen.getByText('Import')).not.toBeDisabled()
+    expect(screen.getByText('Add contact')).not.toBeDisabled()
+  })
+
+  it('shows disabled action buttons for OIDC admin without wallet', () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(true)
+    mockUserQuery(userBuilder().build())
+
+    render(<SpaceAddressBook />)
+
+    expect(screen.getByText('Import')).toBeDisabled()
+    expect(screen.getByText('Add contact')).toBeDisabled()
+  })
+
+  it('shows disabled action buttons when user data is not yet loaded', () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(true)
+    mockUserQuery(undefined)
+
+    render(<SpaceAddressBook />)
+
+    expect(screen.getByText('Import')).toBeDisabled()
+    expect(screen.getByText('Add contact')).toBeDisabled()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -1,5 +1,8 @@
 import { Stack, Typography } from '@mui/material'
 import { useIsInvited, useIsAdmin, useAddressBookSearch, useGetSpaceAddressBook } from '@/features/spaces'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import Track from '@/components/common/Track'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
@@ -14,6 +17,9 @@ const SpaceAddressBook = () => {
   const [searchQuery, setSearchQuery] = useState('')
   const isAdmin = useIsAdmin()
   const isInvited = useIsInvited()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { currentData: user } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
+  const hasWallet = (user?.wallets?.length ?? 0) > 0
   const addressBookItems = useGetSpaceAddressBook()
 
   const filteredAddressBook = useAddressBookSearch(addressBookItems, searchQuery)
@@ -38,9 +44,9 @@ const SpaceAddressBook = () => {
 
         {isAdmin && (
           <Stack direction="row" gap={1}>
-            <ImportAddressBook />
+            <ImportAddressBook disabled={!hasWallet} />
             <Track {...SPACE_EVENTS.ADD_ADDRESS}>
-              <AddContact />
+              <AddContact disabled={!hasWallet} />
             </Track>
           </Stack>
         )}
@@ -55,7 +61,7 @@ const SpaceAddressBook = () => {
       {addressBookItems.length === 0 ? (
         <EmptyAddressBook />
       ) : (
-        filteredAddressBook.length > 0 && <SpaceAddressBookTable entries={filteredAddressBook} />
+        filteredAddressBook.length > 0 && <SpaceAddressBookTable entries={filteredAddressBook} hasWallet={hasWallet} />
       )}
     </>
   )


### PR DESCRIPTION
> OIDC admin lands on address book,                                                                                                                
 > no wallet means no writes allowed,                                                      
 > buttons grayed, icons gone,              
 > backend fix will lift the shroud.

 ## What it solves : [Linear](https://linear.app/safe-global/issue/WA-1915/disable-address-book-actions-for-oidc-users-on-spaces)

 OIDC-authenticated users (email/Google sign-in) cannot perform address book mutations because the backend stores `signer_address` in `createdBy`/`lastUpdatedBy` columns. Since OIDC users have no wallet address, the backend throws `ForbiddenException('Address book writes require wallet authentication')`.

This PR adds a frontend stopgap on the Spaces address book page to prevent OIDC admins from hitting these errors until the backend migrates `createdBy`/`lastUpdatedBy` from wallet address to `userId`.

 ## How this PR fixes it

 ### Detection
 Uses `useUsersGetWithWalletsV1Query` (already cached by `useCurrentMembership`) to check `wallets.length`. OIDC-only users have `wallets: []`.

 ### Gating strategy
 `hasWallet` is computed once in the parent `SpaceAddressBook` component and passed down:

 - **Import + Add contact buttons**: visible but disabled (`disabled={!hasWallet}`)
 - **Edit + Delete icons**: not rendered at all (guard in `SpaceAddressBookTable`)

 ### Cleanup
 When the backend migration lands, search for `hasWallet` in `SpaceAddressBook/` and remove the wallet checks.

 ## How to test it

 1. Sign in via email or Google (OIDC) as a space admin
 2. Navigate to the space address book page (`/spaces/address-book`)
 3. Verify **Import** and **Add contact** buttons are visible but grayed out / disabled
 4. Verify **Edit** (pencil) and **Delete** (trash) icons do not appear on contact rows
 5. Sign in via wallet (SIWE) as a space admin
 6. Verify all four actions are enabled / visible (no regression)
 7. Sign in as a non-admin member
 8. Verify Import, Add contact, Edit, Delete are all hidden (existing behavior unchanged)

 ## Visual summary

 ```mermaid
 flowchart TD
     A[SpaceAddressBook] -->|"hasWallet = wallets.length > 0"| B{isAdmin?}
     B -->|No| C[Hide Import + Add contact]
     B -->|Yes| D{hasWallet?}
     D -->|Yes| E["Import ✓ | Add contact ✓"]
     D -->|No| F["Import ✗ disabled | Add contact ✗ disabled"]

     A -->|"passes hasWallet"| G[SpaceAddressBookTable]
     G --> H{hasWallet?}
     H -->|Yes| I["Render Edit + Delete icons"]
     H -->|No| J["Don't render Edit + Delete"]
 ```

## Screenshots
- For Oidc user: 
<img width="1267" height="285" alt="image" src="https://github.com/user-attachments/assets/693d6004-f568-497a-9505-00895a3f3e95" />

- For Siwe Admin: 
<img width="1265" height="281" alt="image" src="https://github.com/user-attachments/assets/b43607c1-652d-4fc0-b1ed-7fb2e2440a66" />


 ## Checklist

 - [ ] I've tested the branch on mobile 📱
 - [ ] I've documented how it affects the analytics (if at all) 📊
   - No new analytics events. Existing `Track` wrapper around `AddContact` auto-suppresses events when the button is disabled (via `shouldTrack`
 check in `Track` component).
 - [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
   - `SpaceAddressBook/__tests__/index.test.tsx` — 4 tests (non-admin, SIWE admin, OIDC admin, loading)
   - `SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx` — 2 tests (hasWallet true/false)