### PR TITLE
fix: allow nonce edition in tx-builder flow

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@/tests/test-utils'
 import TxNonce from '../index'
 import { SafeTxContext, type SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
+import { TxFlowContext, initialContext as initialTxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
 
 jest.mock('@/hooks/useSafeInfo')
@@ -36,12 +37,19 @@ const defaultSafeTxContext: SafeTxContextParams = {
   isReadOnly: false,
 }
 
-const renderTxNonce = (contextOverrides: Partial<SafeTxContextParams> = {}, canEdit?: boolean) => {
+const renderTxNonce = (
+  contextOverrides: Partial<SafeTxContextParams> = {},
+  canEdit?: boolean,
+  txFlowOverrides: Partial<typeof initialTxFlowContext> = {},
+) => {
   const contextValue = { ...defaultSafeTxContext, ...contextOverrides }
+  const txFlowValue = { ...initialTxFlowContext, ...txFlowOverrides }
   return render(
-    <SafeTxContext.Provider value={contextValue}>
-      <TxNonce {...(canEdit !== undefined ? { canEdit } : {})} />
-    </SafeTxContext.Provider>,
+    <TxFlowContext.Provider value={txFlowValue}>
+      <SafeTxContext.Provider value={contextValue}>
+        <TxNonce {...(canEdit !== undefined ? { canEdit } : {})} />
+      </SafeTxContext.Provider>
+    </TxFlowContext.Provider>,
   )
 }
 
@@ -135,6 +143,23 @@ describe('TxNonce', () => {
     it('does not show reset button when nonce equals recommended', () => {
       renderTxNonce({ nonce: 5, recommendedNonce: 5 })
       expect(screen.queryByRole('button', { name: /reset to recommended nonce/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('rejection flow', () => {
+    it('shows nonce as read-only when isRejection is true in TxFlowContext', () => {
+      renderTxNonce({ nonce: 5, recommendedNonce: 5 }, undefined, { isRejection: true })
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
+
+    it('allows nonce editing for transactions with empty data when not a rejection flow', () => {
+      const safeTx = {
+        data: { nonce: 5, to: '0x123', value: '0', data: '0x', operation: 0 },
+        signatures: new Map(),
+      } as any
+      renderTxNonce({ nonce: 5, recommendedNonce: 5, safeTx }, undefined, { isRejection: false })
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/__tests__/TxNonce.test.tsx
@@ -161,6 +161,16 @@ describe('TxNonce', () => {
       renderTxNonce({ nonce: 5, recommendedNonce: 5, safeTx }, undefined, { isRejection: false })
       expect(screen.getByRole('combobox')).toBeInTheDocument()
     })
+
+    it('locks nonce when confirming an existing rejection tx (isRejection from ConfirmTxFlow)', () => {
+      const safeTx = {
+        data: { nonce: 5, to: '0x123', value: '0', data: '0x', operation: 0 },
+        signatures: new Map(),
+      } as any
+      renderTxNonce({ nonce: 5, recommendedNonce: 5, safeTx }, undefined, { isRejection: true })
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
   })
 
   describe('canEdit prop', () => {

--- a/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxNonce/index.tsx
@@ -18,6 +18,7 @@ import { createFilterOptions } from '@mui/material/Autocomplete'
 import { Controller, useForm } from 'react-hook-form'
 
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
+import { TxFlowContext } from '@/components/tx-flow/TxFlowProvider'
 import RotateLeftIcon from '@mui/icons-material/RotateLeft'
 import NumberField from '@/components/common/NumberField'
 import { useQueuedTxByNonce } from '@/hooks/useTxQueue'
@@ -26,7 +27,6 @@ import useAddressBook from '@/hooks/useAddressBook'
 import { getLatestTransactions } from '@/utils/tx-list'
 import { getTransactionType } from '@/hooks/useTransactionType'
 import usePreviousNonces from '@/hooks/usePreviousNonces'
-import { isRejectionTx } from '@/utils/transactions'
 
 import css from './styles.module.css'
 import classNames from 'classnames'
@@ -107,13 +107,14 @@ const MAX_NONCE_DIFFERENCE = 100
 
 const TxNonceForm = ({ nonce, recommendedNonce }: { nonce: string; recommendedNonce: string }) => {
   const { safeTx, setNonce } = useContext(SafeTxContext)
+  const { isRejection } = useContext(TxFlowContext)
   const previousNonces = usePreviousNonces().map((nonce) => nonce.toString())
   const { safe } = useSafeInfo()
   const [warning, setWarning] = useState<string>('')
 
   const showRecommendedNonceButton = recommendedNonce !== nonce
   const isEditable = !safeTx || safeTx?.signatures.size === 0
-  const readOnly = !isEditable || isRejectionTx(safeTx)
+  const readOnly = !isEditable || isRejection
 
   const formMethods = useForm({
     defaultValues: {

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
@@ -1,5 +1,5 @@
 import type { Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
-import { isSwapOrderTxInfo } from '@/utils/transaction-guards'
+import { isCancellationTxInfo, isSwapOrderTxInfo } from '@/utils/transaction-guards'
 import ConfirmProposedTx from './ConfirmProposedTx'
 import { useTransactionType } from '@/hooks/useTransactionType'
 import SwapIcon from '@/public/images/common/swap.svg'
@@ -12,6 +12,7 @@ import { TxFlowType } from '@/services/analytics'
 const ConfirmTxFlow = ({ txSummary }: { txSummary: Transaction }) => {
   const { text } = useTransactionType(txSummary)
   const isSwapOrder = isSwapOrderTxInfo(txSummary.txInfo)
+  const isRejection = isCancellationTxInfo(txSummary.txInfo)
   const signer = useSigner()
   const { safe } = useSafeInfo()
 
@@ -27,6 +28,7 @@ const ConfirmTxFlow = ({ txSummary }: { txSummary: Transaction }) => {
       txId={txId}
       isExecutable={canExecute}
       onlyExecute={!canSign}
+      isRejection={isRejection}
       txSummary={txSummary}
       ReviewTransactionComponent={(props) => <ConfirmProposedTx txNonce={txNonce} {...props} />}
       eventCategory={TxFlowType.CONFIRM_TX}

--- a/apps/web/src/utils/transactions.ts
+++ b/apps/web/src/utils/transactions.ts
@@ -38,7 +38,6 @@ import { OperationType } from '@safe-global/types-kit'
 import uniqBy from 'lodash/uniqBy'
 import { Errors, logError } from '@/services/exceptions'
 import { type BaseTransaction } from '@safe-global/safe-apps-sdk'
-import { isEmptyHexData } from '@/utils/hex'
 import { isMultiSendCalldata } from './transaction-calldata'
 import { decodeMultiSendData } from '@safe-global/protocol-kit/dist/src/utils'
 import { getOriginPath } from './url'
@@ -533,10 +532,6 @@ export const decodeSafeTxToBaseTransactions = (safeTx: SafeTransaction): BaseTra
     })
   }
   return txs
-}
-
-export const isRejectionTx = (tx?: SafeTransaction) => {
-  return !!tx && !!tx.data.data && isEmptyHexData(tx.data.data) && tx.data.value === '0'
 }
 
 export const isTrustedTx = (tx: Transaction) => {


### PR DESCRIPTION
## What it solves

Root cause: `TxNonceForm` used `isRejectionTx(safeTx)` to detect rejection transactions by inspecting the transaction data (data === '0x' and value === '0'). This check falsely matched transactions created through the Transaction Builder with Proxy ABI (that happen to have empty calldata) or the custom data with empty `hexData`.

Resolves: [WA-1650](https://linear.app/safe-global/issue/WA-1650/bug-transaction-builder-silently-overrides-manually-set-nonce-on)

## How this PR fixes it

Replaced the `isRejectionTx(safeTx)` data check with `isRejection` from `TxFlowContext`, which is an explicit flag set only by actual rejection flows. This way, only intentional rejection transactions lock the nonce — transactions from the Transaction Builder (or any other source) with empty data remain editable.

Files changed:

* TxNonce/index.tsx — import TxFlowContext, use isRejection from context instead of isRejectionTx(safeTx)
* TxNonce.test.tsx — wrap renders with TxFlowContext.Provider, add two new tests for rejection flow behavior

## How to test it
1. Reject tx stays as it was - no editing of nonce
2. Tx Builder `custom data` tx with `0x` - nonce is editable
3. Tx Builder proxy ABI call with value 0 - nonce is editable

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
