### PR TITLE
feat(web): add SelectSafeModal for space-level actions

### DIFF
--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -12,6 +12,7 @@ import { useIsSidebarRoute } from '@/hooks/useIsSidebarRoute'
 import { TxModalContext } from '@/components/tx-flow'
 import { useLoadFeature } from '@/features/__core__'
 import { BatchingFeature } from '@/features/batching'
+import { SpacesFeature } from '@/features/spaces'
 import { AppRoutes } from '@/config/routes'
 import HelpMenu from '@/components/common/HelpMenu'
 import Breadcrumbs from '@/components/common/Breadcrumbs'
@@ -42,6 +43,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
   const [isBatchOpen, setBatchOpen] = useState<boolean>(false)
   const { txFlow, setFullWidth } = useContext(TxModalContext)
   const { BatchSidebar } = useLoadFeature(BatchingFeature)
+  const { SelectSafeModal } = useLoadFeature(SpacesFeature)
   const isSafeLabsTermsPage = pathname === AppRoutes.safeLabsTerms
   const hideHeader = NO_HEADER_ROUTES.includes(pathname)
   const isOnboardingRoute = ONBOARDING_ROUTES.includes(pathname)
@@ -116,6 +118,8 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
       </div>
 
       <HelpMenu />
+
+      <SelectSafeModal />
     </>
   )
 }

--- a/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
+++ b/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
@@ -15,6 +15,8 @@ import { NewTxFlow } from '@/components/tx-flow/flows'
 import { useTxBuilderApp } from '@/hooks/safe-apps/useTxBuilderApp'
 import { useDarkMode } from '@/hooks/useDarkMode'
 import { cn } from '@/utils/cn'
+import { useAppDispatch } from '@/store'
+import { ESafeAction, openSafeActionsModal } from '@/features/spaces/store'
 
 const PassThrough = ({ children }: { children: (ok: boolean) => ReactNode }) => <Fragment>{children(true)}</Fragment>
 
@@ -26,6 +28,7 @@ interface ActionsTrayProps {
 const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactElement => {
   const { setTxFlow } = useContext(TxModalContext)
   const router = useRouter()
+  const dispatch = useAppDispatch()
   const isSwapFeatureEnabled = useIsSwapFeatureEnabled()
   const { link: txBuilderLink } = useTxBuilderApp()
   const isDarkMode = useDarkMode()
@@ -34,10 +37,33 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
   const Wallet = isSpace ? PassThrough : CheckWallet
   const secondaryVariant = isSpace ? 'outline' : 'secondary'
 
+  const openModal = useCallback(
+    (type: ESafeAction) => {
+      dispatch(openSafeActionsModal({ type }))
+    },
+    [dispatch],
+  )
+
   const handleOnSend = useCallback(() => {
+    if (isSpace) {
+      openModal(ESafeAction.Send)
+      return
+    }
     setTxFlow(<NewTxFlow />, undefined, false)
     trackEvent(OVERVIEW_EVENTS.NEW_TRANSACTION)
-  }, [setTxFlow])
+  }, [isSpace, openModal, setTxFlow])
+
+  const handleOnSwap = useCallback(() => {
+    openModal(ESafeAction.Swap)
+  }, [openModal])
+
+  const handleOnReceive = useCallback(() => {
+    openModal(ESafeAction.Receive)
+  }, [openModal])
+
+  const handleOnBuildTx = useCallback(() => {
+    openModal(ESafeAction.BuildTransaction)
+  }, [openModal])
 
   return (
     <div className={cn('shadcn-scope', isDarkMode && 'dark')}>
@@ -54,47 +80,79 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
         )}
 
         <Track {...OVERVIEW_EVENTS.SHOW_QR} label="dashboard">
-          <QrCodeButton>
-            <Button variant={secondaryVariant} className={cn('px-6 hover:bg-border')}>
+          {isSpace ? (
+            <Button variant={secondaryVariant} className={cn('px-6 hover:bg-border')} onClick={handleOnReceive}>
               <ArrowDownLeft className="size-5" />
               Receive
             </Button>
-          </QrCodeButton>
+          ) : (
+            <QrCodeButton>
+              <Button variant={secondaryVariant} className={cn('px-6 hover:bg-border')}>
+                <ArrowDownLeft className="size-5" />
+                Receive
+              </Button>
+            </QrCodeButton>
+          )}
         </Track>
 
         {isSwapFeatureEnabled && !noAssets && (
           <Wallet>
             {(isOk) => (
               <Track {...SWAP_EVENTS.OPEN_SWAPS} label={SWAP_LABELS.dashboard}>
-                <Button
-                  variant={secondaryVariant}
-                  className={cn('px-6 hover:bg-border')}
-                  data-testid="overview-swap-btn"
-                  disabled={!isOk}
-                  render={isOk ? <Link href={{ pathname: AppRoutes.swap, query: router.query }} /> : undefined}
-                >
-                  <Repeat className="size-5" strokeWidth={1.5} />
-                  Swap
-                </Button>
+                {isSpace ? (
+                  <Button
+                    variant={secondaryVariant}
+                    className={cn('px-6 hover:bg-border')}
+                    data-testid="overview-swap-btn"
+                    disabled={!isOk}
+                    onClick={handleOnSwap}
+                  >
+                    <Repeat className="size-5" strokeWidth={1.5} />
+                    Swap
+                  </Button>
+                ) : (
+                  <Button
+                    variant={secondaryVariant}
+                    className={cn('px-6 hover:bg-border')}
+                    data-testid="overview-swap-btn"
+                    disabled={!isOk}
+                    render={isOk ? <Link href={{ pathname: AppRoutes.swap, query: router.query }} /> : undefined}
+                  >
+                    <Repeat className="size-5" strokeWidth={1.5} />
+                    Swap
+                  </Button>
+                )}
               </Track>
             )}
           </Wallet>
         )}
 
         <Wallet>
-          {(isOk) => (
-            <Button
-              variant={secondaryVariant}
-              size={isSpace ? 'default' : 'icon'}
-              className={cn(isSpace ? 'px-6' : 'rounded-lg', 'hover:bg-border')}
-              disabled={!isOk}
-              render={isOk ? <Link href={txBuilderLink} /> : undefined}
-              aria-label="Transaction builder"
-            >
-              <SquareDashedBottomCode className={cn('size-5', !isSpace && 'text-muted-foreground')} strokeWidth={1.5} />
-              {isSpace && 'Build transaction'}
-            </Button>
-          )}
+          {(isOk) =>
+            isSpace ? (
+              <Button
+                variant={secondaryVariant}
+                className="px-6 hover:bg-border"
+                disabled={!isOk}
+                onClick={handleOnBuildTx}
+                aria-label="Transaction builder"
+              >
+                <SquareDashedBottomCode className="size-5" strokeWidth={1.5} />
+                Build transaction
+              </Button>
+            ) : (
+              <Button
+                variant={secondaryVariant}
+                size="icon"
+                className="rounded-lg hover:bg-border"
+                disabled={!isOk}
+                render={isOk ? <Link href={txBuilderLink} /> : undefined}
+                aria-label="Transaction builder"
+              >
+                <SquareDashedBottomCode className="size-5 text-muted-foreground" strokeWidth={1.5} />
+              </Button>
+            )
+          }
         </Wallet>
       </div>
     </div>

--- a/apps/web/src/features/global-search/components/SearchSection/sections/Accounts/AccountsSection.tsx
+++ b/apps/web/src/features/global-search/components/SearchSection/sections/Accounts/AccountsSection.tsx
@@ -4,7 +4,7 @@ import SafeCardReadOnly from '@/features/spaces/components/SafeAccounts/SafeCard
 import { Skeleton } from '@/components/ui/skeleton'
 import type { SectionItemProps } from '../../sectionItems'
 import useGlobalSearchFilter from '@/features/global-search/hooks/useGlobalSearchFilter'
-import useMatchSafe from '@/features/global-search/hooks/useMatchSafe'
+import useMatchSafe from '@/hooks/useMatchSafe'
 import SectionWrapper from '../../SectionWrapper'
 
 const AccountsSection = ({ query, label }: SectionItemProps) => {

--- a/apps/web/src/features/global-search/components/SearchSection/sections/NavigateTo/NavigateToSection.tsx
+++ b/apps/web/src/features/global-search/components/SearchSection/sections/NavigateTo/NavigateToSection.tsx
@@ -1,5 +1,5 @@
-import { ArrowUpRight, Repeat2, SquareDashedBottomCode, WalletCards } from 'lucide-react'
-import { type ReactNode, useCallback, useContext } from 'react'
+import { ArrowUpRight, Coins, Repeat2, SquareDashedBottomCode, WalletCards } from 'lucide-react'
+import { type ReactNode, useCallback, useContext, useMemo } from 'react'
 import { useRouter } from 'next/router'
 import { cn } from '@/utils/cn'
 import type { SectionItemProps } from '../../sectionItems'
@@ -13,39 +13,72 @@ import { useAppDispatch } from '@/store'
 import { closeGlobalSearch } from '@/features/global-search/store'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useIsSwapFeatureEnabled } from '@/features/swap'
+import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
+import { ESafeAction, openSafeActionsModal } from '@/features/spaces/store'
 
 interface NavigationItem {
   icon: ReactNode
   label: string
 }
 
-const NAVIGATION_ITEMS: NavigationItem[] = [
+const COMMON_ITEMS: NavigationItem[] = [
   { icon: <ArrowUpRight className="size-5" />, label: 'Send' },
   { icon: <Repeat2 className="size-5" />, label: 'Swap' },
   { icon: <SquareDashedBottomCode className="size-5" />, label: 'Transaction builder' },
-  { icon: <WalletCards className="size-5" />, label: 'Accounts' },
 ]
 
+const SAFE_LEVEL_ITEM: NavigationItem = { icon: <Coins className="size-5" />, label: 'Assets' }
+const SPACE_LEVEL_ITEM: NavigationItem = { icon: <WalletCards className="size-5" />, label: 'Accounts' }
+
 const NavigateToSection = ({ query, label }: SectionItemProps) => {
-  const filteredItems = useGlobalSearchFilter(NAVIGATION_ITEMS, query, 'label')
   const router = useRouter()
   const dispatch = useAppDispatch()
   const { setTxFlow } = useContext(TxModalContext)
   const { link: txBuilderLink } = useTxBuilderApp()
   const wallet = useWallet()
   const isSwapEnabled = useIsSwapFeatureEnabled()
+  const isSpaceRoute = useIsSpaceRoute()
+
+  const navigationItems = useMemo(
+    () => [...COMMON_ITEMS, isSpaceRoute ? SPACE_LEVEL_ITEM : SAFE_LEVEL_ITEM],
+    [isSpaceRoute],
+  )
+
+  const filteredItems = useGlobalSearchFilter(navigationItems, query, 'label')
 
   const isSafeLevel = typeof router.query.safe === 'string'
+
+  const spaceActionByLabel: Record<string, ESafeAction> = useMemo(
+    () => ({
+      Send: ESafeAction.Send,
+      Swap: ESafeAction.Swap,
+      'Transaction builder': ESafeAction.BuildTransaction,
+    }),
+    [],
+  )
 
   const handleNavigation = useCallback(
     (itemLabel: string) => {
       setTxFlow(undefined)
       dispatch(closeGlobalSearch())
 
-      if (!isSafeLevel) {
-        console.log(`[GlobalSearch] Navigate to: ${itemLabel}`)
+      // Space route: open SelectSafeModal for action items
+      if (isSpaceRoute) {
+        const safeAction = spaceActionByLabel[itemLabel]
+        if (safeAction) {
+          dispatch(openSafeActionsModal({ type: safeAction }))
+          return
+        }
+
+        // Accounts item — navigate to space accounts
+        router.push({
+          pathname: AppRoutes.spaces.safeAccounts,
+          query: { spaceId: router.query.spaceId },
+        })
         return
       }
+
+      if (!isSafeLevel) return
 
       switch (itemLabel) {
         case 'Send':
@@ -62,7 +95,7 @@ const NavigateToSection = ({ query, label }: SectionItemProps) => {
           })
           break
         }
-        case 'Accounts':
+        case 'Assets':
           router.push({
             pathname: AppRoutes.balances.index,
             query: router.query,
@@ -70,7 +103,7 @@ const NavigateToSection = ({ query, label }: SectionItemProps) => {
           break
       }
     },
-    [isSafeLevel, dispatch, setTxFlow, router, txBuilderLink],
+    [isSpaceRoute, isSafeLevel, dispatch, setTxFlow, router, txBuilderLink, spaceActionByLabel],
   )
 
   if (filteredItems.length === 0) return null

--- a/apps/web/src/features/global-search/components/SearchSection/sections/TrustedSafes/TrustedSafesSection.tsx
+++ b/apps/web/src/features/global-search/components/SearchSection/sections/TrustedSafes/TrustedSafesSection.tsx
@@ -3,7 +3,7 @@ import { isMultiChainSafeItem, useAllSafesGrouped, flattenSafeItems } from '@/ho
 import SafeCardReadOnly from '@/features/spaces/components/SafeAccounts/SafeCardReadOnly'
 import type { SectionItemProps } from '../../sectionItems'
 import useGlobalSearchFilter from '@/features/global-search/hooks/useGlobalSearchFilter'
-import useMatchSafe from '@/features/global-search/hooks/useMatchSafe'
+import useMatchSafe from '@/hooks/useMatchSafe'
 import SectionWrapper from '../../SectionWrapper'
 
 const TrustedSafesSection = ({ query, label }: SectionItemProps) => {

--- a/apps/web/src/features/global-search/hooks/useGlobalSearchFilter.ts
+++ b/apps/web/src/features/global-search/hooks/useGlobalSearchFilter.ts
@@ -1,5 +1,6 @@
-import { useEffect, useId, useMemo, useRef } from 'react'
+import { useEffect, useId, useRef } from 'react'
 import { useSectionVisibility } from '@/features/global-search/components/SearchSection/SectionVisibilityContext'
+import useSearchFilter from '@/hooks/useSearchFilter'
 
 type FilterFn<T> = (item: T, query: string) => boolean
 
@@ -17,14 +18,7 @@ const useGlobalSearchFilter = <T>(items: T[], query: string, filterBy: keyof T |
   const id = useId()
   const idRef = useRef(id)
 
-  const filteredItems = useMemo(() => {
-    const trimmed = query.trim().toLowerCase()
-    if (!trimmed) return items
-
-    const matchFn: FilterFn<T> =
-      typeof filterBy === 'function' ? filterBy : (item) => String(item[filterBy]).toLowerCase().includes(trimmed)
-    return items.filter((item) => matchFn(item, trimmed))
-  }, [items, query, filterBy])
+  const filteredItems = useSearchFilter(items, query, filterBy)
 
   useEffect(() => {
     const currentId = idRef.current

--- a/apps/web/src/features/global-search/hooks/useMatchSafe.ts
+++ b/apps/web/src/features/global-search/hooks/useMatchSafe.ts
@@ -1,44 +1,4 @@
-import { useCallback, useMemo } from 'react'
-import { isMultiChainSafeItem, type AllSafeItems } from '@/hooks/safes'
-import { useAppSelector } from '@/store'
-import { selectAllAddressBooks } from '@/store/addressBookSlice'
-import useChains from '@/hooks/useChains'
-
 /**
- * Returns a memoized callback that matches a Safe by address, name,
- * or chain-prefixed address (e.g. "matic:0xf452…").
- * Falls back to addressBooks for the name when the Safe item has no name.
+ * @deprecated Import from '@/hooks/useMatchSafe' instead.
  */
-const useMatchSafe = () => {
-  const addressBooks = useAppSelector(selectAllAddressBooks)
-  const { configs } = useChains()
-
-  const chainIdToShortName = useMemo(
-    () => new Map(configs.map((chain) => [chain.chainId, chain.shortName.toLowerCase()])),
-    [configs],
-  )
-
-  return useCallback(
-    (safe: AllSafeItems[number], q: string): boolean => {
-      const address = safe.address.toLowerCase()
-      const safeName =
-        safe.name ?? addressBooks[isMultiChainSafeItem(safe) ? safe.safes[0].chainId : safe.chainId]?.[safe.address]
-
-      if (address.includes(q) || (safeName?.toLowerCase().includes(q) ?? false)) {
-        return true
-      }
-
-      // Match chain-prefixed addresses (e.g. "matic:0xf452…" or just "matic:")
-      const chainIds = isMultiChainSafeItem(safe) ? safe.safes.map((s) => s.chainId) : [safe.chainId]
-      return chainIds.some((chainId) => {
-        const shortName = chainIdToShortName.get(chainId)
-        if (!shortName) return false
-        const prefixed = `${shortName}:${address}`
-        return prefixed.includes(q)
-      })
-    },
-    [addressBooks, chainIdToShortName],
-  )
-}
-
-export default useMatchSafe
+export { default } from '@/hooks/useMatchSafe'

--- a/apps/web/src/features/global-search/hooks/useMatchSafe.ts
+++ b/apps/web/src/features/global-search/hooks/useMatchSafe.ts
@@ -1,4 +1,0 @@
-/**
- * @deprecated Import from '@/hooks/useMatchSafe' instead.
- */
-export { default } from '@/hooks/useMatchSafe'

--- a/apps/web/src/features/spaces/components/SelectSafeModal/SafeSearch.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafeModal/SafeSearch.tsx
@@ -1,0 +1,24 @@
+import { Search } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+
+interface SafeSearchProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+const SafeSearch = ({ value, onChange }: SafeSearchProps) => {
+  return (
+    <div className="relative">
+      <Search className="absolute left-3 top-1/2 size-5 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+      <Input
+        placeholder="Search for safes"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="pl-10"
+        aria-label="Search for safes"
+      />
+    </div>
+  )
+}
+
+export default SafeSearch

--- a/apps/web/src/features/spaces/components/SelectSafeModal/__tests__/useSafeActionMapper.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafeModal/__tests__/useSafeActionMapper.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import useSafeActionMapper from '../useSafeActionMapper'
+import { TxModalContext, type TxModalContextType } from '@/components/tx-flow'
+import { AppRoutes } from '@/config/routes'
+import { ESafeAction } from '@/features/spaces/store'
+import type { SafeItem } from '@/hooks/safes'
+
+const mockReplace = jest.fn()
+const mockPush = jest.fn()
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: '/current/path',
+    query: { foo: 'bar' },
+    replace: mockReplace,
+    push: mockPush,
+  }),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: () => ({
+    configs: [
+      { chainId: '1', shortName: 'eth' },
+      { chainId: '137', shortName: 'matic' },
+    ],
+  }),
+}))
+
+jest.mock('@/hooks/safe-apps/useTxBuilderApp', () => ({
+  useTxBuilderApp: () => ({
+    link: {
+      pathname: '/apps/open',
+      query: { appUrl: 'https://tx-builder.example' },
+    },
+  }),
+}))
+
+jest.mock('@/components/tx-flow/flows', () => ({
+  NewTxFlow: () => null,
+}))
+
+const mockSafe: SafeItem = {
+  chainId: '1',
+  address: '0x0000000000000000000000000000000000000001',
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+}
+
+const renderMapper = (onReceiveComplete = jest.fn(), setTxFlow = jest.fn()) => {
+  const contextValue: TxModalContextType = {
+    txFlow: undefined,
+    setTxFlow,
+    setFullWidth: jest.fn(),
+    fullWidth: false,
+  } as unknown as TxModalContextType
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TxModalContext.Provider value={contextValue}>{children}</TxModalContext.Provider>
+  )
+
+  return {
+    ...renderHook(() => useSafeActionMapper({ onReceiveComplete }), { wrapper }),
+    onReceiveComplete,
+    setTxFlow,
+  }
+}
+
+describe('useSafeActionMapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockReplace.mockResolvedValue(true)
+    mockPush.mockResolvedValue(true)
+  })
+
+  it('returns a handler for every ESafeAction', () => {
+    const { result } = renderMapper()
+
+    expect(typeof result.current[ESafeAction.Send]).toBe('function')
+    expect(typeof result.current[ESafeAction.Receive]).toBe('function')
+    expect(typeof result.current[ESafeAction.Swap]).toBe('function')
+    expect(typeof result.current[ESafeAction.BuildTransaction]).toBe('function')
+  })
+
+  describe(ESafeAction.Send, () => {
+    it('navigates to the Safe and opens the NewTxFlow', async () => {
+      const { result, setTxFlow } = renderMapper()
+
+      await act(async () => {
+        await result.current[ESafeAction.Send](mockSafe)
+      })
+
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: '/current/path',
+        query: { foo: 'bar', safe: `eth:${mockSafe.address}` },
+      })
+      expect(setTxFlow).toHaveBeenCalledTimes(1)
+      expect(setTxFlow).toHaveBeenCalledWith(expect.anything(), undefined, false)
+    })
+
+    it('awaits navigation before opening the tx flow', async () => {
+      const callOrder: string[] = []
+      mockReplace.mockImplementation(() => {
+        callOrder.push('replace')
+        return Promise.resolve(true)
+      })
+      const setTxFlow = jest.fn(() => {
+        callOrder.push('setTxFlow')
+      })
+
+      const { result } = renderMapper(jest.fn(), setTxFlow)
+
+      await act(async () => {
+        await result.current[ESafeAction.Send](mockSafe)
+      })
+
+      expect(callOrder).toEqual(['replace', 'setTxFlow'])
+    })
+  })
+
+  describe(ESafeAction.Receive, () => {
+    it('navigates to the Safe and invokes onReceiveComplete', async () => {
+      const { result, onReceiveComplete } = renderMapper()
+
+      await act(async () => {
+        await result.current[ESafeAction.Receive](mockSafe)
+      })
+
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: '/current/path',
+        query: { foo: 'bar', safe: `eth:${mockSafe.address}` },
+      })
+      expect(onReceiveComplete).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not open a tx flow', async () => {
+      const { result, setTxFlow } = renderMapper()
+
+      await act(async () => {
+        await result.current[ESafeAction.Receive](mockSafe)
+      })
+
+      expect(setTxFlow).not.toHaveBeenCalled()
+    })
+  })
+
+  describe(ESafeAction.Swap, () => {
+    it('pushes the swap route with the safe query param', async () => {
+      const { result } = renderMapper()
+
+      await act(async () => {
+        await result.current[ESafeAction.Swap](mockSafe)
+      })
+
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: AppRoutes.swap,
+        query: { safe: `eth:${mockSafe.address}` },
+      })
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('resolves the shortName from the chainId', async () => {
+      const { result } = renderMapper()
+
+      await act(async () => {
+        await result.current[ESafeAction.Swap]({ ...mockSafe, chainId: '137' })
+      })
+
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: AppRoutes.swap,
+        query: { safe: `matic:${mockSafe.address}` },
+      })
+    })
+
+    it('falls back to an empty shortName for unknown chains', async () => {
+      const { result } = renderMapper()
+
+      await act(async () => {
+        await result.current[ESafeAction.Swap]({ ...mockSafe, chainId: '999' })
+      })
+
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: AppRoutes.swap,
+        query: { safe: `:${mockSafe.address}` },
+      })
+    })
+  })
+
+  describe(ESafeAction.BuildTransaction, () => {
+    it('pushes the tx-builder link and merges the safe param into its query', async () => {
+      const { result } = renderMapper()
+
+      await act(async () => {
+        await result.current[ESafeAction.BuildTransaction](mockSafe)
+      })
+
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: '/apps/open',
+        query: { appUrl: 'https://tx-builder.example', safe: `eth:${mockSafe.address}` },
+      })
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SelectSafeModal/constants.ts
+++ b/apps/web/src/features/spaces/components/SelectSafeModal/constants.ts
@@ -1,0 +1,8 @@
+import { ESafeAction } from '@/features/spaces/store'
+
+export const safeModalTitles: Record<ESafeAction, string> = {
+  [ESafeAction.Send]: 'Send from',
+  [ESafeAction.Receive]: 'Receive to',
+  [ESafeAction.Swap]: 'Swap from',
+  [ESafeAction.BuildTransaction]: 'Build transaction from',
+}

--- a/apps/web/src/features/spaces/components/SelectSafeModal/index.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafeModal/index.tsx
@@ -47,7 +47,7 @@ const SelectSafeModal = () => {
     <>
       {opened && (
         <Dialog open onOpenChange={(isOpen) => !isOpen && handleClose()}>
-          <DialogContent className="flex max-h-[520px] flex-col gap-0 p-0">
+          <DialogContent className="flex max-h-[520px] flex-col gap-0 overflow-clip p-0">
             <DialogHeader className="shrink-0 p-5 pb-0">
               <DialogTitle className="text-xl font-semibold">{safeModalTitles[actionType]}</DialogTitle>
             </DialogHeader>
@@ -56,7 +56,7 @@ const SelectSafeModal = () => {
               <SafeSearch value={query} onChange={setQuery} />
             </div>
 
-            <div className="relative min-h-0 flex-1 overflow-y-auto px-4 pb-10">
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-10">
               {isLoading ? (
                 <div className="flex flex-col gap-1.5">
                   <Skeleton className="h-[72px] w-full rounded-3xl" />
@@ -79,9 +79,9 @@ const SelectSafeModal = () => {
                   ))}
                 </div>
               )}
-
-              <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent" />
             </div>
+
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent" />
           </DialogContent>
         </Dialog>
       )}

--- a/apps/web/src/features/spaces/components/SelectSafeModal/index.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafeModal/index.tsx
@@ -1,0 +1,98 @@
+import { useState, useCallback, useMemo, Suspense } from 'react'
+import dynamic from 'next/dynamic'
+import { flattenSafeItems, type SafeItem } from '@/hooks/safes'
+import { useSpaceSafes } from '@/features/spaces'
+import useSearchFilter from '@/hooks/useSearchFilter'
+import useMatchSafe from '@/hooks/useMatchSafe'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { selectSafeActionsModalOpen, selectSafeActionsModalType, closeSafeActionsModal } from '@/features/spaces/store'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Skeleton } from '@/components/ui/skeleton'
+import SafeCardReadOnly from '@/features/spaces/components/SafeAccounts/SafeCardReadOnly'
+import SafeSearch from './SafeSearch'
+import useSafeActionMapper from './useSafeActionMapper'
+import { safeModalTitles } from './constants'
+
+const QrModal = dynamic(() => import('@/components/sidebar/QrCodeButton/QrModal'))
+
+const SelectSafeModal = () => {
+  const [query, setQuery] = useState('')
+  const [qrOpen, setQrOpen] = useState(false)
+  const opened = useAppSelector(selectSafeActionsModalOpen)
+  const actionType = useAppSelector(selectSafeActionsModalType)
+  const dispatch = useAppDispatch()
+
+  const { allSafes, isLoading } = useSpaceSafes()
+  const flatSafes = useMemo(() => flattenSafeItems(allSafes), [allSafes])
+  const matchSafe = useMatchSafe()
+  const filteredSafes = useSearchFilter(flatSafes, query, matchSafe)
+  const actionMapper = useSafeActionMapper({
+    onReceiveComplete: () => setQrOpen(true),
+  })
+
+  const handleClose = useCallback(() => {
+    dispatch(closeSafeActionsModal())
+    setQuery('')
+  }, [dispatch])
+
+  const handleSafeClick = useCallback(
+    async (safe: SafeItem) => {
+      handleClose()
+      await actionMapper[actionType](safe)
+    },
+    [actionMapper, actionType, handleClose],
+  )
+
+  return (
+    <>
+      {opened && (
+        <Dialog open onOpenChange={(isOpen) => !isOpen && handleClose()}>
+          <DialogContent className="flex max-h-[520px] flex-col gap-0 p-0">
+            <DialogHeader className="shrink-0 p-5 pb-0">
+              <DialogTitle className="text-xl font-semibold">{safeModalTitles[actionType]}</DialogTitle>
+            </DialogHeader>
+
+            <div className="shrink-0 px-4 py-3">
+              <SafeSearch value={query} onChange={setQuery} />
+            </div>
+
+            <div className="relative min-h-0 flex-1 overflow-y-auto px-4 pb-10">
+              {isLoading ? (
+                <div className="flex flex-col gap-1.5">
+                  <Skeleton className="h-[72px] w-full rounded-3xl" />
+                  <Skeleton className="h-[72px] w-full rounded-3xl" />
+                  <Skeleton className="h-[72px] w-full rounded-3xl" />
+                </div>
+              ) : filteredSafes.length === 0 ? (
+                <p className="py-8 text-center text-sm text-muted-foreground">No safes found</p>
+              ) : (
+                <div className="flex flex-col gap-1.5">
+                  {filteredSafes.map((safe) => (
+                    <SafeCardReadOnly
+                      key={`${safe.chainId}:${safe.address}`}
+                      safe={safe}
+                      hideContextMenu
+                      showPending={false}
+                      onClick={() => void handleSafeClick(safe)}
+                      className="px-4 sm:px-4"
+                    />
+                  ))}
+                </div>
+              )}
+
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background to-transparent" />
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {qrOpen && (
+        <Suspense>
+          <QrModal onClose={() => setQrOpen(false)} />
+        </Suspense>
+      )}
+    </>
+  )
+}
+
+export default SelectSafeModal

--- a/apps/web/src/features/spaces/components/SelectSafeModal/useSafeActionMapper.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafeModal/useSafeActionMapper.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useContext, useMemo } from 'react'
+import { useRouter } from 'next/router'
+import type { SafeItem } from '@/hooks/safes'
+import { TxModalContext } from '@/components/tx-flow'
+import { NewTxFlow } from '@/components/tx-flow/flows'
+import { AppRoutes } from '@/config/routes'
+import useChains from '@/hooks/useChains'
+import { useTxBuilderApp } from '@/hooks/safe-apps/useTxBuilderApp'
+import { ESafeAction } from '@/features/spaces/store'
+
+type SafeActionHandler = (safe: SafeItem) => Promise<void>
+
+interface UseSafeActionMapperOptions {
+  onReceiveComplete: () => void
+}
+
+const useSafeActionMapper = ({
+  onReceiveComplete,
+}: UseSafeActionMapperOptions): Record<ESafeAction, SafeActionHandler> => {
+  const router = useRouter()
+  const { setTxFlow } = useContext(TxModalContext)
+  const { configs: chains } = useChains()
+  const { link: txBuilderLink } = useTxBuilderApp()
+
+  const getShortName = useCallback(
+    (chainId: string) => chains.find((c) => c.chainId === chainId)?.shortName ?? '',
+    [chains],
+  )
+
+  const getSafeQueryParam = useCallback(
+    (safe: SafeItem) => {
+      const shortName = getShortName(safe.chainId)
+      return `${shortName}:${safe.address}`
+    },
+    [getShortName],
+  )
+
+  const navigateToSafe = useCallback(
+    (safe: SafeItem) => {
+      const safeParam = getSafeQueryParam(safe)
+      return router.replace({
+        pathname: router.pathname,
+        query: { ...router.query, safe: safeParam },
+      })
+    },
+    [router, getSafeQueryParam],
+  )
+
+  return useMemo(
+    () => ({
+      [ESafeAction.Send]: async (safe) => {
+        await navigateToSafe(safe)
+        setTxFlow(<NewTxFlow />, undefined, false)
+      },
+
+      [ESafeAction.Receive]: async (safe) => {
+        await navigateToSafe(safe)
+        onReceiveComplete()
+      },
+
+      [ESafeAction.Swap]: async (safe) => {
+        const safeParam = getSafeQueryParam(safe)
+        await router.push({
+          pathname: AppRoutes.swap,
+          query: { safe: safeParam },
+        })
+      },
+
+      [ESafeAction.BuildTransaction]: async (safe) => {
+        const safeParam = getSafeQueryParam(safe)
+        await router.push({
+          pathname: txBuilderLink.pathname,
+          query: { ...(txBuilderLink.query as Record<string, string>), safe: safeParam },
+        })
+      },
+    }),
+    [router, setTxFlow, getSafeQueryParam, navigateToSafe, onReceiveComplete, txBuilderLink],
+  )
+}
+
+export default useSafeActionMapper

--- a/apps/web/src/features/spaces/contract.ts
+++ b/apps/web/src/features/spaces/contract.ts
@@ -31,6 +31,7 @@ import type SpaceSettingsPage from './components/SpaceSettings/Page'
 import type CreateSpaceOnboarding from './components/CreateSpaceOnboarding'
 import type SelectSafesOnboarding from './components/SelectSafesOnboarding'
 import type InviteMembersOnboarding from './components/InviteMembersOnboarding'
+import type SelectSafeModal from './components/SelectSafeModal'
 
 // Utility services
 import type { isUnauthorized, filterSpacesByStatus, getNonDeclinedSpaces } from './utils'
@@ -62,6 +63,9 @@ export interface SpacesContract {
   SpaceSafeAccountsPage: typeof SpaceSafeAccountsPage
   SpaceAddressBookPage: typeof SpaceAddressBookPage
   SpaceSettingsPage: typeof SpaceSettingsPage
+
+  // Modal components (PascalCase) - stub renders null
+  SelectSafeModal: typeof SelectSafeModal
 
   // Onboarding page components (PascalCase) - stub renders null
   CreateSpaceOnboarding: typeof CreateSpaceOnboarding

--- a/apps/web/src/features/spaces/feature.ts
+++ b/apps/web/src/features/spaces/feature.ts
@@ -35,6 +35,7 @@ import SpaceSettingsPage from './components/SpaceSettings/Page'
 import CreateSpaceOnboarding from './components/CreateSpaceOnboarding'
 import SelectSafesOnboarding from './components/SelectSafesOnboarding'
 import InviteMembersOnboarding from './components/InviteMembersOnboarding'
+import SelectSafeModal from './components/SelectSafeModal'
 
 // Service imports
 import { isUnauthorized, filterSpacesByStatus, getNonDeclinedSpaces } from './utils'
@@ -58,6 +59,9 @@ const feature: SpacesContract = {
   SpaceSafeContextMenu,
   SendTransactionButton,
   PendingTxWidget,
+
+  // Modal components
+  SelectSafeModal,
 
   // Onboarding page components
   CreateSpaceOnboarding,

--- a/apps/web/src/features/spaces/index.ts
+++ b/apps/web/src/features/spaces/index.ts
@@ -76,6 +76,16 @@ export { useSpaceSafes } from './hooks/useSpaceSafes'
 // Hooks from useSpacePendingTransactions.ts
 export { useSpacePendingTransactions } from './hooks/useSpacePendingTransactions'
 
+// Store exports (actions, selectors, types)
+export {
+  ESafeAction,
+  openSafeActionsModal,
+  closeSafeActionsModal,
+  selectSafeActionsModal,
+  selectSafeActionsModalOpen,
+  selectSafeActionsModalType,
+} from './store'
+
 // Public types (compile-time only, no runtime cost)
 export { mapSpaceContactsToAddressBookState } from './utils'
 

--- a/apps/web/src/features/spaces/store/index.ts
+++ b/apps/web/src/features/spaces/store/index.ts
@@ -1,0 +1,9 @@
+export {
+  safeActionsModalSlice,
+  ESafeAction,
+  openSafeActionsModal,
+  closeSafeActionsModal,
+  selectSafeActionsModal,
+  selectSafeActionsModalOpen,
+  selectSafeActionsModalType,
+} from './safeActionsModalSlice'

--- a/apps/web/src/features/spaces/store/safeActionsModalSlice.ts
+++ b/apps/web/src/features/spaces/store/safeActionsModalSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from '@/store'
+
+export enum ESafeAction {
+  Send = 'send',
+  Receive = 'receive',
+  Swap = 'swap',
+  BuildTransaction = 'buildTransaction',
+}
+
+interface SafeActionsModalState {
+  opened: boolean
+  type: ESafeAction
+}
+
+const initialState: SafeActionsModalState = {
+  opened: false,
+  type: ESafeAction.Send,
+}
+
+export const safeActionsModalSlice = createSlice({
+  name: 'safeActionsModal',
+  initialState,
+  reducers: {
+    openSafeActionsModal: (state, action: PayloadAction<{ type: ESafeAction }>) => {
+      state.opened = true
+      state.type = action.payload.type
+    },
+    closeSafeActionsModal: (state) => {
+      state.opened = false
+    },
+  },
+})
+
+export const { openSafeActionsModal, closeSafeActionsModal } = safeActionsModalSlice.actions
+
+export const selectSafeActionsModal = (state: RootState) => state[safeActionsModalSlice.name]
+export const selectSafeActionsModalOpen = (state: RootState) => state[safeActionsModalSlice.name].opened
+export const selectSafeActionsModalType = (state: RootState) => state[safeActionsModalSlice.name].type

--- a/apps/web/src/hooks/__tests__/useMatchSafe.test.ts
+++ b/apps/web/src/hooks/__tests__/useMatchSafe.test.ts
@@ -1,0 +1,83 @@
+import { renderHook } from '@/tests/test-utils'
+import useMatchSafe from '../useMatchSafe'
+import * as useChains from '@/hooks/useChains'
+import type { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import type { SafeItem } from '@/hooks/safes'
+
+const mockChains = [
+  { chainId: '1', chainName: 'Ethereum', shortName: 'eth' },
+  { chainId: '11155111', chainName: 'Sepolia', shortName: 'sep' },
+  { chainId: '137', chainName: 'Polygon', shortName: 'matic' },
+] as Chain[]
+
+describe('useMatchSafe', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(useChains, 'default').mockReturnValue({ configs: mockChains })
+  })
+
+  const makeSafe = (overrides: Partial<SafeItem> = {}): SafeItem => ({
+    chainId: '1',
+    address: '0xAbC123def456',
+    isReadOnly: false,
+    isPinned: false,
+    lastVisited: 0,
+    name: undefined,
+    ...overrides,
+  })
+
+  it('matches by address', () => {
+    const { result } = renderHook(() => useMatchSafe())
+    const safe = makeSafe()
+
+    expect(result.current(safe, 'abc123')).toBe(true)
+    expect(result.current(safe, 'zzz')).toBe(false)
+  })
+
+  it('matches by safe name', () => {
+    const { result } = renderHook(() => useMatchSafe())
+    const safe = makeSafe({ name: 'My Treasury' })
+
+    expect(result.current(safe, 'treasury')).toBe(true)
+    expect(result.current(safe, 'vault')).toBe(false)
+  })
+
+  it('matches by address book name when safe has no name', () => {
+    const { result } = renderHook(() => useMatchSafe(), {
+      initialReduxState: {
+        addressBook: {
+          '1': { '0xAbC123def456': 'Team Wallet' },
+        },
+      },
+    })
+    const safe = makeSafe()
+
+    expect(result.current(safe, 'team')).toBe(true)
+  })
+
+  it('matches by chain name', () => {
+    const { result } = renderHook(() => useMatchSafe())
+    const safe = makeSafe({ chainId: '11155111' })
+
+    expect(result.current(safe, 'sepolia')).toBe(true)
+    expect(result.current(safe, 'sep')).toBe(true)
+  })
+
+  it('matches by short name', () => {
+    const { result } = renderHook(() => useMatchSafe())
+    const ethSafe = makeSafe({ chainId: '1' })
+    const maticSafe = makeSafe({ chainId: '137' })
+
+    expect(result.current(ethSafe, 'eth')).toBe(true)
+    expect(result.current(maticSafe, 'matic')).toBe(true)
+    expect(result.current(maticSafe, 'polygon')).toBe(true)
+  })
+
+  it('does not match unrelated chain queries', () => {
+    const { result } = renderHook(() => useMatchSafe())
+    const ethSafe = makeSafe({ chainId: '1' })
+
+    expect(result.current(ethSafe, 'sepolia')).toBe(false)
+    expect(result.current(ethSafe, 'matic')).toBe(false)
+  })
+})

--- a/apps/web/src/hooks/useMatchSafe.ts
+++ b/apps/web/src/hooks/useMatchSafe.ts
@@ -1,23 +1,43 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { isMultiChainSafeItem, type AllSafeItems } from '@/hooks/safes'
 import { useAppSelector } from '@/store'
 import { selectAllAddressBooks } from '@/store/addressBookSlice'
+import useChains from '@/hooks/useChains'
 
 /**
- * Returns a memoized callback that matches a Safe by address or name.
+ * Returns a memoized callback that matches a Safe by address, name, or chain.
  * Falls back to addressBooks for the name when the Safe item has no name.
+ * Chain matching checks chainName (e.g. "Ethereum") and shortName (e.g. "eth", "sep").
  */
 const useMatchSafe = () => {
   const addressBooks = useAppSelector(selectAllAddressBooks)
+  const { configs: chains } = useChains()
+
+  const chainLookup = useMemo(
+    () =>
+      new Map(
+        chains.map((c) => [c.chainId, { chainName: c.chainName.toLowerCase(), shortName: c.shortName.toLowerCase() }]),
+      ),
+    [chains],
+  )
 
   return useCallback(
     (safe: AllSafeItems[number], q: string): boolean => {
       const address = safe.address.toLowerCase()
       const safeName =
         safe.name ?? addressBooks[isMultiChainSafeItem(safe) ? safe.safes[0].chainId : safe.chainId]?.[safe.address]
-      return address.includes(q) || (safeName?.toLowerCase().includes(q) ?? false)
+
+      if (address.includes(q) || (safeName?.toLowerCase().includes(q) ?? false)) {
+        return true
+      }
+
+      const chainIds = isMultiChainSafeItem(safe) ? safe.safes.map((s) => s.chainId) : [safe.chainId]
+      return chainIds.some((id) => {
+        const chain = chainLookup.get(id)
+        return chain && (chain.chainName.includes(q) || chain.shortName.includes(q))
+      })
     },
-    [addressBooks],
+    [addressBooks, chainLookup],
   )
 }
 

--- a/apps/web/src/hooks/useMatchSafe.ts
+++ b/apps/web/src/hooks/useMatchSafe.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react'
+import { isMultiChainSafeItem, type AllSafeItems } from '@/hooks/safes'
+import { useAppSelector } from '@/store'
+import { selectAllAddressBooks } from '@/store/addressBookSlice'
+
+/**
+ * Returns a memoized callback that matches a Safe by address or name.
+ * Falls back to addressBooks for the name when the Safe item has no name.
+ */
+const useMatchSafe = () => {
+  const addressBooks = useAppSelector(selectAllAddressBooks)
+
+  return useCallback(
+    (safe: AllSafeItems[number], q: string): boolean => {
+      const address = safe.address.toLowerCase()
+      const safeName =
+        safe.name ?? addressBooks[isMultiChainSafeItem(safe) ? safe.safes[0].chainId : safe.chainId]?.[safe.address]
+      return address.includes(q) || (safeName?.toLowerCase().includes(q) ?? false)
+    },
+    [addressBooks],
+  )
+}
+
+export default useMatchSafe

--- a/apps/web/src/hooks/useSearchFilter.ts
+++ b/apps/web/src/hooks/useSearchFilter.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react'
+
+type FilterFn<T> = (item: T, query: string) => boolean
+
+/**
+ * Pure search filter hook — filters a list of items based on a search query.
+ *
+ * @param items - The list to filter
+ * @param query - The search string
+ * @param filterBy - Either a key of T to match against, or a callback
+ *                   that returns true to keep the item
+ */
+const useSearchFilter = <T>(items: T[], query: string, filterBy: keyof T | FilterFn<T>): T[] => {
+  return useMemo(() => {
+    const trimmed = query.trim().toLowerCase()
+    if (!trimmed) return items
+
+    const matchFn: FilterFn<T> =
+      typeof filterBy === 'function' ? filterBy : (item) => String(item[filterBy]).toLowerCase().includes(trimmed)
+    return items.filter((item) => matchFn(item, trimmed))
+  }, [items, query, filterBy])
+}
+
+export default useSearchFilter

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -69,6 +69,7 @@ const rootReducer = combineReducers({
   [slices.hnQueueAssessmentsSlice.name]: slices.hnQueueAssessmentsSlice.reducer,
   [slices.calendlySlice.name]: slices.calendlySlice.reducer,
   [slices.globalSearchSlice.name]: slices.globalSearchSlice.reducer,
+  [slices.safeActionsModalSlice.name]: slices.safeActionsModalSlice.reducer,
   [ofacApi.reducerPath]: ofacApi.reducer,
   [safePassApi.reducerPath]: safePassApi.reducer,
   [hypernativeApi.reducerPath]: hypernativeApi.reducer,

--- a/apps/web/src/store/slices.ts
+++ b/apps/web/src/store/slices.ts
@@ -38,3 +38,12 @@ export {
   toggleGlobalSearch,
   selectGlobalSearchOpen,
 } from '@/features/global-search/store'
+export {
+  safeActionsModalSlice,
+  ESafeAction,
+  openSafeActionsModal,
+  closeSafeActionsModal,
+  selectSafeActionsModal,
+  selectSafeActionsModalOpen,
+  selectSafeActionsModalType,
+} from '@/features/spaces/store'


### PR DESCRIPTION
> A modal rises when actions call,
> pick your Safe, then send or swap,
> spaces route each flow with care.

## What it solves

In Spaces, action buttons (Send, Receive, Swap, Build Transaction) need a way for users to select which Safe to operate on before starting a transaction flow. Previously, these actions only worked at the Safe level where the Safe context was already known.

### Linear task
https://linear.app/safe-global/issue/WA-1827/spaces-actions-tray-component-account-modal

## How this PR fixes it

- **New `SelectSafeModal` component**: A dialog that lists all Safes in the current Space, with search/filter support. When a user clicks an action button from a Space-level route, the modal opens so they can pick a target Safe.
- **New `safeActionsModalSlice`** (Redux): Manages modal open/close state and the selected action type (`ESafeAction` enum: Send, Receive, Swap, BuildTransaction).
- **`useSafeActionMapper` hook**: Maps each action type to the correct navigation/flow after a Safe is selected (e.g., Send opens `NewTxFlow`, Swap navigates to `/swap`, Receive opens QR modal).
- **Updated `ActionsTray`**: Space-level buttons now dispatch `openSafeActionsModal` instead of directly navigating or opening flows.
- **Updated `NavigateToSection`**: Global search "Navigate to" items now handle Space routes by opening the SelectSafeModal for actions and navigating to accounts for the "Accounts" item.
- **Extracted reusable hooks**: `useMatchSafe` and `useSearchFilter` moved from `global-search` to `src/hooks/` so both GlobalSearch and SelectSafeModal can share them.
- **Spaces feature contract/feature.ts updated**: `SelectSafeModal` registered as a lazy-loaded component via the feature architecture.

## How to test it

1. Navigate to a Space route
2. Click Send, Receive, Swap, or Build Transaction in the actions tray
3. The SelectSafeModal should open with the correct title (e.g., "Send from")
4. Search for a Safe by name or address
5. Click a Safe — the appropriate flow should open with that Safe selected
6. Open Global Search (Cmd+K) from a Space route and click a "Navigate to" action — modal should open
7. Verify that non-Space routes still work as before (direct navigation, no modal)

## Visual summary

<img width="2744" height="893" alt="image" src="https://github.com/user-attachments/assets/46bad46b-2b0c-4e42-b6cb-513b44e01d50" />


```mermaid
flowchart LR
    A[ActionsTray button click] --> B{Is Space route?}
    B -->|Yes| C[dispatch openSafeActionsModal]
    C --> D[SelectSafeModal opens]
    D --> E[User picks a Safe]
    E --> F[useSafeActionMapper]
    F --> G[Navigate + open flow]
    B -->|No| H[Direct flow / navigation]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla)