### PR TITLE
refactor(mobile): modernize tab bar with translucent blur background

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -3,10 +3,11 @@ import React from 'react'
 import { BlurView } from 'expo-blur'
 import { TabBarIcon } from '@/src/components/navigation/TabBarIcon'
 import { Navbar as AssetsNavbar } from '@/src/features/Assets/components/Navbar/Navbar'
-import { Platform, Pressable, StyleSheet } from 'react-native'
-import { useTheme } from 'tamagui'
+import { Pressable, StyleSheet } from 'react-native'
+import { useTheme, View } from 'tamagui'
 import { useTheme as useCurrentTheme } from '@/src/theme/hooks/useTheme'
 import TransactionHeader from '@/src/features/TxHistory/components/TransactionHeader'
+import { isAndroid } from '@/src/config/constants'
 
 function TabBarBackground() {
   const { isDark } = useCurrentTheme()
@@ -14,8 +15,8 @@ function TabBarBackground() {
   // expo-blur on Android requires BlurTargetView wrapping the content behind the blur,
   // but the tab navigator's internal view hierarchy prevents the ref from capturing screen
   // content. See https://github.com/expo/expo/issues/44165
-  if (Platform.OS === 'android') {
-    return null
+  if (isAndroid) {
+    return <View style={StyleSheet.absoluteFill} backgroundColor={'$backgroundSheet'} opacity={0.98} />
   }
 
   return <BlurView intensity={80} tint={isDark ? 'dark' : 'light'} style={StyleSheet.absoluteFill} />

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,10 +1,25 @@
 import { Tabs } from 'expo-router'
 import React from 'react'
+import { BlurView } from 'expo-blur'
 import { TabBarIcon } from '@/src/components/navigation/TabBarIcon'
 import { Navbar as AssetsNavbar } from '@/src/features/Assets/components/Navbar/Navbar'
-import { Pressable, StyleSheet } from 'react-native'
+import { Platform, Pressable, StyleSheet } from 'react-native'
 import { useTheme } from 'tamagui'
+import { useTheme as useCurrentTheme } from '@/src/theme/hooks/useTheme'
 import TransactionHeader from '@/src/features/TxHistory/components/TransactionHeader'
+
+function TabBarBackground() {
+  const { isDark } = useCurrentTheme()
+
+  // expo-blur on Android requires BlurTargetView wrapping the content behind the blur,
+  // but the tab navigator's internal view hierarchy prevents the ref from capturing screen
+  // content. See https://github.com/expo/expo/issues/44165
+  if (Platform.OS === 'android') {
+    return null
+  }
+
+  return <BlurView intensity={80} tint={isDark ? 'dark' : 'light'} style={StyleSheet.absoluteFill} />
+}
 
 export default function TabLayout() {
   const theme = useTheme()
@@ -19,68 +34,67 @@ export default function TabLayout() {
       tabBarLabelStyle: styles.label,
       tabBarActiveTintColor: activeTintColor,
       tabBarInactiveTintColor: inactiveTintColor,
+      tabBarBackground: () => <TabBarBackground />,
     }),
     [borderTopColor, activeTintColor, inactiveTintColor],
   )
 
   return (
-    <>
-      <Tabs screenOptions={screenOptions}>
-        <Tabs.Screen
-          name="index"
-          options={{
-            header: () => <AssetsNavbar />,
-            title: 'Home',
-            tabBarButtonTestID: 'home-tab',
-            tabBarButton: ({ children, ref, ...rest }) => {
-              return (
-                <Pressable {...rest} style={styles.tabButton}>
-                  {children}
-                </Pressable>
-              )
-            },
-            tabBarIcon: ({ color }) => <TabBarIcon name={'home'} color={color} />,
-          }}
-        />
+    <Tabs screenOptions={screenOptions}>
+      <Tabs.Screen
+        name="index"
+        options={{
+          header: () => <AssetsNavbar />,
+          title: 'Home',
+          tabBarButtonTestID: 'home-tab',
+          tabBarButton: ({ children, ref, ...rest }) => {
+            return (
+              <Pressable {...rest} style={styles.tabButton}>
+                {children}
+              </Pressable>
+            )
+          },
+          tabBarIcon: ({ color }) => <TabBarIcon name={'home'} color={color} />,
+        }}
+      />
 
-        <Tabs.Screen
-          name="transactions"
-          options={{
-            title: 'Transactions',
-            headerTitle: () => <TransactionHeader />,
-            headerStyle: { shadowColor: 'transparent' },
-            headerLeftContainerStyle: { flexGrow: 0 },
-            tabBarButtonTestID: 'transactions-tab',
-            tabBarLabel: 'Transactions',
-            tabBarButton: ({ children, ref, ...rest }) => {
-              return (
-                <Pressable {...rest} style={styles.tabButton}>
-                  {children}
-                </Pressable>
-              )
-            },
-            tabBarIcon: ({ color }) => <TabBarIcon name={'transactions'} color={color} />,
-          }}
-        />
+      <Tabs.Screen
+        name="transactions"
+        options={{
+          title: 'Transactions',
+          headerTitle: () => <TransactionHeader />,
+          headerStyle: { shadowColor: 'transparent' },
+          headerLeftContainerStyle: { flexGrow: 0 },
+          tabBarButtonTestID: 'transactions-tab',
+          tabBarLabel: 'Transactions',
+          tabBarButton: ({ children, ref, ...rest }) => {
+            return (
+              <Pressable {...rest} style={styles.tabButton}>
+                {children}
+              </Pressable>
+            )
+          },
+          tabBarIcon: ({ color }) => <TabBarIcon name={'transactions'} color={color} />,
+        }}
+      />
 
-        <Tabs.Screen
-          name="settings"
-          options={{
-            title: 'Account',
-            headerShown: false,
-            tabBarButtonTestID: 'account-tab',
-            tabBarButton: ({ children, ref, ...rest }) => {
-              return (
-                <Pressable {...rest} style={styles.tabButton}>
-                  {children}
-                </Pressable>
-              )
-            },
-            tabBarIcon: ({ color }) => <TabBarIcon name={'wallet'} color={color} />,
-          }}
-        />
-      </Tabs>
-    </>
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: 'Account',
+          headerShown: false,
+          tabBarButtonTestID: 'account-tab',
+          tabBarButton: ({ children, ref, ...rest }) => {
+            return (
+              <Pressable {...rest} style={styles.tabButton}>
+                {children}
+              </Pressable>
+            )
+          },
+          tabBarIcon: ({ color }) => <TabBarIcon name={'wallet'} color={color} />,
+        }}
+      />
+    </Tabs>
   )
 }
 
@@ -95,13 +109,17 @@ const styles = StyleSheet.create({
     width: '100%',
     margin: 'auto',
     height: 64,
+    position: 'absolute',
+    backgroundColor: 'transparent',
+    elevation: 0,
+    borderTopWidth: StyleSheet.hairlineWidth,
     boxSizing: 'content-box',
-    borderTopWidth: 1,
   },
   label: {
     fontSize: 12,
     fontWeight: 400,
     lineHeight: 16,
-    marginTop: 8,
+    letterSpacing: 0.1,
+    marginTop: 4,
   },
 })


### PR DESCRIPTION
> Frosted glass beneath the tabs,
> content scrolls through, clean and clear,
> hairline edge, soft labels near.

## What it solves

The bottom tab bar uses an opaque background with a hard border, which feels dated compared to modern mobile apps like Google Maps, Linear, and Arc.

Resolves: https://linear.app/safe-global/issue/WA-1961/modernize-bottom-tab-bar-styling

## How this PR fixes it

Adds a translucent frosted-glass background using `expo-blur` on iOS. On Android, `expo-blur` requires a `BlurTargetView` wrapping the content behind the blur, which isn't feasible across the tab navigator's view hierarchy ([expo/expo#44165](https://github.com/expo/expo/issues/44165)), so it falls back to a near-opaque themed surface. The tab bar is now absolutely positioned so content scrolls underneath it, with a hairline separator and refined label typography.

## How to test it

1. Open the app on iOS — verify the tab bar has a frosted glass blur effect with content visible underneath
2. Open the app on Android — verify the tab bar has a clean, near-opaque themed background
3. Switch between light and dark mode on both platforms — the tab bar should adapt
4. Scroll content on any tab — verify content flows underneath the tab bar

## Screenshots

### IOS

<img width="150" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-14 at 16 01 13" src="https://github.com/user-attachments/assets/2c97248a-56ef-4337-88e1-bad373f40a05" />
<img width="150" alt="simulator_screenshot_860A4041-4D01-4615-B622-B7A317D4F17C" src="https://github.com/user-attachments/assets/ddf9176e-ccbd-4941-a03d-9b5e4ed0bc19" />

https://github.com/user-attachments/assets/603ae476-3731-4287-b253-20f0e85cf87a


### Android

<img width="150" alt="image" src="https://github.com/user-attachments/assets/7270da60-8c53-4bc1-85c7-590c936401c2" />
<img width="150" alt="image" src="https://github.com/user-attachments/assets/7976a981-7f23-4549-8757-be069ccfff70" />

https://github.com/user-attachments/assets/a24cc90a-6c49-420a-8ab0-130cdbd73a5e



## Visual summary

```mermaid
flowchart LR
    subgraph Before
        A[Opaque background] --> B[1px solid border]
    end
    subgraph After
        C[BlurView iOS / themed Android] --> D[Hairline border]
        C --> E[position: absolute]
    end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).