### PR TITLE
fix(web/Spaces): avoid invalid requests where `spaceId=0`

### DIFF
--- a/apps/web/src/features/spaces/components/AuthState/index.test.tsx
+++ b/apps/web/src/features/spaces/components/AuthState/index.test.tsx
@@ -1,0 +1,117 @@
+import { render } from '@testing-library/react'
+import AuthState from './index'
+
+const mockUseSpacesGetOneV1Query = jest.fn()
+const mockUseUsersGetWithWalletsV1Query = jest.fn()
+const mockUseHasFeature = jest.fn()
+const mockDispatch = jest.fn()
+let mockIsAuthenticated = true
+let mockIsOidcLoginPending = false
+
+jest.mock('@/store', () => ({
+  useAppSelector: (selector: string) => {
+    if (selector === 'isAuthenticated') return mockIsAuthenticated
+    if (selector === 'selectIsOidcLoginPending') return mockIsOidcLoginPending
+    return undefined
+  },
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: 'isAuthenticated',
+  selectIsOidcLoginPending: 'selectIsOidcLoginPending',
+  setLastUsedSpace: (id: string) => ({ type: 'setLastUsedSpace', payload: id }),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useSpacesGetOneV1Query: (...args: unknown[]) => mockUseSpacesGetOneV1Query(...args),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/users', () => ({
+  useUsersGetWithWalletsV1Query: (...args: unknown[]) => mockUseUsersGetWithWalletsV1Query(...args),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  useHasFeature: () => mockUseHasFeature(),
+}))
+
+jest.mock('../SignedOutState', () => ({
+  __esModule: true,
+  default: () => <div data-testid="signed-out" />,
+}))
+
+jest.mock('../UnauthorizedState', () => ({
+  __esModule: true,
+  default: () => <div data-testid="unauthorized" />,
+}))
+
+jest.mock('../LoadingState', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loading" />,
+}))
+
+jest.mock('@/features/spaces/utils', () => ({
+  isUnauthorized: () => false,
+}))
+
+jest.mock('@/features/spaces', () => ({
+  MemberStatus: { DECLINED: 'DECLINED' },
+}))
+
+describe('AuthState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsAuthenticated = true
+    mockIsOidcLoginPending = false
+    mockUseHasFeature.mockReturnValue(true)
+    mockUseSpacesGetOneV1Query.mockReturnValue({
+      currentData: { id: 1, members: [] },
+      error: undefined,
+      isLoading: false,
+    })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 'u1' } })
+  })
+
+  it('skips the space query when the user is not authenticated', () => {
+    mockIsAuthenticated = false
+
+    render(
+      <AuthState spaceId="7">
+        <div />
+      </AuthState>,
+    )
+
+    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('skips the space query when spaceId is empty', () => {
+    render(
+      <AuthState spaceId="">
+        <div />
+      </AuthState>,
+    )
+
+    // Without the guard, Number('') would be 0 and the query would hit /v1/spaces/0
+    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('skips the space query when spaceId is undefined at runtime', () => {
+    render(
+      <AuthState spaceId={undefined as unknown as string}>
+        <div />
+      </AuthState>,
+    )
+
+    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('fires the space query with the numeric id when authenticated and spaceId is set', () => {
+    render(
+      <AuthState spaceId="42">
+        <div />
+      </AuthState>,
+    )
+
+    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith({ id: 42 }, { skip: false })
+  })
+})

--- a/apps/web/src/features/spaces/components/AuthState/index.test.tsx
+++ b/apps/web/src/features/spaces/components/AuthState/index.test.tsx
@@ -95,6 +95,16 @@ describe('AuthState', () => {
     expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
   })
 
+  it('skips the space query when spaceId is null at runtime (Number(null) is 0)', () => {
+    render(
+      <AuthState spaceId={null as unknown as string}>
+        <div />
+      </AuthState>,
+    )
+
+    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
   it('skips the space query when spaceId is undefined at runtime', () => {
     render(
       <AuthState spaceId={undefined as unknown as string}>

--- a/apps/web/src/features/spaces/components/AuthState/index.tsx
+++ b/apps/web/src/features/spaces/components/AuthState/index.tsx
@@ -15,7 +15,10 @@ const AuthState = ({ spaceId, children }: { spaceId: string; children: ReactNode
   const dispatch = useAppDispatch()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
-  const { currentData, error, isLoading } = useSpacesGetOneV1Query({ id: Number(spaceId) }, { skip: !isUserSignedIn })
+  const { currentData, error, isLoading } = useSpacesGetOneV1Query(
+    { id: Number(spaceId) },
+    { skip: !isUserSignedIn || !spaceId },
+  )
   const isSpacesFeatureEnabled = useHasFeature(FEATURES.SPACES)
   const isOidcLoginPending = useAppSelector(selectIsOidcLoginPending)
 

--- a/apps/web/src/features/spaces/hooks/__tests__/useAllMembers.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useAllMembers.test.ts
@@ -46,18 +46,10 @@ describe('useAllMembers (via useSpaceMembersByStatus / useCurrentMembership)', (
     expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
   })
 
-  it('skips the members query when there is no current spaceId', () => {
+  it('skips the members query when there is no current spaceId (Number(null) is 0 — must not request /v1/spaces/0)', () => {
     mockUseCurrentSpaceId.mockReturnValue(null)
 
     renderHook(() => useSpaceMembersByStatus())
-
-    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
-  })
-
-  it('skips the members query when the explicit spaceId arg is 0', () => {
-    mockUseCurrentSpaceId.mockReturnValue('5')
-
-    renderHook(() => useCurrentMembership(0))
 
     expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
   })

--- a/apps/web/src/features/spaces/hooks/__tests__/useAllMembers.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useAllMembers.test.ts
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react'
+import { useSpaceMembersByStatus, useCurrentMembership } from '../useSpaceMembers'
+
+const mockUseCurrentSpaceId = jest.fn()
+const mockUseMembersGetUsersV1Query = jest.fn()
+let mockIsAuthenticated = true
+
+jest.mock('../useCurrentSpaceId', () => ({
+  useCurrentSpaceId: () => mockUseCurrentSpaceId(),
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: () => mockIsAuthenticated,
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: 'isAuthenticated',
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useMembersGetUsersV1Query: (...args: unknown[]) => mockUseMembersGetUsersV1Query(...args),
+  useMembersGetMembershipV1Query: jest.fn(() => ({ currentData: undefined, isLoading: false })),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/auth', () => ({
+  useAuthGetMeV1Query: jest.fn(() => ({ data: undefined, isLoading: false })),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/users', () => ({
+  useUsersGetWithWalletsV1Query: jest.fn(() => ({ currentData: undefined })),
+}))
+
+describe('useAllMembers (via useSpaceMembersByStatus / useCurrentMembership)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsAuthenticated = true
+    mockUseMembersGetUsersV1Query.mockReturnValue({ data: undefined })
+  })
+
+  it('skips the members query when the user is not authenticated', () => {
+    mockIsAuthenticated = false
+    mockUseCurrentSpaceId.mockReturnValue('3')
+
+    renderHook(() => useSpaceMembersByStatus())
+
+    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('skips the members query when there is no current spaceId', () => {
+    mockUseCurrentSpaceId.mockReturnValue(null)
+
+    renderHook(() => useSpaceMembersByStatus())
+
+    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('skips the members query when the explicit spaceId arg is 0', () => {
+    mockUseCurrentSpaceId.mockReturnValue('5')
+
+    renderHook(() => useCurrentMembership(0))
+
+    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('fires the members query with the numeric spaceId when authenticated and spaceId is set', () => {
+    mockUseCurrentSpaceId.mockReturnValue('9')
+
+    renderHook(() => useSpaceMembersByStatus())
+
+    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith({ spaceId: 9 }, { skip: false })
+  })
+
+  it('prefers the explicit spaceId arg over the current spaceId', () => {
+    mockUseCurrentSpaceId.mockReturnValue('9')
+
+    renderHook(() => useCurrentMembership(2))
+
+    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith({ spaceId: 2 }, { skip: false })
+  })
+})

--- a/apps/web/src/features/spaces/hooks/__tests__/useGetSpaceAddressBook.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useGetSpaceAddressBook.test.ts
@@ -1,0 +1,83 @@
+import { renderHook } from '@testing-library/react'
+import useGetSpaceAddressBook from '../useGetSpaceAddressBook'
+
+const mockUseCurrentSpaceId = jest.fn()
+const mockUseAddressBooksGetAddressBookItemsV1Query = jest.fn()
+let mockIsAuthenticated = true
+
+jest.mock('../useCurrentSpaceId', () => ({
+  useCurrentSpaceId: () => mockUseCurrentSpaceId(),
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: () => mockIsAuthenticated,
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: 'isAuthenticated',
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useAddressBooksGetAddressBookItemsV1Query: (...args: unknown[]) =>
+    mockUseAddressBooksGetAddressBookItemsV1Query(...args),
+}))
+
+describe('useGetSpaceAddressBook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsAuthenticated = true
+    mockUseAddressBooksGetAddressBookItemsV1Query.mockReturnValue({ currentData: undefined })
+  })
+
+  it('skips the query when the user is not authenticated', () => {
+    mockIsAuthenticated = false
+    mockUseCurrentSpaceId.mockReturnValue('7')
+
+    renderHook(() => useGetSpaceAddressBook())
+
+    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('skips the query when there is no current spaceId (null)', () => {
+    mockUseCurrentSpaceId.mockReturnValue(null)
+
+    renderHook(() => useGetSpaceAddressBook())
+
+    // Must NOT fire /v1/spaces/0/address-book — Number(null) would be 0 without the guard
+    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('skips the query when spaceId is an empty string', () => {
+    mockUseCurrentSpaceId.mockReturnValue('')
+
+    renderHook(() => useGetSpaceAddressBook())
+
+    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('fires the query with the numeric spaceId when authenticated and spaceId is set', () => {
+    mockUseCurrentSpaceId.mockReturnValue('42')
+
+    renderHook(() => useGetSpaceAddressBook())
+
+    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith({ spaceId: 42 }, { skip: false })
+  })
+
+  it('returns the address book data when the query resolves', () => {
+    mockUseCurrentSpaceId.mockReturnValue('1')
+    const data = [{ address: '0xabc', name: 'Alice', chainIds: ['1'] }]
+    mockUseAddressBooksGetAddressBookItemsV1Query.mockReturnValue({ currentData: { data } })
+
+    const { result } = renderHook(() => useGetSpaceAddressBook())
+
+    expect(result.current).toEqual(data)
+  })
+
+  it('returns an empty array when the query has no data', () => {
+    mockUseCurrentSpaceId.mockReturnValue('1')
+
+    const { result } = renderHook(() => useGetSpaceAddressBook())
+
+    expect(result.current).toEqual([])
+  })
+})

--- a/apps/web/src/features/spaces/hooks/__tests__/useGetSpaceAddressBook.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useGetSpaceAddressBook.test.ts
@@ -38,12 +38,11 @@ describe('useGetSpaceAddressBook', () => {
     expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
   })
 
-  it('skips the query when there is no current spaceId (null)', () => {
+  it('skips the query when there is no current spaceId (Number(null) is 0 — must not hit /v1/spaces/0/...)', () => {
     mockUseCurrentSpaceId.mockReturnValue(null)
 
     renderHook(() => useGetSpaceAddressBook())
 
-    // Must NOT fire /v1/spaces/0/address-book — Number(null) would be 0 without the guard
     expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
   })
 

--- a/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
@@ -80,7 +80,7 @@ describe('useSpaceSafes', () => {
     expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
   })
 
-  it('skips the query when there is no current spaceId', () => {
+  it('skips the query when there is no current spaceId (Number(null) is 0 — must not hit /v1/spaces/0/...)', () => {
     mockUseCurrentSpaceId.mockReturnValue(null)
 
     renderHook(() => useSpaceSafes())

--- a/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react'
+import { useSpaceSafes } from '../useSpaceSafes'
+
+const mockUseCurrentSpaceId = jest.fn()
+const mockUseSpaceSafesGetV1Query = jest.fn()
+const mockUseGetSpaceAddressBook = jest.fn()
+const mockUseWallet = jest.fn()
+const mockUseAllOwnedSafes = jest.fn()
+const mockUseAllSafesGrouped = jest.fn()
+let mockIsAuthenticated = true
+
+jest.mock('../useCurrentSpaceId', () => ({
+  useCurrentSpaceId: () => mockUseCurrentSpaceId(),
+}))
+
+jest.mock('../useGetSpaceAddressBook', () => ({
+  __esModule: true,
+  default: () => mockUseGetSpaceAddressBook(),
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: (selector: string) => {
+    if (selector === 'isAuthenticated') return mockIsAuthenticated
+    if (selector === 'selectOrderByPreference') return { orderBy: 'name' }
+    return undefined
+  },
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: 'isAuthenticated',
+}))
+
+jest.mock('@/store/orderByPreferenceSlice', () => ({
+  selectOrderByPreference: 'selectOrderByPreference',
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useSpaceSafesGetV1Query: (...args: unknown[]) => mockUseSpaceSafesGetV1Query(...args),
+}))
+
+jest.mock('@/hooks/safes', () => ({
+  _buildSafeItems: jest.fn(() => []),
+  useAllSafesGrouped: () => mockUseAllSafesGrouped(),
+  useAllOwnedSafes: () => mockUseAllOwnedSafes(),
+  getComparator: () => () => 0,
+}))
+
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: () => mockUseWallet(),
+}))
+
+jest.mock('../../utils', () => ({
+  mapSpaceContactsToAddressBookState: jest.fn(() => ({})),
+}))
+
+describe('useSpaceSafes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsAuthenticated = true
+    mockUseGetSpaceAddressBook.mockReturnValue([])
+    mockUseWallet.mockReturnValue({ address: '0xabc' })
+    mockUseAllOwnedSafes.mockReturnValue([{}])
+    mockUseAllSafesGrouped.mockReturnValue({ allMultiChainSafes: [], allSingleSafes: [] })
+    mockUseSpaceSafesGetV1Query.mockReturnValue({
+      currentData: undefined,
+      isLoading: false,
+      isError: false,
+      error: undefined,
+      refetch: jest.fn(),
+    })
+  })
+
+  it('skips the query when the user is not authenticated', () => {
+    mockIsAuthenticated = false
+    mockUseCurrentSpaceId.mockReturnValue('7')
+
+    renderHook(() => useSpaceSafes())
+
+    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('skips the query when there is no current spaceId', () => {
+    mockUseCurrentSpaceId.mockReturnValue(null)
+
+    renderHook(() => useSpaceSafes())
+
+    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('fires the query when authenticated and spaceId is set', () => {
+    mockUseCurrentSpaceId.mockReturnValue('5')
+
+    renderHook(() => useSpaceSafes())
+
+    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith({ spaceId: 5 }, { skip: false })
+  })
+})

--- a/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
+++ b/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
@@ -8,7 +8,7 @@ const useGetSpaceAddressBook = () => {
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: addressBook } = useAddressBooksGetAddressBookItemsV1Query(
     { spaceId: Number(spaceId) },
-    { skip: !isUserSignedIn },
+    { skip: !isUserSignedIn || !spaceId },
   )
 
   return addressBook?.data || []

--- a/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
@@ -28,7 +28,10 @@ const useAllMembers = (spaceId?: number) => {
   const currentSpaceId = useCurrentSpaceId()
   const actualSpaceId = spaceId ?? currentSpaceId
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { data: currentData } = useMembersGetUsersV1Query({ spaceId: Number(actualSpaceId) }, { skip: !isUserSignedIn })
+  const { data: currentData } = useMembersGetUsersV1Query(
+    { spaceId: Number(actualSpaceId) },
+    { skip: !isUserSignedIn || !actualSpaceId },
+  )
   return currentData?.members || []
 }
 

--- a/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
@@ -18,7 +18,7 @@ export const useSpaceSafes = () => {
     isError: isSpaceSafesError,
     error: spaceSafesError,
     refetch: refetchSpaceSafes,
-  } = useSpaceSafesGetV1Query({ spaceId: Number(spaceId) }, { skip: !isUserSignedIn })
+  } = useSpaceSafesGetV1Query({ spaceId: Number(spaceId) }, { skip: !isUserSignedIn || !spaceId })
   const spaceContacts = useGetSpaceAddressBook()
 
   // We are doing this in order to reuse the _buildSafeItems function but only take space contacts into account


### PR DESCRIPTION
> Null spaceId slipped through the skip,
> fired `/v1/spaces/0/...` on login,
> guard added, query stays quiet.

## What it solves

Resolves: [WA-2030](https://linear.app/safe-global/issue/WA-2030/bug-avoid-calls-where-spaceid0)

A call with `spaceId=0` - `GET /v1/spaces/0/address-book` (and sibling `/v1/spaces/0/...` requests) was firing as soon as the user signs into Spaces.

`useCurrentSpaceId()` can return `null` when no `spaceId` is in the URL, no `lastUsedSpace` is stored, and the user's spaces list hasn't resolved yet. `Number(null)` is `0`, so RTK Query issued requests against space id `0`. `useGetSpaceAddressBook` is called transitively by `useMergedAddressBooks` → `useAddressBookItem`, which runs on nearly every page — so the request fired right after login, not only on Space pages.

## How this PR fixes it

Adds a `!spaceId` guard to the RTK Query `skip` option in the four places that were missing it:

- `useGetSpaceAddressBook`
- `useSpaceSafes`
- `useSpaceMembers` → `useAllMembers` (uses `!actualSpaceId` to account for the explicit arg)
- `AuthState` component (`useSpacesGetOneV1Query`)

Sibling hooks (`useSpaceSafesWithQueue`, `useCurrentMemberProfile`, `SpaceSettings`, `SpaceBreadcrumbs`, …) already had the guard — left untouched.

## How to test it

1. Sign out of Spaces.
2. Open DevTools → Network, filter by `spaces/`.
3. Sign in to Spaces from a non-Space route (e.g. a Safe dashboard).
4. **Before:** `GET /v1/spaces/0/address-book` appears (400/404). **After:** no such request.
5. Navigate into a Space; verify the normal `GET /v1/spaces/{realId}/address-book` still fires.
6. Unit tests: `yarn workspace @safe-global/web jest src/features/spaces/hooks/__tests__/useGetSpaceAddressBook.test.ts src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx src/features/spaces/hooks/__tests__/useAllMembers.test.ts src/features/spaces/components/AuthState/index.test.tsx`

## Visual summary

```mermaid
flowchart LR
  A[useCurrentSpaceId] -->|null| B{skip option}
  B -->|Before: skip = !isUserSignedIn| C["Number(null) = 0<br/>GET /v1/spaces/0/..."]
  B -->|After: skip = !isUserSignedIn OR !spaceId| D[query skipped ✓]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (web-only change)
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
