### PR TITLE
fix: topbar styling improvement

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/SafenetStakingButton.tsx
+++ b/apps/web/src/components/common/Header/Topbar/SafenetStakingButton.tsx
@@ -45,25 +45,27 @@ const SafenetStakingButton = () => {
 
   return (
     <Tooltip>
-      <TooltipTrigger
-        render={
-          <Button
-            variant="ghost"
-            size="lg"
-            onClick={handleClick}
-            disabled={navigating}
-            className="cursor-pointer gap-1.5 shrink-0 rounded-lg bg-card hover:bg-muted/30 transition-colors"
-            aria-label="Safenet staking"
-          />
-        }
-      >
-        {navigating ? <Loader2 className="size-5 animate-spin" /> : <SafeTokenIcon width={20} height={20} />}
-        {loading ? (
-          <Skeleton className="h-3 w-6" />
-        ) : (
-          <span className="text-xs text-muted-foreground font-normal">{safeBalance}</span>
-        )}
-      </TooltipTrigger>
+      <div className="flex self-stretch items-stretch rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]">
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleClick}
+              disabled={navigating}
+              className="cursor-pointer gap-1.5 rounded-lg bg-transparent hover:bg-muted/30 transition-colors m-1"
+              aria-label="Safenet staking"
+            />
+          }
+        >
+          {navigating ? <Loader2 className="size-5 animate-spin" /> : <SafeTokenIcon width={20} height={20} />}
+          {loading ? (
+            <Skeleton className="h-3 w-6" />
+          ) : (
+            <span className="text-xs text-muted-foreground font-normal">{safeBalance}</span>
+          )}
+        </TooltipTrigger>
+      </div>
       <TooltipContent>Go to Safenet staking</TooltipContent>
     </Tooltip>
   )

--- a/apps/web/src/components/common/Header/Topbar/index.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.tsx
@@ -69,7 +69,7 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
   return (
     <>
       <header
-        className={`flex flex-wrap items-center px-6 py-4 bg-secondary dark:bg-background ${
+        className={`flex flex-wrap items-start px-6 py-4 bg-secondary dark:bg-background ${
           showMenuButton ? 'justify-between pl-2' : 'justify-between'
         }`}
       >

--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -21,8 +21,9 @@
 
 .mainSpace {
   /* we need it in order to have higher importance than the .main class */
+  /* Must accommodate the absolute-positioned topbar height: py-4 (32px) + SpaceSafeBar BackLink min-h-[60px] + m-1 (8px) = ~100px */
   && {
-    @apply pt-20;
+    @apply pt-[100px];
   }
 }
 

--- a/apps/web/src/components/common/SpaceSafeBar/SpaceNestedSafesButton.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceNestedSafesButton.tsx
@@ -63,7 +63,7 @@ function SpaceNestedSafesButton(): ReactElement | null {
               mixpanelParams={{ [MixpanelEventParams.SAFE_SELECTOR_DROPDOWN]: 'Nested Safes' }}
             >
               <div className="relative flex items-center">
-                <GitMerge className="size-5" />
+                <GitMerge className="size-5 text-muted-foreground" />
                 {displayCount > 0 && (
                   <span className="absolute left-[13px] -top-[5px] flex size-[14px] items-center justify-center rounded-full bg-[rgba(18,255,128,0.1)] text-[10px] font-medium leading-none text-secondary-foreground">
                     {displayCount}

--- a/apps/web/src/features/spaces/components/HeaderNavigation/HeaderNavigation.tsx
+++ b/apps/web/src/features/spaces/components/HeaderNavigation/HeaderNavigation.tsx
@@ -110,23 +110,28 @@ export function HeaderNavigation({
     <div className={cn('flex items-center gap-1')}>
       {/* TODO: Global search button */}
       {showSearch && (
-        <Button
-          variant="ghost"
-          size="icon-lg"
-          onClick={onSearchClick}
-          className="cursor-pointer shrink-0 rounded-lg bg-card hover:bg-muted/30 transition-colors"
-          aria-label="Search"
-        >
-          <Search className="size-5 text-muted-foreground" />
-        </Button>
+        <div className="flex self-stretch items-stretch rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onSearchClick}
+            className="cursor-pointer rounded-lg bg-transparent hover:bg-muted/30 transition-colors m-1"
+            aria-label="Search"
+          >
+            <Search className="size-5 text-muted-foreground" />
+          </Button>
+        </div>
       )}
 
-      <div className="relative" data-testid="notifications-center">
+      <div
+        className="relative flex self-stretch items-stretch rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]"
+        data-testid="notifications-center"
+      >
         <Button
           variant="ghost"
-          size="icon-lg"
+          size="icon-sm"
           onClick={onNotificationsClick}
-          className="cursor-pointer shrink-0 rounded-lg bg-card hover:bg-muted/30 transition-colors"
+          className="cursor-pointer rounded-lg bg-transparent hover:bg-muted/30 transition-colors m-1"
           aria-label="Notifications"
         >
           <Bell className="size-5 text-muted-foreground" />
@@ -134,7 +139,7 @@ export function HeaderNavigation({
 
         {messages > 0 && (
           <span
-            className="absolute z-10 flex items-center justify-center rounded-full bg-[var(--color-secondary-main)] text-white text-[10px] font-bold leading-none min-w-[18px] h-[18px] px-1 -top-[2px] -right-[4px]"
+            className="absolute z-10 flex items-center justify-center rounded-full bg-[rgba(18,255,128,0.1)] text-[10px] font-medium leading-none text-secondary-foreground min-w-[18px] h-[18px] px-1 -top-[2px] -right-[4px]"
             aria-label={`${messages} unread messages`}
           >
             {messages > 99 ? '99+' : messages}
@@ -147,12 +152,15 @@ export function HeaderNavigation({
       {showBatch && (
         <BatchTooltip>
           <Track {...BATCH_EVENTS.BATCH_SIDEBAR_OPEN} label={batchCount}>
-            <div className="relative" data-track="batching: Batch sidebar open">
+            <div
+              className="relative flex self-stretch items-stretch rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]"
+              data-track="batching: Batch sidebar open"
+            >
               <Button
                 variant="ghost"
-                size="icon-lg"
+                size="icon-sm"
                 onClick={onBatchClick}
-                className="cursor-pointer shrink-0 rounded-lg bg-card hover:bg-muted/30 transition-colors"
+                className="cursor-pointer rounded-lg bg-transparent hover:bg-muted/30 transition-colors m-1"
                 aria-label="Batch transactions"
               >
                 <Layers className="size-5 text-muted-foreground" />
@@ -160,7 +168,7 @@ export function HeaderNavigation({
 
               {batchCount > 0 && (
                 <span
-                  className="absolute z-10 flex items-center justify-center rounded-full bg-[var(--color-secondary-main)] text-white text-[10px] font-bold leading-none min-w-[18px] h-[18px] px-1 -top-[2px] -right-[4px]"
+                  className="absolute z-10 flex items-center justify-center rounded-full bg-[rgba(18,255,128,0.1)] text-[10px] font-medium leading-none text-secondary-foreground min-w-[18px] h-[18px] px-1 -top-[2px] -right-[4px]"
                   aria-label={`${batchCount} batched transactions`}
                 >
                   {batchCount > 99 ? '99+' : batchCount}
@@ -172,38 +180,40 @@ export function HeaderNavigation({
       )}
 
       <Track label={OVERVIEW_LABELS.top_bar} {...OVERVIEW_EVENTS.OPEN_ONBOARD}>
-        <Button
-          variant="ghost"
-          size="lg"
-          onClick={onWalletClick}
-          className="cursor-pointer gap-1.5 shrink-0 rounded-lg bg-card hover:bg-muted/30 transition-colors"
-          aria-label={isConnected ? `Wallet ${walletDisplayName}` : 'Connect wallet'}
-          data-testid={isConnected ? 'open-account-center' : 'connect-wallet-btn'}
-        >
-          {isConnected && identiconUrl ? (
-            <div className="relative shrink-0">
-              <img src={identiconUrl} alt="Wallet identicon" className="size-6 rounded-full" />
-              {providerIconSrc && (
-                <img
-                  src={providerIconSrc}
-                  alt={`${walletLabel ?? 'Wallet'} logo`}
-                  className="absolute -bottom-0.5 -right-0.5 size-3.5 rounded-full border-2 border-card bg-background p-px"
-                />
-              )}
-            </div>
-          ) : (
-            <Wallet className="size-5 text-muted-foreground" />
-          )}
-          <span className="text-xs text-muted-foreground font-normal">
-            {isConnected ? walletDisplayName : 'Connect Wallet'}
-          </span>
-          {isConnected &&
-            (walletOpen ? (
-              <ChevronUp className="size-3.5 text-muted-foreground" />
+        <div className="flex self-stretch items-stretch rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onWalletClick}
+            className="cursor-pointer gap-1.5 rounded-lg bg-transparent hover:bg-muted/30 transition-colors m-1"
+            aria-label={isConnected ? `Wallet ${walletDisplayName}` : 'Connect wallet'}
+            data-testid={isConnected ? 'open-account-center' : 'connect-wallet-btn'}
+          >
+            {isConnected && identiconUrl ? (
+              <div className="relative shrink-0">
+                <img src={identiconUrl} alt="Wallet identicon" className="size-6 rounded-full" />
+                {providerIconSrc && (
+                  <img
+                    src={providerIconSrc}
+                    alt={`${walletLabel ?? 'Wallet'} logo`}
+                    className="absolute -bottom-0.5 -right-0.5 size-3.5 rounded-full border-2 border-card bg-background p-px"
+                  />
+                )}
+              </div>
             ) : (
-              <ChevronDown className="size-3.5 text-muted-foreground" />
-            ))}
-        </Button>
+              <Wallet className="size-5 text-muted-foreground" />
+            )}
+            <span className="text-xs text-muted-foreground font-normal">
+              {isConnected ? walletDisplayName : 'Connect Wallet'}
+            </span>
+            {isConnected &&
+              (walletOpen ? (
+                <ChevronUp className="size-3.5 text-muted-foreground" />
+              ) : (
+                <ChevronDown className="size-3.5 text-muted-foreground" />
+              ))}
+          </Button>
+        </div>
       </Track>
     </div>
   )

--- a/apps/web/src/features/walletconnect/components/WcHeaderWidget/WcIcon.tsx
+++ b/apps/web/src/features/walletconnect/components/WcHeaderWidget/WcIcon.tsx
@@ -17,12 +17,12 @@ const WcIcon = ({ sessionCount, sessionIcon, isError, onClick }: WcIconProps): R
 
   return (
     <Track {...WALLETCONNECT_EVENTS.POPUP_OPENED}>
-      <div className="relative">
+      <div className="relative flex self-stretch items-stretch rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]">
         <Button
           variant="ghost"
-          size="icon-lg"
+          size="icon-sm"
           onClick={onClick}
-          className="cursor-pointer shrink-0 rounded-lg bg-card hover:bg-muted/30 transition-colors"
+          className="cursor-pointer rounded-lg bg-transparent hover:bg-muted/30 transition-colors m-1"
           aria-label="WalletConnect"
         >
           <WalletConnectIcon className="size-5 fill-current text-muted-foreground" />
@@ -46,7 +46,7 @@ const WcIcon = ({ sessionCount, sessionIcon, isError, onClick }: WcIconProps): R
 
         {!isError && sessionCount > 1 && (
           <span
-            className="absolute z-10 flex items-center justify-center rounded-full bg-[var(--color-secondary-main)] text-white text-[10px] font-bold leading-none min-w-[18px] h-[18px] px-1 -top-[2px] -right-[4px]"
+            className="absolute z-10 flex items-center justify-center rounded-full bg-[rgba(18,255,128,0.1)] text-[10px] font-medium leading-none text-secondary-foreground min-w-[18px] h-[18px] px-1 -top-[2px] -right-[4px]"
             aria-label={`${sessionCount} WalletConnect sessions`}
           >
             {sessionCount}


### PR DESCRIPTION
## What it solves

The top bar had several visual inconsistencies between `HeaderNavigation` buttons and `SpaceSafeBar` buttons:

1. **Vertical alignment** — Header buttons were vertically centered (`items-center`) instead of top-aligned, making them sit lower than SpaceSafeBar buttons
2. **Content clipping** — The main content area used `pt-20` (80px) which was insufficient for the absolute-positioned topbar's actual height (~100px), causing the bottom of the topbar to be cropped on pages like assets/transactions
3. **Hover style mismatch** — HeaderNavigation/SafenetStaking/WalletConnect buttons were flat single-layer buttons (`bg-card` + `hover:bg-muted/30`), while SpaceSafeBar used a two-layer card structure (outer `bg-card` shell + inner transparent button with `m-1` margin) that reveals a white padding ring on hover
4. **Badge style inconsistency** — Notification and batch count badges used solid green (`bg-[var(--color-secondary-main)]` + `text-white` + `font-bold`), while the nested safes badge used a subtle style (`bg-[rgba(18,255,128,0.1)]` + `text-secondary-foreground` + `font-medium`)
5. **Icon color mismatch** — The nested safes `GitMerge` icon had no color class (inheriting from parent), while all other topbar icons used `text-muted-foreground`

## How this PR fixes it

1. **Topbar alignment**: Changed header from `items-center` to `items-start` so all buttons share the same top edge
2. **Content padding**: Increased `.mainSpace` padding from `pt-20` (80px) to `pt-[100px]` to accommodate the full topbar height
3. **Unified button structure**: Wrapped all HeaderNavigation, SafenetStaking, and WalletConnect buttons in a card container (`bg-card` + `shadow` + `rounded-lg`) with inner `Button` using `bg-transparent` + `m-1` + `hover:bg-muted/30`, matching SpaceSafeBar's pattern. Button sizes adjusted from `icon-lg`/`lg` to `icon-sm`/`sm` to compensate for the added `m-1` margin
4. **Unified badge style**: Changed notification, batch, and WalletConnect session count badges to match nested safes style: `bg-[rgba(18,255,128,0.1)]` + `text-secondary-foreground` + `font-medium`
5. **Unified icon color**: Added `text-muted-foreground` to the nested safes `GitMerge` icon

## How to test it

1. Navigate to a safe account page (e.g., assets or transactions)
2. Verify the topbar is not cropped at the bottom — all content should be fully visible
3. Verify HeaderNavigation buttons (notifications, batch, wallet, search) and SafenetStaking button have a white padding ring visible on hover (matching the SpaceSafeBar back button and chain selector)
4. Verify notification/batch count badges use the subtle semi-transparent green style (not solid green with white text)
5. Verify the nested safes icon color matches other topbar icons (muted gray)
6. Verify all buttons are top-aligned with SpaceSafeBar buttons

## Visual summary
<img width="1512" height="120" alt="Screenshot 2026-04-13 at 12 47 46" src="https://github.com/user-attachments/assets/7f6c23fc-b927-4921-8337-eb5574d0b6bc" />

```mermaid
flowchart TB
  subgraph "Before"
    A1[Header: items-center] --> B1[Buttons vertically centered]
    A1 --> C1[Flat buttons: bg-card + hover:bg-muted/30]
    A1 --> D1[Solid green badges]
    A1 --> E1[pt-20 = content clipped]
  end
  subgraph "After"
    A2[Header: items-start] --> B2[Buttons top-aligned]
    A2 --> C2["Two-layer: card shell + transparent inner button with m-1"]
    A2 --> D2["Subtle badges: bg-rgba 18,255,128,0.1"]
    A2 --> E2["pt-100px = no clipping"]
  end
```

### Files changed

| File | Change |
|------|--------|
| `Topbar/index.tsx` | `items-center` → `items-start` |
| `PageLayout/styles.module.css` | `pt-20` → `pt-[100px]` |
| `HeaderNavigation.tsx` | Two-layer button structure + unified badges |
| `SafenetStakingButton.tsx` | Two-layer button structure |
| `WcIcon.tsx` | Two-layer button structure + unified badge |
| `SpaceNestedSafesButton.tsx` | Added `text-muted-foreground` to icon |

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 -> not affected
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 -> only styling change
