### PR TITLE
fix: hide Explore Earn CTA on unsupported chains in empty positions state

### DIFF
--- a/apps/web/src/features/earn/index.ts
+++ b/apps/web/src/features/earn/index.ts
@@ -6,7 +6,7 @@ export { useIsEarnFeatureEnabled, useIsEarnPromoEnabled } from './hooks'
 
 export { EarnButton } from './components'
 
-export { isEligibleEarnToken } from './services'
+export { isEligibleEarnToken, isEarnSupportedOnChain } from './services'
 
 export { EARN_TITLE } from './constants'
 

--- a/apps/web/src/features/earn/services/__tests__/utils.test.ts
+++ b/apps/web/src/features/earn/services/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { vaultTypeToLabel, isEligibleEarnToken } from '../utils'
+import { vaultTypeToLabel, isEligibleEarnToken, isEarnSupportedOnChain } from '../utils'
 
 describe('vaultTypeToLabel', () => {
   it('maps VaultDeposit to Deposit', () => {
@@ -27,5 +27,16 @@ describe('isEligibleEarnToken', () => {
 
   it('returns undefined for unsupported chain', () => {
     expect(isEligibleEarnToken('137', '0xdAC17F958D2ee523a2206206994597C13D831ec7')).toBeUndefined()
+  })
+})
+
+describe('isEarnSupportedOnChain', () => {
+  it('returns true for supported chains', () => {
+    expect(isEarnSupportedOnChain('1')).toBe(true)
+    expect(isEarnSupportedOnChain('8453')).toBe(true)
+  })
+
+  it('returns false for unsupported chains', () => {
+    expect(isEarnSupportedOnChain('137')).toBe(false)
   })
 })

--- a/apps/web/src/features/earn/services/index.ts
+++ b/apps/web/src/features/earn/services/index.ts
@@ -1,1 +1,1 @@
-export { vaultTypeToLabel, isEligibleEarnToken } from './utils'
+export { vaultTypeToLabel, isEligibleEarnToken, isEarnSupportedOnChain } from './utils'

--- a/apps/web/src/features/earn/services/utils.ts
+++ b/apps/web/src/features/earn/services/utils.ts
@@ -8,3 +8,7 @@ export const vaultTypeToLabel = {
 export const isEligibleEarnToken = (chainId: string, tokenAddress: string) => {
   return EligibleEarnTokens[chainId]?.includes(tokenAddress)
 }
+
+export const isEarnSupportedOnChain = (chainId: string) => {
+  return Boolean(EligibleEarnTokens[chainId]?.length)
+}

--- a/apps/web/src/features/positions/components/PositionsEmpty/__tests__/index.test.tsx
+++ b/apps/web/src/features/positions/components/PositionsEmpty/__tests__/index.test.tsx
@@ -15,16 +15,24 @@ jest.mock('@/features/earn', () => ({
   __esModule: true,
   default: jest.fn(),
   useIsEarnPromoEnabled: jest.fn(() => true),
+  isEarnSupportedOnChain: jest.fn(() => true),
 }))
 
-import { useIsEarnPromoEnabled } from '@/features/earn'
+jest.mock('@/hooks/useChainId', () => jest.fn(() => '1'))
+
+import { isEarnSupportedOnChain, useIsEarnPromoEnabled } from '@/features/earn'
+import useChainId from '@/hooks/useChainId'
 
 const mockTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>
 const mockUseIsEarnFeatureEnabled = useIsEarnPromoEnabled as jest.MockedFunction<typeof useIsEarnPromoEnabled>
+const mockIsEarnSupportedOnChain = isEarnSupportedOnChain as jest.MockedFunction<typeof isEarnSupportedOnChain>
+const mockUseChainId = useChainId as jest.MockedFunction<typeof useChainId>
 
 describe('PositionsEmpty', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseChainId.mockReturnValue('1')
+    mockIsEarnSupportedOnChain.mockReturnValue(true)
   })
 
   describe('when earn feature is enabled', () => {
@@ -90,6 +98,22 @@ describe('PositionsEmpty', () => {
 
       // No button to click, so tracking should not be called
       expect(mockTrackEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when earn is not supported on the current chain', () => {
+    beforeEach(() => {
+      mockUseIsEarnFeatureEnabled.mockReturnValue(true)
+      mockUseChainId.mockReturnValue('137')
+      mockIsEarnSupportedOnChain.mockReturnValue(false)
+    })
+
+    it('should render empty positions message without explore earn button', () => {
+      render(<PositionsEmpty />)
+
+      expect(screen.getByText('You have no active DeFi positions yet')).toBeInTheDocument()
+      expect(screen.queryByText('Explore Earn')).not.toBeInTheDocument()
+      expect(mockIsEarnSupportedOnChain).toHaveBeenCalledWith('137')
     })
   })
 })

--- a/apps/web/src/features/positions/components/PositionsEmpty/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsEmpty/index.tsx
@@ -6,7 +6,8 @@ import { AppRoutes } from '@/config/routes'
 import Track from '@/components/common/Track'
 import { POSITIONS_EVENTS } from '@/services/analytics/events/positions'
 import { MixpanelEventParams } from '@/services/analytics/mixpanel-events'
-import { useIsEarnPromoEnabled } from '@/features/earn'
+import { isEarnSupportedOnChain, useIsEarnPromoEnabled } from '@/features/earn'
+import useChainId from '@/hooks/useChainId'
 
 type PositionsEmptyProps = {
   entryPoint?: string
@@ -14,7 +15,9 @@ type PositionsEmptyProps = {
 
 const PositionsEmpty = ({ entryPoint = 'Dashboard' }: PositionsEmptyProps) => {
   const router = useRouter()
+  const chainId = useChainId()
   const isEarnFeatureEnabled = useIsEarnPromoEnabled()
+  const showExploreEarn = isEarnFeatureEnabled && isEarnSupportedOnChain(chainId)
 
   return (
     <Paper elevation={0} sx={{ p: 3, textAlign: 'center' }}>
@@ -24,7 +27,7 @@ const PositionsEmpty = ({ entryPoint = 'Dashboard' }: PositionsEmptyProps) => {
         You have no active DeFi positions yet
       </Typography>
 
-      {isEarnFeatureEnabled && (
+      {showExploreEarn && (
         <Track
           {...POSITIONS_EVENTS.EMPTY_POSITIONS_EXPLORE_CLICKED}
           mixpanelParams={{


### PR DESCRIPTION
> Polygon has no kiln stream,
> so empty positions stay calm—
> no broken Earn link shown.

### Motivation
- Fix WA-1618 where clicking the **Explore Earn** link from the empty Positions state on unsupported chains (e.g. Polygon) caused a runtime error. 
- Ensure the empty-state CTA is only shown when the Earn/Kiln feature is both enabled and supported on the current chain.

### Description
- Add `isEarnSupportedOnChain(chainId)` in `apps/web/src/features/earn/services/utils.ts` and export it from the Earn service API. 
- Gate the Explore Earn CTA in `PositionsEmpty` behind both `useIsEarnPromoEnabled()` and `isEarnSupportedOnChain(useChainId())` so the button is not rendered on unsupported chains. 
- Update unit tests to cover `isEarnSupportedOnChain` and add a regression test in `PositionsEmpty` to ensure the CTA is hidden when the chain is unsupported. 

```mermaid
flowchart TD
  A[Positions empty state renders] --> B{Earn promo enabled?}
  B -->|No| C[Hide Explore Earn CTA]
  B -->|Yes| D{Chain supported by Earn?}
  D -->|No| C
  D -->|Yes| E[Show Explore Earn CTA]
```

### Testing
- Ran unit tests for the changed files with `yarn workspace @safe-global/web test --runTestsByPath src/features/positions/components/PositionsEmpty/__tests__/index.test.tsx src/features/earn/services/__tests__/utils.test.ts` and both suites passed. 
- Executed `yarn verify:changed:web` which confirmed formatting but surfaced unrelated/flaky test failures outside the scope of these changes; the tests covering the modified code passed. 
- All added/updated tests for the Earn utils and Positions empty-state behavior passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e61495b544832abb82f5407625cd89)