### PR TITLE
fix: rename Optimism chain display name to OP Mainnet

### DIFF
--- a/apps/web/cypress/support/constants.js
+++ b/apps/web/cypress/support/constants.js
@@ -148,7 +148,7 @@ export const networks = {
   berachain: 'Berachain',
   zkSync: 'zkSync Era',
   base: 'Base',
-  optimism: 'Optimism',
+  optimism: 'OP Mainnet',
   gnosisChiado: 'Gnosis Chiado',
 }
 

--- a/apps/web/src/components/new-safe/index.stories.tsx
+++ b/apps/web/src/components/new-safe/index.stories.tsx
@@ -188,7 +188,7 @@ export const CreateSafeAllSteps: StoryObj = {
                   <MenuItem value="1">Ethereum</MenuItem>
                   <MenuItem value="137">Polygon</MenuItem>
                   <MenuItem value="42161">Arbitrum</MenuItem>
-                  <MenuItem value="10">Optimism</MenuItem>
+                  <MenuItem value="10">OP Mainnet</MenuItem>
                 </Select>
               </FormControl>
               <Alert severity="info" sx={{ mb: 3 }}>
@@ -379,7 +379,7 @@ export const CreateSafeInteractive: StoryObj = {
                   <MenuItem value="1">Ethereum</MenuItem>
                   <MenuItem value="137">Polygon</MenuItem>
                   <MenuItem value="42161">Arbitrum</MenuItem>
-                  <MenuItem value="10">Optimism</MenuItem>
+                  <MenuItem value="10">OP Mainnet</MenuItem>
                 </Select>
               </FormControl>
 

--- a/apps/web/src/components/sidebar/QrCodeButton/QrModal.stories.tsx
+++ b/apps/web/src/components/sidebar/QrCodeButton/QrModal.stories.tsx
@@ -152,7 +152,7 @@ export const ArbitrumNetwork: Story = (() => {
 })()
 
 /**
- * QR modal for Optimism network with chain prefix enabled.
+ * QR modal for OP Mainnet network with chain prefix enabled.
  */
 export const OptimismWithPrefix: Story = (() => {
   const setup = createMockStory({
@@ -165,7 +165,7 @@ export const OptimismWithPrefix: Story = (() => {
         data: [
           {
             chainId: '10',
-            chainName: 'Optimism',
+            chainName: 'OP Mainnet',
             shortName: 'oeth',
             nativeCurrency: { symbol: 'ETH', decimals: 18, name: 'Ether' },
             theme: {

--- a/apps/web/src/components/tx/confirmation-views/BridgeTransaction/BridgeTransaction.stories.tsx
+++ b/apps/web/src/components/tx/confirmation-views/BridgeTransaction/BridgeTransaction.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
             chains: {
               data: [
                 { chainId: '1', chainName: 'Ethereum' },
-                { chainId: '10', chainName: 'Optimism' },
+                { chainId: '10', chainName: 'OP Mainnet' },
               ],
             },
           }}

--- a/apps/web/src/components/tx/confirmation-views/UpdateSafe/UpdateSafe.stories.tsx
+++ b/apps/web/src/components/tx/confirmation-views/UpdateSafe/UpdateSafe.stories.tsx
@@ -85,7 +85,7 @@ const mockChain = {
 
 const mockL2Chain = {
   chainId: '10',
-  chainName: 'Optimism',
+  chainName: 'OP Mainnet',
   shortName: 'oeth',
   l2: true,
 } as any

--- a/apps/web/src/features/multichain/components/SafeCreationNetworkInput/index.test.tsx
+++ b/apps/web/src/features/multichain/components/SafeCreationNetworkInput/index.test.tsx
@@ -38,7 +38,7 @@ describe('NetworkMultiSelector', () => {
       .build(),
     chainBuilder()
       .with({ chainId: '10' })
-      .with({ chainName: 'Optimism' })
+      .with({ chainName: 'OP Mainnet' })
       .with({ shortName: 'oeth' })
       .with({ features: [FEATURES.COUNTERFACTUAL, FEATURES.MULTI_CHAIN_SAFE_CREATION] as any })
       .with({ recommendedMasterCopyVersion: '1.4.1' })
@@ -84,7 +84,7 @@ describe('NetworkMultiSelector', () => {
       expect(allOptions).toHaveLength(5)
       allOptions.forEach((option) => expect(option).toHaveAttribute('aria-disabled', 'false'))
       expect(queryByText('Ethereum')).toBeVisible()
-      expect(queryByText('Optimism')).toBeVisible()
+      expect(queryByText('OP Mainnet')).toBeVisible()
       expect(queryByText('Gnosis Chain')).toBeVisible()
       expect(queryByText('ZkSync Era')).toBeVisible()
       expect(queryByText('Worldchain')).toBeVisible()
@@ -145,7 +145,7 @@ describe('NetworkMultiSelector', () => {
     // Only the selected chains remain visible
     await waitFor(() => {
       expect(getByText('Ethereum')).toBeVisible()
-      expect(getByText('Optimism')).toBeVisible()
+      expect(getByText('OP Mainnet')).toBeVisible()
       expect(getByText('Gnosis Chain')).toBeVisible()
       expect(queryByText('Worldchain')).toBeNull()
     })
@@ -158,7 +158,7 @@ describe('NetworkMultiSelector', () => {
     // No more chains are visible
     await waitFor(() => {
       expect(queryByText('Ethereum')).toBeNull()
-      expect(queryByText('Optimism')).toBeNull()
+      expect(queryByText('OP Mainnet')).toBeNull()
       expect(queryByText('Gnosis Chain')).toBeNull()
       expect(queryByText('Worldchain')).toBeNull()
       expect(queryByText('Select at least one network')).toBeVisible()
@@ -183,7 +183,7 @@ describe('NetworkMultiSelector', () => {
       expect(allOptions).toHaveLength(5)
       allOptions.forEach((option) => expect(option).toHaveAttribute('aria-disabled', 'false'))
       expect(queryByText('Ethereum')).toBeVisible()
-      expect(queryByText('Optimism')).toBeVisible()
+      expect(queryByText('OP Mainnet')).toBeVisible()
       expect(queryByText('Gnosis Chain')).toBeVisible()
       expect(queryByText('ZkSync Era')).toBeVisible()
       expect(queryByText('Worldchain')).toBeVisible()
@@ -231,19 +231,19 @@ describe('NetworkMultiSelector', () => {
       expect(allOptions).toHaveLength(5)
       allOptions.forEach((option) => expect(option).toHaveAttribute('aria-disabled', 'false'))
       expect(queryByText('Ethereum')).toBeVisible()
-      expect(queryByText('Optimism')).toBeVisible()
+      expect(queryByText('OP Mainnet')).toBeVisible()
       expect(queryByText('Gnosis Chain')).toBeVisible()
       expect(queryByText('ZkSync Era')).toBeVisible()
       expect(queryByText('Worldchain')).toBeVisible()
     })
 
-    // Select first Optimism and Gnosis Chain
+    // Select first OP Mainnet and Gnosis Chain
     act(() => {
-      userEvent.click(getByText('Optimism'))
+      userEvent.click(getByText('OP Mainnet'))
       userEvent.click(getByText('Gnosis Chain'))
     })
 
-    // As we were connected to Ethereum and had only one selected network different from Ethereum, we should switch the chain to Optimism
+    // As we were connected to Ethereum and had only one selected network different from Ethereum, we should switch the chain to OP Mainnet
     await waitFor(() => {
       expect(mockRouterReplace).toHaveBeenCalledWith({
         pathname: '/new-safe/create',
@@ -272,7 +272,7 @@ describe('NetworkMultiSelector', () => {
       expect(allOptions).toHaveLength(5)
       allOptions.forEach((option) => expect(option).toHaveAttribute('aria-disabled', 'false'))
       expect(queryByText('Ethereum')).toBeVisible()
-      expect(queryByText('Optimism')).toBeVisible()
+      expect(queryByText('OP Mainnet')).toBeVisible()
       expect(queryByText('Gnosis Chain')).toBeVisible()
       expect(queryByText('ZkSync Era')).toBeVisible()
       expect(queryByText('Worldchain')).toBeVisible()
@@ -332,12 +332,12 @@ describe('NetworkMultiSelector', () => {
       const allOptions = getAllByRole('option')
       expect(allOptions).toHaveLength(5)
       allOptions.forEach((option) => expect(option).toHaveAttribute('aria-disabled', 'false'))
-      expect(queryByText('Optimism')).toBeVisible()
+      expect(queryByText('OP Mainnet')).toBeVisible()
     })
 
-    // Select Optimism to trigger a chain switch
+    // Select OP Mainnet to trigger a chain switch
     act(() => {
-      userEvent.click(getByText('Optimism'))
+      userEvent.click(getByText('OP Mainnet'))
     })
 
     await waitFor(() => {
@@ -377,12 +377,12 @@ describe('NetworkMultiSelector', () => {
       const allOptions = getAllByRole('option')
       expect(allOptions).toHaveLength(5)
       allOptions.forEach((option) => expect(option).toHaveAttribute('aria-disabled', 'false'))
-      expect(queryByText('Optimism')).toBeVisible()
+      expect(queryByText('OP Mainnet')).toBeVisible()
     })
 
-    // Select Optimism to trigger a chain switch
+    // Select OP Mainnet to trigger a chain switch
     act(() => {
-      userEvent.click(getByText('Optimism'))
+      userEvent.click(getByText('OP Mainnet'))
     })
 
     await waitFor(() => {

--- a/apps/web/src/tests/mocks/chains.ts
+++ b/apps/web/src/tests/mocks/chains.ts
@@ -475,7 +475,7 @@ const CONFIG_SERVICE_CHAINS: Chain[] = [
     transactionService: 'https://safe-transaction.optimism.gnosis.io',
     contractAddresses,
     chainId: '10',
-    chainName: 'Optimism',
+    chainName: 'OP Mainnet',
     chainLogoUri: '',
     shortName: 'oeth',
     l2: true,

--- a/packages/store/src/gateway/chains/index.ts
+++ b/packages/store/src/gateway/chains/index.ts
@@ -10,6 +10,17 @@ import type {
   FetchArgs,
 } from '@reduxjs/toolkit/query'
 
+// Override chain display names where the API name differs from the canonical name
+const CHAIN_NAME_OVERRIDES: Record<string, string> = {
+  '10': 'OP Mainnet',
+}
+
+const applyChainNameOverrides = (chains: ChainInfo[]): ChainInfo[] =>
+  chains.map((chain) => {
+    const override = CHAIN_NAME_OVERRIDES[chain.chainId]
+    return override ? { ...chain, chainName: override } : chain
+  })
+
 export const chainsAdapter = createEntityAdapter<ChainInfo, string>({ selectId: (chain: ChainInfo) => chain.chainId })
 export const initialState = chainsAdapter.getInitialState()
 
@@ -42,7 +53,7 @@ const getChainsConfigs = async (
     return getChainsConfigs(api, nextUrl, nextResults)
   }
 
-  return { data: chainsAdapter.setAll(initialState, nextResults) }
+  return { data: chainsAdapter.setAll(initialState, applyChainNameOverrides(nextResults)) }
 }
 
 export const apiSliceWithChainsConfig = cgwClient.injectEndpoints({

--- a/packages/utils/src/utils/multicall/deployments.ts
+++ b/packages/utils/src/utils/multicall/deployments.ts
@@ -64,7 +64,7 @@ export const MULTICALL_DEPLOYMENTS: MulticallDeployment[] = [
     url: 'https://testnet.xterscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11?tab=contract',
   },
   {
-    name: 'Optimism',
+    name: 'OP Mainnet',
     chainId: 10,
     url: 'https://optimistic.etherscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11#code',
   },


### PR DESCRIPTION
Override the API-provided chain name for chain ID 10 from "Optimism" to "OP Mainnet" to match official branding.                   
                                                                                                                                     
  ## What it solves                                                                                                                  
                                                                                                                                     
  The config gateway returns chain 10 as `"Optimism"`, but the L1 was rebranded to **OP Mainnet** in 2023. The wallet UI was showing 
  the legacy name everywhere.                                                                                                        
                                                                                                                                     
  ## How this PR fixes it                                                                                                            
                                                                                                                                     
  Renames once at the RTK Query boundary in `packages/store/src/gateway/chains/index.ts` via a `CHAIN_NAME_OVERRIDES` map applied    
  before the entity adapter ingests results. Every store consumer picks up the new name automatically. Static lists                  
  (`multicall/deployments.ts`), mocks, stories, and tests asserting on display text are updated to match.                            
                                                                                                                                     
  ## How to test it                                                                                                                  
                                                                                                                                     
  1. Load the app and confirm chain 10 shows as **OP Mainnet** in the network picker, QR modal, create-Safe flow, and tx confirmation
   views.                                                                                                                            
  2. `yarn workspace @safe-global/store test` and `yarn workspace @safe-global/web test` pass.    
<img width="575" height="953" alt="Screenshot 2026-04-08 at 22 38 57" src="https://github.com/user-attachments/assets/e2d7af6a-7fd6-4497-b88e-a8ec3930f9e3" />
<img width="575" height="953" alt="Screenshot 2026-04-08 at 22 38 57" src="https://github.com/user-attachments/assets/e2d7af6a-7fd6-4497-b88e-a8ec3930f9e3" />

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a display-name override applied when ingesting chain configs, plus corresponding updates to mocks/stories/tests; no chain IDs, RPCs, or transaction logic change.
> 
> **Overview**
> Updates the chain config ingestion in `packages/store/src/gateway/chains/index.ts` to apply a `CHAIN_NAME_OVERRIDES` map (currently for chain ID `10`) so the UI consistently shows **OP Mainnet** even if the gateway returns **Optimism**.
> 
> Aligns surrounding fixtures and UI expectations by updating Cypress constants, Storybook stories, test chain mocks, and Safe creation network selector tests to reference `OP Mainnet` instead of `Optimism`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9788ec83837c3ccaca202c0fb9bf69b69ec25d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->