### PR TITLE
fix(web/Spaces): highlight Sidebar items on all page tabs

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/SafeSidebarContent.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/SafeSidebarContent.tsx
@@ -70,7 +70,13 @@ export const SafeSidebarContent = ({
 
   const isItemActive = useCallback((item: SidebarItemConfig, pathname: string) => {
     if (item.href === AppRoutes.transactions.history) {
-      return pathname === AppRoutes.transactions.history || pathname === AppRoutes.transactions.queue
+      return pathname.startsWith(AppRoutes.transactions.index)
+    }
+    if (item.href === AppRoutes.balances.index) {
+      return pathname.startsWith(AppRoutes.balances.index)
+    }
+    if (item.href === AppRoutes.apps.index) {
+      return pathname.startsWith(AppRoutes.apps.index)
     }
     return pathname === item.href
   }, [])

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/__tests__/SafeSidebarContent.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/__tests__/SafeSidebarContent.test.tsx
@@ -117,7 +117,45 @@ describe('SafeSidebarContent', () => {
 
     expect(options.isItemActive(transactionsItem, AppRoutes.transactions.queue)).toBe(true)
     expect(options.isItemActive(transactionsItem, AppRoutes.transactions.history)).toBe(true)
+    expect(options.isItemActive(transactionsItem, AppRoutes.transactions.messages)).toBe(true)
+    expect(options.isItemActive(transactionsItem, AppRoutes.transactions.msg)).toBe(true)
+    expect(options.isItemActive(transactionsItem, AppRoutes.transactions.tx)).toBe(true)
     expect(options.isItemActive(transactionsItem, AppRoutes.home)).toBe(false)
+  })
+
+  it('marks Assets as active on balances sub-routes', () => {
+    render(<SafeSidebarContent {...defaultProps} />)
+
+    const [, , options] = getCallArgs()
+
+    const assetsItem = {
+      icon: ArrowUpRight,
+      label: 'Assets',
+      href: AppRoutes.balances.index,
+    } as SidebarItemConfig
+
+    expect(options.isItemActive(assetsItem, AppRoutes.balances.index)).toBe(true)
+    expect(options.isItemActive(assetsItem, AppRoutes.balances.nfts)).toBe(true)
+    expect(options.isItemActive(assetsItem, AppRoutes.balances.positions)).toBe(true)
+    expect(options.isItemActive(assetsItem, AppRoutes.home)).toBe(false)
+  })
+
+  it('marks Apps as active on app sub-routes', () => {
+    render(<SafeSidebarContent {...defaultProps} />)
+
+    const [, , options] = getCallArgs()
+
+    const appsItem = {
+      icon: ArrowUpRight,
+      label: 'Apps',
+      href: AppRoutes.apps.index,
+    } as SidebarItemConfig
+
+    expect(options.isItemActive(appsItem, AppRoutes.apps.index)).toBe(true)
+    expect(options.isItemActive(appsItem, AppRoutes.apps.custom)).toBe(true)
+    expect(options.isItemActive(appsItem, AppRoutes.apps.bookmarked)).toBe(true)
+    expect(options.isItemActive(appsItem, AppRoutes.apps.open)).toBe(true)
+    expect(options.isItemActive(appsItem, AppRoutes.home)).toBe(false)
   })
 
   describe('geoblocking', () => {

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
@@ -49,7 +49,7 @@ export const SafeSidebarVariant = ({
     pathname: AppRoutes.settings.setup,
     query: safeAddress ? { safe: safeAddress } : {},
   }
-  const isSettingsActive = router.pathname === AppRoutes.settings.setup
+  const isSettingsActive = router.pathname.startsWith(AppRoutes.settings.index)
 
   const shouldRenderWorkspaceHeaderGroup =
     workspaceHeader.variant === 'backToSpace' || !(isHydrated && isCounterfactualSafe)

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
@@ -526,6 +526,26 @@ describe('SafeSidebarVariant', () => {
       expect(settingsButton).toHaveAttribute('data-active', 'true')
     })
 
+    it('marks Settings as active when on settings sub-tab page', () => {
+      const mockRouter = jest.requireMock('next/router').useRouter as jest.Mock
+      mockRouter.mockReturnValue({
+        push: jest.fn(),
+        query: { safe: '0x123' },
+        pathname: AppRoutes.settings.security,
+      })
+
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createBackHeader()}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      const settingsButton = screen.getByTestId('sidebar-settings-item')
+      expect(settingsButton).toHaveAttribute('data-active', 'true')
+    })
+
     it('shows outdated dot for critical OUTDATED version state', () => {
       mockUseSafeInfo.mockReturnValue({
         safe: { implementationVersionState: ImplementationVersionState.OUTDATED, version: '1.0.0' },


### PR DESCRIPTION
## What it solves

Resolves: [WA-1967](https://linear.app/safe-global/issue/WA-1967/safe-sidebar-transactionsassets-is-not-highlighted-when-sub-tab-is-on)

The Sidebar nav items were not highlighted when a non-default tab was opened on the page.

## How PR fixes it
Adjusts the `pathname` logic when selecting active NavItem.

## How to test it

- Open Settings -> switch between tabs on the page. The Sidebar item should stay highlighted.
- Do the same check on Transactions, Apps and Assets. See ticket for details.

## Visual summary

<img width="1500" height="679" alt="image" src="https://github.com/user-attachments/assets/2ac6e05f-f59e-4ae2-860c-dfc5fd01cd77" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
