### PR TITLE
fix: additional error code for rejected login

### DIFF
--- a/apps/web/src/features/oidc-auth/constants.ts
+++ b/apps/web/src/features/oidc-auth/constants.ts
@@ -15,4 +15,6 @@ export const SIGN_IN_ERROR_DESCRIPTION_MAP: Record<string, string> = {
   method_conflict_otp_required: 'You have signed in with this email before. Please continue with email option.',
   method_conflict_google_required: 'You have signed in with Google before. Please continue with Google.',
   method_conflict: 'You have signed in with this email before. Please use your existing sign-in method to continue.',
+  multiple_verified_primary_users_found:
+    'Multiple accounts found with this email. Please contact support for manual resolution.',
 }


### PR DESCRIPTION
## What it solves

Additional error code mapping for a case with multiple valid user accounts created in Auth0 (defensive approach, should not happen)

Resolves: [WA-2039](https://linear.app/safe-global/issue/WA-2039/fe-map-auth0-errors-to-human-friendly-notifications-in-app)

## How this PR fixes it

- Added error code mapping for `multiple_verified_primary_users_found` - cases where auth0 state is corrupt and there are multiple primary users for he same email (should never happen)

## How to test it

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
