### PR TITLE
fix(web/Spaces): fix Tx History -> Queue redirect

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/SafeSidebarContent.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/SafeSidebarContent.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import { useCallback, useContext, useEffect, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { useRouter } from 'next/router'
 import { safeMainNavigation, safeDefiGroup } from '../../config'
 import { useResolvedSidebarNav } from '../../hooks/useResolvedSidebarNav'
@@ -40,13 +40,6 @@ export const SafeSidebarContent = ({
   const { safe } = useSafeInfo()
   const safeAddress = useSafeQueryParam() || undefined
 
-  // prevents a re-render of nav items when tx data arrives later:
-  useEffect(() => {
-    if (Number(queueSize) > 0 && router.pathname === AppRoutes.transactions.history) {
-      void router.replace({ pathname: AppRoutes.transactions.queue, query: router.query })
-    }
-  }, [queueSize, router.pathname])
-
   const getLink = useCallback(
     (item: SidebarItemConfig) => {
       const spaceId = getQuerySpaceId(router.query)
@@ -55,9 +48,12 @@ export const SafeSidebarContent = ({
         ...(spaceId && { spaceId }),
       }
 
-      return { pathname: item.href, query }
+      const pathname =
+        item.href === AppRoutes.transactions.history && queueSize ? AppRoutes.transactions.queue : item.href
+
+      return { pathname, query }
     },
-    [router.query, safeAddress],
+    [router.query, safeAddress, queueSize],
   )
 
   const isItemDisabled = useCallback(

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/__tests__/SafeSidebarContent.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarContent/__tests__/SafeSidebarContent.test.tsx
@@ -8,14 +8,13 @@ import type { SidebarGroupConfig, SidebarItemConfig } from '../../../types'
 const mockUseResolvedSidebarNav = jest.fn()
 const mockIsRouteEnabled = jest.fn()
 
-const mockRouterReplace = jest.fn()
 const mockRouterPathname = { current: AppRoutes.home }
 
 jest.mock('next/router', () => ({
   useRouter: () => ({
     query: { spaceId: '123', safe: 'eth:0x1' },
     pathname: mockRouterPathname.current,
-    replace: mockRouterReplace,
+    replace: jest.fn(),
   }),
 }))
 
@@ -282,13 +281,13 @@ describe('SafeSidebarContent', () => {
   })
 
   describe('getLink', () => {
-    it('passes href through unchanged for all items regardless of queue size', () => {
-      mockUseQueuedTxsLength.mockReturnValue(3)
+    it('routes Transactions entry to Queue when the queue is non-empty', () => {
+      mockUseQueuedTxsLength.mockReturnValue('3')
       render(<SafeSidebarContent {...defaultProps} />)
 
       const [, , { getLink }] = getCallArgs()
       expect(getLink({ href: AppRoutes.transactions.history } as SidebarItemConfig).pathname).toBe(
-        AppRoutes.transactions.history,
+        AppRoutes.transactions.queue,
       )
       expect(getLink({ href: AppRoutes.home } as SidebarItemConfig).pathname).toBe(AppRoutes.home)
       expect(getLink({ href: AppRoutes.balances.index } as SidebarItemConfig).pathname).toBe(AppRoutes.balances.index)
@@ -298,34 +297,15 @@ describe('SafeSidebarContent', () => {
       expect(getLink({ href: AppRoutes.earn } as SidebarItemConfig).pathname).toBe(AppRoutes.earn)
       expect(getLink({ href: AppRoutes.stake } as SidebarItemConfig).pathname).toBe(AppRoutes.stake)
     })
-  })
 
-  describe('queue redirect', () => {
-    it('redirects to queue when on history page and queue is non-empty', () => {
-      mockRouterPathname.current = AppRoutes.transactions.history
-      mockUseQueuedTxsLength.mockReturnValue(3)
+    it('routes Transactions entry to History when the queue is empty', () => {
+      mockUseQueuedTxsLength.mockReturnValue('')
       render(<SafeSidebarContent {...defaultProps} />)
 
-      expect(mockRouterReplace).toHaveBeenCalledWith({
-        pathname: AppRoutes.transactions.queue,
-        query: expect.anything(),
-      })
-    })
-
-    it('does not redirect when on history page and queue is empty', () => {
-      mockRouterPathname.current = AppRoutes.transactions.history
-      mockUseQueuedTxsLength.mockReturnValue(0)
-      render(<SafeSidebarContent {...defaultProps} />)
-
-      expect(mockRouterReplace).not.toHaveBeenCalled()
-    })
-
-    it('does not redirect when on a non-history page even if queue is non-empty', () => {
-      mockRouterPathname.current = AppRoutes.home
-      mockUseQueuedTxsLength.mockReturnValue(5)
-      render(<SafeSidebarContent {...defaultProps} />)
-
-      expect(mockRouterReplace).not.toHaveBeenCalled()
+      const [, , { getLink }] = getCallArgs()
+      expect(getLink({ href: AppRoutes.transactions.history } as SidebarItemConfig).pathname).toBe(
+        AppRoutes.transactions.history,
+      )
     })
   })
 })


### PR DESCRIPTION
## What it solves

When the user tried to open the Tx History tab, they get redirected to Tx Queue. This is regression from the changes in the Sidebar as there was a redirect to `/queue` if N tx > 0.
Resolves: [WA-2037](https://linear.app/safe-global/issue/WA-2037/bug-tx-history-tab-always-redirects-jumps-to-tx-queue)

## How this PR fixes it
Removed the `useEffect` that called `router.replace` to `/transactions/queue` whenever the path was history and the queue was non-empty. History is no longer overridden after load.

## How to test it
Open a Safe with N tx > 0, click on the "Transactions" in the sidebar - the Tx Queue opens.
Open a Safe with N tx = 0, click on the "Transactions" in the sidebar - the Tx History opens.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
