### PR TITLE
fix(web): align safe apps header and SDK widget with new topbar

### DIFF
--- a/apps/web/src/components/safe-apps/SafeAppsFilters/styles.module.css
+++ b/apps/web/src/components/safe-apps/SafeAppsFilters/styles.module.css
@@ -2,7 +2,7 @@
   background-color: var(--color-background-main);
   z-index: 2;
   position: sticky !important;
-  top: calc(var(--header-height) + 49px);
+  top: 49px;
 
   padding: var(--space-1) 0 var(--space-1) 0;
 }

--- a/apps/web/src/components/safe-apps/SafeAppsHeader/styles.module.css
+++ b/apps/web/src/components/safe-apps/SafeAppsHeader/styles.module.css
@@ -23,7 +23,7 @@
   z-index: 2;
   width: 100%;
   position: sticky !important;
-  top: var(--header-height);
+  top: 0;
   padding: 0 var(--space-3);
 }
 

--- a/apps/web/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
+++ b/apps/web/src/components/safe-apps/SafeAppsSDKLink/styles.module.css
@@ -9,9 +9,16 @@
   position: fixed;
   z-index: 3;
   right: 64px;
-  top: var(--header-height);
-  transition: transform 0.3s ease-in-out;
+  top: var(--topbar-height);
+  transition:
+    transform 0.3s ease-in-out,
+    border-color 0.3s ease-in-out,
+    background-color 0.3s ease-in-out;
   transform: translateY(-24px);
+}
+
+.container > *:not(.openButton) {
+  transition: opacity 0.3s ease-in-out;
 }
 
 .container:focus-visible {
@@ -32,14 +39,34 @@
 }
 
 .container.mini {
-  transform: translateY(-100%);
+  transform: translateY(calc(-100% - var(--topbar-height)));
   transition-duration: 0.4s;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+.container.mini > *:not(.openButton) {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .container:focus,
 .container:hover {
   z-index: 1200;
   transform: translateY(0);
+}
+
+.container.mini:focus,
+.container.mini:hover {
+  transform: translateY(calc(-1 * var(--topbar-height)));
+  border-color: #12ff80;
+  background-color: var(--color-background-main);
+}
+
+.container.mini:focus > *,
+.container.mini:hover > * {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .openButton {
@@ -94,7 +121,6 @@
   margin-top: var(--space-1);
 }
 
-.mini .link,
 .container:focus .link,
 .container:hover .link {
   opacity: 1;


### PR DESCRIPTION
> Old header gone, new topbar tall —
> sticky tabs and SDK card adrift.
> Pin them, fade them, slide them home.

## What it solves

Resolves:
https://linear.app/safe-global/issue/WA-2064/header-how-to-build-on-safe-have-wrong-position
After the migration from the old header to the new `Topbar` (height bumped from `--header-height: 56px` to `--topbar-height: 100px`), three positioning issues showed up on `/apps` and `/apps/custom`:

1. **`SafeAppsSDKLink`** ("How to build on Safe?" widget) overlapped the Topbar at the top of the page because it was anchored at `top: var(--header-height)`.
2. **`SafeAppsHeader`** sticky tabs ("All apps" / "My custom apps") left a transparent ~56px gap above them when scrolling, since they stuck at `--header-height` while the Topbar scrolls away (`position: absolute`).
3. **`SafeAppsFilters`** sticky bar sat at `calc(--header-height + 49px)`, leaving the same gap below the tabs.

The SDK widget's mini-state animation also felt jumpy: opacity / border / background changes were instant while only `transform` was transitioning, and content briefly flashed at the wrong y-position before sliding into place.

## How this PR fixes it

CSS-only changes in three files:

- **`SafeAppsHeader/styles.module.css`** — tabs `top: var(--header-height)` → `top: 0`. New Topbar scrolls away with content, so the tabs should pin to the viewport top.
- **`SafeAppsFilters/styles.module.css`** — `top: calc(var(--header-height) + 49px)` → `top: 49px`. Stays directly below the tabs.
- **`SafeAppsSDKLink/styles.module.css`**:
  - Anchor moved from `--header-height` to `--topbar-height` so the widget sits below the Topbar instead of behind it.
  - Mini state pushes the container further up (`translateY(calc(-100% - var(--topbar-height)))`) so the chevron Fab lands at viewport top (`y=0`) when scrolled, and the rest of the widget (border, background, child elements) becomes transparent — leaving only the Fab visible.
  - Hover-mini explicitly translates to `translateY(calc(-1 * var(--topbar-height)))` so the widget expands at `top: 0` instead of `top: 100px` (closer to where the chevron was).
  - `transition` extended to cover `border-color`, `background-color`, and child `opacity` so the slide / fade-in / border / background reveal happen in sync (fixes the jumpy feel).
  - Removed the legacy `.mini .link` rule that forced the link to expand inside the otherwise-hidden mini container — that was the cause of "Learn more about Safe Apps SDK" peeking out under the chevron.

## How to test it

1. Open `/apps` (Apps list) on a desktop viewport (≥ 1400px works best).
2. **At the top of the page**: confirm "How to build on Safe?" sits directly below the Topbar with no overlap, just like the old prod design.
3. **Scroll down**:
   - The "All apps" / "My custom apps" tabs should pin flush to the top of the viewport (no transparent gap above).
   - The Filters row (Search / Category / Batch) should pin directly below the tabs (no gap between tabs and filters).
   - The SDK widget should slide fully out of view, leaving **only** the green chevron Fab at the very top-right of the viewport.
4. **Hover the chevron Fab** while scrolled:
   - The widget should slide down from the top with the border, background, and content (icon, title, link) fading in synchronously.
   - It should land at viewport top (`y=0`), not 100px down.
5. Move the cursor away — widget should slide back up smoothly, leaving only the Fab.
6. Repeat on `/apps/custom`.
7. Sanity-check the `/apps/open?appUrl=...` route (clicking into a specific app) — `SafeAppsHeader` and `SafeAppsSDKLink` are not rendered there, so behavior should be unchanged.

## Affected flows

- User browses Safe Apps list (`/apps`) — sees pinned tabs, filters, and the SDK widget while scrolling.
- User browses custom Safe Apps list (`/apps/custom`) — same three sticky/fixed elements.
- User hovers the SDK widget chevron after scrolling — widget reveal animation.

## Blast radius

- **Files touched**: 3 CSS modules under `apps/web/src/components/safe-apps/`. No JS, no shared components, no Redux, no API.
- **Consumers of changed CSS modules**: each `styles.module.css` is consumed only by its sibling `index.tsx` — verified via the file tree (CSS modules are scoped). No other components import these styles.
- **Pages rendering these components**: `apps/web/src/pages/apps/index.tsx` and `apps/web/src/pages/apps/custom.tsx` only.
- **Mobile impact**: none. These files live under `apps/web/`; mobile uses Tamagui and does not consume web CSS.
- **Theme / token impact**: none. `--header-height` and `--topbar-height` are still defined in `apps/web/src/styles/globals.css`; we just stop using `--header-height` in three places where it was stale.

## Risks / not checked

- Did **not** test on viewport widths below 1210px (one media query in `SafeAppsSDKLink` — `transform: translateY(-80px)` — was left untouched and may need its own audit if the new Topbar has a different mobile height).
- Did **not** test on touch devices — hover-only interaction means the chevron expansion is desktop-oriented; mobile users would need to focus or tap, which may surface different UX issues.
- Did **not** run Chromatic visual regression locally.
- Did **not** test with `SAFE_APPS` feature flag disabled.
- Did **not** verify the e2e Cypress smoke tests for `/apps`.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    direction TB
    B_Topbar["Topbar (100px)"]
    B_SDK["How to build on Safe?<br/>top: --header-height (56px)<br/>→ overlaps Topbar"]
    B_Tabs["All apps / My custom apps<br/>sticky top: 56px<br/>→ 44px transparent gap"]
    B_Filters["Filters<br/>sticky top: 56px+49px<br/>→ same gap"]
    B_Topbar --- B_SDK
    B_SDK --- B_Tabs
    B_Tabs --- B_Filters
  end
  subgraph After
    direction TB
    A_Topbar["Topbar (100px)"]
    A_SDK["How to build on Safe?<br/>top: --topbar-height (100px)<br/>→ sits below Topbar"]
    A_Tabs["All apps / My custom apps<br/>sticky top: 0<br/>→ flush to viewport top<br/>after Topbar scrolls away"]
    A_Filters["Filters<br/>sticky top: 49px<br/>→ flush below tabs"]
    A_Topbar --- A_SDK
    A_SDK --- A_Tabs
    A_Tabs --- A_Filters
  end
```

```mermaid
sequenceDiagram
  participant User
  participant Page
  participant Container as SDKLink container
  participant Fab as Chevron Fab

  User->>Page: scroll down
  Page->>Container: add .mini class
  Container->>Container: translateY(-100% - 100px)<br/>border + bg → transparent<br/>children opacity → 0
  Container->>Fab: rides container.bottom → y=0 (viewport top)

  User->>Fab: hover
  Container->>Container: translateY(-100px) — top: 0<br/>border + bg restored<br/>children opacity → 1<br/>(all in sync, 0.3s)
  Container->>Fab: rides to bottom of expanded widget

  User->>Page: cursor leaves
  Container->>Container: translateY(-100% - 100px)<br/>(reverse, 0.4s)
```

> Screenshots: please attach before/after captures of (1) top of page, (2) scrolled state showing only the Fab, (3) hovered-while-scrolled showing the expanded widget at viewport top.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
