### PR TITLE
chore(mobile): revert Release 1.0.11 (#7712)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -21,7 +21,7 @@ const config: ExpoConfig = {
   name: name,
   slug: 'safe-mobileapp',
   owner: 'safeglobal',
-  version: '1.0.11',
+  version: '1.0.10',
   extra: {
     storybookEnabled: process.env.STORYBOOK_ENABLED,
     eas: {

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -13,13 +13,6 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
     return context.resolveRequest(context, 'react-native-quick-crypto', platform)
   }
 
-  // viem's barrel export pulls in ws (Node.js WebSocket server) which requires
-  // http, stream, events, etc. On React Native, isows uses the native WebSocket
-  // global instead, so ws never executes. Shim the entire ws package to empty.
-  if (moduleName === 'ws') {
-    return { type: 'empty' }
-  }
-
   return context.resolveRequest(context, moduleName, platform)
 }
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@safe-global/mobile",
   "main": "index.js",
-  "version": "1.0.11",
+  "version": "1.0.10",
   "doctor": {
     "reactNativeDirectoryCheck": {
       "enabled": true

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       "built": true
     }
   },
-  "packageManager": "yarn@4.14.1+sha512.64df448055b2d37ba269d7db535a469b8da93f8ef1140c25fd7a83c00a8fbaacb214ca0e02553b92a2c54cef78bb67d0b4817fab02001df0e24fac0faccc3b42",
+  "packageManager": "yarn@4.12.0",
   "dependencies": {
     "@yarnpkg/types": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 8
   cacheKey: 10
 
 "@adobe/css-tools@npm:^4.4.0":


### PR DESCRIPTION
Release 1.0.11 (#7712) was accidentally squash merged. This reverts commit 82ee42d52400564cd157134ce77ee2eaed692b8c.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
