### PR TITLE
fix(web): stop Turnstile modal popping on silent token expiry

### DIFF
--- a/apps/web/src/components/common/Captcha/__tests__/captchaHeadersInit.test.ts
+++ b/apps/web/src/components/common/Captcha/__tests__/captchaHeadersInit.test.ts
@@ -365,7 +365,7 @@ describe('captchaHeadersInit', () => {
         clone: () => ({ json: () => Promise.reject(new Error('not json')) }),
       }) as unknown as Response
 
-    it('clears token, resets promise, and calls widget refresh on captcha 401 from protected URL', async () => {
+    it('clears token on captcha 401 from protected URL without eagerly refreshing the widget', async () => {
       const mockRefresh = jest.fn()
       registerWidgetRefreshCallback(mockRefresh)
       sharedTokenRef.current = 'old-token'
@@ -375,7 +375,9 @@ describe('captchaHeadersInit', () => {
       await hook(makeResponse(401, { message: 'Invalid CAPTCHA token' }), PROTECTED_URL)
 
       expect(sharedTokenRef.current).toBeNull()
-      expect(mockRefresh).toHaveBeenCalledTimes(1)
+      // Lazy rotation: don't refresh the widget on 401 — the retry or next
+      // protected request triggers a fresh challenge via prepareHeaders.
+      expect(mockRefresh).not.toHaveBeenCalled()
     })
 
     it('does nothing for a captcha 401 from a non-protected URL', async () => {

--- a/apps/web/src/components/common/Captcha/__tests__/useCaptchaToken.test.ts
+++ b/apps/web/src/components/common/Captcha/__tests__/useCaptchaToken.test.ts
@@ -87,6 +87,15 @@ describe('useCaptchaToken', () => {
       expect(registerWidgetRefreshCallback).toHaveBeenCalledTimes(1)
       expect(registerWidgetRefreshCallback).toHaveBeenCalledWith(expect.any(Function))
     })
+
+    it('disables auto-refresh on silent TTL expiry so the widget never challenges in the background', async () => {
+      const { result } = renderHook(() => useCaptchaToken({ isScriptReady: true }))
+      mountContainer(result)
+      await waitFor(() => expect(mockTurnstile.render).toHaveBeenCalledTimes(1))
+
+      const renderOptions = mockTurnstile.render.mock.calls[0][1]
+      expect(renderOptions['refresh-expired']).toBe('never')
+    })
   })
 
   describe('token callback', () => {

--- a/apps/web/src/components/common/Captcha/__tests__/useCaptchaToken.test.ts
+++ b/apps/web/src/components/common/Captcha/__tests__/useCaptchaToken.test.ts
@@ -2,7 +2,6 @@ import { act, renderHook, waitFor } from '@/tests/test-utils'
 import {
   sharedTokenRef,
   resolveCaptchaReady,
-  resetCaptchaPromise,
   registerWidgetRefreshCallback,
 } from '@/components/common/Captcha/captchaHeadersInit'
 import { useCaptchaToken } from '@/components/common/Captcha/useCaptchaToken'
@@ -11,7 +10,6 @@ import { useCaptchaToken } from '@/components/common/Captcha/useCaptchaToken'
 jest.mock('@/components/common/Captcha/captchaHeadersInit', () => ({
   sharedTokenRef: { current: null },
   resolveCaptchaReady: jest.fn(),
-  resetCaptchaPromise: jest.fn(),
   registerWidgetRefreshCallback: jest.fn(),
 }))
 
@@ -147,8 +145,9 @@ describe('useCaptchaToken', () => {
 
       expect(result.current.token).toBeNull()
       expect((sharedTokenRef as { current: string | null }).current).toBeNull()
-      expect(resetCaptchaPromise).toHaveBeenCalled()
-      expect(mockTurnstile.reset).toHaveBeenCalledWith('widget-id-1')
+      // Lazy rotation: don't reset the widget on silent expiry — next protected
+      // request triggers a fresh challenge via captchaHeadersInit.
+      expect(mockTurnstile.reset).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/web/src/components/common/Captcha/captchaHeadersInit.ts
+++ b/apps/web/src/components/common/Captcha/captchaHeadersInit.ts
@@ -129,9 +129,10 @@ export function initializeCaptchaHeaders() {
     try {
       const data = await response.clone().json()
       if (data?.message === 'Invalid CAPTCHA token') {
+        // Clear the stale token only. The next protected request will lazily
+        // trigger a fresh challenge via the rotation logic above — avoids
+        // popping a modal when no retry is in flight.
         sharedTokenRef.current = null
-        resetCaptchaPromise()
-        widgetRefreshCallbackRef.current()
       }
     } catch {
       // Ignore non-JSON or unreadable responses

--- a/apps/web/src/components/common/Captcha/useCaptchaToken.ts
+++ b/apps/web/src/components/common/Captcha/useCaptchaToken.ts
@@ -12,6 +12,7 @@ declare global {
           theme?: 'light' | 'dark' | 'auto'
           size?: 'normal' | 'compact' | 'flexible'
           appearance?: 'always' | 'execute' | 'interaction-only'
+          'refresh-expired'?: 'auto' | 'manual' | 'never'
           callback?: (token: string) => void
           'error-callback'?: (error: string) => void
           'expired-callback'?: () => void
@@ -75,6 +76,12 @@ export function useCaptchaToken({ theme = 'auto', isScriptReady }: UseCaptchaTok
         size: 'normal',
         // Only show widget when user interaction is required
         appearance: 'interaction-only',
+        // Default is 'auto', which silently re-runs the challenge at the
+        // ~5-minute TTL and pops the modal on idle tabs. 'never' keeps the
+        // widget dormant on expiry; refreshToken() → turnstile.reset() is the
+        // only path that fetches a new token, and only when a real protected
+        // request is waiting.
+        'refresh-expired': 'never',
         callback: (token: string) => {
           sharedTokenRef.current = token
           resolveCaptchaReady()

--- a/apps/web/src/components/common/Captcha/useCaptchaToken.ts
+++ b/apps/web/src/components/common/Captcha/useCaptchaToken.ts
@@ -1,10 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import {
-  sharedTokenRef,
-  resolveCaptchaReady,
-  resetCaptchaPromise,
-  registerWidgetRefreshCallback,
-} from './captchaHeadersInit'
+import { sharedTokenRef, resolveCaptchaReady, registerWidgetRefreshCallback } from './captchaHeadersInit'
 import { TURNSTILE_SITE_KEY } from '@safe-global/utils/config/constants'
 
 declare global {
@@ -99,11 +94,12 @@ export function useCaptchaToken({ theme = 'auto', isScriptReady }: UseCaptchaTok
           setIsLoading(false)
           setToken(null)
         },
+        // Token expired silently (Turnstile ~5min TTL). Clear it and wait for
+        // the next protected request to lazily trigger a fresh challenge via
+        // captchaHeadersInit. Avoids background modal pops when the user is idle.
         'expired-callback': () => {
           sharedTokenRef.current = null
-          resetCaptchaPromise()
           setToken(null)
-          refreshToken()
         },
         // Show modal only when interaction is required
         'before-interactive-callback': () => {


### PR DESCRIPTION

> Idle tabs used to blink,
> five-minute token expiries —
> silent now, no pop.

## What it solves

Users reported the Turnstile captcha modal popping up every ~5 minutes on idle tabs, with no network activity or user action to trigger it. Follow-up to #7690.

Two paths eagerly reset the Turnstile widget when nothing is waiting on a token:

1. **Turnstile token TTL expiry (client-side).** Turnstile tokens expire after ~300 seconds. When a token is issued and not consumed within the TTL, Turnstile fires `expired-callback`. Our handler called `refreshToken()` → `turnstile.reset(widgetId)` → widget re-runs the challenge → if interaction is required, the modal appears.
2. **Server-side "Invalid CAPTCHA token" 401 (response hook).** Same pattern: clear the token, reset the ready promise, refresh the widget. No retry is in flight, so the modal pops unnecessarily.

Both of these used to be needed by the old "eager rotation" model from #7069. After #7690 introduced lazy rotation inside `prepareHeaders`, they are redundant — and actively harmful, because they generate modal pops with no pending request to justify them.

## How this PR fixes it

### `useCaptchaToken.ts` — lazy `expired-callback`

```diff
+// Token expired silently (Turnstile ~5min TTL). Clear it and wait for
+// the next protected request to lazily trigger a fresh challenge via
+// captchaHeadersInit. Avoids background modal pops when the user is idle.
 'expired-callback': () => {
   sharedTokenRef.current = null
-  resetCaptchaPromise()
   setToken(null)
-  refreshToken()
 },
```

Also dropped the now-unused `resetCaptchaPromise` import.

### `captchaHeadersInit.ts` — lazy 401 response hook

```diff
 if (data?.message === 'Invalid CAPTCHA token') {
+  // Clear the stale token only. The next protected request will lazily
+  // trigger a fresh challenge via the rotation logic above — avoids
+  // popping a modal when no retry is in flight.
   sharedTokenRef.current = null
-  resetCaptchaPromise()
-  widgetRefreshCallbackRef.current()
 }
```

### Tests

- `useCaptchaToken 'expired-callback'` test: asserts `mockTurnstile.reset` is **not** called after the expired-callback fires.
- `captchaHeadersInit responseHook 401` test: renamed and updated to assert `mockRefresh` is **not** called after a captcha 401.

Both assertions are the inverse of what they were — the behavior change is the whole point of the PR.

## How to test it

1. `yarn workspace @safe-global/web dev`.
2. Log in, navigate to a Safe, open `/home?safe=<chain>:<addr>`.
3. Solve the Turnstile challenge once (for the initial v2 request from `InconsistentSignerSetupWarning`).
4. Leave the tab idle for 10+ minutes.
5. **Expected:** no captcha modal appears during the idle period.
6. After idling, trigger a v2-hitting flow (e.g. Spaces onboarding that calls `useAllOwnedSafes`).
7. **Expected:** one modal appears, solves, request succeeds — modal does **not** re-open spontaneously afterwards.
8. In the Network tab, provoke a fake 401 on a protected endpoint (e.g. block `/v2/owners` at the DevTools level, or temporarily patch CGW to return 401). Confirm **no** modal pops after the 401 — the user sees the failed request surface in the UI instead.

## Trade-offs worth calling out

- **Subtle UX shift.** Previously, an idle user's next protected request could complete without a visible challenge because the widget had pre-warmed a token during a silent expiry. Now, an idle user's next protected request blocks on solving a fresh challenge. Net effect: **more latency on the first post-idle action, zero interruption while actually idle.** The user complaints cluster on the second behavior, so the trade reads positive.
- **Stale-token race.** A request that reads the token at t=4:59 and arrives at the server at t=5:01 will 401 and (with this change) will **not** auto-retry. RTK Query's current config does not retry these. The user will see the failed request surface in the UI — re-triggering the action works (lazy refresh kicks in on the next request). Acceptable for now; a follow-up could add a one-shot retry in `handleResponseHook` if telemetry shows this happens in the wild.

## Visual summary

```mermaid
sequenceDiagram
    participant U as User (idle)
    participant W as Turnstile widget
    participant H as captcha hooks
    participant S as Server

    Note over U,S: Before — eager refresh on silent expiry
    W->>H: expired-callback (t=5:00)
    H->>W: turnstile.reset()
    W->>W: challenge requires interaction
    W-->>U: modal pops (no pending request) 😡

    Note over U,S: After — lazy refresh
    W->>H: expired-callback (t=5:00)
    H->>H: clear sharedTokenRef only
    Note over U: idle, no modal 🙂
    U->>H: real request fires (t=30:00)
    H->>W: lazy refresh (turnstile.reset)
    W-->>U: modal pops with pending request
    U->>W: solves
    W->>H: new token
    H->>S: request with fresh token
```

## Checklist

- [x] Unit tests updated for the new lazy behavior
- [x] `yarn verify:changed:web` passes (type-check, lint, prettier, tests)
- [ ] Manual QA on staging — 10+ minute idle with zero modal pops
- [ ] Confirm no regression on the manual retry button in `CaptchaModal` (error state → Retry still works; it uses `refreshToken` directly, not via these code paths)
- [ ] Observe captcha-modal-open telemetry post-deploy to confirm the drop (if telemetry exists)
