### PR TITLE
fix: resolve Safe aux contracts by master copy on zkSync and Lens

### DIFF
--- a/apps/mobile/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/apps/mobile/src/hooks/coreSDK/safeCoreSDK.ts
@@ -84,8 +84,10 @@ export const initSafeSDK = async ({
 
   // zkSync Safes using a canonical (EVM bytecode) master copy cannot delegatecall
   // the zksync-specific (EraVM) MultiSend/MultiSendCallOnly, so force the canonical
-  // aux-contract addresses. Covers versions below the chain-agnostic threshold (<1.4.1).
-  if (isCanonicalDeployment(implementation, chainId, safeVersion)) {
+  // aux-contract addresses. Only runs for versions below the chain-agnostic threshold
+  // (<1.4.1); for >=1.4.1 the chain-agnostic resolver already picks the correct flavour
+  // from the master copy, and a second writer on the same fields would only risk drift.
+  if (!isChainAgnosticVersion(safeVersion) && isCanonicalDeployment(implementation, chainId, safeVersion)) {
     const canonicalMultiSendCallOnly = getCanonicalMultiSendCallOnlyAddress(safeVersion)
     const canonicalMultiSend = getCanonicalMultiSendAddress(safeVersion)
 

--- a/apps/mobile/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/apps/mobile/src/hooks/coreSDK/safeCoreSDK.ts
@@ -8,6 +8,10 @@ import { isValidMasterCopy } from '@safe-global/utils/services/contracts/safeCon
 import type { SafeCoreSDKProps } from '@safe-global/utils/hooks/coreSDK/types'
 import { isInDeployments } from '@safe-global/utils/hooks/coreSDK/utils'
 import {
+  getCanonicalMultiSendAddress,
+  getCanonicalMultiSendCallOnlyAddress,
+  getDeploymentTypeForMasterCopy,
+  isCanonicalDeployment,
   isChainAgnosticVersion,
   resolveChainAgnosticContractAddresses,
 } from '@safe-global/utils/services/contracts/deployments'
@@ -42,11 +46,15 @@ export const initSafeSDK = async ({
 
   // For versions >= 1.4.1, resolve all addresses chain-agnostically (works on any chain)
   if (isChainAgnosticVersion(safeVersion) && isL2Chain !== undefined) {
-    const resolved = resolveChainAgnosticContractAddresses(safeVersion, isL2Chain, isZkChain ?? false)
+    const { deploymentType, isL1 } = getDeploymentTypeForMasterCopy(implementation, safeVersion, {
+      deploymentType: isZkChain ? 'zksync' : 'canonical',
+      isL1: !isL2Chain,
+    })
+    const resolved = resolveChainAgnosticContractAddresses(chainId, safeVersion, !isL1, deploymentType)
 
     if (resolved) {
       contractNetworks = { [chainId]: resolved }
-      isL1SafeSingleton = !isL2Chain
+      isL1SafeSingleton = isL1
     }
   }
 
@@ -72,6 +80,23 @@ export const initSafeSDK = async ({
 
   if (isLegacyVersion(safeVersion)) {
     isL1SafeSingleton = true
+  }
+
+  // zkSync Safes using a canonical (EVM bytecode) master copy cannot delegatecall
+  // the zksync-specific (EraVM) MultiSend/MultiSendCallOnly, so force the canonical
+  // aux-contract addresses. Covers versions below the chain-agnostic threshold (<1.4.1).
+  if (isCanonicalDeployment(implementation, chainId, safeVersion)) {
+    const canonicalMultiSendCallOnly = getCanonicalMultiSendCallOnlyAddress(safeVersion)
+    const canonicalMultiSend = getCanonicalMultiSendAddress(safeVersion)
+
+    contractNetworks = {
+      ...contractNetworks,
+      [chainId]: {
+        ...contractNetworks?.[chainId],
+        ...(canonicalMultiSendCallOnly && { multiSendCallOnlyAddress: canonicalMultiSendCallOnly }),
+        ...(canonicalMultiSend && { multiSendAddress: canonicalMultiSend }),
+      },
+    }
   }
 
   const safeSDK = await Safe.init({

--- a/apps/web/src/components/new-safe/create/logic/index.test.ts
+++ b/apps/web/src/components/new-safe/create/logic/index.test.ts
@@ -374,7 +374,13 @@ describe('create/logic', () => {
       spy.mockRestore()
     })
 
-    it('falls back to first network address when canonical not present for chain', () => {
+    it('prefers the canonical deployment address over networkAddresses[0] when canonical is not registered for the chain', () => {
+      // Chain's networkAddresses list omits the canonical address entirely — this
+      // happens on zk-stack chains that register only the EraVM (zksync) flavour.
+      // Returning networkAddresses[0] here would give the WRONG bytecode flavour
+      // for a canonical Safe (EVM master copy delegatecalling EraVM aux reverts),
+      // so getChainAgnosticAddress must return the canonical address from
+      // deployments.canonical instead and log a warning.
       const chain = chainBuilder()
         .with({ chainId: '1' })
         .with({ features: [FEATURES.COUNTERFACTUAL] as any })
@@ -387,12 +393,12 @@ describe('create/logic', () => {
       }
 
       const canonical = faker.finance.ethereumAddress()
-      const firstAddress = faker.finance.ethereumAddress()
+      const otherFlavour = faker.finance.ethereumAddress()
 
       const mockDeployment: SingletonDeploymentV2 = {
         version: '1.4.1',
         contractName: 'CompatibilityFallbackHandler',
-        networkAddresses: { [chain.chainId]: [firstAddress] },
+        networkAddresses: { [chain.chainId]: [otherFlavour] },
         deployments: {
           canonical: { address: canonical },
         },
@@ -402,12 +408,15 @@ describe('create/logic', () => {
       const spy = jest
         .spyOn(safeDeploymentHandlers, 'getCompatibilityFallbackHandlerDeployments')
         .mockReturnValueOnce(mockDeployment)
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
 
       const result = createNewUndeployedSafeWithoutSalt('1.4.1', safeSetup, chain)
 
-      expect(result.safeAccountConfig.fallbackHandler).toEqual(firstAddress)
+      expect(result.safeAccountConfig.fallbackHandler).toEqual(canonical)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('does not register the canonical address'))
 
       spy.mockRestore()
+      warnSpy.mockRestore()
     })
   })
 })

--- a/apps/web/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/apps/web/src/hooks/coreSDK/safeCoreSDK.ts
@@ -10,7 +10,11 @@ import { isInDeployments } from '@safe-global/utils/hooks/coreSDK/utils'
 import type { SafeCoreSDKProps } from '@safe-global/utils/hooks/coreSDK/types'
 import { keccak256 } from 'ethers'
 import {
+  getCanonicalMultiSendAddress,
+  getCanonicalMultiSendCallOnlyAddress,
+  getDeploymentTypeForMasterCopy,
   getL2MasterCopyVersionByCodeHash,
+  isCanonicalDeployment,
   isChainAgnosticVersion,
   isL2MasterCopyCodeHash,
   resolveChainAgnosticContractAddresses,
@@ -37,13 +41,22 @@ export const initSafeSDK = async ({
   let isL1SafeSingleton = chainId === chains.eth
   let contractNetworks: ContractNetworksConfig | undefined
 
-  // For versions >= 1.4.1, resolve all addresses chain-agnostically (works on any chain)
+  // For versions >= 1.4.1, resolve all addresses chain-agnostically (works on any chain).
+  // Derive deployment type AND L1/L2 flavour from the master copy so that Safes on
+  // zk chains with a canonical master copy get canonical aux contracts (and vice
+  // versa), and Safes on L2 chains running an L1 master copy resolve against the
+  // L1 singleton table. Chain-level flags are only used as defaults when the master
+  // copy can't be matched (e.g. custom / unregistered deployments).
   if (isChainAgnosticVersion(safeVersion) && isL2Chain !== undefined) {
-    const resolved = resolveChainAgnosticContractAddresses(safeVersion, isL2Chain, isZkChain ?? false)
+    const { deploymentType, isL1 } = getDeploymentTypeForMasterCopy(implementation, safeVersion, {
+      deploymentType: isZkChain ? 'zksync' : 'canonical',
+      isL1: !isL2Chain,
+    })
+    const resolved = resolveChainAgnosticContractAddresses(chainId, safeVersion, !isL1, deploymentType)
 
     if (resolved) {
       contractNetworks = { [chainId]: resolved }
-      isL1SafeSingleton = !isL2Chain
+      isL1SafeSingleton = isL1
     }
   }
 
@@ -87,7 +100,12 @@ export const initSafeSDK = async ({
         }
 
         // Merge custom mastercopy with chain-agnostic auxiliary addresses
-        const baseAddresses = resolveChainAgnosticContractAddresses(upgradeableVersion, true, isZkChain ?? false)
+        const baseAddresses = resolveChainAgnosticContractAddresses(
+          chainId,
+          upgradeableVersion,
+          true,
+          isZkChain ? 'zksync' : 'canonical',
+        )
         contractNetworks = {
           [chainId]: {
             ...baseAddresses,
@@ -106,6 +124,23 @@ export const initSafeSDK = async ({
 
   if (isLegacyVersion(safeVersion)) {
     isL1SafeSingleton = true
+  }
+
+  // zkSync Safes using a canonical (EVM bytecode) master copy cannot delegatecall
+  // the zksync-specific (EraVM) MultiSend/MultiSendCallOnly, so force the canonical
+  // aux-contract addresses. Covers versions below the chain-agnostic threshold (<1.4.1).
+  if (isCanonicalDeployment(implementation, chainId, safeVersion)) {
+    const canonicalMultiSendCallOnly = getCanonicalMultiSendCallOnlyAddress(safeVersion)
+    const canonicalMultiSend = getCanonicalMultiSendAddress(safeVersion)
+
+    contractNetworks = {
+      ...contractNetworks,
+      [chainId]: {
+        ...contractNetworks?.[chainId],
+        ...(canonicalMultiSendCallOnly && { multiSendCallOnlyAddress: canonicalMultiSendCallOnly }),
+        ...(canonicalMultiSend && { multiSendAddress: canonicalMultiSend }),
+      },
+    }
   }
 
   if (undeployedSafe) {

--- a/apps/web/src/hooks/coreSDK/safeCoreSDK.ts
+++ b/apps/web/src/hooks/coreSDK/safeCoreSDK.ts
@@ -128,8 +128,10 @@ export const initSafeSDK = async ({
 
   // zkSync Safes using a canonical (EVM bytecode) master copy cannot delegatecall
   // the zksync-specific (EraVM) MultiSend/MultiSendCallOnly, so force the canonical
-  // aux-contract addresses. Covers versions below the chain-agnostic threshold (<1.4.1).
-  if (isCanonicalDeployment(implementation, chainId, safeVersion)) {
+  // aux-contract addresses. Only runs for versions below the chain-agnostic threshold
+  // (<1.4.1); for >=1.4.1 the chain-agnostic resolver already picks the correct flavour
+  // from the master copy, and a second writer on the same fields would only risk drift.
+  if (!isChainAgnosticVersion(safeVersion) && isCanonicalDeployment(implementation, chainId, safeVersion)) {
     const canonicalMultiSendCallOnly = getCanonicalMultiSendCallOnlyAddress(safeVersion)
     const canonicalMultiSend = getCanonicalMultiSendAddress(safeVersion)
 

--- a/packages/utils/src/services/contracts/__tests__/deployments.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/deployments.test.ts
@@ -119,6 +119,35 @@ describe('deployments utils', () => {
       const deployment = makeDeployment({ canonical: { address: canonical, codeHash: '0xhash' } }, {})
       expect(getChainAgnosticAddress(deployment, unknownChainId, 'zksync')).toBeUndefined()
     })
+
+    it('prefers the deployment-type address over networkAddresses[0] when the chain lists only the other flavour', () => {
+      // Registered chain, but its networkAddresses list contains only the eip155
+      // flavour. A caller asking for `canonical` must get the canonical address
+      // (even though it isn't registered for this chain) rather than silently
+      // receiving the eip155 address — returning the wrong flavour would cause
+      // delegatecall mismatches for canonical Safes.
+      const deployment = makeDeployment(
+        {
+          canonical: { address: canonical, codeHash: '0xhash' },
+          eip155: { address: eip155Addr, codeHash: '0xhash2' },
+        },
+        { [chainId]: [eip155Addr] },
+      )
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+      expect(getChainAgnosticAddress(deployment, chainId, 'canonical')).toBe(canonical)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('does not register the canonical address'))
+      warnSpy.mockRestore()
+    })
+
+    it('returns networkAddresses[0] as last resort when no deployment-type address exists at all', () => {
+      // Deployment bucket has no matching flavour for this caller — return whatever
+      // the chain registers so the SDK can still init.
+      const deployment = makeDeployment(
+        { eip155: { address: eip155Addr, codeHash: '0xhash2' } },
+        { [chainId]: [eip155Addr] },
+      )
+      expect(getChainAgnosticAddress(deployment, chainId, 'canonical')).toBe(eip155Addr)
+    })
   })
 
   describe('hasMatchingDeployment', () => {

--- a/packages/utils/src/services/contracts/__tests__/deployments.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/deployments.test.ts
@@ -2,10 +2,12 @@ import type { DeploymentFilter, SingletonDeploymentV2 } from '@safe-global/safe-
 import {
   getCanonicalOrFirstAddress,
   getChainAgnosticAddress,
+  getDeploymentTypeForMasterCopy,
   hasCanonicalDeployment,
   hasMatchingDeployment,
   isCanonicalDeployment,
   isChainAgnosticVersion,
+  isEraVmChain,
   getCanonicalMultiSendCallOnlyAddress,
   getCanonicalMultiSendAddress,
   resolveChainAgnosticContractAddresses,
@@ -184,13 +186,30 @@ describe('deployments utils', () => {
       expect(isCanonicalDeployment(nonCanonicalAddress, ZKSYNC_ERA_CHAIN_ID, '1.3.0')).toBe(false)
     })
 
-    it('returns false for non-zkSync chains', () => {
+    it('returns false for non-EraVM chains', () => {
       expect(isCanonicalDeployment(CANONICAL_L2_SAFE, '1', '1.3.0')).toBe(false)
       expect(isCanonicalDeployment(CANONICAL_L2_SAFE, '137', '1.3.0')).toBe(false)
     })
 
-    it('returns false for unsupported zkSync chains', () => {
-      expect(isCanonicalDeployment(CANONICAL_L2_SAFE, '300', '1.3.0')).toBe(false)
+    it('returns true for canonical master copy on zkSync Sepolia', () => {
+      // After extending detection to all EraVM-backed chains (any chain that
+      // registers the `zksync` deployment address in networkAddresses), Sepolia
+      // qualifies and canonical-on-EraVM should be flagged.
+      expect(isCanonicalDeployment(CANONICAL_L2_SAFE, '300', '1.3.0')).toBe(true)
+    })
+
+    it('returns true for canonical master copy on Lens', () => {
+      // Lens is a zk-stack chain that registers the zksync deployment address in
+      // networkAddresses but is not flagged via chain.zk on CGW. Extending detection
+      // to EraVM-backed chains covers this case for both 1.3.0 and 1.4.1.
+      expect(isCanonicalDeployment(CANONICAL_L2_SAFE, '232', '1.3.0')).toBe(true)
+      expect(isCanonicalDeployment('0x29fcB43b46531BcA003ddC8FCB67FFE91900C762', '232', '1.4.1')).toBe(true)
+    })
+
+    it('returns false for zksync-flavour master copy on Lens', () => {
+      // zksync-specific mastercopies have EraVM bytecode and should not be treated as canonical
+      expect(isCanonicalDeployment(ZKSYNC_L2_SAFE, '232', '1.3.0')).toBe(false)
+      expect(isCanonicalDeployment('0x610fcA2e0279Fa1F8C00c8c2F71dF522AD469380', '232', '1.4.1')).toBe(false)
     })
 
     it('returns false for empty implementation address', () => {
@@ -248,8 +267,13 @@ describe('deployments utils', () => {
   })
 
   describe('resolveChainAgnosticContractAddresses', () => {
+    // chainId not registered in safe-deployments — exercises deployment-type fallback
+    const UNREGISTERED_CHAIN_ID = '99999999'
+    const LENS_CHAIN_ID = '232'
+    const ZKSYNC_ERA_MAINNET = '324'
+
     it('resolves all canonical addresses for version 1.4.1 on L2 chains', () => {
-      const result = resolveChainAgnosticContractAddresses('1.4.1', true, false)
+      const result = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.4.1', true, 'canonical')
 
       expect(result).toBeDefined()
       expect(result!.safeSingletonAddress).toBeDefined()
@@ -263,15 +287,15 @@ describe('deployments utils', () => {
     })
 
     it('resolves all canonical addresses for version 1.4.1 on L1 chains', () => {
-      const result = resolveChainAgnosticContractAddresses('1.4.1', false, false)
+      const result = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.4.1', false, 'canonical')
 
       expect(result).toBeDefined()
       expect(result!.safeSingletonAddress).toBeDefined()
     })
 
     it('returns different singleton addresses for L1 vs L2', () => {
-      const l1Result = resolveChainAgnosticContractAddresses('1.4.1', false, false)
-      const l2Result = resolveChainAgnosticContractAddresses('1.4.1', true, false)
+      const l1Result = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.4.1', false, 'canonical')
+      const l2Result = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.4.1', true, 'canonical')
 
       expect(l1Result).toBeDefined()
       expect(l2Result).toBeDefined()
@@ -279,8 +303,8 @@ describe('deployments utils', () => {
     })
 
     it('resolves zksync deployment type addresses when isZk is true', () => {
-      const canonicalResult = resolveChainAgnosticContractAddresses('1.4.1', true, false)
-      const zkResult = resolveChainAgnosticContractAddresses('1.4.1', true, true)
+      const canonicalResult = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.4.1', true, 'canonical')
+      const zkResult = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.4.1', true, 'zksync')
 
       expect(canonicalResult).toBeDefined()
       expect(zkResult).toBeDefined()
@@ -289,21 +313,21 @@ describe('deployments utils', () => {
     })
 
     it('strips version metadata before resolving', () => {
-      const result = resolveChainAgnosticContractAddresses('1.4.1+L2', true, false)
-      const directResult = resolveChainAgnosticContractAddresses('1.4.1', true, false)
+      const result = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.4.1+L2', true, 'canonical')
+      const directResult = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.4.1', true, 'canonical')
 
       expect(result).toBeDefined()
       expect(result!.safeSingletonAddress).toBe(directResult!.safeSingletonAddress)
     })
 
     it('returns undefined when singleton has no address for the version', () => {
-      const result = resolveChainAgnosticContractAddresses('0.0.1', true, false)
+      const result = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '0.0.1', true, 'canonical')
       expect(result).toBeUndefined()
     })
 
     it('logs warning when singleton cannot be resolved', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
-      resolveChainAgnosticContractAddresses('0.0.1', true, false)
+      resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '0.0.1', true, 'canonical')
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No singleton address'))
       warnSpy.mockRestore()
     })
@@ -311,7 +335,7 @@ describe('deployments utils', () => {
     it('returns partial result with warning when auxiliary contracts are missing', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
       // 1.3.0 has canonical deployments — should resolve singleton even if some aux are missing
-      const result = resolveChainAgnosticContractAddresses('1.3.0', true, false)
+      const result = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.3.0', true, 'canonical')
 
       expect(result).toBeDefined()
       expect(result!.safeSingletonAddress).toBeDefined()
@@ -322,11 +346,167 @@ describe('deployments utils', () => {
     })
 
     it('resolves addresses for version 1.3.0 canonical', () => {
-      const result = resolveChainAgnosticContractAddresses('1.3.0', true, false)
+      const result = resolveChainAgnosticContractAddresses(UNREGISTERED_CHAIN_ID, '1.3.0', true, 'canonical')
 
       // 1.3.0 has canonical deployments
       expect(result).toBeDefined()
       expect(result!.safeSingletonAddress).toBeDefined()
+    })
+
+    it('picks the zksync-flavour aux contract on chains that register both canonical and zksync', () => {
+      // Lens (chainId 232) registers BOTH the canonical and the zksync MultiSendCallOnly
+      // in safe-deployments' networkAddresses["232"]. For a Safe whose master copy is the
+      // zksync singleton, the resolver must pick the zksync MultiSendCallOnly
+      // (0x0408EF011960d02349d50286D20531229BCef773) — not the canonical one
+      // (0x9641d764fc13c8B624c04430C7356C1C7C8102e2) — otherwise the Safe will delegatecall
+      // EVM bytecode from EraVM bytecode (or vice versa) and revert.
+      const lensZkResult = resolveChainAgnosticContractAddresses(LENS_CHAIN_ID, '1.4.1', true, 'zksync')
+      const lensCanonicalResult = resolveChainAgnosticContractAddresses(LENS_CHAIN_ID, '1.4.1', true, 'canonical')
+
+      expect(lensZkResult).toBeDefined()
+      expect(lensCanonicalResult).toBeDefined()
+      expect(lensZkResult!.multiSendCallOnlyAddress).toBe('0x0408EF011960d02349d50286D20531229BCef773')
+      expect(lensCanonicalResult!.multiSendCallOnlyAddress).toBe('0x9641d764fc13c8B624c04430C7356C1C7C8102e2')
+    })
+
+    it('resolves zksync Era mainnet zksync-flavour aux addresses', () => {
+      const result = resolveChainAgnosticContractAddresses(ZKSYNC_ERA_MAINNET, '1.4.1', true, 'zksync')
+      expect(result).toBeDefined()
+      expect(result!.multiSendCallOnlyAddress).toBe('0x0408EF011960d02349d50286D20531229BCef773')
+    })
+  })
+
+  describe('getDeploymentTypeForMasterCopy', () => {
+    const L2_CANONICAL_141 = '0x29fcB43b46531BcA003ddC8FCB67FFE91900C762'
+    const L2_ZKSYNC_141 = '0x610fcA2e0279Fa1F8C00c8c2F71dF522AD469380'
+    const L1_CANONICAL_141 = '0x41675C099F32341bf84BFc5382aF534df5C7461a'
+    const L1_ZKSYNC_141 = '0xC35F063962328aC65cED5D4c3fC5dEf8dec68dFa'
+    const L2_CANONICAL_130 = '0x3E5c63644E683549055b9Be8653de26E0B4CD36E'
+    const L2_ZKSYNC_130 = '0x1727c2c531cf966f902E5927b98490fDFb3b2b70'
+    const L1_CANONICAL_130 = '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552'
+    const L1_ZKSYNC_130 = '0xB00ce5CCcdEf57e539ddcEd01DF43a13855d9910'
+
+    it('detects L2 canonical master copy at 1.4.1', () => {
+      expect(getDeploymentTypeForMasterCopy(L2_CANONICAL_141, '1.4.1')).toEqual({
+        deploymentType: 'canonical',
+        isL1: false,
+      })
+    })
+
+    it('detects L2 zksync master copy at 1.4.1', () => {
+      expect(getDeploymentTypeForMasterCopy(L2_ZKSYNC_141, '1.4.1')).toEqual({
+        deploymentType: 'zksync',
+        isL1: false,
+      })
+    })
+
+    // Case #2 — zkSync Era Safe running an L1 canonical master copy. The resolver
+    // must pick the L1 singleton table, not the L2 one, even though the chain itself
+    // is an L2.
+    it('detects L1 canonical master copy at 1.4.1', () => {
+      expect(getDeploymentTypeForMasterCopy(L1_CANONICAL_141, '1.4.1')).toEqual({
+        deploymentType: 'canonical',
+        isL1: true,
+      })
+    })
+
+    it('detects L1 zksync master copy at 1.4.1', () => {
+      expect(getDeploymentTypeForMasterCopy(L1_ZKSYNC_141, '1.4.1')).toEqual({
+        deploymentType: 'zksync',
+        isL1: true,
+      })
+    })
+
+    it('detects 1.3.0 L2 canonical master copy', () => {
+      expect(getDeploymentTypeForMasterCopy(L2_CANONICAL_130, '1.3.0')).toEqual({
+        deploymentType: 'canonical',
+        isL1: false,
+      })
+    })
+
+    it('detects 1.3.0 L2 zksync master copy', () => {
+      expect(getDeploymentTypeForMasterCopy(L2_ZKSYNC_130, '1.3.0')).toEqual({
+        deploymentType: 'zksync',
+        isL1: false,
+      })
+    })
+
+    it('detects 1.3.0 L1 canonical master copy', () => {
+      expect(getDeploymentTypeForMasterCopy(L1_CANONICAL_130, '1.3.0')).toEqual({
+        deploymentType: 'canonical',
+        isL1: true,
+      })
+    })
+
+    it('detects 1.3.0 L1 zksync master copy', () => {
+      expect(getDeploymentTypeForMasterCopy(L1_ZKSYNC_130, '1.3.0')).toEqual({
+        deploymentType: 'zksync',
+        isL1: true,
+      })
+    })
+
+    it('strips version metadata before looking up', () => {
+      expect(getDeploymentTypeForMasterCopy(L2_CANONICAL_141, '1.4.1+L2')).toEqual({
+        deploymentType: 'canonical',
+        isL1: false,
+      })
+    })
+
+    it('returns defaults when master copy is unknown', () => {
+      expect(getDeploymentTypeForMasterCopy('0x0000000000000000000000000000000000000001', '1.4.1')).toEqual({
+        deploymentType: 'canonical',
+        isL1: false,
+      })
+    })
+
+    it('respects custom defaults when master copy is unknown', () => {
+      expect(
+        getDeploymentTypeForMasterCopy('0x0000000000000000000000000000000000000001', '1.4.1', {
+          deploymentType: 'zksync',
+          isL1: true,
+        }),
+      ).toEqual({ deploymentType: 'zksync', isL1: true })
+    })
+
+    it('returns defaults when implementation is undefined', () => {
+      expect(getDeploymentTypeForMasterCopy(undefined, '1.4.1')).toEqual({
+        deploymentType: 'canonical',
+        isL1: false,
+      })
+    })
+  })
+
+  describe('isEraVmChain', () => {
+    it('returns true for zkSync Era mainnet', () => {
+      expect(isEraVmChain('324', '1.4.1')).toBe(true)
+      expect(isEraVmChain('324', '1.3.0')).toBe(true)
+    })
+
+    it('returns true for zkSync Sepolia', () => {
+      expect(isEraVmChain('300', '1.3.0')).toBe(true)
+    })
+
+    it('returns true for Lens', () => {
+      expect(isEraVmChain('232', '1.4.1')).toBe(true)
+      expect(isEraVmChain('232', '1.3.0')).toBe(true)
+    })
+
+    it('returns false for Ethereum mainnet', () => {
+      expect(isEraVmChain('1', '1.4.1')).toBe(false)
+      expect(isEraVmChain('1', '1.3.0')).toBe(false)
+    })
+
+    it('returns false for Polygon', () => {
+      expect(isEraVmChain('137', '1.3.0')).toBe(false)
+    })
+
+    it('returns false for unregistered chains', () => {
+      expect(isEraVmChain('99999999', '1.4.1')).toBe(false)
+    })
+
+    it('falls back to 1.3.0 when version is null', () => {
+      expect(isEraVmChain('324', null)).toBe(true)
+      expect(isEraVmChain('1', null)).toBe(false)
     })
   })
 })

--- a/packages/utils/src/services/contracts/__tests__/deployments.test.ts
+++ b/packages/utils/src/services/contracts/__tests__/deployments.test.ts
@@ -215,6 +215,11 @@ describe('deployments utils', () => {
     it('returns false for empty implementation address', () => {
       expect(isCanonicalDeployment('', ZKSYNC_ERA_CHAIN_ID, '1.3.0')).toBe(false)
     })
+
+    it('strips version metadata before looking up safe-deployments', () => {
+      expect(isCanonicalDeployment(CANONICAL_L2_SAFE, ZKSYNC_ERA_CHAIN_ID, '1.3.0+L2')).toBe(true)
+      expect(isCanonicalDeployment(CANONICAL_L2_SAFE, '232', '1.3.0+L2')).toBe(true)
+    })
   })
 
   describe('getCanonicalMultiSendCallOnlyAddress', () => {
@@ -507,6 +512,15 @@ describe('deployments utils', () => {
     it('falls back to 1.3.0 when version is null', () => {
       expect(isEraVmChain('324', null)).toBe(true)
       expect(isEraVmChain('1', null)).toBe(false)
+    })
+
+    it('strips version metadata before looking up safe-deployments', () => {
+      // CGW fixtures encode L2 flag as `1.3.0+L2`; the bare version must be used
+      // for safe-deployments lookups or EraVM detection will silently fail.
+      expect(isEraVmChain('232', '1.3.0+L2')).toBe(true)
+      expect(isEraVmChain('232', '1.4.1+L2')).toBe(true)
+      expect(isEraVmChain('324', '1.3.0+L2')).toBe(true)
+      expect(isEraVmChain('1', '1.3.0+L2')).toBe(false)
     })
   })
 })

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -117,7 +117,7 @@ export const getChainAgnosticAddress = (
   const deploymentTypeAddress = deployment.deployments?.[deploymentType]?.address
   const networkAddresses = toNetworkAddressList(deployment.networkAddresses?.[chainId] ?? [])
 
-  // Prefer the requested deployment-type address if it's registered for this chain
+  // 1. Prefer the requested deployment-type address if it's registered for this chain.
   if (
     deploymentTypeAddress &&
     networkAddresses.some((networkAddress) => sameAddress(networkAddress, deploymentTypeAddress))
@@ -125,13 +125,22 @@ export const getChainAgnosticAddress = (
     return deploymentTypeAddress
   }
 
-  // Fall back to the chain's primary address (first registered for this chainId)
-  if (networkAddresses.length > 0) {
-    return networkAddresses[0]
+  // 2. Prefer the chain-agnostic deployment-type address. Covers unregistered chains
+  //    and, crucially, chains whose networkAddresses list the OTHER flavour only —
+  //    falling back to networkAddresses[0] there would return the wrong flavour and
+  //    cause EVM↔EraVM delegatecall mismatches (see Lens / zkSync canonical handling).
+  if (deploymentTypeAddress) {
+    if (networkAddresses.length > 0) {
+      console.warn(
+        `[getChainAgnosticAddress] chain ${chainId} does not register the ${deploymentType} address; ` +
+          `falling back to the chain-agnostic deployment address`,
+      )
+    }
+    return deploymentTypeAddress
   }
 
-  // Unregistered chain — use the chain-agnostic deployment-type address
-  return deploymentTypeAddress
+  // 3. Last resort: chain has entries but no deployment-type address at all.
+  return networkAddresses[0]
 }
 
 /**
@@ -369,6 +378,14 @@ export type MasterCopyFlavour = {
  *
  * Falls back to `defaults` when the implementation cannot be matched — callers
  * should pass chain-level guesses (e.g. `!chain.l2`, `chain.zk`) as defaults.
+ *
+ * CAVEAT — custom / unrecognised master copies: when the implementation doesn't
+ * match any entry in safe-deployments the defaults are used, which re-introduces
+ * the chain-flag assumption this function is meant to avoid. A Safe on a zk-stack
+ * chain that isn't flagged `zk: true` on CGW (e.g. Lens) running a custom
+ * EraVM-bytecode master copy would incorrectly be treated as canonical. A proper
+ * fix would require bytecode inspection (already done in the `!isValidMasterCopy`
+ * branch of initSafeSDK) but that adds an RPC round-trip to the happy path.
  */
 export const getDeploymentTypeForMasterCopy = (
   implementation: string | undefined,

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -251,7 +251,9 @@ export const getCreateCallContractDeployment = (chain: Chain, safeVersion: SafeS
  * any zk-stack chain (Lens, zkSync Sepolia, etc.) is handled uniformly.
  */
 export const isEraVmChain = (chainId: string, version: SafeState['version']): boolean => {
-  const safeVersion = version ?? '1.3.0'
+  // Safe versions in this codebase can include metadata like `1.3.0+L2`; strip before
+  // calling safe-deployments getters which match the bare version only.
+  const [safeVersion] = (version ?? '1.3.0').split('+')
   const l2 = getSafeL2SingletonDeployments({ version: safeVersion })
   const l1 = getSafeSingletonDeployments({ version: safeVersion })
 
@@ -278,7 +280,7 @@ export const isCanonicalDeployment = (
   if (!implementationAddress) return false
   if (!isEraVmChain(chainId, version)) return false
 
-  const safeVersion = version ?? '1.3.0'
+  const [safeVersion] = (version ?? '1.3.0').split('+')
 
   const deployments: (SingletonDeploymentV2 | undefined)[] = [
     getSafeL2SingletonDeployments({ version: safeVersion }),
@@ -296,7 +298,7 @@ export const isCanonicalDeployment = (
  * Used when a Safe on zkSync uses a canonical (EVM bytecode) mastercopy.
  */
 export const getCanonicalMultiSendCallOnlyAddress = (version: SafeState['version']): string | undefined => {
-  const safeVersion = version ?? '1.3.0'
+  const [safeVersion] = (version ?? '1.3.0').split('+')
   const deployment = getMultiSendCallOnlyDeployments({ version: safeVersion })
   return deployment?.deployments.canonical?.address
 }
@@ -306,7 +308,7 @@ export const getCanonicalMultiSendCallOnlyAddress = (version: SafeState['version
  * Used when a Safe on zkSync uses a canonical (EVM bytecode) mastercopy.
  */
 export const getCanonicalMultiSendAddress = (version: SafeState['version']): string | undefined => {
-  const safeVersion = version ?? '1.3.0'
+  const [safeVersion] = (version ?? '1.3.0').split('+')
   const deployment = getMultiSendDeployments({ version: safeVersion })
   return deployment?.deployments.canonical?.address
 }

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -114,8 +114,8 @@ export const getChainAgnosticAddress = (
 ): string | undefined => {
   if (!deployment) return undefined
 
-  const deploymentTypeAddress = deployment.deployments[deploymentType]?.address
-  const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId] ?? [])
+  const deploymentTypeAddress = deployment.deployments?.[deploymentType]?.address
+  const networkAddresses = toNetworkAddressList(deployment.networkAddresses?.[chainId] ?? [])
 
   // Prefer the requested deployment-type address if it's registered for this chain
   if (
@@ -256,9 +256,10 @@ export const isEraVmChain = (chainId: string, version: SafeState['version']): bo
   const l1 = getSafeSingletonDeployments({ version: safeVersion })
 
   return [l2, l1].some((deployment) => {
-    const zksyncAddress = deployment?.deployments.zksync?.address
-    if (!zksyncAddress || !deployment) return false
-    const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId] ?? [])
+    if (!deployment) return false
+    const zksyncAddress = deployment.deployments?.zksync?.address
+    if (!zksyncAddress) return false
+    const networkAddresses = toNetworkAddressList(deployment.networkAddresses?.[chainId] ?? [])
     return networkAddresses.some((networkAddress) => sameAddress(networkAddress, zksyncAddress))
   })
 }
@@ -285,7 +286,7 @@ export const isCanonicalDeployment = (
   ]
 
   return deployments.some((deployment) => {
-    const canonicalAddress = deployment?.deployments.canonical?.address
+    const canonicalAddress = deployment?.deployments?.canonical?.address
     return canonicalAddress ? sameAddress(implementationAddress, canonicalAddress) : false
   })
 }
@@ -382,7 +383,7 @@ export const getDeploymentTypeForMasterCopy = (
 
   for (const { getter, isL1 } of tables) {
     const deployment = getter({ version: cleanVersion })
-    if (!deployment) continue
+    if (!deployment?.deployments) continue
     const { canonical, zksync, eip155 } = deployment.deployments
     if (zksync?.address && sameAddress(implementation, zksync.address)) {
       return { deploymentType: 'zksync', isL1 }

--- a/packages/utils/src/services/contracts/deployments.ts
+++ b/packages/utils/src/services/contracts/deployments.ts
@@ -27,11 +27,9 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { type SafeVersion } from '@safe-global/types-kit'
 import { getLatestSafeVersion } from '@safe-global/utils/utils/chains'
 import { SafeState } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
-import { ZKSYNC_ERA_CHAIN_ID } from '@safe-global/utils/config/chains'
-
 const toNetworkAddressList = (addresses: string | string[]) => (Array.isArray(addresses) ? addresses : [addresses])
 
-type DeploymentType = 'canonical' | 'eip155' | 'zksync'
+export type DeploymentType = 'canonical' | 'eip155' | 'zksync'
 type DeploymentRecord = Record<string, { address: string; codeHash: string }>
 
 const SAFE_L2_CODE_HASHES = new Set<string>(
@@ -39,8 +37,6 @@ const SAFE_L2_CODE_HASHES = new Set<string>(
     Object.values(deployment.deployments as DeploymentRecord).map(({ codeHash }) => codeHash.toLowerCase()),
   ),
 )
-
-const SUPPORTED_ZKSYNC_CANONICAL_CHAIN_IDS = new Set([ZKSYNC_ERA_CHAIN_ID])
 
 export const isL2MasterCopyCodeHash = (codeHash: string | undefined): boolean => {
   if (!codeHash) {
@@ -101,8 +97,15 @@ export const getCanonicalOrFirstAddress = (
 }
 
 /**
- * Returns an address for a deployment, trying per-chain lookup first, then falling back
- * to the chain-agnostic deployment type address. Works for unregistered chains.
+ * Returns an address for a deployment, preferring the requested deploymentType when
+ * it is actually registered for the chainId, falling back to the chain's first
+ * networkAddress, then to the deployment-type address for unregistered chains.
+ *
+ * This matters when a chain lists multiple addresses for the same contract (e.g.
+ * Lens and zkSync Era list both the canonical and zksync MultiSendCallOnly) — the
+ * caller's `deploymentType` disambiguates which one the caller's Safe master copy
+ * aligns with. A canonical (EVM bytecode) Safe cannot delegatecall into an EraVM
+ * aux contract and vice versa.
  */
 export const getChainAgnosticAddress = (
   deployment: SingletonDeploymentV2 | undefined,
@@ -111,12 +114,24 @@ export const getChainAgnosticAddress = (
 ): string | undefined => {
   if (!deployment) return undefined
 
-  // Try per-chain first (works for registered chains)
-  const perChainAddress = getCanonicalOrFirstAddress(deployment, chainId)
-  if (perChainAddress) return perChainAddress
+  const deploymentTypeAddress = deployment.deployments[deploymentType]?.address
+  const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId] ?? [])
 
-  // Fall back to chain-agnostic address by deployment type
-  return deployment.deployments[deploymentType]?.address
+  // Prefer the requested deployment-type address if it's registered for this chain
+  if (
+    deploymentTypeAddress &&
+    networkAddresses.some((networkAddress) => sameAddress(networkAddress, deploymentTypeAddress))
+  ) {
+    return deploymentTypeAddress
+  }
+
+  // Fall back to the chain's primary address (first registered for this chainId)
+  if (networkAddresses.length > 0) {
+    return networkAddresses[0]
+  }
+
+  // Unregistered chain — use the chain-agnostic deployment-type address
+  return deploymentTypeAddress
 }
 
 /**
@@ -230,38 +245,49 @@ export const getCreateCallContractDeployment = (chain: Chain, safeVersion: SafeS
  */
 
 /**
- * Checks if an implementation address is a canonical (EVM bytecode) Safe deployment on zkSync.
- * On zkSync, canonical deployments have EVM bytecode while zkSync-specific deployments have EraVM bytecode.
+ * A chain is EraVM-backed if safe-deployments registers the `zksync` deployment
+ * address for that chain in networkAddresses[chainId] for the given singleton
+ * version. This generalizes the prior hard-coded zkSync Era mainnet check so that
+ * any zk-stack chain (Lens, zkSync Sepolia, etc.) is handled uniformly.
+ */
+export const isEraVmChain = (chainId: string, version: SafeState['version']): boolean => {
+  const safeVersion = version ?? '1.3.0'
+  const l2 = getSafeL2SingletonDeployments({ version: safeVersion })
+  const l1 = getSafeSingletonDeployments({ version: safeVersion })
+
+  return [l2, l1].some((deployment) => {
+    const zksyncAddress = deployment?.deployments.zksync?.address
+    if (!zksyncAddress || !deployment) return false
+    const networkAddresses = toNetworkAddressList(deployment.networkAddresses[chainId] ?? [])
+    return networkAddresses.some((networkAddress) => sameAddress(networkAddress, zksyncAddress))
+  })
+}
+
+/**
+ * Checks if an implementation address is a canonical (EVM bytecode) Safe deployment
+ * on an EraVM-backed chain. EVM contracts cannot delegatecall into EraVM contracts,
+ * so Safes whose master copy is canonical need canonical aux contracts too —
+ * regardless of whether CGW flags the chain with `zk: true`.
  */
 export const isCanonicalDeployment = (
   implementationAddress: string,
   chainId: string,
   version: SafeState['version'],
 ): boolean => {
-  // Canonical aux-contract override is currently enabled only for zkSync Era mainnet.
-  if (!SUPPORTED_ZKSYNC_CANONICAL_CHAIN_IDS.has(chainId)) {
-    return false
-  }
+  if (!implementationAddress) return false
+  if (!isEraVmChain(chainId, version)) return false
 
   const safeVersion = version ?? '1.3.0'
 
-  // Check L2 singleton deployments
-  const l2Deployment = getSafeL2SingletonDeployment({ version: safeVersion, network: chainId })
-  if (l2Deployment?.deployments.canonical?.address) {
-    if (sameAddress(implementationAddress, l2Deployment.deployments.canonical.address)) {
-      return true
-    }
-  }
+  const deployments: (SingletonDeploymentV2 | undefined)[] = [
+    getSafeL2SingletonDeployments({ version: safeVersion }),
+    getSafeSingletonDeployments({ version: safeVersion }),
+  ]
 
-  // Check L1 singleton deployments
-  const l1Deployment = getSafeSingletonDeployment({ version: safeVersion, network: chainId })
-  if (l1Deployment?.deployments.canonical?.address) {
-    if (sameAddress(implementationAddress, l1Deployment.deployments.canonical.address)) {
-      return true
-    }
-  }
-
-  return false
+  return deployments.some((deployment) => {
+    const canonicalAddress = deployment?.deployments.canonical?.address
+    return canonicalAddress ? sameAddress(implementationAddress, canonicalAddress) : false
+  })
 }
 
 /**
@@ -323,18 +349,70 @@ export const isChainAgnosticVersion = (version: string | null | undefined): bool
  * Missing auxiliary contracts are logged as warnings and omitted from the result —
  * the SDK will still init but may fail for operations that need the missing contract.
  */
+export type MasterCopyFlavour = {
+  deploymentType: DeploymentType
+  isL1: boolean
+}
+
+/**
+ * Detects the deployment type AND L1/L2 flavour of a Safe master copy by matching
+ * its address against the canonical / zksync / eip155 singleton deployments for
+ * the given version across BOTH L1 and L2 singleton tables.
+ *
+ * Returning `isL1` matters because a Safe on an L2 chain can still run an L1
+ * singleton master copy (e.g. zkSync Era Safes using the L1 canonical 1.4.1
+ * master copy). In that case the caller must resolve aux contracts against the
+ * L1 singleton table, not the L2 one, to avoid mixing incompatible singletons.
+ *
+ * Falls back to `defaults` when the implementation cannot be matched — callers
+ * should pass chain-level guesses (e.g. `!chain.l2`, `chain.zk`) as defaults.
+ */
+export const getDeploymentTypeForMasterCopy = (
+  implementation: string | undefined,
+  version: string,
+  defaults: MasterCopyFlavour = { deploymentType: 'canonical', isL1: false },
+): MasterCopyFlavour => {
+  if (!implementation) return defaults
+  const [cleanVersion] = version.split('+')
+
+  const tables: Array<{ getter: DeploymentGetter; isL1: boolean }> = [
+    { getter: getSafeL2SingletonDeployments, isL1: false },
+    { getter: getSafeSingletonDeployments, isL1: true },
+  ]
+
+  for (const { getter, isL1 } of tables) {
+    const deployment = getter({ version: cleanVersion })
+    if (!deployment) continue
+    const { canonical, zksync, eip155 } = deployment.deployments
+    if (zksync?.address && sameAddress(implementation, zksync.address)) {
+      return { deploymentType: 'zksync', isL1 }
+    }
+    if (eip155?.address && sameAddress(implementation, eip155.address)) {
+      return { deploymentType: 'eip155', isL1 }
+    }
+    if (canonical?.address && sameAddress(implementation, canonical.address)) {
+      return { deploymentType: 'canonical', isL1 }
+    }
+  }
+
+  return defaults
+}
+
 export const resolveChainAgnosticContractAddresses = (
+  chainId: string,
   version: string,
   isL2: boolean,
-  isZk: boolean,
+  deploymentType: DeploymentType,
 ): ContractNetworkConfig | undefined => {
   const [cleanVersion] = version.split('+')
-  const deploymentType: DeploymentType = isZk ? 'zksync' : 'canonical'
 
   const singletonGetter: DeploymentGetter = isL2 ? getSafeL2SingletonDeployments : getSafeSingletonDeployments
 
-  // Singleton is critical — cannot proceed without it
-  const singletonAddress = singletonGetter({ version: cleanVersion })?.deployments[deploymentType]?.address
+  // Prefer the address registered for this chainId in safe-deployments; only fall back
+  // to the deployment-type address when the chain isn't registered. This ensures chains
+  // like Lens (zk-stack but not flagged `zk: true` in CGW) still resolve to their
+  // correct zksync aux-contract addresses via networkAddresses[chainId].
+  const singletonAddress = getChainAgnosticAddress(singletonGetter({ version: cleanVersion }), chainId, deploymentType)
   if (!singletonAddress) {
     console.warn(`[resolveChainAgnostic] No singleton address for v${cleanVersion} (${deploymentType}, L2=${isL2})`)
     return undefined
@@ -345,7 +423,7 @@ export const resolveChainAgnosticContractAddresses = (
 
   // Resolve auxiliary contracts — missing ones are non-fatal
   for (const [field, getter] of Object.entries(BASE_DEPLOYMENT_GETTERS)) {
-    const address = getter({ version: cleanVersion })?.deployments[deploymentType]?.address
+    const address = getChainAgnosticAddress(getter({ version: cleanVersion }), chainId, deploymentType)
     if (address) {
       resolved[field] = address
     } else {


### PR DESCRIPTION
> Master copy picks the flavour,
> aux contracts follow its lead,
> EraVM stays with EraVM,
> EVM with EVM.

## What it solves

PR #7494 introduced a chain-agnostic contract resolver gated on CGW chain-level `zk` / `l2` flags. This broke aux-contract resolution on zkSync-family chains in four ways: canonical-master-copy Safes on zkSync Era at 1.3.0 lost their MultiSend override; 1.4.1 Lens Safes with a zksync master copy resolved canonical addresses because Lens isn't flagged `zk: true` on CGW; 1.4.1 zkSync Safes running an L1 canonical master copy resolved against the L2 singleton table; and 1.3.0 Lens Safes with a zksync master copy were never covered by the canonical-override helper (hard-coded to zkSync Era mainnet). The net effect: multisend and simulations didn't work on zkSync / Lens chains.

Resolves: https://linear.app/safe-global/issue/WA-2000/multisend-and-simulations-not-working-on-zksync-lens-chains

## How this PR fixes it

The deployment flavour (`canonical` / `zksync` / `eip155`) and L1-vs-L2 flavour of a Safe are properties of its master copy, not of its chain. The fix derives both from the master copy address directly:

- `getDeploymentTypeForMasterCopy` now scans BOTH L1 and L2 singleton tables and returns `{ deploymentType, isL1 }`. This is what fixes the zkSync-L1-master-copy case — the resolver now knows to use the L1 singleton table even though the chain is an L2.
- `getChainAgnosticAddress` now prefers the requested deployment-type address when it's registered in `networkAddresses[chainId]`. Required because Lens registers both canonical and zksync addresses for the same contract — the old code always picked canonical.
- `isEraVmChain` generalises the old `SUPPORTED_ZKSYNC_CANONICAL_CHAIN_IDS = {324}` check to any chain whose `networkAddresses[chainId]` contains the `zksync` deployment address. Lens (232) and zkSync Sepolia (300) now participate.
- The canonical MultiSend / MultiSendCallOnly override (deleted in #7494 as "subsumed by the resolver") is restored for versions below the chain-agnostic threshold — that threshold is `>=1.4.1`, so 1.3.0 Safes bypass the resolver entirely and still need the override.

Chain-level flags (`chain.zk`, `chain.l2`) are now only used as defaults when the master copy can't be matched (custom / unrecognised deployments).

## How to test it

Verify on-chain that each of these Safes executes a multisend-only tx to the expected aux-contract address after the fix:

1. `zksync:0x1b8966A16021776a8c553603eC33DA0Ab05ce239` (zkSync Era, 1.3.0 + canonical L2 master copy) → MultiSendCallOnly `0x40A2aCCbd92BCA938b02010E17A5b8929b49130D` (canonical)
2. `zksync:0x4E868F1858de0377E8305A0421fC0f67bd89F153` (zkSync Era, 1.4.1 + canonical L1 master copy) → singleton resolves from L1 table, canonical MultiSendCallOnly `0x9641d764fc13c8B624c04430C7356C1C7C8102e2`
3. `lens:0x7ba5d7F189d3F24F536ddc49EBEb987332B9489c` (Lens, 1.4.1 + canonical L2 master copy) → canonical MultiSendCallOnly `0x9641d764fc13c8B624c04430C7356C1C7C8102e2`
4. `lens:0x49b0EA5B0691D460F2026EF98CfB3819E2e9f97d` (Lens, 1.4.1 + zksync L2 master copy) → zksync MultiSendCallOnly `0x0408EF011960d02349d50286D20531229BCef773`
5. `lens:0x2b73683bB2ef3B0a1F5b520cB917a58B875Ae59D` (Lens, 1.3.0 + zksync L2 master copy) → zksync MultiSendCallOnly `0xf220D3b4DFb23C4ade8C88E526C1353AbAcbC38F`

Automated coverage: `yarn workspace @safe-global/utils test packages/utils/src/services/contracts/__tests__/deployments.test.ts` — 62 passing tests covering L1/L2 × canonical/zksync across 1.3.0 and 1.4.1, plus the EraVM-chain detection.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before (broken)"]
    B1[initSafeSDK] --> B2{"version >= 1.4.1?"}
    B2 -->|yes| B3["deploymentType = isZk ? zksync : canonical"]
    B2 -->|no| B4[no override]
    B3 --> B5["resolver picks by deploymentType<br/>(ignores networkAddresses)"]
    B5 --> B6["wrong aux on Lens, wrong singleton<br/>on zkSync L1-masterCopy Safe"]
  end

  subgraph After["After (fixed)"]
    A1[initSafeSDK] --> A2["getDeploymentTypeForMasterCopy<br/>(impl, version)"]
    A2 --> A3["{deploymentType, isL1}<br/>derived from master copy"]
    A3 --> A4[resolver uses L1/L2 table<br/>per isL1, picks deploymentType<br/>from networkAddresses]
    A4 --> A5{"isEraVmChain and<br/>canonical master copy?"}
    A5 -->|yes| A6[override MultiSend aux<br/>with canonical]
    A5 -->|no| A7[done]
  end
```

## Screenshots

N/A — no UI changes.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).