### PR TITLE
fix: disable trusted token filtering without portfolio support

### DIFF
--- a/apps/web/cypress/e2e/smoke/assets.cy.js
+++ b/apps/web/cypress/e2e/smoke/assets.cy.js
@@ -38,12 +38,12 @@ describe('[SMOKE] Assets tests', () => {
     // Disable dust filter to see tokens with no fiat value
     assets.toggleHideDust(false)
 
-    // Verify default tokens list shows only native token
+    // On chains without portfolio support, trusted filtering is disabled.
+    // "Default tokens" therefore behaves like "all tokens".
     assets.toggleShowAllTokens(false)
-    main.verifyValuesExist(assets.tokenListTable, [constants.tokenNames.sepoliaEther])
-    main.verifyValuesDoNotExist(assets.tokenListTable, spamTokens)
+    main.verifyValuesExist(assets.tokenListTable, [constants.tokenNames.sepoliaEther, ...spamTokens])
 
-    // Verify all tokens list shows spam tokens
+    // Verify toggling "Show all tokens" still keeps the full list visible
     assets.toggleShowAllTokens(true)
     spamTokens.push(constants.tokenNames.sepoliaEther)
     main.verifyValuesExist(assets.tokenListTable, spamTokens)

--- a/apps/web/src/hooks/__tests__/useLoadBalances.test.ts
+++ b/apps/web/src/hooks/__tests__/useLoadBalances.test.ts
@@ -195,7 +195,7 @@ describe('useLoadBalances', () => {
   })
 
   test('only use default list if feature is enabled', async () => {
-    jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockImplementation(() => ({
+    const balancesQuerySpy = jest.spyOn(balancesQueries, 'useBalancesGetBalancesV1Query').mockImplementation(() => ({
       currentData: mockBalanceAllTokens,
       isLoading: false,
       error: undefined,
@@ -223,6 +223,16 @@ describe('useLoadBalances', () => {
       expect(result.current[0]?.fiatTotal).toEqual(mockBalanceAllTokens.fiatTotal)
       expect(result.current[1]).toBeUndefined()
     })
+
+    expect(balancesQuerySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chainId: '5',
+        fiatCode: 'EUR',
+        safeAddress,
+        trusted: false,
+      }),
+      expect.any(Object),
+    )
   })
 
   test('use trusted filter for default list and reload on settings change', async () => {

--- a/apps/web/src/hooks/loadables/useLoadBalances.ts
+++ b/apps/web/src/hooks/loadables/useLoadBalances.ts
@@ -16,12 +16,14 @@ export { initialBalancesState, createPortfolioBalances } from '@safe-global/util
 
 export const useTokenListSetting = (): boolean | undefined => {
   const chain = useCurrentChain()
+  const hasPortfolioFeature = useHasFeature(FEATURES.PORTFOLIO_ENDPOINT)
   const settings = useAppSelector(selectSettings)
 
   return useMemo(() => {
+    if (hasPortfolioFeature === false) return false
     if (settings.tokenList === TOKEN_LISTS.ALL) return false
     return chain ? hasFeature(chain, FEATURES.DEFAULT_TOKENLIST) : undefined
-  }, [chain, settings.tokenList])
+  }, [chain, hasPortfolioFeature, settings.tokenList])
 }
 
 /**


### PR DESCRIPTION
> No portfolio path,
> trusted falls back to false,
> tx service shows all.

## What it solves

Resolves: WA-1561

Linear: https://linear.app/safe-global/issue/WA-1561/show-all-token-and-expected-token-list-on-send

On chains without `PORTFOLIO_ENDPOINT`, the send flow should not keep trusted/default-token filtering enabled. Those chains already rely on tx service balances only, so `trusted: true` is the wrong request shape.

## How this PR fixes it

`useTokenListSetting()` now returns `false` when `PORTFOLIO_ENDPOINT` is unavailable, which forces the non-portfolio path to use tx service balances with `trusted: false`.

Also adds a unit regression that asserts the balances query receives `trusted: false` even when the saved setting is `TRUSTED`.

Analytics impact: none.

## How to test it

- Run `yarn workspace @safe-global/web test apps/web/src/hooks/__tests__/useLoadBalances.test.ts --runInBand --watchman=false`
- Optional manual check: open the send flow on Sepolia and confirm non-default tokens are visible

## Visual summary

```mermaid
flowchart LR
  A[No PORTFOLIO_ENDPOINT] --> B[useTokenListSetting = false]
  B --> C[trusted: false]
  C --> D[Tx service balances power send flow]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).