### PR TITLE
fix: update rejected login notifications

### DIFF
--- a/apps/web/src/features/oidc-auth/constants.ts
+++ b/apps/web/src/features/oidc-auth/constants.ts
@@ -4,3 +4,15 @@ export enum OidcConnection {
   EMAIL = 'email',
   GOOGLE = 'google-oauth2',
 }
+
+export const DEFAULT_SIGN_IN_ERROR_MESSAGE = 'Something went wrong while signing in with email'
+
+/**
+ * Maps known OIDC/Auth0 error_description values to user-friendly messages.
+ * Falls back to DEFAULT_SIGN_IN_ERROR_MESSAGE for unknown descriptions.
+ */
+export const SIGN_IN_ERROR_DESCRIPTION_MAP: Record<string, string> = {
+  method_conflict_otp_required: 'You have signed in with this email before. Please continue with email option.',
+  method_conflict_google_required: 'You have signed in with Google before. Please continue with Google.',
+  method_conflict: 'You have signed in with this email before. Please use your existing sign-in method to continue.',
+}

--- a/apps/web/src/features/oidc-auth/hooks/__tests__/useOidcLoginCallback.test.ts
+++ b/apps/web/src/features/oidc-auth/hooks/__tests__/useOidcLoginCallback.test.ts
@@ -131,13 +131,61 @@ describe('useOidcLoginCallback', () => {
     expect(mockReconcileAuth).not.toHaveBeenCalled()
   })
 
-  it('should clean error param from URL via Next.js router', async () => {
+  it('should show mapped error message when error_description is known', async () => {
     sessionStorage.setItem(OIDC_AUTH_PENDING_KEY, '1')
     Object.defineProperty(window, 'location', {
       writable: true,
       value: {
         ...originalLocation,
-        search: '?error=access_denied',
+        search: '?error=access_denied&error_description=method_conflict_otp_required',
+        pathname: '/welcome/spaces',
+      },
+    })
+
+    renderHook(() => useOidcLoginCallback())
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'notifications/showNotification',
+        payload: expect.objectContaining({
+          variant: 'error',
+          message: 'You have signed in with this email before. Please continue with email option.',
+        }),
+      })
+    })
+  })
+
+  it('should show default error message when error_description is unknown', async () => {
+    sessionStorage.setItem(OIDC_AUTH_PENDING_KEY, '1')
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        ...originalLocation,
+        search: '?error=access_denied&error_description=some+unknown+error',
+        pathname: '/welcome/spaces',
+      },
+    })
+
+    renderHook(() => useOidcLoginCallback())
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'notifications/showNotification',
+        payload: expect.objectContaining({
+          variant: 'error',
+          message: 'Something went wrong while signing in with email',
+        }),
+      })
+    })
+  })
+
+  it('should clean error and error_description params from URL via Next.js router', async () => {
+    sessionStorage.setItem(OIDC_AUTH_PENDING_KEY, '1')
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        ...originalLocation,
+        search: '?error=access_denied&error_description=method_conflict',
         pathname: '/welcome/spaces',
       },
     })
@@ -151,13 +199,13 @@ describe('useOidcLoginCallback', () => {
     })
   })
 
-  it('should preserve other query params when cleaning error param', async () => {
+  it('should preserve other query params when cleaning error params', async () => {
     sessionStorage.setItem(OIDC_AUTH_PENDING_KEY, '1')
     Object.defineProperty(window, 'location', {
       writable: true,
       value: {
         ...originalLocation,
-        search: '?spaceId=42&error=access_denied',
+        search: '?spaceId=42&error=access_denied&error_description=method_conflict',
         pathname: '/welcome/spaces',
       },
     })

--- a/apps/web/src/features/oidc-auth/hooks/useOidcLoginCallback.ts
+++ b/apps/web/src/features/oidc-auth/hooks/useOidcLoginCallback.ts
@@ -6,13 +6,13 @@ import { showNotification } from '@/store/notificationsSlice'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import reconcileAuth from '@/store/reconcileAuth'
-import { OIDC_AUTH_PENDING_KEY } from '../constants'
+import { DEFAULT_SIGN_IN_ERROR_MESSAGE, OIDC_AUTH_PENDING_KEY, SIGN_IN_ERROR_DESCRIPTION_MAP } from '../constants'
 
-const EMAIL_SIGN_IN_ERROR = {
-  message: 'Something went wrong while signing in with email',
+const getErrorNotification = (errorDescription: string | null) => ({
+  message: (errorDescription && SIGN_IN_ERROR_DESCRIPTION_MAP[errorDescription]) || DEFAULT_SIGN_IN_ERROR_MESSAGE,
   variant: 'error' as const,
   groupKey: 'email-sign-in-failed',
-}
+})
 
 /**
  * Detects post-OIDC redirect and updates auth state.
@@ -48,11 +48,13 @@ export const useOidcLoginCallback = () => {
       const params = new URLSearchParams(window.location.search)
 
       if (params.has('error')) {
-        dispatch(showNotification(EMAIL_SIGN_IN_ERROR))
+        const errorDescription = params.get('error_description')
+        dispatch(showNotification(getErrorNotification(errorDescription)))
 
         // Read params from window.location.search instead of
         // router.query, which may still be empty before router.isReady on first render.
         params.delete('error')
+        params.delete('error_description')
         const cleanQuery = Object.fromEntries(params.entries())
         routerRef.current.replace({ pathname: routerRef.current.pathname, query: cleanQuery }, undefined, {
           shallow: true,
@@ -60,7 +62,7 @@ export const useOidcLoginCallback = () => {
       } else {
         const result = await reconcileAuth(dispatch)
         if (result === 'unauthenticated') {
-          dispatch(showNotification(EMAIL_SIGN_IN_ERROR))
+          dispatch(showNotification(getErrorNotification(null)))
         }
       }
 


### PR DESCRIPTION
## What it solves 

Maps rejected login attempts to human-friendly notifications

Resolves: [WA-2039](https://linear.app/safe-global/issue/WA-2039/fe-map-auth0-errors-to-human-friendly-notifications-in-app)

## How this PR fixes it

- if `error_description` is present in login redirect and matches a known code - map it to a user-friendly message,
otherwise show a default one.
- test updates

## How to test it
- Login with your primary method
- Afterwards try to login with the other method
- Observe an error

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
