### PR TITLE
fix:  adjust broken Connect Btn width

### DIFF
--- a/apps/web/src/components/common/ConnectWallet/ConnectWalletButton.tsx
+++ b/apps/web/src/components/common/ConnectWallet/ConnectWalletButton.tsx
@@ -8,12 +8,14 @@ const ConnectWalletButton = ({
   small = false,
   text,
   className,
+  fullWidth = false,
 }: {
   onConnect?: () => void
   contained?: boolean
   small?: boolean
   text?: string
   className?: string
+  fullWidth?: boolean
 }): React.ReactElement => {
   const connectWallet = useConnectWallet()
 
@@ -29,6 +31,7 @@ const ConnectWalletButton = ({
       variant={contained ? 'contained' : 'text'}
       size={small ? 'small' : 'medium'}
       disableElevation
+      fullWidth={fullWidth}
       className={cn(className)}
       sx={{ fontSize: small ? ['12px', '13px'] : '' }}
     >

--- a/apps/web/src/components/new-safe/create/NoWalletConnectedWarning/index.tsx
+++ b/apps/web/src/components/new-safe/create/NoWalletConnectedWarning/index.tsx
@@ -13,12 +13,8 @@ const NoWalletConnectedWarning = () => {
     <Alert severity="warning" sx={{ mt: 3 }}>
       <AlertTitle sx={{ fontWeight: 700 }}>No wallet connected</AlertTitle>You need to connect a wallet to create a Safe
       account.
-      <Box
-        sx={{
-          mt: 2,
-        }}
-      >
-        <ConnectWalletButton />
+      <Box sx={{ mt: 2 }}>
+        <ConnectWalletButton fullWidth />
       </Box>
     </Alert>
   )

--- a/apps/web/src/components/new-safe/create/OverviewWidget/index.tsx
+++ b/apps/web/src/components/new-safe/create/OverviewWidget/index.tsx
@@ -45,7 +45,7 @@ const OverviewWidget = ({ safeName, networks }: { safeName: string; networks: Ch
             <Typography variant="body2" color="border.main" textAlign="center" width={1} mb={1}>
               Connect your wallet to continue
             </Typography>
-            <ConnectWalletButton />
+            <ConnectWalletButton fullWidth />
           </Box>
         )}
       </Card>


### PR DESCRIPTION
## What it solves

Resolves: [WA-2048](https://linear.app/safe-global/issue/WA-2048/the-button-is-displaced-on-the-create-account-page)
On `/new-safe/create`, the "Connect" button rendered at its cut width width instead of full-width. That happened because of `className={cn(className)}` optional prop added to the Connect Button component.

## How this PR fixes it
Added a `fullWidth` prop to `ConnectWalletButton`. Passed fullWidth at both call sites: NoWalletConnectedWarning and OverviewWidget.

## How to test it
- Go to `/new-safe/create` **without a connected wallet**.
- Confirm the "Connect" button in the amber warning box spans the full width of the alert.
- Confirm the "Connect" button in the "Your Safe Account preview" card also spans the full card width.

## Screenshots
Before:
<img width="1483" height="752" alt="image" src="https://github.com/user-attachments/assets/14fb35bd-4fd4-47af-aaf0-12cec4747412" />

After:
<img width="1484" height="749" alt="image" src="https://github.com/user-attachments/assets/ffcc4f11-6e00-488e-ab5f-9dfd6571af0e" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 n/a
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 n/a
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
