### PR TITLE
fix(web): accounts header redesign polish

### DIFF
--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -30,7 +30,7 @@ const buttonVariants = cva(
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/80',
         outline:
-          'border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground shadow-xs',
+          'border-border bg-background hover:bg-[var(--unofficial-outline-hover,rgba(0,0,0,0.03))] hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground shadow-xs',
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
         ghost:

--- a/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsHeader/index.tsx
@@ -23,11 +23,11 @@ const AddSafeButton = ({ trackingLabel, onLinkClick }: { trackingLabel: string; 
         variant="outline"
         size="lg"
         onClick={onLinkClick}
-        className="w-full rounded-lg h-full text-base"
+        className="w-full rounded-lg h-full px-5 text-base "
         render={<NextLink href={AppRoutes.newSafe.load} />}
       >
-        <AddIcon color="currentColor" className="fill-primary" />
-        Add account
+        <AddIcon color="currentColor" className="size-5 fill-primary" />
+        Add
       </Button>
     </Track>
   )

--- a/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsNavigation/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { AppRoutes } from '@/config/routes'
 import css from './styles.module.css'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
@@ -6,7 +5,6 @@ import { Chip } from '@mui/material'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
-import { motion } from 'motion/react'
 import { trackEvent } from '@/services/analytics'
 import type { AnalyticsEvent } from '@/services/analytics/types'
 
@@ -32,18 +30,12 @@ const navItems: NavItems = [
   },
 ]
 
-const INDICATOR_LAYOUT_ID = 'accounts-nav-indicator'
-
 const AccountsNavigation = () => {
   const router = useRouter()
-  const [hoveredUrl, setHoveredUrl] = useState<string | null>(null)
 
   const isActiveNavigation = (pathname: string) => {
     return router.pathname === pathname
   }
-
-  const activeUrl = navItems.find((item) => isActiveNavigation(item.url))?.url
-  const highlightedUrl = hoveredUrl ?? activeUrl
 
   const handleClick = (item: Item) => () => {
     if (item.trackEvent && !isActiveNavigation(item.url)) {
@@ -52,22 +44,14 @@ const AccountsNavigation = () => {
   }
 
   return (
-    <nav className={css.nav} onMouseLeave={() => setHoveredUrl(null)}>
+    <nav className={css.nav}>
       {navItems.map((item) => (
         <Link
           key={item.url}
           href={item.url}
           onClick={handleClick(item)}
-          onMouseEnter={() => setHoveredUrl(item.url)}
           className={classNames(css.tab, { [css.active]: isActiveNavigation(item.url) })}
         >
-          {highlightedUrl === item.url && (
-            <motion.div
-              layoutId={INDICATOR_LAYOUT_ID}
-              className={css.indicator}
-              transition={{ type: 'spring', duration: 1, stiffness: 400, damping: 32 }}
-            />
-          )}
           <span className={css.label}>
             {item.label}
             {item.beta && <Chip label="Beta" size="small" sx={{ ml: 1, fontWeight: 'normal', borderRadius: '4px' }} />}

--- a/apps/web/src/features/myAccounts/components/AccountsNavigation/styles.module.css
+++ b/apps/web/src/features/myAccounts/components/AccountsNavigation/styles.module.css
@@ -9,7 +9,6 @@
 }
 
 .tab {
-  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -30,19 +29,10 @@
 
 .active {
   color: var(--color-text-primary);
-}
-
-.indicator {
-  position: absolute;
-  inset: 0;
   background: var(--color-background-secondary);
-  border-radius: 16px;
-  z-index: 0;
 }
 
 .label {
-  position: relative;
-  z-index: 1;
   display: inline-flex;
   align-items: center;
 }

--- a/apps/web/src/features/spaces/components/SignInOptions/index.tsx
+++ b/apps/web/src/features/spaces/components/SignInOptions/index.tsx
@@ -16,8 +16,8 @@ const SignInOptions = ({ afterSignIn, redirectLoading = false }: SignInOptionsPr
     <Box className={css.container}>
       {!$isDisabled && $isReady && (
         <>
-          <EmailSignInButton />
           <GoogleSignInButton />
+          <EmailSignInButton />
           <Divider className={css.divider}>OR</Divider>
         </>
       )}

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -31,7 +31,7 @@ const AddSpaceButton = () => {
       className="h-full rounded-lg px-6 text-base"
       render={<NextLink href={AppRoutes.welcome.createSpace} />}
     >
-      <AddIcon className="fill-current" />
+      <AddIcon className="size-5 fill-[var(--color-static-text-brand)]" />
       Create space
     </Button>
   )


### PR DESCRIPTION
> Strip motion from tabs,
> swap Google above email,
> green plus, outline hover.

## What it solves

Design polish on the Accounts welcome page and Spaces sign-in flow to match the latest Figma. Removes a distracting hover animation, fixes icon sizing/color, reorders sign-in CTAs, and refines the outline button hover.

Resolves:

## How this PR fixes it

- **Accounts nav tabs** (`AccountsNavigation`): removed the `motion/react` sliding indicator that followed the cursor. Replaced with a static background on the active tab and CSS-only text color change on hover (`--color-text-primary`).
- **"Add account" button** (`AccountsHeader`): renamed to "Add", bumped horizontal padding to 20px, and set the `+` icon to 20px.
- **Outline button hover** (`components/ui/button.tsx`): updated the shared `outline` variant hover background to `var(--unofficial-outline-hover, rgba(0,0,0,0.03))`.
- **Sign-in options** (`SignInOptions`): reordered so "Continue with Google" appears above "Continue with email".
- **Create space button** (`SpacesList`): `+` icon bumped to 20px and recolored to Safe brand green via `var(--color-static-text-brand)` (theme-independent, stays green in light & dark).

## How to test it

1. Run the web app: `yarn workspace @safe-global/web dev`.
2. Visit `/welcome/accounts`: hover the "Accounts" / "Spaces" tabs — no sliding indicator, just a text color change. The active tab keeps a static pill background.
3. Confirm the "Add" button shows a `+` icon at 20px, 20px horizontal padding, and a subtle hover background.
4. Visit `/welcome/spaces`: "Continue with Google" renders above "Continue with email".
5. On the Spaces list, the "Create space" CTA `+` icon is 20px and green in both light and dark modes.
6. Hover any other `variant="outline"` button to confirm the new hover background reads correctly.

## Visual summary

```mermaid
flowchart LR
  subgraph Accounts_Header
    A1[Nav tabs] -->|removed| M[motion/react indicator]
    A1 -->|now| S[static active bg + CSS hover color]
    A2[Add button] -->|label| L["Add (was 'Add account')"]
    A2 -->|icon| I1[20px + fill-primary]
    A2 -->|padding| P[20px horizontal]
  end
  subgraph Shared
    B[Button variant=outline] -->|hover bg| H["var(--unofficial-outline-hover, rgba(0,0,0,0.03))"]
  end
  subgraph Spaces
    C1[SignInOptions] -->|reordered| O[Google above Email]
    C2[Create space] -->|icon| I2["20px + var(--color-static-text-brand) (green)"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).