### PR TITLE
feat(web): add dashboard empty states with SetupWidget and improved accounts widget

### DIFF
--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
       >
         <div
           class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-1gdgqta-MuiPaper-root-MuiAccordion-root"
+          data-testid="action-accordion"
           style="--Paper-shadow: none;"
         >
           <h3

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/AccountsWidget.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/AccountsWidget.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react'
-import { Users } from 'lucide-react'
+import { WalletCards } from 'lucide-react'
 import SafeWidget from '@/features/spaces/components/SafeWidget'
 import { AccountWidgetItem } from './AccountWidgetItem'
 import { ExpandableAccountItem } from './ExpandableAccountItem'
@@ -12,6 +12,7 @@ interface AccountsWidgetProps {
   onViewAll?: () => void
   onItemClick?: (safeAddress: string) => void
   action?: ReactNode
+  emptyStateAction?: ReactNode
   error?: string
   onRefresh?: () => void
 }
@@ -25,6 +26,7 @@ const AccountsWidget = ({
   onViewAll,
   onItemClick,
   action,
+  emptyStateAction,
   error,
   onRefresh,
 }: AccountsWidgetProps): ReactElement => {
@@ -42,7 +44,13 @@ const AccountsWidget = ({
   if (isEmpty) {
     return (
       <SafeWidget title="Accounts" action={action} testId="space-dashboard-accounts-widget">
-        <SafeWidget.EmptyState icon={<Users className="size-6" />} text="No accounts yet" />
+        <SafeWidget.EmptyState
+          className="max-w-[229px] mx-auto"
+          icon={<WalletCards className="size-6 text-green-500" />}
+          text="No accounts yet"
+          subtitle="Add your Safe accounts to view balances and manage transactions."
+          action={emptyStateAction}
+        />
       </SafeWidget>
     )
   }

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
@@ -130,7 +130,14 @@ describe('AccountsWidget', () => {
 
     expect(screen.getByText('Accounts')).toBeInTheDocument()
     expect(screen.getByText('No accounts yet')).toBeInTheDocument()
+    expect(screen.getByText('Add your Safe accounts to view balances and manage transactions.')).toBeInTheDocument()
     expect(screen.queryByText('View all accounts')).not.toBeInTheDocument()
+  })
+
+  it('renders the empty state action when provided', () => {
+    render(<AccountsWidget accounts={[]} emptyStateAction={<button>Add account</button>} />)
+
+    expect(screen.getByRole('button', { name: 'Add account' })).toBeInTheDocument()
   })
 
   it('renders the error state with error message', () => {

--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -86,11 +86,19 @@ const _groupAndSort = (
 interface AddAccountsProps {
   buttonVariant?: 'outline' | 'default'
   buttonLabel?: string
+  externalOpen?: boolean
+  onExternalClose?: () => void
 }
 
-const AddAccounts = ({ buttonVariant = 'outline', buttonLabel = 'Add Accounts' }: AddAccountsProps = {}) => {
+const AddAccounts = ({
+  buttonVariant = 'outline',
+  buttonLabel = 'Add Accounts',
+  externalOpen,
+  onExternalClose,
+}: AddAccountsProps = {}) => {
   const isAdmin = useIsAdmin()
   const [open, setOpen] = useState<boolean>(false)
+  const isOpen = externalOpen ?? open
   const [error, setError] = useState<string>()
   const [manualSafes, setManualSafes] = useState<SafeItems>([])
   const hasResetForOpen = useRef(false)
@@ -203,13 +211,13 @@ const AddAccounts = ({ buttonVariant = 'outline', buttonLabel = 'Add Accounts' }
 
   // Reset form when modal opens
   useEffect(() => {
-    if (open && !hasResetForOpen.current) {
+    if (isOpen && !hasResetForOpen.current) {
       reset({ selectedSafes: defaultSelectedSafes })
       hasResetForOpen.current = true
-    } else if (!open) {
+    } else if (!isOpen) {
       hasResetForOpen.current = false
     }
-  }, [open, defaultSelectedSafes, reset])
+  }, [isOpen, defaultSelectedSafes, reset])
 
   const onSubmit = handleSubmit(async (data) => {
     const safesToAdd = getSelectedSafes(data.selectedSafes, spaceSafes).map(([key]) => {
@@ -302,6 +310,7 @@ const AddAccounts = ({ buttonVariant = 'outline', buttonLabel = 'Add Accounts' }
     setManualSafes([])
     setValue('selectedSafes', {}) // Reset doesn't seem to work consistently with an object
     setOpen(false)
+    onExternalClose?.()
   }
 
   useEffect(() => {
@@ -314,23 +323,25 @@ const AddAccounts = ({ buttonVariant = 'outline', buttonLabel = 'Add Accounts' }
 
   return (
     <>
-      <Button
-        size="lg"
-        className="font-bold px-4 py-0"
-        variant={buttonVariant}
-        disabled={!isAdmin}
-        onClick={() => setOpen(true)}
-        title={!isAdmin ? 'You need to be an Admin to add accounts' : ''}
-      >
-        <Plus
-          className={cn('size-4 mr-1', {
-            'text-green-500': buttonVariant === 'default',
-          })}
-        />
-        {buttonLabel}
-      </Button>
+      {externalOpen === undefined && (
+        <Button
+          size="lg"
+          className="font-bold px-4 py-0"
+          variant={buttonVariant}
+          disabled={!isAdmin}
+          onClick={() => setOpen(true)}
+          title={!isAdmin ? 'You need to be an Admin to add accounts' : ''}
+        >
+          <Plus
+            className={cn('size-4 mr-1', {
+              'text-green-500': buttonVariant === 'default',
+            })}
+          />
+          {buttonLabel}
+        </Button>
+      )}
 
-      <ModalDialog open={open} fullScreen hideChainIndicator>
+      <ModalDialog open={isOpen} fullScreen hideChainIndicator>
         <div className={cn('shadcn-scope', isDarkMode && 'dark')}>
           <div className="flex h-dvh max-h-dvh w-full min-w-0 max-w-full flex-col overflow-hidden overflow-x-hidden bg-secondary p-4">
             <div className="mx-auto flex justify-center min-h-0 w-full min-w-0 max-w-full flex-1 flex-col gap-6 sm:max-w-[520px]">

--- a/apps/web/src/features/spaces/components/AddAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/index.tsx
@@ -83,7 +83,12 @@ const _groupAndSort = (
   return [...multi, ...single].sort(sortComparator)
 }
 
-const AddAccounts = () => {
+interface AddAccountsProps {
+  buttonVariant?: 'outline' | 'default'
+  buttonLabel?: string
+}
+
+const AddAccounts = ({ buttonVariant = 'outline', buttonLabel = 'Add Accounts' }: AddAccountsProps = {}) => {
   const isAdmin = useIsAdmin()
   const [open, setOpen] = useState<boolean>(false)
   const [error, setError] = useState<string>()
@@ -310,15 +315,19 @@ const AddAccounts = () => {
   return (
     <>
       <Button
-        size="sm"
-        className="font-bold"
-        variant="outline"
+        size="lg"
+        className="font-bold px-4 py-0"
+        variant={buttonVariant}
         disabled={!isAdmin}
         onClick={() => setOpen(true)}
         title={!isAdmin ? 'You need to be an Admin to add accounts' : ''}
       >
-        <Plus className="size-4" />
-        Add Accounts
+        <Plus
+          className={cn('size-4 mr-1', {
+            'text-green-500': buttonVariant === 'default',
+          })}
+        />
+        {buttonLabel}
       </Button>
 
       <ModalDialog open={open} fullScreen hideChainIndicator>

--- a/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AggregatedBalances.tsx
@@ -16,7 +16,13 @@ import { Button } from '@/components/ui/button'
 import { DashboardHeader } from '@/features/spaces/components/Dashboard/DashboardHeader'
 import QrModal from '@/components/sidebar/QrCodeButton/QrModal'
 
-const AggregatedBalance = ({ safeItems }: { safeItems: SafeItem[] }) => {
+const AggregatedBalance = ({
+  safeItems,
+  accountsLoading = false,
+}: {
+  safeItems: SafeItem[]
+  accountsLoading?: boolean
+}) => {
   const currency = useAppSelector(selectCurrency)
   const router = useRouter()
   const { link: txBuilderLink } = useTxBuilderApp()
@@ -47,6 +53,7 @@ const AggregatedBalance = ({ safeItems }: { safeItems: SafeItem[] }) => {
 
   if (isLoading) return <AggregatedBalanceSkeleton />
 
+  const isDimmed = safeItems.length === 0 || accountsLoading
   const formattedValue = formatCurrencyPrecise(aggregatedBalance, currency)
 
   const handleSend = async () => {
@@ -78,19 +85,21 @@ const AggregatedBalance = ({ safeItems }: { safeItems: SafeItem[] }) => {
 
   return (
     <>
-      <DashboardHeader
-        value={formattedValue}
-        onSend={handleSend}
-        onReceive={handleReceive}
-        onSwap={handleSwap}
-        onBuildTransaction={handleBuildTransaction}
-        otherActions={
-          <Button variant="ghost" size="sm" className="text-muted-foreground">
-            <MoreVertical className="size-4 text-foreground" />
-            Customize
-          </Button>
-        }
-      />
+      <div className={isDimmed ? 'opacity-50' : undefined}>
+        <DashboardHeader
+          value={formattedValue}
+          onSend={handleSend}
+          onReceive={handleReceive}
+          onSwap={handleSwap}
+          onBuildTransaction={handleBuildTransaction}
+          otherActions={
+            <Button variant="ghost" size="sm" className="text-muted-foreground">
+              <MoreVertical className="size-4 text-foreground" />
+              Customize
+            </Button>
+          }
+        />
+      </div>
       {isReceiveModalOpen && <QrModal onClose={handleReceiveClose} />}
     </>
   )

--- a/apps/web/src/features/spaces/components/Dashboard/PendingTxWidget.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/PendingTxWidget.tsx
@@ -62,7 +62,7 @@ const PendingTxWidget = ({
   if (isEmpty) {
     return (
       <SafeWidget title="Pending" testId="space-dashboard-pending-widget">
-        <SafeWidget.EmptyState icon={<Users className="size-6" />} text="No pending transactions" />
+        <SafeWidget.EmptyState icon={<Users className="size-6 text-green-500" />} text="No pending transactions" />
       </SafeWidget>
     )
   }

--- a/apps/web/src/features/spaces/components/Dashboard/__tests__/index.test.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/__tests__/index.test.tsx
@@ -51,6 +51,7 @@ jest.mock('@/features/spaces', () => ({
   useIsInvited: jest.fn(),
   useTrackSpace: jest.fn(),
   useSpacePendingTransactions: jest.fn(),
+  useGetSpaceAddressBook: jest.fn(() => []),
   SpacesFeature: { name: 'spaces' },
 }))
 
@@ -62,6 +63,8 @@ jest.mock('@/features/myAccounts', () => ({
 jest.mock('@/features/__core__', () => ({
   useLoadFeature: jest.fn(),
 }))
+
+jest.mock('@/services/local-storage/useLocalStorage', () => jest.fn(() => [{}, jest.fn()]))
 
 jest.mock('@/hooks/safes', () => ({
   flattenSafeItems: jest.fn((items: unknown[]) => items),
@@ -75,6 +78,7 @@ jest.mock('../AddAccountsCard', () => () => null)
 jest.mock('../AggregatedBalances', () => () => null)
 jest.mock('../../InviteBanner/PreviewInvite', () => () => null)
 jest.mock('@/features/spaces/components/AddAccounts', () => () => null)
+jest.mock('../../SetupWidget', () => () => null)
 jest.mock('@/components/common/Track', () => {
   const Track = ({ children }: { children: React.ReactNode }) => <>{children}</>
   Track.displayName = 'Track'
@@ -123,7 +127,7 @@ const restoreDefaultMocks = () => {
   const useSpaceAccountsDataMock = useSpaceAccountsData as jest.Mock
 
   useCurrentSpaceIdMock.mockReturnValue(MOCK_SPACE_ID)
-  useSpaceSafesMock.mockReturnValue({ allSafes: [{ address: MOCK_SAFE_ADDRESS, chainId: '1' }] })
+  useSpaceSafesMock.mockReturnValue({ allSafes: [{ address: MOCK_SAFE_ADDRESS, chainId: '1' }], isLoading: false })
   useSpaceMembersByStatusMock.mockReturnValue({ activeMembers: [] })
   useIsInvitedMock.mockReturnValue(false)
   useSpacePendingTransactionsMock.mockReturnValue({

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -22,6 +22,7 @@ import AddAccounts from '@/features/spaces/components/AddAccounts'
 import { useRouter } from 'next/router'
 import AggregatedBalance from './AggregatedBalances'
 import SafeWidget from '../SafeWidget'
+import SetupWidget from '../SetupWidget'
 
 const AddActionsAction = () => {
   return (
@@ -45,7 +46,7 @@ const PENDING_TX_DISPLAY_LIMIT = 4
 const SpaceDashboard = () => {
   const { AccountsWidget, $isReady } = useLoadFeature(MyAccountsFeature)
   const { PendingTxWidget } = useLoadFeature(SpacesFeature)
-  const { allSafes: safes } = useSpaceSafes()
+  const { allSafes: safes, isLoading: isSafesLoading } = useSpaceSafes()
   const safeItems = flattenSafeItems(safes)
   const spaceId = useCurrentSpaceId()
   const { activeMembers } = useSpaceMembersByStatus()
@@ -137,15 +138,19 @@ const SpaceDashboard = () => {
             )}
           </Grid>
           <Grid size={{ xs: 12, md: 6 }}>
-            <PendingTxWidget
-              transactions={pendingTxs}
-              loading={isPendingTxLoading}
-              error={pendingTxError ? String(pendingTxError) : undefined}
-              remainingCount={remainingPendingTxCount > 0 ? remainingPendingTxCount : undefined}
-              onViewAll={handleViewAllPendingTxs}
-              onRefresh={refetchPendingTxs}
-              onItemClick={handlePendingTxItemClick}
-            />
+            {safeItems.length === 0 && !isSafesLoading ? (
+              <SetupWidget />
+            ) : (
+              <PendingTxWidget
+                transactions={pendingTxs}
+                loading={isPendingTxLoading}
+                error={pendingTxError ? String(pendingTxError) : undefined}
+                remainingCount={remainingPendingTxCount > 0 ? remainingPendingTxCount : undefined}
+                onViewAll={handleViewAllPendingTxs}
+                onRefresh={refetchPendingTxs}
+                onItemClick={handlePendingTxItemClick}
+              />
+            )}
           </Grid>
         </Grid>
       </>

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import Grid from '@mui/material/Grid2'
 import { flattenSafeItems } from '@/hooks/safes'
 import {
@@ -23,8 +23,8 @@ import { useRouter } from 'next/router'
 import AggregatedBalance from './AggregatedBalances'
 import SafeWidget from '../SafeWidget'
 import SetupWidget from '../SetupWidget'
-import { Skeleton } from '@/components/ui/skeleton'
 import { Card } from '@/components/ui/card'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
 
 const AddActionsAction = () => {
   return (
@@ -60,6 +60,9 @@ const SpaceDashboard = () => {
     error: pendingTxError,
     refetch: refetchPendingTxs,
   } = useSpacePendingTransactions(PENDING_TX_DISPLAY_LIMIT)
+  const [setupDismissed, setSetupDismissed] = useState(false)
+  const [dismissedSpaces = {}] = useLocalStorage<Record<string, number>>('setupWidgetDismissed')
+  const isSetupDismissedForSpace = spaceId ? (dismissedSpaces[spaceId] ?? 0) > Date.now() : false
   useTrackSpace(safes, activeMembers)
   const router = useRouter()
 
@@ -107,6 +110,7 @@ const SpaceDashboard = () => {
   }
 
   const remainingPendingTxCount = Math.max(0, pendingTxCount - PENDING_TX_DISPLAY_LIMIT)
+  const showSetupWidget = safeItems.length === 0 && !isSafesLoading && !setupDismissed && !isSetupDismissedForSpace
 
   return (
     <>
@@ -140,8 +144,8 @@ const SpaceDashboard = () => {
             )}
           </Grid>
           <Grid size={{ xs: 12, md: 6 }}>
-            {safeItems.length === 0 && !isSafesLoading ? (
-              <SetupWidget />
+            {showSetupWidget ? (
+              <SetupWidget onDismiss={() => setSetupDismissed(true)} />
             ) : (
               <PendingTxWidget
                 transactions={pendingTxs}

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -23,7 +23,6 @@ import { useRouter } from 'next/router'
 import AggregatedBalance from './AggregatedBalances'
 import SafeWidget from '../SafeWidget'
 import SetupWidget from '../SetupWidget'
-import { Card } from '@/components/ui/card'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 
 const AddActionsAction = () => {

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -23,6 +23,8 @@ import { useRouter } from 'next/router'
 import AggregatedBalance from './AggregatedBalances'
 import SafeWidget from '../SafeWidget'
 import SetupWidget from '../SetupWidget'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Card } from '@/components/ui/card'
 
 const AddActionsAction = () => {
   return (
@@ -153,6 +155,11 @@ const SpaceDashboard = () => {
             )}
           </Grid>
         </Grid>
+        {safeItems.length > 0 && (
+          <div className="mt-4">
+            <SetupWidget loading={isOverviewLoading} horizontal />
+          </div>
+        )}
       </>
     </>
   )

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -1,8 +1,4 @@
 import { useEffect } from 'react'
-import MembersCard from './MembersCard'
-import SpacesCTACard from './SpacesCTACard'
-import AddressBookCard from './ImportAddressBookCard'
-import { Grid2, Typography } from '@mui/material'
 import Grid from '@mui/material/Grid2'
 import { flattenSafeItems } from '@/hooks/safes'
 import {
@@ -14,7 +10,6 @@ import {
   useSpacePendingTransactions,
   SpacesFeature,
 } from '@/features/spaces'
-import AddAccountsCard from './AddAccountsCard'
 import { AppRoutes } from '@/config/routes'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
@@ -32,6 +27,14 @@ const AddActionsAction = () => {
   return (
     <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
       <AddAccounts />
+    </Track>
+  )
+}
+
+const EmptyStateAddAction = () => {
+  return (
+    <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
+      <AddAccounts buttonVariant="default" buttonLabel="Add account" />
     </Track>
   )
 }
@@ -106,71 +109,46 @@ const SpaceDashboard = () => {
     <>
       {isInvited && <PreviewInvite />}
 
-      {safeItems.length > 0 ? (
-        <>
-          <Grid container>
-            <Grid size={12}>
-              <AggregatedBalance safeItems={safeItems} />
-            </Grid>
+      <>
+        <Grid container>
+          <Grid size={12}>
+            <AggregatedBalance safeItems={safeItems} accountsLoading={isOverviewLoading} />
           </Grid>
+        </Grid>
 
-          <Grid container spacing={3}>
-            <Grid data-testid="dashboard-safe-list" size={{ xs: 12, md: 6 }}>
-              {$isReady ? (
-                <AccountsWidget
-                  accounts={accounts}
-                  loading={isOverviewLoading}
-                  remainingCount={remainingCount > 0 ? remainingCount : undefined}
-                  onViewAll={handleViewAll}
-                  onItemClick={handleItemClick}
-                  action={<AddActionsAction />}
-                  error={error}
-                  onRefresh={refetch}
-                />
-              ) : (
-                <SafeWidget title="Accounts" action={<AddActionsAction />} testId="space-dashboard-accounts-widget">
-                  <div className="animate-pulse rounded-lg bg-muted" />
-                </SafeWidget>
-              )}
-            </Grid>
-            <Grid size={{ xs: 12, md: 6 }}>
-              <PendingTxWidget
-                transactions={pendingTxs}
-                loading={isPendingTxLoading}
-                error={pendingTxError ? String(pendingTxError) : undefined}
-                remainingCount={remainingPendingTxCount > 0 ? remainingPendingTxCount : undefined}
-                onViewAll={handleViewAllPendingTxs}
-                onRefresh={refetchPendingTxs}
-                onItemClick={handlePendingTxItemClick}
+        <Grid container spacing={3}>
+          <Grid data-testid="dashboard-safe-list" size={{ xs: 12, md: 6 }}>
+            {$isReady ? (
+              <AccountsWidget
+                accounts={accounts}
+                loading={isOverviewLoading}
+                remainingCount={remainingCount > 0 ? remainingCount : undefined}
+                onViewAll={handleViewAll}
+                onItemClick={handleItemClick}
+                action={accounts.length > 0 ? <AddActionsAction /> : undefined}
+                emptyStateAction={<EmptyStateAddAction />}
+                error={error}
+                onRefresh={refetch}
               />
-            </Grid>
+            ) : (
+              <SafeWidget title="Accounts" action={<AddActionsAction />} testId="space-dashboard-accounts-widget">
+                <div className="animate-pulse rounded-lg bg-muted" />
+              </SafeWidget>
+            )}
           </Grid>
-        </>
-      ) : (
-        <>
-          <Typography variant="h1" fontWeight={700} mb={4}>
-            Getting started
-          </Typography>
-
-          <Grid container spacing={3}>
-            <Grid size={12}>
-              <AddAccountsCard />
-            </Grid>
-
-            <Grid2 size={{ xs: 12, md: 4 }}>
-              <AddressBookCard />
-            </Grid2>
-
-            <Grid size={{ xs: 12, md: 4 }}>
-              <MembersCard />
-            </Grid>
-
-            <Grid2 size={{ xs: 12, md: 4 }}>
-              <SpacesCTACard />
-            </Grid2>
+          <Grid size={{ xs: 12, md: 6 }}>
+            <PendingTxWidget
+              transactions={pendingTxs}
+              loading={isPendingTxLoading}
+              error={pendingTxError ? String(pendingTxError) : undefined}
+              remainingCount={remainingPendingTxCount > 0 ? remainingPendingTxCount : undefined}
+              onViewAll={handleViewAllPendingTxs}
+              onRefresh={refetchPendingTxs}
+              onItemClick={handlePendingTxItemClick}
+            />
           </Grid>
-        </>
-      )}
+        </Grid>
+      </>
     </>
   )
 }

--- a/apps/web/src/features/spaces/components/SafeWidget/SafeWidget.stories.tsx
+++ b/apps/web/src/features/spaces/components/SafeWidget/SafeWidget.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { ChevronRight, Users } from 'lucide-react'
+import { ChevronRight, Plus, WalletCards } from 'lucide-react'
 import SafeWidget from './index'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -88,7 +88,18 @@ export const Assets: Story = {
 export const EmptyState: Story = {
   render: () => (
     <SafeWidget title="Accounts">
-      <SafeWidget.EmptyState icon={<Users className="size-6" />} text="No accounts yet" />
+      <SafeWidget.EmptyState
+        icon={<WalletCards className="size-6 text-[#22C55E]" />}
+        iconContainerClassName="bg-accent"
+        text="No accounts yet"
+        subtitle="Add your Safe accounts to view balances and manage transactions."
+        action={
+          <Button size="sm">
+            <Plus className="size-4" />
+            Add account
+          </Button>
+        }
+      />
     </SafeWidget>
   ),
 }

--- a/apps/web/src/features/spaces/components/SafeWidget/SafeWidgetRoot.tsx
+++ b/apps/web/src/features/spaces/components/SafeWidget/SafeWidgetRoot.tsx
@@ -26,7 +26,7 @@ const SafeWidgetRoot = ({
       data-testid={testId}
       className={cn('flex h-full min-h-0 flex-col rounded-sm bg-card p-1', className)}
     >
-      <div className="flex shrink-0 items-center px-6 justify-between pb-2 pt-6">
+      <div className="flex shrink-0 items-center px-6 justify-between pb-3 pt-6">
         <div className={cn('flex items-center', onTitleClick && 'cursor-pointer')} onClick={onTitleClick}>
           <Typography variant="h4">{title}</Typography>
         </div>

--- a/apps/web/src/features/spaces/components/SafeWidget/WidgetEmptyState.tsx
+++ b/apps/web/src/features/spaces/components/SafeWidget/WidgetEmptyState.tsx
@@ -1,4 +1,5 @@
-import type { ReactElement, ReactNode } from 'react'
+import { useEffect, useRef, type ReactElement, type ReactNode } from 'react'
+import { motion } from 'motion/react'
 import { Typography } from '@/components/ui/typography'
 import { cn } from '@/utils/cn'
 
@@ -11,6 +12,13 @@ interface WidgetEmptyStateProps {
   className?: string
 }
 
+const STROKE_ANIMATION: KeyframeAnimationOptions = {
+  duration: 800,
+  easing: 'ease-out',
+  delay: 200,
+  fill: 'forwards',
+}
+
 const WidgetEmptyState = ({
   icon,
   text,
@@ -19,20 +27,54 @@ const WidgetEmptyState = ({
   className,
   iconContainerClassName,
 }: WidgetEmptyStateProps): ReactElement => {
+  const iconRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!iconRef.current) return
+    const elements = iconRef.current.querySelectorAll('path, line, polyline, circle, rect')
+    elements.forEach((el) => {
+      const svgEl = el as SVGGeometryElement
+      if (typeof svgEl.getTotalLength !== 'function') return
+      const length = svgEl.getTotalLength()
+      svgEl.style.strokeDasharray = `${length}`
+      svgEl.style.strokeDashoffset = `${length}`
+      svgEl.animate([{ strokeDashoffset: `${length}` }, { strokeDashoffset: '0' }], STROKE_ANIMATION)
+    })
+  }, [])
+
   return (
     <div className={cn('flex flex-1 flex-col items-center gap-4 py-10 justify-center h-fit', className)}>
-      <div className={cn('flex size-14 items-center justify-center rounded-full bg-green-100', iconContainerClassName)}>
+      <motion.div
+        ref={iconRef}
+        className={cn('flex size-14 items-center justify-center rounded-full bg-green-100', iconContainerClassName)}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.4, ease: 'easeOut' }}
+      >
         {icon}
-      </div>
-      <div className="flex flex-col items-center gap-2 text-center">
+      </motion.div>
+      <motion.div
+        className="flex flex-col items-center gap-2 text-center"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.35, ease: 'easeOut', delay: 0.15 }}
+      >
         <Typography variant="paragraph-bold">{text}</Typography>
         {subtitle && (
           <Typography variant="paragraph-small" color="muted">
             {subtitle}
           </Typography>
         )}
-      </div>
-      {action}
+      </motion.div>
+      {action && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.35, ease: 'easeOut', delay: 0.3 }}
+        >
+          {action}
+        </motion.div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/SafeWidget/WidgetEmptyState.tsx
+++ b/apps/web/src/features/spaces/components/SafeWidget/WidgetEmptyState.tsx
@@ -1,20 +1,36 @@
 import type { ReactElement, ReactNode } from 'react'
 import { Typography } from '@/components/ui/typography'
+import { cn } from '@/utils/cn'
 
 interface WidgetEmptyStateProps {
   icon: ReactNode
   text: string
   subtitle?: string
   action?: ReactNode
+  iconContainerClassName?: string
+  className?: string
 }
 
-const WidgetEmptyState = ({ icon, text, subtitle, action }: WidgetEmptyStateProps): ReactElement => {
+const WidgetEmptyState = ({
+  icon,
+  text,
+  subtitle,
+  action,
+  className,
+  iconContainerClassName,
+}: WidgetEmptyStateProps): ReactElement => {
   return (
-    <div className="flex flex-1 flex-col items-center gap-5 p-8 justify-center h-fit">
-      <div className="flex size-10 items-center justify-center rounded-lg bg-muted">{icon}</div>
-      <div className="flex flex-col items-center gap-1 text-center text-muted-foreground">
+    <div className={cn('flex flex-1 flex-col items-center gap-4 py-10 justify-center h-fit', className)}>
+      <div className={cn('flex size-14 items-center justify-center rounded-full bg-green-100', iconContainerClassName)}>
+        {icon}
+      </div>
+      <div className="flex flex-col items-center gap-2 text-center">
         <Typography variant="paragraph-bold">{text}</Typography>
-        {subtitle && <Typography variant="paragraph-small">{subtitle}</Typography>}
+        {subtitle && (
+          <Typography variant="paragraph-small" color="muted">
+            {subtitle}
+          </Typography>
+        )}
       </div>
       {action}
     </div>

--- a/apps/web/src/features/spaces/components/SafeWidget/__tests__/WidgetEmptyState.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeWidget/__tests__/WidgetEmptyState.test.tsx
@@ -34,4 +34,13 @@ describe('WidgetEmptyState', () => {
     expect(screen.getByText('No items found')).toBeInTheDocument()
     expect(screen.queryByText('Please try again.')).not.toBeInTheDocument()
   })
+
+  it('applies custom icon container className', () => {
+    const { container } = render(
+      <WidgetEmptyState icon={<span data-testid="icon" />} text="Empty" iconContainerClassName="bg-accent" />,
+    )
+
+    const iconContainer = container.querySelector('[data-testid="icon"]')?.parentElement
+    expect(iconContainer?.className).toContain('bg-accent')
+  })
 })

--- a/apps/web/src/features/spaces/components/SetupWidget/SetupWidget.stories.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/SetupWidget.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SetupWidget from './index'
+
+const meta: Meta<typeof SetupWidget> = {
+  component: SetupWidget,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ backgroundColor: 'var(--color-background-default, #f4f4f4)', padding: '2rem' }}>
+        <div style={{ maxWidth: '560px' }}>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithDismissHandler: Story = {
+  args: {
+    onDismiss: () => console.log('Dismissed'),
+  },
+}

--- a/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
@@ -1,5 +1,16 @@
-import { render, screen, fireEvent } from '@/tests/test-utils'
+import { render, screen, fireEvent, waitFor } from '@/tests/test-utils'
 import SetupWidget from '../index'
+
+jest.mock('@/features/spaces', () => ({
+  useSpaceSafes: jest.fn(() => ({ allSafes: [] })),
+  useSpaceMembersByStatus: jest.fn(() => ({ activeMembers: [] })),
+  useGetSpaceAddressBook: jest.fn(() => []),
+}))
+
+jest.mock('@/hooks/safes', () => ({
+  flattenSafeItems: jest.fn((items: unknown[]) => items),
+  isMultiChainSafeItem: jest.fn(() => false),
+}))
 
 describe('SetupWidget', () => {
   it('renders the widget title', () => {
@@ -23,13 +34,14 @@ describe('SetupWidget', () => {
     expect(screen.getByText('Dismiss')).toBeInTheDocument()
   })
 
-  it('calls onDismiss when dismiss is clicked', () => {
-    const onDismiss = jest.fn()
-    render(<SetupWidget onDismiss={onDismiss} />)
+  it('hides the widget when dismiss is clicked', async () => {
+    render(<SetupWidget />)
 
     fireEvent.click(screen.getByText('Dismiss'))
 
-    expect(onDismiss).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(screen.queryByText('Set up your Space')).not.toBeInTheDocument()
+    })
   })
 
   it('logs to console when a step is clicked', () => {
@@ -46,5 +58,32 @@ describe('SetupWidget', () => {
     render(<SetupWidget />)
 
     expect(screen.getByTestId('space-dashboard-setup-widget')).toBeInTheDocument()
+  })
+
+  it('sorts incomplete steps before completed ones', () => {
+    const { useSpaceSafes, useSpaceMembersByStatus, useGetSpaceAddressBook } =
+      jest.requireMock<typeof import('@/features/spaces')>('@/features/spaces')
+
+    ;(useGetSpaceAddressBook as jest.Mock).mockReturnValue([{ name: 'Alice', address: '0x1' }])
+    ;(useSpaceSafes as jest.Mock).mockReturnValue({ allSafes: [{ address: '0x2', chainId: '1' }] })
+    ;(useSpaceMembersByStatus as jest.Mock).mockReturnValue({ activeMembers: [] })
+
+    render(<SetupWidget />)
+
+    const allStepLabels = [
+      'Import your address book',
+      'Add your Safe accounts',
+      'Invite team members',
+      'Explore Spaces',
+    ]
+    const steps = screen
+      .getAllByRole('button')
+      .filter((el) => allStepLabels.some((label) => el.textContent?.includes(label)))
+
+    // Completed steps should appear before incomplete ones
+    expect(steps[0]).toHaveTextContent('Import your address book')
+    expect(steps[1]).toHaveTextContent('Add your Safe accounts')
+    expect(steps[2]).toHaveTextContent('Invite team members')
+    expect(steps[3]).toHaveTextContent('Explore Spaces')
   })
 })

--- a/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
@@ -3,7 +3,7 @@ import SetupWidget from '../index'
 
 jest.mock('@/features/spaces', () => ({
   useSpaceSafes: jest.fn(() => ({ allSafes: [] })),
-  useSpaceMembersByStatus: jest.fn(() => ({ activeMembers: [] })),
+  useSpaceMembersByStatus: jest.fn(() => ({ activeMembers: [], invitedMembers: [] })),
   useGetSpaceAddressBook: jest.fn(() => []),
 }))
 
@@ -11,6 +11,17 @@ jest.mock('@/hooks/safes', () => ({
   flattenSafeItems: jest.fn((items: unknown[]) => items),
   isMultiChainSafeItem: jest.fn(() => false),
 }))
+
+jest.mock('../../SpaceAddressBook/Import/ImportAddressBookDialog', () => () => (
+  <div data-testid="import-address-book-dialog" />
+))
+
+jest.mock(
+  '../../AddAccounts',
+  () =>
+    ({ externalOpen }: { externalOpen?: boolean }) =>
+      externalOpen ? <div data-testid="add-accounts-dialog" /> : null,
+)
 
 describe('SetupWidget', () => {
   it('renders the widget title', () => {
@@ -44,14 +55,12 @@ describe('SetupWidget', () => {
     })
   })
 
-  it('logs to console when a step is clicked', () => {
-    const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+  it('opens the import address book dialog when step is clicked', () => {
     render(<SetupWidget />)
 
     fireEvent.click(screen.getByText('Import your address book'))
 
-    expect(consoleSpy).toHaveBeenCalledWith('Setup step clicked:', 'address-book')
-    consoleSpy.mockRestore()
+    expect(screen.getByTestId('import-address-book-dialog')).toBeInTheDocument()
   })
 
   it('renders the test id', () => {
@@ -60,13 +69,13 @@ describe('SetupWidget', () => {
     expect(screen.getByTestId('space-dashboard-setup-widget')).toBeInTheDocument()
   })
 
-  it('sorts incomplete steps before completed ones', () => {
+  it('sorts completed steps before incomplete ones', () => {
     const { useSpaceSafes, useSpaceMembersByStatus, useGetSpaceAddressBook } =
       jest.requireMock<typeof import('@/features/spaces')>('@/features/spaces')
 
     ;(useGetSpaceAddressBook as jest.Mock).mockReturnValue([{ name: 'Alice', address: '0x1' }])
     ;(useSpaceSafes as jest.Mock).mockReturnValue({ allSafes: [{ address: '0x2', chainId: '1' }] })
-    ;(useSpaceMembersByStatus as jest.Mock).mockReturnValue({ activeMembers: [] })
+    ;(useSpaceMembersByStatus as jest.Mock).mockReturnValue({ activeMembers: [], invitedMembers: [] })
 
     render(<SetupWidget />)
 
@@ -85,5 +94,21 @@ describe('SetupWidget', () => {
     expect(steps[1]).toHaveTextContent('Add your Safe accounts')
     expect(steps[2]).toHaveTextContent('Invite team members')
     expect(steps[3]).toHaveTextContent('Explore Spaces')
+  })
+
+  it('disables click on completed steps', () => {
+    const { useSpaceSafes, useGetSpaceAddressBook } =
+      jest.requireMock<typeof import('@/features/spaces')>('@/features/spaces')
+
+    ;(useGetSpaceAddressBook as jest.Mock).mockReturnValue([{ name: 'Alice', address: '0x1' }])
+    ;(useSpaceSafes as jest.Mock).mockReturnValue({ allSafes: [{ address: '0x2', chainId: '1' }] })
+
+    render(<SetupWidget />)
+
+    // Click the completed "Import your address book" step
+    fireEvent.click(screen.getByText('Import your address book'))
+
+    // Dialog should NOT open since the step is completed
+    expect(screen.queryByTestId('import-address-book-dialog')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@/tests/test-utils'
+import type * as SpacesModule from '@/features/spaces'
 import SetupWidget from '../index'
 
 jest.mock('@/features/spaces', () => ({
@@ -18,18 +19,29 @@ jest.mock('@/hooks/safes', () => ({
   isMultiChainSafeItem: jest.fn(() => false),
 }))
 
-jest.mock('../../SpaceAddressBook/Import/ImportAddressBookDialog', () => () => (
-  <div data-testid="import-address-book-dialog" />
-))
+jest.mock(
+  '../../SpaceAddressBook/Import/ImportAddressBookDialog',
+  () =>
+    function MockImportAddressBookDialog() {
+      return <div data-testid="import-address-book-dialog" />
+    },
+)
 
 jest.mock(
   '../../AddAccounts',
   () =>
-    ({ externalOpen }: { externalOpen?: boolean }) =>
-      externalOpen ? <div data-testid="add-accounts-dialog" /> : null,
+    function MockAddAccounts({ externalOpen }: { externalOpen?: boolean }) {
+      return externalOpen ? <div data-testid="add-accounts-dialog" /> : null
+    },
 )
 
-jest.mock('../../SpaceInfoModal', () => () => <div data-testid="space-info-modal" />)
+jest.mock(
+  '../../SpaceInfoModal',
+  () =>
+    function MockSpaceInfoModal() {
+      return <div data-testid="space-info-modal" />
+    },
+)
 
 describe('SetupWidget', () => {
   it('renders the widget title', () => {
@@ -82,7 +94,7 @@ describe('SetupWidget', () => {
 
   it('sorts completed steps before incomplete ones', () => {
     const { useSpaceSafes, useSpaceMembersByStatus, useGetSpaceAddressBook } =
-      jest.requireMock<typeof import('@/features/spaces')>('@/features/spaces')
+      jest.requireMock<typeof SpacesModule>('@/features/spaces')
 
     ;(useGetSpaceAddressBook as jest.Mock).mockReturnValue([{ name: 'Alice', address: '0x1' }])
     ;(useSpaceSafes as jest.Mock).mockReturnValue({ allSafes: [{ address: '0x2', chainId: '1' }] })
@@ -116,8 +128,7 @@ describe('SetupWidget', () => {
   })
 
   it('disables click on completed steps', () => {
-    const { useSpaceSafes, useGetSpaceAddressBook } =
-      jest.requireMock<typeof import('@/features/spaces')>('@/features/spaces')
+    const { useSpaceSafes, useGetSpaceAddressBook } = jest.requireMock<typeof SpacesModule>('@/features/spaces')
 
     ;(useGetSpaceAddressBook as jest.Mock).mockReturnValue([{ name: 'Alice', address: '0x1' }])
     ;(useSpaceSafes as jest.Mock).mockReturnValue({ allSafes: [{ address: '0x2', chainId: '1' }] })

--- a/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@/tests/test-utils'
+import SetupWidget from '../index'
+
+describe('SetupWidget', () => {
+  it('renders the widget title', () => {
+    render(<SetupWidget />)
+
+    expect(screen.getByText('Set up your Space')).toBeInTheDocument()
+  })
+
+  it('renders all four setup steps', () => {
+    render(<SetupWidget />)
+
+    expect(screen.getByText('Import your address book')).toBeInTheDocument()
+    expect(screen.getByText('Add your Safe accounts')).toBeInTheDocument()
+    expect(screen.getByText('Invite team members')).toBeInTheDocument()
+    expect(screen.getByText('Explore Spaces')).toBeInTheDocument()
+  })
+
+  it('renders the dismiss button', () => {
+    render(<SetupWidget />)
+
+    expect(screen.getByText('Dismiss')).toBeInTheDocument()
+  })
+
+  it('calls onDismiss when dismiss is clicked', () => {
+    const onDismiss = jest.fn()
+    render(<SetupWidget onDismiss={onDismiss} />)
+
+    fireEvent.click(screen.getByText('Dismiss'))
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs to console when a step is clicked', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation()
+    render(<SetupWidget />)
+
+    fireEvent.click(screen.getByText('Import your address book'))
+
+    expect(consoleSpy).toHaveBeenCalledWith('Setup step clicked:', 'address-book')
+    consoleSpy.mockRestore()
+  })
+
+  it('renders the test id', () => {
+    render(<SetupWidget />)
+
+    expect(screen.getByTestId('space-dashboard-setup-widget')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
@@ -5,6 +5,12 @@ jest.mock('@/features/spaces', () => ({
   useSpaceSafes: jest.fn(() => ({ allSafes: [] })),
   useSpaceMembersByStatus: jest.fn(() => ({ activeMembers: [], invitedMembers: [] })),
   useGetSpaceAddressBook: jest.fn(() => []),
+  useCurrentSpaceId: jest.fn(() => '1'),
+}))
+
+jest.mock('@/services/local-storage/useLocalStorage', () => ({
+  __esModule: true,
+  default: jest.fn(() => [{}, jest.fn()]),
 }))
 
 jest.mock('@/hooks/safes', () => ({
@@ -22,6 +28,8 @@ jest.mock(
     ({ externalOpen }: { externalOpen?: boolean }) =>
       externalOpen ? <div data-testid="add-accounts-dialog" /> : null,
 )
+
+jest.mock('../../SpaceInfoModal', () => () => <div data-testid="space-info-modal" />)
 
 describe('SetupWidget', () => {
   it('renders the widget title', () => {
@@ -50,9 +58,12 @@ describe('SetupWidget', () => {
 
     fireEvent.click(screen.getByText('Dismiss'))
 
-    await waitFor(() => {
-      expect(screen.queryByText('Set up your Space')).not.toBeInTheDocument()
-    })
+    await waitFor(
+      () => {
+        expect(screen.queryByText('Set up your Space')).not.toBeInTheDocument()
+      },
+      { timeout: 3000 },
+    )
   })
 
   it('opens the import address book dialog when step is clicked', () => {
@@ -94,6 +105,14 @@ describe('SetupWidget', () => {
     expect(steps[1]).toHaveTextContent('Add your Safe accounts')
     expect(steps[2]).toHaveTextContent('Invite team members')
     expect(steps[3]).toHaveTextContent('Explore Spaces')
+  })
+
+  it('opens the Introducing Spaces modal when Explore Spaces is clicked', () => {
+    render(<SetupWidget />)
+
+    fireEvent.click(screen.getByText('Explore Spaces'))
+
+    expect(screen.getByTestId('space-info-modal')).toBeInTheDocument()
   })
 
   it('disables click on completed steps', () => {

--- a/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/__tests__/SetupWidget.test.tsx
@@ -9,9 +9,17 @@ jest.mock('@/features/spaces', () => ({
   useCurrentSpaceId: jest.fn(() => '1'),
 }))
 
+const mockSetDismissedSpaces = jest.fn()
+const mockSetCompletedSpaces = jest.fn()
+
 jest.mock('@/services/local-storage/useLocalStorage', () => ({
   __esModule: true,
-  default: jest.fn(() => [{}, jest.fn()]),
+  default: jest.fn((key: string) => {
+    if (key === 'setupWidgetCompleted') {
+      return [{}, mockSetCompletedSpaces]
+    }
+    return [{}, mockSetDismissedSpaces]
+  }),
 }))
 
 jest.mock('@/hooks/safes', () => ({
@@ -38,12 +46,38 @@ jest.mock(
 jest.mock(
   '../../SpaceInfoModal',
   () =>
-    function MockSpaceInfoModal() {
-      return <div data-testid="space-info-modal" />
+    function MockSpaceInfoModal({ onClose }: { onClose: () => void }) {
+      return (
+        <div data-testid="space-info-modal">
+          <button data-testid="close-space-info-modal" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      )
     },
 )
 
 describe('SetupWidget', () => {
+  beforeEach(() => {
+    mockSetDismissedSpaces.mockClear()
+    mockSetCompletedSpaces.mockClear()
+
+    const useLocalStorage = jest.requireMock<{ default: jest.Mock }>('@/services/local-storage/useLocalStorage')
+    useLocalStorage.default.mockImplementation((key: string) => {
+      if (key === 'setupWidgetCompleted') {
+        return [{}, mockSetCompletedSpaces]
+      }
+      return [{}, mockSetDismissedSpaces]
+    })
+
+    const { useSpaceSafes, useSpaceMembersByStatus, useGetSpaceAddressBook } =
+      jest.requireMock<typeof SpacesModule>('@/features/spaces')
+
+    ;(useGetSpaceAddressBook as jest.Mock).mockReturnValue([])
+    ;(useSpaceSafes as jest.Mock).mockReturnValue({ allSafes: [] })
+    ;(useSpaceMembersByStatus as jest.Mock).mockReturnValue({ activeMembers: [], invitedMembers: [] })
+  })
+
   it('renders the widget title', () => {
     render(<SetupWidget />)
 
@@ -125,6 +159,57 @@ describe('SetupWidget', () => {
     fireEvent.click(screen.getByText('Explore Spaces'))
 
     expect(screen.getByTestId('space-info-modal')).toBeInTheDocument()
+  })
+
+  it('marks the space as completed when Explore Spaces modal is closed and all steps are done', () => {
+    const { useSpaceSafes, useSpaceMembersByStatus, useGetSpaceAddressBook } =
+      jest.requireMock<typeof SpacesModule>('@/features/spaces')
+
+    ;(useGetSpaceAddressBook as jest.Mock).mockReturnValue([{ name: 'Alice', address: '0x1' }])
+    ;(useSpaceSafes as jest.Mock).mockReturnValue({ allSafes: [{ address: '0x2', chainId: '1' }] })
+    ;(useSpaceMembersByStatus as jest.Mock).mockReturnValue({
+      activeMembers: [{ id: '1' }, { id: '2' }],
+      invitedMembers: [],
+    })
+
+    render(<SetupWidget />)
+
+    fireEvent.click(screen.getByText('Explore Spaces'))
+    expect(screen.getByTestId('space-info-modal')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('close-space-info-modal'))
+
+    expect(mockSetCompletedSpaces).toHaveBeenCalledWith(expect.any(Function))
+
+    const updaterFn = mockSetCompletedSpaces.mock.calls[0][0]
+    const result = updaterFn({})
+    expect(result).toEqual({ '1': true })
+  })
+
+  it('does not mark the space as completed when Explore Spaces modal is closed but steps are incomplete', () => {
+    render(<SetupWidget />)
+
+    fireEvent.click(screen.getByText('Explore Spaces'))
+    expect(screen.getByTestId('space-info-modal')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('close-space-info-modal'))
+
+    expect(mockSetCompletedSpaces).not.toHaveBeenCalled()
+  })
+
+  it('does not render when the space setup is completed', () => {
+    const useLocalStorage = jest.requireMock<{ default: jest.Mock }>('@/services/local-storage/useLocalStorage')
+
+    useLocalStorage.default.mockImplementation((key: string) => {
+      if (key === 'setupWidgetCompleted') {
+        return [{ '1': true }, mockSetCompletedSpaces]
+      }
+      return [{}, mockSetDismissedSpaces]
+    })
+
+    render(<SetupWidget />)
+
+    expect(screen.queryByText('Set up your Space')).not.toBeInTheDocument()
   })
 
   it('disables click on completed steps', () => {

--- a/apps/web/src/features/spaces/components/SetupWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/index.tsx
@@ -6,7 +6,10 @@ import SafeWidget from '../SafeWidget'
 import { cn } from '@/utils/cn'
 import { useSpaceSafes, useSpaceMembersByStatus, useGetSpaceAddressBook } from '@/features/spaces'
 import { flattenSafeItems } from '@/hooks/safes'
-import { Skeleton } from '@/components/ui/skeleton'
+import ImportAddressBookDialog from '../SpaceAddressBook/Import/ImportAddressBookDialog'
+import AddAccounts from '../AddAccounts'
+import AddMemberModal from '../AddMemberModal'
+import type { LucideIcon } from 'lucide-react'
 
 interface StepsDependencies {
   addressBookCount: number
@@ -14,7 +17,14 @@ interface StepsDependencies {
   teamMembersCount: number
 }
 
-const SETUP_STEPS = [
+interface SetupStep {
+  key: string
+  label: string
+  icon: LucideIcon
+  activeFn?: (deps: StepsDependencies) => boolean
+}
+
+const SETUP_STEPS: SetupStep[] = [
   {
     key: 'address-book',
     activeFn: ({ addressBookCount }: StepsDependencies) => addressBookCount > 0,
@@ -33,9 +43,8 @@ const SETUP_STEPS = [
     label: 'Invite team members',
     icon: UsersRound,
   },
+  { key: 'explore', label: 'Explore Spaces', icon: Rocket },
 ]
-
-const EXPLORE_STEP = { key: 'explore', label: 'Explore Spaces', icon: Rocket }
 
 interface SetupWidgetProps {
   onDismiss?: () => void
@@ -43,131 +52,121 @@ interface SetupWidgetProps {
   loading?: boolean
 }
 
-const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): ReactElement => {
+const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): ReactElement | null => {
   const [dismissed, setDismissed] = useState(false)
+  const [importOpen, setImportOpen] = useState(false)
+  const [addAccountsOpen, setAddAccountsOpen] = useState(false)
+  const [addMemberOpen, setAddMemberOpen] = useState(false)
   const addressBook = useGetSpaceAddressBook()
   const { allSafes } = useSpaceSafes()
-  const { activeMembers } = useSpaceMembersByStatus()
+  const { activeMembers, invitedMembers } = useSpaceMembersByStatus()
 
   const deps: StepsDependencies = {
     addressBookCount: addressBook.length,
     safeAccountsCount: flattenSafeItems(allSafes).length,
-    teamMembersCount: activeMembers.length,
+    teamMembersCount: activeMembers.length + invitedMembers.length,
   }
 
   const sortedSteps = useMemo(() => {
     return [...SETUP_STEPS].sort((a, b) => {
-      return Number(b.activeFn(deps)) - Number(a.activeFn(deps))
+      const aActive = a.activeFn ? a.activeFn(deps) : false
+      const bActive = b.activeFn ? b.activeFn(deps) : false
+      return Number(bActive) - Number(aActive)
     })
   }, [deps.addressBookCount, deps.safeAccountsCount, deps.teamMembersCount])
 
   const handleStepClick = (stepKey: string) => {
-    console.log('Setup step clicked:', stepKey)
+    if (stepKey === 'address-book') {
+      setImportOpen(true)
+    } else if (stepKey === 'safe-accounts') {
+      setAddAccountsOpen(true)
+    } else if (stepKey === 'team-members') {
+      setAddMemberOpen(true)
+    }
   }
 
   const handleDismiss = () => {
     setDismissed(true)
   }
 
-  return (
-    <AnimatePresence onExitComplete={onDismiss}>
-      {!dismissed && (
-        <motion.div initial={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.3, ease: 'easeInOut' }}>
-          <SafeWidget
-            title="Set up your Space"
-            testId="space-dashboard-setup-widget"
-            action={
-              <Typography
-                variant="paragraph-small"
-                color="muted"
-                className="cursor-pointer"
-                onClick={handleDismiss}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => e.key === 'Enter' && handleDismiss()}
-              >
-                Dismiss
-              </Typography>
-            }
-          >
-            <div
-              className={cn('flex flex-col gap-2 px-2 pb-2', {
-                'flex-row': horizontal,
-              })}
-            >
-              <AnimatePresence mode="wait">
-                {loading
-                  ? Array.from({ length: SETUP_STEPS.length }).map((_, index) => (
-                      <Skeleton key={index} className={cn('h-16 w-full rounded-3xl', { 'flex-1': horizontal })} />
-                    ))
-                  : sortedSteps.map(({ key, label, icon: Icon, activeFn }, index) => {
-                      const isCompleted = activeFn(deps)
+  if (loading) return null
 
-                      return (
-                        <motion.div
-                          key={key}
-                          role="button"
-                          tabIndex={0}
-                          initial={{ opacity: 0, y: 10 }}
-                          animate={{ opacity: isCompleted ? 0.6 : 1, y: 0 }}
-                          transition={{ duration: 0.3, ease: 'easeOut', delay: index * 0.08 }}
-                          onClick={() => handleStepClick(key)}
-                          onKeyDown={(e) => e.key === 'Enter' && handleStepClick(key)}
-                          className={cn(
-                            'flex cursor-pointer items-center gap-4 rounded-3xl p-4 transition-colors',
-                            isCompleted ? 'bg-muted/50' : 'bg-muted hover:bg-muted/70',
-                            { 'flex-1': horizontal },
-                          )}
-                        >
-                          <div
-                            className={cn(
-                              'flex size-9 shrink-0 items-center justify-center rounded-full',
-                              isCompleted ? 'bg-green-200' : 'bg-green-100',
-                            )}
-                          >
-                            {isCompleted ? (
-                              <Check className="size-5 text-green-600" />
-                            ) : (
-                              <Icon className="size-5 text-green-500" />
-                            )}
-                          </div>
-                          <Typography
-                            variant="paragraph-bold"
-                            className={cn('flex-1', { 'line-through': isCompleted })}
-                          >
-                            {label}
-                          </Typography>
-                          {!isCompleted && <ChevronRight className="size-5 text-muted-foreground" />}
-                        </motion.div>
-                      )
-                    })}
-              </AnimatePresence>
-              <motion.div
-                role="button"
-                tabIndex={0}
-                onClick={() => handleStepClick(EXPLORE_STEP.key)}
-                onKeyDown={(e) => e.key === 'Enter' && handleStepClick(EXPLORE_STEP.key)}
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.3, ease: 'easeOut' }}
-                className={cn(
-                  'flex cursor-pointer items-center gap-4 rounded-3xl bg-muted p-4 transition-colors hover:bg-muted/70',
-                  { 'flex-1': horizontal },
-                )}
-              >
-                <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-green-100">
-                  <EXPLORE_STEP.icon className="size-5 text-green-500" />
-                </div>
-                <Typography variant="paragraph-bold" className="flex-1">
-                  {EXPLORE_STEP.label}
+  return (
+    <>
+      <AnimatePresence onExitComplete={onDismiss}>
+        {!dismissed && (
+          <motion.div initial={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.3, ease: 'easeInOut' }}>
+            <SafeWidget
+              title="Set up your Space"
+              testId="space-dashboard-setup-widget"
+              action={
+                <Typography
+                  variant="paragraph-small"
+                  color="muted"
+                  className="cursor-pointer"
+                  onClick={handleDismiss}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => e.key === 'Enter' && handleDismiss()}
+                >
+                  Dismiss
                 </Typography>
-                <ChevronRight className="size-5 text-muted-foreground" />
-              </motion.div>
-            </div>
-          </SafeWidget>
-        </motion.div>
-      )}
-    </AnimatePresence>
+              }
+            >
+              <div
+                className={cn('flex flex-col gap-2 px-2 pb-2', {
+                  'flex-row': horizontal,
+                })}
+              >
+                {sortedSteps.map(({ key, label, icon: Icon, activeFn }, index) => {
+                  const isCompleted = activeFn ? activeFn(deps) : false
+
+                  return (
+                    <motion.div
+                      key={key}
+                      role="button"
+                      tabIndex={isCompleted ? undefined : 0}
+                      aria-disabled={isCompleted}
+                      initial={{ opacity: 0, y: 10 }}
+                      animate={{ opacity: isCompleted ? 0.6 : 1, y: 0 }}
+                      transition={{ duration: 0.3, ease: 'easeOut', delay: index * 0.08 }}
+                      onClick={() => !isCompleted && handleStepClick(key)}
+                      onKeyDown={(e) => e.key === 'Enter' && !isCompleted && handleStepClick(key)}
+                      className={cn(
+                        'flex items-center gap-4 rounded-3xl p-4 transition-colors',
+                        isCompleted ? 'cursor-not-allowed bg-muted/50' : 'cursor-pointer bg-muted hover:bg-muted/70',
+                        { 'flex-1': horizontal },
+                      )}
+                    >
+                      <div
+                        className={cn(
+                          'flex size-9 shrink-0 items-center justify-center rounded-full',
+                          isCompleted ? 'bg-green-200' : 'bg-green-100',
+                        )}
+                      >
+                        {isCompleted ? (
+                          <Check className="size-5 text-green-600" />
+                        ) : (
+                          <Icon className="size-5 text-green-500" />
+                        )}
+                      </div>
+                      <Typography variant="paragraph-bold" className={cn('flex-1', { 'line-through': isCompleted })}>
+                        {label}
+                      </Typography>
+                      {!isCompleted && <ChevronRight className="size-5 text-muted-foreground" />}
+                    </motion.div>
+                  )
+                })}
+              </div>
+            </SafeWidget>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {importOpen && <ImportAddressBookDialog handleClose={() => setImportOpen(false)} />}
+      <AddAccounts externalOpen={addAccountsOpen} onExternalClose={() => setAddAccountsOpen(false)} />
+      {addMemberOpen && <AddMemberModal onClose={() => setAddMemberOpen(false)} />}
+    </>
   )
 }
 

--- a/apps/web/src/features/spaces/components/SetupWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/index.tsx
@@ -1,14 +1,17 @@
-import { useMemo, useState, type ReactElement } from 'react'
+import { useEffect, useMemo, useState, type ReactElement } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { BookUser, Check, ChevronRight, Rocket, UsersRound, WalletCards } from 'lucide-react'
 import { Typography } from '@/components/ui/typography'
 import SafeWidget from '../SafeWidget'
 import { cn } from '@/utils/cn'
-import { useSpaceSafes, useSpaceMembersByStatus, useGetSpaceAddressBook } from '@/features/spaces'
+import { useSpaceSafes, useSpaceMembersByStatus, useGetSpaceAddressBook, useCurrentSpaceId } from '@/features/spaces'
 import { flattenSafeItems } from '@/hooks/safes'
+import { addDays } from 'date-fns'
+import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import ImportAddressBookDialog from '../SpaceAddressBook/Import/ImportAddressBookDialog'
 import AddAccounts from '../AddAccounts'
 import AddMemberModal from '../AddMemberModal'
+import SpaceInfoModal from '../SpaceInfoModal'
 import type { LucideIcon } from 'lucide-react'
 
 interface StepsDependencies {
@@ -46,6 +49,9 @@ const SETUP_STEPS: SetupStep[] = [
   { key: 'explore', label: 'Explore Spaces', icon: Rocket },
 ]
 
+const DISMISS_STORAGE_KEY = 'setupWidgetDismissed'
+const DISMISS_DAYS = 3
+
 interface SetupWidgetProps {
   onDismiss?: () => void
   horizontal?: boolean
@@ -57,9 +63,26 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
   const [importOpen, setImportOpen] = useState(false)
   const [addAccountsOpen, setAddAccountsOpen] = useState(false)
   const [addMemberOpen, setAddMemberOpen] = useState(false)
+  const [exploreOpen, setExploreOpen] = useState(false)
+  const [dismissedSpaces = {}, setDismissedSpaces] = useLocalStorage<Record<string, number>>(DISMISS_STORAGE_KEY)
+  const spaceId = useCurrentSpaceId()
   const addressBook = useGetSpaceAddressBook()
   const { allSafes } = useSpaceSafes()
   const { activeMembers, invitedMembers } = useSpaceMembersByStatus()
+
+  // Clean up expired dismissals on mount
+  useEffect(() => {
+    const now = Date.now()
+    const expired = Object.entries(dismissedSpaces).filter(([, expiry]) => expiry <= now)
+
+    if (expired.length > 0) {
+      setDismissedSpaces((prev = {}) => {
+        const updated = { ...prev }
+        expired.forEach(([key]) => delete updated[key])
+        return updated
+      })
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const deps: StepsDependencies = {
     addressBookCount: addressBook.length,
@@ -82,6 +105,8 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
       setAddAccountsOpen(true)
     } else if (stepKey === 'team-members') {
       setAddMemberOpen(true)
+    } else if (stepKey === 'explore') {
+      setExploreOpen(true)
     }
   }
 
@@ -89,11 +114,23 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
     setDismissed(true)
   }
 
-  if (loading) return null
+  const persistDismiss = () => {
+    if (spaceId) {
+      setDismissedSpaces((prev = {}) => ({
+        ...prev,
+        [spaceId]: addDays(new Date(), DISMISS_DAYS).getTime(),
+      }))
+    }
+    onDismiss?.()
+  }
+
+  const isDismissedForSpace = spaceId ? (dismissedSpaces[spaceId] ?? 0) > Date.now() : false
+
+  if (loading || isDismissedForSpace) return null
 
   return (
     <>
-      <AnimatePresence onExitComplete={onDismiss}>
+      <AnimatePresence onExitComplete={persistDismiss}>
         {!dismissed && (
           <motion.div initial={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.3, ease: 'easeInOut' }}>
             <SafeWidget
@@ -166,6 +203,7 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
       {importOpen && <ImportAddressBookDialog handleClose={() => setImportOpen(false)} />}
       <AddAccounts externalOpen={addAccountsOpen} onExternalClose={() => setAddAccountsOpen(false)} />
       {addMemberOpen && <AddMemberModal onClose={() => setAddMemberOpen(false)} />}
+      {exploreOpen && <SpaceInfoModal onClose={() => setExploreOpen(false)} />}
     </>
   )
 }

--- a/apps/web/src/features/spaces/components/SetupWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/index.tsx
@@ -1,68 +1,173 @@
-import type { ReactElement } from 'react'
-import { BookUser, ChevronRight, Rocket, UsersRound, WalletCards } from 'lucide-react'
+import { useMemo, useState, type ReactElement } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import { BookUser, Check, ChevronRight, Rocket, UsersRound, WalletCards } from 'lucide-react'
 import { Typography } from '@/components/ui/typography'
 import SafeWidget from '../SafeWidget'
+import { cn } from '@/utils/cn'
+import { useSpaceSafes, useSpaceMembersByStatus, useGetSpaceAddressBook } from '@/features/spaces'
+import { flattenSafeItems } from '@/hooks/safes'
+import { Skeleton } from '@/components/ui/skeleton'
+
+interface StepsDependencies {
+  addressBookCount: number
+  safeAccountsCount: number
+  teamMembersCount: number
+}
 
 const SETUP_STEPS = [
-  { key: 'address-book', label: 'Import your address book', icon: BookUser },
-  { key: 'safe-accounts', label: 'Add your Safe accounts', icon: WalletCards },
-  { key: 'team-members', label: 'Invite team members', icon: UsersRound },
-  { key: 'explore', label: 'Explore Spaces', icon: Rocket },
-] as const
+  {
+    key: 'address-book',
+    activeFn: ({ addressBookCount }: StepsDependencies) => addressBookCount > 0,
+    label: 'Import your address book',
+    icon: BookUser,
+  },
+  {
+    key: 'safe-accounts',
+    activeFn: ({ safeAccountsCount }: StepsDependencies) => safeAccountsCount > 0,
+    label: 'Add your Safe accounts',
+    icon: WalletCards,
+  },
+  {
+    key: 'team-members',
+    activeFn: ({ teamMembersCount }: StepsDependencies) => teamMembersCount > 1,
+    label: 'Invite team members',
+    icon: UsersRound,
+  },
+]
+
+const EXPLORE_STEP = { key: 'explore', label: 'Explore Spaces', icon: Rocket }
 
 interface SetupWidgetProps {
   onDismiss?: () => void
+  horizontal?: boolean
+  loading?: boolean
 }
 
-const SetupWidget = ({ onDismiss }: SetupWidgetProps): ReactElement => {
+const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): ReactElement => {
+  const [dismissed, setDismissed] = useState(false)
+  const addressBook = useGetSpaceAddressBook()
+  const { allSafes } = useSpaceSafes()
+  const { activeMembers } = useSpaceMembersByStatus()
+
+  const deps: StepsDependencies = {
+    addressBookCount: addressBook.length,
+    safeAccountsCount: flattenSafeItems(allSafes).length,
+    teamMembersCount: activeMembers.length,
+  }
+
+  const sortedSteps = useMemo(() => {
+    return [...SETUP_STEPS].sort((a, b) => {
+      return Number(b.activeFn(deps)) - Number(a.activeFn(deps))
+    })
+  }, [deps.addressBookCount, deps.safeAccountsCount, deps.teamMembersCount])
+
   const handleStepClick = (stepKey: string) => {
     console.log('Setup step clicked:', stepKey)
   }
 
   const handleDismiss = () => {
-    console.log('Setup widget dismissed')
-    onDismiss?.()
+    setDismissed(true)
   }
 
   return (
-    <SafeWidget
-      title="Set up your Space"
-      testId="space-dashboard-setup-widget"
-      action={
-        <Typography
-          variant="paragraph-small"
-          color="muted"
-          className="cursor-pointer"
-          onClick={handleDismiss}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => e.key === 'Enter' && handleDismiss()}
-        >
-          Dismiss
-        </Typography>
-      }
-    >
-      <div className="flex flex-col gap-2 px-2 pb-2">
-        {SETUP_STEPS.map(({ key, label, icon: Icon }) => (
-          <div
-            key={key}
-            role="button"
-            tabIndex={0}
-            onClick={() => handleStepClick(key)}
-            onKeyDown={(e) => e.key === 'Enter' && handleStepClick(key)}
-            className="flex cursor-pointer items-center gap-4 rounded-3xl bg-muted p-4 transition-colors hover:bg-muted/70"
+    <AnimatePresence onExitComplete={onDismiss}>
+      {!dismissed && (
+        <motion.div initial={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.3, ease: 'easeInOut' }}>
+          <SafeWidget
+            title="Set up your Space"
+            testId="space-dashboard-setup-widget"
+            action={
+              <Typography
+                variant="paragraph-small"
+                color="muted"
+                className="cursor-pointer"
+                onClick={handleDismiss}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => e.key === 'Enter' && handleDismiss()}
+              >
+                Dismiss
+              </Typography>
+            }
           >
-            <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-green-100">
-              <Icon className="size-5 text-green-500" />
+            <div
+              className={cn('flex flex-col gap-2 px-2 pb-2', {
+                'flex-row': horizontal,
+              })}
+            >
+              <AnimatePresence mode="wait">
+                {loading
+                  ? Array.from({ length: SETUP_STEPS.length }).map((_, index) => (
+                      <Skeleton key={index} className={cn('h-16 w-full rounded-3xl', { 'flex-1': horizontal })} />
+                    ))
+                  : sortedSteps.map(({ key, label, icon: Icon, activeFn }, index) => {
+                      const isCompleted = activeFn(deps)
+
+                      return (
+                        <motion.div
+                          key={key}
+                          role="button"
+                          tabIndex={0}
+                          initial={{ opacity: 0, y: 10 }}
+                          animate={{ opacity: isCompleted ? 0.6 : 1, y: 0 }}
+                          transition={{ duration: 0.3, ease: 'easeOut', delay: index * 0.08 }}
+                          onClick={() => handleStepClick(key)}
+                          onKeyDown={(e) => e.key === 'Enter' && handleStepClick(key)}
+                          className={cn(
+                            'flex cursor-pointer items-center gap-4 rounded-3xl p-4 transition-colors',
+                            isCompleted ? 'bg-muted/50' : 'bg-muted hover:bg-muted/70',
+                            { 'flex-1': horizontal },
+                          )}
+                        >
+                          <div
+                            className={cn(
+                              'flex size-9 shrink-0 items-center justify-center rounded-full',
+                              isCompleted ? 'bg-green-200' : 'bg-green-100',
+                            )}
+                          >
+                            {isCompleted ? (
+                              <Check className="size-5 text-green-600" />
+                            ) : (
+                              <Icon className="size-5 text-green-500" />
+                            )}
+                          </div>
+                          <Typography
+                            variant="paragraph-bold"
+                            className={cn('flex-1', { 'line-through': isCompleted })}
+                          >
+                            {label}
+                          </Typography>
+                          {!isCompleted && <ChevronRight className="size-5 text-muted-foreground" />}
+                        </motion.div>
+                      )
+                    })}
+              </AnimatePresence>
+              <motion.div
+                role="button"
+                tabIndex={0}
+                onClick={() => handleStepClick(EXPLORE_STEP.key)}
+                onKeyDown={(e) => e.key === 'Enter' && handleStepClick(EXPLORE_STEP.key)}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3, ease: 'easeOut' }}
+                className={cn(
+                  'flex cursor-pointer items-center gap-4 rounded-3xl bg-muted p-4 transition-colors hover:bg-muted/70',
+                  { 'flex-1': horizontal },
+                )}
+              >
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-green-100">
+                  <EXPLORE_STEP.icon className="size-5 text-green-500" />
+                </div>
+                <Typography variant="paragraph-bold" className="flex-1">
+                  {EXPLORE_STEP.label}
+                </Typography>
+                <ChevronRight className="size-5 text-muted-foreground" />
+              </motion.div>
             </div>
-            <Typography variant="paragraph-bold" className="flex-1">
-              {label}
-            </Typography>
-            <ChevronRight className="size-5 text-muted-foreground" />
-          </div>
-        ))}
-      </div>
-    </SafeWidget>
+          </SafeWidget>
+        </motion.div>
+      )}
+    </AnimatePresence>
   )
 }
 

--- a/apps/web/src/features/spaces/components/SetupWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/index.tsx
@@ -50,6 +50,7 @@ const SETUP_STEPS: SetupStep[] = [
 ]
 
 const DISMISS_STORAGE_KEY = 'setupWidgetDismissed'
+const COMPLETED_STORAGE_KEY = 'setupWidgetCompleted'
 const DISMISS_DAYS = 3
 
 interface SetupWidgetProps {
@@ -65,6 +66,7 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
   const [addMemberOpen, setAddMemberOpen] = useState(false)
   const [exploreOpen, setExploreOpen] = useState(false)
   const [dismissedSpaces = {}, setDismissedSpaces] = useLocalStorage<Record<string, number>>(DISMISS_STORAGE_KEY)
+  const [completedSpaces = {}, setCompletedSpaces] = useLocalStorage<Record<string, boolean>>(COMPLETED_STORAGE_KEY)
   const spaceId = useCurrentSpaceId()
   const addressBook = useGetSpaceAddressBook()
   const { allSafes } = useSpaceSafes()
@@ -110,6 +112,19 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
     }
   }
 
+  const allRequiredStepsCompleted = SETUP_STEPS.every((step) => !step.activeFn || step.activeFn(deps))
+
+  const handleExploreClose = () => {
+    setExploreOpen(false)
+
+    if (spaceId && allRequiredStepsCompleted) {
+      setCompletedSpaces((prev = {}) => ({
+        ...prev,
+        [spaceId]: true,
+      }))
+    }
+  }
+
   const handleDismiss = () => {
     setDismissed(true)
   }
@@ -125,8 +140,9 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
   }
 
   const isDismissedForSpace = spaceId ? (dismissedSpaces[spaceId] ?? 0) > Date.now() : false
+  const isCompletedForSpace = spaceId ? completedSpaces[spaceId] === true : false
 
-  if (loading || isDismissedForSpace) return null
+  if (loading || isDismissedForSpace || isCompletedForSpace) return null
 
   return (
     <>
@@ -203,7 +219,7 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
       {importOpen && <ImportAddressBookDialog handleClose={() => setImportOpen(false)} />}
       <AddAccounts externalOpen={addAccountsOpen} onExternalClose={() => setAddAccountsOpen(false)} />
       {addMemberOpen && <AddMemberModal onClose={() => setAddMemberOpen(false)} />}
-      {exploreOpen && <SpaceInfoModal onClose={() => setExploreOpen(false)} />}
+      {exploreOpen && <SpaceInfoModal onClose={handleExploreClose} />}
     </>
   )
 }

--- a/apps/web/src/features/spaces/components/SetupWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/index.tsx
@@ -1,0 +1,71 @@
+import type { ReactElement } from 'react'
+import { BookUser, ChevronRight, Rocket, UsersRound, WalletCards } from 'lucide-react'
+import { Typography } from '@/components/ui/typography'
+import SafeWidget from '../SafeWidget'
+
+const SETUP_STEPS = [
+  { key: 'address-book', label: 'Import your address book', icon: BookUser },
+  { key: 'safe-accounts', label: 'Add your Safe accounts', icon: WalletCards },
+  { key: 'team-members', label: 'Invite team members', icon: UsersRound },
+  { key: 'explore', label: 'Explore Spaces', icon: Rocket },
+] as const
+
+interface SetupWidgetProps {
+  onDismiss?: () => void
+}
+
+const SetupWidget = ({ onDismiss }: SetupWidgetProps): ReactElement => {
+  const handleStepClick = (stepKey: string) => {
+    console.log('Setup step clicked:', stepKey)
+  }
+
+  const handleDismiss = () => {
+    console.log('Setup widget dismissed')
+    onDismiss?.()
+  }
+
+  return (
+    <SafeWidget
+      title="Set up your Space"
+      testId="space-dashboard-setup-widget"
+      action={
+        <Typography
+          variant="paragraph-small"
+          color="muted"
+          className="cursor-pointer"
+          onClick={handleDismiss}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => e.key === 'Enter' && handleDismiss()}
+        >
+          Dismiss
+        </Typography>
+      }
+    >
+      <div className="flex flex-col gap-2 px-2 pb-2">
+        {SETUP_STEPS.map(({ key, label, icon: Icon }) => (
+          <div
+            key={key}
+            role="button"
+            tabIndex={0}
+            onClick={() => handleStepClick(key)}
+            onKeyDown={(e) => e.key === 'Enter' && handleStepClick(key)}
+            className="flex cursor-pointer items-center gap-4 rounded-3xl bg-muted p-4 transition-colors hover:bg-muted/70"
+          >
+            <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-green-100">
+              <Icon className="size-5 text-green-500" />
+            </div>
+            <Typography variant="paragraph-bold" className="flex-1">
+              {label}
+            </Typography>
+            <ChevronRight className="size-5 text-muted-foreground" />
+          </div>
+        ))}
+      </div>
+    </SafeWidget>
+  )
+}
+
+export { SetupWidget }
+export type { SetupWidgetProps }
+export default SetupWidget


### PR DESCRIPTION
> Empty states get their due,
> setup widget guides new spaces through,
> dismiss reveals pending queue.

## What it solves

The Spaces dashboard lacked proper empty states for when a space has no Safe accounts, no address book entries, or no team members. The accounts widget empty state also needed visual refinement to match the updated Figma design.

## How this PR fixes it

- **SetupWidget**: New guided setup checklist component that walks users through space onboarding steps (import address book, add accounts, invite members, explore spaces). Supports dismiss with 3-day localStorage persistence per space, step completion tracking, sorted display, and entry/exit animations.
- **Accounts widget empty state**: Updated to use the `WalletCards` icon, added subtitle text, and an action button for adding accounts directly from the empty state.
- **Dashboard integration**: Shows SetupWidget when a space has no accounts. When dismissed (in-session or from localStorage), falls back to the PendingTxWidget. Also shows a horizontal SetupWidget below the main grid when accounts exist.
- **Explore Spaces step**: Opens the "Introducing Spaces" modal (`SpaceInfoModal`) when clicked.
- **AddAccounts**: Enhanced with external open/close state handling for use as a controlled component from parent widgets.

## How to test it

1. Navigate to a space with no Safe accounts — the SetupWidget should appear in the right column
2. Click each step to verify the correct dialog/modal opens:
   - "Import your address book" → Import dialog
   - "Add your Safe accounts" → Add accounts dialog
   - "Invite team members" → Add member modal
   - "Explore Spaces" → Introducing Spaces modal
3. Complete steps and verify they show as checked and sort to the top
4. Click "Dismiss" — the SetupWidget should animate out and the PendingTxWidget should appear
5. Refresh the page — the widget should remain dismissed (for 3 days)
6. Add a Safe account — verify the horizontal SetupWidget appears below the grid

## Visual summary

```mermaid
flowchart TB
    subgraph Dashboard["Space Dashboard - Right Column"]
        A{Has Safe accounts?}
        A -->|No| B{SetupWidget dismissed?}
        B -->|No| C[SetupWidget]
        B -->|Yes| D[PendingTxWidget]
        A -->|Yes| D
    end

    subgraph SetupWidget["SetupWidget Steps"]
        S1[Import address book] --> ImportDialog
        S2[Add Safe accounts] --> AddAccountsDialog
        S3[Invite team members] --> AddMemberModal
        S4[Explore Spaces] --> SpaceInfoModal
    end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).