### PR TITLE
fix(web): Spaces address book name overflow and FAB-pagination overlap

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -52,16 +52,18 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
             <TableRow key={entry.address}>
               {/* Name */}
               <TableCell className="font-bold">
-                <span className="inline-flex items-center gap-1.5">
-                  {entry.isLocal && (
-                    <SvgIcon
-                      component={AddressBookIcon}
-                      inheritViewBox
-                      sx={{ fontSize: 16, color: 'text.secondary' }}
-                    />
-                  )}
-                  {entry.name}
-                </span>
+                <Tooltip title={entry.name} arrow>
+                  <div className="flex items-center gap-1.5 overflow-hidden">
+                    {entry.isLocal && (
+                      <SvgIcon
+                        component={AddressBookIcon}
+                        inheritViewBox
+                        sx={{ fontSize: 16, color: 'text.secondary', flexShrink: 0 }}
+                      />
+                    )}
+                    <span className="min-w-0 truncate">{entry.name}</span>
+                  </div>
+                </Tooltip>
               </TableCell>
 
               {/* Address */}
@@ -127,7 +129,7 @@ function SpaceAddressBookTable({ entries }: SpaceAddressBookTableProps) {
       </Table>
 
       {totalPages > 1 && (
-        <div className="flex items-center justify-between pt-4">
+        <div className="flex items-center justify-between pt-4 pr-16">
           <p className="text-muted-foreground text-sm">
             {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, entries.length)} of {entries.length}
           </p>


### PR DESCRIPTION
> Names grow too long, they spill over —
> truncate, tooltip, the column holds.
> Chevrons hid behind the help orb —
> nudge them left, the page breathes again.

Resolves: [WA-2086](https://linear.app/safe-global/issue/WA-2086/addressbook-name-is-overlapped-with-the-address-on-the-mac-13)

## What it solves

Two Spaces address book UI bugs on narrow viewports (reported on Mac 13\"):

1. **Name overlaps Address column.** Long contact names rendered outside the Name cell because the cell used `inline-flex` with `whitespace-nowrap` and no `overflow` handling on a `table-fixed` layout — the column's fixed width was respected, but content spilled visually into the Address column.
2. **Help FAB covers the pagination \"next\" button.** The fixed help button (`bottom: 24px; right: 24px; 48×48px`) sat on top of the right chevron in the pagination row, making it unclickable.

## How this PR fixes it

`apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx`:

1. **Name cell** — wrap name + icon in a flex row with `overflow-hidden`, put the name text in a `<span class=\"min-w-0 truncate\">`, and wrap the whole thing in an MUI `Tooltip` so the full name shows on hover.
   - `min-w-0` is the load-bearing bit: flex items default to `min-width: auto` (= intrinsic content width, which for `white-space: nowrap` text is the full string). Without it, `truncate`'s `overflow: hidden` clips the span's box but the span still expands to its natural width, so no ellipsis appears. `min-w-0` lets the flex child shrink below its intrinsic width and lets `text-overflow: ellipsis` actually kick in.
   - Icon gets `flexShrink: 0` so it never shrinks away when space is tight.
2. **Pagination row** — add `pr-16` (64px right padding). The help FAB occupies `right: 24px` + `width: 48px` = 72px from the viewport right edge; 64px of internal right padding pushes the chevrons left so they clear the FAB's footprint even when the card is near-flush with the viewport edge.

## How to test it

1. Open a Space with many address book contacts (>25 so pagination appears).
2. Add a contact with a very long name (~30+ characters).
3. Narrow the window to ~Mac 13\" width (≤1440px, sidebar open).
4. Verify:
   - Name truncates with \"…\" and does not touch the Address column.
   - Hovering the name shows the full value in a tooltip.
   - Both pagination chevrons are fully clickable and not covered by the black help `?` FAB.
5. Widen the window: layout remains correct, no odd gap next to the FAB.

## Affected flows

- Spaces → Address book → Workspace contacts tab (paginated long list).
- Spaces → Address book → My contacts tab (same table component).
- Any contact with a long name (truncation + tooltip).

## Blast radius

- Single component: `SpaceAddressBookTable.tsx`.
- No shared hook, selector, slice, endpoint, or feature flag touched.
- No mobile impact (web-only component).
- No persistence / cache / schema impact.

## Risks / not checked

- Did not pixel-verify on an actual Mac 13\" device — relied on token math (FAB footprint 72px vs pagination `pr-16` = 64px of card-internal padding; main layout adds its own horizontal padding around the card).
- Did not add a new unit test; existing `SpaceAddressBookTable.test.tsx` still passes. Truncation is a pure-CSS concern that jsdom does not exercise meaningfully.
- Did not test on mobile (the component is web-only; no mobile surface).
- Did not verify with help FAB disabled (non-official hosts) — the `pr-16` remains but is harmless there.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before"]
    B1["TableCell (table-fixed, w-20%, whitespace-nowrap, no overflow)"]
    B1 --> B2["inline-flex (no overflow)"]
    B2 --> B3["long name text"]
    B3 -. "spills into Address column" .-> BX((visual overflow))
    BP["Pagination: flex justify-between (no right padding)"]
    BP -. "right chevron under FAB" .-> BY((click blocked))
  end
  subgraph After["After"]
    A1["TableCell"]
    A1 --> A2["Tooltip wraps row"]
    A2 --> A3["flex + overflow-hidden"]
    A3 --> A4["icon (flexShrink:0)"]
    A3 --> A5["span.min-w-0.truncate"]
    A5 --> A6["text-overflow: ellipsis ✓"]
    AP["Pagination: flex justify-between + pr-16"]
    AP --> AQ["chevrons 64px in from card edge, clear of FAB"]
  end
```

UI reference: see screenshots on the linked Linear ticket.

## Checklist

- [ ] I've tested the branch on mobile 📱 (n/a — web-only component)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (CSS-only fix, not testable in jsdom; existing tests pass)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)