### PR TITLE
fix(web/Spaces): API button in the collapsed Spaces Sidebar

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar.tsx
@@ -4,7 +4,7 @@ import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Typography } from '@/components/ui/typography'
-import { SidebarMenu, SidebarMenuItem, SidebarMenuButton } from '@/components/ui/sidebar'
+import { SidebarMenu, SidebarMenuItem, SidebarMenuButton, useSidebar } from '@/components/ui/sidebar'
 import { cn } from '@/utils/cn'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import css from './styles.module.css'
@@ -14,16 +14,21 @@ const COLLAPSED_KEY = 'api-cta-sidebar-collapsed'
 
 export const ApiCtaSidebar = (): ReactElement => {
   const [isCollapsed = false, setIsCollapsed] = useLocalStorage<boolean>(COLLAPSED_KEY)
+  const { state } = useSidebar()
+  const isIconCollapsed = state === 'collapsed'
+  const showCollapsedButton = isCollapsed || isIconCollapsed
 
-  if (isCollapsed) {
+  if (showCollapsedButton) {
     return (
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton
             size="lg"
             className={cn(css.sidebarInteractive, css.footerHelp, css.sidebarNavItem)}
-            onClick={() => setIsCollapsed(false)}
+            onClick={!isIconCollapsed ? () => setIsCollapsed(false) : undefined}
             data-testid="api-cta-collapsed"
+            aria-label="API"
+            render={isIconCollapsed ? <a href={API_DOCS_URL} target="_blank" rel="noopener noreferrer" /> : undefined}
           >
             <Image
               src="/images/spaces/api-sidebar.svg"
@@ -32,8 +37,8 @@ export const ApiCtaSidebar = (): ReactElement => {
               height={16}
               className="dark:brightness-0 dark:invert"
             />
-            <span className="flex-1">API</span>
-            <Badge className="text-[10px] px-1 py-0 leading-none">New</Badge>
+            <span className="flex-1 group-data-[collapsible=icon]:hidden">API</span>
+            <Badge className="text-[10px] px-1 py-0 leading-none group-data-[collapsible=icon]:hidden">New</Badge>
           </SidebarMenuButton>
         </SidebarMenuItem>
       </SidebarMenu>

--- a/apps/web/src/features/spaces/components/Sidebar/__tests__/ApiCtaSidebar.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/__tests__/ApiCtaSidebar.test.tsx
@@ -4,6 +4,7 @@ import { ApiCtaSidebar } from '../ApiCtaSidebar'
 
 const mockSetIsCollapsed = jest.fn()
 let mockIsCollapsed = false
+let mockSidebarState: 'expanded' | 'collapsed' = 'expanded'
 
 jest.mock('@/services/local-storage/useLocalStorage', () => jest.fn(() => [mockIsCollapsed, mockSetIsCollapsed]))
 
@@ -18,16 +19,25 @@ jest.mock('@/components/ui/sidebar', () => ({
   SidebarMenuButton: ({
     children,
     onClick,
+    render,
     'data-testid': testId,
   }: {
     children: ReactNode
     onClick?: () => void
+    render?: React.ReactElement<{ href?: string; target?: string; rel?: string }>
     'data-testid'?: string
   }) => (
     <button data-testid={testId} onClick={onClick}>
-      {children}
+      {render ? (
+        <a href={render.props.href} target={render.props.target} rel={render.props.rel}>
+          {children}
+        </a>
+      ) : (
+        children
+      )}
     </button>
   ),
+  useSidebar: () => ({ state: mockSidebarState, isMobile: false }),
 }))
 
 jest.mock('@/components/ui/button', () => ({
@@ -53,6 +63,7 @@ describe('ApiCtaSidebar', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockIsCollapsed = false
+    mockSidebarState = 'expanded'
   })
 
   describe('expanded state (default)', () => {
@@ -146,6 +157,29 @@ describe('ApiCtaSidebar', () => {
       fireEvent.click(screen.getByTestId('api-cta-collapsed'))
 
       expect(mockSetIsCollapsed).toHaveBeenCalledWith(false)
+    })
+  })
+
+  describe('icon-collapsed sidebar state', () => {
+    beforeEach(() => {
+      mockSidebarState = 'collapsed'
+      mockIsCollapsed = false
+    })
+
+    it('renders the collapsed menu button even when CTA is expanded', () => {
+      render(<ApiCtaSidebar />)
+
+      expect(screen.getByTestId('api-cta-collapsed')).toBeInTheDocument()
+      expect(screen.queryByTestId('api-cta-sidebar')).not.toBeInTheDocument()
+    })
+
+    it('links to the API docs when collapsed', () => {
+      render(<ApiCtaSidebar />)
+
+      const link = screen.getByRole('link', { name: /API/i })
+      expect(link).toHaveAttribute('href', 'https://developer.safe.global/login')
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     })
   })
 })

--- a/apps/web/src/features/spaces/components/Sidebar/__tests__/SidebarCommonFooter.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/__tests__/SidebarCommonFooter.test.tsx
@@ -89,6 +89,10 @@ jest.mock('../config', () => ({
   },
 }))
 
+jest.mock('../ApiCtaSidebar', () => ({
+  ApiCtaSidebar: () => <div data-testid="api-cta-sidebar" />,
+}))
+
 describe('SidebarCommonFooter', () => {
   beforeEach(() => {
     jest.clearAllMocks()


### PR DESCRIPTION
> Icon-only CTA in collapsed state,
> expanded card still shows its face,
> tests mock the new dependency.

## What it solves

Resolves: [WA-1925](https://linear.app/safe-global/issue/WA-1925/api-cta-breaks-in-collapsed-sidebar-mode)

Cropped API icon/text in the collapsed Spaces sidebar and inconsistent CTA behavior.

## How this PR fixes it

- Show the API CTA as icon-only when the sidebar is collapsed (regardless of CTA expanded/collapsed state).
- In icon-collapsed mode, clicking the CTA now opens the API docs link.
- Keep expanded CTA card rendering (with icon) in the expanded sidebar.
- Update tests to account for the sidebar state and mock the CTA in the footer test.

## How to test it

1. Go to a Spaces route.
2. Collapse the sidebar to icon mode.
3. Verify the API CTA shows only the icon and clicking it opens the API docs link.
4. Expand the sidebar and verify the full CTA card shows with the icon and content.

## Visual summary

Before: 
<img width="49" height="47" alt="image" src="https://github.com/user-attachments/assets/8cd180b2-3016-4b92-83ed-ed404f880ae0" />

After:
<img width="28" height="25" alt="image" src="https://github.com/user-attachments/assets/b2073e18-cc44-4547-b31b-dedf826c6131" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 N/A
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
