### PR TITLE
Display untrusted Safe warning in RiskConfirmation for signed messages and update tests

### DIFF
--- a/apps/web/src/components/tx-flow/features/RiskConfirmation.tsx
+++ b/apps/web/src/components/tx-flow/features/RiskConfirmation.tsx
@@ -6,13 +6,15 @@ import Track from '@/components/common/Track'
 import { MODALS_EVENTS } from '@/services/analytics'
 import { SafeTxContext } from '../SafeTxProvider'
 import { useSafeShield } from '@/features/safe-shield/SafeShieldContext'
+import { SafeStatus } from '@safe-global/utils/features/safe-shield/types'
 
 export const RiskConfirmation = () => {
-  const { needsRiskConfirmation, isRiskConfirmed, setIsRiskConfirmed } = useSafeShield()
+  const { needsRiskConfirmation, isRiskConfirmed, setIsRiskConfirmed, safeAnalysis } = useSafeShield()
   const { safeTx } = useContext(SafeTxContext)
 
   // We either scan a tx or a message if tx is undefined
   const isTransaction = !!safeTx
+  const isUntrustedSafeMessage = !isTransaction && safeAnalysis?.type === SafeStatus.UNTRUSTED
 
   const toggleConfirmation = () => {
     setIsRiskConfirmed((prev) => !prev)
@@ -29,7 +31,9 @@ export const RiskConfirmation = () => {
           data-testid="risk-confirmation-checkbox"
           label={
             <Typography variant="body2" data-testid="risk-confirmation-text">
-              I understand the risks and would like to proceed with this {isTransaction ? 'transaction' : 'message'}.
+              {isUntrustedSafeMessage
+                ? 'I understand this Safe is untrusted and would like to proceed with this message.'
+                : `I understand the risks and would like to proceed with this ${isTransaction ? 'transaction' : 'message'}.`}
             </Typography>
           }
           control={<Checkbox checked={isRiskConfirmed} onChange={toggleConfirmation} color="primary" />}

--- a/apps/web/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
+++ b/apps/web/src/components/tx-flow/flows/SignMessage/SignMessage.test.tsx
@@ -28,6 +28,7 @@ import { SafeShieldProvider } from '@/features/safe-shield/SafeShieldContext'
 import type { ReactElement } from 'react'
 import { SafeTxContext } from '@/components/tx-flow/SafeTxProvider'
 import type { SafeTxContextParams } from '@/components/tx-flow/SafeTxProvider'
+import { SafeStatus, Severity } from '@safe-global/utils/features/safe-shield/types'
 
 import * as useIsPinnedSafeHook from '@/hooks/useIsPinnedSafe'
 import * as useTrustSafeHook from '@/features/myAccounts/hooks/useTrustSafe'
@@ -832,7 +833,7 @@ describe('SignMessage', () => {
       })
     })
 
-    it('shows RiskConfirmation checkbox when threat is detected', async () => {
+    it('shows RiskConfirmation checkbox with untrusted Safe warning when signing a message', async () => {
       jest.spyOn(require('@/features/safe-shield/SafeShieldContext'), 'useSafeShield').mockReturnValue({
         needsRiskConfirmation: true,
         isRiskConfirmed: false,
@@ -843,7 +844,13 @@ describe('SignMessage', () => {
         recipient: undefined,
         contract: undefined,
         threat: undefined,
-        safeAnalysis: null,
+        safeAnalysis: {
+          severity: Severity.CRITICAL,
+          type: SafeStatus.UNTRUSTED,
+          title: 'Untrusted Safe',
+          description:
+            "You're creating a transaction from a Safe that isn't in your trusted list. Trust it if you recognize it.",
+        },
         addToTrustedList: jest.fn(),
       })
 
@@ -853,7 +860,9 @@ describe('SignMessage', () => {
 
       await waitFor(() => {
         expect(getByTestId('risk-confirmation-checkbox')).toBeInTheDocument()
-        expect(getByText('I understand the risks and would like to proceed with this message.')).toBeInTheDocument()
+        expect(
+          getByText('I understand this Safe is untrusted and would like to proceed with this message.'),
+        ).toBeInTheDocument()
       })
     })
   })


### PR DESCRIPTION
### Motivation
- Clarify the risk confirmation copy when the user is signing a message from an untrusted Safe so the user knows the Safe itself is untrusted.
- Ensure the UI and tests reflect the SafeShield analysis state for message signing flows.

### Description
- Read `safeAnalysis` from `useSafeShield` and import `SafeStatus` to detect untrusted Safe messages in `RiskConfirmation`.
- Add `isUntrustedSafeMessage` and render a specific label: "I understand this Safe is untrusted and would like to proceed with this message." when signing an untrusted Safe message, otherwise keep the original transaction/message wording.
- Update `SignMessage.test.tsx` to include `SafeStatus` and `Severity`, provide a mocked `safeAnalysis` with `type: SafeStatus.UNTRUSTED`, and assert the new untrusted Safe confirmation text is rendered.

### Testing
- Ran the updated unit tests for the message signing flow using Jest via `yarn test` and the `SignMessage` spec, and the updated tests passed.
- Verified the `RiskConfirmation` rendering test asserting the untrusted Safe message copy succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef63ad7698832aafbf84e32356e851)