### PR TITLE
fix(web): remove txBuilder scroll

### DIFF
--- a/apps/web/src/components/safe-apps/AppFrame/styles.module.css
+++ b/apps/web/src/components/safe-apps/AppFrame/styles.module.css
@@ -1,6 +1,6 @@
 .wrapper {
   width: 100%;
-  height: calc(100vh - var(--header-height));
+  height: calc(100vh - 100px);
 }
 
 .iframe {


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/WA-2062/the-scroll-appeard-on-the-tx-builder-for-mac13

## How this PR fixes it
It removes txBuilder scroll on the tx builder page.

## How to test it


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
