### PR TITLE
chore: remove @cowprotocol/* from npmPreapprovedPackages age gate bypass

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -21,7 +21,5 @@ packageExtensions:
 # they are updated within the last 24 hours
 npmMinimalAgeGate: 1440
 # Allow in-house @safe-global packages to bypass the age gate
-# Allow @cowprotocol/* so widget/SDK upgrades are not blocked for 24h after publish
 npmPreapprovedPackages:
   - '@safe-global/*'
-  - '@cowprotocol/*'


### PR DESCRIPTION
> Remove CoW Protocol from the age-gate bypass,
> no more pre-approved `@cowprotocol/*` in yarn config.

## What it solves

Removes `@cowprotocol/*` from the `npmPreapprovedPackages` age-gate bypass in `.yarnrc.yml`. These packages no longer need special treatment — the recent CoW widget upgrade that prompted the original bypass has been completed.

## How this PR fixes it

Removes the `@cowprotocol/*` entry and its associated comment from `npmPreapprovedPackages`. The `@safe-global/*` bypass remains in place as it covers in-house packages.

## How to test it

No functional change — verify `.yarnrc.yml` only contains `@safe-global/*` in `npmPreapprovedPackages`.

## Visual summary

```mermaid
flowchart LR
  A[".yarnrc.yml npmPreapprovedPackages"] --> B["@safe-global/* ✅ (kept)"]
  A -. removed .-> C["@cowprotocol/* ❌ (removed)"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
