### PR TITLE
chore: Replace POST /v1/spaces/create-with-user with  POST /v1/spaces

### DIFF
--- a/apps/web/src/features/spaces/components/CreateSpaceOnboarding/hooks/useSpaceSubmit.test.ts
+++ b/apps/web/src/features/spaces/components/CreateSpaceOnboarding/hooks/useSpaceSubmit.test.ts
@@ -35,7 +35,7 @@ jest.mock('@/store/notificationsSlice', () => ({
 }))
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
-  useSpacesCreateWithUserV1Mutation: () => [mockCreateSpaceWithUser],
+  useSpacesCreateV1Mutation: () => [mockCreateSpaceWithUser],
   useSpacesUpdateV1Mutation: () => [mockUpdateSpace],
 }))
 

--- a/apps/web/src/features/spaces/components/CreateSpaceOnboarding/hooks/useSpaceSubmit.ts
+++ b/apps/web/src/features/spaces/components/CreateSpaceOnboarding/hooks/useSpaceSubmit.ts
@@ -1,9 +1,6 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
-import {
-  useSpacesCreateWithUserV1Mutation,
-  useSpacesUpdateV1Mutation,
-} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useSpacesCreateV1Mutation, useSpacesUpdateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useAppDispatch } from '@/store'
 import { setLastUsedSpace } from '@/store/authSlice'
 import { showNotification } from '@/store/notificationsSlice'
@@ -22,7 +19,7 @@ const useSpaceSubmit = (
   const [isSubmitting, setIsSubmitting] = useState(false)
   const router = useRouter()
   const dispatch = useAppDispatch()
-  const [createSpaceWithUser] = useSpacesCreateWithUserV1Mutation()
+  const [createSpaceWithUser] = useSpacesCreateV1Mutation()
   const [updateSpace] = useSpacesUpdateV1Mutation()
 
   const editSpace = async (name: string) => {

--- a/apps/web/src/features/spaces/components/SpaceCreationModal/SpaceCreationModal.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCreationModal/SpaceCreationModal.test.tsx
@@ -32,7 +32,7 @@ jest.mock('@/store/notificationsSlice', () => ({
 }))
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
-  useSpacesCreateWithUserV1Mutation: () => [mockCreateSpaceWithUser],
+  useSpacesCreateV1Mutation: () => [mockCreateSpaceWithUser],
 }))
 
 jest.mock('@/components/common/NameInput', () => ({

--- a/apps/web/src/features/spaces/components/SpaceCreationModal/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCreationModal/index.tsx
@@ -1,4 +1,4 @@
-import { useSpacesCreateWithUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useSpacesCreateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useRouter } from 'next/router'
 import { type ReactElement, useState } from 'react'
 import { Alert, Box, Button, CircularProgress, DialogActions, DialogContent, SvgIcon, Typography } from '@mui/material'
@@ -19,7 +19,7 @@ function SpaceCreationModal({ onClose }: { onClose: () => void }): ReactElement 
   const router = useRouter()
   const dispatch = useAppDispatch()
   const methods = useForm<{ name: string }>({ mode: 'onChange' })
-  const [createSpaceWithUser] = useSpacesCreateWithUserV1Mutation()
+  const [createSpaceWithUser] = useSpacesCreateV1Mutation()
   const { handleSubmit, formState } = methods
 
   const onSubmit = handleSubmit(async (data) => {


### PR DESCRIPTION
## What it solves

The endpoints are identical, so POST `/v1/spaces/create-with-user` is being deprecated

Resolves: [WA-1914](https://linear.app/safe-global/issue/WA-1914/deprecate-create-with-user-endpoint-update-frontend-to-use-spaces-post)

## How this PR fixes it
Replace all occurrences of `POST /v1/spaces/create-with-user` with `POST /v1/spaces`

## How to test it
Creation of a new space should work as before, no changes

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
