### PR TITLE
feat(mobile): add WalletConnect transaction execution support

### DIFF
--- a/apps/mobile/src/features/ConfirmTx/components/PendingTxInfo/PendingTxInfo.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/PendingTxInfo/PendingTxInfo.tsx
@@ -19,7 +19,7 @@ export const PendingTxInfo = ({ createdAt, pendingTx }: { createdAt: number | nu
         </View>
       )}
 
-      {pendingTx?.type === ExecutionMethod.WITH_PK && (
+      {(pendingTx?.type === ExecutionMethod.WITH_PK || pendingTx?.type === ExecutionMethod.WITH_WC) && (
         <View alignItems="center" flexDirection="row" justifyContent="space-between">
           <Text color="$textSecondaryLight">Transaction hash</Text>
           <HashDisplay value={pendingTx.txHash} showVisualIdentifier={false} />

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewAndExecuteContainer.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewAndExecuteContainer.tsx
@@ -18,6 +18,7 @@ import { selectActiveChain } from '@/src/store/chains'
 import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
 import { getExecutionMethod } from './helpers'
 import { parseFeeParams } from '@/src/utils/feeParams'
+import { useOptionalWalletConnectContext } from '@/src/features/WalletConnect/context/WalletConnectContext'
 import useGasFee from '../../hooks/useGasFee'
 import { useTransactionExecution } from '../../hooks/useTransactionExecution'
 import { useExecutionFunds } from '../../hooks/useExecutionFunds'
@@ -67,12 +68,16 @@ export function ReviewAndExecuteContainer() {
     [estimatedFeeParams],
   )
 
+  // WalletConnect provider
+  const wcContext = useOptionalWalletConnectContext()
+
   // Execution
   const { execute } = useTransactionExecution({
     txId: txId || '',
     executionMethod,
     signerAddress: activeSigner?.value || '',
     feeParams,
+    wcProvider: wcContext?.provider,
   })
 
   // Execution flow (state + handler)

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.tsx
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/ReviewExecuteFooter.tsx
@@ -12,6 +12,7 @@ import { getSubmitButtonText } from './helpers'
 import { Alert } from '@/src/components/Alert'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { Signer } from '@/src/store/signersSlice'
+import { WalletConnectGate } from '@/src/features/WalletConnect/components/WalletConnectGate'
 
 interface ReviewExecuteFooterProps {
   txId: string
@@ -47,6 +48,9 @@ export function ReviewExecuteFooter({
   const isButtonDisabled = !hasSufficientFunds || isExecuting
   const buttonText = isExecuting ? 'Executing...' : getSubmitButtonText(hasSufficientFunds)
 
+  const signerAddress = (activeSigner?.value ?? '') as Address
+  const wcSignerAddress = executionMethod === ExecutionMethod.WITH_WC ? signerAddress : ''
+
   return (
     <View paddingHorizontal="$4" gap="$3" paddingBottom={insets.bottom ? insets.bottom : '$4'}>
       <Container
@@ -56,7 +60,7 @@ export function ReviewExecuteFooter({
         paddingVertical={'$3'}
         borderColor="$borderLight"
       >
-        <SelectExecutor executionMethod={executionMethod} address={activeSigner?.value as Address} txId={txId} />
+        <SelectExecutor executionMethod={executionMethod} address={signerAddress} txId={txId} />
 
         <EstimatedNetworkFee
           executionMethod={executionMethod}
@@ -81,9 +85,11 @@ export function ReviewExecuteFooter({
           <SafeSkeleton height={44} width="100%" radius={12} />
         </SafeSkeleton.Group>
       ) : (
-        <SafeButton onPress={onConfirmPress} width="100%" disabled={isButtonDisabled} loading={isExecuting}>
-          {buttonText}
-        </SafeButton>
+        <WalletConnectGate signerAddress={wcSignerAddress}>
+          <SafeButton onPress={onConfirmPress} width="100%" disabled={isButtonDisabled} loading={isExecuting}>
+            {buttonText}
+          </SafeButton>
+        </WalletConnectGate>
       )}
     </View>
   )

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.test.ts
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.test.ts
@@ -35,6 +35,13 @@ const mockLedgerSigner: Signer = {
   derivationPath: "m/44'/60'/0'/0/0",
 }
 
+const mockWalletConnectSigner: Signer = {
+  value: '0x789',
+  name: 'WC Signer',
+  type: 'walletconnect',
+  walletName: 'MetaMask',
+}
+
 describe('helpers', () => {
   describe('getExecutionMethod', () => {
     it('should return WITH_RELAY when relay is requested and available', () => {
@@ -70,6 +77,21 @@ describe('helpers', () => {
     it('should fallback to WITH_LEDGER when relay not available and signer is Ledger', () => {
       const result = getExecutionMethod(ExecutionMethod.WITH_RELAY, false, mockChainWithRelay, mockLedgerSigner)
       expect(result).toBe(ExecutionMethod.WITH_LEDGER)
+    })
+
+    it('should return WITH_WC when signer is WalletConnect', () => {
+      const result = getExecutionMethod(ExecutionMethod.WITH_PK, true, mockChainWithRelay, mockWalletConnectSigner)
+      expect(result).toBe(ExecutionMethod.WITH_WC)
+    })
+
+    it('should return WITH_RELAY over WITH_WC when relay is requested and available', () => {
+      const result = getExecutionMethod(ExecutionMethod.WITH_RELAY, true, mockChainWithRelay, mockWalletConnectSigner)
+      expect(result).toBe(ExecutionMethod.WITH_RELAY)
+    })
+
+    it('should fallback to WITH_WC when relay not available and signer is WalletConnect', () => {
+      const result = getExecutionMethod(ExecutionMethod.WITH_RELAY, false, mockChainWithRelay, mockWalletConnectSigner)
+      expect(result).toBe(ExecutionMethod.WITH_WC)
     })
 
     it('should return WITH_PK when no signer is provided', () => {
@@ -148,6 +170,16 @@ describe('helpers', () => {
     it('should return "standard" when relay is selected with private key signer', () => {
       expect(determineExecutionPath(mockPrivateKeySigner, true, ExecutionMethod.WITH_RELAY)).toBe('standard')
       expect(determineExecutionPath(mockPrivateKeySigner, false, ExecutionMethod.WITH_RELAY)).toBe('standard')
+    })
+
+    it('should return "walletconnect" when signer is WalletConnect', () => {
+      expect(determineExecutionPath(mockWalletConnectSigner, true)).toBe('walletconnect')
+      expect(determineExecutionPath(mockWalletConnectSigner, false)).toBe('walletconnect')
+    })
+
+    it('should return "standard" when relay is selected with WalletConnect signer', () => {
+      expect(determineExecutionPath(mockWalletConnectSigner, true, ExecutionMethod.WITH_RELAY)).toBe('standard')
+      expect(determineExecutionPath(mockWalletConnectSigner, false, ExecutionMethod.WITH_RELAY)).toBe('standard')
     })
 
     it('should return "biometrics" when biometrics is not enabled', () => {

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.ts
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.ts
@@ -7,7 +7,7 @@ import { Signer } from '@/src/store/signersSlice'
 /**
  * Execution path types for the confirm flow
  */
-export type ExecutionPath = 'ledger' | 'biometrics' | 'standard'
+export type ExecutionPath = 'ledger' | 'walletconnect' | 'biometrics' | 'standard'
 
 /**
  * Determines the execution method based on user selection, relay availability, and signer type
@@ -27,6 +27,11 @@ export const getExecutionMethod = (
   // Ledger signer uses Ledger execution
   if (signer?.type === 'ledger') {
     return ExecutionMethod.WITH_LEDGER
+  }
+
+  // WalletConnect signer uses WC execution
+  if (signer?.type === 'walletconnect') {
+    return ExecutionMethod.WITH_WC
   }
 
   // Default to private key execution
@@ -73,6 +78,11 @@ export const determineExecutionPath = (
   // Ledger signer uses Ledger path (unless relay was selected above)
   if (activeSigner?.type === 'ledger') {
     return 'ledger'
+  }
+
+  // WalletConnect signer uses standard path (no local key, skip biometrics)
+  if (activeSigner?.type === 'walletconnect') {
+    return 'walletconnect'
   }
 
   if (!isBiometricsEnabled) {

--- a/apps/mobile/src/features/ExecuteTx/hooks/useExecutionFlow.test.ts
+++ b/apps/mobile/src/features/ExecuteTx/hooks/useExecutionFlow.test.ts
@@ -31,6 +31,13 @@ describe('useExecutionFlow', () => {
     derivationPath: "m/44'/60'/0'/0/0",
   }
 
+  const mockWalletConnectSigner: Signer = {
+    value: '0x789',
+    name: 'WC Signer',
+    type: 'walletconnect',
+    walletName: 'MetaMask',
+  }
+
   const mockFeeParams: FeeParams = {
     maxFeePerGas: BigInt('1000000000'),
     maxPriorityFeePerGas: BigInt('100000000'),
@@ -132,6 +139,50 @@ describe('useExecutionFlow', () => {
         }),
       })
       expect(mockExecute).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('WalletConnect flow', () => {
+    it('should execute directly without ledger or biometrics redirect', async () => {
+      const { result } = renderHook(() =>
+        useExecutionFlow({
+          ...defaultParams,
+          activeSigner: mockWalletConnectSigner,
+          executionMethod: ExecutionMethod.WITH_WC,
+        }),
+      )
+
+      await act(async () => {
+        await result.current.handleConfirmPress()
+      })
+
+      expect(mockExecute).toHaveBeenCalled()
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: '/execution-success',
+        params: { txId: 'tx123' },
+      })
+      expect(mockPush).not.toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: '/execute-transaction/ledger-connect' }),
+      )
+      expect(mockPush).not.toHaveBeenCalledWith(expect.objectContaining({ pathname: '/biometrics-opt-in' }))
+    })
+
+    it('should skip biometrics even when biometrics is not enabled', async () => {
+      const { result } = renderHook(() =>
+        useExecutionFlow({
+          ...defaultParams,
+          activeSigner: mockWalletConnectSigner,
+          executionMethod: ExecutionMethod.WITH_WC,
+          isBiometricsEnabled: false,
+        }),
+      )
+
+      await act(async () => {
+        await result.current.handleConfirmPress()
+      })
+
+      expect(mockExecute).toHaveBeenCalled()
+      expect(mockPush).not.toHaveBeenCalledWith(expect.objectContaining({ pathname: '/biometrics-opt-in' }))
     })
   })
 

--- a/apps/mobile/src/features/ExecuteTx/hooks/useExecutionFlow.ts
+++ b/apps/mobile/src/features/ExecuteTx/hooks/useExecutionFlow.ts
@@ -64,7 +64,7 @@ export const useExecutionFlow = ({
       return
     }
 
-    // Standard flow - execute directly
+    // WalletConnect and standard flow - execute directly
     try {
       setIsExecuting(true)
       await execute()

--- a/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.ts
+++ b/apps/mobile/src/features/ExecuteTx/hooks/useTransactionExecution.ts
@@ -13,7 +13,9 @@ import useSafeInfo from '@/src/hooks/useSafeInfo'
 import { executePrivateKeyTx } from '@/src/services/tx-execution/privateKeyExecutor'
 import { executeRelayTx } from '@/src/services/tx-execution/relayExecutor'
 import { executeLedgerTx } from '@/src/services/tx-execution/ledgerExecutor'
+import { executeWalletConnectTx } from '@/src/services/tx-execution/walletConnectExecutor'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
+import type { Provider } from '@reown/appkit-common-react-native'
 
 export enum ExecutionStatus {
   IDLE = 'idle',
@@ -28,6 +30,7 @@ interface UseTransactionExecutionProps {
   signerAddress: string
   feeParams: EstimatedFeeValues | null
   executionMethod: ExecutionMethod
+  wcProvider?: Provider
 }
 
 export function useTransactionExecution({
@@ -35,6 +38,7 @@ export function useTransactionExecution({
   signerAddress,
   executionMethod,
   feeParams,
+  wcProvider,
 }: UseTransactionExecutionProps) {
   const [status, setStatus] = useState<ExecutionStatus>(ExecutionStatus.IDLE)
   const dispatch = useAppDispatch()
@@ -75,6 +79,18 @@ export function useTransactionExecution({
         feeParams,
       })
     },
+    [ExecutionMethod.WITH_WC]: async () => {
+      if (!wcProvider) {
+        throw new Error('WalletConnect provider not available')
+      }
+      return await executeWalletConnectTx({
+        chain: activeChain,
+        activeSafe,
+        txId,
+        signerAddress,
+        provider: wcProvider,
+      })
+    },
   }
 
   const execute = useCallback(async () => {
@@ -101,7 +117,18 @@ export function useTransactionExecution({
 
       throw error
     }
-  }, [executionMethod, activeChain, activeSafe, safe, txId, signerAddress, feeParams, relayMutation, dispatch])
+  }, [
+    executionMethod,
+    activeChain,
+    activeSafe,
+    safe,
+    txId,
+    signerAddress,
+    feeParams,
+    relayMutation,
+    wcProvider,
+    dispatch,
+  ])
 
   const retry = useCallback(() => {
     execute()

--- a/apps/mobile/src/features/HowToExecuteSheet/HowToExecuteSheet.container.tsx
+++ b/apps/mobile/src/features/HowToExecuteSheet/HowToExecuteSheet.container.tsx
@@ -51,6 +51,16 @@ const getActiveSignerRightNode = (
   )
 }
 
+const getSignerExecutionMethod = (signer: SignerInfo): ExecutionMethod => {
+  if (signer.type === 'ledger') {
+    return ExecutionMethod.WITH_LEDGER
+  }
+  if (signer.type === 'walletconnect') {
+    return ExecutionMethod.WITH_WC
+  }
+  return ExecutionMethod.WITH_PK
+}
+
 export const HowToExecuteSheetContainer = () => {
   const router = useRouter()
   const dispatch = useAppDispatch()
@@ -133,20 +143,19 @@ export const HowToExecuteSheetContainer = () => {
           {/* Signers List */}
           <View gap="$2">
             {items.map((item) => {
+              const signerMethod = getSignerExecutionMethod(item)
+              const isSelected = executionMethod === signerMethod && activeSigner?.value === item.value
+
               return (
                 <View
                   key={item.value}
                   width="100%"
                   borderRadius={'$4'}
-                  backgroundColor={
-                    executionMethod === ExecutionMethod.WITH_PK && activeSigner?.value === item.value
-                      ? '$backgroundSecondary'
-                      : 'transparent'
-                  }
+                  backgroundColor={isSelected ? '$backgroundSecondary' : 'transparent'}
                 >
                   <SignersCard
                     transparent
-                    onPress={() => handleExecutionMethodSelect(ExecutionMethod.WITH_PK, item)}
+                    onPress={() => handleExecutionMethodSelect(signerMethod, item)}
                     name={<ContactDisplayNameContainer address={item.value as Address} />}
                     address={item.value as Address}
                     balance={`${item.balance ? formatVisualAmount(item.balance, activeChain.nativeCurrency.decimals) : '0'} ${

--- a/apps/mobile/src/features/HowToExecuteSheet/types.ts
+++ b/apps/mobile/src/features/HowToExecuteSheet/types.ts
@@ -2,4 +2,5 @@ export enum ExecutionMethod {
   WITH_RELAY = 'with_relay',
   WITH_PK = 'with_pk',
   WITH_LEDGER = 'with_ledger',
+  WITH_WC = 'with_wc',
 }

--- a/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.tsx
+++ b/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
-import { AppKit, AppKitProvider, useAccount, useAppKit, useWalletInfo } from '@reown/appkit-react-native'
+import { AppKit, AppKitProvider, useAccount, useAppKit, useProvider, useWalletInfo } from '@reown/appkit-react-native'
+import type { Provider } from '@reown/appkit-common-react-native'
 import { Platform } from 'react-native'
 import { FullWindowOverlay } from 'react-native-screens'
 import { useAppSelector } from '@/src/store/hooks'
@@ -15,6 +16,7 @@ interface WalletConnectContextValue
     Pick<ReturnType<typeof useReconnectFlow>, 'reconnect'>,
     Pick<ReturnType<typeof useSwitchNetwork>, 'switchNetwork' | 'switchNetworkIfNeeded' | 'isWrongNetwork'>,
     Pick<ReturnType<typeof useWalletConnectSigning>, 'sign' | 'hasProvider'> {
+  provider: Provider | undefined
   isWalletConnectSigner: (address: string) => boolean
   isConnected: ReturnType<typeof useAccount>['isConnected']
   address: ReturnType<typeof useAccount>['address']
@@ -53,6 +55,7 @@ function WalletConnectContextBridge({ onContextReady }: { onContextReady: (v: Wa
   const { reconnect } = useReconnectFlow()
   const { switchNetwork, switchNetworkIfNeeded, isWrongNetwork } = useSwitchNetwork()
   const { sign, hasProvider } = useWalletConnectSigning()
+  const { provider } = useProvider()
   useChainSync()
   const appKitHook = useAppKit()
   const { address, chainId, isConnected } = useAccount()
@@ -85,6 +88,7 @@ function WalletConnectContextBridge({ onContextReady }: { onContextReady: (v: Wa
       isWrongNetwork,
       sign,
       hasProvider,
+      provider,
       address,
       chainId,
       walletInfo,
@@ -101,6 +105,7 @@ function WalletConnectContextBridge({ onContextReady }: { onContextReady: (v: Wa
       isWrongNetwork,
       sign,
       hasProvider,
+      provider,
       address,
       chainId,
       walletInfo,

--- a/apps/mobile/src/features/WalletConnect/context/__tests__/WalletConnectContext.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/context/__tests__/WalletConnectContext.test.tsx
@@ -57,6 +57,7 @@ jest.mock('@reown/appkit-react-native', () => ({
   useAppKit: () => mockAppKit,
   useAccount: () => mockAccount,
   useWalletInfo: () => mockWalletInfoResult,
+  useProvider: () => ({ provider: undefined }),
 }))
 
 const mockInstance = {} as NonNullable<React.ComponentProps<typeof WalletConnectProvider>['instance']>

--- a/apps/mobile/src/services/tx-execution/walletConnectExecutor.test.ts
+++ b/apps/mobile/src/services/tx-execution/walletConnectExecutor.test.ts
@@ -1,6 +1,6 @@
 import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
 import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
-import type { SafeInfo } from '@/src/types/address'
+import type { Address, SafeInfo } from '@/src/types/address'
 import type { Provider } from '@reown/appkit-common-react-native'
 
 const mockFetchTransactionDetails = jest.fn()
@@ -45,20 +45,23 @@ jest.mock('@/src/utils/logger', () => ({
 import { executeWalletConnectTx } from './walletConnectExecutor'
 import { faker } from '@faker-js/faker'
 
+const fakeAddress = () => faker.finance.ethereumAddress() as Address
+
 const VALID_TX_HASH = faker.string.hexadecimal({ length: 64, prefix: '0x' })
 
+const safeAddress = fakeAddress()
 const mockChain = { chainId: '1' } as Chain
-const mockActiveSafe: SafeInfo = { address: '0xSafe', chainId: '1' }
+const mockActiveSafe: SafeInfo = { address: safeAddress, chainId: '1' }
 
 const createMockProvider = (txHash = VALID_TX_HASH): Provider =>
   ({
     request: jest.fn().mockResolvedValue(txHash),
   }) as unknown as Provider
 
-const createMockSDK = (threshold = 1, owners = ['0xSigner'], approvedOwners: string[] = []) => ({
+const createMockSDK = (threshold = 1, owners = [fakeAddress()], approvedOwners: string[] = []) => ({
   getThreshold: jest.fn().mockResolvedValue(threshold),
   getOwners: jest.fn().mockResolvedValue(owners),
-  getTransactionHash: jest.fn().mockResolvedValue('0xTxHash'),
+  getTransactionHash: jest.fn().mockResolvedValue(faker.string.hexadecimal({ length: 64, prefix: '0x' })),
   getOwnersWhoApprovedTx: jest.fn().mockResolvedValue(approvedOwners),
   getEncodedTransaction: jest.fn().mockResolvedValue('0xEncodedData'),
 })
@@ -78,19 +81,22 @@ const createMockSafeTx = (existingSignatures: string[] = []) => {
 }
 
 describe('executeWalletConnectTx', () => {
+  const signerAddress = fakeAddress()
+  const otherSigner = fakeAddress()
+
   beforeEach(() => {
     jest.clearAllMocks()
     mockExtractTxInfo.mockReturnValue({
-      txParams: { to: '0xTo', value: '0', data: '0x' },
-      signatures: { '0xOtherSigner': '0xSig' },
+      txParams: { to: fakeAddress(), value: '0', data: '0x' },
+      signatures: { [otherSigner]: '0xSig' },
     })
     mockGetUserNonce.mockResolvedValue(5)
   })
 
   it('should execute a transaction via WalletConnect provider', async () => {
     const mockProvider = createMockProvider()
-    const mockSDK = createMockSDK()
-    const mockSafeTx = createMockSafeTx(['0xOtherSigner'])
+    const mockSDK = createMockSDK(1, [signerAddress])
+    const mockSafeTx = createMockSafeTx([otherSigner])
 
     mockGetSafeSDK.mockReturnValue(mockSDK)
     mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
@@ -100,7 +106,7 @@ describe('executeWalletConnectTx', () => {
       chain: mockChain,
       activeSafe: mockActiveSafe,
       txId: 'tx123',
-      signerAddress: '0xSigner',
+      signerAddress,
       provider: mockProvider,
     })
 
@@ -108,8 +114,8 @@ describe('executeWalletConnectTx', () => {
       method: 'eth_sendTransaction',
       params: [
         {
-          from: '0xSigner',
-          to: '0xSafe',
+          from: signerAddress,
+          to: safeAddress,
           data: '0xEncodedData',
         },
       ],
@@ -119,9 +125,9 @@ describe('executeWalletConnectTx', () => {
       type: ExecutionMethod.WITH_WC,
       txId: 'tx123',
       chainId: '1',
-      safeAddress: '0xSafe',
+      safeAddress,
       txHash: VALID_TX_HASH,
-      walletAddress: '0xSigner',
+      walletAddress: signerAddress,
       walletNonce: 5,
     })
   })
@@ -134,7 +140,7 @@ describe('executeWalletConnectTx', () => {
         chain: mockChain,
         activeSafe: mockActiveSafe,
         txId: 'tx123',
-        signerAddress: '0xSigner',
+        signerAddress,
         provider: createMockProvider(),
       }),
     ).rejects.toThrow('Safe SDK not initialized')
@@ -142,8 +148,7 @@ describe('executeWalletConnectTx', () => {
 
   it('should not add duplicate pre-validated signature when signer already approved on-chain', async () => {
     const mockProvider = createMockProvider()
-    // Signer has already approved on-chain (returned by getOwnersWhoApprovedTx)
-    const mockSDK = createMockSDK(1, ['0xSigner'], ['0xSigner'])
+    const mockSDK = createMockSDK(1, [signerAddress], [signerAddress])
     const mockSafeTx = createMockSafeTx()
 
     mockGetSafeSDK.mockReturnValue(mockSDK)
@@ -154,7 +159,7 @@ describe('executeWalletConnectTx', () => {
       chain: mockChain,
       activeSafe: mockActiveSafe,
       txId: 'tx123',
-      signerAddress: '0xSigner',
+      signerAddress,
       provider: mockProvider,
     })
 
@@ -163,7 +168,7 @@ describe('executeWalletConnectTx', () => {
   })
 
   it('should throw when threshold is not met', async () => {
-    const mockSDK = createMockSDK(3, ['0xSigner'], [])
+    const mockSDK = createMockSDK(3, [signerAddress], [])
     const mockSafeTx = createMockSafeTx()
 
     mockGetSafeSDK.mockReturnValue(mockSDK)
@@ -175,7 +180,7 @@ describe('executeWalletConnectTx', () => {
         chain: mockChain,
         activeSafe: mockActiveSafe,
         txId: 'tx123',
-        signerAddress: '0xSigner',
+        signerAddress,
         provider: createMockProvider(),
       }),
     ).rejects.toThrow('signature')
@@ -195,8 +200,8 @@ describe('executeWalletConnectTx', () => {
       return Promise.resolve(5)
     })
 
-    const mockSDK = createMockSDK()
-    const mockSafeTx = createMockSafeTx(['0xOtherSigner'])
+    const mockSDK = createMockSDK(1, [signerAddress])
+    const mockSafeTx = createMockSafeTx([otherSigner])
 
     mockGetSafeSDK.mockReturnValue(mockSDK)
     mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
@@ -206,7 +211,7 @@ describe('executeWalletConnectTx', () => {
       chain: mockChain,
       activeSafe: mockActiveSafe,
       txId: 'tx123',
-      signerAddress: '0xSigner',
+      signerAddress,
       provider: mockProvider,
     })
 
@@ -225,8 +230,8 @@ describe('executeWalletConnectTx', () => {
       request: jest.fn().mockResolvedValue(invalidHash),
     } as unknown as Provider
 
-    const mockSDK = createMockSDK()
-    const mockSafeTx = createMockSafeTx(['0xOtherSigner'])
+    const mockSDK = createMockSDK(1, [signerAddress])
+    const mockSafeTx = createMockSafeTx([otherSigner])
 
     mockGetSafeSDK.mockReturnValue(mockSDK)
     mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
@@ -237,7 +242,7 @@ describe('executeWalletConnectTx', () => {
         chain: mockChain,
         activeSafe: mockActiveSafe,
         txId: 'tx123',
-        signerAddress: '0xSigner',
+        signerAddress,
         provider: mockProvider,
       }),
     ).rejects.toThrow('invalid transaction hash')
@@ -248,8 +253,8 @@ describe('executeWalletConnectTx', () => {
       request: jest.fn().mockRejectedValue(new Error('User rejected')),
     } as unknown as Provider
 
-    const mockSDK = createMockSDK()
-    const mockSafeTx = createMockSafeTx(['0xOtherSigner'])
+    const mockSDK = createMockSDK(1, [signerAddress])
+    const mockSafeTx = createMockSafeTx([otherSigner])
 
     mockGetSafeSDK.mockReturnValue(mockSDK)
     mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
@@ -260,9 +265,190 @@ describe('executeWalletConnectTx', () => {
         chain: mockChain,
         activeSafe: mockActiveSafe,
         txId: 'tx123',
-        signerAddress: '0xSigner',
+        signerAddress,
         provider: mockProvider,
       }),
     ).rejects.toThrow('User rejected')
+  })
+
+  it('should add pre-validated signatures for on-chain approvers', async () => {
+    const owner1 = fakeAddress()
+    const owner2 = fakeAddress()
+    const mockProvider = createMockProvider()
+    const mockSDK = createMockSDK(2, [owner1, owner2], [owner1])
+    const mockSafeTx = createMockSafeTx([owner2])
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await executeWalletConnectTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: 'tx123',
+      signerAddress: owner2,
+      provider: mockProvider,
+    })
+
+    expect(mockSafeTx.addSignature).toHaveBeenCalledWith(expect.objectContaining({ signer: owner1 }))
+    expect(mockSafeTx.signatures.size).toBe(2)
+  })
+
+  it('should add pre-validated signatures for multiple on-chain approvers', async () => {
+    const ownerA = fakeAddress()
+    const ownerB = fakeAddress()
+    const ownerC = fakeAddress()
+    const mockProvider = createMockProvider()
+    const mockSDK = createMockSDK(3, [ownerA, ownerB, ownerC], [ownerA, ownerB])
+    const mockSafeTx = createMockSafeTx()
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await executeWalletConnectTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: 'tx123',
+      signerAddress: ownerC,
+      provider: mockProvider,
+    })
+
+    // 2 on-chain approvers + 1 executor
+    expect(mockSafeTx.signatures.size).toBe(3)
+  })
+
+  it('should match signer address case-insensitively', async () => {
+    const upperCaseOwner = fakeAddress().toUpperCase().replace('0X', '0x') as Address
+    const lowerCaseSigner = upperCaseOwner.toLowerCase() as Address
+    const mockProvider = createMockProvider()
+    const mockSDK = createMockSDK(1, [upperCaseOwner], [])
+    const mockSafeTx = createMockSafeTx()
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await executeWalletConnectTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: 'tx123',
+      signerAddress: lowerCaseSigner,
+      provider: mockProvider,
+    })
+
+    expect(mockSafeTx.addSignature).toHaveBeenCalledWith(expect.objectContaining({ signer: lowerCaseSigner }))
+  })
+
+  it('should not add pre-validated signature for non-owner executor', async () => {
+    const owner = fakeAddress()
+    const nonOwner = fakeAddress()
+    const mockProvider = createMockProvider()
+    // threshold=1, one existing signature meets it, executor is not an owner
+    const mockSDK = createMockSDK(1, [owner], [])
+    const mockSafeTx = createMockSafeTx([owner])
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await executeWalletConnectTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: 'tx123',
+      signerAddress: nonOwner,
+      provider: mockProvider,
+    })
+
+    expect(mockSafeTx.addSignature).not.toHaveBeenCalled()
+  })
+
+  it('should not add executor signature when threshold already met', async () => {
+    const owner1 = fakeAddress()
+    const owner2 = fakeAddress()
+    const mockProvider = createMockProvider()
+    const mockSDK = createMockSDK(2, [owner1, owner2], [])
+    const mockSafeTx = createMockSafeTx([owner1, owner2])
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await executeWalletConnectTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: 'tx123',
+      signerAddress: owner1,
+      provider: mockProvider,
+    })
+
+    expect(mockSafeTx.addSignature).not.toHaveBeenCalled()
+  })
+
+  it('should use singular form when 1 signature is missing', async () => {
+    const owner = fakeAddress()
+    const mockSDK = createMockSDK(2, [owner], [])
+    const mockSafeTx = createMockSafeTx()
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await expect(
+      executeWalletConnectTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: 'tx123',
+        signerAddress: owner,
+        provider: createMockProvider(),
+      }),
+    ).rejects.toThrow('1 more signature')
+  })
+
+  it('should use plural form when multiple signatures are missing', async () => {
+    const owner = fakeAddress()
+    const mockSDK = createMockSDK(3, [owner], [])
+    const mockSafeTx = createMockSafeTx()
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await expect(
+      executeWalletConnectTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: 'tx123',
+        signerAddress: owner,
+        provider: createMockProvider(),
+      }),
+    ).rejects.toThrow('2 more signatures')
+  })
+
+  it('should pass correct arguments to dependencies', async () => {
+    const mockProvider = createMockProvider()
+    const mockSDK = createMockSDK(1, [signerAddress])
+    const mockSafeTx = createMockSafeTx([otherSigner])
+    const txDetails = { detailedExecutionInfo: { type: 'MULTISIG' } }
+    const txParams = { to: fakeAddress(), value: '0', data: '0x' }
+    const signatures = { [otherSigner]: '0xSig' }
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue(txDetails)
+    mockExtractTxInfo.mockReturnValue({ txParams, signatures })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await executeWalletConnectTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: 'tx123',
+      signerAddress,
+      provider: mockProvider,
+    })
+
+    expect(mockFetchTransactionDetails).toHaveBeenCalledWith('1', 'tx123')
+    expect(mockExtractTxInfo).toHaveBeenCalledWith(txDetails, safeAddress)
+    expect(mockCreateExistingTx).toHaveBeenCalledWith(txParams, signatures)
+    expect(mockGetUserNonce).toHaveBeenCalledWith(mockChain, signerAddress)
   })
 })

--- a/apps/mobile/src/services/tx-execution/walletConnectExecutor.test.ts
+++ b/apps/mobile/src/services/tx-execution/walletConnectExecutor.test.ts
@@ -43,11 +43,14 @@ jest.mock('@/src/utils/logger', () => ({
 }))
 
 import { executeWalletConnectTx } from './walletConnectExecutor'
+import { faker } from '@faker-js/faker'
+
+const VALID_TX_HASH = faker.string.hexadecimal({ length: 64, prefix: '0x' })
 
 const mockChain = { chainId: '1' } as Chain
 const mockActiveSafe: SafeInfo = { address: '0xSafe', chainId: '1' }
 
-const createMockProvider = (txHash = '0xTxHash'): Provider =>
+const createMockProvider = (txHash = VALID_TX_HASH): Provider =>
   ({
     request: jest.fn().mockResolvedValue(txHash),
   }) as unknown as Provider
@@ -117,7 +120,7 @@ describe('executeWalletConnectTx', () => {
       txId: 'tx123',
       chainId: '1',
       safeAddress: '0xSafe',
-      txHash: '0xTxHash',
+      txHash: VALID_TX_HASH,
       walletAddress: '0xSigner',
       walletNonce: 5,
     })
@@ -161,7 +164,7 @@ describe('executeWalletConnectTx', () => {
     const mockProvider = {
       request: jest.fn().mockImplementation(() => {
         callOrder.push('provider.request')
-        return Promise.resolve('0xTxHash')
+        return Promise.resolve(VALID_TX_HASH)
       }),
     } as unknown as Provider
 
@@ -186,6 +189,36 @@ describe('executeWalletConnectTx', () => {
     })
 
     expect(callOrder).toEqual(['getUserNonce', 'provider.request'])
+  })
+
+  it.each([
+    null,
+    undefined,
+    '',
+    'not-a-hash',
+    '0x123',
+    '0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+  ])('should throw when provider returns invalid tx hash: %s', async (invalidHash) => {
+    const mockProvider = {
+      request: jest.fn().mockResolvedValue(invalidHash),
+    } as unknown as Provider
+
+    const mockSDK = createMockSDK()
+    const mockSafeTx = createMockSafeTx(['0xOtherSigner'])
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await expect(
+      executeWalletConnectTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: 'tx123',
+        signerAddress: '0xSigner',
+        provider: mockProvider,
+      }),
+    ).rejects.toThrow('invalid transaction hash')
   })
 
   it('should handle provider rejection', async () => {

--- a/apps/mobile/src/services/tx-execution/walletConnectExecutor.test.ts
+++ b/apps/mobile/src/services/tx-execution/walletConnectExecutor.test.ts
@@ -140,6 +140,28 @@ describe('executeWalletConnectTx', () => {
     ).rejects.toThrow('Safe SDK not initialized')
   })
 
+  it('should not add duplicate pre-validated signature when signer already approved on-chain', async () => {
+    const mockProvider = createMockProvider()
+    // Signer has already approved on-chain (returned by getOwnersWhoApprovedTx)
+    const mockSDK = createMockSDK(1, ['0xSigner'], ['0xSigner'])
+    const mockSafeTx = createMockSafeTx()
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await executeWalletConnectTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: 'tx123',
+      signerAddress: '0xSigner',
+      provider: mockProvider,
+    })
+
+    // addSignature should be called once (from ownersWhoApprovedTx), not twice
+    expect(mockSafeTx.addSignature).toHaveBeenCalledTimes(1)
+  })
+
   it('should throw when threshold is not met', async () => {
     const mockSDK = createMockSDK(3, ['0xSigner'], [])
     const mockSafeTx = createMockSafeTx()

--- a/apps/mobile/src/services/tx-execution/walletConnectExecutor.test.ts
+++ b/apps/mobile/src/services/tx-execution/walletConnectExecutor.test.ts
@@ -1,0 +1,213 @@
+import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeInfo } from '@/src/types/address'
+import type { Provider } from '@reown/appkit-common-react-native'
+
+const mockFetchTransactionDetails = jest.fn()
+const mockExtractTxInfo = jest.fn()
+const mockCreateExistingTx = jest.fn()
+const mockGetSafeSDK = jest.fn()
+const mockGetUserNonce = jest.fn()
+
+jest.mock('@/src/services/tx/fetchTransactionDetails', () => ({
+  fetchTransactionDetails: (...args: unknown[]) => mockFetchTransactionDetails(...args),
+}))
+jest.mock('@/src/services/tx/extractTx', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockExtractTxInfo(...args),
+}))
+jest.mock('@/src/services/tx/tx-sender/create', () => ({
+  createExistingTx: (...args: unknown[]) => mockCreateExistingTx(...args),
+}))
+jest.mock('@/src/hooks/coreSDK/safeCoreSDK', () => ({
+  getSafeSDK: () => mockGetSafeSDK(),
+}))
+jest.mock('@/src/services/web3', () => ({
+  getUserNonce: (...args: unknown[]) => mockGetUserNonce(...args),
+}))
+jest.mock('@safe-global/protocol-kit/dist/src/utils', () => ({
+  generatePreValidatedSignature: (address: string) => ({
+    signer: address,
+    data: `pre-validated-${address}`,
+    staticPart: () => `pre-validated-${address}`,
+    dynamicPart: () => '',
+    isContractSignature: false,
+  }),
+}))
+jest.mock('@safe-global/utils/utils/addresses', () => ({
+  sameAddress: (a: string, b: string) => a.toLowerCase() === b.toLowerCase(),
+}))
+jest.mock('@/src/utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+}))
+
+import { executeWalletConnectTx } from './walletConnectExecutor'
+
+const mockChain = { chainId: '1' } as Chain
+const mockActiveSafe: SafeInfo = { address: '0xSafe', chainId: '1' }
+
+const createMockProvider = (txHash = '0xTxHash'): Provider =>
+  ({
+    request: jest.fn().mockResolvedValue(txHash),
+  }) as unknown as Provider
+
+const createMockSDK = (threshold = 1, owners = ['0xSigner'], approvedOwners: string[] = []) => ({
+  getThreshold: jest.fn().mockResolvedValue(threshold),
+  getOwners: jest.fn().mockResolvedValue(owners),
+  getTransactionHash: jest.fn().mockResolvedValue('0xTxHash'),
+  getOwnersWhoApprovedTx: jest.fn().mockResolvedValue(approvedOwners),
+  getEncodedTransaction: jest.fn().mockResolvedValue('0xEncodedData'),
+})
+
+const createMockSafeTx = (existingSignatures: string[] = []) => {
+  const signatures = new Map<string, unknown>()
+  existingSignatures.forEach((addr) => {
+    signatures.set(addr.toLowerCase(), { signer: addr })
+  })
+  return {
+    data: {},
+    signatures,
+    addSignature: jest.fn((sig: { signer: string }) => {
+      signatures.set(sig.signer.toLowerCase(), sig)
+    }),
+  }
+}
+
+describe('executeWalletConnectTx', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockExtractTxInfo.mockReturnValue({
+      txParams: { to: '0xTo', value: '0', data: '0x' },
+      signatures: { '0xOtherSigner': '0xSig' },
+    })
+    mockGetUserNonce.mockResolvedValue(5)
+  })
+
+  it('should execute a transaction via WalletConnect provider', async () => {
+    const mockProvider = createMockProvider()
+    const mockSDK = createMockSDK()
+    const mockSafeTx = createMockSafeTx(['0xOtherSigner'])
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    const result = await executeWalletConnectTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: 'tx123',
+      signerAddress: '0xSigner',
+      provider: mockProvider,
+    })
+
+    expect(mockProvider.request).toHaveBeenCalledWith({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from: '0xSigner',
+          to: '0xSafe',
+          data: '0xEncodedData',
+        },
+      ],
+    })
+
+    expect(result).toEqual({
+      type: ExecutionMethod.WITH_WC,
+      txId: 'tx123',
+      chainId: '1',
+      safeAddress: '0xSafe',
+      txHash: '0xTxHash',
+      walletAddress: '0xSigner',
+      walletNonce: 5,
+    })
+  })
+
+  it('should throw when Safe SDK is not initialized', async () => {
+    mockGetSafeSDK.mockReturnValue(null)
+
+    await expect(
+      executeWalletConnectTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: 'tx123',
+        signerAddress: '0xSigner',
+        provider: createMockProvider(),
+      }),
+    ).rejects.toThrow('Safe SDK not initialized')
+  })
+
+  it('should throw when threshold is not met', async () => {
+    const mockSDK = createMockSDK(3, ['0xSigner'], [])
+    const mockSafeTx = createMockSafeTx()
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await expect(
+      executeWalletConnectTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: 'tx123',
+        signerAddress: '0xSigner',
+        provider: createMockProvider(),
+      }),
+    ).rejects.toThrow('signature')
+  })
+
+  it('should fetch wallet nonce before sending the transaction', async () => {
+    const callOrder: string[] = []
+    const mockProvider = {
+      request: jest.fn().mockImplementation(() => {
+        callOrder.push('provider.request')
+        return Promise.resolve('0xTxHash')
+      }),
+    } as unknown as Provider
+
+    mockGetUserNonce.mockImplementation(() => {
+      callOrder.push('getUserNonce')
+      return Promise.resolve(5)
+    })
+
+    const mockSDK = createMockSDK()
+    const mockSafeTx = createMockSafeTx(['0xOtherSigner'])
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await executeWalletConnectTx({
+      chain: mockChain,
+      activeSafe: mockActiveSafe,
+      txId: 'tx123',
+      signerAddress: '0xSigner',
+      provider: mockProvider,
+    })
+
+    expect(callOrder).toEqual(['getUserNonce', 'provider.request'])
+  })
+
+  it('should handle provider rejection', async () => {
+    const mockProvider = {
+      request: jest.fn().mockRejectedValue(new Error('User rejected')),
+    } as unknown as Provider
+
+    const mockSDK = createMockSDK()
+    const mockSafeTx = createMockSafeTx(['0xOtherSigner'])
+
+    mockGetSafeSDK.mockReturnValue(mockSDK)
+    mockFetchTransactionDetails.mockResolvedValue({ detailedExecutionInfo: {} })
+    mockCreateExistingTx.mockResolvedValue(mockSafeTx)
+
+    await expect(
+      executeWalletConnectTx({
+        chain: mockChain,
+        activeSafe: mockActiveSafe,
+        txId: 'tx123',
+        signerAddress: '0xSigner',
+        provider: mockProvider,
+      }),
+    ).rejects.toThrow('User rejected')
+  })
+})

--- a/apps/mobile/src/services/tx-execution/walletConnectExecutor.ts
+++ b/apps/mobile/src/services/tx-execution/walletConnectExecutor.ts
@@ -12,6 +12,8 @@ import type { SafeInfo } from '@/src/types/address'
 import type { Provider } from '@reown/appkit-common-react-native'
 import { maybePlural } from '@safe-global/utils/utils/formatters'
 
+const TX_HASH_REGEX = /^0x[0-9a-fA-F]{64}$/
+
 interface ExecuteWalletConnectTxParams {
   chain: Chain
   activeSafe: SafeInfo
@@ -91,6 +93,10 @@ export const executeWalletConnectTx = async ({
       },
     ],
   })
+
+  if (!txHashResult || !TX_HASH_REGEX.test(txHashResult)) {
+    throw new Error(`WalletConnect returned an invalid transaction hash: ${txHashResult}`)
+  }
 
   logger.info('Transaction executed via WalletConnect', {
     signerAddress,

--- a/apps/mobile/src/services/tx-execution/walletConnectExecutor.ts
+++ b/apps/mobile/src/services/tx-execution/walletConnectExecutor.ts
@@ -62,7 +62,7 @@ export const executeWalletConnectTx = async ({
 
   // If executor is an owner and we still need signatures, add pre-validated
   const isOwner = owners.some((o) => sameAddress(o, signerAddress))
-  if (threshold > safeTx.signatures.size && isOwner) {
+  if (threshold > safeTx.signatures.size && isOwner && !safeTx.signatures.has(signerAddress.toLowerCase())) {
     safeTx.addSignature(generatePreValidatedSignature(signerAddress))
   }
 

--- a/apps/mobile/src/services/tx-execution/walletConnectExecutor.ts
+++ b/apps/mobile/src/services/tx-execution/walletConnectExecutor.ts
@@ -68,7 +68,7 @@ export const executeWalletConnectTx = async ({
 
   if (threshold > safeTx.signatures.size) {
     const missing = threshold - safeTx.signatures.size
-    throw new Error(`There ${missing > 1 ? 'are' : 'is'} ${missing} signature${maybePlural(missing)} missing`)
+    throw new Error(`Transaction requires ${missing} more signature${maybePlural(missing)}`)
   }
 
   const encodedTx = await sdk.getEncodedTransaction(safeTx)

--- a/apps/mobile/src/services/tx-execution/walletConnectExecutor.ts
+++ b/apps/mobile/src/services/tx-execution/walletConnectExecutor.ts
@@ -1,0 +1,110 @@
+import { getUserNonce } from '@/src/services/web3'
+import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
+import { getSafeSDK } from '@/src/hooks/coreSDK/safeCoreSDK'
+import { fetchTransactionDetails } from '@/src/services/tx/fetchTransactionDetails'
+import extractTxInfo from '@/src/services/tx/extractTx'
+import { createExistingTx } from '@/src/services/tx/tx-sender/create'
+import { generatePreValidatedSignature } from '@safe-global/protocol-kit/dist/src/utils'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import logger from '@/src/utils/logger'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeInfo } from '@/src/types/address'
+import type { Provider } from '@reown/appkit-common-react-native'
+import { maybePlural } from '@safe-global/utils/utils/formatters'
+
+interface ExecuteWalletConnectTxParams {
+  chain: Chain
+  activeSafe: SafeInfo
+  txId: string
+  signerAddress: string
+  provider: Provider
+}
+
+interface ExecuteWalletConnectTxResult {
+  type: ExecutionMethod.WITH_WC
+  txId: string
+  chainId: string
+  safeAddress: string
+  txHash: string
+  walletAddress: string
+  walletNonce: number
+}
+
+export const executeWalletConnectTx = async ({
+  chain,
+  activeSafe,
+  txId,
+  signerAddress,
+  provider,
+}: ExecuteWalletConnectTxParams): Promise<ExecuteWalletConnectTxResult> => {
+  const sdk = getSafeSDK()
+  if (!sdk) {
+    throw new Error('Safe SDK not initialized')
+  }
+
+  const txDetails = await fetchTransactionDetails(activeSafe.chainId, txId)
+  const { txParams, signatures } = extractTxInfo(txDetails, activeSafe.address)
+  const safeTx = await createExistingTx(txParams, signatures)
+
+  // Add pre-validated signatures for owners who have approved on-chain
+  const threshold = await sdk.getThreshold()
+  const owners = await sdk.getOwners()
+  const txHash = await sdk.getTransactionHash(safeTx)
+  const ownersWhoApprovedTx = await sdk.getOwnersWhoApprovedTx(txHash)
+
+  for (const owner of ownersWhoApprovedTx) {
+    if (!safeTx.signatures.has(owner.toLowerCase())) {
+      safeTx.addSignature(generatePreValidatedSignature(owner))
+    }
+  }
+
+  // If executor is an owner and we still need signatures, add pre-validated
+  const isOwner = owners.some((o) => sameAddress(o, signerAddress))
+  if (threshold > safeTx.signatures.size && isOwner) {
+    safeTx.addSignature(generatePreValidatedSignature(signerAddress))
+  }
+
+  if (threshold > safeTx.signatures.size) {
+    const missing = threshold - safeTx.signatures.size
+    throw new Error(`There ${missing > 1 ? 'are' : 'is'} ${missing} signature${maybePlural(missing)} missing`)
+  }
+
+  const encodedTx = await sdk.getEncodedTransaction(safeTx)
+
+  // Fetch nonce before sending to capture the pre-tx nonce for the pending tx watcher
+  const walletNonce = await getUserNonce(chain, signerAddress)
+
+  logger.info('Sending execution via WalletConnect', {
+    signerAddress,
+    txId,
+    threshold,
+    signaturesCount: safeTx.signatures.size,
+  })
+
+  const txHashResult = await provider.request<string>({
+    method: 'eth_sendTransaction',
+    params: [
+      {
+        from: signerAddress,
+        to: activeSafe.address,
+        data: encodedTx,
+      },
+    ],
+  })
+
+  logger.info('Transaction executed via WalletConnect', {
+    signerAddress,
+    txId,
+    txHash: txHashResult,
+  })
+
+  return {
+    type: ExecutionMethod.WITH_WC,
+    txId,
+    chainId: chain.chainId,
+    safeAddress: activeSafe.address,
+    txHash: txHashResult,
+    walletAddress: signerAddress,
+    walletNonce,
+  }
+}

--- a/apps/mobile/src/store/middleware/pendingTxs.ts
+++ b/apps/mobile/src/store/middleware/pendingTxs.ts
@@ -175,8 +175,8 @@ const runWatchers = async (listenerApi: AppListenerEffectAPI, pendingTxs: Pendin
       continue
     }
 
-    // Handle single transactions
-    if (pendingTx.type === ExecutionMethod.WITH_PK) {
+    // Handle single transactions (private key or WalletConnect)
+    if (pendingTx.type === ExecutionMethod.WITH_PK || pendingTx.type === ExecutionMethod.WITH_WC) {
       const { walletAddress, walletNonce, txHash } = pendingTx
       await runWatcher(listenerApi, txHash, chainId, walletAddress, walletNonce, txId)
     }
@@ -192,7 +192,7 @@ export const pendingTxsListeners = (startListening: AppStartListening) => {
       if (action.payload.type === ExecutionMethod.WITH_RELAY) {
         startIndexingWatcher(listenerApi, txId, chainId)
         startRelayWatcher(listenerApi, txId, action.payload.taskId, chainId)
-      } else if (action.payload.type === ExecutionMethod.WITH_PK) {
+      } else {
         const { txHash, walletAddress, walletNonce } = action.payload
         runWatcher(listenerApi, txHash, chainId, walletAddress, walletNonce, txId)
       }

--- a/apps/mobile/src/store/pendingTxsSlice.ts
+++ b/apps/mobile/src/store/pendingTxsSlice.ts
@@ -10,7 +10,7 @@ export enum PendingStatus {
 }
 
 type PendingSingleTxBase = {
-  type: ExecutionMethod.WITH_PK
+  type: ExecutionMethod.WITH_PK | ExecutionMethod.WITH_WC
   chainId: string
   safeAddress: string
   txHash: string
@@ -59,7 +59,7 @@ export const pendingTxsSlice = createSlice({
       action: PayloadAction<
         | {
             txId: string
-            type: ExecutionMethod.WITH_PK
+            type: ExecutionMethod.WITH_PK | ExecutionMethod.WITH_WC
             chainId: string
             safeAddress: string
             txHash: string


### PR DESCRIPTION
> WC signers could sign but not execute,
> now the external wallet takes the call,
> threshold met, transaction sent.

## What it solves

WalletConnect signers can confirm (sign) transactions but cannot execute them on-chain. The execution method falls back to private key signing, which fails because there is no local key available.

Resolves: https://linear.app/safe-global/issue/WA-1965/execute-transactions-with-walletconnect-signer

## How this PR fixes it

Adds a new `WITH_WC` execution method that builds the Safe transaction with all required signatures, encodes the `execTransaction` call, and sends it to the connected external wallet via `eth_sendTransaction`. The external wallet handles gas estimation, signing, and broadcasting.

Key decisions:
- WalletConnect execution skips the biometrics flow since there is no local key to protect
- The execute button is wrapped with `WalletConnectGate` to validate the session before allowing execution
- Uses `sameAddress` for case-insensitive owner comparison when adding pre-validated signatures
- Wallet nonce is fetched before sending the transaction to correctly track the pending tx

## How to test it

1. Connect an external wallet via WalletConnect (e.g. Zerion, MetaMask)
2. Create or find a transaction that has enough confirmations to execute
3. Open the "How to execute" sheet and select the WalletConnect signer
4. Tap execute — verify the external wallet receives the transaction request and can execute it
5. After execution, verify the transaction appears in pending transactions with the correct tx hash

## Screenshots

N/A — this is a logic change; the UI reuses existing components.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
EOF