### PR TITLE
feat(mobile): add developer toggle to disable screen recording protection

### DIFF
--- a/apps/mobile/src/features/Developer/Developer.container.tsx
+++ b/apps/mobile/src/features/Developer/Developer.container.tsx
@@ -2,12 +2,38 @@ import { Developer } from '@/src/features/Developer/components/Developer'
 import * as Device from 'expo-device'
 import * as Application from 'expo-application'
 import { GATEWAY_URL } from '@/src/config/constants'
-import { useAppSelector } from '@/src/store/hooks'
+import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
 import { selectFCMToken } from '@/src/store/notificationsSlice'
+import { selectScreenProtectionDisabled, setScreenProtectionDisabled } from '@/src/store/settingsSlice'
 import { type Info } from '@/src/features/Developer/types'
+import { useCallback } from 'react'
+import { Alert } from 'react-native'
 
 export const DeveloperContainer = () => {
   const fcmToken = useAppSelector(selectFCMToken)
+  const screenProtectionDisabled = useAppSelector(selectScreenProtectionDisabled)
+  const dispatch = useAppDispatch()
+
+  const onToggleScreenProtection = useCallback(() => {
+    if (!screenProtectionDisabled) {
+      Alert.alert(
+        'Disable screen protection?',
+        'This will allow screen recording and screenshots on sensitive screens like private key display. ' +
+          'A malicious actor could record your screen while sensitive data is visible. ' +
+          'This is a developer setting and you are not supposed to use it.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Disable protection',
+            style: 'destructive',
+            onPress: () => dispatch(setScreenProtectionDisabled(true)),
+          },
+        ],
+      )
+    } else {
+      dispatch(setScreenProtectionDisabled(false))
+    }
+  }, [dispatch, screenProtectionDisabled])
 
   const info: Info = {
     device: {
@@ -30,5 +56,12 @@ export const DeveloperContainer = () => {
       fcmToken: fcmToken || '',
     },
   }
-  return <Developer info={info} />
+
+  return (
+    <Developer
+      info={info}
+      screenProtectionDisabled={screenProtectionDisabled}
+      onToggleScreenProtection={onToggleScreenProtection}
+    />
+  )
 }

--- a/apps/mobile/src/features/Developer/components/Developer.tsx
+++ b/apps/mobile/src/features/Developer/components/Developer.tsx
@@ -1,11 +1,14 @@
 import { View, Text, ScrollView, H2 } from 'tamagui'
 import { CopyButton } from '@/src/components/CopyButton'
+import { LoadableSwitch } from '@/src/components/LoadableSwitch'
 import { type Info } from '@/src/features/Developer/types'
 import { getCrashlytics } from '@react-native-firebase/crashlytics'
 import { SafeButton } from '@/src/components/SafeButton'
 
 type DeveloperProps = {
   info: Info
+  screenProtectionDisabled: boolean
+  onToggleScreenProtection: () => void
 }
 
 type InfoProps = {
@@ -31,7 +34,7 @@ const Info = ({ info }: InfoProps) => {
     </View>
   )
 }
-export const Developer = ({ info }: DeveloperProps) => {
+export const Developer = ({ info, screenProtectionDisabled, onToggleScreenProtection }: DeveloperProps) => {
   return (
     <View flex={1}>
       <ScrollView paddingHorizontal={'$4'}>
@@ -42,6 +45,21 @@ export const Developer = ({ info }: DeveloperProps) => {
         <View marginTop={'$2'}>
           <H2>Device Info</H2>
           <Info info={info.device} />
+        </View>
+        <View marginTop={'$4'}>
+          <View flexDirection={'row'} justifyContent={'space-between'} alignItems={'center'}>
+            <View flex={1} marginRight={'$2'}>
+              <Text fontWeight={600}>Disable screen recording protection</Text>
+              <Text fontSize={'$3'} color={'$textSecondary'}>
+                Allows screen recording and screenshots on sensitive screens. For testing only.
+              </Text>
+            </View>
+            <LoadableSwitch
+              testID="toggle-screen-protection"
+              value={screenProtectionDisabled}
+              onChange={onToggleScreenProtection}
+            />
+          </View>
         </View>
         <View marginTop={'$4'}>
           <Text>The button below will crash the app on purpose. This is for testing purposes only.</Text>

--- a/apps/mobile/src/hooks/__tests__/useScreenProtection.test.ts
+++ b/apps/mobile/src/hooks/__tests__/useScreenProtection.test.ts
@@ -13,12 +13,22 @@ jest.mock('react-native-capture-protection', () => ({
   },
 }))
 
+jest.mock('@/src/store/hooks', () => ({
+  useAppSelector: jest.fn(),
+}))
+
+jest.mock('@/src/store/settingsSlice', () => ({
+  selectScreenProtectionDisabled: jest.fn(),
+}))
+
 const mockUseFocusEffect = jest.requireMock('expo-router').useFocusEffect
 const mockCaptureProtection = jest.requireMock('react-native-capture-protection').CaptureProtection
+const { useAppSelector } = require('@/src/store/hooks')
 
 describe('useScreenProtection', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    useAppSelector.mockReturnValue(false)
   })
 
   it('should call useFocusEffect with correct parameters', () => {
@@ -77,5 +87,17 @@ describe('useScreenProtection', () => {
 
     expect(mockCaptureProtection.prevent).toHaveBeenCalledTimes(1)
     expect(mockCaptureProtection.prevent).toHaveBeenCalledWith(customOptions)
+  })
+
+  it('should skip screen protection when screenProtectionDisabled is true', () => {
+    useAppSelector.mockReturnValue(true)
+
+    renderHook(() => useScreenProtection())
+
+    const focusEffectCallback = mockUseFocusEffect.mock.calls[0][0]
+    const cleanup = focusEffectCallback()
+
+    expect(mockCaptureProtection.prevent).not.toHaveBeenCalled()
+    expect(cleanup).toBeUndefined()
   })
 })

--- a/apps/mobile/src/hooks/useScreenProtection.ts
+++ b/apps/mobile/src/hooks/useScreenProtection.ts
@@ -1,6 +1,8 @@
 import { useFocusEffect } from 'expo-router'
 import { useCallback } from 'react'
 import { CaptureProtection } from 'react-native-capture-protection'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectScreenProtectionDisabled } from '@/src/store/settingsSlice'
 
 export interface ScreenProtectionOptions {
   screenshot?: boolean
@@ -21,13 +23,19 @@ export const useScreenProtection = (
     appSwitcher: true,
   },
 ) => {
+  const screenProtectionDisabled = useAppSelector(selectScreenProtectionDisabled)
+
   useFocusEffect(
     useCallback(() => {
+      if (screenProtectionDisabled) {
+        return
+      }
+
       CaptureProtection.prevent(options)
 
       return () => {
         CaptureProtection.allow()
       }
-    }, [options]),
+    }, [options, screenProtectionDisabled]),
   )
 }

--- a/apps/mobile/src/store/__tests__/settingsSlice.test.ts
+++ b/apps/mobile/src/store/__tests__/settingsSlice.test.ts
@@ -3,6 +3,8 @@ import settingsReducer, {
   selectTokenList,
   setDataCollectionConsented,
   selectDataCollectionConsented,
+  setScreenProtectionDisabled,
+  selectScreenProtectionDisabled,
   TOKEN_LISTS,
   type SettingsState,
 } from '../settingsSlice'
@@ -18,6 +20,7 @@ describe('settingsSlice', () => {
     hideDust: true,
     preferFiatInput: true,
     dataCollectionConsented: false,
+    screenProtectionDisabled: false,
     env: {
       rpc: {},
       tenderly: {
@@ -118,6 +121,53 @@ describe('settingsSlice', () => {
       })
       const state = store.getState() as RootState
       expect(selectDataCollectionConsented(state)).toBe(false)
+    })
+  })
+
+  describe('setScreenProtectionDisabled', () => {
+    it('should set screenProtectionDisabled to true', () => {
+      const state = settingsReducer(initialState, setScreenProtectionDisabled(true))
+      expect(state.screenProtectionDisabled).toBe(true)
+    })
+
+    it('should set screenProtectionDisabled to false', () => {
+      const previousState = { ...initialState, screenProtectionDisabled: true }
+      const state = settingsReducer(previousState, setScreenProtectionDisabled(false))
+      expect(state.screenProtectionDisabled).toBe(false)
+    })
+  })
+
+  describe('selectScreenProtectionDisabled', () => {
+    it('should default to false', () => {
+      const store = configureStore({
+        reducer: { settings: settingsReducer },
+        preloadedState: { settings: initialState },
+      })
+      const state = store.getState() as RootState
+      expect(selectScreenProtectionDisabled(state)).toBe(false)
+    })
+
+    it('should return true when set', () => {
+      const store = configureStore({
+        reducer: { settings: settingsReducer },
+        preloadedState: { settings: { ...initialState, screenProtectionDisabled: true } },
+      })
+      const state = store.getState() as RootState
+      expect(selectScreenProtectionDisabled(state)).toBe(true)
+    })
+
+    it('should default to false when undefined (persist migration)', () => {
+      const store = configureStore({
+        reducer: { settings: settingsReducer },
+        preloadedState: {
+          settings: {
+            ...initialState,
+            screenProtectionDisabled: undefined as unknown as boolean,
+          },
+        },
+      })
+      const state = store.getState() as RootState
+      expect(selectScreenProtectionDisabled(state)).toBe(false)
     })
   })
 })

--- a/apps/mobile/src/store/settingsSlice.test.ts
+++ b/apps/mobile/src/store/settingsSlice.test.ts
@@ -25,6 +25,7 @@ const createMockStore = (initialState?: Partial<SettingsState>) => {
         hideDust: true,
         preferFiatInput: true,
         dataCollectionConsented: false,
+        screenProtectionDisabled: false,
         env: { rpc: {}, tenderly: { url: '', accessToken: '' } },
         ...initialState,
       },

--- a/apps/mobile/src/store/settingsSlice.ts
+++ b/apps/mobile/src/store/settingsSlice.ts
@@ -18,6 +18,7 @@ export interface SettingsState {
   hideDust: boolean
   preferFiatInput: boolean
   dataCollectionConsented: boolean
+  screenProtectionDisabled: boolean
   env: EnvState
 }
 
@@ -29,6 +30,7 @@ const initialState: SettingsState = {
   hideDust: true,
   preferFiatInput: true,
   dataCollectionConsented: false,
+  screenProtectionDisabled: false,
   env: {
     rpc: {},
     tenderly: {
@@ -62,6 +64,9 @@ const settingsSlice = createSlice({
     },
     setDataCollectionConsented: (state, { payload }: PayloadAction<boolean>) => {
       state.dataCollectionConsented = payload
+    },
+    setScreenProtectionDisabled: (state, { payload }: PayloadAction<boolean>) => {
+      state.screenProtectionDisabled = payload
     },
     setRpc: (state, { payload }: PayloadAction<{ chainId: string; rpc: string }>) => {
       const { chainId, rpc } = payload
@@ -106,6 +111,11 @@ export const selectRpc = createSelector(selectSettingsState, (settings) => {
 
 export const selectTenderly = createSelector(selectSettingsState, (settings) => settings?.env?.tenderly)
 
+export const selectScreenProtectionDisabled = createSelector(
+  selectSettingsState,
+  (settings) => settings.screenProtectionDisabled ?? false,
+)
+
 export const {
   updateSettings,
   resetSettings,
@@ -114,5 +124,6 @@ export const {
   setHideDust,
   setPreferFiatInput,
   setDataCollectionConsented,
+  setScreenProtectionDisabled,
 } = settingsSlice.actions
 export default settingsSlice.reducer

--- a/apps/mobile/src/tests/test-utils.tsx
+++ b/apps/mobile/src/tests/test-utils.tsx
@@ -27,6 +27,7 @@ const defaultSettings: SettingsState = {
   hideDust: true,
   preferFiatInput: true,
   dataCollectionConsented: false,
+  screenProtectionDisabled: false,
   env: {
     rpc: {},
     tenderly: {


### PR DESCRIPTION
> A toggle hides in dev settings,
> lets testers record what they see,
> no more black screens.

## What it solves

Screen recording protection blacks out sensitive screens (private key display, signer import) in QA video recordings, making it impossible to visually verify those flows through recorded sessions.

## How this PR fixes it

Adds a persistent toggle in the hidden developer menu (Settings → 3-tap version text → Developer) that disables `react-native-capture-protection` on protected screens. When enabling, a confirmation alert warns about security implications. The setting persists across restarts via Redux/MMKV with a `?? false` fallback for existing users (no store migration needed).

## How to test it

1. Open the app → Settings → tap the version/implementation text 3 times to reveal the Developer menu
2. Tap "Developer" → find the "Disable screen recording protection" toggle
3. Toggle it ON → confirm the security alert dialog
4. Navigate to a signer's private key screen → start a screen recording → verify the screen is visible (not blacked out)
5. Go back to Developer → toggle it OFF → return to private key screen → verify recording shows a black screen again
6. Kill and restart the app → verify the toggle state persisted

## Visual summary

```mermaid
flowchart LR
    A[Developer Screen] -->|Toggle ON| B[Alert.alert confirmation]
    B -->|Confirm| C[Redux: screenProtectionDisabled = true]
    C --> D[useScreenProtection hook]
    D -->|disabled| E[Skip CaptureProtection.prevent]
    D -->|enabled| F[Call CaptureProtection.prevent]
```

## Screenshots

N/A - requires physical device testing. The toggle uses the existing `LoadableSwitch` component consistent with other Settings toggles.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).