### PR TITLE
feat(web): update corner radius for Spaces and Safe M2 (WA-2003)

### DIFF
--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ReviewTransaction should display a confirmation screen 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-1w4z6qv-MuiPaper-root-MuiCard-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-gvoogg-MuiPaper-root-MuiCard-root"
     style="--Paper-shadow: none;"
   >
     <div
@@ -104,7 +104,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
         class="MuiBox-root css-1yuhvjn"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-wrhbuy-MuiPaper-root-MuiAccordion-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-mu8qg7-MuiPaper-root-MuiAccordion-root"
           color="info"
           style="--Paper-shadow: none;"
         >
@@ -244,7 +244,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                           .
                         </p>
                         <div
-                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-shqplw-MuiPaper-root"
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-bob4d2-MuiPaper-root"
                           style="--Paper-shadow: none;"
                         >
                           <div
@@ -659,7 +659,7 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
 exports[`ReviewTransaction should display a loading component 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-1w4z6qv-MuiPaper-root-MuiCard-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-gvoogg-MuiPaper-root-MuiCard-root"
     style="--Paper-shadow: none;"
   >
     <div
@@ -724,7 +724,7 @@ exports[`ReviewTransaction should display a loading component 1`] = `
 exports[`ReviewTransaction should display an error screen 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-1w4z6qv-MuiPaper-root-MuiCard-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-gvoogg-MuiPaper-root-MuiCard-root"
     style="--Paper-shadow: none;"
   >
     <div

--- a/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/BatchTransactions/__snapshots__/BatchTransactions.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`BatchTransactions should render a list of batch transactions 1`] = `
         class="accordion"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-1gdgqta-MuiPaper-root-MuiAccordion-root"
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-1622vx-MuiPaper-root-MuiAccordion-root"
           data-testid="action-accordion"
           style="--Paper-shadow: none;"
         >

--- a/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.test.tsx.snap
+++ b/apps/web/src/components/tx/confirmation-views/SettingsChange/__snapshots__/SettingsChange.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SettingsChange should display the SettingsChange component with newOwner details 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1nt2i3f-MuiPaper-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-3m5je5-MuiPaper-root"
     style="--Paper-shadow: none;"
   >
     <p
@@ -86,7 +86,7 @@ exports[`SettingsChange should display the SettingsChange component with newOwne
     </div>
   </div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 container css-zpxm0u-MuiPaper-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 container css-1n5z6j7-MuiPaper-root"
     style="--Paper-shadow: none;"
   >
     <p
@@ -177,7 +177,7 @@ exports[`SettingsChange should display the SettingsChange component with newOwne
 exports[`SettingsChange should display the SettingsChange component with owner details 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 container css-zpxm0u-MuiPaper-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 container css-1n5z6j7-MuiPaper-root"
     style="--Paper-shadow: none;"
   >
     <p

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -24,7 +24,7 @@ import { cn } from '@/utils/cn'
  */
 
 const buttonVariants = cva(
-  "focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-sm border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "focus-visible:border-ring cursor-pointer focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
   {
     variants: {
       variant: {

--- a/apps/web/src/features/spaces/components/Dashboard/ImportAddressBookCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/ImportAddressBookCard.tsx
@@ -20,7 +20,7 @@ const AddressBookCard = () => {
 
   return (
     <>
-      <Paper sx={{ p: 3, borderRadius: '12px', height: '100%' }}>
+      <Paper sx={{ p: 3, borderRadius: '24px', height: '100%' }}>
         <Box position="relative" width={1}>
           <Box className={classnames(css.iconBG, css.iconBGBlue)}>
             <SvgIcon component={AddressBookIcon} inheritViewBox color="info" />

--- a/apps/web/src/features/spaces/components/Dashboard/MembersCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/MembersCard.tsx
@@ -20,7 +20,7 @@ const MembersCard = () => {
 
   return (
     <>
-      <Paper sx={{ p: 3, borderRadius: '12px' }}>
+      <Paper sx={{ p: 3, borderRadius: '24px' }}>
         <Box position="relative" width={1}>
           <Box className={classnames(css.iconBG, css.iconBGBlue)}>
             <SvgIcon component={MemberIcon} inheritViewBox color="info" />

--- a/apps/web/src/features/spaces/components/Dashboard/SpacesCTACard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/SpacesCTACard.tsx
@@ -16,7 +16,7 @@ const SpacesCTACard = () => {
 
   return (
     <>
-      <Paper sx={{ p: 3, borderRadius: '12px', height: '100%' }}>
+      <Paper sx={{ p: 3, borderRadius: '24px', height: '100%' }}>
         <Box position="relative" width={1}>
           <Box className={css.iconBG}>
             <SvgIcon component={LightbulbIcon} inheritViewBox />

--- a/apps/web/src/features/spaces/components/SafeWidget/SafeWidgetRoot.tsx
+++ b/apps/web/src/features/spaces/components/SafeWidget/SafeWidgetRoot.tsx
@@ -24,7 +24,7 @@ const SafeWidgetRoot = ({
     <div
       data-slot="safe-widget"
       data-testid={testId}
-      className={cn('flex h-full min-h-0 flex-col rounded-sm bg-card p-1', className)}
+      className={cn('flex h-full min-h-0 flex-col rounded-xl bg-card p-1', className)}
     >
       <div className="flex shrink-0 items-center px-6 justify-between pb-3 pt-6">
         <div className={cn('flex items-center', onTitleClick && 'cursor-pointer')} onClick={onTitleClick}>

--- a/packages/theme/src/generators/mui.ts
+++ b/packages/theme/src/generators/mui.ts
@@ -260,25 +260,39 @@ export function generateMuiTheme(mode: PaletteMode): Theme {
       MuiAccordionDetails: { styleOverrides: { root: ({ theme }) => ({ padding: theme.spacing(2) }) } },
       MuiCard: {
         styleOverrides: {
-          root: ({ theme }) => ({
-            borderRadius: theme.shape.borderRadius,
+          root: {
+            borderRadius: 24,
             boxSizing: 'border-box',
             border: '2px solid transparent',
             boxShadow: 'none',
-          }),
+          },
         },
       },
-      MuiDialog: { defaultProps: { fullWidth: true } },
+      MuiDialog: {
+        defaultProps: { fullWidth: true },
+        styleOverrides: { paper: ({ theme }) => ({ borderRadius: theme.shape.borderRadius }) },
+      },
       MuiDialogContent: { styleOverrides: { root: ({ theme }) => ({ padding: theme.spacing(3) }) } },
       MuiDivider: { styleOverrides: { root: ({ theme }) => ({ borderColor: theme.palette.border.light }) } },
       MuiPaper: {
         defaultProps: { elevation: 0 },
         styleOverrides: {
           outlined: ({ theme }) => ({ borderWidth: 2, borderColor: theme.palette.border.light }),
-          root: ({ theme }) => ({ borderRadius: theme.shape.borderRadius, backgroundImage: 'none' }),
+          root: { borderRadius: 24, backgroundImage: 'none' },
         },
       },
-      MuiPopover: { defaultProps: { elevation: 2 }, styleOverrides: { paper: { overflow: 'visible' } } },
+      MuiPopover: {
+        defaultProps: { elevation: 2 },
+        styleOverrides: {
+          paper: ({ theme }) => ({ overflow: 'visible', borderRadius: theme.shape.borderRadius }),
+        },
+      },
+      MuiMenu: {
+        styleOverrides: { paper: ({ theme }) => ({ borderRadius: theme.shape.borderRadius }) },
+      },
+      MuiAutocomplete: {
+        styleOverrides: { paper: ({ theme }) => ({ borderRadius: theme.shape.borderRadius }) },
+      },
       MuiIconButton: { styleOverrides: { sizeSmall: { padding: '4px' } } },
       MuiToggleButton: { styleOverrides: { root: { textTransform: 'none' } } },
       MuiChip: {
@@ -317,7 +331,11 @@ export function generateMuiTheme(mode: PaletteMode): Theme {
             '& .MuiAlert-icon': { color: theme.palette.text.primary },
             '&.MuiPaper-root': { backgroundColor: theme.palette.background.main },
           }),
-          root: ({ theme }) => ({ color: theme.palette.text.primary, padding: '12px 16px' }),
+          root: ({ theme }) => ({
+            color: theme.palette.text.primary,
+            padding: '12px 16px',
+            borderRadius: theme.shape.borderRadius,
+          }),
         },
       },
       MuiTableHead: {


### PR DESCRIPTION
> Buttons twelve, widgets twenty-four,
> Paper cards rounder than before,
> menus kept calm at their old six.

## What it solves

Resolves: [WA-2003](https://linear.app/safe-global/issue/WA-2003/corner-radius-general)

For M1 we kept the legacy 8px radius everywhere because the standalone-Safe sidebar wasn't shipped yet. For M2 we're shipping it, so corner radii are updated to match the new Figma design: **buttons 12px**, **cards/containers/widgets 24px**.

## How this PR fixes it

Scoped to the M2 design surface (Spaces + Safe level), with a guardrail on legacy MUI to avoid rounding dropdowns and modals too hard.

**shadcn / Tailwind surfaces (M2):**
- `components/ui/button.tsx` — base `rounded-sm` (8px) → `rounded-md` (12px). Hits every shadcn Button: Topbar, ActionsTray, SpaceSafeBar, Spaces, myAccounts, safe-overview.
- `features/spaces/components/SafeWidget/SafeWidgetRoot.tsx` — `rounded-sm` → `rounded-xl` (24px). Hits all Spaces + Safe dashboard widgets (pending tx, accounts, setup, etc.).
- shadcn `Card` already uses `rounded-xl` (24px) — no change needed.

**Spaces Dashboard MUI Paper cards:**
- `Dashboard/MembersCard.tsx`, `Dashboard/SpacesCTACard.tsx`, `Dashboard/ImportAddressBookCard.tsx` — inline `borderRadius: '12px'` → `'24px'`.

**MUI theme (`packages/theme/src/generators/mui.ts`):**
- `MuiCard.root.borderRadius`: 6 → **24**
- `MuiPaper.root.borderRadius`: 6 → **24**
- Scoped overrides (kept at `theme.shape.borderRadius` = 6) so paper-backed surfaces that aren't cards don't over-round:
  - `MuiDialog.paper`
  - `MuiPopover.paper`
  - `MuiMenu.paper`
  - `MuiAutocomplete.paper`
  - `MuiAlert.root`
- `MuiAccordion.root` and `MuiFilledInput.root` already set explicit radii → untouched.
- `MuiButton.root` left at 6px (MUI Button is not on the M2 surface; shadcn Button covers M2 CTAs).

## How to test it

1. Check out `fix/border-radius` and run `yarn workspace @safe-global/web dev`.
2. Navigate to Spaces (any space → dashboard). All widgets should have **24px** corners, all shadcn buttons should have **12px** corners, the dashboard Members / Learn more / Import address book cards should have **24px** corners.
3. Navigate to a standalone Safe (Safe-level sidebar). Same widget/button radii should apply.
4. Open dropdowns / menus / autocompletes (Safe selector, chain selector, context menus) and confirm they still render with the old smaller radius (6px) — no giant round corners on menus.
5. Open dialogs (e.g. add member, create space) and confirm they aren't over-rounded.
6. Sanity-check legacy surfaces outside M2 (tx flows, settings) to confirm Paper/Card now have 24px corners — expected per ticket, since the MUI theme change is global.

## Visual summary

```mermaid
flowchart LR
    subgraph M1[Before - M1]
        B1[Buttons 8px]
        B2[Widgets 8px]
        B3[Dashboard cards 12px]
        B4[MUI Paper/Card 6px]
    end
    subgraph M2[After - M2 / WA-2003]
        A1[Buttons 12px]
        A2[Widgets 24px]
        A3[Dashboard cards 24px]
        A4[MUI Paper/Card 24px]
        A5[Dialog/Popover/Menu/Autocomplete/Alert kept 6px]
    end
    M1 --> M2
```

Screenshots to add once the dev server has been eyeballed.

## Checklist

- [ ] I've tested the branch on mobile 📱 (n/a — web-only change; mobile uses Tamagui tokens, not MUI)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (visual-only change covered by Chromatic)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
