### PR TITLE
fix(web/Spaces): tooltip only on hover

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
@@ -100,7 +100,7 @@ export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: Na
     menuButton
   ) : (
     <Tooltip>
-      <TooltipTrigger className="block w-full">{menuButton}</TooltipTrigger>
+      <TooltipTrigger render={<span className="block w-full" />}>{menuButton}</TooltipTrigger>
       {item.disabled && <TooltipContent side="right">You need to activate your Safe first.</TooltipContent>}
     </Tooltip>
   )


### PR DESCRIPTION
## What it solves

Resolves: [WA-2060](https://linear.app/safe-global/issue/WA-2060/your-need-to-activate-you-space-tooltip-is-displayed-by-default)
The tooltip in t he sidebar items was shown always for CF safes, not only on hover.

Before:
<img width="643" height="586" alt="image" src="https://github.com/user-attachments/assets/f1265076-3c5a-45ed-9c27-ee1ec3f491d2" />

After:
<img width="670" height="574" alt="image" src="https://github.com/user-attachments/assets/24baea2c-8500-4e1b-9382-4971cad6eba8" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
