### PR TITLE
fix(web): show pending transactions for all multichain accounts on spaces accounts

### DIFF
--- a/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
@@ -5,18 +5,21 @@ import Identicon from '@/components/common/Identicon'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { TriangleAlert, Copy, Check, RotateCw } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Tooltip } from '@mui/material'
 import FiatBalance from '../SelectSafesOnboarding/components/FiatBalance'
 import ThresholdBadge from '../SelectSafesOnboarding/components/ThresholdBadge'
 import useSafeCardData from '../SelectSafesOnboarding/hooks/useSafeCardData'
 import { useLoadFeature } from '@/features/__core__'
 import { SpacesFeature } from '@/features/spaces'
-import { useGetSafeOverviewQuery } from '@/store/api/gateway'
+import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
 import { useChain } from '@/hooks/useChains'
 import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
+import useWallet from '@/hooks/wallets/useWallet'
+import { useAppSelector } from '@/store'
+import { selectCurrency } from '@/store/settingsSlice'
 import { cn } from '@/utils/cn'
 
 interface SafeCardReadOnlyProps {
@@ -44,25 +47,31 @@ const SafeCardReadOnly = ({
   const router = useRouter()
   const isMultiChain = isMultiChainSafeItem(safe)
   const { name, fiatValue, threshold, ownersCount, elementRef } = useSafeCardData(safe)
-  const safes = isMultiChain ? (safe as MultiChainSafeItem).safes : [safe as SafeItem]
+  const safes = useMemo<SafeItem[]>(
+    () => (isMultiChain ? (safe as MultiChainSafeItem).safes : [safe as SafeItem]),
+    [isMultiChain, safe],
+  )
   const singleSafe = safes[0]
   const spaces = useLoadFeature(SpacesFeature)
   const chain = useChain(singleSafe?.chainId || '')
   const displayName = useSafeDisplayName(safe.address, singleSafe?.chainId || '', name)
+  const currency = useAppSelector(selectCurrency)
+  const { address: walletAddress } = useWallet() || {}
 
-  // Fetch SafeOverview for pending transaction info
+  // Fetch SafeOverviews for pending transaction info — aggregated across all chains for multi-chain items
   const {
-    data: safeOverview,
+    data: safeOverviews,
     isLoading: isLoadingOverview,
     isError: isOverviewError,
     error: overviewError,
     refetch: refetchOverview,
-  } = useGetSafeOverviewQuery(
-    { chainId: singleSafe?.chainId, safeAddress: singleSafe?.address },
-    { skip: !singleSafe || !showPending },
-  )
+  } = useGetMultipleSafeOverviewsQuery({ currency, walletAddress, safes }, { skip: safes.length === 0 || !showPending })
 
-  const hasQueuedItems = !isLoadingOverview && !isOverviewError && safeOverview && (safeOverview.queued ?? 0) > 0
+  const queuedCount = useMemo(
+    () => safeOverviews?.reduce((sum, overview) => sum + (overview.queued ?? 0), 0) ?? 0,
+    [safeOverviews],
+  )
+  const hasQueuedItems = !isLoadingOverview && !isOverviewError && queuedCount > 0
 
   const isClickable = Boolean(singleSafe) && !disabled
   const tooltipTitle = disabled ? (disabledTooltip ?? '') : !singleSafe ? 'Safe data is not available' : ''
@@ -177,7 +186,7 @@ const SafeCardReadOnly = ({
             hasQueuedItems && (
               <div className="flex shrink-0 items-center gap-1 mr-8">
                 <Badge variant="secondary" className="text-xs">
-                  {safeOverview.queued} pending
+                  {queuedCount} pending
                 </Badge>
               </div>
             )


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/WA-1949/space-my-accounts-make-sure-that-pending-txs-from-all-networks-are

## How this PR fixes it
It shows the pending txs amounts for all the multi-chain accounts now.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
