### PR TITLE
refactor(mobile): unify signer type badges across the app

### DIFF
--- a/apps/mobile/src/components/SignerTypeBadge/SignerTypeBadge.tsx
+++ b/apps/mobile/src/components/SignerTypeBadge/SignerTypeBadge.tsx
@@ -1,57 +1,33 @@
 import React from 'react'
-import { Badge } from '@/src/components/Badge'
-import { SafeSkeleton } from '@/src/components/SafeSkeleton'
-import { BadgeThemeTypes } from '@/src/components/Badge/Badge'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectSignerByAddress } from '@/src/store/signersSlice'
-import { SafeFontIcon } from '../SafeFontIcon'
+import { LedgerSignerBadge } from '@/src/features/Ledger/components/LedgerSignerBadge'
+import { WalletConnectBadge } from '@/src/features/WalletConnect/components/WalletConnectBadge'
 
 interface SignerBadgeProps {
   address: `0x${string}`
   size?: number
   fontSize?: number
-  theme?: BadgeThemeTypes
-  isLoading?: boolean
-  bordered?: boolean
   testID?: string
+  skipStatus?: boolean
 }
 
 export const SignerTypeBadge = ({
   address,
-  size = 24,
+  size = 32,
   fontSize = 10,
-  theme = 'badge_warning',
-  isLoading = false,
-  bordered = false,
   testID,
+  skipStatus = false,
 }: SignerBadgeProps) => {
   const signer = useAppSelector((state) => selectSignerByAddress(state, address))
 
-  if (isLoading) {
-    return <SafeSkeleton radius="round" height={size} width={size} />
+  if (signer?.type === 'walletconnect') {
+    return <WalletConnectBadge address={address} testID={testID} size={size} skipStatus={skipStatus} />
   }
 
   if (signer?.type === 'ledger') {
-    return (
-      <Badge
-        content={<SafeFontIcon name="hardware" size={12} color="$color" />}
-        textContentProps={{
-          fontSize,
-          fontWeight: 500,
-        }}
-        circleSize={size}
-        themeName={theme}
-        circleProps={
-          bordered
-            ? {
-                bordered: true,
-                borderColor: '$colorContrast',
-              }
-            : undefined
-        }
-        testID={testID}
-      />
-    )
+    return <LedgerSignerBadge size={size} fontSize={fontSize} testID={testID} />
   }
+
   return null
 }

--- a/apps/mobile/src/components/transactions-list/Card/SignersCard/SignersCard.tsx
+++ b/apps/mobile/src/components/transactions-list/Card/SignersCard/SignersCard.tsx
@@ -1,11 +1,9 @@
 import React, { useMemo } from 'react'
 import { Text, View, type TextProps } from 'tamagui'
 import { Identicon } from '@/src/components/Identicon'
-import { BadgeWrapper } from '@/src/components/BadgeWrapper'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { EthAddress } from '@/src/components/EthAddress'
 import { Address } from '@/src/types/address'
-import { SignerTypeBadge } from '@/src/components/SignerTypeBadge'
 
 type SignersCardProps = {
   name?: string | React.ReactNode
@@ -98,13 +96,7 @@ export function SignersCard({
           )}
         </View>
       }
-      leftNode={
-        <View width="$10">
-          <BadgeWrapper badge={<SignerTypeBadge address={address} theme="badge_background" />} position="bottom-right">
-            <Identicon address={address} size={40} />
-          </BadgeWrapper>
-        </View>
-      }
+      leftNode={<Identicon address={address} size={40} />}
       rightNode={rightNode}
     />
   )

--- a/apps/mobile/src/features/ChangeSignerSheet/ChangeSignerSheet.container.tsx
+++ b/apps/mobile/src/features/ChangeSignerSheet/ChangeSignerSheet.container.tsx
@@ -21,13 +21,13 @@ import { TransactionDetails } from '@safe-global/store/gateway/AUTO_GENERATED/tr
 import { getTotalFee } from '@safe-global/utils/hooks/useDefaultGasPrice'
 import { toBigInt } from 'ethers'
 import { formatVisualAmount } from '@safe-global/utils/utils/formatters'
-import { WalletConnectBadge } from '@/src/features/WalletConnect/components/WalletConnectBadge'
+import { SignerTypeBadge } from '@/src/components/SignerTypeBadge'
 
 const getActiveSignerRightNode = (totalFee: bigint, item: SignerInfo & { balance: string }) => {
   return (
     <View flexDirection="row" alignItems="center" gap="$2">
       {toBigInt(item.balance) < totalFee && <Text>Insufficient balance</Text>}
-      <WalletConnectBadge address={item.value} testID="signer-wc-badge" />
+      <SignerTypeBadge address={item.value as Address} testID={`signer-type-badge-${item.value}`} />
     </View>
   )
 }

--- a/apps/mobile/src/features/HowToExecuteSheet/HowToExecuteSheet.container.tsx
+++ b/apps/mobile/src/features/HowToExecuteSheet/HowToExecuteSheet.container.tsx
@@ -2,7 +2,6 @@ import { SafeBottomSheet } from '@/src/components/SafeBottomSheet'
 import React from 'react'
 import { Text, View, ScrollView } from 'tamagui'
 import { Container } from '@/src/components/Container'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { SignersCard } from '@/src/components/transactions-list/Card/SignersCard'
 import { Address } from 'blo'
@@ -31,23 +30,18 @@ import { RelayUnavailable } from './components/RelayUnavailable/RelayUnavailable
 import { hasFeature } from '@safe-global/utils/utils/chains'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import { useAppDispatch } from '@/src/store/hooks'
+import { SignerTypeBadge } from '@/src/components/SignerTypeBadge'
 
-const getActiveSignerRightNode = (
-  totalFee: bigint,
-  item: SignerInfo & { balance: string },
-  executionMethod: ExecutionMethod,
-  activeSigner?: SignerInfo,
-) => {
-  if (activeSigner?.value === item.value && executionMethod !== ExecutionMethod.WITH_RELAY) {
-    return <SafeFontIcon name="check" color="$color" />
-  }
-
+const getActiveSignerRightNode = (totalFee: bigint, item: SignerInfo & { balance: string }) => {
   return (
-    toBigInt(item.balance) < totalFee && (
-      <Container backgroundColor="$backgroundSecondary" paddingVertical="$1" paddingHorizontal="$3">
-        <Text color="$colorSecondary">Not enough gas</Text>
-      </Container>
-    )
+    <View flexDirection="row" alignItems="center" gap="$2">
+      {toBigInt(item.balance) < totalFee && (
+        <Container backgroundColor="$backgroundSecondary" paddingVertical="$1" paddingHorizontal="$3">
+          <Text color="$colorSecondary">Not enough gas</Text>
+        </Container>
+      )}
+      <SignerTypeBadge address={item.value as Address} testID={`signer-type-badge-${item.value}`} />
+    </View>
   )
 }
 
@@ -152,7 +146,7 @@ export const HowToExecuteSheetContainer = () => {
                     balance={`${item.balance ? formatVisualAmount(item.balance, activeChain.nativeCurrency.decimals) : '0'} ${
                       activeChain.nativeCurrency.symbol
                     }`}
-                    rightNode={getActiveSignerRightNode(totalFee, item, executionMethod, activeSigner)}
+                    rightNode={getActiveSignerRightNode(totalFee, item)}
                   />
                 </View>
               )

--- a/apps/mobile/src/features/Ledger/components/LedgerSignerBadge.tsx
+++ b/apps/mobile/src/features/Ledger/components/LedgerSignerBadge.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Badge } from '@/src/components/Badge'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+
+interface LedgerSignerBadgeProps {
+  size?: number
+  fontSize?: number
+  testID?: string
+}
+
+export const LedgerSignerBadge = ({ size = 24, fontSize = 10, testID }: LedgerSignerBadgeProps) => (
+  <Badge
+    content={<SafeFontIcon name="hardware" size={12} color="$color" />}
+    textContentProps={{
+      fontSize,
+      fontWeight: 500,
+    }}
+    circleSize={size}
+    themeName="badge_background"
+    testID={testID}
+  />
+)

--- a/apps/mobile/src/features/Signer/components/SignerView.tsx
+++ b/apps/mobile/src/features/Signer/components/SignerView.tsx
@@ -14,7 +14,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { SafeListItem } from '@/src/components/SafeListItem'
 import { BadgeWrapper } from '@/src/components/BadgeWrapper'
 import { SignerTypeBadge } from '@/src/components/SignerTypeBadge'
-import { WalletConnectBadge } from '@/src/features/WalletConnect/components/WalletConnectBadge'
 import { useWalletConnectStatus } from '@/src/features/WalletConnect/hooks/useWalletConnectStatus'
 
 type Props = {
@@ -58,17 +57,8 @@ export const SignerView = ({
   return (
     <YStack flex={1}>
       <ScrollView flex={1}>
-        <View justifyContent={'center'} alignItems={'center'} paddingTop={isWcSigner ? '$6' : undefined}>
-          <BadgeWrapper
-            badge={
-              isWcSigner ? (
-                <WalletConnectBadge address={signerAddress} testID="signer-wc-badge" />
-              ) : (
-                <SignerTypeBadge address={signerAddress as Address} theme="badge_background" bordered={true} />
-              )
-            }
-            position={isWcSigner ? 'top-right' : 'bottom-right'}
-          >
+        <View justifyContent={'center'} alignItems={'center'} paddingTop={'$3'}>
+          <BadgeWrapper badge={<SignerTypeBadge address={signerAddress as Address} />} position="top-right">
             <Identicon address={signerAddress as Address} size={56} />
           </BadgeWrapper>
         </View>

--- a/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
+++ b/apps/mobile/src/features/Signers/components/SignersList/SignersListItem.tsx
@@ -3,7 +3,6 @@ import { MenuView, NativeActionEvent, MenuAction } from '@react-native-menu/menu
 import { useSignersActions } from './hooks/useSignersActions'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { SignersCard } from '@/src/components/transactions-list/Card/SignersCard'
-import { WalletConnectBadge } from '@/src/features/WalletConnect/components/WalletConnectBadge'
 import { AddressInfo } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import { SignerSection } from './SignersList'
 import { View } from 'tamagui'
@@ -17,6 +16,8 @@ import { ImportedBadge } from './ImportedBadge'
 import { useCopyAndDispatchToast } from '@/src/hooks/useCopyAndDispatchToast'
 import { router } from 'expo-router'
 import logger from '@/src/utils/logger'
+import { SignerTypeBadge } from '@/src/components/SignerTypeBadge'
+import { Address } from '@/src/types/address'
 
 interface SignersListItemProps {
   item: AddressInfo
@@ -86,12 +87,11 @@ function SignersListItem({ item, signersGroup }: SignersListItemProps) {
             rightNode={
               <View flexDirection="row" alignItems="center" flexShrink={0} gap="$2">
                 {signer?.type === 'private-key' && <ImportedBadge />}
-
-                {signer?.type === 'walletconnect' && (
-                  <WalletConnectBadge address={item.value} testID={`wc-badge-${item.value}`} skipStatus />
-                )}
-
-                {/* Invisible spacer matching menu width so card content doesn't overlap */}
+                <SignerTypeBadge
+                  address={item.value as Address}
+                  testID={`signer-type-badge-${item.value}`}
+                  skipStatus
+                />
                 <View width={32} />
               </View>
             }


### PR DESCRIPTION
> Badges scattered, each screen its own,
> now one component picks the right one shown.

## What it solves

Signer type badges (Ledger, WalletConnect) were rendered inconsistently across screens, with each screen importing and conditionally rendering the specific badge component directly.

Resolves: https://linear.app/safe-global/issue/WA-1971/unify-signer-type-badges-across-the-app

## How this PR fixes it

`SignerTypeBadge` now handles both ledger and WalletConnect signer types, dispatching to `LedgerSignerBadge` or `WalletConnectBadge` internally. All screens use this single component instead of importing badge components directly. The ledger badge rendering was extracted into a dedicated `LedgerSignerBadge` presentational component in the Ledger feature folder.

Notable: `SignersCard` no longer renders a badge overlay on the avatar — badges are now shown in `rightNode` by callers. The active signer checkmark in `HowToExecuteSheet` was removed as part of a UI simplification.

## How to test it

1. Open the signers list — verify Ledger signers show the hardware badge and WalletConnect signers show the WC badge
2. Tap a signer to open the detail view — verify the correct badge appears on the avatar
3. Navigate to "Change signer" and "How to execute" sheets — verify badges display correctly for all signer types
4. Verify private-key signers show no signer type badge (only the "Imported" badge in the signers list)

## Screenshots
### IOS
<img width="150" alt="simulator_screenshot_0EE8ED3F-3AFB-466C-BF6D-4E5FC263BCCE" src="https://github.com/user-attachments/assets/f4fe7c26-510b-4c32-9370-064824d9c538" />
<img width="150" alt="simulator_screenshot_C965ACAF-9CC1-4490-B1CC-86F6B2349B5A" src="https://github.com/user-attachments/assets/e00c4e05-bc1f-4241-b5db-cd5c97c38689" />
<img width="150" alt="simulator_screenshot_9FF61C9E-D153-4E27-9E1F-B9BC4FD8CEF7" src="https://github.com/user-attachments/assets/c0a7d3fd-b627-4d5d-a1e7-50ffc752aa81" />
<img width="150" alt="simulator_screenshot_CCDA2AB9-B473-430B-930C-C27DD2009739" src="https://github.com/user-attachments/assets/f0dff298-dc0c-455c-bf21-60e7ee34980e" />

### Android
<img width="150" alt="image" src="https://github.com/user-attachments/assets/5090b152-3392-42de-b2ad-8e491138166c" />
<img width="150" alt="image" src="https://github.com/user-attachments/assets/812cc476-d980-4ffa-85de-41689b78e827" />
<img width="150" alt="image" src="https://github.com/user-attachments/assets/cf74dbda-57de-4349-be8d-26642ca6119e" />
<img width="150" alt="image" src="https://github.com/user-attachments/assets/842ee2b4-9b08-440c-9355-70491f3d204c" />
<img width="150" alt="image" src="https://github.com/user-attachments/assets/855612bd-267e-4049-86c9-01b6d9cff720" />

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
