### PR TITLE
fix(web): restore accounts sidebar border color across themes

### DIFF
--- a/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
@@ -4,6 +4,7 @@ import { AppRoutes } from '@/config/routes'
 import AccountsNavigation from '../AccountsNavigation'
 import CreateButton from '../CreateButton'
 import { useHasFeature } from '@/hooks/useChains'
+import { useDarkMode } from '@/hooks/useDarkMode'
 import useWallet from '@/hooks/wallets/useWallet'
 import AddIcon from '@/public/images/common/add.svg'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics'
@@ -35,13 +36,18 @@ const AddSafeButton = ({ trackingLabel, onLinkClick }: { trackingLabel: string; 
 const AccountsHeader = ({ isSidebar, onLinkClick }: { isSidebar: boolean; onLinkClick?: () => void }) => {
   const wallet = useWallet()
   const router = useRouter()
+  const isDarkMode = useDarkMode()
   const isSpacesFeatureEnabled = useHasFeature(FEATURES.SPACES)
   const isLoginPage = router.pathname === AppRoutes.welcome.accounts
   const trackingLabel = isLoginPage ? OVERVIEW_LABELS.login_page : OVERVIEW_LABELS.sidebar
 
   return (
     <div
-      className={cn('flex justify-between gap-4 py-6 max-[599px]:flex-col', isSidebar && 'border-border border-b px-4')}
+      className={cn(
+        'shadcn-scope flex justify-between gap-4 py-6 max-[599px]:flex-col',
+        isDarkMode && 'dark',
+        isSidebar && 'border-border border-b px-4',
+      )}
     >
       {isSidebar || !isSpacesFeatureEnabled ? (
         <Typography variant={isSidebar ? 'h3' : 'h1'}>Accounts</Typography>


### PR DESCRIPTION
> Sidebar border went astray,
> shadcn-scope lights the way,
> gray in day, dark by night.

## What it solves

The accounts sidebar divider was using `border-accent`, which resolves to a nearly-white `#f5f5f5` in light mode and a semi-transparent green (`#12ff8033`) in dark mode — neither matches the intended neutral gray divider.

## How this PR fixes it

- Switches the divider to `border-border` so it uses the `--border` token (`#e5e5e5` light / `#404040` dark).
- Adds a local `shadcn-scope` + conditional `dark` class on the header root so the `--border` CSS var resolves correctly. The scope's dark variant selector is `.shadcn-scope.dark` (same element, not descendant), so `useDarkMode()` is used to apply `dark` alongside `shadcn-scope`.

## How to test it

1. `yarn workspace @safe-global/web dev`
2. Open the sidebar on any page that renders the accounts list.
3. Verify the header divider is light gray in light mode and dark gray in dark mode.
4. Toggle the theme and confirm the border color flips accordingly.

## Visual summary

```mermaid
flowchart LR
  A[AccountsHeader root div] -->|adds| B[shadcn-scope class]
  A -->|adds when dark| C[dark class]
  B --> D["--border var resolves"]
  C --> D
  D --> E[border-border renders correct gray]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).