### PR TITLE
fix(web/Spaces): change Update Required warning for Settings in the sidebar

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/styles.module.css
+++ b/apps/web/src/features/spaces/components/Sidebar/styles.module.css
@@ -132,8 +132,8 @@
 
 .outdatedDot {
   position: absolute;
-  top: 4px;
-  right: 2px;
+  top: -3px;
+  right: -3px;
   width: 8px;
   height: 8px;
   border-radius: 50%;

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
@@ -94,7 +94,7 @@ export const SafeSidebarVariant = ({
                 {displayMainNavItems.map((item, index) => (
                   <NavItem key={item?.href ?? `skeleton-main-${index}`} item={item} isLoading={isLoading} />
                 ))}
-                <SidebarMenuItem className="relative">
+                <SidebarMenuItem>
                   <SidebarMenuButton
                     size="lg"
                     isActive={isSettingsActive}
@@ -105,13 +105,15 @@ export const SafeSidebarVariant = ({
                   >
                     <Tooltip>
                       <TooltipTrigger>
-                        <Settings className="text-muted-foreground" />
+                        <span className="relative">
+                          <Settings className="text-muted-foreground" />
+                          {isOutdated && <span className={css.outdatedDot} aria-hidden />}
+                        </span>
                       </TooltipTrigger>
                       <TooltipContent side="right">Settings</TooltipContent>
                     </Tooltip>
                     <span>Settings</span>
                   </SidebarMenuButton>
-                  {isOutdated && <span className={css.outdatedDot} aria-hidden />}
                 </SidebarMenuItem>
               </SidebarMenu>
             </SidebarGroupContent>


### PR DESCRIPTION
## What it solves

Resolves: [WA-1972](https://linear.app/safe-global/issue/WA-1972/side-bar-change-position-for-the-updates-required-in-the-settings)

The Update Required red dot was placed wrongly in the Settings - in the corner of NavItem instead of the Setings icon.

## How this PR fixes it
Places the red dot to the Settings icon.

## How to test it
Go to a Safe with old mastercopy: /settings/setup?safe=eth:0x220866B1A2219f40e72f5c628B65D54268cA3A9D
The red dot in Settings should be on the Settings icon.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
