### PR TITLE
refactor(mobile): event-driven WalletConnect hooks

### DIFF
--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -1,20 +1,21 @@
 import { faker } from '@faker-js/faker'
+import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useImportSignerFlow } from '../useImportSignerFlow'
+import type { EventsControllerState } from '@reown/appkit-core-react-native'
 
 const mockAddress = faker.finance.ethereumAddress() as `0x${string}`
+const checksumAddress = getAddress(mockAddress)
 
 const mockRouterPush = jest.fn()
-const mockRouterDismiss = jest.fn()
 const mockOpen = jest.fn()
-const mockDisconnect = jest.fn()
+const mockDisconnect = jest.fn().mockResolvedValue(undefined)
 const mockValidateAddressOwnership = jest.fn()
 const mockSwitchNetworkIfNeeded = jest.fn().mockResolvedValue(undefined)
 
 jest.mock('expo-router', () => ({
   router: {
     push: (...args: unknown[]) => mockRouterPush(...args),
-    dismiss: (...args: unknown[]) => mockRouterDismiss(...args),
   },
 }))
 
@@ -26,32 +27,60 @@ jest.mock('../useSwitchNetwork', () => ({
   useSwitchNetwork: () => ({ switchNetworkIfNeeded: mockSwitchNetworkIfNeeded }),
 }))
 
-// Mutable state object the hook reads on each render
-const mockWalletState = {
-  address: undefined as string | undefined,
-  isConnected: false,
-  walletInfo: undefined as { name: string } | undefined,
-}
+// Capture event subscriptions registered by useStableAppKitEvent.
+// Must remain the same object reference since jest.mock is hoisted.
+const eventSubscriptions: Record<string, ((state: EventsControllerState) => void) | undefined> = {}
 
 jest.mock('@reown/appkit-react-native', () => ({
   useAppKit: () => ({ open: mockOpen, disconnect: mockDisconnect }),
-  useAccount: () => ({
-    isConnected: mockWalletState.isConnected,
-    address: mockWalletState.address,
-  }),
-  useWalletInfo: () => ({ walletInfo: mockWalletState.walletInfo }),
+  useAccount: () => ({ isConnected: true, address: mockAddress }),
+  useWalletInfo: () => ({ walletInfo: { name: 'MetaMask', icon: 'metamask-icon' } }),
+  useAppKitEventSubscription: (event: string, callback: (state: EventsControllerState) => void) => {
+    eventSubscriptions[event] = callback
+  },
 }))
 
-const setConnected = (address: string, walletName = 'MetaMask') => {
-  mockWalletState.address = address
-  mockWalletState.isConnected = true
-  mockWalletState.walletInfo = { name: walletName }
+function fireConnectSuccess(address?: string, walletName = 'MetaMask') {
+  const state = {
+    timestamp: Date.now(),
+    data: {
+      type: 'track' as const,
+      event: 'CONNECT_SUCCESS' as const,
+      address,
+      properties: { name: walletName },
+    },
+    pendingWalletImpressions: [],
+  }
+
+  eventSubscriptions['CONNECT_SUCCESS']?.(state as EventsControllerState)
 }
 
-const setDisconnected = () => {
-  mockWalletState.address = undefined
-  mockWalletState.isConnected = false
-  mockWalletState.walletInfo = undefined
+function fireConnectError() {
+  const state = {
+    timestamp: Date.now(),
+    data: {
+      type: 'track' as const,
+      event: 'CONNECT_ERROR' as const,
+      properties: { message: 'Connection failed' },
+    },
+    pendingWalletImpressions: [],
+  }
+
+  eventSubscriptions['CONNECT_ERROR']?.(state as EventsControllerState)
+}
+
+function fireUserRejected() {
+  const state = {
+    timestamp: Date.now(),
+    data: {
+      type: 'track' as const,
+      event: 'USER_REJECTED' as const,
+      properties: { message: 'User rejected' },
+    },
+    pendingWalletImpressions: [],
+  }
+
+  eventSubscriptions['USER_REJECTED']?.(state as EventsControllerState)
 }
 
 const renderImportFlow = () => renderHook(() => useImportSignerFlow())
@@ -59,38 +88,49 @@ const renderImportFlow = () => renderHook(() => useImportSignerFlow())
 describe('useImportSignerFlow', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    setDisconnected()
+
+    Object.keys(eventSubscriptions).forEach((key) => {
+      eventSubscriptions[key] = undefined
+    })
   })
 
-  it('opens the wallet modal when initiateConnection is called', () => {
+  it('disconnects and opens the wallet modal when initiateConnection is called', async () => {
     const { result } = renderImportFlow()
 
-    act(() => {
-      result.current.initiateConnection()
+    await act(async () => {
+      await result.current.initiateConnection()
     })
 
+    expect(mockDisconnect).toHaveBeenCalled()
     expect(mockOpen).toHaveBeenCalledWith({ view: 'Connect' })
   })
 
   it('navigates to name-signer when connected address is an owner', async () => {
     mockValidateAddressOwnership.mockResolvedValue({ isOwner: true })
 
-    const { result, rerender } = renderImportFlow()
+    const { result } = renderImportFlow()
 
-    act(() => {
-      result.current.initiateConnection()
+    await act(async () => {
+      await result.current.initiateConnection()
     })
 
-    setConnected(mockAddress)
-    rerender({})
+    mockDisconnect.mockClear()
+
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
 
     await waitFor(() => {
-      expect(mockValidateAddressOwnership).toHaveBeenCalled()
+      expect(mockValidateAddressOwnership).toHaveBeenCalledWith(checksumAddress)
       expect(mockSwitchNetworkIfNeeded).toHaveBeenCalled()
       expect(mockDisconnect).not.toHaveBeenCalled()
       expect(mockRouterPush).toHaveBeenCalledWith(
         expect.objectContaining({
           pathname: '/import-signers/name-signer',
+          params: expect.objectContaining({
+            address: checksumAddress,
+            walletName: 'MetaMask',
+          }),
         }),
       )
     })
@@ -99,14 +139,17 @@ describe('useImportSignerFlow', () => {
   it('disconnects and navigates to error when connected address is not an owner', async () => {
     mockValidateAddressOwnership.mockResolvedValue({ isOwner: false })
 
-    const { result, rerender } = renderImportFlow()
+    const { result } = renderImportFlow()
 
-    act(() => {
-      result.current.initiateConnection()
+    await act(async () => {
+      await result.current.initiateConnection()
     })
 
-    setConnected(mockAddress)
-    rerender({})
+    mockDisconnect.mockClear()
+
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
 
     await waitFor(() => {
       expect(mockDisconnect).toHaveBeenCalled()
@@ -121,14 +164,17 @@ describe('useImportSignerFlow', () => {
   it('disconnects and navigates to error when validation throws', async () => {
     mockValidateAddressOwnership.mockRejectedValue(new Error('Network error'))
 
-    const { result, rerender } = renderImportFlow()
+    const { result } = renderImportFlow()
 
-    act(() => {
-      result.current.initiateConnection()
+    await act(async () => {
+      await result.current.initiateConnection()
     })
 
-    setConnected(mockAddress)
-    rerender({})
+    mockDisconnect.mockClear()
+
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
 
     await waitFor(() => {
       expect(mockDisconnect).toHaveBeenCalled()
@@ -140,66 +186,124 @@ describe('useImportSignerFlow', () => {
     })
   })
 
-  it('does not navigate when wallet connects without user initiation', () => {
-    setConnected(mockAddress)
-
+  it('does not navigate when CONNECT_SUCCESS fires without user initiation', () => {
     renderImportFlow()
+
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
 
     expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
   })
 
-  it('does not navigate again for the same address after reconnect', async () => {
+  it('does not navigate again for the same CONNECT_SUCCESS event', async () => {
     mockValidateAddressOwnership.mockResolvedValue({ isOwner: true })
 
-    const { result, rerender } = renderImportFlow()
+    const { result } = renderImportFlow()
 
-    act(() => {
-      result.current.initiateConnection()
+    await act(async () => {
+      await result.current.initiateConnection()
     })
 
-    setConnected(mockAddress)
-    rerender({})
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledTimes(1)
     })
 
-    rerender({})
+    // Fire another CONNECT_SUCCESS without re-initiating — should be ignored
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
 
     expect(mockRouterPush).toHaveBeenCalledTimes(1)
   })
 
-  it('allows navigation after disconnect and reconnect', async () => {
+  it('allows navigation after re-initiating connection', async () => {
     mockValidateAddressOwnership.mockResolvedValue({ isOwner: true })
 
-    const { result, rerender } = renderImportFlow()
+    const { result } = renderImportFlow()
 
-    act(() => {
-      result.current.initiateConnection()
+    // First connection
+    await act(async () => {
+      await result.current.initiateConnection()
     })
 
-    setConnected(mockAddress)
-    rerender({})
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledTimes(1)
     })
 
-    // Disconnect
-    setDisconnected()
-    rerender({})
-
-    // Reconnect
-    act(() => {
-      result.current.initiateConnection()
+    // Second connection
+    await act(async () => {
+      await result.current.initiateConnection()
     })
 
-    setConnected(mockAddress)
-    rerender({})
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledTimes(2)
     })
+  })
+
+  it('ignores CONNECT_SUCCESS without address', async () => {
+    const { result } = renderImportFlow()
+
+    await act(async () => {
+      await result.current.initiateConnection()
+    })
+
+    act(() => {
+      fireConnectSuccess(undefined)
+    })
+
+    expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('resets connectInitiatedRef on CONNECT_ERROR', async () => {
+    const { result } = renderImportFlow()
+
+    await act(async () => {
+      await result.current.initiateConnection()
+    })
+
+    act(() => {
+      fireConnectError()
+    })
+
+    // Now fire a CONNECT_SUCCESS — should be ignored since ref was reset
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
+
+    expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
+  })
+
+  it('resets connectInitiatedRef on USER_REJECTED', async () => {
+    const { result } = renderImportFlow()
+
+    await act(async () => {
+      await result.current.initiateConnection()
+    })
+
+    act(() => {
+      fireUserRejected()
+    })
+
+    // Now fire a CONNECT_SUCCESS — should be ignored since ref was reset
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
+
+    expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useOnAppKitConnect.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useOnAppKitConnect.test.ts
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react-native'
+import { useOnAppKitConnect } from '../useOnAppKitConnect'
+
+const subscriptions: Record<string, ((state: unknown) => void) | undefined> = {}
+
+jest.mock('@reown/appkit-react-native', () => ({
+  useAppKitEventSubscription: (event: string, callback: (state: unknown) => void) => {
+    subscriptions[event] = callback
+  },
+}))
+
+function fireEvent(event: string, data: Record<string, unknown> = {}) {
+  subscriptions[event]?.({
+    timestamp: Date.now(),
+    data: { type: 'track', event, ...data },
+    pendingWalletImpressions: [],
+  })
+}
+
+describe('useOnAppKitConnect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    Object.keys(subscriptions).forEach((key) => {
+      subscriptions[key] = undefined
+    })
+  })
+
+  it('subscribes to CONNECT_SUCCESS, CONNECT_ERROR, and USER_REJECTED', () => {
+    renderHook(() => useOnAppKitConnect(jest.fn(), jest.fn()))
+
+    expect(subscriptions['CONNECT_SUCCESS']).toBeDefined()
+    expect(subscriptions['CONNECT_ERROR']).toBeDefined()
+    expect(subscriptions['USER_REJECTED']).toBeDefined()
+  })
+
+  it('calls onSuccess with narrowed event data on CONNECT_SUCCESS', () => {
+    const onSuccess = jest.fn()
+
+    renderHook(() => useOnAppKitConnect(onSuccess, jest.fn()))
+
+    fireEvent('CONNECT_SUCCESS', {
+      address: '0x1234',
+      properties: { name: 'MetaMask' },
+    })
+
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'CONNECT_SUCCESS',
+        address: '0x1234',
+        properties: { name: 'MetaMask' },
+      }),
+    )
+  })
+
+  it('calls onFailure on CONNECT_ERROR', () => {
+    const onFailure = jest.fn()
+
+    renderHook(() => useOnAppKitConnect(jest.fn(), onFailure))
+
+    fireEvent('CONNECT_ERROR', { properties: { message: 'failed' } })
+
+    expect(onFailure).toHaveBeenCalled()
+  })
+
+  it('calls onFailure on USER_REJECTED', () => {
+    const onFailure = jest.fn()
+
+    renderHook(() => useOnAppKitConnect(jest.fn(), onFailure))
+
+    fireEvent('USER_REJECTED', { properties: { message: 'rejected' } })
+
+    expect(onFailure).toHaveBeenCalled()
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
@@ -1,32 +1,21 @@
 import { faker } from '@faker-js/faker'
+import { getAddress } from 'ethers'
 import { renderHook, act } from '@/src/tests/test-utils'
 import { useReconnectFlow } from '../useReconnectFlow'
+import type { EventsControllerState } from '@reown/appkit-core-react-native'
 
 const mockAddress = faker.finance.ethereumAddress() as `0x${string}`
 const mockOtherAddress = faker.finance.ethereumAddress() as `0x${string}`
 
 const mockRouterPush = jest.fn()
 const mockOpen = jest.fn()
-const mockDisconnect = jest.fn()
+const mockDisconnect = jest.fn().mockResolvedValue(undefined)
 const mockSwitchNetworkIfNeeded = jest.fn().mockResolvedValue(undefined)
 
 jest.mock('expo-router', () => ({
   router: {
     push: (...args: unknown[]) => mockRouterPush(...args),
   },
-}))
-
-// Mutable state object the mock reads on each render
-const mockWalletState = {
-  address: undefined as string | undefined,
-  isConnected: false,
-  walletInfo: undefined as { name: string } | undefined,
-}
-
-jest.mock('@reown/appkit-react-native', () => ({
-  useAppKit: () => ({ open: mockOpen, disconnect: mockDisconnect, switchNetwork: jest.fn() }),
-  useAccount: () => ({ address: mockWalletState.address, isConnected: mockWalletState.isConnected }),
-  useWalletInfo: () => ({ walletInfo: mockWalletState.walletInfo }),
 }))
 
 jest.mock('../useSwitchNetwork', () => ({
@@ -36,16 +25,58 @@ jest.mock('../useSwitchNetwork', () => ({
   }),
 }))
 
-const setConnected = (address: string, walletName = 'MetaMask') => {
-  mockWalletState.address = address
-  mockWalletState.isConnected = true
-  mockWalletState.walletInfo = { name: walletName }
+// Capture event subscriptions registered by useStableAppKitEvent.
+// Must remain the same object reference since jest.mock is hoisted.
+const eventSubscriptions: Record<string, ((state: EventsControllerState) => void) | undefined> = {}
+
+jest.mock('@reown/appkit-react-native', () => ({
+  useAppKit: () => ({ open: mockOpen, disconnect: mockDisconnect }),
+  useAppKitEventSubscription: (event: string, callback: (state: EventsControllerState) => void) => {
+    eventSubscriptions[event] = callback
+  },
+}))
+
+function fireConnectSuccess(address?: string) {
+  const state = {
+    timestamp: Date.now(),
+    data: {
+      type: 'track' as const,
+      event: 'CONNECT_SUCCESS' as const,
+      address,
+      properties: { name: 'MetaMask' },
+    },
+    pendingWalletImpressions: [],
+  }
+
+  eventSubscriptions['CONNECT_SUCCESS']?.(state as EventsControllerState)
 }
 
-const setDisconnected = () => {
-  mockWalletState.address = undefined
-  mockWalletState.isConnected = false
-  mockWalletState.walletInfo = undefined
+function fireConnectError() {
+  const state = {
+    timestamp: Date.now(),
+    data: {
+      type: 'track' as const,
+      event: 'CONNECT_ERROR' as const,
+      properties: { message: 'Connection failed' },
+    },
+    pendingWalletImpressions: [],
+  }
+
+  eventSubscriptions['CONNECT_ERROR']?.(state as EventsControllerState)
+}
+
+function fireUserRejected() {
+  const state = {
+    timestamp: Date.now(),
+    data: {
+      type: 'track' as const,
+      event: 'USER_REJECTED' as const,
+      properties: { message: 'User rejected' },
+    },
+    pendingWalletImpressions: [],
+  }
+
+  eventSubscriptions['USER_REJECTED']?.(state as EventsControllerState)
 }
 
 const renderReconnectFlow = () => renderHook(() => useReconnectFlow())
@@ -53,43 +84,75 @@ const renderReconnectFlow = () => renderHook(() => useReconnectFlow())
 describe('useReconnectFlow', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    setDisconnected()
+
+    Object.keys(eventSubscriptions).forEach((key) => {
+      eventSubscriptions[key] = undefined
+    })
   })
 
-  it('opens the wallet modal when reconnect is called', () => {
+  it('disconnects and opens the wallet modal when reconnect is called', async () => {
     const { result } = renderReconnectFlow()
 
-    act(() => {
-      result.current.reconnect(mockAddress)
+    await act(async () => {
+      await result.current.reconnect(mockAddress)
     })
 
+    expect(mockDisconnect).toHaveBeenCalled()
     expect(mockOpen).toHaveBeenCalledWith({ view: 'Connect' })
   })
 
-  it('switches network when reconnected address matches', () => {
-    const { result, rerender } = renderReconnectFlow()
+  it('switches network when reconnected address matches', async () => {
+    const { result } = renderReconnectFlow()
 
-    act(() => {
-      result.current.reconnect(mockAddress)
+    await act(async () => {
+      await result.current.reconnect(mockAddress)
     })
 
-    setConnected(mockAddress)
-    rerender({})
+    mockDisconnect.mockClear()
+
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
 
     expect(mockSwitchNetworkIfNeeded).toHaveBeenCalled()
     expect(mockDisconnect).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
   })
 
-  it('disconnects and navigates to error when address does not match', () => {
-    const { result, rerender } = renderReconnectFlow()
+  it('disconnects and navigates to error when address does not match', async () => {
+    const { result } = renderReconnectFlow()
 
-    act(() => {
-      result.current.reconnect(mockAddress)
+    await act(async () => {
+      await result.current.reconnect(mockAddress)
     })
 
-    setConnected(mockOtherAddress)
-    rerender({})
+    mockDisconnect.mockClear()
+
+    act(() => {
+      fireConnectSuccess(mockOtherAddress)
+    })
+
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/import-signers/reconnect-error',
+        params: { address: getAddress(mockAddress) },
+      }),
+    )
+  })
+
+  it('disconnects and navigates to error when CONNECT_SUCCESS has no address', async () => {
+    const { result } = renderReconnectFlow()
+
+    await act(async () => {
+      await result.current.reconnect(mockAddress)
+    })
+
+    mockDisconnect.mockClear()
+
+    act(() => {
+      fireConnectSuccess(undefined)
+    })
 
     expect(mockDisconnect).toHaveBeenCalled()
     expect(mockRouterPush).toHaveBeenCalledWith(
@@ -99,13 +162,52 @@ describe('useReconnectFlow', () => {
     )
   })
 
-  it('does not act when wallet connects without reconnect initiation', () => {
-    setConnected(mockAddress)
-
+  it('does not act when CONNECT_SUCCESS fires without reconnect initiation', () => {
     renderReconnectFlow()
 
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
+
     expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
-    expect(mockDisconnect).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('resets pendingAddressRef on CONNECT_ERROR', async () => {
+    const { result } = renderReconnectFlow()
+
+    await act(async () => {
+      await result.current.reconnect(mockAddress)
+    })
+
+    act(() => {
+      fireConnectError()
+    })
+
+    // Now fire a CONNECT_SUCCESS — should be ignored since ref was reset
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
+
+    expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
+  })
+
+  it('resets pendingAddressRef on USER_REJECTED', async () => {
+    const { result } = renderReconnectFlow()
+
+    await act(async () => {
+      await result.current.reconnect(mockAddress)
+    })
+
+    act(() => {
+      fireUserRejected()
+    })
+
+    // Now fire a CONNECT_SUCCESS — should be ignored since ref was reset
+    act(() => {
+      fireConnectSuccess(mockAddress)
+    })
+
+    expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useStableAppKitEvent.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useStableAppKitEvent.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react-native'
+import { useStableAppKitEvent } from '../useStableAppKitEvent'
+
+const subscriptions: Record<string, ((state: unknown) => void) | undefined> = {}
+
+jest.mock('@reown/appkit-react-native', () => ({
+  useAppKitEventSubscription: (event: string, callback: (state: unknown) => void) => {
+    subscriptions[event] = callback
+  },
+}))
+
+function makeState(event: string) {
+  return { timestamp: Date.now(), data: { type: 'track', event }, pendingWalletImpressions: [] }
+}
+
+describe('useStableAppKitEvent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    Object.keys(subscriptions).forEach((key) => {
+      subscriptions[key] = undefined
+    })
+  })
+
+  it('subscribes to the specified event', () => {
+    const callback = jest.fn()
+
+    renderHook(() => useStableAppKitEvent('CONNECT_SUCCESS', callback))
+
+    expect(subscriptions['CONNECT_SUCCESS']).toBeDefined()
+  })
+
+  it('forwards event state to the callback when event name matches', () => {
+    const callback = jest.fn()
+
+    renderHook(() => useStableAppKitEvent('CONNECT_SUCCESS', callback))
+
+    const mockState = makeState('CONNECT_SUCCESS')
+    subscriptions['CONNECT_SUCCESS']?.(mockState)
+
+    expect(callback).toHaveBeenCalledWith(mockState)
+  })
+
+  it('filters out events whose data.event does not match the subscribed event', () => {
+    const callback = jest.fn()
+
+    renderHook(() => useStableAppKitEvent('CONNECT_SUCCESS', callback))
+
+    subscriptions['CONNECT_SUCCESS']?.(makeState('DISCONNECT_SUCCESS'))
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('uses the latest callback without re-subscribing', () => {
+    const firstCallback = jest.fn()
+    const secondCallback = jest.fn()
+
+    const { rerender } = renderHook(({ cb }) => useStableAppKitEvent('CONNECT_SUCCESS', cb), {
+      initialProps: { cb: firstCallback },
+    })
+
+    const initialSubscription = subscriptions['CONNECT_SUCCESS']
+
+    rerender({ cb: secondCallback })
+
+    // Subscription reference should be stable (same function)
+    expect(subscriptions['CONNECT_SUCCESS']).toBe(initialSubscription)
+
+    // But calling it should invoke the latest callback
+    const mockState = makeState('CONNECT_SUCCESS')
+    subscriptions['CONNECT_SUCCESS']?.(mockState)
+
+    expect(firstCallback).not.toHaveBeenCalled()
+    expect(secondCallback).toHaveBeenCalledWith(mockState)
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -1,88 +1,99 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import { router } from 'expo-router'
 import { getAddress } from 'ethers'
 import { useAccount, useAppKit, useWalletInfo } from '@reown/appkit-react-native'
 import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipValidation'
 import Logger from '@/src/utils/logger'
 import { useSwitchNetwork } from './useSwitchNetwork'
+import { useOnAppKitConnect } from './useOnAppKitConnect'
 
 /**
  * Handles the signer import flow: ownership validation and navigation
  * after a new wallet connects via WalletConnect.
+ *
+ * Uses CONNECT_SUCCESS event subscription instead of useEffect to respond
+ * directly to connection events. The connectInitiatedRef guard ensures
+ * only user-initiated connections (via initiateConnection()) trigger the
+ * flow — auto-reconnects and connections from useReconnectFlow are ignored.
  */
 export function useImportSignerFlow() {
   const { open, disconnect } = useAppKit()
-  const { address, isConnected: walletIsConnected } = useAccount()
+  const { address: accountAddress, isConnected: walletIsConnected } = useAccount()
   const { walletInfo } = useWalletInfo()
   const { switchNetworkIfNeeded } = useSwitchNetwork()
   const { validateAddressOwnership } = useAddressOwnershipValidation()
 
-  const registeredRef = useRef<string | null>(null)
   const connectInitiatedRef = useRef(false)
 
-  const isConnected = Boolean(walletIsConnected && address && walletInfo)
+  const isConnected = Boolean(walletIsConnected && accountAddress && walletInfo)
 
-  const pushConnectSignerError = useCallback(() => {
-    if (!address) {
-      return
-    }
+  const pushConnectSignerError = useCallback(
+    (address: string) => {
+      disconnect()
 
-    disconnect()
+      router.push({
+        pathname: '/import-signers/connect-signer-error',
+        params: { address, walletIcon: walletInfo?.icon ?? '' },
+      })
+    },
+    [disconnect, walletInfo?.icon],
+  )
 
-    router.push({
-      pathname: '/import-signers/connect-signer-error',
-      params: { address: getAddress(address), walletIcon: walletInfo?.icon ?? '' },
-    })
-  }, [address, disconnect, walletInfo?.icon])
-
-  // Validate ownership then navigate when the user initiates a new connection
-  useEffect(() => {
-    if (!connectInitiatedRef.current || !isConnected || !address || !walletInfo) {
-      return
-    }
-
-    connectInitiatedRef.current = false
-
-    const checksumAddress = getAddress(address)
-
-    const validateAndNavigate = async () => {
-      try {
-        const result = await validateAddressOwnership(checksumAddress)
-
-        if (result.isOwner) {
-          await switchNetworkIfNeeded()
-          registeredRef.current = address
-
-          router.push({
-            pathname: '/import-signers/name-signer',
-            params: {
-              address: checksumAddress,
-              walletName: walletInfo.name ?? '',
-            },
-          })
-        } else {
-          pushConnectSignerError()
-        }
-      } catch (error) {
-        Logger.error('Error validating signer ownership:', error)
-        pushConnectSignerError()
+  useOnAppKitConnect(
+    (eventData) => {
+      if (!connectInitiatedRef.current) {
+        return
       }
-    }
 
-    validateAndNavigate()
-  }, [isConnected, address, walletInfo, validateAddressOwnership, switchNetworkIfNeeded, pushConnectSignerError])
+      connectInitiatedRef.current = false
 
-  // Reset guard when wallet disconnects so reconnection triggers navigation
-  useEffect(() => {
-    if (!walletIsConnected) {
-      registeredRef.current = null
-    }
-  }, [walletIsConnected])
+      const rawAddress = eventData.address
 
-  const initiateConnection = useCallback(() => {
+      if (!rawAddress) {
+        Logger.warn('CONNECT_SUCCESS fired without address')
+        return
+      }
+
+      const checksumAddress = getAddress(rawAddress)
+      const walletName = eventData.properties.name ?? ''
+
+      const validateAndNavigate = async () => {
+        try {
+          const result = await validateAddressOwnership(checksumAddress)
+
+          if (result.isOwner) {
+            await switchNetworkIfNeeded()
+
+            router.push({
+              pathname: '/import-signers/name-signer',
+              params: {
+                address: checksumAddress,
+                walletName,
+              },
+            })
+          } else {
+            pushConnectSignerError(checksumAddress)
+          }
+        } catch (error) {
+          Logger.error('Error validating signer ownership:', error)
+          pushConnectSignerError(checksumAddress)
+        }
+      }
+
+      validateAndNavigate().catch((error) => {
+        Logger.error('Unexpected error in validateAndNavigate:', error)
+      })
+    },
+    () => {
+      connectInitiatedRef.current = false
+    },
+  )
+
+  const initiateConnection = useCallback(async () => {
+    await disconnect()
     connectInitiatedRef.current = true
     open({ view: 'Connect' })
-  }, [open])
+  }, [disconnect, open])
 
   return { initiateConnection, isConnected }
 }

--- a/apps/mobile/src/features/WalletConnect/hooks/useOnAppKitConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useOnAppKitConnect.ts
@@ -1,0 +1,21 @@
+import type { Event } from '@reown/appkit-common-react-native'
+import { useStableAppKitEvent } from './useStableAppKitEvent'
+
+export type ConnectSuccessEvent = Extract<Event, { event: 'CONNECT_SUCCESS' }>
+
+/**
+ * Subscribes to the AppKit CONNECT_SUCCESS event (with typed payload)
+ * and resets state on CONNECT_ERROR / USER_REJECTED.
+ *
+ * @param onSuccess  Called with the narrowed CONNECT_SUCCESS event data.
+ * @param onFailure  Called when the connection fails or is rejected by the user.
+ *                   Use this to reset ref guards so they don't leak.
+ */
+export function useOnAppKitConnect(onSuccess: (event: ConnectSuccessEvent) => void, onFailure: () => void) {
+  useStableAppKitEvent('CONNECT_SUCCESS', (state) => {
+    onSuccess(state.data as ConnectSuccessEvent)
+  })
+
+  useStableAppKitEvent('CONNECT_ERROR', onFailure)
+  useStableAppKitEvent('USER_REJECTED', onFailure)
+}

--- a/apps/mobile/src/features/WalletConnect/hooks/useOnAppKitConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useOnAppKitConnect.ts
@@ -1,7 +1,4 @@
-import type { Event } from '@reown/appkit-common-react-native'
-import { useStableAppKitEvent } from './useStableAppKitEvent'
-
-export type ConnectSuccessEvent = Extract<Event, { event: 'CONNECT_SUCCESS' }>
+import { AppKitEvent, useStableAppKitEvent } from './useStableAppKitEvent'
 
 /**
  * Subscribes to the AppKit CONNECT_SUCCESS event (with typed payload)
@@ -11,10 +8,8 @@ export type ConnectSuccessEvent = Extract<Event, { event: 'CONNECT_SUCCESS' }>
  * @param onFailure  Called when the connection fails or is rejected by the user.
  *                   Use this to reset ref guards so they don't leak.
  */
-export function useOnAppKitConnect(onSuccess: (event: ConnectSuccessEvent) => void, onFailure: () => void) {
-  useStableAppKitEvent('CONNECT_SUCCESS', (state) => {
-    onSuccess(state.data as ConnectSuccessEvent)
-  })
+export function useOnAppKitConnect(onSuccess: (event: AppKitEvent<'CONNECT_SUCCESS'>) => void, onFailure: () => void) {
+  useStableAppKitEvent('CONNECT_SUCCESS', (state) => onSuccess(state.data))
 
   useStableAppKitEvent('CONNECT_ERROR', onFailure)
   useStableAppKitEvent('USER_REJECTED', onFailure)

--- a/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
@@ -1,49 +1,61 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
 import { router } from 'expo-router'
-import { useAccount, useAppKit, useWalletInfo } from '@reown/appkit-react-native'
+import { useAppKit } from '@reown/appkit-react-native'
 import { getAddress } from 'ethers'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useSwitchNetwork } from './useSwitchNetwork'
+import { useOnAppKitConnect } from './useOnAppKitConnect'
 
 /**
  * Handles the first WalletConnect reconnection attempt for existing signers.
  * On address mismatch, navigates to ReconnectError which owns subsequent retries.
+ *
+ * Uses CONNECT_SUCCESS event subscription instead of useEffect to respond
+ * directly to connection events. The pendingAddressRef guard ensures only
+ * user-initiated reconnections (via reconnect()) trigger the flow —
+ * auto-reconnects and connections from useImportSignerFlow are ignored.
  */
 export function useReconnectFlow() {
   const { open, disconnect } = useAppKit()
-  const { address, isConnected: walletIsConnected } = useAccount()
-  const { walletInfo } = useWalletInfo()
   const { switchNetworkIfNeeded } = useSwitchNetwork()
   const pendingAddressRef = useRef<string | null>(null)
 
-  useEffect(() => {
-    if (!pendingAddressRef.current || !walletIsConnected || !address || !walletInfo) {
-      return
-    }
+  useOnAppKitConnect(
+    (eventData) => {
+      if (!pendingAddressRef.current) {
+        return
+      }
 
-    const reconnectAddress = getAddress(pendingAddressRef.current)
-    pendingAddressRef.current = null
+      const reconnectAddress = getAddress(pendingAddressRef.current)
+      pendingAddressRef.current = null
 
-    if (!sameAddress(reconnectAddress, address)) {
-      disconnect()
+      const connectedAddress = eventData.address
 
-      router.push({
-        pathname: '/import-signers/reconnect-error',
-        params: { address: reconnectAddress },
-      })
+      if (!connectedAddress || !sameAddress(reconnectAddress, connectedAddress)) {
+        disconnect()
 
-      return
-    }
+        router.push({
+          pathname: '/import-signers/reconnect-error',
+          params: { address: reconnectAddress },
+        })
 
-    switchNetworkIfNeeded()
-  }, [walletIsConnected, address, walletInfo, disconnect, switchNetworkIfNeeded])
+        return
+      }
+
+      switchNetworkIfNeeded()
+    },
+    () => {
+      pendingAddressRef.current = null
+    },
+  )
 
   const reconnect = useCallback(
-    (signerAddress: string) => {
+    async (signerAddress: string) => {
+      await disconnect()
       pendingAddressRef.current = signerAddress
       open({ view: 'Connect' })
     },
-    [open],
+    [disconnect, open],
   )
 
   return { reconnect }

--- a/apps/mobile/src/features/WalletConnect/hooks/useStableAppKitEvent.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useStableAppKitEvent.ts
@@ -1,7 +1,17 @@
 import { useCallback, useRef } from 'react'
 import { useAppKitEventSubscription } from '@reown/appkit-react-native'
-import type { EventsControllerState } from '@reown/appkit-core-react-native'
-import type { EventName } from '@reown/appkit-common-react-native'
+import type { EventsControllerState as CoreEventsControllerState } from '@reown/appkit-core-react-native'
+import type { EventName, Event } from '@reown/appkit-common-react-native'
+
+export type AppKitEvent<N extends EventName> = Extract<Event, { event: N }>
+type EventsControllerState<N extends EventName> = Omit<CoreEventsControllerState, 'data'> & { data: AppKitEvent<N> }
+
+const isEventControllerState = <N extends EventName>(
+  state: CoreEventsControllerState,
+  eventName: N,
+): state is EventsControllerState<N> => {
+  return state.data.event === eventName
+}
 
 /**
  * Subscribes to a specific AppKit event with a ref-stabilized callback.
@@ -10,12 +20,15 @@ import type { EventName } from '@reown/appkit-common-react-native'
  * changes. This wrapper stores the latest callback in a ref so the
  * subscription is created once and never torn down on re-renders.
  */
-export function useStableAppKitEvent(event: EventName, callback: (state: EventsControllerState) => void) {
+export function useStableAppKitEvent<E extends EventName>(
+  event: E,
+  callback: (state: EventsControllerState<E>) => void,
+) {
   const callbackRef = useRef(callback)
   callbackRef.current = callback
 
-  const stableCallback = useCallback((state: EventsControllerState) => {
-    if (state.data.event === event) {
+  const stableCallback = useCallback((state: CoreEventsControllerState) => {
+    if (isEventControllerState(state, event)) {
       callbackRef.current(state)
     }
   }, [])

--- a/apps/mobile/src/features/WalletConnect/hooks/useStableAppKitEvent.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useStableAppKitEvent.ts
@@ -1,0 +1,24 @@
+import { useCallback, useRef } from 'react'
+import { useAppKitEventSubscription } from '@reown/appkit-react-native'
+import type { EventsControllerState } from '@reown/appkit-core-react-native'
+import type { EventName } from '@reown/appkit-common-react-native'
+
+/**
+ * Subscribes to a specific AppKit event with a ref-stabilized callback.
+ *
+ * `useAppKitEventSubscription` re-subscribes whenever the callback identity
+ * changes. This wrapper stores the latest callback in a ref so the
+ * subscription is created once and never torn down on re-renders.
+ */
+export function useStableAppKitEvent(event: EventName, callback: (state: EventsControllerState) => void) {
+  const callbackRef = useRef(callback)
+  callbackRef.current = callback
+
+  const stableCallback = useCallback((state: EventsControllerState) => {
+    if (state.data.event === event) {
+      callbackRef.current(state)
+    }
+  }, [])
+
+  useAppKitEventSubscription(event, stableCallback)
+}


### PR DESCRIPTION
Replace useEffect-based reactive patterns in useImportSignerFlow and useReconnectFlow with direct AppKit event subscriptions.

- Extract useStableAppKitEvent: ref-stabilized wrapper around useAppKitEventSubscription that filters by event name to prevent cross-event contamination from valtio proxy mutations
- Extract useOnAppKitConnect: shared hook subscribing to CONNECT_SUCCESS, CONNECT_ERROR, and USER_REJECTED with typed payload
- Refactor useImportSignerFlow and useReconnectFlow to use event callbacks instead of useEffect watching reactive state
- Disconnect before opening the connect modal to prevent stale CONNECT_SUCCESS replays from previously connected wallets

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
