### PR TITLE
fix(mobile): remove extra padding and border from mobile components

### DIFF
--- a/apps/mobile/src/app/import-signers/index.tsx
+++ b/apps/mobile/src/app/import-signers/index.tsx
@@ -1,12 +1,10 @@
 import React from 'react'
 import { View } from 'tamagui'
 import { ImportSignersContainer } from '@/src/features/ImportSigners'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
-function ImportSignersPage() {
-  const { bottom } = useSafeAreaInsets()
 
+function ImportSignersPage() {
   return (
-    <View style={{ flex: 1 }} paddingBottom={bottom}>
+    <View style={{ flex: 1 }}>
       <ImportSignersContainer />
     </View>
   )

--- a/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewFooter.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewFooter.tsx
@@ -25,8 +25,6 @@ export function ReviewFooter({ txId, activeSigner, isSigningLoading, onConfirmPr
       backgroundColor="$background"
       paddingHorizontal="$4"
       paddingVertical="$3"
-      borderTopWidth={1}
-      borderTopColor="$borderLight"
       gap="$3"
       paddingBottom={insets.bottom ? insets.bottom : '$4'}
     >


### PR DESCRIPTION
> Footer border gone, padding trimmed,
> mobile views breathe, layouts slimmed.

## What it solves

Fixes visual inconsistencies in the mobile app where the import signers page had unnecessary bottom padding and the ReviewFooter component had an unwanted top border.

## How this PR fixes it

Removes the `useSafeAreaInsets` bottom padding from the import signers page (the container already handles safe area) and strips the `borderTopWidth`/`borderTopColor` from the ReviewFooter component.

## How to test it

1. Open the import signers page on a device with a home indicator — verify there's no extra bottom padding
2. Navigate to a transaction review screen — verify the footer no longer has a visible top border
3. Check both views on devices with and without a notch/home indicator

## Screenshots

### IOS
<img width="150" alt="simulator_screenshot_156921B1-FA7F-4CD7-9032-61BDD22898CC" src="https://github.com/user-attachments/assets/05d428ea-d1e5-4fc2-b84b-e785af870aba" />

<img width="150" alt="simulator_screenshot_0026361E-3413-45DC-8D52-DA97F7453EA5" src="https://github.com/user-attachments/assets/93ff6b46-a561-4860-beeb-d2531f8d7965" />
<img width="150" alt="simulator_screenshot_64A6D4E4-CBC5-46A7-9364-7A52E1AD3170" src="https://github.com/user-attachments/assets/af201aaa-c65b-4c5d-9af7-4e5622fa1c79" />

https://github.com/user-attachments/assets/01bc8cfa-acb9-41af-b3c3-d4ea6dba5ade

### Android
<img width="150" alt="image" src="https://github.com/user-attachments/assets/1b21a1a7-b4f3-465a-a393-81807d60d481" />
<img width="150" alt="image" src="https://github.com/user-attachments/assets/d722ec77-a882-4390-a406-a22c7bb35db5" />

<img width="150" alt="image" src="https://github.com/user-attachments/assets/39e6c603-3a63-471b-9976-7b12559132b1" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).