### PR TITLE
chore(ci): add scheduled AUTO_GENERATED drift check

### DIFF
--- a/.github/workflows/store-codegen-drift.yml
+++ b/.github/workflows/store-codegen-drift.yml
@@ -1,0 +1,99 @@
+name: Store Codegen Drift
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-drift:
+    permissions:
+      contents: read
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/yarn
+        with:
+          after-install: 'false'
+      - run: yarn workspace @safe-global/store build:dev
+      - name: Check for drift
+        id: drift
+        run: git diff --exit-code -- packages/store/scripts/api-schema/schema.json packages/store/src/gateway/AUTO_GENERATED/
+
+      - name: Capture changed files
+        if: failure() && steps.drift.outcome == 'failure'
+        run: git diff --name-only -- packages/store/scripts/api-schema/schema.json packages/store/src/gateway/AUTO_GENERATED/ > "${RUNNER_TEMP}/drift-files.txt"
+
+      - name: Open or update drift issue
+        if: failure() && steps.drift.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const path = require('path')
+            const marker = '<!-- store-codegen-drift -->'
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const driftPath = path.join(process.env.RUNNER_TEMP, 'drift-files.txt')
+            const raw = fs.existsSync(driftPath) ? fs.readFileSync(driftPath, 'utf8') : ''
+            const files = raw.trim() || '(no files listed)'
+            const body = [
+              marker,
+              'The scheduled `Store Codegen Drift` workflow detected that `packages/store/src/gateway/AUTO_GENERATED/` is out of sync with the staging CGW schema.',
+              '',
+              `**Failing run:** ${runUrl}`,
+              '',
+              '**Fix:**',
+              '```bash',
+              'yarn workspace @safe-global/store build:dev',
+              '# commit the resulting changes',
+              '```',
+              '',
+              '**Changed files:**',
+              '```',
+              files,
+              '```',
+              '',
+              'This issue will auto-close the next time the workflow succeeds.',
+            ].join('\n')
+            const q = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:body "${marker}" author:app/github-actions`
+            const { data } = await github.rest.search.issuesAndPullRequests({ q })
+            if (data.items.length > 0) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: data.items[0].number,
+                body: `New drift detected in run ${runUrl}.\n\nChanged files:\n\`\`\`\n${files}\n\`\`\``,
+              })
+            } else {
+              await github.rest.issues.create({
+                ...context.repo,
+                title: 'CI: store codegen drift detected',
+                body,
+              })
+            }
+
+      - name: Close drift issue on success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- store-codegen-drift -->'
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const q = `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:body "${marker}" author:app/github-actions`
+            const { data } = await github.rest.search.issuesAndPullRequests({ q })
+            for (const issue of data.items) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issue.number,
+                body: `Drift resolved in run ${runUrl}. Auto-closing.`,
+              })
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              })
+            }


### PR DESCRIPTION
> Staging schema shifts in the night,
> generated files slip out of sight,
> a daily job diffs them right.

## What it solves

Resolves: a silent CI gap for upstream schema drift in \`packages/store/src/gateway/AUTO_GENERATED/\`.

The existing \`store-codegen-check.yml\` is path-scoped — it only runs when a PR already touches \`schema.json\` or \`AUTO_GENERATED/\`. If the staging CGW API schema changes while no PR touches those files, the generated code rots silently until someone regenerates locally (or it hits prod). The \`.schema-hash\` file tracks the mapping but nothing in CI compares it.

## How this PR fixes it

Adds a new workflow \`store-codegen-drift.yml\` that runs on:

- **Schedule** — daily at 06:00 UTC
- **\`workflow_dispatch\`** — manual trigger for on-demand checks

The job re-runs \`yarn workspace @safe-global/store build:dev\` (fetches fresh staging schema + regenerates) and then \`git diff --exit-code\` against \`schema.json\` and \`AUTO_GENERATED/\`. Any drift fails the workflow and surfaces as a normal GitHub workflow-failure notification.

Design choice: scheduled (not PR-triggered) so staging-API churn doesn't flake unrelated PRs. The existing path-scoped PR check still handles intra-PR consistency; this new job closes the upstream-drift gap.

Uses \`after-install: 'false'\` on the shared \`yarn\` action to skip the web contract-type generation (not needed for store codegen).

## How to test it

- [ ] Trigger manually from the Actions tab: **Store Codegen Drift → Run workflow**. It should succeed on a clean \`dev\`.
- [ ] To simulate drift, temporarily modify any file under \`packages/store/src/gateway/AUTO_GENERATED/\` on a branch and trigger the workflow against that ref — it should fail at the \`Fail on drift\` step with a non-empty \`git diff\`.
- [ ] Verify the scheduled run appears in the Actions tab after the first 06:00 UTC window.

## Visual summary

\`\`\`mermaid
flowchart LR
  subgraph Before
    A1[PR opened] -->|touches AUTO_GENERATED?| B1{Path match}
    B1 -->|yes| C1[store-codegen-check runs]
    B1 -->|no| D1[No check — upstream drift<br/>goes undetected]
  end
  subgraph After
    A2[Daily 06:00 UTC] --> E[store-codegen-drift]
    F[workflow_dispatch] --> E
    E --> G[yarn build:dev]
    G --> H[git diff --exit-code]
    H -->|drift| I[Fail — notify team]
    H -->|clean| J[Pass]
  end
\`\`\`

## Checklist

- [x] I've tested the branch on mobile — N/A (CI-only change)
- [x] I've documented how it affects the analytics (if at all) — N/A
- [x] I've written a unit/e2e test for it (if applicable) — N/A (workflow file)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

Generated with [Claude Code](https://claude.com/claude-code)