### PR TITLE
chore: exact-match release branch in Start Web Release workflow

### DIFF
--- a/.github/workflows/web-release-start.yml
+++ b/.github/workflows/web-release-start.yml
@@ -125,11 +125,10 @@ jobs:
 
       - name: Check for concurrent release
         run: |
-          git fetch origin
-          if git ls-remote --exit-code --heads origin release >/dev/null 2>&1; then
+          RELEASE_COMMIT=$(git ls-remote origin refs/heads/release | cut -f1)
+          if [ -n "$RELEASE_COMMIT" ]; then
             # Release branch exists, check if it differs from base
-            BASE_COMMIT=$(git rev-parse origin/${{ steps.base.outputs.branch }})
-            RELEASE_COMMIT=$(git rev-parse origin/release)
+            BASE_COMMIT=$(git ls-remote origin "refs/heads/${{ steps.base.outputs.branch }}" | cut -f1)
             if [ "$RELEASE_COMMIT" != "$BASE_COMMIT" ]; then
               echo "⚠️  Warning: The 'release' branch already exists and differs from ${{ steps.base.outputs.branch }}"
               echo "This may indicate a concurrent or in-progress release."


### PR DESCRIPTION

> Loose ref glob caught `mobile/release`,
> hotfix runs died at rev-parse.
> Fully qualify, compare SHAs,
> release unblocks again.

## What it solves

Resolves: the `🚀 Start Web Release` workflow fails on every hotfix/release attempt with:

```
fatal: ambiguous argument 'origin/release': unknown revision or path not in the working tree.
Error: Process completed with exit code 128.
```

**Root cause:** the `Check for concurrent release` step at `.github/workflows/web-release-start.yml:126` does:

```bash
if git ls-remote --exit-code --heads origin release >/dev/null 2>&1; then
  BASE_COMMIT=$(git rev-parse origin/${{ steps.base.outputs.branch }})
  RELEASE_COMMIT=$(git rev-parse origin/release)
  ...
```

Two latent bugs that compound:

1. **Loose `ls-remote` pattern.** Bare `release` (no slashes) matches any ref whose **last path component** equals `release`. `refs/heads/mobile/release` matches → the `if` body is entered even when `refs/heads/release` does not exist on the remote.
2. **`rev-parse` against a ref that isn't in the local clone.** `actions/checkout` does not guarantee `origin/release` is populated in the runner's `.git/` refs, and the preceding `git fetch origin` doesn't add it either. Even if `release` existed remotely, `rev-parse origin/release` would error out with `exit 128`, and `bash -e` kills the step.

The bug only surfaced once `mobile/release` came into existence. Before that, `ls-remote` returned non-zero and the buggy body was skipped entirely.

## How this PR fixes it

- Change the `ls-remote` pattern to the fully-qualified ref `refs/heads/release`, so only the real `release` branch matches — `mobile/release` and any other `*/release` no longer trigger the `if`.
- Replace `git rev-parse origin/<ref>` with `git ls-remote origin refs/heads/<ref> | cut -f1`. This reads SHAs directly from the remote, so the check no longer depends on which refs `actions/checkout` happened to fetch locally.
- Drop the now-unused `git fetch origin` preceding the check.

Behavior preserved:

| Remote state | Before | After |
| --- | --- | --- |
| `release` does not exist | Skip if no `*/release` ref exists; fail if one does | Skip |
| `release` exists, SHA == base SHA | Skip | Skip |
| `release` exists, SHA != base SHA | Fail with warning | Fail with warning |

## How to test it

1. Confirm the fix locally:
   ```bash
   # With mobile/release present on the remote, the new pattern should NOT match:
   git ls-remote --exit-code --heads origin refs/heads/release; echo "exit=$?"
   # exit=2 (no match, expected)

   git ls-remote --exit-code --heads origin release; echo "exit=$?"
   # exit=0 (matches mobile/release — this is the bug)
   ```
2. Run the workflow from the Actions UI with a test branch:
   - **Actions → 🚀 Start Web Release → Run workflow**
   - Version: any unused patch (e.g. `1.87.4`)
   - Release type: `hotfix`
   - Base branch: a throw-away branch based off `main`
3. Verify the `Check for concurrent release` step prints `✅ Safe to create/update release branch` and the workflow proceeds to create `release` and open the PR.
4. (Optional) To exercise the failure branch: push a `release` branch pointing at a commit other than the base, then re-run. The step should fail with the existing `⚠️ Warning: The 'release' branch already exists...` message. Delete the test `release` branch afterwards.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before (buggy)"]
    A1["git ls-remote --heads origin <b>release</b>"] --> B1{"matches ANY ref ending in /release"}
    B1 -->|"mobile/release exists"| C1["enter if block"]
    C1 --> D1["git rev-parse origin/release"]
    D1 --> E1["fatal: unknown revision<br/>exit 128"]
  end
  subgraph After["After (fixed)"]
    A2["git ls-remote origin <b>refs/heads/release</b>"] --> B2{"exact match only"}
    B2 -->|"release does NOT exist"| C2["skip block"]
    B2 -->|"release exists"| D2["compare SHAs from ls-remote output"]
    D2 --> E2["proceed or fail cleanly"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A (CI-only change)
- [ ] I've documented how it affects the analytics (if at all) 📊 — N/A
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — N/A (shell snippet in a GitHub Actions step)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).