### PR TITLE
feat: redesign Spaces Address Book page with shadcn

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/ActivityLog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/ActivityLog.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from 'react'
+import Identicon from '@/components/common/Identicon'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import type { AddressBookEntry } from './SpaceAddressBookTable'
+
+export function formatDate(dateStr: string): string {
+  if (!dateStr) return ''
+  const date = new Date(dateStr)
+  if (isNaN(date.getTime())) return ''
+  const now = new Date()
+  const yesterday = new Date(now)
+  yesterday.setDate(yesterday.getDate() - 1)
+
+  const timeStr = date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+
+  if (date.toDateString() === now.toDateString()) {
+    return `Today at ${timeStr}`
+  }
+  if (date.toDateString() === yesterday.toDateString()) {
+    return `Yesterday at ${timeStr}`
+  }
+  return `${date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} at ${timeStr}`
+}
+
+export type ActivityEvent = {
+  type: 'added' | 'updated'
+  entry: AddressBookEntry
+  date: string
+  actor: string
+}
+
+export function buildActivityEvents(entries: AddressBookEntry[]): ActivityEvent[] {
+  const events: ActivityEvent[] = []
+
+  for (const entry of entries) {
+    if (entry.createdAt) {
+      events.push({
+        type: 'added',
+        entry,
+        date: entry.createdAt,
+        actor: entry.createdBy,
+      })
+    }
+    if (entry.updatedAt && entry.createdAt && entry.updatedAt !== entry.createdAt) {
+      events.push({
+        type: 'updated',
+        entry,
+        date: entry.updatedAt,
+        actor: entry.lastUpdatedBy,
+      })
+    }
+  }
+
+  events.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+  return events
+}
+
+function ActorName({ address }: { address: string }) {
+  return (
+    <span className="inline-flex font-bold [&>div]:inline-flex [&>div]:items-center">
+      <EthHashInfo address={address} showAvatar={false} onlyName showPrefix={false} showCopyButton={false} />
+    </span>
+  )
+}
+
+function ActivityLog({ entries }: { entries: AddressBookEntry[] }) {
+  const events = useMemo(() => buildActivityEvents(entries), [entries])
+
+  if (events.length === 0) {
+    return <p className="text-muted-foreground text-sm">No activity yet.</p>
+  }
+
+  return (
+    <div className="divide-y">
+      {events.map((event, i) => (
+        <div key={`${event.entry.address}-${event.type}-${i}`} className="flex items-start gap-3 py-3">
+          <div className="shrink-0 pt-0.5">
+            <Identicon address={event.actor} size={32} />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="flex flex-wrap items-center gap-x-1 text-sm">
+              <ActorName address={event.actor} />
+              <span>{event.type}</span>
+              <span className="font-bold">{event.entry.name}</span>
+            </p>
+            <p className="text-muted-foreground mt-0.5 text-xs">{formatDate(event.date)}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default ActivityLog

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
@@ -1,4 +1,5 @@
 import { Alert, DialogActions, Stack, Button, DialogContent, Typography, CircularProgress, Box } from '@mui/material'
+import { Button as ShadcnButton } from '@/components/ui/button'
 import PlusIcon from '@/public/images/common/plus.svg'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
 import ModalDialog from '@/components/common/ModalDialog'
@@ -98,9 +99,10 @@ const AddContact = () => {
 
   return (
     <>
-      <Button variant="contained" size="small" startIcon={<PlusIcon />} onClick={handleOpen}>
+      <ShadcnButton size="sm" onClick={handleOpen}>
+        <PlusIcon />
         Add contact
-      </Button>
+      </ShadcnButton>
       <ModalDialog open={open} onClose={handleClose} dialogTitle="Add contact" hideChainIndicator>
         <FormProvider {...methods}>
           <form onSubmit={onSubmit}>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/index.tsx
@@ -1,19 +1,16 @@
 import ImportIcon from '@/public/images/common/import.svg'
-import { Button, SvgIcon } from '@mui/material'
+import { SvgIcon } from '@mui/material'
 import { useState } from 'react'
 import ImportAddressBookDialog from './ImportAddressBookDialog'
+import { Button } from '@/components/ui/button'
 
 const ImportAddressBook = () => {
   const [open, setOpen] = useState(false)
 
   return (
     <>
-      <Button
-        variant="outlined"
-        size="small"
-        startIcon={<SvgIcon component={ImportIcon} inheritViewBox fontSize="small" color="primary" />}
-        onClick={() => setOpen(true)}
-      >
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        <SvgIcon component={ImportIcon} inheritViewBox fontSize="small" />
         Import
       </Button>
       {open && <ImportAddressBookDialog handleClose={() => setOpen(false)} />}

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -1,94 +1,155 @@
-import EnhancedTable from '@/components/common/EnhancedTable'
+import { useEffect, useState } from 'react'
+import { Box, Chip, Tooltip } from '@mui/material'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
 import EthHashInfo from '@/components/common/EthHashInfo'
-import tableCss from '@/components/common/EnhancedTable/styles.module.css'
-import Identicon from '@/components/common/Identicon'
-import { Box, Chip, Stack, Tooltip } from '@mui/material'
 import { NetworkLogosList } from '@/features/multichain'
 import ChainIndicator from '@/components/common/ChainIndicator'
+import { SvgIcon } from '@mui/material'
+import AddressBookIcon from '@/public/images/sidebar/address-book.svg'
 import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import SpaceAddressBookActions from './SpaceAddressBookActions'
-import { ContactSource } from '@/hooks/useAllAddressBooks'
 import useChains from '@/hooks/useChains'
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 
-const headCells = [
-  { id: 'contact', label: 'Contact', disableSort: true },
-  { id: 'networks', label: 'Networks', disableSort: true },
-  { id: 'actions', label: '' },
-]
+export type AddressBookEntry = SpaceAddressBookItemDto & {
+  isLocal: boolean
+  createdAt?: string
+  updatedAt?: string
+}
 
 type SpaceAddressBookTableProps = {
-  entries: SpaceAddressBookItemDto[]
+  entries: AddressBookEntry[]
 }
+
+const PAGE_SIZE = 25
 
 function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
   const chains = useChains()
+  const [page, setPage] = useState(0)
 
-  const rows = entries.map((entry) => ({
-    cells: {
-      contact: {
-        rawValue: entry.address,
-        mobileLabel: 'Contact',
-        content: (
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Identicon address={entry.address} size={32} />
-            <Box sx={{ '& .ethHashInfo-name': { fontWeight: 700 } }}>
-              <Stack direction="column" spacing={0.5}>
-                <EthHashInfo
-                  showAvatar={false}
-                  address={entry.address}
-                  name={entry.name}
-                  shortAddress={false}
-                  showPrefix={false}
-                  addressBookNameSource={ContactSource.space}
-                  hasExplorer
-                  showCopyButton
-                />
-              </Stack>
-            </Box>
-          </Stack>
-        ),
-      },
-      networks: {
-        rawValue: entry.chainIds.length,
-        mobileLabel: 'Networks',
-        content: (
-          <>
-            <Tooltip
-              title={
-                <Box>
-                  {entry.chainIds.map((chainId) => (
-                    <Box key={chainId} sx={{ p: '4px 0px' }}>
-                      <ChainIndicator chainId={chainId} />
+  // Reset to first page when entries change (tab switch, search)
+  useEffect(() => {
+    setPage(0)
+  }, [entries])
+
+  const totalPages = Math.ceil(entries.length / PAGE_SIZE)
+  const paginatedEntries = entries.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+
+  return (
+    <>
+      <Table className="table-fixed">
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[20%]">Name</TableHead>
+            <TableHead className="w-[35%]">Address</TableHead>
+            <TableHead className="w-[15%]">Chains</TableHead>
+            <TableHead className="w-[20%]">Added by</TableHead>
+            <TableHead className="w-[10%]" />
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          {paginatedEntries.map((entry) => (
+            <TableRow key={entry.address}>
+              {/* Name */}
+              <TableCell className="font-bold">
+                <span className="inline-flex items-center gap-1.5">
+                  {entry.isLocal && (
+                    <SvgIcon
+                      component={AddressBookIcon}
+                      inheritViewBox
+                      sx={{ fontSize: 16, color: 'text.secondary' }}
+                    />
+                  )}
+                  {entry.name}
+                </span>
+              </TableCell>
+
+              {/* Address */}
+              <TableCell>
+                <div style={{ fontSize: '0.8em' }}>
+                  <EthHashInfo
+                    address={entry.address}
+                    shortAddress={false}
+                    showPrefix={false}
+                    showName={false}
+                    highlight4bytes
+                    hasExplorer
+                    showCopyButton
+                    avatarSize={24}
+                  />
+                </div>
+              </TableCell>
+
+              {/* Chains */}
+              <TableCell>
+                <Tooltip
+                  title={
+                    <Box>
+                      {entry.chainIds.map((chainId) => (
+                        <Box key={chainId} sx={{ p: '4px 0px' }}>
+                          <ChainIndicator chainId={chainId} />
+                        </Box>
+                      ))}
                     </Box>
-                  ))}
-                </Box>
-              }
-              arrow
-            >
-              <Box sx={{ display: 'inline-block' }}>
-                {chains.configs.length === entry.chainIds.length ? (
-                  <Chip label="All" size="small" />
-                ) : (
-                  <NetworkLogosList networks={entry.chainIds.map((chainId) => ({ chainId }))} />
-                )}
-              </Box>
-            </Tooltip>
-          </>
-        ),
-      },
-      actions: {
-        rawValue: '',
-        sticky: true,
-        content: (
-          <div className={tableCss.actions}>
-            <SpaceAddressBookActions entry={entry} />
-          </div>
-        ),
-      },
-    },
-  }))
+                  }
+                  arrow
+                >
+                  <span className="inline-flex" style={{ transform: 'scale(0.85)', transformOrigin: 'left center' }}>
+                    {chains.configs.length === entry.chainIds.length ? (
+                      <Chip label="All" size="small" />
+                    ) : (
+                      <NetworkLogosList networks={entry.chainIds.map((chainId) => ({ chainId }))} />
+                    )}
+                  </span>
+                </Tooltip>
+              </TableCell>
 
-  return <EnhancedTable rows={rows} headCells={headCells} mobileVariant />
+              {/* Added by */}
+              <TableCell>
+                {entry.createdBy ? (
+                  <EthHashInfo
+                    address={entry.createdBy}
+                    avatarSize={20}
+                    onlyName
+                    showPrefix={false}
+                    showCopyButton={false}
+                  />
+                ) : null}
+              </TableCell>
+
+              {/* Actions */}
+              <TableCell className="text-right">
+                {!entry.isLocal && <SpaceAddressBookActions entry={entry} />}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-4">
+          <p className="text-muted-foreground text-sm">
+            {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, entries.length)} of {entries.length}
+          </p>
+          <div className="flex gap-1">
+            <Button variant="outline" size="icon-sm" disabled={page === 0} onClick={() => setPage((p) => p - 1)}>
+              <ChevronLeftIcon />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              disabled={page >= totalPages - 1}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              <ChevronRightIcon />
+            </Button>
+          </div>
+        </div>
+      )}
+    </>
+  )
 }
 
 export default SpaceAddressBookTable

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/ActivityLog.test.ts
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/ActivityLog.test.ts
@@ -1,0 +1,132 @@
+import { formatDate, buildActivityEvents } from '../ActivityLog'
+import type { AddressBookEntry } from '../SpaceAddressBookTable'
+
+const makeEntry = (overrides: Partial<AddressBookEntry> = {}): AddressBookEntry => ({
+  name: 'Alice',
+  address: '0x1234567890abcdef1234567890abcdef12345678',
+  chainIds: ['1'],
+  createdBy: '0xaaaa',
+  lastUpdatedBy: '0xbbbb',
+  isLocal: false,
+  ...overrides,
+})
+
+describe('ActivityLog', () => {
+  describe('formatDate', () => {
+    it('returns empty string for empty input', () => {
+      expect(formatDate('')).toBe('')
+    })
+
+    it('returns empty string for invalid date', () => {
+      expect(formatDate('not-a-date')).toBe('')
+    })
+
+    it('formats today as "Today at HH:MM"', () => {
+      const now = new Date()
+      const result = formatDate(now.toISOString())
+      expect(result).toMatch(/^Today at /)
+    })
+
+    it('formats yesterday as "Yesterday at HH:MM"', () => {
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const result = formatDate(yesterday.toISOString())
+      expect(result).toMatch(/^Yesterday at /)
+    })
+
+    it('formats older dates as "Mon DD at HH:MM"', () => {
+      const result = formatDate('2025-01-15T10:30:00Z')
+      expect(result).toMatch(/at /)
+      expect(result).not.toMatch(/^Today/)
+      expect(result).not.toMatch(/^Yesterday/)
+    })
+  })
+
+  describe('buildActivityEvents', () => {
+    it('returns empty array for empty entries', () => {
+      expect(buildActivityEvents([])).toEqual([])
+    })
+
+    it('returns empty array when entries have no createdAt', () => {
+      const entry = makeEntry()
+      expect(buildActivityEvents([entry])).toEqual([])
+    })
+
+    it('creates an "added" event for an entry with createdAt', () => {
+      const entry = makeEntry({ createdAt: '2025-01-01T10:00:00Z' })
+      const events = buildActivityEvents([entry])
+
+      expect(events).toHaveLength(1)
+      expect(events[0].type).toBe('added')
+      expect(events[0].actor).toBe('0xaaaa')
+      expect(events[0].date).toBe('2025-01-01T10:00:00Z')
+    })
+
+    it('creates both "added" and "updated" events when updatedAt differs from createdAt', () => {
+      const entry = makeEntry({
+        createdAt: '2025-01-01T10:00:00Z',
+        updatedAt: '2025-01-02T12:00:00Z',
+      })
+      const events = buildActivityEvents([entry])
+
+      expect(events).toHaveLength(2)
+      expect(events[0].type).toBe('updated')
+      expect(events[0].actor).toBe('0xbbbb')
+      expect(events[1].type).toBe('added')
+      expect(events[1].actor).toBe('0xaaaa')
+    })
+
+    it('does not create "updated" event when updatedAt equals createdAt', () => {
+      const entry = makeEntry({
+        createdAt: '2025-01-01T10:00:00Z',
+        updatedAt: '2025-01-01T10:00:00Z',
+      })
+      const events = buildActivityEvents([entry])
+
+      expect(events).toHaveLength(1)
+      expect(events[0].type).toBe('added')
+    })
+
+    it('sorts events newest first', () => {
+      const entries = [
+        makeEntry({
+          name: 'Older',
+          address: '0x1111',
+          createdAt: '2025-01-01T10:00:00Z',
+        }),
+        makeEntry({
+          name: 'Newer',
+          address: '0x2222',
+          createdAt: '2025-06-15T10:00:00Z',
+        }),
+      ]
+      const events = buildActivityEvents(entries)
+
+      expect(events).toHaveLength(2)
+      expect(events[0].entry.name).toBe('Newer')
+      expect(events[1].entry.name).toBe('Older')
+    })
+
+    it('interleaves added and updated events by date', () => {
+      const entries = [
+        makeEntry({
+          name: 'First',
+          address: '0x1111',
+          createdAt: '2025-01-01T10:00:00Z',
+          updatedAt: '2025-03-01T10:00:00Z',
+        }),
+        makeEntry({
+          name: 'Second',
+          address: '0x2222',
+          createdAt: '2025-02-01T10:00:00Z',
+        }),
+      ]
+      const events = buildActivityEvents(entries)
+
+      expect(events).toHaveLength(3)
+      expect(events[0]).toMatchObject({ type: 'updated', entry: { name: 'First' } })
+      expect(events[1]).toMatchObject({ type: 'added', entry: { name: 'Second' } })
+      expect(events[2]).toMatchObject({ type: 'added', entry: { name: 'First' } })
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -1,62 +1,171 @@
-import { Stack, Typography } from '@mui/material'
+import { useMemo, useState } from 'react'
+import { Typography } from '@mui/material'
 import { useIsInvited, useIsAdmin, useAddressBookSearch, useGetSpaceAddressBook } from '@/features/spaces'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
+import useAllAddressBooks from '@/hooks/useAllAddressBooks'
+import type { AddressBookEntry } from './SpaceAddressBookTable'
+import { useDarkMode } from '@/hooks/useDarkMode'
+import { cn } from '@/utils/cn'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { Input } from '@/components/ui/input'
+import { Search } from 'lucide-react'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import Track from '@/components/common/Track'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import AddContact from './AddContact'
 import EmptyAddressBook from './EmptyAddressBook'
 import SpaceAddressBookTable from './SpaceAddressBookTable'
+import ActivityLog from './ActivityLog'
 import ImportAddressBook from './Import'
-import SearchInput from '../SearchInput'
-import { useState } from 'react'
 
 const SpaceAddressBook = () => {
   const [searchQuery, setSearchQuery] = useState('')
+  const [activeTab, setActiveTab] = useState('workspace')
   const isAdmin = useIsAdmin()
   const isInvited = useIsInvited()
+  const isDarkMode = useDarkMode()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { currentData: user } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
   const addressBookItems = useGetSpaceAddressBook()
+  const allLocalAddressBooks = useAllAddressBooks()
 
-  const filteredAddressBook = useAddressBookSearch(addressBookItems, searchQuery)
+  const mySpaceContacts: AddressBookEntry[] = useMemo(
+    () =>
+      addressBookItems
+        .filter((item) => user?.wallets.some((w) => sameAddress(w.address, item.createdBy)))
+        .map((item) => ({ ...item, isLocal: false })),
+    [addressBookItems, user?.wallets],
+  )
+
+  const localContacts: AddressBookEntry[] = useMemo(() => {
+    // Aggregate local contacts across all chains, grouping chainIds per address
+    const walletAddress = user?.wallets[0]?.address ?? ''
+    const byAddress = new Map<string, { address: string; name: string; chainIds: Set<string> }>()
+    for (const [chainId, book] of Object.entries(allLocalAddressBooks)) {
+      for (const [address, name] of Object.entries(book)) {
+        const key = address.toLowerCase()
+        const existing = byAddress.get(key)
+        if (existing) {
+          existing.chainIds.add(chainId)
+        } else {
+          byAddress.set(key, { address, name, chainIds: new Set([chainId]) })
+        }
+      }
+    }
+    return Array.from(byAddress.values()).map(({ address, name, chainIds }) => ({
+      name,
+      address,
+      chainIds: Array.from(chainIds),
+      createdBy: walletAddress,
+      lastUpdatedBy: '',
+      isLocal: true,
+    }))
+  }, [allLocalAddressBooks, user?.wallets])
+
+  // Merge space contacts created by me + local contacts (excluding duplicates already in space)
+  const myContacts: AddressBookEntry[] = useMemo(() => {
+    const uniqueLocal = localContacts.filter(
+      (local) => !mySpaceContacts.some((space) => sameAddress(space.address, local.address)),
+    )
+    return [...mySpaceContacts, ...uniqueLocal]
+  }, [mySpaceContacts, localContacts])
+
+  const filteredAllRaw = useAddressBookSearch(addressBookItems, searchQuery)
+  const filteredAll: AddressBookEntry[] = useMemo(
+    () => filteredAllRaw.map((item) => ({ ...item, isLocal: false })),
+    [filteredAllRaw],
+  )
+  const filteredMine = useAddressBookSearch(myContacts, searchQuery) as AddressBookEntry[]
 
   return (
     <>
       {isInvited && <PreviewInvite />}
-      <Typography variant="h1" mb={3}>
-        Address book
-      </Typography>
 
-      <Stack
-        direction="row"
-        justifyContent="space-between"
-        alignItems="flex-start"
-        mb={3}
-        flexWrap="wrap"
-        gap={2}
-        flexDirection={{ xs: 'column-reverse', md: 'row' }}
-      >
-        <SearchInput onSearch={setSearchQuery} />
+      <div className={cn('shadcn-scope', isDarkMode && 'dark')}>
+        {/* Header row: title + subtitle left, buttons right */}
+        <div className="mt-6 mb-6 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <Typography variant="h1">Address book</Typography>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Org-verified contacts are shared with all Workspace members.
+            </p>
+          </div>
 
-        {isAdmin && (
-          <Stack direction="row" gap={1}>
-            <ImportAddressBook />
-            <Track {...SPACE_EVENTS.ADD_ADDRESS}>
-              <AddContact />
-            </Track>
-          </Stack>
+          {isAdmin && (
+            <div className="flex shrink-0 gap-2">
+              <ImportAddressBook />
+              <Track {...SPACE_EVENTS.ADD_ADDRESS}>
+                <AddContact />
+              </Track>
+            </div>
+          )}
+        </div>
+
+        {addressBookItems.length === 0 && localContacts.length === 0 ? (
+          <EmptyAddressBook />
+        ) : (
+          <Tabs
+            defaultValue="workspace"
+            onValueChange={(val) => {
+              setSearchQuery('')
+              setActiveTab(val)
+            }}
+          >
+            <TabsList variant="line">
+              <TabsTrigger value="workspace" className="cursor-pointer">
+                Workspace contacts ({addressBookItems.length})
+              </TabsTrigger>
+              <TabsTrigger value="mine" className="cursor-pointer">
+                My contacts ({myContacts.length})
+              </TabsTrigger>
+              <TabsTrigger value="activity" className="cursor-pointer">
+                Activity log
+              </TabsTrigger>
+            </TabsList>
+
+            {/* Search bar below tabs (hidden on activity tab) */}
+            {activeTab !== 'activity' && (
+              <div className="relative mt-4 mb-4 w-full sm:max-w-[320px]">
+                <Search className="text-muted-foreground absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+                <Input
+                  placeholder="Search"
+                  aria-label="Search contacts by name or address"
+                  className="bg-white pl-8 dark:bg-white/10"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+              </div>
+            )}
+
+            <div className="bg-card rounded-lg border p-4">
+              <TabsContent value="workspace">
+                {searchQuery && filteredAll.length === 0 ? (
+                  <p className="text-muted-foreground mb-2 text-sm">Found 0 results</p>
+                ) : (
+                  <SpaceAddressBookTable entries={filteredAll} />
+                )}
+              </TabsContent>
+
+              <TabsContent value="mine">
+                {searchQuery && filteredMine.length === 0 ? (
+                  <p className="text-muted-foreground mb-2 text-sm">Found 0 results</p>
+                ) : filteredMine.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">You haven&apos;t added any contacts yet.</p>
+                ) : (
+                  <SpaceAddressBookTable entries={filteredMine} />
+                )}
+              </TabsContent>
+
+              <TabsContent value="activity">
+                <ActivityLog entries={filteredAll} />
+              </TabsContent>
+            </div>
+          </Tabs>
         )}
-      </Stack>
-
-      {searchQuery && !filteredAddressBook.length && (
-        <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">
-          Found 0 results
-        </Typography>
-      )}
-
-      {addressBookItems.length === 0 ? (
-        <EmptyAddressBook />
-      ) : (
-        filteredAddressBook.length > 0 && <SpaceAddressBookTable entries={filteredAddressBook} />
-      )}
+      </div>
     </>
   )
 }


### PR DESCRIPTION
## What it solves

Redesigns the Spaces Address Book page (`/spaces/address-book`) from MUI to shadcn components, adds tabs for workspace/personal contacts and an activity log.

**Depends on:** safe-global/safe-client-gateway#3024

## How this PR fixes it

- Replaces MUI layout with shadcn Tabs, Table, Button, and Input components (wrapped in `shadcn-scope` for CSS isolation)
- **Workspace contacts** tab: all space address book entries
- **My contacts** tab: space contacts created by current user (matched via `useUsersGetWithWalletsV1Query` for multi-wallet/email auth support) + locally stored browser contacts with address book icon
- **Activity log** tab: timeline of contact additions/updates with actor, action, contact name, and timestamp (requires safe-global/safe-client-gateway#3024 for `createdAt`/`updatedAt` fields)
- New table columns: Name (bold), Address (highlight4bytes, 0.8em), Chains (scaled 85%), Added by (avatar + name)
- Client-side pagination (25 per page) with fixed column widths
- Import / Add contact trigger buttons migrated to shadcn; modal dialogs remain MUI unchanged
- Search bar below tabs filters per active tab, resets on tab switch, hidden on Activity log tab

**Files changed:**
- `SpaceAddressBook/index.tsx` — full rewrite with tabs, search, local contact merging
- `SpaceAddressBook/SpaceAddressBookTable.tsx` — shadcn Table with pagination and new columns
- `SpaceAddressBook/ActivityLog.tsx` — new Activity log timeline component
- `SpaceAddressBook/Import/index.tsx` — shadcn Button
- `SpaceAddressBook/AddContact.tsx` — shadcn trigger Button
- `hooks/useAllAddressBooks.ts` — updated local contact mapping

## How to test it

1. Navigate to `/spaces/address-book` in a space where you're an admin
2. Verify all three tabs render with correct counts
3. Search filters the active tab; switching tabs clears the search
4. "My contacts" shows your space contacts + local browser contacts (with address book icon)
5. "Added by" shows avatar + name for space contacts, current user for local contacts
6. Activity log shows timeline of additions/updates with correct timestamps (needs CGW with safe-global/safe-client-gateway#3024)
7. Import and Add Contact buttons open existing modals
8. Pagination appears when >25 contacts
9. Empty state (no contacts) shows card without tabs
10. Non-admin users don't see Import/Add buttons
11. Test in dark mode

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).