### PR TITLE
chore: updated sign in text

### DIFF
--- a/apps/web/cypress/e2e/pages/spaces.page.js
+++ b/apps/web/cypress/e2e/pages/spaces.page.js
@@ -167,7 +167,7 @@ const spaceDashboardWidgetSelectorByTitle = {
 // ===========================================
 
 export function clickOnSignInBtn() {
-  cy.contains('Sign in with').click()
+  cy.contains('Continue with').click()
 }
 
 export function waitForSpacesWelcomeReady() {

--- a/apps/web/cypress/e2e/pages/spaces.page.js
+++ b/apps/web/cypress/e2e/pages/spaces.page.js
@@ -167,7 +167,7 @@ const spaceDashboardWidgetSelectorByTitle = {
 // ===========================================
 
 export function clickOnSignInBtn() {
-  cy.contains('Continue with').click()
+  cy.get('[data-testid="continue-with-wallet-btn"]').click()
 }
 
 export function waitForSpacesWelcomeReady() {

--- a/apps/web/src/features/spaces/components/SignInOptions/index.tsx
+++ b/apps/web/src/features/spaces/components/SignInOptions/index.tsx
@@ -26,7 +26,7 @@ const SignInOptions = ({ afterSignIn, redirectLoading = false }: SignInOptionsPr
         afterSignIn={afterSignIn}
         redirectLoading={redirectLoading}
         buttonStyle="walletBtnSecondary"
-        buttonText={{ connected: 'Sign in with', disconnected: 'Continue with wallet' }}
+        buttonText={{ connected: 'Continue with', disconnected: 'Continue with wallet' }}
       />
     </Box>
   )

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -44,7 +44,7 @@ const SignedOutState = ({ afterSignIn, redirectLoading }: { afterSignIn: () => v
       </Typography>
 
       <Typography color="text.secondary" mb={3}>
-        To view or create a space, sign in with your wallet.
+        Sign in to view or create a Space.
       </Typography>
 
       <SignInOptions afterSignIn={afterSignIn} redirectLoading={redirectLoading} />


### PR DESCRIPTION
> Sign-in copy refreshed for Spaces,                                                     
> "Continue with" replaces "Sign in with",                                               
> one line, one button, tests follow.                                                                                                             
                                                                                                                                                    
## What it solves : [Linear](https://linear.app/safe-global/issue/WA-1952/copy-fixes)                                                                                                                               
                                                                                                                                                    
Updates the Spaces sign-in copy for clarity and consistency:                                                                                      
- Landing description was verbose and used lowercase "space"             
- Wallet button said "Sign in with MetaMask" even when a wallet was already connected, which read awkwardly alongside the "Sign in" heading       
                                                                                                                                                    
## How this PR fixes it                                                                                                                           
                                                                                                                                                    
- `SpacesList/index.tsx`: "To view or create a space, sign in with your wallet." → "Sign in to view or create a Space."                           
- `SignInOptions/index.tsx`: connected `buttonText` "Sign in with" → "Continue with" (renders as "Continue with MetaMask \n eth:0x3e7c…C0a7")
- `cypress/e2e/pages/spaces.page.js`: updated `clickOnSignInBtn()` selector from `cy.contains('Sign in with')` to `cy.contains('Continue with')`  to match the new button label                                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                    
  Checklist                                                                                                                                         
                                                                                                                                                    
  - I've tested the branch on mobile                                                                                                                
  - I've documented how it affects the analytics (if at all)
  - I've written a unit/e2e test for it (updated Cypress page object)
  
  Screenshots:
  
<img width="835" height="512" alt="image" src="https://github.com/user-attachments/assets/68bff92c-b0ef-4b49-b678-0ac2ccae8cd7" />

<img width="408" height="549" alt="image" src="https://github.com/user-attachments/assets/f1f8cc3c-e5a7-40a1-9d96-edbde414ed01" />

<img width="432" height="564" alt="image" src="https://github.com/user-attachments/assets/be988f83-341d-4530-b8d4-c5beebbba614" />
