### PR TITLE
fix: Design Improvements

### DIFF
--- a/apps/web/src/components/welcome/WelcomeLogin/WalletLogin.tsx
+++ b/apps/web/src/components/welcome/WelcomeLogin/WalletLogin.tsx
@@ -7,7 +7,8 @@ import { useEffect, useState } from 'react'
 import { WalletMinimal } from 'lucide-react'
 import css from './styles.module.css'
 
-export type WalletLoginButtonStyle = 'walletBtnPrimary' | 'walletBtnSecondary'
+// 'walletBtnStatic' is intentionally theme-agnostic — used on the welcome page which has a fixed white background
+export type WalletLoginButtonStyle = 'walletBtnPrimary' | 'walletBtnSecondary' | 'walletBtnStatic'
 
 export interface WalletLoginButtonText {
   connected?: string
@@ -58,13 +59,14 @@ const WalletLogin = ({
         className={css[buttonStyle]}
         data-testid="continue-with-wallet-btn"
         disabled={isLoading}
+        disableElevation
       >
         {isLoading ? (
           <CircularProgress size={20} sx={{ color: '#fff' }} />
         ) : (
           <Box justifyContent="space-between" display="flex" flexDirection="row" alignItems="center" gap={1}>
             <Box display="flex" flexDirection="column" alignItems="flex-start">
-              <Typography variant="subtitle2" fontWeight={700}>
+              <Typography variant="subtitle2" fontWeight={600}>
                 {buttonText?.connected ?? 'Continue with'} {wallet.label}
               </Typography>
               {wallet.address && (

--- a/apps/web/src/components/welcome/WelcomeLogin/index.tsx
+++ b/apps/web/src/components/welcome/WelcomeLogin/index.tsx
@@ -34,7 +34,13 @@ const WelcomeLogin = () => {
 
         <Box className={css.fullWidth}>
           <Track {...OVERVIEW_EVENTS.OPEN_ONBOARD} label={OVERVIEW_LABELS.welcome_page}>
-            <WalletLogin onLogin={performAuth} onContinue={performAuth} fullWidth isLoading={loading} />
+            <WalletLogin
+              onLogin={performAuth}
+              onContinue={performAuth}
+              fullWidth
+              isLoading={loading}
+              buttonStyle="walletBtnStatic"
+            />
           </Track>
         </Box>
 

--- a/apps/web/src/components/welcome/WelcomeLogin/styles.module.css
+++ b/apps/web/src/components/welcome/WelcomeLogin/styles.module.css
@@ -60,7 +60,7 @@
   color: var(--color-text-primary);
   border-radius: 16px;
   padding: 10px 28px;
-  font-weight: 500;
+  font-weight: 600;
   font-size: 14px;
   text-transform: none;
   min-height: 36px;
@@ -68,4 +68,14 @@
 
 .walletBtnSecondary:hover {
   background-color: var(--color-border-light);
+}
+
+.walletBtnStatic {
+  color: #fff;
+  background-color: #121312;
+  min-height: 42px;
+}
+
+.walletBtnStatic:hover {
+  background-color: #121312;
 }

--- a/apps/web/src/features/oidc-auth/components/OidcSignInButton/styles.module.css
+++ b/apps/web/src/features/oidc-auth/components/OidcSignInButton/styles.module.css
@@ -4,7 +4,7 @@
   border-radius: 16px;
   padding: 10px 28px;
   border: none;
-  font-weight: 500;
+  font-weight: 600;
   font-size: 14px;
   text-transform: none;
   width: 100%;


### PR DESCRIPTION
## What it solves

Resolves: [WA-1955](https://linear.app/safe-global/issue/WA-1955/button-text-to-bold) [WA-1954](https://linear.app/safe-global/issue/WA-1954/remove-shadow)

## How this PR fixes it

The welcome page (`WelcomeLogin`) has a fixed white background that doesn't follow the app theme. The `walletBtnPrimary` style used theme CSS variables, causing hover color changes and potential theme-mode inconsistencies on that page.

## Changes

* `WalletLoginButtonStyle`— added 'walletBtnStatic' variant: hardcoded #fff text / #121312 background with no hover color change. Marked with a comment explaining it's intentionally theme-agnostic for the welcome page.
* `WelcomeLogin` — switches WalletLogin to use buttonStyle="walletBtnStatic".
* `WalletLogin` — added disableElevation to the "continue with wallet" button (was already on the disconnected button); reduced fontWeight from 700 → 600 on the wallet label.
* `walletBtnSecondary / OidcSignInButton` — font-weight bumped from 500 → 600 for visual consistency across sign-in buttons.

## How to test it

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
