### PR TITLE
feat: redesign captcha modal with branded layout

### DIFF
--- a/apps/web/src/components/common/Captcha/CaptchaModal.tsx
+++ b/apps/web/src/components/common/Captcha/CaptchaModal.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, DialogContent, Typography } from '@mui/material'
 import ModalDialog from '@/components/common/ModalDialog'
+import SafeLogo from '@/public/images/logo-no-text.svg'
 
 interface CaptchaModalProps {
   open: boolean
@@ -13,15 +14,26 @@ const CaptchaModal = ({ open, onWidgetContainerReady, error, onRetry }: CaptchaM
     <ModalDialog
       open={open}
       hideChainIndicator
-      dialogTitle="Security check"
       // Keep mounted so the widget container stays in DOM for Turnstile to render into
       keepMounted
     >
       <DialogContent>
-        <Box display="flex" flexDirection="column" alignItems="center" gap={2} py={2}>
+        <Box display="flex" flexDirection="column" alignItems="center" gap={3} pt={4} pb={3}>
+          <SafeLogo alt="Safe logo" width={56} height={56} />
+
+          <Box textAlign="center">
+            <Typography variant="h4" fontWeight="bold" gutterBottom>
+              Let us know it&apos;s you
+            </Typography>
+
+            <Typography variant="body2" color="text.secondary" maxWidth={360} mx="auto">
+              A quick check to confirm you&apos;re human — it helps us deliver the highest level of security.
+            </Typography>
+          </Box>
+
           {error ? (
             <>
-              <Typography variant="body1" color="error">
+              <Typography variant="body2" color="error">
                 Verification failed. Please try again.
               </Typography>
 
@@ -31,11 +43,7 @@ const CaptchaModal = ({ open, onWidgetContainerReady, error, onRetry }: CaptchaM
                 </Button>
               )}
             </>
-          ) : (
-            <Typography variant="body1" color="text.secondary">
-              Please complete the check below.
-            </Typography>
-          )}
+          ) : null}
 
           <Box ref={onWidgetContainerReady} />
         </Box>


### PR DESCRIPTION
> Logo centers the stage, title speaks plain,
> "Let us know it's you" — security made humane.

## What it solves

The previous captcha modal used a generic "Security check" title bar with minimal context, making it feel abrupt and out of brand.

## How this PR fixes it

Redesigns `CaptchaModal` to match a cleaner, more intentional layout:

- Removes the generic dialog title bar
- Adds the Safe logo icon centered at the top
- Replaces the terse helper text with a clear heading ("Let us know it's you") and a human-friendly subtitle explaining the purpose of the check
- Updates error state styling to match the new layout

## How to test it

1. Trigger a Cloudflare Turnstile challenge (requires `TURNSTILE_SITE_KEY` to be set in your `.env.local`)
2. Verify the modal shows: Safe logo → heading → subtitle → Turnstile widget
3. Test the error state by simulating a failed verification and confirming the retry button appears

## Visual summary

<img width="905" height="626" alt="image" src="https://github.com/user-attachments/assets/51694651-3e39-4e49-a816-f7f1088a0dd0" />

