### PR TITLE
fix: fix batch tx popup is cut by transaction modal

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
@@ -26,7 +26,6 @@ import ChainIndicator from '@/components/common/ChainIndicator'
 import SafeInfo from '@/components/tx-flow/common/SafeInfo'
 import SafeShieldWidget from '@/features/safe-shield'
 import { SafeShieldProvider } from '@/features/safe-shield/SafeShieldContext'
-import { cn } from '@/utils/cn'
 
 export const TxLayoutHeader = ({
   hideNonce,

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -41,9 +41,10 @@ function PopoverContent({
   alignOffset = 0,
   side = 'bottom',
   sideOffset = 4,
+  anchor,
   ...props
 }: PopoverPrimitive.Popup.Props &
-  Pick<PopoverPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset'>) {
+  Pick<PopoverPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset' | 'anchor'>) {
   const portalContainer = usePortalContainer()
   return (
     <PopoverPrimitive.Portal container={portalContainer}>
@@ -52,6 +53,7 @@ function PopoverContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
+        anchor={anchor}
         className="isolate z-[var(--z-overlay)]"
       >
         <PopoverPrimitive.Popup

--- a/apps/web/src/features/batching/components/BatchTooltip/index.tsx
+++ b/apps/web/src/features/batching/components/BatchTooltip/index.tsx
@@ -1,38 +1,42 @@
-import { type ReactElement, useEffect, useState } from 'react'
+import { type ReactElement, useEffect, useRef, useState } from 'react'
 import { CircleCheck } from 'lucide-react'
+import { Popover, PopoverContent } from '@/components/ui/popover'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
 
 /**
  * Notification tooltip that appears when a transaction is added to the batch.
- * Subscribes to TxEvent.BATCH_ADD and shows a success message.
- * Dismisses on any click (including clicking the tooltip itself).
+ * Subscribes to TxEvent.BATCH_ADD and shows a success message anchored to the
+ * batch indicator. Renders via portal so it escapes the topbar's stacking
+ * context and layers above any open tx modal. Dismisses on any click.
  */
 const BatchTooltip = ({ children }: { children: ReactElement }) => {
-  const [show, setShow] = useState(false)
+  const [open, setOpen] = useState(false)
+  const anchorRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    return txSubscribe(TxEvent.BATCH_ADD, () => setShow(true))
+    return txSubscribe(TxEvent.BATCH_ADD, () => setOpen(true))
   }, [])
 
   useEffect(() => {
-    if (!show) return
-    const dismiss = () => setShow(false)
+    if (!open) return
+    const dismiss = () => setOpen(false)
     document.addEventListener('click', dismiss)
     return () => document.removeEventListener('click', dismiss)
-  }, [show])
+  }, [open])
 
   return (
-    <div className="relative">
-      {children}
-      {show && (
-        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 z-[var(--z-overlay)] rounded-md border border-border bg-popover p-4 shadow-md animate-in fade-in-0 zoom-in-95">
+    <>
+      <div ref={anchorRef}>{children}</div>
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverContent anchor={anchorRef} side="bottom" align="center" sideOffset={8} className="w-auto p-4">
           <div className="flex flex-col items-center gap-2">
             <CircleCheck className="size-[53px] text-[var(--color-success-main)]" />
             <span className="text-base font-bold whitespace-nowrap">Transaction is added to batch</span>
           </div>
-        </div>
-      )}
-    </div>
+        </PopoverContent>
+      </Popover>
+    </>
   )
 }
 


### PR DESCRIPTION
## What it solves

Resolves:
https://linear.app/safe-global/issue/WA-2068/add-to-batched-txs-list-in-the-header-is-broken
The "Transaction is added to batch" success popup was hidden behind the transaction modal on the transactions page. Users only saw a thin slice of the green check icon peeking out below the topbar.

## How this PR fixes it

**Root cause:** `.topbar` in [`PageLayout/styles.module.css`](apps/web/src/components/common/PageLayout/styles.module.css) uses `position: absolute; z-index: 1`, which creates a stacking context. The popup's inner `z-index: 1400` was trapped inside that context. Meanwhile `TxModalDialog` portals to `document.body` with `z-index: 3`. At the root stacking order: topbar (1) < dialog (3), so the entire topbar subtree (popup included) sits below the dialog.

**Fix:** render the popup through base-ui's `Popover.Portal` (into `document.body`) so it escapes the topbar stacking context. At the root level, popup (1400) > dialog (3), so it wins.

Changes:
- [`apps/web/src/features/batching/components/BatchTooltip/index.tsx`](apps/web/src/features/batching/components/BatchTooltip/index.tsx) — rewritten with `Popover` + `PopoverContent` anchored to a ref. No `PopoverTrigger`, so the Layers button's existing `onClick` (open BatchSidebar) keeps working untouched.
- [`apps/web/src/components/ui/popover.tsx`](apps/web/src/components/ui/popover.tsx) — `PopoverContent` now forwards an optional `anchor` prop to `Positioner` (mirrors the existing pattern in [`combobox.tsx`](apps/web/src/components/ui/combobox.tsx)).

## How to test it

1. Open a Safe with a draft batch containing ≥1 transaction.
2. Trigger any `BATCH_ADD` event while a `TxModalDialog` is open (e.g. add a tx to batch from the New Transaction flow).
3. The "Transaction is added to batch" popup should appear below the batch icon in the topbar, fully visible above the modal.
4. Click anywhere → popup dismisses.
5. Click the batch icon itself → BatchSidebar still opens.

## Affected flows

- Batch add notification — appears whenever a transaction is added to the draft batch.

## Blast radius

- `BatchTooltip` — only consumer is [`HeaderNavigation`](apps/web/src/features/spaces/components/HeaderNavigation/HeaderNavigation.tsx) (one call site). Public API (`{ children: ReactElement }`) unchanged.
- `PopoverContent` — added optional `anchor` prop, backward compatible. All existing callers (sidebar profile, stories, etc.) omit it and behave identically.
- No Redux / RTK Query / feature flag / route / persistence changes.
- Mobile: shared packages untouched; this component is web-only.

## Risks / not checked

- Did not add an automated regression test — the bug is a stacking-context / layout issue, which jsdom doesn't render. Proper coverage needs Cypress visual/e2e.

## Visual summary
<img width="1280" height="479" alt="Screenshot 2026-04-24 at 18 12 53" src="https://github.com/user-attachments/assets/ec052a11-e5bb-49f1-9ded-60c7eabb61b0" />

```mermaid
flowchart TB
  subgraph Before["Before — popup trapped inside topbar stacking context"]
    direction TB
    B_root["Root stacking order"]
    B_topbar["topbar (position: absolute, z-index: 1)<br/>└─ BatchTooltip popup (z-index: 1400, capped inside)"]
    B_dialog["TxModalDialog portal (z-index: 3) ← covers popup"]
    B_root --> B_topbar
    B_root --> B_dialog
  end

  subgraph After["After — popup portals to body, escapes the cap"]
    direction TB
    A_root["Root stacking order"]
    A_topbar["topbar (z-index: 1)<br/>└─ anchor ref only"]
    A_dialog["TxModalDialog portal (z-index: 3)"]
    A_popup["BatchTooltip Popover.Portal (z-index: 1400) ← above dialog"]
    A_root --> A_topbar
    A_root --> A_dialog
    A_root --> A_popup
  end
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — bug is layout-level; needs visual/e2e, see "Risks"
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).