### PR TITLE
chore: add regression checklist and LSP guidance for AI contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,33 @@ Resolves:
 
 ## How to test it
 
+## Affected flows
+
+<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->
+
+## Blast radius
+
+<!--
+List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
+Include where relevant:
+- Shared hooks / components / selectors / slices touched and their known consumers
+- RTK Query endpoints / API contracts
+- Feature flags / chain configs
+- Persistence / cache / migration implications
+- Routes or layouts affected indirectly
+- Mobile impact (shared packages)
+-->
+
+## Risks / not checked
+
+<!--
+Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
+Example:
+- Did not verify behavior with feature flag X disabled
+- Did not test on mobile
+- Did not exercise the retry / error path manually
+-->
+
 ## Visual summary
 
 <!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->
@@ -15,6 +42,7 @@ Resolves:
 - [ ] I've tested the branch on mobile 📱
 - [ ] I've documented how it affects the analytics (if at all) 📊
 - [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
+- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,42 @@ sg -p 'useMemo(() => $$$, [$$$, chainId, $$$])' --lang tsx apps/web/src/
 
 Install: `brew install ast-grep` or `npm install -g @ast-grep/cli`
 
+### TypeScript LSP (symbol-aware navigation)
+
+When available in your agent environment, the `LSP` tool exposes the TypeScript language server and indexes the entire monorepo (`apps/` + `packages/`, ~40k+ symbols). Use it for any question about **what a symbol is** or **who uses it** — it follows imports, re-exports, and module resolution, and ignores matches in comments and strings. This is strictly more accurate than `grep` for symbol-level questions, and complements `ast-grep` (which is best for structural pattern matching).
+
+**When to reach for LSP (strongly preferred over `grep`):**
+
+- "Who consumes this hook / component / selector / slice / endpoint / type?" → `findReferences`
+- "Where is this symbol defined?" → `goToDefinition`
+- "What are all implementations of this interface?" → `goToImplementation`
+- "What's the exported API of this file?" → `documentSymbol`
+- "Does a symbol named X exist anywhere, and where?" → `workspaceSymbol`
+- "Who calls this function, and whom does it call?" → `prepareCallHierarchy` + `incomingCalls` / `outgoingCalls`
+- "What type is this expression?" → `hover`
+
+**When to reach for `ast-grep` instead:**
+
+- Structural patterns, not symbol identity. E.g. "every `useMemo` whose deps array contains `chainId`", "every call to `createSlice` with a given shape".
+
+**When plain `grep` is still fine:**
+
+- Searching strings, comments, config, copy/UI text, file names, or anything that isn't a TS/TSX identifier.
+
+**Gotcha — default exports:** For files that use `export default`, target the identifier on the `export default` line, not the local `const`/`function` binding, or you will miss all the importing consumers. Example: for `apps/web/src/hooks/useSafeInfo.ts`, aiming `findReferences` at the local `const useSafeInfo` binding returns ~2 refs; aiming at `export default useSafeInfo` returns 500+ refs across the codebase. For named exports this does not matter.
+
+**All operations take:** `filePath`, `line` (1-based), `character` (1-based), `operation`.
+
+```
+# Examples
+operation=documentSymbol  filePath=apps/web/src/hooks/useSafeInfo.ts  line=1 character=1
+operation=findReferences  filePath=apps/web/src/hooks/useSafeInfo.ts  line=29 character=16  # the "default" identifier
+operation=goToDefinition  filePath=apps/web/src/hooks/useSafeInfo.ts  line=4  character=10  # selectSafeInfo import
+operation=workspaceSymbol filePath=<any .ts file>                     line=1  character=1   # index-wide symbol search
+```
+
+**Cost note:** `workspaceSymbol` with an empty/broad query returns tens of thousands of entries (1.7 MB+) and will be truncated to a persisted file — use it with a specific query, or prefer `findReferences` / `goToDefinition` starting from a known site.
+
 ## Unified Theme System
 
 The project uses `@safe-global/theme` package as a single source of truth for all design tokens (colors, spacing, typography, radius) across web and mobile.
@@ -259,6 +295,45 @@ The repo provides automated verification:
 - If `verify:changed` reports a missing test, write one before committing
 - Do NOT run type-check, lint, prettier, and test separately — use `verify`
 - Do NOT commit without a clean `verify:changed` pass
+
+### Pre-implementation regression checklist (REQUIRED)
+
+Before writing code for any non-trivial change (anything beyond a typo, doc tweak, or single-line local fix), you MUST produce a regression checklist and include it in your response to the user. Optimise for **impact analysis**, not diff completion: a change to a shared hook, selector, component, slice, or API endpoint touches many user journeys, and plain text search is not enough to find them.
+
+**Build the checklist in this order:**
+
+1. **Map the surface.** Identify what you are touching: the primary file(s), plus any shared hooks, components, selectors, Redux slices, RTK Query endpoints, feature flags, routes, or persisted state involved.
+2. **Find consumers with symbol-aware search.** For "who uses this symbol?" questions, prefer the `LSP` tool's `findReferences` (see "TypeScript LSP" above) — it follows imports, re-exports, and module resolution across the whole monorepo. Use `ast-grep` for structural pattern questions (e.g. "every `useMemo` with `chainId` in deps"). Fall back to plain `grep` only for strings, comments, config, or UI copy. Plain text search misses structural usages, matches inside comments/strings, and does not follow re-exports.
+3. **Translate consumers into flows.** For each consumer, name the user journey it belongs to (create / edit / delete / retry / empty / error / offline / permission / feature-flag-off / mobile variant).
+4. **List tests to add or run.** Happy path, each neighbouring flow, regression-sensitive paths, and invariant properties. Prefer targeted tests around shared contracts over broad E2E sweeps.
+5. **State what you will NOT verify.** Be explicit. This exposes false confidence.
+
+**Required checklist format (paste into your response before implementing):**
+
+```
+### Regression checklist
+
+**Primary flow changed:** <one sentence>
+
+**Surfaces touched:**
+- <shared hook / component / selector / slice / endpoint / flag / route>
+
+**Neighbouring flows to verify:**
+- <flow A> — <why it could be affected>
+- <flow B> — <why it could be affected>
+
+**Tests to add/run:**
+- <test name or description>
+
+**Not verified (risks):**
+- <what you are skipping and why>
+```
+
+**Rules:**
+
+- Do NOT start editing code until this checklist exists in the conversation. For small, strictly local changes, a one-line "local change, no shared surfaces touched" note is sufficient.
+- When you open the PR, carry the relevant lines into the "Affected flows", "Blast radius", and "Risks / not checked" fields of the PR template.
+- If the checklist reveals that a shared abstraction has many unknown consumers, slow down and investigate before coding — that is the signal this process is designed to surface.
 
 1. **Install dependencies**: `yarn install` (from the repository root).
    - Uses Yarn 4 (managed via `corepack`)


### PR DESCRIPTION
> Symbols beat grep for finding consumers,
> blast-radius thinking before the diff,
> name what you did not check.

## What it solves

AI-authored PRs in this repo often pass local review but miss neighbouring flows. The agent edits the changed file correctly, but never builds a reliable model of the blast radius of a shared hook / selector / slice / component / endpoint, so behaviourally-coupled flows regress. Two root causes:

1. No required step that forces impact analysis before the agent starts editing.
2. PR template has no field for reviewers to probe "what else could this have broken?" — reviewers default to judging the diff, not the surface.

## How this PR fixes it

Two docs changes, no code:

1. **`AGENTS.md` — new `### Pre-implementation regression checklist (REQUIRED)` subsection under Workflow → Fast Feedback Loop.** Agents must, before editing code for any non-trivial change, produce a structured checklist with: primary flow changed, surfaces touched, neighbouring flows to verify, tests to add/run, and what was *not* verified. The checklist is explicitly tied into the PR template fields below.

2. **`AGENTS.md` — new `### TypeScript LSP (symbol-aware navigation)` subsection under Architecture Overview.** Documents the `LSP` agent tool (verified to be available and indexing ~40k+ symbols across `apps/` and `packages/`) as the preferred primitive for the "find consumers" step — strictly better than `grep` for symbol-level questions because it follows imports and re-exports. Includes a decision matrix (LSP vs ast-grep vs grep), operation-level guidance, parameter shape with worked examples, the default-export gotcha, and a cost note on `workspaceSymbol`.

3. **`.github/PULL_REQUEST_TEMPLATE.md` — three new required sections** between "How to test it" and "Visual summary":
   - **Affected flows** — primary user journey(s) intentionally changed
   - **Blast radius** — surfaces touched and known dependents (shared hooks / components / selectors / slices / endpoints / flags / routes / mobile impact)
   - **Risks / not checked** — explicit list of what was not verified
   Plus a matching checklist item.

The regression checklist in AGENTS.md is the *agent-side* mechanism; the PR template fields are the *reviewer-side* mechanism. The two are designed to chain: the checklist's bullets become the PR sections.

## How to test it

This PR touches only docs and the PR template — no runtime code, no tests to run.

- [x] `yarn verify:changed` no-op confirmed (no `.ts/.tsx/.js/.jsx` files modified, so the Stop hook early-exits).
- [ ] Reviewer check: open this PR's "Edit" view and confirm the template renders the new sections correctly.
- [ ] Reviewer check: read the `AGENTS.md` diff top-to-bottom and sanity-check that the LSP guidance, gotcha, and cost note match the tool's real behaviour (the default-export example — 2 refs vs 500+ on `useSafeInfo.ts` — was measured against the live LSP server on this branch).

## Affected flows

- **AI agent workflow** — all future non-trivial AI-authored changes in this repo must now produce a regression checklist before editing and carry it into the PR template.
- **PR authoring (any contributor)** — three new sections must be filled for every new PR opened against `dev`.
- **PR review** — reviewers now have explicit fields to probe impact analysis, not just diff correctness.

## Blast radius

- **`.github/PULL_REQUEST_TEMPLATE.md`** — applies to every newly opened PR in `safe-global/safe-wallet-monorepo`. Pre-existing open PRs are unaffected (GitHub only seeds the template on PR creation).
- **`AGENTS.md`** — consumed by `CLAUDE.md` (which reads `AGENTS.md`) and by any other agent tooling that honours `AGENTS.md` (GEMINI.md, Copilot instructions, etc.). No code import graph is affected.
- **No shared hooks / selectors / slices / RTK Query endpoints / feature flags / routes / persistence / cache / migrations touched.**
- **Mobile impact:** none. No `packages/*` or `apps/mobile/*` files changed.
- **CI:** none. The template is markdown; lint/type-check/tests do not run against it. The `Stop` verify hook early-exits on doc-only changes.

## Risks / not checked

- Did not verify rendering of the PR template in the GitHub "New PR" UI — GitHub will render the `<!-- -->` comment hints as guidance, which is the intended behaviour, but worth a human glance.
- Did not regenerate downstream agent prompts that may cache `AGENTS.md` — other agent harnesses will pick up the new rules on their next read.
- The regression checklist is a process rule, not an automated check. Enforcement is social / review-time. A CI bot to block PRs missing the three new sections is out of scope for this PR and can be a follow-up if drift is observed.
- Did not test the LSP guidance against non-Claude-Code harnesses — the tool name `LSP` and its operation set are specific to this agent's environment. The section is prefixed "When available in your agent environment, …" to make that explicit.

## Visual summary

New required workflow for non-trivial AI-authored changes:

```mermaid
flowchart TB
  A[Task received] --> B{Non-trivial?}
  B -->|No, local one-liner| Z[Implement]
  B -->|Yes| C[Map the surface<br/>files, hooks, selectors, slices, endpoints, flags, routes]
  C --> D[Find consumers<br/>LSP findReferences preferred<br/>ast-grep for patterns<br/>grep last resort]
  D --> E[Translate consumers into user flows<br/>create / edit / delete / retry / empty / error / mobile / flag-off]
  E --> F[List tests to add or run]
  F --> G[State what will NOT be verified]
  G --> H[Post regression checklist to user]
  H --> Z
  Z --> P[Open PR]
  P --> Q[Fill template:<br/>Affected flows • Blast radius • Risks / not checked]
  Q --> R[Reviewer probes the surface,<br/>not just the diff]
```

## Checklist

- [x] I've tested the branch on mobile 📱 — N/A, docs-only change
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — N/A, docs-only
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)