### PR TITLE
fix(mobile): block signer import when address already has a different-type signer

### DIFF
--- a/apps/mobile/src/features/ImportSigner/hooks/__tests__/useImportPrivateKey.test.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/__tests__/useImportPrivateKey.test.ts
@@ -1,3 +1,4 @@
+import { Alert } from 'react-native'
 import { renderHook, act } from '@/src/tests/test-utils'
 import { useImportPrivateKey } from '../useImportPrivateKey'
 import { ethers } from 'ethers'
@@ -5,6 +6,7 @@ import Clipboard from '@react-native-clipboard/clipboard'
 import Logger from '@/src/utils/logger'
 import { storePrivateKey } from '@/src/hooks/useSign/useSign'
 import useDelegate from '@/src/hooks/useDelegate'
+import type { Signer } from '@/src/store/signersSlice'
 
 jest.mock('@react-native-clipboard/clipboard')
 jest.mock('@/src/hooks/useSign/useSign')
@@ -12,6 +14,8 @@ jest.mock('@/src/hooks/useDelegate')
 jest.mock('expo-router', () => ({
   useRouter: jest.fn(),
 }))
+
+jest.spyOn(Alert, 'alert').mockImplementation(() => undefined)
 
 const mockClipboard = Clipboard as jest.Mocked<typeof Clipboard>
 const mockStorePrivateKey = storePrivateKey as jest.MockedFunction<typeof storePrivateKey>
@@ -354,6 +358,32 @@ describe('useImportPrivateKey', () => {
 
       expect(result.current.error).toBe('Invalid private key or seed phrase.')
       expect(mockStorePrivateKey).not.toHaveBeenCalled()
+      expect(mockRouter.push).not.toHaveBeenCalled()
+    })
+
+    it('should block import and show alert when a different-type signer exists for the address', async () => {
+      const existing: Signer = {
+        value: EXPECTED_ADDRESS,
+        name: 'WC Signer',
+        logoUri: null,
+        type: 'walletconnect',
+      }
+
+      const { result } = renderHook(() => useImportPrivateKey(), {
+        signers: { [EXPECTED_ADDRESS]: existing },
+      })
+
+      act(() => {
+        result.current.handleInputChange(VALID_PRIVATE_KEY)
+      })
+
+      await act(async () => {
+        await result.current.handleImport()
+      })
+
+      expect(Alert.alert).toHaveBeenCalledWith('Signer already imported', expect.any(String), expect.any(Array))
+      expect(mockStorePrivateKey).not.toHaveBeenCalled()
+      expect(mockCreateDelegate).not.toHaveBeenCalled()
       expect(mockRouter.push).not.toHaveBeenCalled()
     })
   })

--- a/apps/mobile/src/features/ImportSigner/hooks/__tests__/useImportSeedPhraseAddress.test.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/__tests__/useImportSeedPhraseAddress.test.ts
@@ -1,3 +1,4 @@
+import { Alert } from 'react-native'
 import { renderHook, act } from '@/src/tests/test-utils'
 import { useImportSeedPhraseAddress } from '../useImportSeedPhraseAddress'
 import { ethers } from 'ethers'
@@ -5,11 +6,14 @@ import Logger from '@/src/utils/logger'
 import { storePrivateKey } from '@/src/hooks/useSign/useSign'
 import useDelegate from '@/src/hooks/useDelegate'
 import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipValidation'
+import type { Signer } from '@/src/store/signersSlice'
 
 // Mock ONLY I/O boundaries
 jest.mock('@/src/hooks/useSign/useSign')
 jest.mock('@/src/hooks/useDelegate')
 jest.mock('@/src/hooks/useAddressOwnershipValidation')
+
+jest.spyOn(Alert, 'alert').mockImplementation(() => undefined)
 
 const mockStorePrivateKey = storePrivateKey as jest.MockedFunction<typeof storePrivateKey>
 const mockUseDelegate = useDelegate as jest.MockedFunction<typeof useDelegate>
@@ -609,6 +613,37 @@ describe('useImportSeedPhraseAddress', () => {
           index: 0,
         },
       })
+    })
+  })
+
+  describe('signer collision', () => {
+    it('should block import and leave Keychain untouched when a different-type signer exists for the address', async () => {
+      const existing: Signer = {
+        value: VALID_ADDRESS,
+        name: 'Existing WC',
+        logoUri: null,
+        type: 'walletconnect',
+      }
+
+      mockValidateAddressOwnership.mockResolvedValue({
+        isOwner: true,
+        ownerInfo: { value: VALID_ADDRESS },
+      })
+
+      const { result } = renderHook(() => useImportSeedPhraseAddress(), {
+        signers: { [VALID_ADDRESS]: existing },
+      })
+
+      let importResult
+      await act(async () => {
+        importResult = await result.current.importAddress(VALID_ADDRESS, DERIVATION_PATH, 0, VALID_PRIVATE_KEY)
+      })
+
+      expect(importResult).toEqual({ success: false })
+      expect(Alert.alert).toHaveBeenCalledWith('Signer already imported', expect.any(String), expect.any(Array))
+      expect(mockStorePrivateKey).not.toHaveBeenCalled()
+      expect(mockCreateDelegate).not.toHaveBeenCalled()
+      expect(result.current.isImporting).toBe(false)
     })
   })
 })

--- a/apps/mobile/src/features/ImportSigner/hooks/__tests__/useSignerCollisionGuard.test.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/__tests__/useSignerCollisionGuard.test.ts
@@ -33,25 +33,30 @@ describe('useSignerCollisionGuard', () => {
     jest.clearAllMocks()
   })
 
-  describe('checkCollision', () => {
-    it('returns null when no signer exists for the address', () => {
+  describe('returns false (no block) when', () => {
+    it('no signer exists for the address', () => {
       const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
-      expect(result.current.checkCollision(ADDRESS_A, 'private-key')).toBeNull()
+      expect(result.current.guardAgainstCollision(ADDRESS_A, 'private-key')).toBe(false)
+      expect(Alert.alert).not.toHaveBeenCalled()
     })
 
-    it('returns null when an unrelated address has a signer', () => {
+    it('an unrelated address has a signer', () => {
       const { result } = renderHook(
         () => useSignerCollisionGuard(),
         preloadSigners({ [ADDRESS_B]: { ...pkSigner, value: ADDRESS_B } }),
       )
-      expect(result.current.checkCollision(ADDRESS_A, 'walletconnect')).toBeNull()
+      expect(result.current.guardAgainstCollision(ADDRESS_A, 'walletconnect')).toBe(false)
+      expect(Alert.alert).not.toHaveBeenCalled()
     })
 
-    it('returns null when the same type is re-imported (idempotent)', () => {
+    it('the same type is re-imported (idempotent)', () => {
       const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: pkSigner }))
-      expect(result.current.checkCollision(ADDRESS_A, 'private-key')).toBeNull()
+      expect(result.current.guardAgainstCollision(ADDRESS_A, 'private-key')).toBe(false)
+      expect(Alert.alert).not.toHaveBeenCalled()
     })
+  })
 
+  describe('returns true and alerts on cross-type collision', () => {
     it.each([
       ['private-key → walletconnect', pkSigner, 'walletconnect' as const],
       ['private-key → ledger', pkSigner, 'ledger' as const],
@@ -59,22 +64,23 @@ describe('useSignerCollisionGuard', () => {
       ['ledger → walletconnect', ledgerSigner, 'walletconnect' as const],
       ['walletconnect → private-key', wcSigner, 'private-key' as const],
       ['walletconnect → ledger', wcSigner, 'ledger' as const],
-    ])('returns the existing signer on cross-type collision (%s)', (_label, existing, newType) => {
+    ])('%s', (_label, existing, newType) => {
       const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: existing }))
-      expect(result.current.checkCollision(ADDRESS_A, newType)).toEqual(existing)
+      expect(result.current.guardAgainstCollision(ADDRESS_A, newType)).toBe(true)
+      expect(Alert.alert).toHaveBeenCalledWith('Signer already imported', expect.any(String), expect.any(Array))
     })
 
     it('matches case-insensitively via sameAddress', () => {
       const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: pkSigner }))
-      expect(result.current.checkCollision(ADDRESS_A.toLowerCase(), 'walletconnect')).toEqual(pkSigner)
-      expect(result.current.checkCollision(ADDRESS_A.toUpperCase(), 'walletconnect')).toEqual(pkSigner)
+      expect(result.current.guardAgainstCollision(ADDRESS_A.toLowerCase(), 'walletconnect')).toBe(true)
+      expect(result.current.guardAgainstCollision(ADDRESS_A.toUpperCase(), 'walletconnect')).toBe(true)
     })
   })
 
-  describe('showCollisionAlert', () => {
-    it('describes a private-key signer in the alert', () => {
-      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
-      result.current.showCollisionAlert(pkSigner)
+  describe('alert copy', () => {
+    it('describes a private-key signer', () => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: pkSigner }))
+      result.current.guardAgainstCollision(ADDRESS_A, 'walletconnect')
       expect(Alert.alert).toHaveBeenCalledWith(
         'Signer already imported',
         expect.stringContaining('private key'),
@@ -82,9 +88,9 @@ describe('useSignerCollisionGuard', () => {
       )
     })
 
-    it('describes a Ledger signer in the alert', () => {
-      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
-      result.current.showCollisionAlert(ledgerSigner)
+    it('describes a Ledger signer', () => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: ledgerSigner }))
+      result.current.guardAgainstCollision(ADDRESS_A, 'walletconnect')
       expect(Alert.alert).toHaveBeenCalledWith(
         'Signer already imported',
         expect.stringContaining('Ledger'),
@@ -93,8 +99,8 @@ describe('useSignerCollisionGuard', () => {
     })
 
     it('names the wallet for a WalletConnect signer with walletName', () => {
-      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
-      result.current.showCollisionAlert(wcSigner)
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: wcSigner }))
+      result.current.guardAgainstCollision(ADDRESS_A, 'private-key')
       expect(Alert.alert).toHaveBeenCalledWith(
         'Signer already imported',
         expect.stringContaining('MetaMask'),
@@ -103,8 +109,8 @@ describe('useSignerCollisionGuard', () => {
     })
 
     it('falls back to "WalletConnect" when walletName is missing', () => {
-      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
-      result.current.showCollisionAlert(wcSignerNoName)
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: wcSignerNoName }))
+      result.current.guardAgainstCollision(ADDRESS_A, 'private-key')
       expect(Alert.alert).toHaveBeenCalledWith(
         'Signer already imported',
         expect.stringContaining('WalletConnect'),

--- a/apps/mobile/src/features/ImportSigner/hooks/__tests__/useSignerCollisionGuard.test.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/__tests__/useSignerCollisionGuard.test.ts
@@ -59,11 +59,9 @@ describe('useSignerCollisionGuard', () => {
   describe('returns true and alerts on cross-type collision', () => {
     it.each([
       ['private-key → walletconnect', pkSigner, 'walletconnect' as const],
+      ['walletconnect → private-key', wcSigner, 'private-key' as const],
       ['private-key → ledger', pkSigner, 'ledger' as const],
       ['ledger → private-key', ledgerSigner, 'private-key' as const],
-      ['ledger → walletconnect', ledgerSigner, 'walletconnect' as const],
-      ['walletconnect → private-key', wcSigner, 'private-key' as const],
-      ['walletconnect → ledger', wcSigner, 'ledger' as const],
     ])('%s', (_label, existing, newType) => {
       const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: existing }))
       expect(result.current.guardAgainstCollision(ADDRESS_A, newType)).toBe(true)

--- a/apps/mobile/src/features/ImportSigner/hooks/__tests__/useSignerCollisionGuard.test.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/__tests__/useSignerCollisionGuard.test.ts
@@ -1,0 +1,115 @@
+import { Alert } from 'react-native'
+import { faker } from '@faker-js/faker'
+import { renderHook } from '@/src/tests/test-utils'
+import { useSignerCollisionGuard } from '../useSignerCollisionGuard'
+import type { Signer } from '@/src/store/signersSlice'
+
+jest.spyOn(Alert, 'alert').mockImplementation(() => undefined)
+
+const ADDRESS_A = faker.finance.ethereumAddress()
+const ADDRESS_B = faker.finance.ethereumAddress()
+
+const pkSigner: Signer = { value: ADDRESS_A, name: 'PK Owner', logoUri: null, type: 'private-key' }
+const ledgerSigner: Signer = {
+  value: ADDRESS_A,
+  name: 'Ledger Owner',
+  logoUri: null,
+  type: 'ledger',
+  derivationPath: "m/44'/60'/0'/0/0",
+}
+const wcSigner: Signer = {
+  value: ADDRESS_A,
+  name: 'WC Owner',
+  logoUri: null,
+  type: 'walletconnect',
+  walletName: 'MetaMask',
+}
+const wcSignerNoName: Signer = { value: ADDRESS_A, name: 'WC Owner', logoUri: null, type: 'walletconnect' }
+
+const preloadSigners = (signers: Record<string, Signer>) => ({ signers })
+
+describe('useSignerCollisionGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('checkCollision', () => {
+    it('returns null when no signer exists for the address', () => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
+      expect(result.current.checkCollision(ADDRESS_A, 'private-key')).toBeNull()
+    })
+
+    it('returns null when an unrelated address has a signer', () => {
+      const { result } = renderHook(
+        () => useSignerCollisionGuard(),
+        preloadSigners({ [ADDRESS_B]: { ...pkSigner, value: ADDRESS_B } }),
+      )
+      expect(result.current.checkCollision(ADDRESS_A, 'walletconnect')).toBeNull()
+    })
+
+    it('returns null when the same type is re-imported (idempotent)', () => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: pkSigner }))
+      expect(result.current.checkCollision(ADDRESS_A, 'private-key')).toBeNull()
+    })
+
+    it.each([
+      ['private-key → walletconnect', pkSigner, 'walletconnect' as const],
+      ['private-key → ledger', pkSigner, 'ledger' as const],
+      ['ledger → private-key', ledgerSigner, 'private-key' as const],
+      ['ledger → walletconnect', ledgerSigner, 'walletconnect' as const],
+      ['walletconnect → private-key', wcSigner, 'private-key' as const],
+      ['walletconnect → ledger', wcSigner, 'ledger' as const],
+    ])('returns the existing signer on cross-type collision (%s)', (_label, existing, newType) => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: existing }))
+      expect(result.current.checkCollision(ADDRESS_A, newType)).toEqual(existing)
+    })
+
+    it('matches case-insensitively via sameAddress', () => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({ [ADDRESS_A]: pkSigner }))
+      expect(result.current.checkCollision(ADDRESS_A.toLowerCase(), 'walletconnect')).toEqual(pkSigner)
+      expect(result.current.checkCollision(ADDRESS_A.toUpperCase(), 'walletconnect')).toEqual(pkSigner)
+    })
+  })
+
+  describe('showCollisionAlert', () => {
+    it('describes a private-key signer in the alert', () => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
+      result.current.showCollisionAlert(pkSigner)
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Signer already imported',
+        expect.stringContaining('private key'),
+        expect.any(Array),
+      )
+    })
+
+    it('describes a Ledger signer in the alert', () => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
+      result.current.showCollisionAlert(ledgerSigner)
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Signer already imported',
+        expect.stringContaining('Ledger'),
+        expect.any(Array),
+      )
+    })
+
+    it('names the wallet for a WalletConnect signer with walletName', () => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
+      result.current.showCollisionAlert(wcSigner)
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Signer already imported',
+        expect.stringContaining('MetaMask'),
+        expect.any(Array),
+      )
+    })
+
+    it('falls back to "WalletConnect" when walletName is missing', () => {
+      const { result } = renderHook(() => useSignerCollisionGuard(), preloadSigners({}))
+      result.current.showCollisionAlert(wcSignerNoName)
+      expect(Alert.alert).toHaveBeenCalledWith(
+        'Signer already imported',
+        expect.stringContaining('WalletConnect'),
+        expect.any(Array),
+      )
+    })
+  })
+})

--- a/apps/mobile/src/features/ImportSigner/hooks/useImportPrivateKey.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useImportPrivateKey.ts
@@ -6,6 +6,7 @@ import { storePrivateKey } from '@/src/hooks/useSign/useSign'
 import useDelegate from '@/src/hooks/useDelegate'
 import Logger from '@/src/utils/logger'
 import { detectInputType, InputType } from '@/src/utils/inputDetection'
+import { useSignerCollisionGuard } from './useSignerCollisionGuard'
 
 const ERROR_MESSAGE = 'Invalid private key or seed phrase.'
 export const useImportPrivateKey = () => {
@@ -15,6 +16,7 @@ export const useImportPrivateKey = () => {
   const [error, setError] = useState<string | undefined>(undefined)
   const router = useRouter()
   const { createDelegate } = useDelegate()
+  const { checkCollision, showCollisionAlert } = useSignerCollisionGuard()
 
   const handleInputChange = (text: string) => {
     setInput(text)
@@ -52,6 +54,12 @@ export const useImportPrivateKey = () => {
 
     if (inputType === 'private-key' && wallet) {
       // Handle private key import (existing flow)
+      const existingSigner = checkCollision(wallet.address, 'private-key')
+      if (existingSigner) {
+        showCollisionAlert(existingSigner)
+        return
+      }
+
       try {
         // Store the private key
         await storePrivateKey(wallet.address, trimmedInput)

--- a/apps/mobile/src/features/ImportSigner/hooks/useImportPrivateKey.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useImportPrivateKey.ts
@@ -16,7 +16,7 @@ export const useImportPrivateKey = () => {
   const [error, setError] = useState<string | undefined>(undefined)
   const router = useRouter()
   const { createDelegate } = useDelegate()
-  const { checkCollision, showCollisionAlert } = useSignerCollisionGuard()
+  const { guardAgainstCollision } = useSignerCollisionGuard()
 
   const handleInputChange = (text: string) => {
     setInput(text)
@@ -54,9 +54,7 @@ export const useImportPrivateKey = () => {
 
     if (inputType === 'private-key' && wallet) {
       // Handle private key import (existing flow)
-      const existingSigner = checkCollision(wallet.address, 'private-key')
-      if (existingSigner) {
-        showCollisionAlert(existingSigner)
+      if (guardAgainstCollision(wallet.address, 'private-key')) {
         return
       }
 

--- a/apps/mobile/src/features/ImportSigner/hooks/useImportSeedPhraseAddress.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useImportSeedPhraseAddress.ts
@@ -5,6 +5,7 @@ import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipVa
 import { storePrivateKey } from '@/src/hooks/useSign/useSign'
 import useDelegate from '@/src/hooks/useDelegate'
 import Logger from '@/src/utils/logger'
+import { useSignerCollisionGuard } from './useSignerCollisionGuard'
 
 interface ImportError {
   code: 'VALIDATION' | 'IMPORT' | 'OWNER_VALIDATION'
@@ -28,6 +29,7 @@ export const useImportSeedPhraseAddress = () => {
   const [error, setError] = useState<ImportError | null>(null)
   const { validateAddressOwnership } = useAddressOwnershipValidation()
   const { createDelegate } = useDelegate()
+  const { checkCollision, showCollisionAlert } = useSignerCollisionGuard()
 
   const clearError = useCallback(() => {
     setError(null)
@@ -54,6 +56,13 @@ export const useImportSeedPhraseAddress = () => {
             code: 'OWNER_VALIDATION',
             message: 'This address is not an owner of the Safe Account',
           })
+          setIsImporting(false)
+          return { success: false }
+        }
+
+        const existingSigner = checkCollision(address, 'private-key')
+        if (existingSigner) {
+          showCollisionAlert(existingSigner)
           setIsImporting(false)
           return { success: false }
         }
@@ -99,7 +108,7 @@ export const useImportSeedPhraseAddress = () => {
         return { success: false }
       }
     },
-    [dispatch, validateAddressOwnership, createDelegate],
+    [dispatch, validateAddressOwnership, createDelegate, checkCollision, showCollisionAlert],
   )
 
   return {

--- a/apps/mobile/src/features/ImportSigner/hooks/useImportSeedPhraseAddress.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useImportSeedPhraseAddress.ts
@@ -29,7 +29,7 @@ export const useImportSeedPhraseAddress = () => {
   const [error, setError] = useState<ImportError | null>(null)
   const { validateAddressOwnership } = useAddressOwnershipValidation()
   const { createDelegate } = useDelegate()
-  const { checkCollision, showCollisionAlert } = useSignerCollisionGuard()
+  const { guardAgainstCollision } = useSignerCollisionGuard()
 
   const clearError = useCallback(() => {
     setError(null)
@@ -60,9 +60,7 @@ export const useImportSeedPhraseAddress = () => {
           return { success: false }
         }
 
-        const existingSigner = checkCollision(address, 'private-key')
-        if (existingSigner) {
-          showCollisionAlert(existingSigner)
+        if (guardAgainstCollision(address, 'private-key')) {
           setIsImporting(false)
           return { success: false }
         }
@@ -108,7 +106,7 @@ export const useImportSeedPhraseAddress = () => {
         return { success: false }
       }
     },
-    [dispatch, validateAddressOwnership, createDelegate, checkCollision, showCollisionAlert],
+    [dispatch, validateAddressOwnership, createDelegate, guardAgainstCollision],
   )
 
   return {

--- a/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
@@ -13,9 +13,13 @@ const describeExistingSigner = (existing: Signer): string => {
       return 'as a Ledger signer'
     case 'walletconnect':
       return existing.walletName ? `via ${existing.walletName}` : 'as a WalletConnect signer'
+    default:
+      // Exhaustiveness check: if a new signer kind is added to the union,
+      // `existing satisfies never` fails to compile. The runtime return is
+      // a safe fallback in case a mismatched shape slips past TS.
+      existing satisfies never
+      return 'as an existing signer'
   }
-  // Defensive fallback in case a future signer type slips past the compile-time check
-  return 'as an existing signer'
 }
 
 const showCollisionAlert = (existing: Signer) => {

--- a/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
@@ -1,6 +1,5 @@
 import { Alert } from 'react-native'
-import { useCallback } from 'react'
-import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { useCallback, useMemo } from 'react'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectSigners, type Signer } from '@/src/store/signersSlice'
 
@@ -30,16 +29,23 @@ const showCollisionAlert = (existing: Signer) => {
 export const useSignerCollisionGuard = () => {
   const signers = useAppSelector(selectSigners)
 
+  // Normalize once per signers change so the guard is O(1) per import attempt,
+  // regardless of how addresses were cased when they were stored.
+  const signersByNormalizedAddress = useMemo(
+    () => new Map(Object.values(signers).map((signer) => [signer.value.toLowerCase(), signer])),
+    [signers],
+  )
+
   const guardAgainstCollision = useCallback(
     (address: string, newType: SignerKind): boolean => {
-      const existing = Object.values(signers).find((signer) => sameAddress(signer.value, address))
+      const existing = signersByNormalizedAddress.get(address.toLowerCase())
       if (!existing || existing.type === newType) {
         return false
       }
       showCollisionAlert(existing)
       return true
     },
-    [signers],
+    [signersByNormalizedAddress],
   )
 
   return { guardAgainstCollision }

--- a/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
@@ -17,27 +17,28 @@ const describeExistingSigner = (existing: Signer): string => {
   }
 }
 
+const showCollisionAlert = (existing: Signer) => {
+  Alert.alert(
+    'Signer already imported',
+    `This address is already imported ${describeExistingSigner(existing)}. Remove it under Settings → Signers first, or use the existing signer to sign transactions.`,
+    [{ text: 'OK' }],
+  )
+}
+
 export const useSignerCollisionGuard = () => {
   const signers = useAppSelector(selectSigners)
 
-  const checkCollision = useCallback(
-    (address: string, newType: SignerKind): Signer | null => {
+  const guardAgainstCollision = useCallback(
+    (address: string, newType: SignerKind): boolean => {
       const existing = Object.values(signers).find((signer) => sameAddress(signer.value, address))
       if (!existing || existing.type === newType) {
-        return null
+        return false
       }
-      return existing
+      showCollisionAlert(existing)
+      return true
     },
     [signers],
   )
 
-  const showCollisionAlert = useCallback((existing: Signer) => {
-    Alert.alert(
-      'Signer already imported',
-      `This address is already imported ${describeExistingSigner(existing)}. Remove it under Settings → Signers first, or use the existing signer to sign transactions.`,
-      [{ text: 'OK' }],
-    )
-  }, [])
-
-  return { checkCollision, showCollisionAlert }
+  return { guardAgainstCollision }
 }

--- a/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
@@ -1,0 +1,43 @@
+import { Alert } from 'react-native'
+import { useCallback } from 'react'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { useAppSelector } from '@/src/store/hooks'
+import { selectSigners, type Signer } from '@/src/store/signersSlice'
+
+type SignerKind = Signer['type']
+
+const describeExistingSigner = (existing: Signer): string => {
+  switch (existing.type) {
+    case 'private-key':
+      return 'as a private key signer'
+    case 'ledger':
+      return 'as a Ledger signer'
+    case 'walletconnect':
+      return existing.walletName ? `via ${existing.walletName}` : 'as a WalletConnect signer'
+  }
+}
+
+export const useSignerCollisionGuard = () => {
+  const signers = useAppSelector(selectSigners)
+
+  const checkCollision = useCallback(
+    (address: string, newType: SignerKind): Signer | null => {
+      const existing = Object.values(signers).find((signer) => sameAddress(signer.value, address))
+      if (!existing || existing.type === newType) {
+        return null
+      }
+      return existing
+    },
+    [signers],
+  )
+
+  const showCollisionAlert = useCallback((existing: Signer) => {
+    Alert.alert(
+      'Signer already imported',
+      `This address is already imported ${describeExistingSigner(existing)}. Remove it under Settings → Signers first, or use the existing signer to sign transactions.`,
+      [{ text: 'OK' }],
+    )
+  }, [])
+
+  return { checkCollision, showCollisionAlert }
+}

--- a/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useSignerCollisionGuard.ts
@@ -15,6 +15,8 @@ const describeExistingSigner = (existing: Signer): string => {
     case 'walletconnect':
       return existing.walletName ? `via ${existing.walletName}` : 'as a WalletConnect signer'
   }
+  // Defensive fallback in case a future signer type slips past the compile-time check
+  return 'as an existing signer'
 }
 
 const showCollisionAlert = (existing: Signer) => {

--- a/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.test.ts
+++ b/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.test.ts
@@ -1,3 +1,4 @@
+import { Alert } from 'react-native'
 import { renderHook, waitFor, act } from '@/src/tests/test-utils'
 import { useImportLedgerAddress } from './useImportLedgerAddress'
 import { ledgerDMKService } from '@/src/services/ledger/ledger-dmk.service'
@@ -521,6 +522,54 @@ describe('useImportLedgerAddress', () => {
         type: 'ledger',
         derivationPath: mockPath,
       })
+    })
+  })
+
+  describe('signer collision', () => {
+    let alertSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined)
+    })
+
+    it('should block import and leave existing signer untouched when a different-type signer exists for the address', async () => {
+      const mockAddress = createMockAddress()
+      const mockPath = createMockPath()
+      const mockIndex = createMockIndex()
+
+      setupSuccessfulOwnershipValidation(mockAddress, mockSafeAddress, mockChainId)
+
+      const existingSigner = {
+        value: mockAddress,
+        name: 'Existing PK',
+        logoUri: null,
+        type: 'private-key' as const,
+      }
+
+      const initialState: Partial<RootState> = {
+        ...getDefaultInitialState(mockSafeAddress, mockChainId),
+        signers: {
+          [mockAddress]: existingSigner,
+        },
+      }
+
+      const hookResult = renderHook(() => useImportLedgerAddress(), initialState)
+      const { result } = hookResult
+      const store = hookResult.store as { getState: () => RootState }
+
+      let importResult
+      await act(async () => {
+        importResult = await result.current.importAddress(mockAddress, mockPath, mockIndex, 'Ledger Device')
+      })
+
+      expect(importResult).toEqual({ success: false })
+      expect(alertSpy).toHaveBeenCalledWith('Signer already imported', expect.any(String), expect.any(Array))
+      expect(mockLedgerDMKService.disconnect).not.toHaveBeenCalled()
+      expect(result.current.isImporting).toBe(false)
+
+      const state = store.getState() as RootState
+      const signers = selectSigners(state)
+      expect(signers[mockAddress]).toEqual(existingSigner)
     })
   })
 })

--- a/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.ts
+++ b/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.ts
@@ -29,7 +29,7 @@ export const useImportLedgerAddress = () => {
   const [isImporting, setIsImporting] = useState(false)
   const [error, setError] = useState<ImportError | null>(null)
   const { validateAddressOwnership } = useAddressOwnershipValidation()
-  const { checkCollision, showCollisionAlert } = useSignerCollisionGuard()
+  const { guardAgainstCollision } = useSignerCollisionGuard()
 
   const clearError = useCallback(() => {
     setError(null)
@@ -60,9 +60,7 @@ export const useImportLedgerAddress = () => {
           return { success: false }
         }
 
-        const existingSigner = checkCollision(address, 'ledger')
-        if (existingSigner) {
-          showCollisionAlert(existingSigner)
+        if (guardAgainstCollision(address, 'ledger')) {
           setIsImporting(false)
           return { success: false }
         }
@@ -98,7 +96,7 @@ export const useImportLedgerAddress = () => {
         return { success: false }
       }
     },
-    [dispatch, validateAddressOwnership, checkCollision, showCollisionAlert],
+    [dispatch, validateAddressOwnership, guardAgainstCollision],
   )
 
   return {

--- a/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.ts
+++ b/apps/mobile/src/features/Ledger/hooks/useImportLedgerAddress.ts
@@ -3,6 +3,7 @@ import { useAppDispatch } from '@/src/store/hooks'
 import { addSignerWithEffects } from '@/src/store/signerThunks'
 import { ledgerDMKService } from '@/src/services/ledger/ledger-dmk.service'
 import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipValidation'
+import { useSignerCollisionGuard } from '@/src/features/ImportSigner/hooks/useSignerCollisionGuard'
 import logger from '@/src/utils/logger'
 
 type ImportError = {
@@ -28,6 +29,7 @@ export const useImportLedgerAddress = () => {
   const [isImporting, setIsImporting] = useState(false)
   const [error, setError] = useState<ImportError | null>(null)
   const { validateAddressOwnership } = useAddressOwnershipValidation()
+  const { checkCollision, showCollisionAlert } = useSignerCollisionGuard()
 
   const clearError = useCallback(() => {
     setError(null)
@@ -54,6 +56,13 @@ export const useImportLedgerAddress = () => {
             code: 'OWNER_VALIDATION',
             message: 'This address is not an owner of the Safe Account',
           })
+          setIsImporting(false)
+          return { success: false }
+        }
+
+        const existingSigner = checkCollision(address, 'ledger')
+        if (existingSigner) {
+          showCollisionAlert(existingSigner)
           setIsImporting(false)
           return { success: false }
         }
@@ -89,7 +98,7 @@ export const useImportLedgerAddress = () => {
         return { success: false }
       }
     },
-    [dispatch, validateAddressOwnership],
+    [dispatch, validateAddressOwnership, checkCollision, showCollisionAlert],
   )
 
   return {

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -207,7 +207,7 @@ describe('useImportSignerFlow', () => {
     expect(mockRouterPush).not.toHaveBeenCalled()
   })
 
-  it('logs the error and returns cleanly when disconnect rejects on a collision', async () => {
+  it('logs error and continues when disconnect fails during collision', async () => {
     mockValidateAddressOwnership.mockResolvedValue({ isOwner: true })
     const disconnectError = new Error('teardown failed')
     mockDisconnect.mockRejectedValueOnce(disconnectError)

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -4,10 +4,16 @@ import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useImportSignerFlow } from '../useImportSignerFlow'
 import { UserRejectedError } from '../useConnect'
+import Logger from '@/src/utils/logger'
 import type { ConnectResult } from '../useConnect'
 import type { Signer } from '@/src/store/signersSlice'
 
 jest.spyOn(Alert, 'alert').mockImplementation(() => undefined)
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}))
 
 const mockAddress = faker.finance.ethereumAddress() as `0x${string}`
 const checksumAddress = getAddress(mockAddress)
@@ -197,6 +203,38 @@ describe('useImportSignerFlow', () => {
       expect(Alert.alert).toHaveBeenCalledWith('Signer already imported', expect.any(String), expect.any(Array))
     })
 
+    expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('logs the error and returns cleanly when disconnect rejects on a collision', async () => {
+    mockValidateAddressOwnership.mockResolvedValue({ isOwner: true })
+    const disconnectError = new Error('teardown failed')
+    mockDisconnect.mockRejectedValueOnce(disconnectError)
+
+    const existing: Signer = {
+      value: checksumAddress,
+      name: 'Existing PK',
+      logoUri: null,
+      type: 'private-key',
+    }
+
+    const { result } = renderImportFlow({ signers: { [checksumAddress]: existing } })
+
+    act(() => {
+      result.current.initiateConnection()
+    })
+
+    await act(async () => {
+      mockConnectResolve({ address: mockAddress, walletName: 'MetaMask', walletIcon: 'icon' })
+    })
+
+    await waitFor(() => {
+      expect(mockDisconnect).toHaveBeenCalled()
+      expect(Logger.error).toHaveBeenCalledWith('Failed to disconnect WC session after collision:', disconnectError)
+    })
+
+    expect(Alert.alert).toHaveBeenCalledWith('Signer already imported', expect.any(String), expect.any(Array))
     expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
   })

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -1,9 +1,13 @@
+import { Alert } from 'react-native'
 import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useImportSignerFlow } from '../useImportSignerFlow'
 import { UserRejectedError } from '../useConnect'
 import type { ConnectResult } from '../useConnect'
+import type { Signer } from '@/src/store/signersSlice'
+
+jest.spyOn(Alert, 'alert').mockImplementation(() => undefined)
 
 const mockAddress = faker.finance.ethereumAddress() as `0x${string}`
 const checksumAddress = getAddress(mockAddress)
@@ -47,7 +51,8 @@ jest.mock('../useConnect', () => ({
   useConnect: () => mockConnect,
 }))
 
-const renderImportFlow = () => renderHook(() => useImportSignerFlow())
+const renderImportFlow = (initialStore?: { signers?: Record<string, Signer> }) =>
+  renderHook(() => useImportSignerFlow(), initialStore)
 
 describe('useImportSignerFlow', () => {
   beforeEach(() => {
@@ -164,6 +169,35 @@ describe('useImportSignerFlow', () => {
     })
 
     expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('disconnects and shows alert when a different-type signer exists for the address', async () => {
+    mockValidateAddressOwnership.mockResolvedValue({ isOwner: true })
+
+    const existing: Signer = {
+      value: checksumAddress,
+      name: 'Existing PK',
+      logoUri: null,
+      type: 'private-key',
+    }
+
+    const { result } = renderImportFlow({ signers: { [checksumAddress]: existing } })
+
+    act(() => {
+      result.current.initiateConnection()
+    })
+
+    await act(async () => {
+      mockConnectResolve({ address: mockAddress, walletName: 'MetaMask', walletIcon: 'icon' })
+    })
+
+    await waitFor(() => {
+      expect(mockDisconnect).toHaveBeenCalled()
+      expect(Alert.alert).toHaveBeenCalledWith('Signer already imported', expect.any(String), expect.any(Array))
+    })
+
+    expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -3,6 +3,7 @@ import { router } from 'expo-router'
 import { getAddress } from 'ethers'
 import { useAppKit } from '@reown/appkit-react-native'
 import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipValidation'
+import { useSignerCollisionGuard } from '@/src/features/ImportSigner/hooks/useSignerCollisionGuard'
 import Logger from '@/src/utils/logger'
 import { useSwitchNetwork } from './useSwitchNetwork'
 import { useConnect, UserRejectedError } from './useConnect'
@@ -15,6 +16,7 @@ export function useImportSignerFlow() {
   const { disconnect } = useAppKit()
   const { switchNetworkIfNeeded } = useSwitchNetwork()
   const { validateAddressOwnership } = useAddressOwnershipValidation()
+  const { checkCollision, showCollisionAlert } = useSignerCollisionGuard()
   const connect = useConnect()
 
   const initiateConnection = useCallback(async () => {
@@ -24,6 +26,13 @@ export function useImportSignerFlow() {
       const result = await validateAddressOwnership(checksumAddress)
 
       if (result.isOwner) {
+        const existingSigner = checkCollision(checksumAddress, 'walletconnect')
+        if (existingSigner) {
+          disconnect()
+          showCollisionAlert(existingSigner)
+          return
+        }
+
         await switchNetworkIfNeeded()
 
         router.push({
@@ -43,7 +52,7 @@ export function useImportSignerFlow() {
         Logger.error('Error during signer import:', error)
       }
     }
-  }, [connect, validateAddressOwnership, switchNetworkIfNeeded, disconnect])
+  }, [connect, validateAddressOwnership, switchNetworkIfNeeded, disconnect, checkCollision, showCollisionAlert])
 
   return { initiateConnection }
 }

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -27,7 +27,11 @@ export function useImportSignerFlow() {
 
       if (result.isOwner) {
         if (guardAgainstCollision(checksumAddress, 'walletconnect')) {
-          disconnect()
+          try {
+            await disconnect()
+          } catch (disconnectError) {
+            Logger.error('Failed to disconnect WC session after collision:', disconnectError)
+          }
           return
         }
 

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -16,7 +16,7 @@ export function useImportSignerFlow() {
   const { disconnect } = useAppKit()
   const { switchNetworkIfNeeded } = useSwitchNetwork()
   const { validateAddressOwnership } = useAddressOwnershipValidation()
-  const { checkCollision, showCollisionAlert } = useSignerCollisionGuard()
+  const { guardAgainstCollision } = useSignerCollisionGuard()
   const connect = useConnect()
 
   const initiateConnection = useCallback(async () => {
@@ -26,10 +26,8 @@ export function useImportSignerFlow() {
       const result = await validateAddressOwnership(checksumAddress)
 
       if (result.isOwner) {
-        const existingSigner = checkCollision(checksumAddress, 'walletconnect')
-        if (existingSigner) {
+        if (guardAgainstCollision(checksumAddress, 'walletconnect')) {
           disconnect()
-          showCollisionAlert(existingSigner)
           return
         }
 
@@ -52,7 +50,7 @@ export function useImportSignerFlow() {
         Logger.error('Error during signer import:', error)
       }
     }
-  }, [connect, validateAddressOwnership, switchNetworkIfNeeded, disconnect, checkCollision, showCollisionAlert])
+  }, [connect, validateAddressOwnership, switchNetworkIfNeeded, disconnect, guardAgainstCollision])
 
   return { initiateConnection }
 }


### PR DESCRIPTION
> Four commits to guard against
> overwrite of one signer by another,
> one alert, one hook, no loss.

## What it solves

Before this fix, importing a signer via private key and then connecting the same address via WalletConnect (or Ledger, or any cross-type combination) silently overwrote the earlier record in the mobile Redux store. Disconnecting the newer signer then removed the record entirely, so the user lost access to the original signer even though its private key was still in the Keychain (orphaned, not deleted).

Resolves: [WA-1997](https://linear.app/safe-global/issue/WA-1997)

## How this PR fixes it

A shared `useSignerCollisionGuard` hook detects cross-type address collisions (case-insensitive via `sameAddress`) and shows an alert that names the existing signer, including the wallet name for WalletConnect imports (e.g. "via MetaMask"). The guard is wired into all four import entry points (PK, seed-phrase, Ledger, WalletConnect). On collision the flow aborts **before** any Keychain write, delegate creation, or Redux dispatch. The WalletConnect path additionally awaits `disconnect()` inside a try/catch so session teardown errors are logged rather than swallowed.

Same-type re-imports (e.g. re-importing the same private key, reconnecting the same WC wallet) are still allowed — they're an idempotent refresh.

The Redux reducer and thunk are intentionally untouched, so the data-import / restore path keeps its overwrite semantics.

Orphaned Keychain entries from users who already hit the pre-fix bug are **out of scope** — they're still present but not affirmatively surfaced. Those users can re-import via private key and the Keychain silently reconciles.

## How to test it

1. Fresh install / reset app state. Add a Safe on any chain you own.
2. Import signer `0xABC…` via **private key** — Settings → Signers shows it.
3. Tap *Connect a wallet app* and complete the WalletConnect flow with the **same** `0xABC…`. **Expected:** alert titled "Signer already imported" — private-key entry is still there, WC session is torn down, no duplicate.
4. Repeat step 3 with a **Ledger** import for the same address → same alert.
5. Swap starting types: import via Ledger or WC first, then attempt PK import for the same address → same alert.
6. Different addresses coexist fine: import PK `0xABC…` + connect WC with `0xDEF…` → both visible, both usable.
7. Data import restore with a mixed-type export still populates all signers (no regression).

## Screenshot
<img width="150" alt="simulator_screenshot_CF2CB727-2C67-4234-B85D-AE32527DAE02" src="https://github.com/user-attachments/assets/c1c0a7b9-a297-4836-bff4-9ef14852469c" />

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before"]
    A1[PK import 0xABC] -->|dispatch| R1[addSigner]
    B1[WC connect 0xABC] -->|dispatch| R1
    R1 -->|overwrite| S1[(state.signers 0xABC = WC)]
    C1[WC disconnect] -->|removeSigner| S2[(state empty)]
    N1[PK key orphaned in Keychain]
  end
  subgraph After["After"]
    A2[PK import 0xABC] -->|dispatch| R2[addSigner]
    B2[WC connect 0xABC] --> G[useSignerCollisionGuard]
    G -->|alert and skip| X[no state change]
    R2 --> S3[(state.signers 0xABC = PK)]
  end
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact; alerts are not tracked
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — guard unit tests + collision branch in every integration hook + disconnect-rejection coverage

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
