### PR TITLE
fix(mobile): rename QR scan button to 'Continue' for Apple compliance

### DIFF
--- a/apps/mobile/src/components/Camera/QrCamera.tsx
+++ b/apps/mobile/src/components/Camera/QrCamera.tsx
@@ -81,7 +81,7 @@ function CameraLens({
     }
   }, [hasPermission, isCameraActive, onActivateCamera, onPressSettings])
 
-  const buttonText = 'Enable camera'
+  const buttonText = 'Continue'
   const buttonAction = handleGrantOrActivatePress
 
   return (


### PR DESCRIPTION
> Apple flagged "Enable camera",
> a button that steers the user's hand.
> Swap one word, ship again.

## What it solves

Apple rejected submission 1.0.11 under Guideline 5.1.1(iv) — the QR scan pre-prompt's "Enable camera" button directs users toward granting the camera permission. Apple's remediation text explicitly asks for neutral wording ("Continue" / "Next").

Resolves: WA-2044

## How this PR fixes it

One-line copy change: button label goes from "Enable camera" → "Continue" in `QrCamera.tsx`. The pre-prompt itself is allowed by Apple — only the directive wording was the problem.

We deliberately keep the pre-prompt (rather than triggering the iOS permission dialog directly) because users previously complained that immediate permission prompts felt jarring. The heading ("Scan a QR code") and footer text ("Scan the QR code of the account you want to import...") already provide context, so "Continue" reads naturally without needing extra copy inside the lens.

## How to test it

1. On iOS, go to the account import flow that opens the QR scanner (fresh install or after revoking camera permission in Settings).
2. Verify the pre-prompt screen shows the button labeled **"Continue"** (not "Enable camera").
3. Tap Continue → iOS system permission dialog appears.
4. Deny permission → verify the recovery flow still works (tapping the button opens Settings).

## Visual summary

```mermaid
flowchart LR
  A[User lands on QR scan] --> B[Pre-prompt screen]
  B --> C["[ Continue ]"]
  C --> D[iOS system permission dialog]
  D -->|Allow| E[Camera active]
  D -->|Deny| F[Open Settings link]
```

Screenshot: button label change only — the rest of the screen is unchanged.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).