### PR TITLE
feat: hide SafeBar for account creation and adding

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
@@ -103,10 +103,12 @@ jest.mock('./SpaceBackLink', () => {
   return { __esModule: true, default: MockSpaceBackLink }
 })
 
+import { usePathname } from 'next/navigation'
 import { useIsQualifiedSafe } from '@/features/spaces'
 import { useSpaceSafeSelectorItems } from './hooks/useSpaceSafeSelectorItems'
 import { useSpaceBackLink } from './hooks/useSpaceBackLink'
 
+const mockUsePathname = usePathname as jest.Mock
 const mockUseIsQualifiedSafe = useIsQualifiedSafe as jest.Mock
 const mockUseSpaceSafeSelectorItems = useSpaceSafeSelectorItems as jest.Mock
 const mockUseSpaceBackLink = useSpaceBackLink as jest.Mock
@@ -114,6 +116,7 @@ const mockUseSpaceBackLink = useSpaceBackLink as jest.Mock
 describe('SpaceSafeBar', () => {
   beforeEach(() => {
     jest.resetAllMocks()
+    mockUsePathname.mockReturnValue('/home')
     mockUseSpaceSafeSelectorItems.mockReturnValue({
       items: mockItems,
       selectedItemId: '1:0xSafe1',
@@ -217,4 +220,16 @@ describe('SpaceSafeBar', () => {
     expect(getByTestId('space-back-link')).toBeInTheDocument()
     expect(getByTestId('safe-selector-dropdown')).toBeInTheDocument()
   })
+
+  it.each([['/welcome/accounts'], ['/welcome/spaces'], ['/new-safe/create'], ['/new-safe/load']])(
+    'renders nothing on hidden route %s',
+    (pathname) => {
+      mockUsePathname.mockReturnValue(pathname)
+
+      const { queryByTestId } = render(<SpaceSafeBar />)
+      expect(queryByTestId('safe-selector-dropdown')).not.toBeInTheDocument()
+      expect(queryByTestId('space-chain-selector')).not.toBeInTheDocument()
+      expect(queryByTestId('space-nested-safes-button')).not.toBeInTheDocument()
+    },
+  )
 })

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -23,7 +23,12 @@ import SpaceChainSelector from './SpaceChainSelector'
 import SpaceNestedSafesButton from './SpaceNestedSafesButton'
 import AccountsModal from './AccountsModal'
 
-const HIDDEN_ROUTES = [AppRoutes.welcome.accounts, AppRoutes.welcome.spaces]
+const HIDDEN_ROUTES = [
+  AppRoutes.welcome.accounts,
+  AppRoutes.welcome.spaces,
+  AppRoutes.newSafe.create,
+  AppRoutes.newSafe.load,
+]
 
 function DropdownHeader({ isPinned, onPin }: { isPinned: boolean; onPin: () => void }) {
   return (

--- a/apps/web/src/components/new-safe/create/index.tsx
+++ b/apps/web/src/components/new-safe/create/index.tsx
@@ -188,7 +188,6 @@ const CreateSafe = () => {
         columnSpacing={3}
         sx={{
           justifyContent: 'center',
-          mt: [2, null, 7],
         }}
       >
         <Grid item xs={12}>

--- a/apps/web/src/components/new-safe/load/index.tsx
+++ b/apps/web/src/components/new-safe/load/index.tsx
@@ -57,7 +57,6 @@ const LoadSafe = ({ initialData }: { initialData?: TxStepperProps<LoadSafeFormDa
         container
         columnSpacing={3}
         sx={{
-          mt: [2, null, 7],
           justifyContent: 'center',
         }}
       >


### PR DESCRIPTION
## What it solves

Resolves: UI polish for `/new-safe/create` and `/new-safe/load`.

On these two pages the user has not yet picked a Safe, so the in-topbar Safe-level controls (`SafeSelectorDropdown`, `SpaceNestedSafesButton`, `SpaceChainSelector`) have no meaningful context and only add noise. On top of that, the page `Grid` container declared a responsive `mt: [2, null, 7]` which rendered as a ~56px gap between the topbar and the "Create new Safe Account" / "Add existing Safe Account" heading on desktop.

## How this PR fixes it

- **Hide the Safe-level navigation** on the two onboarding routes. `SpaceSafeBar` already supports a `HIDDEN_ROUTES` list (previously used for `welcome/accounts` and `welcome/spaces`); extended it with `AppRoutes.newSafe.create` and `AppRoutes.newSafe.load` so the whole bar returns `null` on those pathnames.
- **Remove the oversized top margin** on `CreateSafe` and `LoadSafe`. Dropped `mt: [2, null, 7]` from the outer `Grid` `sx` on both pages. The existing `.mainSpace` `padding-top: var(--topbar-height)` still reserves room for the fixed topbar, so content no longer slides under it — it just no longer gets an extra 56px on top of that reserved space.
- **Tests**: extended `SpaceSafeBar/index.test.tsx` with an `it.each` table covering all four hidden routes (the two existing ones plus the two new ones), asserting that none of `SafeSelectorDropdown`, `SpaceChainSelector`, `SpaceNestedSafesButton` render.

### Files touched

- `apps/web/src/components/common/SpaceSafeBar/index.tsx` — HIDDEN_ROUTES extended.
- `apps/web/src/components/common/SpaceSafeBar/index.test.tsx` — new hidden-route assertions, `usePathname` mock now overridable per test.
- `apps/web/src/components/new-safe/create/index.tsx` — removed `mt: [2, null, 7]`.
- `apps/web/src/components/new-safe/load/index.tsx` — removed `mt: [2, null, 7]`.

## How to test it

1. `yarn workspace @safe-global/web dev`
2. Navigate to `http://localhost:3000/new-safe/create`:
   - The topbar's left side should be empty — no Safe dropdown, no chain selector, no nested-safe button.
   - The right side (wallet, search, notifications) is unchanged.
   - The "Create new Safe Account" heading should sit directly below the topbar with no extra vertical gap.
3. Navigate to `http://localhost:3000/new-safe/load`:
   - Same as above — empty left side of topbar, heading flush against the topbar.
4. Sanity check regressions by loading a Safe (`/home?safe=...`) and a space page:
   - The dropdown, chain selector, and nested-safe button must still appear as before.
5. Run unit tests: `yarn workspace @safe-global/web jest src/components/common/SpaceSafeBar/index.test.tsx` — 14 tests pass, including 4 parameterised hidden-route cases.

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    T1[Topbar] --> B1[SpaceSafeBar<br/>ChainSelector · NestedSafe · Dropdown]
    T1 --> R1[HeaderNavigation<br/>wallet · search · notifications]
    M1[Grid mt=56px] --> H1["Create new Safe Account<br/>heading"]
  end
  subgraph After
    T2[Topbar] --> B2[SpaceSafeBar returns null<br/>on /new-safe/create, /new-safe/load]
    T2 --> R2[HeaderNavigation<br/>unchanged]
    M2[Grid mt=0] --> H2["Create new Safe Account<br/>heading flush to topbar"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).