### PR TITLE
fix: button icon color in dark mode and brand fill token

### DIFF
--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -28,7 +28,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/80 dark:[&_svg]:text-black',
         outline:
           'border-border bg-background hover:bg-[var(--unofficial-outline-hover,rgba(0,0,0,0.03))] hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground shadow-xs',
         secondary:

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -31,7 +31,7 @@ const AddSpaceButton = () => {
       className="h-full rounded-lg px-6 text-base"
       render={<NextLink href={AppRoutes.welcome.createSpace} />}
     >
-      <AddIcon className="size-5 fill-[var(--color-static-text-brand)]" />
+      <AddIcon className="size-5 fill-primary-foreground" />
       Create space
     </Button>
   )


### PR DESCRIPTION
> Dark mode button icons,
> brand fill token swap inline,
> contrast restored.

## What it solves

- Primary buttons in dark mode rendered SVG icons in white-on-yellow, hurting contrast.
- The SpacesList \`AddSpaceButton\` was using a raw CSS variable instead of a theme token for the \`+\` icon fill.

## How this PR fixes it

- \`apps/web/src/components/ui/button.tsx\`: adds \`dark:[&_svg]:text-black\` to the default variant so SVG icons inside the primary button render dark in dark mode (matching the yellow-on-dark brand contrast).
- \`apps/web/src/features/spaces/components/SpacesList/index.tsx\`: replaces \`fill-[var(--color-static-text-brand)]\` with \`fill-primary-foreground\` to align with the shared token system.

## How to test it

- [ ] Toggle dark mode and confirm the default \`Button\` variant renders icons in black.
- [ ] Visit the Spaces list as a logged-in user and confirm the \`Create space\` button renders a properly tinted \`+\` icon in both themes.
- [ ] Sanity-check other primary buttons with leading icons across the app.

## Visual summary

\`\`\`mermaid
flowchart LR
  A[Button default variant] -->|light mode| B[svg: primary-foreground]
  A -->|dark mode| C[svg: black<br/>via dark:[&_svg]:text-black]
  D[AddSpaceButton AddIcon] --> E[fill-primary-foreground<br/>theme token]
\`\`\`

## Checklist

- [x] Tests pass locally (\`yarn verify:changed:web\` — 3199/3199 passed, prettier clean)
- [x] No \`any\` types introduced
- [x] Uses theme tokens instead of raw CSS vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)