### PR TITLE
fix(mobile): surface error when wallet can't honor the active Safe's chain

### DIFF
--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
@@ -1,41 +1,53 @@
 import { renderHook, act } from '@/src/tests/test-utils'
-import { useConnect, ConnectError, UserRejectedError } from '../useConnect'
+import { useConnect, ConnectError, UnsupportedChainError, UserRejectedError } from '../useConnect'
 
 const mockOpen = jest.fn()
+const mockDisconnect = jest.fn().mockResolvedValue(undefined)
+const mockSwitchNetwork = jest.fn().mockResolvedValue(undefined)
 
 const mockWalletState = {
   address: undefined as string | undefined,
   isConnected: false,
   walletInfo: undefined as { name: string; icon: string } | undefined,
+  chain: undefined as { caipNetworkId: string } | undefined,
 }
 
 jest.mock('@reown/appkit-react-native', () => ({
-  useAppKit: () => ({ open: mockOpen }),
+  useAppKit: () => ({ open: mockOpen, disconnect: mockDisconnect, switchNetwork: mockSwitchNetwork }),
   useAccount: () => ({
     isConnected: mockWalletState.isConnected,
     address: mockWalletState.address,
+    chain: mockWalletState.chain,
   }),
   useWalletInfo: () => ({ walletInfo: mockWalletState.walletInfo }),
 }))
 
-const eventCallbacks: Record<string, (() => void) | undefined> = {}
+type EventCallback = (state?: { data: { address?: string; properties: { caipNetworkId?: string } } }) => void
+const eventCallbacks: Record<string, EventCallback | undefined> = {}
 
 jest.mock('../useStableAppKitEvent', () => ({
-  useStableAppKitEvent: (event: string, callback: () => void) => {
+  useStableAppKitEvent: (event: string, callback: EventCallback) => {
     eventCallbacks[event] = callback
   },
 }))
 
-const setConnected = (address: string, walletName = 'MetaMask', walletIcon = 'icon-url') => {
+const setConnected = (
+  address: string,
+  walletName = 'MetaMask',
+  walletIcon = 'icon-url',
+  caipNetworkId = 'eip155:1',
+) => {
   mockWalletState.address = address
   mockWalletState.isConnected = true
   mockWalletState.walletInfo = { name: walletName, icon: walletIcon }
+  mockWalletState.chain = { caipNetworkId }
 }
 
 const setDisconnected = () => {
   mockWalletState.address = undefined
   mockWalletState.isConnected = false
   mockWalletState.walletInfo = undefined
+  mockWalletState.chain = undefined
 }
 
 describe('useConnect', () => {
@@ -241,6 +253,217 @@ describe('useConnect', () => {
       address: '0xDEF',
       walletName: 'Phantom',
       walletIcon: 'phantom-icon',
+    })
+  })
+
+  describe('CONNECT_SUCCESS chain guard', () => {
+    const activeSafeStore = {
+      activeSafe: { address: '0x0000000000000000000000000000000000000001' as const, chainId: '1' },
+    }
+
+    beforeEach(() => {
+      mockSwitchNetwork.mockResolvedValue(undefined)
+    })
+
+    it('attempts to switch network when caipNetworkId does not match the active Safe chain', async () => {
+      const { result } = renderHook(() => useConnect(), activeSafeStore)
+
+      let rejected: Error | undefined
+      act(() => {
+        result.current().catch((e: Error) => {
+          rejected = e
+        })
+      })
+
+      await act(async () => {
+        eventCallbacks['CONNECT_SUCCESS']?.({
+          data: { address: '0xABC', properties: { caipNetworkId: 'eip155:137' } },
+        })
+      })
+
+      expect(mockSwitchNetwork).toHaveBeenCalledWith('eip155:1')
+      expect(rejected).toBeUndefined()
+      expect(mockDisconnect).not.toHaveBeenCalled()
+    })
+
+    it('rejects with UnsupportedChainError when switchNetwork throws', async () => {
+      mockSwitchNetwork.mockRejectedValueOnce(new Error('Chain not supported'))
+
+      const { result } = renderHook(() => useConnect(), activeSafeStore)
+
+      let rejected: Error | undefined
+      act(() => {
+        result.current().catch((e: Error) => {
+          rejected = e
+        })
+      })
+
+      await act(async () => {
+        eventCallbacks['CONNECT_SUCCESS']?.({
+          data: { address: '0xABC', properties: { caipNetworkId: 'eip155:137' } },
+        })
+      })
+
+      expect(rejected).toBeInstanceOf(UnsupportedChainError)
+      expect(mockDisconnect).toHaveBeenCalled()
+    })
+
+    it('rejects via timeout when switchNetwork resolves but chain never settles', async () => {
+      jest.useFakeTimers()
+
+      const { result } = renderHook(() => useConnect(), activeSafeStore)
+
+      let rejected: Error | undefined
+      act(() => {
+        result.current().catch((e: Error) => {
+          rejected = e
+        })
+      })
+
+      await act(async () => {
+        eventCallbacks['CONNECT_SUCCESS']?.({
+          data: { address: '0xABC', properties: { caipNetworkId: 'eip155:137' } },
+        })
+      })
+
+      expect(mockSwitchNetwork).toHaveBeenCalledWith('eip155:1')
+      expect(rejected).toBeUndefined()
+
+      await act(async () => {
+        jest.advanceTimersByTime(8000)
+      })
+
+      expect(rejected).toBeInstanceOf(UnsupportedChainError)
+      expect(mockDisconnect).toHaveBeenCalled()
+
+      jest.useRealTimers()
+    })
+
+    it('resolves after switchNetwork succeeds and state settles on the correct chain', async () => {
+      const { result, rerender } = renderHook(() => useConnect(), activeSafeStore)
+
+      let resolved: unknown
+      let rejected: Error | undefined
+      act(() => {
+        result.current().then(
+          (r) => {
+            resolved = r
+          },
+          (e: Error) => {
+            rejected = e
+          },
+        )
+      })
+
+      await act(async () => {
+        eventCallbacks['CONNECT_SUCCESS']?.({
+          data: { address: '0xABC', properties: { caipNetworkId: 'eip155:137' } },
+        })
+      })
+
+      expect(mockSwitchNetwork).toHaveBeenCalledWith('eip155:1')
+
+      // Simulate post-switch state update: wallet now connected on chain 1.
+      setConnected('0xABC', 'Rainbow', 'rainbow-icon', 'eip155:1')
+      rerender({})
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(resolved).toEqual({ address: '0xABC', walletName: 'Rainbow', walletIcon: 'rainbow-icon' })
+      expect(rejected).toBeUndefined()
+      expect(mockDisconnect).not.toHaveBeenCalled()
+    })
+
+    it('resolver does not resolve while wallet state is on the wrong chain', async () => {
+      const { result, rerender } = renderHook(() => useConnect(), activeSafeStore)
+
+      let resolved: unknown
+      let rejected: Error | undefined
+      act(() => {
+        result.current().then(
+          (r) => {
+            resolved = r
+          },
+          (e: Error) => {
+            rejected = e
+          },
+        )
+      })
+
+      // State flips to connected on the wrong chain *before* any CONNECT_SUCCESS event.
+      // The resolver must not fire until the chain matches the active Safe.
+      setConnected('0xABC', 'Rainbow', 'rainbow-icon', 'eip155:137')
+      rerender({})
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(resolved).toBeUndefined()
+      expect(rejected).toBeUndefined()
+    })
+
+    it('does not attempt to switch when caipNetworkId matches and address is present', async () => {
+      const { result } = renderHook(() => useConnect(), activeSafeStore)
+
+      let rejected: Error | undefined
+      act(() => {
+        result.current().catch((e: Error) => {
+          rejected = e
+        })
+      })
+
+      await act(async () => {
+        eventCallbacks['CONNECT_SUCCESS']?.({
+          data: { address: '0xABC', properties: { caipNetworkId: 'eip155:1' } },
+        })
+      })
+
+      expect(mockSwitchNetwork).not.toHaveBeenCalled()
+      expect(rejected).toBeUndefined()
+      expect(mockDisconnect).not.toHaveBeenCalled()
+    })
+
+    it('ignores CONNECT_SUCCESS when no active Safe is set', async () => {
+      const { result } = renderHook(() => useConnect())
+
+      let rejected: Error | undefined
+      act(() => {
+        result.current().catch((e: Error) => {
+          rejected = e
+        })
+      })
+
+      await act(async () => {
+        eventCallbacks['CONNECT_SUCCESS']?.({
+          data: { properties: { caipNetworkId: 'eip155:137' } },
+        })
+      })
+
+      expect(mockSwitchNetwork).not.toHaveBeenCalled()
+      expect(rejected).toBeUndefined()
+      expect(mockDisconnect).not.toHaveBeenCalled()
+    })
+
+    it('does not switch when address is present and caipNetworkId is missing', async () => {
+      const { result } = renderHook(() => useConnect(), activeSafeStore)
+
+      let rejected: Error | undefined
+      act(() => {
+        result.current().catch((e: Error) => {
+          rejected = e
+        })
+      })
+
+      await act(async () => {
+        eventCallbacks['CONNECT_SUCCESS']?.({ data: { address: '0xABC', properties: {} } })
+      })
+
+      expect(mockSwitchNetwork).not.toHaveBeenCalled()
+      expect(rejected).toBeUndefined()
+      expect(mockDisconnect).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useImportSignerFlow } from '../useImportSignerFlow'
-import { UserRejectedError } from '../useConnect'
+import { UnsupportedChainError, UserRejectedError } from '../useConnect'
 import Logger from '@/src/utils/logger'
 import type { ConnectResult } from '../useConnect'
 import type { Signer } from '@/src/store/signersSlice'
@@ -161,6 +161,26 @@ describe('useImportSignerFlow', () => {
 
     expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('shows an alert when wallet does not support the active Safe chain', async () => {
+    const { result } = renderImportFlow()
+
+    act(() => {
+      result.current.initiateConnection()
+    })
+
+    await act(async () => {
+      mockConnectReject(new UnsupportedChainError())
+    })
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Unsupported network', expect.any(String), expect.any(Array))
+    })
+
+    expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
+    expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(Logger.error).not.toHaveBeenCalled()
   })
 
   it('does nothing when connect fails (connection error)', async () => {

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
@@ -1,9 +1,12 @@
+import { Alert } from 'react-native'
 import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useReconnectFlow } from '../useReconnectFlow'
-import { UserRejectedError } from '../useConnect'
+import { UnsupportedChainError, UserRejectedError } from '../useConnect'
 import type { ConnectResult } from '../useConnect'
+
+jest.spyOn(Alert, 'alert').mockImplementation(() => undefined)
 
 const mockAddress = faker.finance.ethereumAddress() as `0x${string}`
 const mockOtherAddress = faker.finance.ethereumAddress() as `0x${string}`
@@ -97,6 +100,26 @@ describe('useReconnectFlow', () => {
         }),
       )
     })
+  })
+
+  it('shows an alert when wallet does not support the active Safe chain', async () => {
+    const { result } = renderReconnectFlow()
+
+    act(() => {
+      result.current.reconnect(mockAddress)
+    })
+
+    await act(async () => {
+      mockConnectReject(new UnsupportedChainError())
+    })
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Unsupported network', expect.any(String), expect.any(Array))
+    })
+
+    expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
+    expect(mockDisconnect).not.toHaveBeenCalled()
+    expect(mockRouterPush).not.toHaveBeenCalled()
   })
 
   it('does nothing when connect is rejected', async () => {

--- a/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef } from 'react'
+import { Alert } from 'react-native'
 import { useAccount, useAppKit, useWalletInfo } from '@reown/appkit-react-native'
+import { selectActiveSafe } from '@/src/store/activeSafeSlice'
+import { useAppSelector } from '@/src/store/hooks'
+import Logger from '@/src/utils/logger'
 import { useStableAppKitEvent } from './useStableAppKitEvent'
 
 export interface ConnectResult {
@@ -22,37 +26,136 @@ export class UserRejectedError extends Error {
   }
 }
 
+export class UnsupportedChainError extends Error {
+  constructor() {
+    super('Wallet does not support the active chain')
+    this.name = 'UnsupportedChainError'
+  }
+}
+
+/**
+ * Shared alert shown when a WalletConnect flow fails with
+ * UnsupportedChainError. Colocated with the error class so the
+ * copy stays in sync across consumers.
+ */
+export const showUnsupportedChainAlert = () => {
+  Alert.alert(
+    'Unsupported network',
+    "The connected wallet doesn't support the network of the active Safe. Please connect a wallet that supports it, or switch to a different Safe.",
+    [{ text: 'OK' }],
+  )
+}
+
 interface PendingConnect {
   resolve: (result: ConnectResult) => void
   reject: (error: Error) => void
 }
 
+// How long to wait after a successful `switchNetwork` before concluding the
+// wallet silently ignored the switch. Covers the known Reown behavior where
+// switchNetwork resolves without actually changing chain when the internal
+// connection state is stale.
+const SWITCH_SETTLE_TIMEOUT_MS = 8000
+
 /**
  * Returns a `connect()` function that opens the AppKit modal and
  * returns a promise resolving with the connected wallet's address
- * and name. Rejects on CONNECT_ERROR or USER_REJECTED.
+ * and name. Rejects on CONNECT_ERROR, USER_REJECTED, or when the
+ * wallet cannot honor the active Safe's chain (UnsupportedChainError).
  */
 export function useConnect() {
-  const { open } = useAppKit()
-  const { address, isConnected } = useAccount()
+  const { open, disconnect, switchNetwork } = useAppKit()
+  const { address, isConnected, chain } = useAccount()
   const { walletInfo } = useWalletInfo()
+  const activeSafe = useAppSelector(selectActiveSafe)
   const pendingRef = useRef<PendingConnect | null>(null)
+  const switchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Normalize to a canonical decimal CAIP-2 id so comparisons against Reown's
+  // `caipNetworkId` (e.g. `eip155:1`) don't silently fail on zero-padded or
+  // hex-encoded chainId strings from upstream config.
+  const expectedCaipId: `eip155:${number}` | null = activeSafe ? `eip155:${parseInt(activeSafe.chainId, 10)}` : null
+
+  const clearSwitchTimeout = () => {
+    if (switchTimeoutRef.current) {
+      clearTimeout(switchTimeoutRef.current)
+      switchTimeoutRef.current = null
+    }
+  }
+
+  const rejectUnsupported = () => {
+    if (!pendingRef.current) {
+      return
+    }
+    const { reject } = pendingRef.current
+    pendingRef.current = null
+    clearSwitchTimeout()
+    void (async () => {
+      try {
+        await disconnect()
+      } catch (error) {
+        Logger.warn('Failed to disconnect after unsupported-chain connection:', error)
+      }
+    })()
+    reject(new UnsupportedChainError())
+  }
+
+  // Resolver: only resolve when state is fully connected AND the wallet is on
+  // the active Safe's chain. The chain gate prevents a race where the state
+  // effect fires before the CONNECT_SUCCESS handler's switchNetwork settles.
   useEffect(() => {
     if (!pendingRef.current || !isConnected || !address || !walletInfo?.name || !walletInfo?.icon) {
+      return
+    }
+    if (expectedCaipId && chain?.caipNetworkId !== expectedCaipId) {
       return
     }
 
     const { resolve } = pendingRef.current
     pendingRef.current = null
+    clearSwitchTimeout()
     resolve({ address, walletName: walletInfo.name, walletIcon: walletInfo.icon })
-  }, [isConnected, address, walletInfo])
+  }, [isConnected, address, walletInfo, chain, expectedCaipId])
 
   useEffect(() => {
     return () => {
       pendingRef.current = null
+      clearSwitchTimeout()
     }
   }, [])
+
+  useStableAppKitEvent('CONNECT_SUCCESS', ({ data }) => {
+    if (!pendingRef.current || !activeSafe || !expectedCaipId) {
+      return
+    }
+
+    const { caipNetworkId } = data.properties
+    const wrongChain = caipNetworkId && caipNetworkId !== expectedCaipId
+
+    // Wallet connected on the right chain with an account — resolver will handle it.
+    if (data.address && !wrongChain) {
+      return
+    }
+
+    // Wallet is on a different chain but has an account. Try to switch; if the
+    // switch throws, reject. If it resolves, the resolver useEffect handles
+    // success — with a timeout safety net for wallets that resolve without
+    // actually switching.
+    switchNetwork(expectedCaipId)
+      .then(() => {
+        if (!pendingRef.current) {
+          return
+        }
+        switchTimeoutRef.current = setTimeout(() => {
+          Logger.warn('switchNetwork resolved but chain did not settle in time')
+          rejectUnsupported()
+        }, SWITCH_SETTLE_TIMEOUT_MS)
+      })
+      .catch((switchError) => {
+        Logger.warn('Failed to switch network after unsupported-chain connection:', switchError)
+        rejectUnsupported()
+      })
+  })
 
   useStableAppKitEvent('CONNECT_ERROR', () => {
     if (!pendingRef.current) {
@@ -60,6 +163,7 @@ export function useConnect() {
     }
     const { reject } = pendingRef.current
     pendingRef.current = null
+    clearSwitchTimeout()
     reject(new ConnectError('Connection failed'))
   })
 
@@ -69,6 +173,7 @@ export function useConnect() {
     }
     const { reject } = pendingRef.current
     pendingRef.current = null
+    clearSwitchTimeout()
     reject(new UserRejectedError())
   })
 

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -6,7 +6,7 @@ import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipVa
 import { useSignerCollisionGuard } from '@/src/features/ImportSigner/hooks/useSignerCollisionGuard'
 import Logger from '@/src/utils/logger'
 import { useSwitchNetwork } from './useSwitchNetwork'
-import { useConnect, UserRejectedError } from './useConnect'
+import { useConnect, UnsupportedChainError, UserRejectedError, showUnsupportedChainAlert } from './useConnect'
 
 /**
  * Handles the signer import flow: ownership validation and navigation
@@ -50,6 +50,10 @@ export function useImportSignerFlow() {
         })
       }
     } catch (error) {
+      if (error instanceof UnsupportedChainError) {
+        showUnsupportedChainAlert()
+        return
+      }
       if (!(error instanceof UserRejectedError)) {
         Logger.error('Error during signer import:', error)
       }

--- a/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
@@ -4,7 +4,7 @@ import { useAppKit } from '@reown/appkit-react-native'
 import { getAddress } from 'ethers'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useSwitchNetwork } from './useSwitchNetwork'
-import { useConnect } from './useConnect'
+import { useConnect, UnsupportedChainError, showUnsupportedChainAlert } from './useConnect'
 
 /**
  * Handles the first WalletConnect reconnection attempt for existing signers.
@@ -33,7 +33,11 @@ export function useReconnectFlow() {
         }
 
         switchNetworkIfNeeded()
-      } catch {
+      } catch (error) {
+        if (error instanceof UnsupportedChainError) {
+          showUnsupportedChainAlert()
+          return
+        }
         // CONNECT_ERROR or USER_REJECTED — no action needed
       }
     },

--- a/apps/mobile/src/features/WalletConnect/hooks/useSwitchNetwork.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useSwitchNetwork.ts
@@ -29,14 +29,14 @@ export function useSwitchNetwork() {
       return
     }
     if (String(walletChainId) !== activeSafe.chainId) {
-      await appKitSwitchNetwork(`eip155:${activeSafe.chainId}`).catch(() => {
+      await appKitSwitchNetwork(`eip155:${parseInt(activeSafe.chainId, 10)}`).catch(() => {
         Logger.warn('Failed to switch wallet network, continuing with validation')
       })
     }
   }, [walletChainId, activeSafe, appKitSwitchNetwork])
 
   const switchNetwork = useCallback(
-    (chainId: string) => appKitSwitchNetwork(`eip155:${chainId}`),
+    (chainId: string) => appKitSwitchNetwork(`eip155:${parseInt(chainId, 10)}`),
     [appKitSwitchNetwork],
   )
 


### PR DESCRIPTION
> Wallet connects but can't sign,
> promise hangs, user stares blind —
> now switch, then alert.

## What it solves

When a user connects a wallet via WalletConnect that doesn't support the active Safe's chain, the `connect()` promise hung forever — no error, no feedback, no escape. Reown's AppKit fires neither `CONNECT_ERROR` nor `USER_REJECTED` in that scenario.

Resolves: [WA-1996](https://linear.app/safe-global/issue/WA-1996/no-error-if-there-is-an-issue-with-connection)

## How this PR fixes it

The `CONNECT_SUCCESS` handler in `useConnect` now compares Reown's `caipNetworkId` against the active Safe's chain. On mismatch it attempts `switchNetwork`; if the switch throws, it disconnects and rejects with a new `UnsupportedChainError`. An 8-second timeout covers the less-obvious Reown behavior where `switchNetwork` resolves without actually switching (silent no-op when internal state is stale).

A chain gate in the resolver `useEffect` prevents the complementary race: without it, state updates from `useAccount()` could satisfy the pending promise on the wrong chain before the switch attempt settled.

Consumers (`useImportSignerFlow`, `useReconnectFlow`) catch `UnsupportedChainError` and show a shared "Unsupported network" alert. `chainId` comparisons normalize via `parseInt` so zero-padded or hex-encoded chainIds upstream don't silently fail the match.

## How to test it

1. Open the mobile app and select a Safe on a chain your test wallet doesn't support (e.g., a Safe on Base if your wallet only has Ethereum mainnet enabled).
2. Tap to import a signer or reconnect → scan the WalletConnect QR code → approve in your wallet.
3. Expect an "Unsupported network" alert; tapping OK should leave the import/reconnect flow in a recoverable state.
4. Repeat with a wallet that **does** support the Safe's chain but is currently on a different one — expect the wallet to prompt a network switch; approving should proceed normally.

## Screenshots

N/A — the new UI is a standard `Alert.alert` dialog.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).