### PR TITLE
fix: zkSync deployments contract addresses instead of canonical by default

### DIFF
--- a/apps/mobile/src/services/contracts/safeContracts.ts
+++ b/apps/mobile/src/services/contracts/safeContracts.ts
@@ -45,7 +45,7 @@ export const getReadOnlyMultiSendCallOnlyContract = async (
   // cannot delegatecall to EraVM contracts.
   let customContractAddress: string | undefined
   if (chainId && implementationAddress && isCanonicalDeployment(implementationAddress, chainId, safeVersion)) {
-    customContractAddress = getCanonicalMultiSendCallOnlyAddress(safeVersion)
+    customContractAddress = getCanonicalMultiSendCallOnlyAddress(chainId, safeVersion)
   }
 
   return getMultiSendCallOnlyContract({

--- a/apps/web/src/services/contracts/safeContracts.ts
+++ b/apps/web/src/services/contracts/safeContracts.ts
@@ -104,7 +104,7 @@ export const getReadOnlyMultiSendCallOnlyContract = async (
   // cannot delegatecall to EraVM contracts.
   let customContractAddress: string | undefined
   if (chainId && implementationAddress && isCanonicalDeployment(implementationAddress, chainId, version)) {
-    customContractAddress = getCanonicalMultiSendCallOnlyAddress(version)
+    customContractAddress = getCanonicalMultiSendCallOnlyAddress(chainId, version)
   }
 
   return getMultiSendCallOnlyContract({

--- a/packages/utils/src/services/contracts/__tests__/deployments.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/deployments.test.ts
@@ -13,12 +13,8 @@ import {
 } from '../../contracts/deployments'
 import { ZKSYNC_ERA_CHAIN_ID } from '../../../config/chains'
 
-// Per safe-deployments src/assets/vX.Y.Z/multi_send_call_only.json, only v1.3.0 and v1.4.1
-// declare a zkSync-specific MultiSendCallOnly deployment. v1.5.0 has canonical only.
-const ZKSYNC_MULTISEND_CALL_ONLY_BY_VERSION: Record<string, string> = {
-  '1.3.0': '0xf220D3b4DFb23C4ade8C88E526C1353AbAcbC38F',
-  '1.4.1': '0x0408EF011960d02349d50286D20531229BCef773',
-}
+// Only v1.3.0 and v1.4.1 ship a zkSync-specific MultiSendCallOnly; v1.5.0 is canonical-only.
+const ZKSYNC_MULTISEND_CALL_ONLY_VERSIONS = ['1.3.0', '1.4.1'] as const
 
 describe('deployments utils', () => {
   const chainId = '1'
@@ -338,57 +334,50 @@ describe('deployments utils', () => {
     })
   })
 
-  // eip155 MultiSendCallOnly deployment exists only for v1.3.0. Chain 1 lists
-  // ["canonical", "eip155"] under networkAddresses, so the same "canonical or first"
-  // bug pattern applied: callers requesting `'eip155'` could get the canonical address.
+  // eip155 MultiSendCallOnly ships only in v1.3.0.
   describe('eip155 MultiSendCallOnly v1.3.0', () => {
     const deployment = getMultiSendCallOnlyDeployments({ version: '1.3.0' })
-    const EIP155_MULTISEND_CALL_ONLY_V130 = '0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B'
+    const eip155Address = deployment?.deployments.eip155?.address
     const MAINNET_CHAIN_ID = '1'
+    const CANONICAL_ONLY_CHAIN_ID = '30'
 
-    it('safe-deployments declares the eip155 address for v1.3.0', () => {
-      expect(deployment?.deployments.eip155?.address).toBe(EIP155_MULTISEND_CALL_ONLY_V130)
+    it('safe-deployments declares an eip155 address for v1.3.0', () => {
+      expect(eip155Address).toBeDefined()
     })
 
     it('getChainAgnosticAddress returns the eip155 address on chain 1 with deploymentType="eip155"', () => {
       const address = getChainAgnosticAddress(deployment, MAINNET_CHAIN_ID, 'eip155')
-      expect(address).toBe(EIP155_MULTISEND_CALL_ONLY_V130)
+      expect(address).toBe(eip155Address)
+    })
+
+    it('does NOT return the eip155 address on a canonical-only chain (chain 30)', () => {
+      const address = getChainAgnosticAddress(deployment, CANONICAL_ONLY_CHAIN_ID, 'eip155')
+      expect(address).not.toBe(eip155Address)
     })
   })
 
-  // Regression tests for zkSync Era MultiSendCallOnly address resolution across all Safe
-  // contract versions that ship a zkSync-specific deployment (v1.3.0 and v1.4.1).
-  // The zkSync deployment JSON lists the zkSync and canonical addresses together under
-  // networkAddresses["324"], so any code path that returns the "canonical or first network
-  // address" will incorrectly prefer the canonical (EVM bytecode) address over the
-  // zkSync-specific (EraVM) one that EraVM-bytecode Safes need to delegatecall to.
-  describe.each(Object.entries(ZKSYNC_MULTISEND_CALL_ONLY_BY_VERSION))(
-    'zkSync Era MultiSendCallOnly v%s',
-    (version, expectedZkAddress) => {
-      const deployment = getMultiSendCallOnlyDeployments({ version })
+  describe.each(ZKSYNC_MULTISEND_CALL_ONLY_VERSIONS)('zkSync Era MultiSendCallOnly v%s', (version) => {
+    const deployment = getMultiSendCallOnlyDeployments({ version })
+    const expectedZkAddress = deployment?.deployments.zksync?.address
 
-      it(`safe-deployments declares the zkSync-specific address for v${version}`, () => {
-        expect(deployment?.deployments.zksync?.address).toBe(expectedZkAddress)
-      })
+    it(`safe-deployments declares a zkSync-specific address for v${version}`, () => {
+      expect(expectedZkAddress).toBeDefined()
+    })
 
-      it(`getChainAgnosticAddress returns the zkSync address on chain 324 with deploymentType="zksync" for v${version}`, () => {
-        const address = getChainAgnosticAddress(deployment, ZKSYNC_ERA_CHAIN_ID, 'zksync')
-        expect(address).toBe(expectedZkAddress)
-      })
+    it(`getChainAgnosticAddress returns the zkSync address on chain 324 with deploymentType="zksync" for v${version}`, () => {
+      const address = getChainAgnosticAddress(deployment, ZKSYNC_ERA_CHAIN_ID, 'zksync')
+      expect(address).toBe(expectedZkAddress)
+    })
 
-      it(`resolveChainAgnosticContractAddresses returns the zkSync MultiSendCallOnly address when isZk=true for v${version}`, () => {
-        const resolved = resolveChainAgnosticContractAddresses(version, true, true)
-        expect(resolved).toBeDefined()
-        expect(resolved!.multiSendCallOnlyAddress).toBe(expectedZkAddress)
-      })
+    it(`resolveChainAgnosticContractAddresses returns the zkSync MultiSendCallOnly address when isZk=true for v${version}`, () => {
+      const resolved = resolveChainAgnosticContractAddresses(version, true, true)
+      expect(resolved).toBeDefined()
+      expect(resolved!.multiSendCallOnlyAddress).toBe(expectedZkAddress)
+    })
 
-      // Regression guard matching PR #7580's pattern: never return a deployment-type-specific
-      // address for a chain where that deployment type isn't registered. Requesting 'zksync'
-      // on mainnet (which has only canonical) must not leak the zkSync EraVM address.
-      it(`does NOT return the zkSync address on mainnet (chain 1) for v${version}`, () => {
-        const address = getChainAgnosticAddress(deployment, '1', 'zksync')
-        expect(address).not.toBe(expectedZkAddress)
-      })
-    },
-  )
+    it(`does NOT return the zkSync address on mainnet (chain 1) for v${version}`, () => {
+      const address = getChainAgnosticAddress(deployment, '1', 'zksync')
+      expect(address).not.toBe(expectedZkAddress)
+    })
+  })
 })

--- a/packages/utils/src/services/contracts/__tests__/deployments.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/deployments.test.ts
@@ -12,9 +12,12 @@ import {
   resolveChainAgnosticContractAddresses,
 } from '../../contracts/deployments'
 import { ZKSYNC_ERA_CHAIN_ID } from '../../../config/chains'
+import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 
-// Only v1.3.0 and v1.4.1 ship a zkSync-specific MultiSendCallOnly; v1.5.0 is canonical-only.
-const ZKSYNC_MULTISEND_CALL_ONLY_VERSIONS = ['1.3.0', '1.4.1'] as const
+// picks the zk address for 1.5.0 if/when it has a zkSync deployment:
+const ZKSYNC_MULTISEND_CALL_ONLY_VERSIONS = (['1.3.0', '1.4.1', '1.5.0'] as const).filter(
+  (v) => getMultiSendCallOnlyDeployments({ version: v })?.deployments.zksync?.address,
+)
 
 describe('deployments utils', () => {
   const chainId = '1'
@@ -203,16 +206,99 @@ describe('deployments utils', () => {
   })
 
   describe('getCanonicalMultiSendCallOnlyAddress', () => {
-    it('returns canonical MultiSendCallOnly address for version 1.3.0', () => {
-      const address = getCanonicalMultiSendCallOnlyAddress('1.3.0')
-      // Canonical MultiSendCallOnly 1.3.0 address
-      expect(address).toBe('0x40A2aCCbd92BCA938b02010E17A5b8929b49130D')
+    const MAINNET = '1'
+    const ZKSYNC = '324'
+    const SOPHON = '50104' // zkSync-only: no canonical in any version.
+    const ROPSTEN = '3' // v1.3.0 canonical only — exercises v1.4.1 → v1.3.0 fallback.
+    const FORWARD_ONLY_CHAIN = '63' // v1.5.0 canonical only — proves we never walk upward.
+    const EIP155_ONLY_V130 = '16' // v1.3.0 registered but as eip155, no canonical.
+
+    let warnSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
     })
 
-    it('falls back to 1.3.0 for null version', () => {
-      const address = getCanonicalMultiSendCallOnlyAddress(null)
-      // Should fallback to 1.3.0
-      expect(address).toBe('0x40A2aCCbd92BCA938b02010E17A5b8929b49130D')
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    it('returns the requested version when canonical is registered on the chain', () => {
+      const v130 = getMultiSendCallOnlyDeployments({ version: '1.3.0' })?.deployments.canonical?.address
+      expect(getCanonicalMultiSendCallOnlyAddress(MAINNET, '1.3.0')).toBe(v130)
+    })
+
+    it('returns v1.5.0 canonical on mainnet where v1.5.0 is registered', () => {
+      const v150 = getMultiSendCallOnlyDeployments({ version: '1.5.0' })?.deployments.canonical?.address
+      expect(getCanonicalMultiSendCallOnlyAddress(MAINNET, '1.5.0')).toBe(v150)
+    })
+
+    it('falls back from v1.5.0 to v1.4.1 canonical on zkSync (324)', () => {
+      const v141 = getMultiSendCallOnlyDeployments({ version: '1.4.1' })?.deployments.canonical?.address
+      expect(getCanonicalMultiSendCallOnlyAddress(ZKSYNC, '1.5.0')).toBe(v141)
+    })
+
+    it('falls back from v1.4.1 to v1.3.0 canonical on Ropsten', () => {
+      const v130 = getMultiSendCallOnlyDeployments({ version: '1.3.0' })?.deployments.canonical?.address
+      expect(getCanonicalMultiSendCallOnlyAddress(ROPSTEN, '1.4.1')).toBe(v130)
+    })
+
+    it('falls back from v1.5.0 through v1.4.1 to v1.3.0 canonical on Ropsten', () => {
+      const v130 = getMultiSendCallOnlyDeployments({ version: '1.3.0' })?.deployments.canonical?.address
+      expect(getCanonicalMultiSendCallOnlyAddress(ROPSTEN, '1.5.0')).toBe(v130)
+    })
+
+    // Invariant: walks newest→oldest from requested, never upward.
+    it('does NOT walk upward — requesting v1.3.0 on a v1.5.0-only chain returns undefined', () => {
+      expect(getCanonicalMultiSendCallOnlyAddress(FORWARD_ONLY_CHAIN, '1.3.0')).toBeUndefined()
+    })
+
+    it('does NOT walk upward — requesting v1.4.1 on a v1.5.0-only chain returns undefined', () => {
+      expect(getCanonicalMultiSendCallOnlyAddress(FORWARD_ONLY_CHAIN, '1.4.1')).toBeUndefined()
+    })
+
+    it('returns undefined on a chain where canonical is never registered (Sophon, 50104)', () => {
+      expect(getCanonicalMultiSendCallOnlyAddress(SOPHON, '1.4.1')).toBeUndefined()
+      expect(getCanonicalMultiSendCallOnlyAddress(SOPHON, '1.3.0')).toBeUndefined()
+      expect(getCanonicalMultiSendCallOnlyAddress(SOPHON, '1.5.0')).toBeUndefined()
+    })
+
+    it('returns undefined when a chain registers the version but not the canonical type', () => {
+      expect(getCanonicalMultiSendCallOnlyAddress(EIP155_ONLY_V130, '1.3.0')).toBeUndefined()
+    })
+
+    it('returns undefined for a chainId not in safe-deployments at all', () => {
+      expect(getCanonicalMultiSendCallOnlyAddress('99999999999', '1.4.1')).toBeUndefined()
+    })
+
+    it('falls back to v1.3.0 when version is null and canonical is registered on the chain', () => {
+      const v130 = getMultiSendCallOnlyDeployments({ version: '1.3.0' })?.deployments.canonical?.address
+      expect(getCanonicalMultiSendCallOnlyAddress(MAINNET, null)).toBe(v130)
+    })
+
+    it('returns undefined when version is null and chain has no canonical registration', () => {
+      expect(getCanonicalMultiSendCallOnlyAddress(SOPHON, null)).toBeUndefined()
+    })
+
+    it('falls back to v1.3.0 when version is undefined and canonical is registered on the chain', () => {
+      const v130 = getMultiSendCallOnlyDeployments({ version: '1.3.0' })?.deployments.canonical?.address
+      expect(getCanonicalMultiSendCallOnlyAddress(MAINNET, undefined)).toBe(v130)
+    })
+
+    it('handles a version string not in the fallback list without crashing', () => {
+      expect(() => getCanonicalMultiSendCallOnlyAddress(MAINNET, '1.2.0' as SafeState['version'])).not.toThrow()
+    })
+
+    it('logs a warning when no canonical is registered on the chain', () => {
+      getCanonicalMultiSendCallOnlyAddress(SOPHON, '1.4.1')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[MultiSendCallOnly]'))
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(SOPHON))
+    })
+
+    it('does NOT log a warning on the happy path', () => {
+      getCanonicalMultiSendCallOnlyAddress(MAINNET, '1.3.0')
+      expect(warnSpy).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/utils/src/services/contracts/__tests__/deployments.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/deployments.test.ts
@@ -14,10 +14,18 @@ import {
 import { ZKSYNC_ERA_CHAIN_ID } from '../../../config/chains'
 import type { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 
-// picks the zk address for 1.5.0 if/when it has a zkSync deployment:
+// Picks the zk address for 1.5.0 if/when it has a zkSync deployment.
 const ZKSYNC_MULTISEND_CALL_ONLY_VERSIONS = (['1.3.0', '1.4.1', '1.5.0'] as const).filter(
   (v) => getMultiSendCallOnlyDeployments({ version: v })?.deployments.zksync?.address,
 )
+
+// Guard: if safe-deployments ever drops all zkSync entries, describe.each below generates
+// zero tests and the suite silently passes. Fail loudly instead.
+describe('zkSync test setup', () => {
+  it('has zkSync MultiSendCallOnly deployments available for versioned tests', () => {
+    expect(ZKSYNC_MULTISEND_CALL_ONLY_VERSIONS).not.toHaveLength(0)
+  })
+})
 
 describe('deployments utils', () => {
   const chainId = '1'
@@ -285,8 +293,10 @@ describe('deployments utils', () => {
       expect(getCanonicalMultiSendCallOnlyAddress(MAINNET, undefined)).toBe(v130)
     })
 
-    it('handles a version string not in the fallback list without crashing', () => {
-      expect(() => getCanonicalMultiSendCallOnlyAddress(MAINNET, '1.2.0' as SafeState['version'])).not.toThrow()
+    // Requested version older than any MultiSendCallOnly release → no candidates pass the
+    // semver `<= requested` filter → returns undefined rather than walking upward.
+    it('returns undefined when requested version is older than the oldest candidate (v1.2.0)', () => {
+      expect(getCanonicalMultiSendCallOnlyAddress(MAINNET, '1.2.0' as SafeState['version'])).toBeUndefined()
     })
 
     it('logs a warning when no canonical is registered on the chain', () => {

--- a/packages/utils/src/services/contracts/__tests__/deployments.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/deployments.test.ts
@@ -1,3 +1,4 @@
+import { getMultiSendCallOnlyDeployments } from '@safe-global/safe-deployments'
 import type { DeploymentFilter, SingletonDeploymentV2 } from '@safe-global/safe-deployments'
 import {
   getCanonicalOrFirstAddress,
@@ -11,6 +12,13 @@ import {
   resolveChainAgnosticContractAddresses,
 } from '../../contracts/deployments'
 import { ZKSYNC_ERA_CHAIN_ID } from '../../../config/chains'
+
+// Per safe-deployments src/assets/vX.Y.Z/multi_send_call_only.json, only v1.3.0 and v1.4.1
+// declare a zkSync-specific MultiSendCallOnly deployment. v1.5.0 has canonical only.
+const ZKSYNC_MULTISEND_CALL_ONLY_BY_VERSION: Record<string, string> = {
+  '1.3.0': '0xf220D3b4DFb23C4ade8C88E526C1353AbAcbC38F',
+  '1.4.1': '0x0408EF011960d02349d50286D20531229BCef773',
+}
 
 describe('deployments utils', () => {
   const chainId = '1'
@@ -329,4 +337,58 @@ describe('deployments utils', () => {
       expect(result!.safeSingletonAddress).toBeDefined()
     })
   })
+
+  // eip155 MultiSendCallOnly deployment exists only for v1.3.0. Chain 1 lists
+  // ["canonical", "eip155"] under networkAddresses, so the same "canonical or first"
+  // bug pattern applied: callers requesting `'eip155'` could get the canonical address.
+  describe('eip155 MultiSendCallOnly v1.3.0', () => {
+    const deployment = getMultiSendCallOnlyDeployments({ version: '1.3.0' })
+    const EIP155_MULTISEND_CALL_ONLY_V130 = '0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B'
+    const MAINNET_CHAIN_ID = '1'
+
+    it('safe-deployments declares the eip155 address for v1.3.0', () => {
+      expect(deployment?.deployments.eip155?.address).toBe(EIP155_MULTISEND_CALL_ONLY_V130)
+    })
+
+    it('getChainAgnosticAddress returns the eip155 address on chain 1 with deploymentType="eip155"', () => {
+      const address = getChainAgnosticAddress(deployment, MAINNET_CHAIN_ID, 'eip155')
+      expect(address).toBe(EIP155_MULTISEND_CALL_ONLY_V130)
+    })
+  })
+
+  // Regression tests for zkSync Era MultiSendCallOnly address resolution across all Safe
+  // contract versions that ship a zkSync-specific deployment (v1.3.0 and v1.4.1).
+  // The zkSync deployment JSON lists the zkSync and canonical addresses together under
+  // networkAddresses["324"], so any code path that returns the "canonical or first network
+  // address" will incorrectly prefer the canonical (EVM bytecode) address over the
+  // zkSync-specific (EraVM) one that EraVM-bytecode Safes need to delegatecall to.
+  describe.each(Object.entries(ZKSYNC_MULTISEND_CALL_ONLY_BY_VERSION))(
+    'zkSync Era MultiSendCallOnly v%s',
+    (version, expectedZkAddress) => {
+      const deployment = getMultiSendCallOnlyDeployments({ version })
+
+      it(`safe-deployments declares the zkSync-specific address for v${version}`, () => {
+        expect(deployment?.deployments.zksync?.address).toBe(expectedZkAddress)
+      })
+
+      it(`getChainAgnosticAddress returns the zkSync address on chain 324 with deploymentType="zksync" for v${version}`, () => {
+        const address = getChainAgnosticAddress(deployment, ZKSYNC_ERA_CHAIN_ID, 'zksync')
+        expect(address).toBe(expectedZkAddress)
+      })
+
+      it(`resolveChainAgnosticContractAddresses returns the zkSync MultiSendCallOnly address when isZk=true for v${version}`, () => {
+        const resolved = resolveChainAgnosticContractAddresses(version, true, true)
+        expect(resolved).toBeDefined()
+        expect(resolved!.multiSendCallOnlyAddress).toBe(expectedZkAddress)
+      })
+
+      // Regression guard matching PR #7580's pattern: never return a deployment-type-specific
+      // address for a chain where that deployment type isn't registered. Requesting 'zksync'
+      // on mainnet (which has only canonical) must not leak the zkSync EraVM address.
+      it(`does NOT return the zkSync address on mainnet (chain 1) for v${version}`, () => {
+        const address = getChainAgnosticAddress(deployment, '1', 'zksync')
+        expect(address).not.toBe(expectedZkAddress)
+      })
+    },
+  )
 })

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -77,7 +77,7 @@ export const hasCanonicalDeployment = (deployment: SingletonDeploymentV2 | undef
     return false
   }
 
-  const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId])
+  const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId] ?? [])
 
   return networkAddresses.some((networkAddress) => sameAddress(canonicalAddress, networkAddress))
 }
@@ -280,16 +280,8 @@ export const isCanonicalDeployment = (
   return false
 }
 
-// Newest --> oldest (fallback candidates) starting from the requested version
+// Newest --> oldest. Filtered with semver at call time so we never walk above the requested version.
 const CANONICAL_FALLBACK_VERSIONS = ['1.5.0', '1.4.1', '1.3.0'] as const
-type CanonicalFallbackVersion = (typeof CANONICAL_FALLBACK_VERSIONS)[number]
-
-const isCanonicalRegisteredOnChain = (deployment: SingletonDeploymentV2 | undefined, chainId: string): boolean => {
-  const canonicalAddress = deployment?.deployments.canonical?.address
-  if (!canonicalAddress) return false
-  const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId] ?? [])
-  return networkAddresses.some((addr) => sameAddress(addr, canonicalAddress))
-}
 
 /**
  * Canonical MultiSendCallOnly address for `chainId` at `version`, falling back to older
@@ -299,13 +291,12 @@ export const getCanonicalMultiSendCallOnlyAddress = (
   chainId: string,
   version: SafeState['version'],
 ): string | undefined => {
-  const requested = (version ?? '1.3.0') as CanonicalFallbackVersion
-  const startIndex = CANONICAL_FALLBACK_VERSIONS.indexOf(requested)
-  const candidates = startIndex >= 0 ? CANONICAL_FALLBACK_VERSIONS.slice(startIndex) : CANONICAL_FALLBACK_VERSIONS
+  const requested = version ?? '1.3.0'
+  const candidates = CANONICAL_FALLBACK_VERSIONS.filter((candidate) => semverSatisfies(candidate, `<=${requested}`))
 
   for (const candidate of candidates) {
     const deployment = getMultiSendCallOnlyDeployments({ version: candidate })
-    if (isCanonicalRegisteredOnChain(deployment, chainId)) {
+    if (hasCanonicalDeployment(deployment, chainId)) {
       return deployment!.deployments.canonical!.address
     }
   }

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -101,8 +101,17 @@ export const getCanonicalOrFirstAddress = (
 }
 
 /**
- * Returns an address for a deployment, trying per-chain lookup first, then falling back
- * to the chain-agnostic deployment type address. Works for unregistered chains.
+ * Returns an address for a deployment.
+ *
+ * When a non-default `deploymentType` is requested (e.g. `'zksync'`), the type-specific
+ * address is returned only if it is actually registered for this chain. This is required
+ * on zkSync, where networkAddresses lists both the zkSync (EraVM) and canonical (EVM)
+ * addresses together and EraVM Safes cannot delegatecall to EVM auxiliary contracts.
+ * Guarding on explicit registration prevents handing back an address that was never
+ * deployed on the target chain (same regression shape as #7494).
+ *
+ * Otherwise, falls back to per-chain lookup (canonical-or-first network address), then to
+ * the chain-agnostic deployment-type address for unregistered chains.
  */
 export const getChainAgnosticAddress = (
   deployment: SingletonDeploymentV2 | undefined,
@@ -111,11 +120,18 @@ export const getChainAgnosticAddress = (
 ): string | undefined => {
   if (!deployment) return undefined
 
-  // Try per-chain first (works for registered chains)
+  if (deploymentType !== 'canonical') {
+    const typeSpecificAddress = deployment.deployments[deploymentType]?.address
+    const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId] ?? [])
+    const isRegisteredOnChain =
+      typeSpecificAddress && networkAddresses.some((addr) => sameAddress(addr, typeSpecificAddress))
+
+    if (isRegisteredOnChain) return typeSpecificAddress
+  }
+
   const perChainAddress = getCanonicalOrFirstAddress(deployment, chainId)
   if (perChainAddress) return perChainAddress
 
-  // Fall back to chain-agnostic address by deployment type
   return deployment.deployments[deploymentType]?.address
 }
 

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -280,14 +280,38 @@ export const isCanonicalDeployment = (
   return false
 }
 
+// Newest --> oldest (fallback candidates) starting from the requested version
+const CANONICAL_FALLBACK_VERSIONS = ['1.5.0', '1.4.1', '1.3.0'] as const
+type CanonicalFallbackVersion = (typeof CANONICAL_FALLBACK_VERSIONS)[number]
+
+const isCanonicalRegisteredOnChain = (deployment: SingletonDeploymentV2 | undefined, chainId: string): boolean => {
+  const canonicalAddress = deployment?.deployments.canonical?.address
+  if (!canonicalAddress) return false
+  const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId] ?? [])
+  return networkAddresses.some((addr) => sameAddress(addr, canonicalAddress))
+}
+
 /**
- * Gets the canonical MultiSendCallOnly address for a given version.
- * Used when a Safe on zkSync uses a canonical (EVM bytecode) mastercopy.
+ * Canonical MultiSendCallOnly address for `chainId` at `version`, falling back to older
+ * versions. Returns `undefined` if no canonical is registered on the chain.
  */
-export const getCanonicalMultiSendCallOnlyAddress = (version: SafeState['version']): string | undefined => {
-  const safeVersion = version ?? '1.3.0'
-  const deployment = getMultiSendCallOnlyDeployments({ version: safeVersion })
-  return deployment?.deployments.canonical?.address
+export const getCanonicalMultiSendCallOnlyAddress = (
+  chainId: string,
+  version: SafeState['version'],
+): string | undefined => {
+  const requested = (version ?? '1.3.0') as CanonicalFallbackVersion
+  const startIndex = CANONICAL_FALLBACK_VERSIONS.indexOf(requested)
+  const candidates = startIndex >= 0 ? CANONICAL_FALLBACK_VERSIONS.slice(startIndex) : CANONICAL_FALLBACK_VERSIONS
+
+  for (const candidate of candidates) {
+    const deployment = getMultiSendCallOnlyDeployments({ version: candidate })
+    if (isCanonicalRegisteredOnChain(deployment, chainId)) {
+      return deployment!.deployments.canonical!.address
+    }
+  }
+
+  console.warn(`[MultiSendCallOnly] No canonical registered on chain ${chainId} for v${requested} or older`)
+  return undefined
 }
 
 /**


### PR DESCRIPTION
> zkSync asks for zksync,
> canonical bytecode leaks through—
> guard on registration.

## What it solves

Resolves: [WA-2000](https://linear.app/safe-global/issue/WA-2000/multisend-and-simulations-not-working-on-zksync-lens-chains)
The "first network address" fallback handed back an address that was never deployed on the target chain. `getChainAgnosticAddress(..., 'zksync')` could return the zkSync-type address on chains where no zkSync deployment is registered, or return the canonical (EVM) address.

## How this PR fixes it

When a non-default `deploymentType` (e.g. `'zksync'`, `'eip155'`) is requested, `getChainAgnosticAddress` now returns the type-specific address only if it is explicitly listed under `networkAddresses[chainId]`. If not registered, it falls through to the existing per-chain and chain-agnostic lookups. So we do not return an address that was never deployed on the target chain.

## How to test it

1. Run `yarn workspace @safe-global/utils test packages/utils/src/services/contracts/__tests__/deployments.test.ts`
2. Verify the new `eip155 MultiSendCallOnly v1.3.0` and `zkSync Era MultiSendCallOnly v1.3.0 / v1.4.1` describe blocks all pass, including the `does NOT return ...` negative guards
3. Manually: on zkSync Era (chain 324), build a transaction that resolves the MultiSendCallOnly address via `resolveChainAgnosticContractAddresses(version, true, true)` and confirm it returns the zkSync-specific EraVM address (not the canonical EVM one)

## Visual summary

```mermaid
flowchart TB
  subgraph Before_broken
    A1["getChainAgnosticAddress(dep, '324', 'zksync')"] --> B1["getCanonicalOrFirstAddress(dep, '324')"]
    B1 --> C1["networkAddresses['324'] = ['zksync','canonical','eip155']"]
    C1 --> D1["hasCanonical? yes → return canonical"]
    D1 --> E1["❌ EVM address, EraVM Safe cannot delegatecall"]
  end
  subgraph After_fixed
    A2["getChainAgnosticAddress(dep, '324', 'zksync')"] --> B2["typeAddress = deployments.zksync.address"]
    B2 --> C2["Is typeAddress in networkAddresses['324']?"]
    C2 -->|Yes| D2["✅ return zksync EraVM address"]
    C2 -->|No, e.g. chain 1| E2["fall through to canonical-or-first"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 N/A
- [ ] I've documented how it affects the analytics (if at all) 📊 N/A
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).