### PR TITLE
fix: Dont render empty FiatValue component

### DIFF
--- a/apps/web/src/components/common/TokenAmountInput/TokenAmountInput.test.tsx
+++ b/apps/web/src/components/common/TokenAmountInput/TokenAmountInput.test.tsx
@@ -317,19 +317,19 @@ describe('TokenAmountInput', () => {
       expect(fiatDisplay.textContent).toContain('500')
     })
 
-    it('should hide fiat value when amount is empty', () => {
+    it('should not render fiat value when amount is empty', () => {
       render(<FiatTestWrapper defaultTokenAddress={USDC_ADDRESS} defaultAmount="" />)
 
-      expect(screen.getByTestId('fiat-display')).not.toBeVisible()
+      expect(screen.queryByTestId('fiat-display')).not.toBeInTheDocument()
     })
 
-    it('should hide fiat value when amount is "0"', () => {
+    it('should not render fiat value when amount is "0"', () => {
       render(<FiatTestWrapper defaultTokenAddress={USDC_ADDRESS} defaultAmount="0" />)
 
-      expect(screen.getByTestId('fiat-display')).not.toBeVisible()
+      expect(screen.queryByTestId('fiat-display')).not.toBeInTheDocument()
     })
 
-    it('should hide fiat value when token has no fiatConversion', () => {
+    it('should not render fiat value when token has no fiatConversion', () => {
       const balancesNoFiat: Balances['items'] = [
         {
           ...mockBalances[1],
@@ -339,10 +339,10 @@ describe('TokenAmountInput', () => {
 
       render(<FiatTestWrapper defaultTokenAddress={USDC_ADDRESS} defaultAmount="50" balances={balancesNoFiat} />)
 
-      expect(screen.getByTestId('fiat-display')).not.toBeVisible()
+      expect(screen.queryByTestId('fiat-display')).not.toBeInTheDocument()
     })
 
-    it('should hide fiat value when fiatConversion is "0"', () => {
+    it('should not render fiat value when fiatConversion is "0"', () => {
       const balancesZeroFiat: Balances['items'] = [
         {
           ...mockBalances[1],
@@ -352,19 +352,19 @@ describe('TokenAmountInput', () => {
 
       render(<FiatTestWrapper defaultTokenAddress={USDC_ADDRESS} defaultAmount="50" balances={balancesZeroFiat} />)
 
-      expect(screen.getByTestId('fiat-display')).not.toBeVisible()
+      expect(screen.queryByTestId('fiat-display')).not.toBeInTheDocument()
     })
 
-    it('should hide fiat value when selectedToken is undefined', () => {
+    it('should not render fiat value when selectedToken is undefined', () => {
       render(<FiatTestWrapper defaultTokenAddress="0x0000000000000000000000000000000000000001" defaultAmount="50" />)
 
-      expect(screen.getByTestId('fiat-display')).not.toBeVisible()
+      expect(screen.queryByTestId('fiat-display')).not.toBeInTheDocument()
     })
 
-    it('should hide fiat value for negative amounts', () => {
+    it('should not render fiat value for negative amounts', () => {
       render(<FiatTestWrapper defaultTokenAddress={USDC_ADDRESS} defaultAmount="-5" />)
 
-      expect(screen.getByTestId('fiat-display')).not.toBeVisible()
+      expect(screen.queryByTestId('fiat-display')).not.toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/components/common/TokenAmountInput/index.tsx
+++ b/apps/web/src/components/common/TokenAmountInput/index.tsx
@@ -115,7 +115,7 @@ const TokenAmountInput = ({
   }, [resetField, amountField, trigger, deps, defaultValues, fieldArray])
 
   return (
-    <div>
+    <>
       <FormControl
         data-testid="token-amount-section"
         className={classNames(css.outline, { [css.error]: isAmountError })}
@@ -178,18 +178,12 @@ const TokenAmountInput = ({
           </TextField>
         </div>
       </FormControl>
-      <Typography
-        data-testid="fiat-display"
-        variant="caption"
-        color="text.secondary"
-        className={css.fiatDisplay}
-        sx={{
-          visibility: fiatValue != null ? 'visible' : 'hidden',
-        }}
-      >
-        <FiatValue value={fiatValue ?? 0} precise />
-      </Typography>
-    </div>
+      {fiatValue != null && (
+        <Typography data-testid="fiat-display" variant="caption" color="text.secondary" className={css.fiatDisplay}>
+          <FiatValue value={fiatValue} precise />
+        </Typography>
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## What it solves

If FiatValue is not computed or null dont render hidden component, so no gap is shown

Resolves:

## How this PR fixes it

## How to test it

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
