### PR TITLE
tests(mobile): e2e coverage for WalletConnectGate flows

### DIFF
--- a/apps/mobile/docs/e2e-tests-guidelines.md
+++ b/apps/mobile/docs/e2e-tests-guidelines.md
@@ -14,6 +14,12 @@ This document outlines best practices for writing and maintaining end-to-end tes
   - **Screen:** `settings-screen`
 - **Uniqueness:** It's virtually impossible to have unique testIDs across the app. We should make sure that every screen
   has unique testIDs.
+- **Exception — TestCtrls triggers:** The hidden buttons in
+  [`TestCtrls.e2e.tsx`](../src/tests/e2e-maestro/components/TestCtrls.e2e.tsx)
+  that seed Redux state for a scenario use the `e2e<PascalCase>` form
+  (e.g. `e2eConnectSignerOwner`, `e2eWcGateReconnect`). These IDs only
+  exist in e2e builds and are scoped to test setup, so they are kept
+  visually distinct from product testIDs.
 
 ---
 

--- a/apps/mobile/e2e/tests/connect-signer/__suite__.yml
+++ b/apps/mobile/e2e/tests/connect-signer/__suite__.yml
@@ -1,0 +1,19 @@
+appId: ${APP_ID}
+tags:
+  - connect-signer
+  - suite
+---
+# Connect Signer Test Suite
+# Runs all connect signer and WalletConnect gate tests
+
+- runFlow:
+    file: ./connect-signer-success.yml
+
+- runFlow:
+    file: ./connect-signer-not-owner.yml
+
+- runFlow:
+    file: ./wc-gate-reconnect.yml
+
+- runFlow:
+    file: ./wc-gate-switch-network.yml

--- a/apps/mobile/e2e/tests/connect-signer/__suite__.yml
+++ b/apps/mobile/e2e/tests/connect-signer/__suite__.yml
@@ -1,6 +1,7 @@
 appId: ${APP_ID}
 tags:
   - connect-signer
+  - wc-gate
   - suite
 ---
 # Connect Signer Test Suite

--- a/apps/mobile/e2e/tests/connect-signer/wc-gate-reconnect.yml
+++ b/apps/mobile/e2e/tests/connect-signer/wc-gate-reconnect.yml
@@ -9,40 +9,10 @@ tags:
 - runFlow:
     file: ../../utils/setup/app-start.yml
 
-# Setup: onboard with pending tx safe, WC signer with expired session
-- tapOn:
-    id: 'e2eWcGateReconnect'
-
-# Wait for pending transactions list to load
-- extendedWaitUntil:
-    visible:
-      id: 'pending-tx-list'
-    timeout: 10000
-
-# Tap on the first pending transaction (Send)
-- extendedWaitUntil:
-    visible:
-      text: 'Send'
-    timeout: 10000
-- tapOn:
-    text: 'Send'
-    index: 0
-
-# Wait for the Confirm transaction screen
-- extendedWaitUntil:
-    visible:
-      text: 'Confirm transaction'
-    timeout: 10000
-
-# Tap Continue to navigate to the review screen
-- assertVisible:
-    text: 'Continue'
-- tapOn:
-    text: 'Continue'
-
-# Wait for the review screen to load
-- waitForAnimationToEnd:
-    timeout: 2000
+- runFlow:
+    file: ../../utils/setup/open-review-and-execute.yml
+    env:
+      SETUP_BUTTON_ID: 'e2eWcGateReconnect'
 
 # Verify the WalletConnect gate shows "Reconnect wallet to continue"
 # instead of the normal execute/confirm button

--- a/apps/mobile/e2e/tests/connect-signer/wc-gate-reconnect.yml
+++ b/apps/mobile/e2e/tests/connect-signer/wc-gate-reconnect.yml
@@ -1,0 +1,65 @@
+appId: ${APP_ID}
+tags:
+  - connect-signer
+  - wc-gate
+---
+# WalletConnect Gate: Session expired → "Reconnect wallet to continue"
+# Uses pendingTxSafe1 with a WC signer whose session is NOT active.
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+# Setup: onboard with pending tx safe, WC signer with expired session
+- tapOn:
+    id: 'e2eWcGateReconnect'
+
+# Wait for pending transactions list to load
+- extendedWaitUntil:
+    visible:
+      id: 'pending-tx-list'
+    timeout: 10000
+
+# Tap on the first pending transaction (Send)
+- extendedWaitUntil:
+    visible:
+      text: 'Send'
+    timeout: 10000
+- tapOn:
+    text: 'Send'
+    index: 0
+
+# Wait for the Confirm transaction screen
+- extendedWaitUntil:
+    visible:
+      text: 'Confirm transaction'
+    timeout: 10000
+
+# Tap Continue to navigate to the review screen
+- assertVisible:
+    text: 'Continue'
+- tapOn:
+    text: 'Continue'
+
+# Wait for the review screen to load
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# Verify the WalletConnect gate shows "Reconnect wallet to continue"
+# instead of the normal execute/confirm button
+- extendedWaitUntil:
+    visible:
+      id: 'reconnect-wallet-button'
+    timeout: 10000
+- assertVisible: 'Reconnect wallet to continue'
+
+# Tap "Reconnect wallet to continue" — the e2e mock marks the session active
+- tapOn:
+    id: 'reconnect-wallet-button'
+
+# Verify the gate is dismissed and the normal execute button appears
+- extendedWaitUntil:
+    visible:
+      text: '.*(Execute transaction|Insufficient funds).*'
+    timeout: 10000
+- assertNotVisible:
+    id: 'reconnect-wallet-button'

--- a/apps/mobile/e2e/tests/connect-signer/wc-gate-reconnect.yml
+++ b/apps/mobile/e2e/tests/connect-signer/wc-gate-reconnect.yml
@@ -26,10 +26,9 @@ tags:
 - tapOn:
     id: 'reconnect-wallet-button'
 
-# Verify the gate is dismissed and the normal execute button appears
+# Verify the gate is dismissed (the underlying execute/insufficient-funds
+# button is intentionally not asserted — those are distinct semantic states)
 - extendedWaitUntil:
-    visible:
-      text: '.*(Execute transaction|Insufficient funds).*'
+    notVisible:
+      id: 'reconnect-wallet-button'
     timeout: 10000
-- assertNotVisible:
-    id: 'reconnect-wallet-button'

--- a/apps/mobile/e2e/tests/connect-signer/wc-gate-switch-network.yml
+++ b/apps/mobile/e2e/tests/connect-signer/wc-gate-switch-network.yml
@@ -26,10 +26,9 @@ tags:
 - tapOn:
     id: 'switch-network-button'
 
-# Verify the gate is dismissed and the normal execute button appears
+# Verify the gate is dismissed (the underlying execute/insufficient-funds
+# button is intentionally not asserted — those are distinct semantic states)
 - extendedWaitUntil:
-    visible:
-      text: '.*(Execute transaction|Insufficient funds).*'
+    notVisible:
+      id: 'switch-network-button'
     timeout: 10000
-- assertNotVisible:
-    id: 'switch-network-button'

--- a/apps/mobile/e2e/tests/connect-signer/wc-gate-switch-network.yml
+++ b/apps/mobile/e2e/tests/connect-signer/wc-gate-switch-network.yml
@@ -9,40 +9,10 @@ tags:
 - runFlow:
     file: ../../utils/setup/app-start.yml
 
-# Setup: onboard with pending tx safe, WC signer on wrong network
-- tapOn:
-    id: 'e2eWcGateWrongNetwork'
-
-# Wait for pending transactions list to load
-- extendedWaitUntil:
-    visible:
-      id: 'pending-tx-list'
-    timeout: 10000
-
-# Tap on the first pending transaction (Send)
-- extendedWaitUntil:
-    visible:
-      text: 'Send'
-    timeout: 10000
-- tapOn:
-    text: 'Send'
-    index: 0
-
-# Wait for the Confirm transaction screen
-- extendedWaitUntil:
-    visible:
-      text: 'Confirm transaction'
-    timeout: 10000
-
-# Tap Continue to navigate to the review screen
-- assertVisible:
-    text: 'Continue'
-- tapOn:
-    text: 'Continue'
-
-# Wait for the review screen to load
-- waitForAnimationToEnd:
-    timeout: 2000
+- runFlow:
+    file: ../../utils/setup/open-review-and-execute.yml
+    env:
+      SETUP_BUTTON_ID: 'e2eWcGateWrongNetwork'
 
 # Verify the WalletConnect gate shows "Switch network to continue"
 # instead of the normal execute/confirm button

--- a/apps/mobile/e2e/tests/connect-signer/wc-gate-switch-network.yml
+++ b/apps/mobile/e2e/tests/connect-signer/wc-gate-switch-network.yml
@@ -1,0 +1,65 @@
+appId: ${APP_ID}
+tags:
+  - connect-signer
+  - wc-gate
+---
+# WalletConnect Gate: Wrong network → "Switch network to continue"
+# Uses pendingTxSafe1 with a WC signer connected on the wrong chain.
+
+- runFlow:
+    file: ../../utils/setup/app-start.yml
+
+# Setup: onboard with pending tx safe, WC signer on wrong network
+- tapOn:
+    id: 'e2eWcGateWrongNetwork'
+
+# Wait for pending transactions list to load
+- extendedWaitUntil:
+    visible:
+      id: 'pending-tx-list'
+    timeout: 10000
+
+# Tap on the first pending transaction (Send)
+- extendedWaitUntil:
+    visible:
+      text: 'Send'
+    timeout: 10000
+- tapOn:
+    text: 'Send'
+    index: 0
+
+# Wait for the Confirm transaction screen
+- extendedWaitUntil:
+    visible:
+      text: 'Confirm transaction'
+    timeout: 10000
+
+# Tap Continue to navigate to the review screen
+- assertVisible:
+    text: 'Continue'
+- tapOn:
+    text: 'Continue'
+
+# Wait for the review screen to load
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# Verify the WalletConnect gate shows "Switch network to continue"
+# instead of the normal execute/confirm button
+- extendedWaitUntil:
+    visible:
+      id: 'switch-network-button'
+    timeout: 10000
+- assertVisible: 'Switch network to continue'
+
+# Tap "Switch network to continue" — the e2e mock clears isWrongNetwork
+- tapOn:
+    id: 'switch-network-button'
+
+# Verify the gate is dismissed and the normal execute button appears
+- extendedWaitUntil:
+    visible:
+      text: '.*(Execute transaction|Insufficient funds).*'
+    timeout: 10000
+- assertNotVisible:
+    id: 'switch-network-button'

--- a/apps/mobile/e2e/utils/setup/open-review-and-execute.yml
+++ b/apps/mobile/e2e/utils/setup/open-review-and-execute.yml
@@ -1,0 +1,49 @@
+appId: ${APP_ID}
+tags:
+  - util
+---
+# ===========================================
+# Open Review and Execute Flow
+# ===========================================
+# Shared flow for navigating from app start to the Review and Execute screen
+# of the first pending transaction. Use after a TestCtrls button has seeded
+# Redux with a pending-tx safe and any required signer/session state.
+#
+# Environment variables:
+#   SETUP_BUTTON_ID: testID of the TestCtrls button that seeds the scenario
+#                    Example: 'e2eWcGateReconnect'
+
+# Seed Redux state for the scenario
+- tapOn:
+    id: '${SETUP_BUTTON_ID}'
+
+# Wait for pending transactions list to load
+- extendedWaitUntil:
+    visible:
+      id: 'pending-tx-list'
+    timeout: 10000
+
+# Tap on the first pending transaction (Send)
+- extendedWaitUntil:
+    visible:
+      text: 'Send'
+    timeout: 10000
+- tapOn:
+    text: 'Send'
+    index: 0
+
+# Wait for the Confirm transaction screen
+- extendedWaitUntil:
+    visible:
+      text: 'Confirm transaction'
+    timeout: 10000
+
+# Tap Continue to navigate to the review screen
+- assertVisible:
+    text: 'Continue'
+- tapOn:
+    text: 'Continue'
+
+# Wait for the review screen to load
+- waitForAnimationToEnd:
+    timeout: 2000

--- a/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.e2e.tsx
+++ b/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.e2e.tsx
@@ -105,8 +105,13 @@ export function WalletConnectProvider({ children }: WalletConnectProviderProps) 
     }
   }, [])
 
-  const reconnect = useCallback(async (_signerAddress: string) => {
-    Logger.info('[E2E] reconnect called')
+  const reconnect = useCallback(async (signerAddress: string) => {
+    Logger.info('[E2E] reconnect called — marking session active for', signerAddress)
+    walletConnectE2eState.set({
+      isConnected: true,
+      address: getAddress(signerAddress),
+      hasProvider: true,
+    })
   }, [])
 
   const switchNetwork = useCallback(async (_chainId: string) => {
@@ -114,7 +119,8 @@ export function WalletConnectProvider({ children }: WalletConnectProviderProps) 
   }, [])
 
   const switchNetworkIfNeeded = useCallback(async () => {
-    Logger.info('[E2E] switchNetworkIfNeeded called')
+    Logger.info('[E2E] switchNetworkIfNeeded called — clearing isWrongNetwork')
+    walletConnectE2eState.set({ isWrongNetwork: false })
   }, [])
 
   const sign = useCallback(async (_params: unknown): Promise<unknown> => {

--- a/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.e2e.tsx
+++ b/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.e2e.tsx
@@ -110,7 +110,6 @@ export function WalletConnectProvider({ children }: WalletConnectProviderProps) 
     walletConnectE2eState.set({
       isConnected: true,
       address: getAddress(signerAddress),
-      hasProvider: true,
     })
   }, [])
 

--- a/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
+++ b/apps/mobile/src/tests/e2e-maestro/components/TestCtrls.e2e.tsx
@@ -4,7 +4,13 @@ import { useDispatch } from 'react-redux'
 import { useRouter } from 'expo-router'
 import { useState } from 'react'
 import { setupOnboardedAccount, setupTestOnboarding, setupSeedPhraseImportAccount } from '../setup/onboardingSetup'
-import { setupConnectSignerOwner, setupConnectSignerNonOwner, switchToOwnerState } from '../setup/connectSignerSetup'
+import {
+  setupConnectSignerOwner,
+  setupConnectSignerNonOwner,
+  switchToOwnerState,
+  setupWcGateReconnect,
+  setupWcGateWrongNetwork,
+} from '../setup/connectSignerSetup'
 import { setupOnboardedAccountForAssets } from '../setup/assetsSetup'
 import { setupPositionsTestSafe } from '../setup/positionsSetup'
 import {
@@ -228,6 +234,20 @@ export function TestCtrls() {
         <Pressable
           testID="e2eSwitchToOwnerState"
           onPress={() => switchToOwnerState()}
+          accessibilityRole="button"
+          style={BTN}
+        />
+
+        {/* WalletConnect Gate Scenarios */}
+        <Pressable
+          testID="e2eWcGateReconnect"
+          onPress={() => setupWcGateReconnect(dispatch, router)}
+          accessibilityRole="button"
+          style={BTN}
+        />
+        <Pressable
+          testID="e2eWcGateWrongNetwork"
+          onPress={() => setupWcGateWrongNetwork(dispatch, router)}
           accessibilityRole="button"
           style={BTN}
         />

--- a/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
@@ -3,7 +3,7 @@ import type { Router } from 'expo-router'
 import { addSafe } from '@/src/store/safesSlice'
 import { setActiveSafe } from '@/src/store/activeSafeSlice'
 import { updatePromptAttempts } from '@/src/store/notificationsSlice'
-import { addSigner } from '@/src/store/signersSlice'
+import { addSigner, Signer } from '@/src/store/signersSlice'
 import { setActiveSigner } from '@/src/store/activeSignerSlice'
 import { setExecutionMethod } from '@/src/store/executionMethodSlice'
 import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
@@ -89,11 +89,11 @@ const setupWcGateBase = (dispatch: Dispatch, router: Router, wcOverrides: Partia
   setupBaseConfig(dispatch)
 
   // Add the signer as a WalletConnect type (not private-key)
-  const wcSigner = {
+  const wcSigner: Signer = {
     value: mockedPendingTxSignerAddress,
     name: 'WC Gate Signer',
     logoUri: null,
-    type: 'walletconnect' as const,
+    type: 'walletconnect',
     walletName: WALLET_NAME,
     walletIcon: WALLET_ICON,
   }

--- a/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
@@ -3,8 +3,22 @@ import type { Router } from 'expo-router'
 import { addSafe } from '@/src/store/safesSlice'
 import { setActiveSafe } from '@/src/store/activeSafeSlice'
 import { updatePromptAttempts } from '@/src/store/notificationsSlice'
-import { walletConnectE2eState } from '@/src/features/WalletConnect/context/walletConnectE2eState'
-import { mockedActiveAccount, mockedActiveSafeInfo } from './mockData'
+import { addSigner } from '@/src/store/signersSlice'
+import { setActiveSigner } from '@/src/store/activeSignerSlice'
+import { setExecutionMethod } from '@/src/store/executionMethodSlice'
+import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
+import {
+  walletConnectE2eState,
+  WalletConnectE2eState,
+} from '@/src/features/WalletConnect/context/walletConnectE2eState'
+import {
+  mockedActiveAccount,
+  mockedActiveSafeInfo,
+  pendingTxSafe1,
+  pendingTxSafeInfo1,
+  mockedPendingTxSignerAddress,
+} from './mockData'
+import { setupBaseConfig, setupSafe } from './setupHelpers'
 import { Address } from '@/src/types/address'
 
 /** First owner from the mocked Safe — used for the happy path. */
@@ -60,4 +74,61 @@ export const setupConnectSignerNonOwner = (dispatch: Dispatch, router: Router) =
   walletConnectE2eState.reset()
   setWcState(NON_OWNER_ADDRESS, false)
   onboardAndNavigate(dispatch, router)
+}
+
+// ---------------------------------------------------------------------------
+// WalletConnectGate E2E tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared setup for WalletConnectGate tests.
+ * Creates a pending-tx safe with a WC signer and configures the gate state.
+ */
+const setupWcGateBase = (dispatch: Dispatch, router: Router, wcOverrides: Partial<WalletConnectE2eState>) => {
+  walletConnectE2eState.reset()
+  setupBaseConfig(dispatch)
+
+  // Add the signer as a WalletConnect type (not private-key)
+  const wcSigner = {
+    value: mockedPendingTxSignerAddress,
+    name: 'WC Gate Signer',
+    logoUri: null,
+    type: 'walletconnect' as const,
+    walletName: WALLET_NAME,
+    walletIcon: WALLET_ICON,
+  }
+  dispatch(addSigner(wcSigner))
+
+  // Set up the pending tx safe and activate the WC signer
+  setupSafe(dispatch, pendingTxSafe1, pendingTxSafeInfo1, 'WC Gate Test Safe')
+  dispatch(setActiveSigner({ safeAddress: pendingTxSafe1.address, signer: wcSigner }))
+  dispatch(setActiveSafe(pendingTxSafe1))
+
+  // Force execution method to WITH_WC so relay doesn't override the gate
+  dispatch(setExecutionMethod(ExecutionMethod.WITH_WC))
+
+  // Configure the WC session / network state
+  walletConnectE2eState.set(wcOverrides)
+
+  router.replace('/pending-transactions')
+}
+
+/** Setup: WC signer with expired session → gate shows "Reconnect wallet to continue". */
+export const setupWcGateReconnect = (dispatch: Dispatch, router: Router) => {
+  setupWcGateBase(dispatch, router, {
+    isConnected: false,
+    address: undefined,
+    hasProvider: false,
+  })
+}
+
+/** Setup: WC signer connected on wrong network → gate shows "Switch network to continue". */
+export const setupWcGateWrongNetwork = (dispatch: Dispatch, router: Router) => {
+  setupWcGateBase(dispatch, router, {
+    isConnected: true,
+    address: mockedPendingTxSignerAddress,
+    walletInfo: { name: WALLET_NAME, icon: WALLET_ICON },
+    hasProvider: true,
+    isWrongNetwork: true,
+  })
 }

--- a/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
@@ -3,8 +3,7 @@ import type { Router } from 'expo-router'
 import { addSafe } from '@/src/store/safesSlice'
 import { setActiveSafe } from '@/src/store/activeSafeSlice'
 import { updatePromptAttempts } from '@/src/store/notificationsSlice'
-import { addSigner, Signer } from '@/src/store/signersSlice'
-import { setActiveSigner } from '@/src/store/activeSignerSlice'
+import { Signer } from '@/src/store/signersSlice'
 import { setExecutionMethod } from '@/src/store/executionMethodSlice'
 import { ExecutionMethod } from '@/src/features/HowToExecuteSheet/types'
 import {
@@ -18,7 +17,7 @@ import {
   pendingTxSafeInfo1,
   mockedPendingTxSignerAddress,
 } from './mockData'
-import { setupBaseConfig, setupSafe } from './setupHelpers'
+import { setupPendingTxSafe } from './setupHelpers'
 import { Address } from '@/src/types/address'
 
 /** First owner from the mocked Safe — used for the happy path. */
@@ -86,9 +85,7 @@ export const setupConnectSignerNonOwner = (dispatch: Dispatch, router: Router) =
  */
 const setupWcGateBase = (dispatch: Dispatch, router: Router, wcOverrides: Partial<WalletConnectE2eState>) => {
   walletConnectE2eState.reset()
-  setupBaseConfig(dispatch)
 
-  // Add the signer as a WalletConnect type (not private-key)
   const wcSigner: Signer = {
     value: mockedPendingTxSignerAddress,
     name: 'WC Gate Signer',
@@ -97,12 +94,10 @@ const setupWcGateBase = (dispatch: Dispatch, router: Router, wcOverrides: Partia
     walletName: WALLET_NAME,
     walletIcon: WALLET_ICON,
   }
-  dispatch(addSigner(wcSigner))
 
-  // Set up the pending tx safe and activate the WC signer
-  setupSafe(dispatch, pendingTxSafe1, pendingTxSafeInfo1, 'WC Gate Test Safe')
-  dispatch(setActiveSigner({ safeAddress: pendingTxSafe1.address, signer: wcSigner }))
-  dispatch(setActiveSafe(pendingTxSafe1))
+  setupPendingTxSafe(dispatch, pendingTxSafe1, pendingTxSafeInfo1, 'WC Gate Test Safe', mockedPendingTxSignerAddress, {
+    signer: wcSigner,
+  })
 
   // Force execution method to WITH_WC so relay doesn't override the gate
   dispatch(setExecutionMethod(ExecutionMethod.WITH_WC))

--- a/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/connectSignerSetup.ts
@@ -115,11 +115,9 @@ const setupWcGateBase = (dispatch: Dispatch, router: Router, wcOverrides: Partia
 
 /** Setup: WC signer with expired session → gate shows "Reconnect wallet to continue". */
 export const setupWcGateReconnect = (dispatch: Dispatch, router: Router) => {
-  setupWcGateBase(dispatch, router, {
-    isConnected: false,
-    address: undefined,
-    hasProvider: false,
-  })
+  // Post-reset defaults already model an expired WC session
+  // (isConnected=false, address=undefined). No overrides needed.
+  setupWcGateBase(dispatch, router, {})
 }
 
 /** Setup: WC signer connected on wrong network → gate shows "Switch network to continue". */
@@ -127,8 +125,6 @@ export const setupWcGateWrongNetwork = (dispatch: Dispatch, router: Router) => {
   setupWcGateBase(dispatch, router, {
     isConnected: true,
     address: mockedPendingTxSignerAddress,
-    walletInfo: { name: WALLET_NAME, icon: WALLET_ICON },
-    hasProvider: true,
     isWrongNetwork: true,
   })
 }

--- a/apps/mobile/src/tests/e2e-maestro/setup/setupHelpers.ts
+++ b/apps/mobile/src/tests/e2e-maestro/setup/setupHelpers.ts
@@ -5,7 +5,7 @@ import { updateSettings } from '@/src/store/settingsSlice'
 import { updatePromptAttempts } from '@/src/store/notificationsSlice'
 import { addSafe } from '@/src/store/safesSlice'
 import { addContact } from '@/src/store/addressBookSlice'
-import { addSigner } from '@/src/store/signersSlice'
+import { addSigner, Signer } from '@/src/store/signersSlice'
 import { setActiveSigner } from '@/src/store/activeSignerSlice'
 import { setActiveSafe } from '@/src/store/activeSafeSlice'
 
@@ -55,6 +55,10 @@ export const setupSigner = (dispatch: Dispatch, signerAddress: string) => {
  * - Signer setup
  * - Safe setup
  * - Active signer and safe
+ *
+ * By default registers a private-key signer for `signerAddress`.
+ * Pass `options.signer` to register a pre-built signer (e.g. a WalletConnect
+ * signer) instead.
  */
 export const setupPendingTxSafe = (
   dispatch: Dispatch,
@@ -62,12 +66,19 @@ export const setupPendingTxSafe = (
   info: SafeOverview,
   name: string,
   signerAddress: string,
+  options: { signer?: Signer } = {},
 ) => {
   setupBaseConfig(dispatch)
 
-  const mockedSigner = setupSigner(dispatch, signerAddress)
+  let signer: Signer
+  if (options.signer) {
+    signer = options.signer
+    dispatch(addSigner(signer))
+  } else {
+    signer = setupSigner(dispatch, signerAddress)
+  }
 
   setupSafe(dispatch, account, info, name)
-  dispatch(setActiveSigner({ safeAddress: account.address, signer: mockedSigner }))
+  dispatch(setActiveSigner({ safeAddress: account.address, signer }))
   dispatch(setActiveSafe(account))
 }

--- a/docs/resolutions.md
+++ b/docs/resolutions.md
@@ -1,0 +1,15 @@
+# Yarn `resolutions` rationale
+
+The root [`package.json`](../package.json) `resolutions` block forces specific
+versions of transitive dependencies. Each entry has a reason — without one
+it's impossible to tell, months later, whether a pin is still load-bearing
+or safe to drop. Add a short note here whenever a new entry is added.
+
+## Entries
+
+- **`isows: 1.0.7`** — dedup the transitive version that ships under viem
+  (1.0.6 → 1.0.7 is a maintenance bump, no CVE; the pin avoids two copies
+  in the bundle when other packages resolve isows differently).
+
+> When you add an entry to `resolutions`, add the matching line here in the
+> same commit.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@ethersproject/signing-key/elliptic": "^6.6.1",
     "stylus": "0.64.0",
     "viem": "2.21.55",
+    "isows": "1.0.7",
     "webpack": "5.97.1",
     "react-native-quick-base64": "2.2.2",
     "@tamagui/image@npm:2.0.0-rc.26": "patch:@tamagui/image@npm%3A2.0.0-rc.26#~/.yarn/patches/@tamagui-image-npm-2.0.0-rc.26-04087a216c.patch"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30989,12 +30989,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isows@npm:1.0.6":
-  version: 1.0.6
-  resolution: "isows@npm:1.0.6"
+"isows@npm:1.0.7":
+  version: 1.0.7
+  resolution: "isows@npm:1.0.7"
   peerDependencies:
     ws: "*"
-  checksum: 10/ab9e85b50bcc3d70aa5ec875aa2746c5daf9321cb376ed4e5434d3c2643c5d62b1f466d93a05cd2ad0ead5297224922748c31707cb4fbd68f5d05d0479dce99c
+  checksum: 10/044b949b369872882af07b60b613b5801ae01b01a23b5b72b78af80c8103bbeed38352c3e8ceff13a7834bc91fd2eb41cf91ec01d59a041d8705680e6b0ec546
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> WalletConnect gate appears.
> Tap reconnect, tap switch-network.
> Gate clears, execute returns.

## What it solves

Adds Maestro e2e coverage for the two non-signing WalletConnectGate states (expired session, wrong network) on the Review-and-Execute screen. Also lands review feedback consolidated against the original commit.

Resolves: [WA-1858](https://linear.app/safe-global/issue/WA-1858/e2e-tests-for-the-connect-signer-flow)

## How this PR fixes it

The gate sits between an active WalletConnect signer and the execute-transaction button. Two non-signing states render a CTA there: "Reconnect wallet to continue" (expired session) and "Switch network to continue" (wrong chain). Maestro tests now exercise both: seed Redux + e2e WC state via TestCtrls buttons → navigate to Review-and-Execute → assert the gate appears → tap → assert the gate dismisses.

Notable choices:

- The mock `WalletConnectContext.e2e.tsx` fakes the AppKit-driven `reconnect` / `switchNetworkIfNeeded` by flipping the e2e state directly — no real AppKit modal involvement.
- The shared "navigate from app start to Review-and-Execute" flow is extracted to `apps/mobile/e2e/utils/setup/open-review-and-execute.yml` and parameterised by the TestCtrls button id, so future gate tests are one-liners.
- Gate dismissal is asserted via `extendedWaitUntil: notVisible` on the gate testID — intentionally not coupling the test to the underlying execute-button copy. "Execute transaction" vs "Insufficient funds" are distinct semantic states; collapsing them in one regex would silently pass a funds-error regression.

## How to test it

1. Build the e2e app: `yarn workspace @safe-global/mobile e2e:metro-ios`.
2. Run the full suite: `maestro test apps/mobile/e2e/tests/connect-signer/__suite__.yml`.
3. Or run each gate flow individually:
   - `maestro test apps/mobile/e2e/tests/connect-signer/wc-gate-reconnect.yml`
   - `maestro test apps/mobile/e2e/tests/connect-signer/wc-gate-switch-network.yml`
4. Confirm both transition through: setup → gate visible → tap → gate dismissed.

## Affected flows

- Review and Execute screen, WalletConnect signer path (the only consumer of `WalletConnectGate`).

## Blast radius

- `WalletConnectContext.e2e.tsx` — only loaded under `RN_SRC_EXT=e2e.tsx` (Metro source-extension override). Production builds resolve `WalletConnectContext.tsx` (unchanged).
- `setupHelpers.setupPendingTxSafe` — extended with an optional `options.signer` parameter. The 5 existing private-key callers are untouched; default behaviour preserved.
- New `e2eWcGateReconnect` / `e2eWcGateWrongNetwork` TestCtrls triggers — only rendered in e2e builds.
- `package.json` resolution `isows@1.0.7` — transitive dedup under viem (no CVE); rationale logged in `docs/resolutions.md`.
- Docs: e2e guidelines now codify the `e2e<PascalCase>` exception for TestCtrls trigger ids vs. kebab-case product testIDs.

## Risks / not checked

- Tests were exercised on iOS only; Android e2e was not run.
- Only `pendingTxSafe1` fixture is exercised; other pending-tx safes are not.
- The mock's `sign()` still throws `not implemented in test mode` — sign-path coverage is out of scope for this PR.
- No production code path changed, so production behaviour was not retested.

## Visual summary

```mermaid
sequenceDiagram
  participant Maestro
  participant TestCtrls
  participant Redux
  participant Gate as WalletConnectGate
  participant Mock as WalletConnectContext.e2e

  Maestro->>TestCtrls: tap e2eWcGateReconnect
  TestCtrls->>Mock: walletConnectE2eState.reset()
  TestCtrls->>Redux: seed pending-tx safe + WC signer
  Maestro->>Maestro: navigate to Review and Execute
  Note over Gate: address=undefined → "Reconnect wallet to continue"
  Maestro->>Gate: tap reconnect-wallet-button
  Gate->>Mock: reconnect(signerAddress)
  Mock->>Mock: state.address := signerAddress
  Note over Gate: session active → render children (Execute transaction)
  Maestro->>Gate: assert reconnect-wallet-button is gone
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).