### PR TITLE
tests(mobile): add E2E tests for Connect Signer flow

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -106,6 +106,23 @@ To View stories press `i` on iOS or `a` on Android.
 We use [Maestro](https://maestro.mobile.dev/) for E2E testing. Before running tests, install Maestro following the
 documentation for your OS.
 
+### Configure env variables
+
+Maestro tests rely on environment variables that must be set before running tests. The
+`app-start.yml` utility provides sensible defaults when variables are unset, but Maestro Studio does **not** read defaults from YAML files, so you must pass them explicitly.
+
+| Variable           | Description                                                          | iOS (production)            | iOS (dev)                       | Android (production)    | Android (dev)               |
+| ------------------ | -------------------------------------------------------------------- | --------------------------- | ------------------------------- | ----------------------- | --------------------------- |
+| `APP_ID`           | Bundle / package identifier of the installed app                     | `global.safe.mobileapp.ios` | `global.safe.mobileapp.ios.dev` | `global.safe.mobileapp` | `global.safe.mobileapp.dev` |
+| `IS_DEV_MODE`      | Set to `"true"` to dismiss dev-only dialogs on start                 | `false` (default)           | `true`                          | `false` (default)       | `true`                      |
+| `SKIP_CLEAN_START` | Set to `"true"` to preserve app state between tests (used in suites) | `false` (default)           |
+
+> [!TIP]
+>
+> When `APP_ID` is not set, `app-start.yml` defaults to the production bundle ID for the current platform. If you
+> built the app with `APP_VARIANT=development`, you **must** pass the dev bundle ID or Maestro will hang at the
+> "Launch app" step because it cannot find the app.
+
 ### Run a dev build and E2E tests
 
 To build the app for tests:

--- a/apps/mobile/e2e/tests/connect-signer/connect-signer-not-owner.yml
+++ b/apps/mobile/e2e/tests/connect-signer/connect-signer-not-owner.yml
@@ -1,0 +1,48 @@
+appId: ${APP_ID}
+tags:
+  - connect-signer
+---
+# Error path: Connect wallet that is NOT an owner of the active Safe
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+# Setup: onboard with test Safe, configure WC mock to return a non-owner address
+- tapOn:
+    id: 'e2eConnectSignerNonOwner'
+
+# Wait for home to load
+- assertVisible:
+    id: 'home-tab'
+
+# Navigate to Settings → Signers → Add signer
+- tapOn: 'Account, tab, 3 of 3'
+- tapOn:
+    id: 'settings-signers-list-item'
+- tapOn:
+    id: 'import-signer-button'
+
+# Tap "Connect wallet app"
+- tapOn:
+    id: 'connectSigner'
+
+# Verify Error screen with wallet icon and error status badge
+- assertVisible:
+    id: 'connect-signer-error'
+- assertVisible: "Can't sign with this wallet"
+- assertVisible:
+    id: 'wc-badge-error'
+- assertVisible:
+    id: 'wc-badge-error-status-error'
+
+# Switch e2e state so the next connection resolves as an owner
+- tapOn:
+    id: 'e2eSwitchToOwnerState'
+
+# Tap "Connect a different wallet"
+- tapOn:
+    id: 'connect-signer-error-done'
+
+# Verify Name Signer screen appears (owner address accepted)
+- assertVisible: 'Name your signer'
+- assertVisible: 'E2E Wallet - 3472'

--- a/apps/mobile/e2e/tests/connect-signer/connect-signer-success.yml
+++ b/apps/mobile/e2e/tests/connect-signer/connect-signer-success.yml
@@ -45,18 +45,21 @@ tags:
     id: 'name-signer-input'
 - assertVisible: 'E2E Wallet - 3472'
 
-# Test validation: clear name and type a name that is too long (>20 chars)
+# Test validation: clear name — button should be disabled when empty
 - tapOn:
     id: 'clear-name-button'
+- assertVisible:
+    id: 'name-signer-continue'
+    enabled: false
+
+# Test validation: type a name that is too long (>20 chars) — button should stay disabled
 - tapOn:
     id: 'name-signer-input'
 - inputText: 'This name is way too long'
 - assertVisible: 'Name must be at most 20 characters long'
-# Continue button should be disabled — tapping should not navigate away
 - assertVisible:
     id: 'name-signer-continue'
-- assertNotVisible:
-    id: 'import-success'
+    enabled: false
 
 # Clear the too-long text and type a valid custom name
 - hideKeyboard
@@ -66,7 +69,10 @@ tags:
     id: 'name-signer-input'
 - inputText: 'My WC Signer'
 
-# Tap Continue
+# Continue button should be re-enabled with valid input
+- assertVisible:
+    id: 'name-signer-continue'
+    enabled: true
 - tapOn:
     id: 'name-signer-continue'
 

--- a/apps/mobile/e2e/tests/connect-signer/connect-signer-success.yml
+++ b/apps/mobile/e2e/tests/connect-signer/connect-signer-success.yml
@@ -1,0 +1,88 @@
+appId: ${APP_ID}
+tags:
+  - connect-signer
+---
+# Happy path: Connect wallet → Name signer → Success → Signers list
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+# Setup: onboard with test Safe, configure WC mock to return an owner address
+- tapOn:
+    id: 'e2eConnectSignerOwner'
+
+# Wait for home to load
+- assertVisible:
+    id: 'home-tab'
+
+# Navigate to Settings → Signers
+- tapOn: 'Account, tab, 3 of 3'
+- tapOn:
+    id: 'settings-signers-list-item'
+- assertVisible: 'Signers'
+
+# Verify the owner address is in the list but has no wallet icon badge (not yet imported)
+- assertVisible:
+    id: 'signer-0x3336745b7EA628F5134Bd9d08aa68b4979fA3472'
+- assertNotVisible:
+    id: 'signer-type-badge-0x3336745b7EA628F5134Bd9d08aa68b4979fA3472'
+
+# Tap "Add signer"
+- tapOn:
+    id: 'import-signer-button'
+- assertVisible: 'Add signer'
+
+# Verify "Connect wallet app" option is visible
+- assertVisible: 'Connect wallet app'
+
+# Tap "Connect wallet app"
+- tapOn:
+    id: 'connectSigner'
+
+# Verify Name Signer screen appears with prefilled name
+- assertVisible: 'Name your signer'
+- assertVisible:
+    id: 'name-signer-input'
+- assertVisible: 'E2E Wallet - 3472'
+
+# Test validation: clear name and type a name that is too long (>20 chars)
+- tapOn:
+    id: 'clear-name-button'
+- tapOn:
+    id: 'name-signer-input'
+- inputText: 'This name is way too long'
+- assertVisible: 'Name must be at most 20 characters long'
+# Continue button should be disabled — tapping should not navigate away
+- assertVisible:
+    id: 'name-signer-continue'
+- assertNotVisible:
+    id: 'import-success'
+
+# Clear the too-long text and type a valid custom name
+- hideKeyboard
+- tapOn:
+    id: 'clear-name-button'
+- tapOn:
+    id: 'name-signer-input'
+- inputText: 'My WC Signer'
+
+# Tap Continue
+- tapOn:
+    id: 'name-signer-continue'
+
+# Verify Success screen
+- assertVisible:
+    id: 'import-success'
+- assertVisible: 'Your signer is ready!'
+- assertVisible: 'My WC Signer, 0x3336...3472'
+
+# Tap Done
+- tapOn:
+    id: 'import-success-continue'
+
+# Verify we're back on Signers list
+- assertVisible:
+    id: 'signers-screen'
+
+# Verify imported signer shows with the submitted name
+- assertVisible: 'My WC Signer, 0x3336...3472'

--- a/apps/mobile/e2e/tests/connect-signer/connect-signer-success.yml
+++ b/apps/mobile/e2e/tests/connect-signer/connect-signer-success.yml
@@ -92,3 +92,17 @@ tags:
 
 # Verify imported signer shows with the submitted name
 - assertVisible: 'My WC Signer, 0x3336...3472'
+
+# Tap on the imported signer to open details
+- tapOn:
+    id: 'signer-0x3336745b7EA628F5134Bd9d08aa68b4979fA3472'
+
+# Verify signer details page shows wallet icon and connected status badge
+- assertVisible: 'My WC Signer'
+- assertVisible: 'Address'
+- assertVisible:
+    id: 'signer-detail-badge'
+- assertVisible:
+    id: 'signer-detail-badge-status-connected'
+- assertVisible:
+    id: 'remove-wc-signer-button'

--- a/apps/mobile/src/features/Signer/components/SignerView.tsx
+++ b/apps/mobile/src/features/Signer/components/SignerView.tsx
@@ -58,7 +58,10 @@ export const SignerView = ({
     <YStack flex={1}>
       <ScrollView flex={1}>
         <View justifyContent={'center'} alignItems={'center'} paddingTop={'$3'}>
-          <BadgeWrapper badge={<SignerTypeBadge address={signerAddress as Address} />} position="top-right">
+          <BadgeWrapper
+            badge={<SignerTypeBadge address={signerAddress as Address} testID="signer-detail-badge" />}
+            position="top-right"
+          >
             <Identicon address={signerAddress as Address} size={56} />
           </BadgeWrapper>
         </View>

--- a/apps/mobile/src/features/WalletConnect/components/WalletConnectBadge/WalletConnectBadge.tsx
+++ b/apps/mobile/src/features/WalletConnect/components/WalletConnectBadge/WalletConnectBadge.tsx
@@ -92,6 +92,7 @@ function WalletConnectBadgeInner({
       content={<SafeFontIcon name={statusIcon} color={color} size={statusSize} />}
       circleSize={statusSize}
       circleProps={{ backgroundColor: '$backgroundLight' }}
+      testID={testID ? `${testID}-status-${resolvedStatus}` : undefined}
     />
   )
 

--- a/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.e2e.tsx
+++ b/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.e2e.tsx
@@ -1,0 +1,175 @@
+/**
+ * E2E override for WalletConnectContext.
+ *
+ * Included via RN_SRC_EXT=e2e.tsx Metro file override.
+ * Replaces the real AppKit-based provider with a mock
+ * controlled by walletConnectE2eState.
+ *
+ * - initiateConnection reads connectResult and isOwner from the e2e state
+ *   and navigates directly — no real CGW API call needed.
+ * - Session/network state is driven by TestCtrls buttons.
+ */
+import React, { createContext, useCallback, useContext, useMemo } from 'react'
+import { useSyncExternalStore } from 'react'
+import { router } from 'expo-router'
+import { getAddress } from 'ethers'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectSigners } from '@/src/store/signersSlice'
+import { walletConnectE2eState } from './walletConnectE2eState'
+import Logger from '@/src/utils/logger'
+
+interface WalletConnectContextValue {
+  initiateConnection: () => Promise<void>
+  reconnect: (signerAddress: string) => Promise<void>
+  switchNetwork: (chainId: string) => Promise<void>
+  switchNetworkIfNeeded: () => Promise<void>
+  isWrongNetwork: boolean
+  sign: (params: unknown) => Promise<unknown>
+  hasProvider: boolean
+  provider: undefined
+  isWalletConnectSigner: (address: string) => boolean
+  isConnected: boolean
+  address: string | undefined
+  chainId: number | undefined
+  walletInfo: { name: string; icon?: string } | undefined
+  disconnect: () => Promise<void>
+  open: () => Promise<void>
+}
+
+const WalletConnectContext = createContext<WalletConnectContextValue | null>(null)
+
+export function useWalletConnectContext(): WalletConnectContextValue {
+  const value = useContext(WalletConnectContext)
+
+  if (!value) {
+    throw new Error('useWalletConnectContext must be used within a WalletConnectProvider')
+  }
+
+  return value
+}
+
+export function useOptionalWalletConnectContext(): WalletConnectContextValue | null {
+  return useContext(WalletConnectContext)
+}
+
+interface WalletConnectProviderProps {
+  children: React.ReactNode
+  instance: unknown
+}
+
+export function WalletConnectProvider({ children }: WalletConnectProviderProps) {
+  const e2eState = useSyncExternalStore(walletConnectE2eState.subscribe, walletConnectE2eState.get)
+  const signers = useAppSelector(selectSigners)
+
+  const isWalletConnectSigner = useCallback(
+    (signerAddress: string) => signers[signerAddress]?.type === 'walletconnect',
+    [signers],
+  )
+
+  const initiateConnection = useCallback(async () => {
+    const currentState = walletConnectE2eState.get()
+    const { connectResult, connectError, isOwner } = currentState
+
+    if (connectError) {
+      Logger.info('[E2E] initiateConnection rejected:', connectError)
+      return
+    }
+
+    if (!connectResult) {
+      Logger.info('[E2E] initiateConnection: no connectResult configured')
+      return
+    }
+
+    const { address, walletName, walletIcon } = connectResult
+    const checksumAddress = getAddress(address)
+
+    // Update session state so downstream components see the "connected" wallet
+    walletConnectE2eState.set({
+      isConnected: true,
+      address: checksumAddress,
+      walletInfo: { name: walletName, icon: walletIcon },
+      hasProvider: true,
+    })
+
+    // Use isOwner flag from e2e state — no CGW API call needed
+    if (isOwner) {
+      router.push({
+        pathname: '/import-signers/name-signer',
+        params: { address: checksumAddress, walletName },
+      })
+    } else {
+      router.push({
+        pathname: '/import-signers/connect-signer-error',
+        params: { address: checksumAddress, walletIcon },
+      })
+    }
+  }, [])
+
+  const reconnect = useCallback(async (_signerAddress: string) => {
+    Logger.info('[E2E] reconnect called')
+  }, [])
+
+  const switchNetwork = useCallback(async (_chainId: string) => {
+    Logger.info('[E2E] switchNetwork called')
+  }, [])
+
+  const switchNetworkIfNeeded = useCallback(async () => {
+    Logger.info('[E2E] switchNetworkIfNeeded called')
+  }, [])
+
+  const sign = useCallback(async (_params: unknown) => {
+    Logger.info('[E2E] sign called')
+    return {} as unknown
+  }, [])
+
+  const disconnect = useCallback(async () => {
+    walletConnectE2eState.set({
+      isConnected: false,
+      address: undefined,
+      walletInfo: undefined,
+      hasProvider: false,
+    })
+  }, [])
+
+  const open = useCallback(async () => {
+    Logger.info('[E2E] open called')
+  }, [])
+
+  const value = useMemo<WalletConnectContextValue>(
+    () => ({
+      initiateConnection,
+      reconnect,
+      switchNetwork,
+      switchNetworkIfNeeded,
+      isWrongNetwork: e2eState.isWrongNetwork,
+      sign,
+      hasProvider: e2eState.hasProvider,
+      provider: undefined,
+      isWalletConnectSigner,
+      isConnected: e2eState.isConnected,
+      address: e2eState.address,
+      chainId: e2eState.chainId,
+      walletInfo: e2eState.walletInfo,
+      disconnect,
+      open,
+    }),
+    [
+      initiateConnection,
+      reconnect,
+      switchNetwork,
+      switchNetworkIfNeeded,
+      e2eState.isWrongNetwork,
+      sign,
+      e2eState.hasProvider,
+      isWalletConnectSigner,
+      e2eState.isConnected,
+      e2eState.address,
+      e2eState.chainId,
+      e2eState.walletInfo,
+      disconnect,
+      open,
+    ],
+  )
+
+  return <WalletConnectContext.Provider value={value}>{children}</WalletConnectContext.Provider>
+}

--- a/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.e2e.tsx
+++ b/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.e2e.tsx
@@ -54,7 +54,7 @@ export function useOptionalWalletConnectContext(): WalletConnectContextValue | n
 
 interface WalletConnectProviderProps {
   children: React.ReactNode
-  instance: unknown
+  instance?: unknown
 }
 
 export function WalletConnectProvider({ children }: WalletConnectProviderProps) {
@@ -117,9 +117,8 @@ export function WalletConnectProvider({ children }: WalletConnectProviderProps) 
     Logger.info('[E2E] switchNetworkIfNeeded called')
   }, [])
 
-  const sign = useCallback(async (_params: unknown) => {
-    Logger.info('[E2E] sign called')
-    return {} as unknown
+  const sign = useCallback(async (_params: unknown): Promise<unknown> => {
+    throw new Error('E2E: Signing not implemented in test mode')
   }, [])
 
   const disconnect = useCallback(async () => {

--- a/apps/mobile/src/features/WalletConnect/context/walletConnectE2eState.ts
+++ b/apps/mobile/src/features/WalletConnect/context/walletConnectE2eState.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared state for E2E testing of WalletConnect flows.
+ *
+ * TestCtrls buttons call set() to configure mock connection results.
+ * WalletConnectContext.e2e.tsx subscribes via useSyncExternalStore.
+ */
+
+export interface WalletConnectE2eState {
+  /** What initiateConnection resolves with (happy path) */
+  connectResult: {
+    address: string
+    walletName: string
+    walletIcon: string
+  } | null
+
+  /** What initiateConnection rejects with (error path) */
+  connectError: 'connect_error' | 'user_rejected' | null
+
+  /**
+   * Whether the connected address should be treated as a Safe owner.
+   * Bypasses the real CGW API call for deterministic E2E tests.
+   */
+  isOwner: boolean
+
+  /** Session state (read by WalletConnectGate via useWalletConnectStatus) */
+  isConnected: boolean
+  address: string | undefined
+  chainId: number | undefined
+  walletInfo: { name: string; icon?: string } | undefined
+
+  /** Gate states */
+  isWrongNetwork: boolean
+  hasProvider: boolean
+}
+
+const initialState: WalletConnectE2eState = {
+  connectResult: null,
+  connectError: null,
+  isOwner: false,
+  isConnected: false,
+  address: undefined,
+  chainId: undefined,
+  walletInfo: undefined,
+  isWrongNetwork: false,
+  hasProvider: false,
+}
+
+let listeners: (() => void)[] = []
+let state: WalletConnectE2eState = { ...initialState }
+
+function get(): WalletConnectE2eState {
+  return state
+}
+
+function set(next: Partial<WalletConnectE2eState>) {
+  state = { ...state, ...next }
+  listeners.forEach((l) => l())
+}
+
+function reset() {
+  state = { ...initialState }
+  listeners.forEach((l) => l())
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.push(listener)
+  return () => {
+    listeners = listeners.filter((l) => l !== listener)
+  }
+}
+
+export const walletConnectE2eState = { get, set, reset, subscribe }

--- a/apps/mobile/src/features/WalletConnect/context/walletConnectE2eState.ts
+++ b/apps/mobile/src/features/WalletConnect/context/walletConnectE2eState.ts
@@ -48,18 +48,28 @@ const initialState: WalletConnectE2eState = {
 let listeners: (() => void)[] = []
 let state: WalletConnectE2eState = { ...initialState }
 
+function notifyListeners() {
+  for (const listener of listeners) {
+    try {
+      listener()
+    } catch (error) {
+      console.error('[E2E] walletConnectE2eState listener error:', error)
+    }
+  }
+}
+
 function get(): WalletConnectE2eState {
   return state
 }
 
 function set(next: Partial<WalletConnectE2eState>) {
   state = { ...state, ...next }
-  listeners.forEach((l) => l())
+  notifyListeners()
 }
 
 function reset() {
   state = { ...initialState }
-  listeners.forEach((l) => l())
+  notifyListeners()
 }
 
 function subscribe(listener: () => void): () => void {

--- a/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
+++ b/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux'
 import { useRouter } from 'expo-router'
 import { useState } from 'react'
 import { setupOnboardedAccount, setupTestOnboarding, setupSeedPhraseImportAccount } from '../setup/onboardingSetup'
-import { setupConnectSignerOwner, setupConnectSignerNonOwner } from '../setup/connectSignerSetup'
+import { setupConnectSignerOwner, setupConnectSignerNonOwner, switchToOwnerState } from '../setup/connectSignerSetup'
 import { setupOnboardedAccountForAssets } from '../setup/assetsSetup'
 import { setupPositionsTestSafe } from '../setup/positionsSetup'
 import {
@@ -222,6 +222,12 @@ export function TestCtrls() {
         <Pressable
           testID="e2eConnectSignerNonOwner"
           onPress={() => setupConnectSignerNonOwner(dispatch, router)}
+          accessibilityRole="button"
+          style={BTN}
+        />
+        <Pressable
+          testID="e2eSwitchToOwnerState"
+          onPress={() => switchToOwnerState()}
           accessibilityRole="button"
           style={BTN}
         />

--- a/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
+++ b/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux'
 import { useRouter } from 'expo-router'
 import { useState } from 'react'
 import { setupOnboardedAccount, setupTestOnboarding, setupSeedPhraseImportAccount } from '../setup/onboardingSetup'
+import { setupConnectSignerOwner, setupConnectSignerNonOwner } from '../setup/connectSignerSetup'
 import { setupOnboardedAccountForAssets } from '../setup/assetsSetup'
 import { setupPositionsTestSafe } from '../setup/positionsSetup'
 import {
@@ -207,6 +208,20 @@ export function TestCtrls() {
               isLoading: false,
             })
           }
+          accessibilityRole="button"
+          style={BTN}
+        />
+
+        {/* Connect Signer Scenarios */}
+        <Pressable
+          testID="e2eConnectSignerOwner"
+          onPress={() => setupConnectSignerOwner(dispatch, router)}
+          accessibilityRole="button"
+          style={BTN}
+        />
+        <Pressable
+          testID="e2eConnectSignerNonOwner"
+          onPress={() => setupConnectSignerNonOwner(dispatch, router)}
           accessibilityRole="button"
           style={BTN}
         />

--- a/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
@@ -7,20 +7,16 @@ import { walletConnectE2eState } from '@/src/features/WalletConnect/context/wall
 import { mockedActiveAccount, mockedActiveSafeInfo } from './mockData'
 import { Address } from '@/src/types/address'
 
-/**
- * Known owner of the test Safe (0x2f3e...Fbb6 on Sepolia).
- * Used for the happy path: ownership validation will succeed.
- */
-const OWNER_ADDRESS = '0x3336745b7EA628F5134Bd9d08aa68b4979fA3472'
+/** First owner from the mocked Safe — used for the happy path. */
+const OWNER_ADDRESS = mockedActiveSafeInfo.owners[0].value
 
-/**
- * Random address that is NOT an owner of the test Safe.
- * Used for the error path: ownership validation will fail.
- */
+/** Address that is NOT an owner of the test Safe — used for the error path. */
 const NON_OWNER_ADDRESS = '0x000000000000000000000000000000000000dEaD'
 
 const WALLET_NAME = 'E2E Wallet'
-const WALLET_ICON = 'https://safe-wallet-web.dev.5afe.dev/images/safe-logo-green.png'
+/** 1x1 green PNG pixel — avoids external URL dependency in tests. */
+const WALLET_ICON =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
 
 /**
  * Set the WC e2e state for the next connection attempt.

--- a/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
@@ -19,24 +19,22 @@ const OWNER_ADDRESS = '0x3336745b7EA628F5134Bd9d08aa68b4979fA3472'
  */
 const NON_OWNER_ADDRESS = '0x000000000000000000000000000000000000dEaD'
 
-/**
- * Setup happy path: connect a wallet that IS an owner of the active Safe.
- *
- * - Onboards with the test Safe
- * - Configures walletConnectE2eState to resolve with an owner address
- * - Navigates to the tabs (home)
- */
-export const setupConnectSignerOwner = (dispatch: Dispatch, router: Router) => {
-  walletConnectE2eState.reset()
-  walletConnectE2eState.set({
-    connectResult: {
-      address: OWNER_ADDRESS,
-      walletName: 'E2E Wallet',
-      walletIcon: 'https://safe-wallet-web.dev.5afe.dev/images/safe-logo-green.png',
-    },
-    isOwner: true,
-  })
+const WALLET_NAME = 'E2E Wallet'
+const WALLET_ICON = 'https://safe-wallet-web.dev.5afe.dev/images/safe-logo-green.png'
 
+/**
+ * Set the WC e2e state for the next connection attempt.
+ * Does NOT touch Redux or navigation.
+ */
+const setWcState = (address: string, isOwner: boolean) => {
+  walletConnectE2eState.set({
+    connectResult: { address, walletName: WALLET_NAME, walletIcon: WALLET_ICON },
+    isOwner,
+  })
+}
+
+/** Onboard with the test Safe and navigate to home. */
+const onboardAndNavigate = (dispatch: Dispatch, router: Router) => {
   dispatch(
     addSafe({
       address: mockedActiveSafeInfo.address.value as Address,
@@ -49,30 +47,21 @@ export const setupConnectSignerOwner = (dispatch: Dispatch, router: Router) => {
 }
 
 /**
- * Setup error path: connect a wallet that is NOT an owner of the active Safe.
- *
- * - Onboards with the test Safe
- * - Configures walletConnectE2eState to resolve with a non-owner address
- * - Navigates to the tabs (home)
+ * Switch the WC e2e state to resolve as an owner on the next connection attempt.
+ * Use mid-test on the error screen before tapping "Connect a different wallet".
  */
+export const switchToOwnerState = () => setWcState(OWNER_ADDRESS, true)
+
+/** Setup happy path: onboard + configure WC mock to return an owner address. */
+export const setupConnectSignerOwner = (dispatch: Dispatch, router: Router) => {
+  walletConnectE2eState.reset()
+  setWcState(OWNER_ADDRESS, true)
+  onboardAndNavigate(dispatch, router)
+}
+
+/** Setup error path: onboard + configure WC mock to return a non-owner address. */
 export const setupConnectSignerNonOwner = (dispatch: Dispatch, router: Router) => {
   walletConnectE2eState.reset()
-  walletConnectE2eState.set({
-    connectResult: {
-      address: NON_OWNER_ADDRESS,
-      walletName: 'E2E Wallet',
-      walletIcon: 'https://safe-wallet-web.dev.5afe.dev/images/safe-logo-green.png',
-    },
-    isOwner: false,
-  })
-
-  dispatch(
-    addSafe({
-      address: mockedActiveSafeInfo.address.value as Address,
-      info: { [mockedActiveSafeInfo.chainId]: mockedActiveSafeInfo },
-    }),
-  )
-  dispatch(setActiveSafe(mockedActiveAccount))
-  dispatch(updatePromptAttempts(1))
-  router.replace('/(tabs)')
+  setWcState(NON_OWNER_ADDRESS, false)
+  onboardAndNavigate(dispatch, router)
 }

--- a/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
@@ -1,0 +1,78 @@
+import type { Dispatch } from '@reduxjs/toolkit'
+import type { Router } from 'expo-router'
+import { addSafe } from '@/src/store/safesSlice'
+import { setActiveSafe } from '@/src/store/activeSafeSlice'
+import { updatePromptAttempts } from '@/src/store/notificationsSlice'
+import { walletConnectE2eState } from '@/src/features/WalletConnect/context/walletConnectE2eState'
+import { mockedActiveAccount, mockedActiveSafeInfo } from './mockData'
+import { Address } from '@/src/types/address'
+
+/**
+ * Known owner of the test Safe (0x2f3e...Fbb6 on Sepolia).
+ * Used for the happy path: ownership validation will succeed.
+ */
+const OWNER_ADDRESS = '0x3336745b7EA628F5134Bd9d08aa68b4979fA3472'
+
+/**
+ * Random address that is NOT an owner of the test Safe.
+ * Used for the error path: ownership validation will fail.
+ */
+const NON_OWNER_ADDRESS = '0x000000000000000000000000000000000000dEaD'
+
+/**
+ * Setup happy path: connect a wallet that IS an owner of the active Safe.
+ *
+ * - Onboards with the test Safe
+ * - Configures walletConnectE2eState to resolve with an owner address
+ * - Navigates to the tabs (home)
+ */
+export const setupConnectSignerOwner = (dispatch: Dispatch, router: Router) => {
+  walletConnectE2eState.reset()
+  walletConnectE2eState.set({
+    connectResult: {
+      address: OWNER_ADDRESS,
+      walletName: 'E2E Wallet',
+      walletIcon: 'https://safe-wallet-web.dev.5afe.dev/images/safe-logo-green.png',
+    },
+    isOwner: true,
+  })
+
+  dispatch(
+    addSafe({
+      address: mockedActiveSafeInfo.address.value as Address,
+      info: { [mockedActiveSafeInfo.chainId]: mockedActiveSafeInfo },
+    }),
+  )
+  dispatch(setActiveSafe(mockedActiveAccount))
+  dispatch(updatePromptAttempts(1))
+  router.replace('/(tabs)')
+}
+
+/**
+ * Setup error path: connect a wallet that is NOT an owner of the active Safe.
+ *
+ * - Onboards with the test Safe
+ * - Configures walletConnectE2eState to resolve with a non-owner address
+ * - Navigates to the tabs (home)
+ */
+export const setupConnectSignerNonOwner = (dispatch: Dispatch, router: Router) => {
+  walletConnectE2eState.reset()
+  walletConnectE2eState.set({
+    connectResult: {
+      address: NON_OWNER_ADDRESS,
+      walletName: 'E2E Wallet',
+      walletIcon: 'https://safe-wallet-web.dev.5afe.dev/images/safe-logo-green.png',
+    },
+    isOwner: false,
+  })
+
+  dispatch(
+    addSafe({
+      address: mockedActiveSafeInfo.address.value as Address,
+      info: { [mockedActiveSafeInfo.chainId]: mockedActiveSafeInfo },
+    }),
+  )
+  dispatch(setActiveSafe(mockedActiveAccount))
+  dispatch(updatePromptAttempts(1))
+  router.replace('/(tabs)')
+}


### PR DESCRIPTION
> Mock the wallet, test the gate,
> owner passes, stranger waits,
> badges glow on details page.

## What it solves

Adds Maestro E2E test coverage for the Connect Signer (WalletConnect) flow on mobile — both the happy path (owner wallet) and error path (non-owner wallet). Previously this flow had no automated test coverage.

Resolves: https://linear.app/safe-global/issue/WA-1858/e2e-tests-for-the-connect-signer-flow

## How this PR fixes it

Uses the existing Metro file override pattern (`RN_SRC_EXT=e2e.tsx`) to replace the real `WalletConnectContext` with a mock that reads from an external `useSyncExternalStore`-based state store. This avoids any dependency on AppKit or real WC sessions. An `isOwner` boolean flag bypasses the CGW API ownership check entirely, making tests deterministic.

The `WalletConnectBadge` component now derives a testID for its status badge (`{testID}-status-{status}`), and the signer detail page passes a testID to `SignerTypeBadge` — both small additions to make badge states assertable in Maestro.

## How to test it

1. Build the E2E app: `APP_ENV=e2e npx expo run:ios`
2. Run the happy path test: `maestro test apps/mobile/e2e/tests/connect-signer/connect-signer-success.yml`
3. Run the error path test: `maestro test apps/mobile/e2e/tests/connect-signer/connect-signer-not-owner.yml`
4. Both tests should pass end-to-end on the iOS simulator

## Visual summary

```mermaid
flowchart TD
    A[TestCtrls button] --> B[Setup Redux + WC e2e state]
    B --> C[Navigate to Signers → Add signer]
    C --> D[Tap Connect wallet app]
    D --> E{isOwner?}
    E -->|Yes| F[Name Signer screen]
    F --> G[Validate name input disabled/enabled states]
    G --> H[Success screen]
    H --> I[Signers list — verify name]
    I --> J[Signer details — verify badge + status]
    E -->|No| K[Error screen — verify error badge]
    K --> L[switchToOwnerState]
    L --> M[Tap Connect a different wallet]
    M --> F
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

---

[![Safe Engineering](https://img.shields.io/badge/Safe-Engineering-12ff80)](https://github.com/5afe/safe-engineering-plugin) Generated with [Claude Code](https://claude.com/claude-code)