### PR TITLE
chore: add Turborepo with remote caching

### DIFF
--- a/.github/actions/yarn/action.yml
+++ b/.github/actions/yarn/action.yml
@@ -7,6 +7,14 @@ inputs:
     description: 'Run web after-install step to generate contract types'
     required: false
     default: 'true'
+  turbo-token:
+    description: 'Turborepo remote cache token (Vercel PAT)'
+    required: false
+    default: ''
+  turbo-team:
+    description: 'Turborepo remote cache team slug'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -17,6 +25,14 @@ runs:
       with:
         node-version: '24.14.0'
         cache: 'yarn'
+
+    - name: Export Turbo remote cache env
+      if: inputs.turbo-token != ''
+      shell: bash
+      run: |
+        echo "TURBO_TOKEN=${{ inputs.turbo-token }}" >> "$GITHUB_ENV"
+        echo "TURBO_TEAM=${{ inputs.turbo-team }}" >> "$GITHUB_ENV"
+        echo "TURBO_REMOTE_ONLY=false" >> "$GITHUB_ENV"
 
     - name: Restore Yarn Cache & Types
       id: restore-yarn-types

--- a/.github/workflows/web-checks.yml
+++ b/.github/workflows/web-checks.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/yarn
+        with:
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
+          turbo-team: ${{ vars.TURBO_TEAM }}
       - name: Run ESLint with suggestions (PR only)
         if: github.event_name == 'pull_request'
         uses: CatChen/eslint-suggestion-action@v4.1.29
@@ -39,7 +42,7 @@ jobs:
           config-path: './apps/web/eslint.config.mjs'
       - name: Run ESLint (push only)
         if: github.event_name == 'push'
-        run: yarn workspace @safe-global/web lint
+        run: yarn turbo run lint --filter=@safe-global/web
 
   prettier:
     permissions:
@@ -50,6 +53,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/yarn
+        with:
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
+          turbo-team: ${{ vars.TURBO_TEAM }}
       - name: Run Prettier check
         run: yarn workspace @safe-global/web prettier
 
@@ -62,9 +68,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/yarn
+        with:
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
+          turbo-team: ${{ vars.TURBO_TEAM }}
       - name: Type check
-        run: yarn type-check
-        working-directory: apps/web
+        run: yarn turbo run type-check --filter=@safe-global/web
 
   knip-exports:
     permissions:
@@ -75,8 +83,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/yarn
+        with:
+          turbo-token: ${{ secrets.TURBO_TOKEN }}
+          turbo-team: ${{ vars.TURBO_TEAM }}
       - name: Check for unused exports
-        run: yarn workspace @safe-global/web knip:exports
+        run: yarn turbo run knip:exports --filter=@safe-global/web
 
   notify:
     if: failure() && github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,10 @@ yarn-error.log*
 # vercel
 .vercel
 
+# turborepo
+.turbo/
+**/.turbo/
+
 # typescript
 *.tsbuildinfo
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,9 @@
 .env
 .env.*
 
+# Turborepo cache
+**/.turbo/
+
 # Mobile
 apps/mobile/android
 apps/mobile/ios

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,28 @@ yarn workspace @safe-global/web test
 yarn workspace @safe-global/web storybook
 ```
 
+## Turborepo
+
+Root-level `lint`, `type-check`, and `test` run through [Turborepo](https://turborepo.com). Tasks are cached by input hash and re-used on subsequent runs — locally and in CI.
+
+```bash
+yarn type-check                                   # all workspaces (cached)
+yarn turbo run type-check --filter=@safe-global/web    # scoped
+yarn turbo run test --filter=@safe-global/utils... # package + dependents
+```
+
+Cache directory is `.turbo/` (gitignored). Task definitions live in `turbo.json`.
+
+### Remote cache
+
+CI reads `TURBO_TOKEN` (repo secret) and `TURBO_TEAM` (repo variable) via `.github/actions/yarn`. These must be configured once per Vercel team:
+
+1. Create or pick a Vercel team; copy the team slug → set repo variable `TURBO_TEAM`.
+2. Create a Vercel personal access token with access to that team → set repo secret `TURBO_TOKEN`.
+3. Locally: `yarn turbo login && yarn turbo link` to enable remote cache in development.
+
+Self-hosted cache (e.g. [ducktors/turborepo-remote-cache](https://github.com/ducktors/turborepo-remote-cache)) can be wired by setting `TURBO_API`, `TURBO_TOKEN`, `TURBO_TEAM` — the same env vars the Vercel backend uses.
+
 ## Architecture Overview
 
 - **apps/web** - Next.js web application

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "tools/codemods/*"
   ],
   "scripts": {
-    "lint": "turbo run lint",
-    "type-check": "turbo run type-check",
-    "test": "turbo run test",
+    "lint": "turbo run lint --",
+    "type-check": "turbo run type-check --",
+    "test": "turbo run test --",
     "test:scripts": "yarn workspace @safe-global/web jest --config ../../scripts/jest.config.cjs",
     "eslint": "yarn workspaces foreach --all -pt run eslint",
     "prettier": "prettier --check . --config ./.prettierrc --ignore-path ./.prettierignore",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "tools/codemods/*"
   ],
   "scripts": {
-    "lint": "yarn workspaces foreach --all -pt run lint",
-    "type-check": "yarn workspaces foreach --all -pt run type-check",
-    "test": "yarn workspaces foreach --all -pt run test",
+    "lint": "turbo run lint",
+    "type-check": "turbo run type-check",
+    "test": "turbo run test",
     "test:scripts": "yarn workspace @safe-global/web jest --config ../../scripts/jest.config.cjs",
     "eslint": "yarn workspaces foreach --all -pt run eslint",
     "prettier": "prettier --check . --config ./.prettierrc --ignore-path ./.prettierignore",
@@ -45,7 +45,8 @@
     "lint-staged": "^16.2.7",
     "msw": "^2.7.3",
     "prettier": "^3.6.2",
-    "storybook": "^10.2.7"
+    "storybook": "^10.2.7",
+    "turbo": "^2.9.6"
   },
   "dependenciesMeta": {
     "cypress": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "ui": "stream",
+  "globalDependencies": [
+    "tsconfig.base.json",
+    ".prettierrc",
+    ".prettierignore",
+    "config/tsconfig/*",
+    "config/eslint/*"
+  ],
+  "globalEnv": ["NODE_ENV", "CI", "TZ"],
+  "globalPassThroughEnv": ["TURBO_TOKEN", "TURBO_TEAM", "TURBO_API", "TURBO_REMOTE_CACHE_SIGNATURE_KEY"],
+  "tasks": {
+    "type-check": {
+      "inputs": ["src/**/*.{ts,tsx,js,jsx,json}", "tsconfig*.json", "package.json", "next-env.d.ts", "**/*.d.ts"],
+      "outputs": [],
+      "outputLogs": "new-only"
+    },
+    "lint": {
+      "inputs": ["src/**/*.{ts,tsx,js,jsx}", "eslint.config.{js,mjs,cjs,ts}", ".eslintrc*", "package.json"],
+      "outputs": [],
+      "outputLogs": "new-only"
+    },
+    "test": {
+      "inputs": [
+        "src/**/*.{ts,tsx,js,jsx,json,snap}",
+        "jest.config.{js,cjs,mjs,ts}",
+        "jest.setup.{js,cjs,mjs,ts}",
+        "package.json",
+        "**/*.d.ts"
+      ],
+      "outputs": ["coverage/**"],
+      "env": ["NEXT_PUBLIC_IS_OFFICIAL_HOST", "DEBUG_PRINT_LIMIT", "LC_ALL"],
+      "outputLogs": "new-only"
+    },
+    "prettier": {
+      "inputs": ["**/*.{ts,tsx,js,jsx,json,md,yml,yaml,css,scss}", "../../.prettierrc", "../../.prettierignore"],
+      "outputs": [],
+      "outputLogs": "new-only"
+    },
+    "knip:exports": {
+      "inputs": ["src/**", "knip.{js,ts,json}", "package.json"],
+      "outputs": [],
+      "outputLogs": "new-only"
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13345,6 +13345,7 @@ __metadata:
     msw: "npm:^2.7.3"
     prettier: "npm:^3.6.2"
     storybook: "npm:^10.2.7"
+    turbo: "npm:^2.9.6"
   dependenciesMeta:
     cypress:
       built: true
@@ -18130,6 +18131,48 @@ __metadata:
   version: 1.0.4
   resolution: "@tsconfig/node16@npm:1.0.4"
   checksum: 10/202319785901f942a6e1e476b872d421baec20cf09f4b266a1854060efbf78cde16a4d256e8bc949d31e6cd9a90f1e8ef8fb06af96a65e98338a2b6b0de0a0ff
+  languageName: node
+  linkType: hard
+
+"@turbo/darwin-64@npm:2.9.6":
+  version: 2.9.6
+  resolution: "@turbo/darwin-64@npm:2.9.6"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@turbo/darwin-arm64@npm:2.9.6":
+  version: 2.9.6
+  resolution: "@turbo/darwin-arm64@npm:2.9.6"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@turbo/linux-64@npm:2.9.6":
+  version: 2.9.6
+  resolution: "@turbo/linux-64@npm:2.9.6"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@turbo/linux-arm64@npm:2.9.6":
+  version: 2.9.6
+  resolution: "@turbo/linux-arm64@npm:2.9.6"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@turbo/windows-64@npm:2.9.6":
+  version: 2.9.6
+  resolution: "@turbo/windows-64@npm:2.9.6"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@turbo/windows-arm64@npm:2.9.6":
+  version: 2.9.6
+  resolution: "@turbo/windows-arm64@npm:2.9.6"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -43422,6 +43465,35 @@ __metadata:
   dependencies:
     safe-buffer: "npm:^5.0.1"
   checksum: 10/7f0d9ed5c22404072b2ae8edc45c071772affd2ed14a74f03b4e71b4dd1a14c3714d85aed64abcaaee5fec2efc79002ba81155c708f4df65821b444abb0cfade
+  languageName: node
+  linkType: hard
+
+"turbo@npm:^2.9.6":
+  version: 2.9.6
+  resolution: "turbo@npm:2.9.6"
+  dependencies:
+    "@turbo/darwin-64": "npm:2.9.6"
+    "@turbo/darwin-arm64": "npm:2.9.6"
+    "@turbo/linux-64": "npm:2.9.6"
+    "@turbo/linux-arm64": "npm:2.9.6"
+    "@turbo/windows-64": "npm:2.9.6"
+    "@turbo/windows-arm64": "npm:2.9.6"
+  dependenciesMeta:
+    "@turbo/darwin-64":
+      optional: true
+    "@turbo/darwin-arm64":
+      optional: true
+    "@turbo/linux-64":
+      optional: true
+    "@turbo/linux-arm64":
+      optional: true
+    "@turbo/windows-64":
+      optional: true
+    "@turbo/windows-arm64":
+      optional: true
+  bin:
+    turbo: bin/turbo
+  checksum: 10/e2378f55c12029bed600b9080e3d40805431f11ed2c79a9fd57176fb18b75fd85f3bc1fc69ef2f601fb65fc6a4bf19c169f4102590bd47173b66c81a729c789a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> Pipelines through Turborepo,
> cache hits where CI re-ran,
> FULL TURBO, 43s → 150ms.

## What it solves

Resolves: no task cache across the monorepo. Every CI run, every Stop-hook `verify:changed`, every dev machine re-runs the same `type-check` / `lint` / `test` on unchanged code. With 2 apps + shared packages that adds up fast.

## How this PR fixes it

Introduces [Turborepo](https://turborepo.com) on top of the existing Yarn 4 workspaces:

- `turbo.json` pipelines `type-check`, `lint`, `test`, `prettier`, and `knip:exports` with per-task `inputs` so cache keys are scoped to the files each task actually reads.
- Root `lint` / `type-check` / `test` scripts now delegate to `turbo run ... --`, preserving arg pass-through for things like the husky pre-push `yarn run lint --fix`.
- Workspace-level scripts are unchanged — turbo just orchestrates.
- Remote-cache plumbing added: `.github/actions/yarn` accepts `turbo-token` / `turbo-team` inputs and exports them as env for all subsequent steps. `web-checks.yml` wired to use `turbo run ... --filter=@safe-global/web`.
- Other workflows (web-unit-tests, mobile, tx-builder, package-utils) left alone — they wrap around coverage-reporter actions that don't play nicely with a turbo wrapper. Migrate task-by-task after remote cache is verified working.

### Known: pre-existing circular dep

Turbo flags `@safe-global/store ↔ @safe-global/test` — the store's devDeps include `test`, and `test` depends on `store`. Pipeline no longer uses `^task` deps, so the cycle is non-fatal (just a warning). Worth untangling in a follow-up.

## How to test it

**Locally (no remote cache):**
```bash
yarn install
yarn turbo run type-check --filter=@safe-global/theme   # cache miss ~1.6s
yarn turbo run type-check --filter=@safe-global/theme   # cache hit  ~90ms  FULL TURBO
yarn lint       # full-monorepo, cached after first run
yarn type-check # full-monorepo, cached after first run
```

**Remote cache (one-time org setup required before CI benefits):**
1. Create / pick a Vercel team, copy its slug → set repo **variable** `TURBO_TEAM`.
2. Mint a Vercel PAT scoped to that team → set repo **secret** `TURBO_TOKEN`.
3. Developers: `yarn turbo login && yarn turbo link`.

Without those secrets, CI still works — it just runs everything without remote cache (local `.turbo/` cache still applies per-runner).

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    A1[yarn lint] --> B1[workspaces foreach]
    B1 --> C1[eslint × 6 workspaces<br/>every run, no cache]
  end
  subgraph After
    A2[yarn lint] --> B2[turbo run lint]
    B2 --> D2{Cache?}
    D2 -->|local hit| E2[skip, log replay]
    D2 -->|remote hit| F2[download artifact]
    D2 -->|miss| G2[eslint src<br/>then upload]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A, build tooling
- [x] I've documented how it affects the analytics (if at all) 📊 — N/A
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — N/A, infra

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)