### PR TITLE
fix(web): remove grid from NoSpacesState hierarchy

### DIFF
--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -72,9 +72,11 @@ const NoSpacesState = () => {
             What are spaces?
           </Link>
         </Box>
-        <Track {...SPACE_EVENTS.CREATE_SPACE_MODAL} label={SPACE_LABELS.space_list_page}>
-          <AddSpaceButton />
-        </Track>
+        <div className="h-12">
+          <Track {...SPACE_EVENTS.CREATE_SPACE_MODAL} label={SPACE_LABELS.space_list_page}>
+            <AddSpaceButton />
+          </Track>
+        </div>
       </Card>
       {isInfoOpen && <SpaceInfoModal onClose={() => setIsInfoOpen(false)} />}
     </>
@@ -103,7 +105,7 @@ const SpacesList = () => {
 
   const afterSignIn = useCallback(() => {
     setHasSignedIn(true)
-  }, [])
+  }, [setHasSignedIn])
 
   return (
     <Box className={css.container}>
@@ -125,17 +127,19 @@ const SpacesList = () => {
           ))}
 
         {isUserSignedIn || (!redirectLoading && pendingInvites.length) ? (
-          <Grid2 container spacing={2} flexWrap="wrap" data-testid="org-list">
+          <>
             {activeSpaces.length > 0 ? (
-              activeSpaces.map((space) => (
-                <Grid2 size={{ xs: 12, md: 6 }} key={space.name}>
-                  <SpaceCard space={space} currentUserId={currentUser?.id} />
-                </Grid2>
-              ))
+              <Grid2 container spacing={2} flexWrap="wrap" data-testid="org-list">
+                {activeSpaces.map((space) => (
+                  <Grid2 size={{ xs: 12, md: 6 }} key={space.name}>
+                    <SpaceCard space={space} currentUserId={currentUser?.id} />
+                  </Grid2>
+                ))}
+              </Grid2>
             ) : (
               <NoSpacesState />
             )}
-          </Grid2>
+          </>
         ) : (
           <SignedOutState afterSignIn={afterSignIn} redirectLoading={redirectLoading} />
         )}


### PR DESCRIPTION
> Grid wrapped the empty state,
> squeezed the add-space button —
> unwrap, let it breathe.

## What it solves

The `NoSpacesState` was rendered inside a `Grid2` container meant for the list of space cards, which constrained the layout of the empty state and the "Add space" button.

## How this PR fixes it

- Moves the `Grid2` container inside the `activeSpaces.map(...)` branch so it only wraps actual space cards.
- Wraps `AddSpaceButton` in a fixed-height `div` (`h-12`) so it keeps consistent sizing in the empty state.
- `NoSpacesState` now renders outside the grid hierarchy.

## How to test it

- [ ] Sign in without any spaces → verify the empty state renders correctly with the "Add space" button properly sized.
- [ ] Sign in with existing spaces → verify the list still renders in a responsive 2-column grid on `md+`.
- [ ] Verify pending invites still render alongside the list.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[SpacesList] --> G1[Grid2 container]
    G1 --> SC1[SpaceCard items]
    G1 --> NS1[NoSpacesState - constrained]
  end
  subgraph After
    A2[SpacesList] --> C{activeSpaces > 0?}
    C -->|yes| G2[Grid2 container] --> SC2[SpaceCard items]
    C -->|no| NS2[NoSpacesState - free]
  end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)