### PR TITLE
fix(web/Spaces): No flickering in the Safe Selector Dropdown

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
+import SafeSelectorDropdown from './index'
+import type { SafeItemData } from './types'
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}))
+
+jest.mock('./components/SafeSelectorTriggerContent', () => ({
+  __esModule: true,
+  default: () => <span data-testid="safe-selector-trigger-content" />,
+}))
+
+jest.mock('./components/SafeDropdownContainer', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+/**
+ * Simulates a controlled Select that calls onValueChange with the newly chosen id,
+ * then again with the previous id (e.g. before the router updates selectedItemId).
+ * See SafeSelectorDropdown + SpaceSafeBar: selection is driven by the URL async.
+ */
+jest.mock('@/components/ui/select', () => {
+  const React = require('react') as typeof import('react')
+  const NEW_ID = '2:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+  const PREV_ID = '1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+  return {
+    __esModule: true,
+    Select: ({
+      children,
+      value,
+      onValueChange,
+    }: {
+      children?: React.ReactNode
+      value?: string
+      onValueChange?: (next: string | null) => void
+    }) => (
+      <div data-testid="mock-select-root" data-mock-controlled-value={value}>
+        <button
+          type="button"
+          data-testid="simulate-double-onvaluechange"
+          onClick={() => {
+            onValueChange?.(NEW_ID)
+            onValueChange?.(PREV_ID)
+          }}
+        >
+          simulate double onValueChange
+        </button>
+        {children}
+      </div>
+    ),
+    SelectTrigger: ({ children, ...rest }: { children?: React.ReactNode }) => (
+      <button type="button" data-testid="select-trigger" {...rest}>
+        {children}
+      </button>
+    ),
+    SelectValue: ({ children }: { children?: React.ReactNode }) => <span>{children}</span>,
+  }
+})
+
+const createItem = (overrides: Partial<SafeItemData> = {}): SafeItemData => ({
+  id: '1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  name: 'Safe A',
+  address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  threshold: 1,
+  owners: 2,
+  balance: '100',
+  chains: [{ chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' }],
+  ...overrides,
+})
+
+/**
+ * Mirrors `handleItemSelect` in SpaceSafeBar: each selection resolves chain shortName then calls
+ * `router.push({ pathname: AppRoutes.home, query: { safe: shortName:address } })`.
+ * Production implementation: `useSpaceSafeSelectorItems.ts` (`handleItemSelect`, `router.push` after `trackEvent`).
+ */
+function SafeSelectorWithSpaceSafeBarNavigation({
+  items,
+  selectedItemId,
+}: {
+  items: SafeItemData[]
+  selectedItemId: string
+}) {
+  const router = useRouter()
+  const onItemSelect = (itemId: string) => {
+    const colonIndex = itemId.indexOf(':')
+    const chainId = itemId.slice(0, colonIndex)
+    const address = itemId.slice(colonIndex + 1)
+    const shortName = chainId === '1' ? 'eth' : 'oeth'
+    router.push({ pathname: AppRoutes.home, query: { safe: `${shortName}:${address}` } })
+  }
+  return <SafeSelectorDropdown items={items} selectedItemId={selectedItemId} onItemSelect={onItemSelect} />
+}
+
+describe('SafeSelectorDropdown', () => {
+  describe('controlled Select double onValueChange', () => {
+    it('calls onItemSelect once when Select fires new id then snap-back to the previous id', async () => {
+      const user = userEvent.setup()
+      const onItemSelect = jest.fn()
+      const itemA = createItem()
+      const itemB = createItem({
+        id: '2:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        name: 'Safe B',
+        address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        chains: [{ chainId: '2', chainName: 'Another', chainLogoUri: null, shortName: 'oeth' }],
+      })
+
+      render(<SafeSelectorDropdown items={[itemA, itemB]} selectedItemId={itemA.id} onItemSelect={onItemSelect} />)
+
+      await user.click(screen.getByTestId('simulate-double-onvaluechange'))
+
+      expect(onItemSelect).toHaveBeenCalledTimes(1)
+      expect(onItemSelect).toHaveBeenCalledWith(itemB.id)
+    })
+
+    /**
+     * One navigation per selection — snap-back to the previous id must not trigger a second push.
+     */
+    it('performs one router.push when onItemSelect is wired like SpaceSafeBar and Select double-fires', async () => {
+      const mockPush = jest.fn()
+      jest.mocked(useRouter).mockReturnValue({ push: mockPush } as unknown as ReturnType<typeof useRouter>)
+
+      const user = userEvent.setup()
+      const itemA = createItem()
+      const itemB = createItem({
+        id: '2:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        name: 'Safe B',
+        address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        chains: [{ chainId: '2', chainName: 'Another', chainLogoUri: null, shortName: 'oeth' }],
+      })
+
+      render(<SafeSelectorWithSpaceSafeBarNavigation items={[itemA, itemB]} selectedItemId={itemA.id} />)
+
+      await user.click(screen.getByTestId('simulate-double-onvaluechange'))
+
+      expect(mockPush).toHaveBeenCalledTimes(1)
+      expect(mockPush).toHaveBeenCalledWith({
+        pathname: AppRoutes.home,
+        query: { safe: `oeth:${itemB.address}` },
+      })
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useRouter } from 'next/router'
@@ -25,7 +26,6 @@ jest.mock('./components/SafeDropdownContainer', () => ({
  * See SafeSelectorDropdown + SpaceSafeBar: selection is driven by the URL async.
  */
 jest.mock('@/components/ui/select', () => {
-  const React = require('react') as typeof import('react')
   const NEW_ID = '2:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
   const PREV_ID = '1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.test.ts
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.test.ts
@@ -60,4 +60,27 @@ describe('useSafeSelectorState', () => {
     act(() => result.current.closeDropdown())
     expect(result.current.dropdownOpen).toBe(false)
   })
+
+  /**
+   * When a controlled Select emits onValueChange twice (new id, then snap-back to the previous id
+   * before the URL updates), only the first call is forwarded — the second matches currentSelectionId.
+   */
+  it('ignores handleSafeChange when the value matches the current selection (revert snap-back)', () => {
+    const onItemSelect = jest.fn()
+    const { result } = renderHook(() =>
+      useSafeSelectorState({
+        items: [createItem('1:0xA'), createItem('2:0xB')],
+        selectedItemId: '1:0xA',
+        onItemSelect,
+      }),
+    )
+
+    act(() => {
+      result.current.handleSafeChange('2:0xB')
+      result.current.handleSafeChange('1:0xA')
+    })
+
+    expect(onItemSelect).toHaveBeenCalledTimes(1)
+    expect(onItemSelect).toHaveBeenCalledWith('2:0xB')
+  })
 })

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.ts
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.ts
@@ -44,8 +44,7 @@ export const useSafeSelectorState = ({
   const handleSafeChange = useCallback(
     (value: string | null) => {
       const itemId = value ?? ''
-      // Controlled Select can emit a second onValueChange with the previous id before the URL updates.
-      // Skipping avoids a duplicate router.push and address-bar flicker (see SafeSelectorDropdown tests).
+      // Skip reselecting the previous id before the URL updates
       const currentSelectionId = selectedItemId ?? selectedItem?.id ?? ''
       if (itemId === currentSelectionId) return
       onItemSelect?.(itemId)

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.ts
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.ts
@@ -44,9 +44,13 @@ export const useSafeSelectorState = ({
   const handleSafeChange = useCallback(
     (value: string | null) => {
       const itemId = value ?? ''
+      // Controlled Select can emit a second onValueChange with the previous id before the URL updates.
+      // Skipping avoids a duplicate router.push and address-bar flicker (see SafeSelectorDropdown tests).
+      const currentSelectionId = selectedItemId ?? selectedItem?.id ?? ''
+      if (itemId === currentSelectionId) return
       onItemSelect?.(itemId)
     },
-    [onItemSelect],
+    [onItemSelect, selectedItemId, selectedItem],
   )
 
   const closeDropdown = useCallback(() => {


### PR DESCRIPTION
## What it solves

Resolves: [WA-1942](https://linear.app/safe-global/issue/WA-1942/bug-safe-selector-dropdown-double-fires-onvaluechange-reverting)

There was address-bar flickering when selecting a Safe in the Safe Selector Dropdown. The controlled Select component fires onValueChange twice — once with the new id, then again with the previous id before the URL updates - causing a duplicate `router.push`.

## How this PR fixes it
Added a guard in useSafeSelectorState.handleSafeChange that skips the callback when the incoming value matches the currently selected item id. This prevents the snap-back call from triggering a second navigation.

## How to test it
1. Open a Space with multiple Safes in the sidebar.
2. Select a different Safe from the Safe Selector Dropdown.
3. Confirm the address bar in the Safe Selector Dropdown does not flicker back to the previous Safe.

## Visual summary
```
flowchart LR
  A[Select fires onValueChange with new id] --> B[handleSafeChange]
  B --> C{matches current selection?}
  C -->|No| D[call onItemSelect → router.push]
  C -->|Yes - snap-back| E[skip — no duplicate push]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
