### PR TITLE
Fix doubler corners on pop ups

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
+++ b/apps/web/src/components/common/Header/Topbar/NotificationsPopover.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useImperativeHandle, type MouseEvent, type ReactElement } from 'react'
 import Popover from '@mui/material/Popover'
-import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import IconButton from '@mui/material/IconButton'
 import MuiLink from '@mui/material/Link'
@@ -61,65 +60,64 @@ const NotificationsPopover = forwardRef<NotificationsPopoverRef>((_props, ref): 
       transformOrigin={{ vertical: 'top', horizontal: 'left' }}
       sx={{ mt: 1 }}
       transitionDuration={0}
+      slotProps={{ paper: { className: notificationCss.popoverContainer } }}
     >
-      <Paper className={notificationCss.popoverContainer}>
-        <div className={notificationCss.popoverHeader}>
-          <div>
-            <Typography data-testid="notifications-title" variant="h4" component="span" fontWeight={700}>
-              Notifications
-            </Typography>
-            {unreadCount > 0 && (
-              <Typography variant="caption" className={notificationCss.unreadCount}>
-                {unreadCount}
-              </Typography>
-            )}
-          </div>
-          {notifications.length > 0 && (
-            <MuiLink onClick={handleClear} variant="body2" component="button" sx={{ textDecoration: 'unset' }}>
-              Clear all
-            </MuiLink>
-          )}
-        </div>
-
+      <div className={notificationCss.popoverHeader}>
         <div>
-          <NotificationCenterList notifications={notificationsToShow} handleClose={handleClose} />
-        </div>
-
-        <div className={notificationCss.popoverFooter}>
-          {canExpand && (
-            <>
-              <IconButton
-                onClick={() => setShowAll((prev) => !prev)}
-                disableRipple
-                className={notificationCss.expandButton}
-              >
-                <UnreadBadge
-                  invisible={showAll || unreadCount <= NOTIFICATION_CENTER_LIMIT}
-                  anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
-                >
-                  <ExpandIcon color="border" />
-                </UnreadBadge>
-              </IconButton>
-              <Typography sx={{ color: ({ palette }) => palette.border.main }}>
-                {showAll ? 'Hide' : `${notifications.length - NOTIFICATION_CENTER_LIMIT} other notifications`}
-              </Typography>
-            </>
-          )}
-
-          {hasPushNotifications && (
-            <Link href={{ pathname: AppRoutes.settings.notifications, query: router.query }} passHref legacyBehavior>
-              <MuiLink
-                data-testid="notifications-button"
-                className={notificationCss.settingsLink}
-                variant="body2"
-                onClick={onSettingsClick}
-              >
-                <SvgIcon component={SettingsIcon} inheritViewBox fontSize="small" /> Push notifications settings
-              </MuiLink>
-            </Link>
+          <Typography data-testid="notifications-title" variant="h4" component="span" fontWeight={700}>
+            Notifications
+          </Typography>
+          {unreadCount > 0 && (
+            <Typography variant="caption" className={notificationCss.unreadCount}>
+              {unreadCount}
+            </Typography>
           )}
         </div>
-      </Paper>
+        {notifications.length > 0 && (
+          <MuiLink onClick={handleClear} variant="body2" component="button" sx={{ textDecoration: 'unset' }}>
+            Clear all
+          </MuiLink>
+        )}
+      </div>
+
+      <div>
+        <NotificationCenterList notifications={notificationsToShow} handleClose={handleClose} />
+      </div>
+
+      <div className={notificationCss.popoverFooter}>
+        {canExpand && (
+          <>
+            <IconButton
+              onClick={() => setShowAll((prev) => !prev)}
+              disableRipple
+              className={notificationCss.expandButton}
+            >
+              <UnreadBadge
+                invisible={showAll || unreadCount <= NOTIFICATION_CENTER_LIMIT}
+                anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+              >
+                <ExpandIcon color="border" />
+              </UnreadBadge>
+            </IconButton>
+            <Typography sx={{ color: ({ palette }) => palette.border.main }}>
+              {showAll ? 'Hide' : `${notifications.length - NOTIFICATION_CENTER_LIMIT} other notifications`}
+            </Typography>
+          </>
+        )}
+
+        {hasPushNotifications && (
+          <Link href={{ pathname: AppRoutes.settings.notifications, query: router.query }} passHref legacyBehavior>
+            <MuiLink
+              data-testid="notifications-button"
+              className={notificationCss.settingsLink}
+              variant="body2"
+              onClick={onSettingsClick}
+            >
+              <SvgIcon component={SettingsIcon} inheritViewBox fontSize="small" /> Push notifications settings
+            </MuiLink>
+          </Link>
+        )}
+      </div>
     </Popover>
   )
 })

--- a/apps/web/src/components/notification-center/NotificationCenter/index.tsx
+++ b/apps/web/src/components/notification-center/NotificationCenter/index.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, type ReactElement, type MouseEvent } from 'react'
 import ButtonBase from '@mui/material/ButtonBase'
 import Popover from '@mui/material/Popover'
-import Paper from '@mui/material/Paper'
 import Typography from '@mui/material/Typography'
 import IconButton from '@mui/material/IconButton'
 import MuiLink from '@mui/material/Link'
@@ -144,71 +143,70 @@ const NotificationCenter = (): ReactElement => {
           },
         }}
         transitionDuration={0}
+        slotProps={{ paper: { className: css.popoverContainer } }}
       >
-        <Paper className={css.popoverContainer}>
-          <div className={css.popoverHeader}>
-            <div>
-              <Typography data-testid="notifications-title" variant="h4" component="span" fontWeight={700}>
-                Notifications
-              </Typography>
-              {hasUnread && (
-                <Typography variant="caption" className={css.unreadCount}>
-                  {unreadCount}
-                </Typography>
-              )}
-            </div>
-            {notifications.length > 0 && (
-              <MuiLink onClick={handleClear} variant="body2" component="button" sx={{ textDecoration: 'unset' }}>
-                Clear all
-              </MuiLink>
-            )}
-          </div>
-
+        <div className={css.popoverHeader}>
           <div>
-            <NotificationCenterList notifications={notificationsToShow} handleClose={handleClose} />
-          </div>
-
-          <div className={css.popoverFooter}>
-            {canExpand && (
-              <>
-                <IconButton onClick={() => setShowAll((prev) => !prev)} disableRipple className={css.expandButton}>
-                  <UnreadBadge
-                    invisible={showAll || unreadCount <= NOTIFICATION_CENTER_LIMIT}
-                    anchorOrigin={{
-                      vertical: 'top',
-                      horizontal: 'left',
-                    }}
-                  >
-                    <ExpandIcon color="border" />
-                  </UnreadBadge>
-                </IconButton>
-                <Typography sx={{ color: ({ palette }) => palette.border.main }}>
-                  {showAll ? 'Hide' : `${notifications.length - NOTIFICATION_CENTER_LIMIT} other notifications`}
-                </Typography>
-              </>
+            <Typography data-testid="notifications-title" variant="h4" component="span" fontWeight={700}>
+              Notifications
+            </Typography>
+            {hasUnread && (
+              <Typography variant="caption" className={css.unreadCount}>
+                {unreadCount}
+              </Typography>
             )}
+          </div>
+          {notifications.length > 0 && (
+            <MuiLink onClick={handleClear} variant="body2" component="button" sx={{ textDecoration: 'unset' }}>
+              Clear all
+            </MuiLink>
+          )}
+        </div>
 
-            {hasPushNotifications && (
-              <Link
-                href={{
-                  pathname: AppRoutes.settings.notifications,
-                  query: router.query,
-                }}
-                passHref
-                legacyBehavior
-              >
-                <MuiLink
-                  data-testid="notifications-button"
-                  className={css.settingsLink}
-                  variant="body2"
-                  onClick={onSettingsClick}
+        <div>
+          <NotificationCenterList notifications={notificationsToShow} handleClose={handleClose} />
+        </div>
+
+        <div className={css.popoverFooter}>
+          {canExpand && (
+            <>
+              <IconButton onClick={() => setShowAll((prev) => !prev)} disableRipple className={css.expandButton}>
+                <UnreadBadge
+                  invisible={showAll || unreadCount <= NOTIFICATION_CENTER_LIMIT}
+                  anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'left',
+                  }}
                 >
-                  <SvgIcon component={SettingsIcon} inheritViewBox fontSize="small" /> Push notifications settings
-                </MuiLink>
-              </Link>
-            )}
-          </div>
-        </Paper>
+                  <ExpandIcon color="border" />
+                </UnreadBadge>
+              </IconButton>
+              <Typography sx={{ color: ({ palette }) => palette.border.main }}>
+                {showAll ? 'Hide' : `${notifications.length - NOTIFICATION_CENTER_LIMIT} other notifications`}
+              </Typography>
+            </>
+          )}
+
+          {hasPushNotifications && (
+            <Link
+              href={{
+                pathname: AppRoutes.settings.notifications,
+                query: router.query,
+              }}
+              passHref
+              legacyBehavior
+            >
+              <MuiLink
+                data-testid="notifications-button"
+                className={css.settingsLink}
+                variant="body2"
+                onClick={onSettingsClick}
+              >
+                <SvgIcon component={SettingsIcon} inheritViewBox fontSize="small" /> Push notifications settings
+              </MuiLink>
+            </Link>
+          )}
+        </div>
       </Popover>
     </>
   )

--- a/apps/web/src/components/notification-center/NotificationCenter/styles.module.css
+++ b/apps/web/src/components/notification-center/NotificationCenter/styles.module.css
@@ -11,6 +11,7 @@
 .popoverContainer {
   width: 446px;
   border: 1px solid var(--color-border-light);
+  border-radius: 24px;
 }
 
 @media (max-width: 599.95px) {


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/WA-2059/double-corners-on-the-notifications-pop-up

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
