### PR TITLE
feat(gtf): track gas payment source on tx events

### DIFF
--- a/apps/web/src/components/tx-flow/TxFlowProvider.tsx
+++ b/apps/web/src/components/tx-flow/TxFlowProvider.tsx
@@ -165,7 +165,7 @@ const TxFlowProvider = <T extends unknown>({
   const { safe } = useSafeInfo()
   const isProposer = useIsWalletProposer()
   const chainId = useChainId()
-  const { safeTx, txOrigin } = useContext(SafeTxContext)
+  const { safeTx, txOrigin, gtfPaymentMode } = useContext(SafeTxContext)
   const isCorrectNonce = useValidateNonce(safeTx)
   const { transactionExecution } = useAppSelector(selectSettings)
   const [shouldExecute, setShouldExecute] = useState<boolean>(transactionExecution)
@@ -206,7 +206,16 @@ const TxFlowProvider = <T extends unknown>({
   }, [])
 
   const isGtfChain = useHasFeature(FEATURES.GTF) ?? false
-  const gasPaymentSource = isGtfChain && safeTx ? (isGtfSafePaid(safeTx.data) ? 'safe' : 'signing_wallet') : undefined
+  const gasPaymentSource =
+    !isGtfChain || !safeTx
+      ? undefined
+      : safeTx.signatures.size > 0
+        ? isGtfSafePaid(safeTx.data)
+          ? 'safe'
+          : 'signing_wallet'
+        : gtfPaymentMode === 'safe'
+          ? 'safe'
+          : 'signing_wallet'
 
   const trackTxEvent = useCallback(
     async (txId: string, isExecuted = false, isRoleExecution = false, isProposerCreation = false) => {

--- a/apps/web/src/components/tx-flow/TxFlowProvider.tsx
+++ b/apps/web/src/components/tx-flow/TxFlowProvider.tsx
@@ -30,6 +30,9 @@ import { useIsCounterfactualSafe } from '@/features/counterfactual'
 import useTxDetails from '@/hooks/useTxDetails'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useSafeShield } from '@/features/safe-shield/SafeShieldContext'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { isGtfSafePaid } from '@/features/gtf/utils/isGtfSafePaid'
 
 export type TxFlowContextType<T extends unknown = any> = {
   step: number
@@ -202,6 +205,9 @@ const TxFlowProvider = <T extends unknown>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const isGtfChain = useHasFeature(FEATURES.GTF) ?? false
+  const gasPaymentSource = isGtfChain && safeTx ? (isGtfSafePaid(safeTx.data) ? 'safe' : 'signing_wallet') : undefined
+
   const trackTxEvent = useCallback(
     async (txId: string, isExecuted = false, isRoleExecution = false, isProposerCreation = false) => {
       const { data: details } = await trigger({ chainId, id: txId })
@@ -218,9 +224,10 @@ const TxFlowProvider = <T extends unknown>({
         txOrigin,
         isMassPayout,
         safe.threshold,
+        gasPaymentSource,
       )
     },
-    [chainId, isCreation, trigger, signer?.isSafe, txOrigin, data, safe.threshold],
+    [chainId, isCreation, trigger, signer?.isSafe, txOrigin, data, safe.threshold, gasPaymentSource],
   )
 
   const value = {

--- a/apps/web/src/components/tx/shared/tracking.test.ts
+++ b/apps/web/src/components/tx/shared/tracking.test.ts
@@ -274,6 +274,78 @@ describe('trackTxEvents', () => {
     })
   })
 
+  describe('gasPaymentSource property', () => {
+    it('attaches Gas Payment Source to creation event when provided', () => {
+      trackTxEvents(
+        baseDetails,
+        true, // isCreation
+        false, // isExecuted
+        false,
+        false,
+        false,
+        undefined,
+        false,
+        2,
+        'safe',
+      )
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ action: TX_EVENTS.CREATE.action }),
+        expect.objectContaining({
+          [MixpanelEventParams.GAS_PAYMENT_SOURCE]: 'safe',
+        }),
+      )
+    })
+
+    it('attaches Gas Payment Source to execution event when provided', () => {
+      trackTxEvents(
+        baseDetails,
+        false, // isCreation
+        true, // isExecuted
+        false,
+        false,
+        false,
+        undefined,
+        false,
+        2,
+        'signing_wallet',
+      )
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ action: TX_EVENTS.EXECUTE.action }),
+        expect.objectContaining({
+          [MixpanelEventParams.GAS_PAYMENT_SOURCE]: 'signing_wallet',
+        }),
+      )
+    })
+
+    it('attaches Gas Payment Source to both events when isCreation and isExecuted are both true', () => {
+      trackTxEvents(baseDetails, true, true, false, false, false, undefined, false, 1, 'safe')
+
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ action: TX_EVENTS.CREATE.action }),
+        expect.objectContaining({ [MixpanelEventParams.GAS_PAYMENT_SOURCE]: 'safe' }),
+      )
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ action: TX_EVENTS.EXECUTE.action }),
+        expect.objectContaining({ [MixpanelEventParams.GAS_PAYMENT_SOURCE]: 'safe' }),
+      )
+    })
+
+    it('omits Gas Payment Source when arg is undefined', () => {
+      trackTxEvents(baseDetails, true, false, false, false, false, undefined, false, 2)
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ action: TX_EVENTS.CREATE.action }),
+        expect.not.objectContaining({
+          [MixpanelEventParams.GAS_PAYMENT_SOURCE]: expect.anything(),
+        }),
+      )
+    })
+  })
+
   describe('execution variants (Transaction Executed)', () => {
     it('should track EXECUTE_VIA_PARENT with Mixpanel properties when isParentSigner is true', () => {
       trackTxEvents(

--- a/apps/web/src/components/tx/shared/tracking.ts
+++ b/apps/web/src/components/tx/shared/tracking.ts
@@ -51,6 +51,7 @@ export function trackTxEvents(
   origin?: string,
   isMassPayout: boolean = false,
   threshold?: number,
+  gasPaymentSource?: 'safe' | 'signing_wallet',
 ) {
   const isNestedConfirmation = !!details && isNestedConfirmationTxInfo(details.txInfo)
 
@@ -67,6 +68,9 @@ export function trackTxEvents(
     }
     if (threshold !== undefined) {
       properties[MixpanelEventParams.THRESHOLD] = threshold
+    }
+    if (gasPaymentSource !== undefined) {
+      properties[MixpanelEventParams.GAS_PAYMENT_SOURCE] = gasPaymentSource
     }
     return properties
   }

--- a/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
+++ b/apps/web/src/features/speedup/components/SpeedUpModal/index.tsx
@@ -20,9 +20,10 @@ import { isWalletRejection } from '@/utils/wallets'
 import { type TransactionOptions } from '@safe-global/types-kit'
 import { PendingTxType, type PendingProcessingTx } from '@/store/pendingTxsSlice'
 import useAsync from '@safe-global/utils/hooks/useAsync'
-import { MODALS_EVENTS, trackEvent } from '@/services/analytics'
+import { MODALS_EVENTS, trackEvent, MixpanelEventParams } from '@/services/analytics'
 import { TX_EVENTS } from '@/services/analytics/events/transactions'
 import { getTransactionTrackingType } from '@/services/analytics/tx-tracking'
+import { isGtfSafePaid } from '@/features/gtf/utils/isGtfSafePaid'
 import { trackError } from '@/services/exceptions'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'
 import CheckWallet from '@/components/common/CheckWallet'
@@ -44,6 +45,7 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
   const [speedUpFee] = useGasPrice(true)
   const [waitingForConfirmation, setWaitingForConfirmation] = useState(false)
   const isEIP1559 = useHasFeature(FEATURES.EIP1559)
+  const isGtfChain = useHasFeature(FEATURES.GTF) ?? false
 
   const wallet = useWallet()
   const onboard = useOnboard()
@@ -94,7 +96,11 @@ const SpeedUpModal = ({ open, handleClose, pendingTx, txId, txHash, signerAddres
         )
         const { data: details } = await trigger({ chainId: chainInfo.chainId, id: txId })
         const txType = getTransactionTrackingType(details)
-        trackEvent({ ...TX_EVENTS.SPEED_UP, label: txType })
+        const gasPaymentSource = isGtfChain ? (isGtfSafePaid(safeTx.data) ? 'safe' : 'signing_wallet') : undefined
+        trackEvent(
+          { ...TX_EVENTS.SPEED_UP, label: txType },
+          gasPaymentSource ? { [MixpanelEventParams.GAS_PAYMENT_SOURCE]: gasPaymentSource } : undefined,
+        )
       } else {
         await dispatchCustomTxSpeedUp(
           txOptions as Omit<TransactionOptions, 'nonce'> & { nonce: number },

--- a/apps/web/src/services/analytics/mixpanel-events.ts
+++ b/apps/web/src/services/analytics/mixpanel-events.ts
@@ -99,6 +99,7 @@ export enum MixpanelEventParams {
   CHAIN_ID = 'Chain ID',
   TX_ID = 'TX ID',
   SAFE_SELECTOR_DROPDOWN = 'Safe Selector Dropdown',
+  GAS_PAYMENT_SOURCE = 'Gas Payment Source',
 }
 
 export enum SafeAppLaunchLocation {


### PR DESCRIPTION
> two events, one new prop:
> 'safe' or 'signing_wallet' on GTF txs,
> derived from safeTx.data.

## What it solves

Resolves [PLA-1246](https://linear.app/safe-global/issue/PLA-1246) — the analytics-tracking portion. The on-chain tracking spike is split out and will be filed as a separate ticket.

Today we cannot answer \"what fraction of GTF transactions pay gas from the Safe vs from the signing wallet?\" in Mixpanel. This PR adds the signal.

## How this PR fixes it

- Adds \`MixpanelEventParams.GAS_PAYMENT_SOURCE = 'Gas Payment Source'\`.
- Threads an optional \`gasPaymentSource: 'safe' | 'signing_wallet'\` arg through \`trackTxEvents\` (the funnel covering 8 of the create/execute variants); merged into Mixpanel properties only when defined.
- \`TxFlowProvider\` computes the value from \`useHasFeature(FEATURES.GTF)\` + \`isGtfSafePaid(safeTx.data)\` and passes it in.
- \`SpeedUpModal\` (SAFE_TX branch) does the same, since speed-up is a separate dispatch site outside the funnel.
- All other dispatch sites (counterfactual, spending-limit, bulk execute, sign-message, custom speed-up) are unchanged — they have no \`safeTx\` and naturally emit no \`gas_payment_source\`.

### Why a chain-feature gate is needed (correction to original brainstorm)

\`isGtfSafePaid(safeTx.data)\` returns \`false\` for both **(i) GTF tx paid from signer** (\`baseGas: 0\`, regular Safe tx) and **(ii) non-GTF tx** — they're indistinguishable on the wire. Without \`useHasFeature(FEATURES.GTF)\` we couldn't emit \`'signing_wallet'\` correctly.

## How to test it

1. On a GTF-enabled chain (e.g. Sepolia per current config), open a tx flow and submit. In Mixpanel, look for \`Transaction Submitted\` with property \`Gas Payment Source: 'safe'\` (default).
2. Toggle \"Pay fees from\" → \"Signer\" before signing → resubmit. Property should be \`'signing_wallet'\`.
3. On a non-GTF chain, submit a tx → property is absent on \`Transaction Submitted\` / \`Transaction Executed\`.
4. Speed up a pending GTF SAFE_TX → property present on the \`Transaction Executed\` event.
5. Spending-limit / counterfactual / sign-message flows → property absent.

## Affected flows

- All 8 main-funnel variants on GTF chains: CREATE, CREATE_VIA_ROLE, CREATE_VIA_PROPOSER, CREATE_VIA_PARENT, EXECUTE, EXECUTE_VIA_ROLE, EXECUTE_VIA_PARENT, EXECUTE_IN_PARENT
- Speed-up (SAFE_TX branch) on GTF chains

## Blast radius

- New Mixpanel param key \`'Gas Payment Source'\` (additive — Mixpanel auto-learns the schema; no migration)
- \`trackTxEvents\` signature gains a 10th positional arg (optional, default undefined). Existing call sites compile unchanged
- 5 files modified; no Redux / persistence changes; no UI changes
- Mobile: not affected (web-only feature)

## Risks / not checked

- Did not exercise real Mixpanel ingestion — relying on type-check + 4 new unit tests for property shape correctness
- Did not run Cypress E2E
- Did not manually QA every nested-safe / role / proposer code path on a live GTF chain
- Data team should be aware that \`Gas Payment Source\` is a new property on these events

## Visual summary

\`\`\`mermaid
flowchart LR
  subgraph Caller[TxFlowProvider / SpeedUpModal]
    Chain[useHasFeature FEATURES.GTF] --> Gate
    Tx[safeTx.data] --> Gate
    Gate{isGtfChain && safeTx?}
  end
  Gate -->|no| Omit[undefined → property omitted]
  Gate -->|yes| Detect{isGtfSafePaid}
  Detect -->|true| Safe['safe']
  Detect -->|false| Signer['signing_wallet']
  Safe --> Track[trackTxEvents / trackEvent]
  Signer --> Track
  Track --> Mix[Mixpanel: TRANSACTION_SUBMITTED / TRANSACTION_EXECUTED]
\`\`\`

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A (web-only)
- [x] I've documented how it affects the analytics 📊 — new \`Gas Payment Source\` Mixpanel property; data team to be notified
- [x] I've written a unit/e2e test for it 🧑‍💻 — 4 new cases in \`tracking.test.ts\` (creation event, execution event, both events, omission when undefined)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).