### PR TITLE
chore: sign release tag commit

### DIFF
--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -34,6 +34,18 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_tag_gpgsign: true
+          git_config_global: true
+          git_committer_name: 'github-actions[bot]'
+          git_committer_email: 'github-actions[bot]@users.noreply.github.com'
 
       - name: Verify PR commits are in main
         if: github.event.pull_request.merged != true
@@ -56,7 +68,7 @@ jobs:
 
       - name: Create a git tag
         if: steps.version.outputs.version
-        run: git tag ${{ steps.version.outputs.version }} && git push --tags
+        run: git tag -s ${{ steps.version.outputs.version }} -m "${{ steps.version.outputs.version }}" && git push --tags
 
       - name: Trigger Docker Hub release
         if: steps.version.outputs.version


### PR DESCRIPTION
## What it solves

Automatic release flow creates non-signed commits, blocking further release steps

Resolves: [WA-1924](https://linear.app/safe-global/issue/WA-1924/automatic-release-flow-creates-non-signed-commits-blocking-further)

## How this PR fixes it
1. Added GPG key import step to `web-tag-release.yml` — mirrors the setup from `web-release-start.yml`, with `git_tag_gpgsign: true` to auto-sign tags
2. Changed `git tag` to `git tag -s` — creates a GPG-signed tag with a message, which will pass verification on push

## How to test it
Next time we run auto release we will see if it works :)

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
