### PR TITLE
fix(mobile): use `AppGroupIdentifier` Info.plist key for MMKV v4

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -40,7 +40,9 @@ const config: ExpoConfig = {
       NSFaceIDUsageDescription: 'Enabling Face ID allows you to create/access secure keys.',
       UIBackgroundModes: ['remote-notification'],
       NSBluetoothPeripheralUsageDescription: 'Allow Bluetooth access to connect to Ledger devices.',
-      AppGroup: IS_DEV ? 'group.global.safe.mobileapp.ios.dev' : 'group.global.safe.mobileapp.ios',
+      // Read by react-native-mmkv v4 to place the MMKV store in the App Group container.
+      // Renaming this key to anything else (e.g. v3's `AppGroup`) strands data in the old location on upgrade.
+      AppGroupIdentifier: IS_DEV ? 'group.global.safe.mobileapp.ios.dev' : 'group.global.safe.mobileapp.ios',
       // https://github.com/expo/expo/issues/39739
       UIDesignRequiresCompatibility: true,
       // https://github.com/react-native-share/react-native-share/issues/1669


### PR DESCRIPTION
> React-native-mmkv v4
> renamed the Info.plist key;
> data seemed lost — it wasn't.

## What it solves

After upgrading to 1.0.10 (build 354+), iOS users see a clean **Get started** screen and all existing safes/signers appear lost. On Android the app is fine.

Resolves: https://linear.app/safe-global/issue/WA-1993/app-update-from-109-to-1010-wipes-data

## How this PR fixes it

The culprit is the `react-native-mmkv` v3 → v4 upgrade (#7480). v4 renamed the Info.plist key it reads to resolve the App Group container from `AppGroup` → `AppGroupIdentifier`. Our `app.config.ts` still sets the old key, so on iOS:

1. `HybridMMKVPlatformContext.getAppGroupDirectory()` doesn't find `AppGroupIdentifier` and returns `nil`.
2. `createMMKV()` silently falls back to `Documents/mmkv/`.
3. 1.0.9's data, which lives at `<AppGroupContainer>/…`, is orphaned — the store looks empty.

Renaming the key routes v4 back to the same App Group container that v1.0.9 wrote to, so existing data reappears after the update. Nothing was ever actually lost on the device.

**Caveat for users who already opened 1.0.10:** they wrote fresh state into `Documents/mmkv/`. After this fix ships, their 1.0.9 data returns, but anything added on 1.0.10 stays stranded. If we want to recover that too, a one-shot copy `Documents/mmkv/` → AppGroup container on first launch would do it — happy to add in a follow-up if desired.

**Android is unaffected** — `HybridMMKVPlatformContext.kt` always uses `filesDir + /mmkv`; no app-group concept.

Reference: [react-native-mmkv V4 upgrade guide](https://github.com/mrousavy/react-native-mmkv/blob/main/docs/V4_UPGRADE_GUIDE.md).

## How to test it

1. Install **1.0.9 (build 339)** from TestFlight/prod, sign in, import a safe and a signer.
2. Install a dev build of this branch **over** the existing app (do not uninstall first).
3. Open the app → existing safes and signers should be visible (no "Get started" screen).
4. On Android, verify upgrade from 1.0.9 → this branch is still uneventful.

## Visual summary

```mermaid
flowchart LR
  subgraph Before ["1.0.10 (broken)"]
    A1[MMKV v4] -->|reads| K1["Info.plist:<br/>AppGroup ❌"]
    A1 -->|falls back| D1["Documents/mmkv/<br/>(empty, fresh)"]
    old1[1.0.9 data] -.orphaned.-> G1["AppGroup container<br/>(unreachable)"]
  end
  subgraph After ["this PR"]
    A2[MMKV v4] -->|reads| K2["Info.plist:<br/>AppGroupIdentifier ✅"]
    A2 -->|resolves to| G2["AppGroup container"]
    old2[1.0.9 data] -->|restored| G2
  end
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — n/a
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — not feasible for a native Info.plist key change

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).