### PR TITLE
chore(mobile): remove Rabby + Phantom from AppKit config

### DIFF
--- a/apps/mobile/src/features/WalletConnect/appKit.ts
+++ b/apps/mobile/src/features/WalletConnect/appKit.ts
@@ -84,26 +84,6 @@ export function createAppKitInstance(networks: [Network, ...Network[]], defaultN
       '0b415a746fb9ee99cce155c2ceca0c6f6061b1dbca2d722b3ba16381d0562150', // SafePal
       '15c8b91ade1a4e58f3ce4e7a0dd7f42b47db0c8df7e0d84f63eb39bcb96c4e0f', // Bybit Wallet
     ],
-    customWallets: [
-      {
-        id: 'rabby',
-        name: 'Rabby',
-        homepage: 'https://rabby.io',
-        mobile_link: 'rabby://',
-        image_url: 'https://app.safe.global/images/apps/rabby.png',
-        app_store: 'https://apps.apple.com/us/app/rabby-wallet-crypto-evm/id6474381673',
-        play_store: 'https://play.google.com/store/apps/details?id=com.debank.rabbymobile',
-      },
-      {
-        id: 'phantom',
-        name: 'Phantom',
-        homepage: 'https://phantom.app',
-        mobile_link: 'phantom://',
-        image_url: 'https://app.safe.global/images/apps/phantom.png',
-        app_store: 'https://apps.apple.com/us/app/phantom-trade-markets/id1598432977',
-        play_store: 'https://play.google.com/store/apps/details?id=app.phantom',
-      },
-    ],
     themeVariables: {
       accent: '#12FF80',
     },


### PR DESCRIPTION
## What it solves
Eliminate the custom wallets section from the AppKit instance configuration in appKit.ts. They both don't support the WalletConnect protocol.

## How this PR fixes it

## How to test it
1. Navigate to the signers list page
2. Click **Add signer** -> **Connect wallet app**
3. Verify that neither Rabby not Phantom appear in the list of supported wallets

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
