### PR TITLE
fix(web): topbar alignment and Safe App page overflow

### DIFF
--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -69,6 +69,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
         <div
           className={classnames(css.topbar, {
             [css.topbarCollapsed]: isSpaceRoute && !isSpacesSidebarExpanded,
+            [css.topbarNoSidebar]: !isSidebarVisible || !isSidebarRoute,
             [css.topbarElevated]: isTopbarElevated,
           })}
         >

--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -10,6 +10,10 @@
   left: 4rem;
 }
 
+.topbarNoSidebar {
+  left: 0;
+}
+
 .topbarElevated {
   position: fixed;
   z-index: 99;

--- a/apps/web/src/components/safe-apps/AppFrame/styles.module.css
+++ b/apps/web/src/components/safe-apps/AppFrame/styles.module.css
@@ -1,6 +1,6 @@
 .wrapper {
   width: 100%;
-  height: calc(100vh - var(--header-height));
+  height: calc(100vh - var(--topbar-height) - var(--footer-height));
 }
 
 .iframe {


### PR DESCRIPTION
> Sidebar folds, topbar follows,
> Safe App page snaps to one viewport,
> queue bar climbs back into view.

## What it solves

Resolves the broken layout on the Transaction Builder page (and any other Safe App):

- **Topbar doesn't follow the sidebar.** When the sidebar is collapsed, the topbar stays at `left: 230px`, leaving an empty strip on the left of the viewport.
- **Page overflows by 111px.** The AppFrame wrapper height was calculated against the legacy `--header-height: 56px`, but the actual topbar is 100px tall and the footer is ~67px. Net result: the page is 111px taller than the viewport, so the bottom-anchored `(N) Transaction queue` panel sits below the fold and requires scrolling to reach.

## How this PR fixes it

1. **PageLayout** ([apps/web/src/components/common/PageLayout/index.tsx](apps/web/src/components/common/PageLayout/index.tsx), [styles.module.css](apps/web/src/components/common/PageLayout/styles.module.css)) — adds a `.topbarNoSidebar { left: 0 }` class, applied with the same condition as `.mainNoSidebar` (`!isSidebarVisible || !isSidebarRoute`). When the sidebar isn't displayed, the topbar shifts to the left edge in lockstep with the main content.
2. **AppFrame** ([apps/web/src/components/safe-apps/AppFrame/styles.module.css](apps/web/src/components/safe-apps/AppFrame/styles.module.css)) — corrects the `.wrapper` height calc from `100vh - var(--header-height)` to `100vh - var(--topbar-height) - var(--footer-height)`. The wrapper plus the layout's top padding (topbar) and bottom footer now sum to exactly 100vh, eliminating the overflow.

## How to test it

1. On a desktop viewport, open any Safe App (e.g. Transaction Builder):
   - The topbar should span the full viewport width with no empty gap on the left.
   - The page should not scroll vertically; the `(N) Transaction queue` panel must be visible at the bottom without scrolling.
2. On a regular Safe page (e.g. `/home`), manually collapse the sidebar via the toggle handle: the topbar should glide to `left: 0`. Reopen the sidebar — topbar should return to `left: 230px`.
3. Visit routes that have a header but no sidebar (`/terms`, `/imprint`, `/share/safe-app`, `/welcome/accounts`): the topbar should hug the left edge and align with the content below.
4. Open a tx-flow or recovery modal: elevation behavior introduced in #7753 should be unchanged (topbar fixed and elevated above the modal backdrop).
5. Mobile (< 900px): existing media query keeps `left: 0`; behavior should be unchanged.

## Affected flows

- All Safe App pages (Transaction Builder, WalletConnect, Drain Account, custom dapps).
- Desktop users manually toggling the sidebar on Safe routes.
- Routes in `NO_SIDEBAR_ROUTES` that still render a header: `/`, `/welcome/accounts`, `/welcome/spaces`, `/terms`, `/imprint`, `/privacy`, `/cookie`, `/licenses`, `/new-safe/create`, `/new-safe/load`, `/share/safe-app`, `/spaces`.
- Available iframe height inside every Safe App is reduced by ~55px (was sized against the wrong header constant).

## Blast radius

- **`PageLayout`** is the root layout for every page; the new class only attaches when the sidebar is hidden, so sidebar-visible Safe and Spaces routes are untouched.
- **`AppFrame`** is shared by all Safe Apps; the wrapper height change affects every Safe App's iframe area equally.
- **CSS variables** in `globals.css` are not modified. `--header-height: 56px` remains in use by 11 other places (legacy MUI Header, Notifications, PageHeader, Popup, SafeAppsHeader, etc.); none of them are touched here.
- **Untouched surfaces**: Redux slices, RTK Query endpoints, feature flags, chain configs, mobile shared packages, persistence, and routing.
- **Z-index / elevation**: `useTopbarElevation` from #7753 is untouched. `.topbarElevated` and the new `.topbarNoSidebar` both target `left: 0`, so they coexist without conflict when both apply.

## Risks / not checked

- Verified only Transaction Builder for the AppFrame change. Other Safe Apps (WalletConnect, Drain Account, etc.) share the same wrapper and should benefit identically, but I didn't open them.
- Did not test on mobile. Mobile relies on the existing media-query override (`left: 0`), so behavior should be unchanged.
- `--footer-height: 67px` is a convention; the actual footer has no enforced height. On very narrow viewports the footer text may wrap and exceed 67px, reintroducing a small amount of scroll.
- Did not run the E2E suite — only `verify:changed:web`.
- No unit tests added; both changes are pure CSS class toggles with no new logic branches.

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    direction TB
    B1["Sidebar hidden<br/>(Safe App / no-sidebar routes)"] --> B2["topbar.left = 230px<br/>misaligned"]
    B3["AppFrame wrapper<br/>height = 100vh - 56px"] --> B4["main total = 100vh + 111px<br/>queue bar below viewport"]
  end
  subgraph After
    direction TB
    A1["Sidebar hidden"] --> A2["topbarNoSidebar class<br/>topbar.left = 0"]
    A3["AppFrame wrapper<br/>height = 100vh - 100px - 67px"] --> A4["main total = 100vh<br/>queue bar in view"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — pure CSS class toggles, no new logic
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

