### PR TITLE
feat: make all accounts button sticky and add scrolling chevron

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
@@ -83,7 +83,8 @@ const MultiChainSafeItemRow = ({ item }: MultiChainSafeItemRowProps) => {
               <SelectItem
                 key={`${chain.chainId}:${item.address}`}
                 value={`${chain.chainId}:${item.address}`}
-                className="flex items-center gap-3 rounded-md px-3 py-2 cursor-pointer data-[state=checked]:bg-muted hover:bg-muted/30"
+                // [&>span.absolute]:hidden suppresses the built-in checkmark span (see SelectItem in ui/select.tsx) — this row uses its own right-aligned StatusBadge / queued count / balance instead, and the checkmark would overlap them.
+                className="flex items-center gap-3 rounded-md px-3 py-2 cursor-pointer data-[state=checked]:bg-muted hover:bg-muted/30 [&>span.absolute]:hidden"
               >
                 <ChainLogo chainId={chain.chainId} />
                 <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.test.tsx
@@ -1,0 +1,153 @@
+import React, { act } from 'react'
+import { render, screen } from '@testing-library/react'
+import SafeDropdownContainer from './SafeDropdownContainer'
+import type { SafeItemData } from '../types'
+
+// Render SelectContent as a plain div carrying the `data-slot` marker that the
+// component's `closest()` lookup relies on, so the scroll-hint effect can find it.
+jest.mock('@/components/ui/select', () => ({
+  __esModule: true,
+  SelectContent: ({ children, className }: { children?: React.ReactNode; className?: string }) => (
+    <div data-slot="select-content" data-testid="select-content" className={className}>
+      {children}
+    </div>
+  ),
+  SelectItem: ({ children, value }: { children?: React.ReactNode; value?: string }) => (
+    <div data-testid="select-item" data-value={value}>
+      {children}
+    </div>
+  ),
+}))
+
+jest.mock('./SafeItem', () => ({
+  __esModule: true,
+  default: ({ name }: { name: string }) => <div data-testid="safe-item">{name}</div>,
+}))
+
+jest.mock('./MultiChainSafeItemRow', () => ({
+  __esModule: true,
+  default: ({ item }: { item: SafeItemData }) => <div data-testid="multi-chain-row">{item.name}</div>,
+}))
+
+const createItem = (overrides: Partial<SafeItemData> = {}): SafeItemData => ({
+  id: '1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  name: 'Safe A',
+  address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  threshold: 1,
+  owners: 2,
+  balance: '100',
+  chains: [{ chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' }],
+  ...overrides,
+})
+
+const setScrollMetrics = (
+  el: HTMLElement,
+  { scrollHeight, clientHeight, scrollTop }: { scrollHeight: number; clientHeight: number; scrollTop: number },
+) => {
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, value: scrollHeight })
+  Object.defineProperty(el, 'clientHeight', { configurable: true, value: clientHeight })
+  Object.defineProperty(el, 'scrollTop', { configurable: true, writable: true, value: scrollTop })
+}
+
+const fireScroll = (el: HTMLElement) => {
+  act(() => {
+    el.dispatchEvent(new Event('scroll'))
+  })
+}
+
+describe('SafeDropdownContainer', () => {
+  describe('footer', () => {
+    it('renders the footer node when provided', () => {
+      render(
+        <SafeDropdownContainer
+          items={[createItem()]}
+          onItemSelect={jest.fn()}
+          closeDropdown={jest.fn()}
+          footer={<div data-testid="footer-node">All Accounts</div>}
+        />,
+      )
+
+      expect(screen.getByTestId('footer-node')).toBeInTheDocument()
+    })
+
+    it('invokes the footer callback with closeDropdown when footer is a function', () => {
+      const closeDropdown = jest.fn()
+      const footerFn = jest.fn(() => <div data-testid="footer-node">FooterFn</div>)
+
+      render(
+        <SafeDropdownContainer
+          items={[createItem()]}
+          onItemSelect={jest.fn()}
+          closeDropdown={closeDropdown}
+          footer={footerFn}
+        />,
+      )
+
+      expect(footerFn).toHaveBeenCalledWith(closeDropdown)
+      expect(screen.getByTestId('footer-node')).toBeInTheDocument()
+    })
+
+    it('does not render the footer wrapper when no footer prop is passed', () => {
+      render(<SafeDropdownContainer items={[createItem()]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
+
+      expect(screen.queryByTestId('scroll-hint')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('scroll hint', () => {
+    it('hides the hint when content does not overflow', () => {
+      render(
+        <SafeDropdownContainer
+          items={[createItem()]}
+          onItemSelect={jest.fn()}
+          closeDropdown={jest.fn()}
+          footer={<div>Footer</div>}
+        />,
+      )
+
+      const scroller = screen.getByTestId('select-content')
+      setScrollMetrics(scroller, { scrollHeight: 200, clientHeight: 320, scrollTop: 0 })
+      fireScroll(scroller)
+
+      expect(screen.queryByTestId('scroll-hint')).not.toBeInTheDocument()
+    })
+
+    it('shows the hint when content overflows and the user has not scrolled to the bottom', () => {
+      render(
+        <SafeDropdownContainer
+          items={[createItem()]}
+          onItemSelect={jest.fn()}
+          closeDropdown={jest.fn()}
+          footer={<div>Footer</div>}
+        />,
+      )
+
+      const scroller = screen.getByTestId('select-content')
+      setScrollMetrics(scroller, { scrollHeight: 1000, clientHeight: 320, scrollTop: 0 })
+      fireScroll(scroller)
+
+      expect(screen.getByTestId('scroll-hint')).toBeInTheDocument()
+    })
+
+    it('hides the hint once the user reaches the bottom', () => {
+      render(
+        <SafeDropdownContainer
+          items={[createItem()]}
+          onItemSelect={jest.fn()}
+          closeDropdown={jest.fn()}
+          footer={<div>Footer</div>}
+        />,
+      )
+
+      const scroller = screen.getByTestId('select-content')
+      setScrollMetrics(scroller, { scrollHeight: 1000, clientHeight: 320, scrollTop: 0 })
+      fireScroll(scroller)
+      expect(screen.getByTestId('scroll-hint')).toBeInTheDocument()
+
+      setScrollMetrics(scroller, { scrollHeight: 1000, clientHeight: 320, scrollTop: 680 })
+      fireScroll(scroller)
+
+      expect(screen.queryByTestId('scroll-hint')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.test.tsx
@@ -3,6 +3,15 @@ import { render, screen } from '@testing-library/react'
 import SafeDropdownContainer from './SafeDropdownContainer'
 import type { SafeItemData } from '../types'
 
+// jsdom doesn't implement ResizeObserver; the component uses one to catch popup
+// size changes. A noop stub is enough since tests drive scroll state explicitly.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+;(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver = ResizeObserverStub
+
 // Render SelectContent as a plain div carrying the `data-slot` marker that the
 // component's `closest()` lookup relies on, so the scroll-hint effect can find it.
 jest.mock('@/components/ui/select', () => ({

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -86,7 +86,15 @@ const SafeDropdownContainer = ({
 
     update()
     scroller.addEventListener('scroll', update, { passive: true })
-    return () => scroller.removeEventListener('scroll', update)
+    // base-ui sizes the popup async and avatars/logos load late, so the initial
+    // measurement often misses the overflow. Observe size changes to catch up.
+    const resizeObserver = new ResizeObserver(update)
+    resizeObserver.observe(scroller)
+    Array.from(scroller.children).forEach((child) => resizeObserver.observe(child))
+    return () => {
+      scroller.removeEventListener('scroll', update)
+      resizeObserver.disconnect()
+    }
   }, [filteredItems.length, isLoading, isError])
 
   const renderContent = () => {

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -119,7 +119,7 @@ const SafeDropdownContainer = ({
       align="start"
       side="bottom"
       alignItemWithTrigger={false}
-      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[20rem] overflow-y-auto bg-card border-0 ring-0 rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
+      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[20rem] overflow-y-auto overscroll-y-none bg-card border-0 ring-0 rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
       sideOffset={20}
       alignOffset={9}
       collisionAvoidance={{ side: 'none', align: 'shift' }}

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -1,4 +1,5 @@
-import { RotateCw } from 'lucide-react'
+import { ChevronDown, RotateCw } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import { SelectContent, SelectItem } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
@@ -65,6 +66,29 @@ const SafeDropdownContainer = ({
   // Multi-chain items stay visible even when currently selected so the user can expand and switch chains.
   const filteredItems = items.filter((item) => item.chains.length > 1 || item.id !== selectedItemId)
 
+  const footerRef = useRef<HTMLDivElement>(null)
+  const [showScrollHint, setShowScrollHint] = useState(false)
+
+  // Custom scroll hint replaces base-ui's built-in scroll arrows: they sit at `bottom: 0`
+  // (colliding with the sticky footer) and don't animate, so users miss that the list is scrollable.
+  useEffect(() => {
+    const el = footerRef.current
+    if (!el) return
+    // base-ui's Popup is the scroll container; reach it via the project's `data-slot` marker.
+    const scroller = el.closest<HTMLElement>('[data-slot="select-content"]')
+    if (!scroller) return
+
+    const update = () => {
+      const hasOverflow = scroller.scrollHeight > scroller.clientHeight + 1
+      const atBottom = scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 1
+      setShowScrollHint(hasOverflow && !atBottom)
+    }
+
+    update()
+    scroller.addEventListener('scroll', update, { passive: true })
+    return () => scroller.removeEventListener('scroll', update)
+  }, [filteredItems.length, isLoading, isError])
+
   const renderContent = () => {
     if (isError) {
       return <DropdownContentError onRetry={onRetry} />
@@ -95,14 +119,25 @@ const SafeDropdownContainer = ({
       align="start"
       side="bottom"
       alignItemWithTrigger={false}
-      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[20rem] overflow-y-auto bg-card border-0 ring-0 rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[20rem] overflow-y-auto bg-card border-0 ring-0 rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
       sideOffset={20}
       alignOffset={9}
       collisionAvoidance={{ side: 'none', align: 'shift' }}
     >
       {header}
       {renderContent()}
-      {typeof footer === 'function' ? footer(closeDropdown) : footer}
+      {footer && (
+        <div ref={footerRef} className="sticky bottom-0 z-10 bg-card">
+          {showScrollHint && (
+            <ChevronDown
+              data-testid="scroll-hint"
+              aria-hidden
+              className="pointer-events-none absolute -top-3 left-1/2 size-4 -translate-x-1/2 animate-bounce text-muted-foreground"
+            />
+          )}
+          {typeof footer === 'function' ? footer(closeDropdown) : footer}
+        </div>
+      )}
     </SelectContent>
   )
 }


### PR DESCRIPTION
> All Accounts pinned to the bottom edge,
> bouncing chevron when more is below,
> stills the moment the list runs out.

## What it solves

https://linear.app/safe-global/issue/EPD-474/safe-selector-dropdown-all-accounts-btn-should-be-sticky

Two related discoverability problems in the Safe selector dropdown (the one anchored in `SpaceSafeBar` at the top of every Safe page):

- **The "All Accounts" button scrolled out of view.** It was rendered as the last child of `SelectContent` and shared the same `max-h-[20rem] overflow-y-auto` container as the safe list. Once a user trusted more than ~4 safes, the button was below the fold and required scrolling all the way down to reach.
- **Users didn't realise the dropdown was scrollable.** Scrollbars are hidden (`[scrollbar-width:none]`), and base-ui's auto-managed `SelectScrollDownArrow` is just a static chevron sitting at `bottom: 0`. Users with many safes assumed the visible list was the full list.

## How this PR fixes it

All changes are scoped to [`SafeDropdownContainer`](apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx). One file edited, one test file added.

1. **Sticky footer.** Wrapped the `footer` slot in a `sticky bottom-0 z-10 bg-card` div so it pins to the bottom of the popup viewport while items scroll behind it. `position: sticky` works here because base-ui's `Popup` is the scroll container (we pass `alignItemWithTrigger={false}`, so `Select.List` does not become its own scroller — verified against base-ui source).
2. **Hide base-ui's built-in scroll arrows for this dropdown only.** Added `[&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden` to the `SelectContent` className. They would otherwise collide with the sticky footer at `bottom-0` and (because they don't animate) didn't solve the discoverability issue anyway.
3. **Custom animated scroll hint.** A bouncing `ChevronDown` floats just above the sticky footer when the content overflows and the user is not at the bottom. State is driven by a small `scroll` listener on the popup (`scrollHeight > clientHeight + 1 && scrollTop + clientHeight < scrollHeight - 1`). The popup is reached via `el.closest('[data-slot="select-content"]')` from the footer ref — no new ref plumbing.
4. **Tests.** Six unit tests covering: footer rendering, function-form footer receiving `closeDropdown`, no footer → no hint, no overflow → no hint, overflow + not at bottom → hint shown, scrolled to bottom → hint disappears.

## How to test it

1. Sign in with a wallet that has trusted ≥ 6 safes (or pin a few in `Welcome → Accounts`) so the dropdown overflows.
2. Open the safe selector dropdown from the top of any Safe page.
   - The "All Accounts" button should be visible at the bottom of the popup without scrolling.
   - A small bouncing chevron should appear directly above the button.
3. Scroll the list down to the bottom — the bouncing chevron should disappear; the "All Accounts" button stays put.
4. Scroll back up — the chevron reappears.
5. Open the dropdown for a wallet with only 1–3 safes (no overflow). The chevron should never show; the footer still renders normally at the bottom.
6. With a wallet not connected (and no pinned safes), the footer slot is the "Connect wallet" variant — confirm it is also pinned at the bottom and the chevron behaves the same way.
7. Confirm other `Select`-based dropdowns in the app (chain selector, network picker, etc.) are unchanged — the scroll-arrow hiding is scoped to this `SelectContent` only.

## Affected flows

- Opening the safe selector and switching to another trusted safe (every authenticated Safe page).
- Navigating from the dropdown footer to the full **All Accounts** modal.
- Connect-wallet entry point inside the dropdown when the wallet is disconnected and the user has no pinned safes.

## Blast radius

- **`SafeDropdownContainer`** — the only renderer of `SelectContent` for this dropdown. Used by `SafeSelectorDropdown` → `SpaceSafeBar`, which mounts on every Safe page. The sticky footer wrapper renders only when a `footer` prop is passed (currently: `SpaceSafeBar` only).
- **`SelectContent` overrides** — `[&_[data-slot=select-scroll-down-button]]:hidden` is a Tailwind arbitrary variant on this dropdown's instance only. The shadcn `SelectContent` and `SelectScrollDownButton` components in [`apps/web/src/components/ui/select.tsx`](apps/web/src/components/ui/select.tsx) are untouched, so all other `Select` usages keep their default scroll arrows.
- **`closest('[data-slot="select-content"]')`** — depends on the `data-slot="select-content"` attribute set by the project's shadcn `SelectContent` wrapper. Stable as long as we don't strip slot attributes from that file.
- **No changes** to: Redux slices, RTK Query endpoints, feature flags, chain configs, routing, persistence, mobile shared packages, or analytics.

## Risks / not checked

- Did not run Chromatic to capture a visual diff. The change is small and localized, but the dropdown is rendered across many stories — worth a glance at the Chromatic report.
- Did not stress-test with very large lists (e.g. 100+ safes). The `scroll` listener is `passive` and only sets boolean state, so performance should be fine, but I didn't measure.
- Did not exercise screen-reader behaviour. The chevron is `aria-hidden` (purely decorative); the sticky footer still sits at the natural end of the list in DOM order, so focus order is unchanged.
## Visual summary

```mermaid
flowchart TB
  subgraph Before
    direction TB
    B1["SelectContent<br/>max-h-20rem, overflow-y-auto"] --> B2[header]
    B1 --> B3[items...]
    B1 --> B4["footer<br/>(scrolls with items, often below the fold)"]
    B1 --> B5["base-ui ScrollDownArrow<br/>bottom-0, static chevron"]
  end
  subgraph After
    direction TB
    A1["SelectContent<br/>max-h-20rem, overflow-y-auto<br/>+ hide built-in arrows"] --> A2[header]
    A1 --> A3[items...]
    A1 --> A4["sticky footer wrapper<br/>sticky bottom-0, bg-card"]
    A4 --> A5["bouncing ChevronDown<br/>shown when not at bottom"]
    A4 --> A6["footer (All Accounts / Connect wallet)"]
  end
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — 6 unit tests in `SafeDropdownContainer.test.tsx`
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
