### PR TITLE
feat(web/Spaces): Beamer and Contact Support in the Sidebar

### DIFF
--- a/apps/web/src/components/common/HelpMenu/index.tsx
+++ b/apps/web/src/components/common/HelpMenu/index.tsx
@@ -1,0 +1,82 @@
+import { useState, useCallback, type ReactElement } from 'react'
+import { Menu, MenuItem, ListItemIcon, ListItemText, SvgIcon } from '@mui/material'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
+import { OpenInNewRounded } from '@mui/icons-material'
+import { useLoadFeature } from '@/features/__core__'
+import { SupportChatFeature, useSupportChat } from '@/features/support-chat'
+import { useIsOfficialHost } from '@/hooks/useIsOfficialHost'
+import css from './styles.module.css'
+
+const HELP_CENTER_URL = 'https://help.safe.global'
+
+type HelpMenuProps = {
+  anchorEl: HTMLElement | null
+  onClose: () => void
+}
+
+const HelpMenu = ({ anchorEl, onClose }: HelpMenuProps): ReactElement | null => {
+  const [isSupportOpen, setSupportOpen] = useState(false)
+  const { SupportChatDrawer, $isDisabled } = useLoadFeature(SupportChatFeature)
+  const { config, user } = useSupportChat()
+  const isOfficialHost = useIsOfficialHost()
+
+  const isMenuOpen = Boolean(anchorEl)
+  const showSupport = !$isDisabled && isOfficialHost
+
+  const handleHelpCenterClick = useCallback(() => {
+    window.open(HELP_CENTER_URL, '_blank', 'noopener,noreferrer')
+    onClose()
+  }, [onClose])
+
+  const handleContactSupportClick = useCallback(() => {
+    setSupportOpen(true)
+    onClose()
+  }, [onClose])
+
+  const handleSupportClose = useCallback(() => {
+    setSupportOpen(false)
+  }, [])
+
+  return (
+    <>
+      <Menu
+        className={css.menu}
+        anchorEl={anchorEl}
+        open={isMenuOpen}
+        onClose={onClose}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+      >
+        <MenuItem onClick={handleHelpCenterClick}>
+          <ListItemIcon>
+            <HelpOutlineIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Help center</ListItemText>
+          <SvgIcon component={OpenInNewRounded} fontSize="small" sx={{ color: 'text.secondary', ml: 1 }} />
+        </MenuItem>
+
+        {showSupport ? (
+          <MenuItem onClick={handleContactSupportClick}>
+            <ListItemIcon>
+              <ChatBubbleOutlineIcon fontSize="small" />
+            </ListItemIcon>
+            <ListItemText>Contact support</ListItemText>
+          </MenuItem>
+        ) : null}
+      </Menu>
+
+      {showSupport ? (
+        <SupportChatDrawer open={isSupportOpen} onClose={handleSupportClose} config={config} user={user} />
+      ) : null}
+    </>
+  )
+}
+
+export default HelpMenu

--- a/apps/web/src/components/common/HelpMenu/styles.module.css
+++ b/apps/web/src/components/common/HelpMenu/styles.module.css
@@ -1,0 +1,22 @@
+.menu :global .MuiPaper-root {
+  border-radius: 8px !important;
+}
+
+.menu :global .MuiList-root {
+  padding: 4px;
+}
+
+.menu :global .MuiMenuItem-root {
+  padding: 8px 12px;
+  min-height: 40px;
+  border-radius: 8px !important;
+  gap: var(--space-1);
+}
+
+.menu :global .MuiMenuItem-root:hover {
+  background-color: var(--color-secondary-background);
+}
+
+.menu :global .MuiListItemIcon-root {
+  min-width: 26px;
+}

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
@@ -1,10 +1,9 @@
-import type { ReactElement } from 'react'
+import { useState, useCallback, type ReactElement } from 'react'
 import { SidebarFooter, SidebarMenu, SidebarMenuItem, SidebarMenuButton } from '@/components/ui/sidebar'
 import { cn } from '@/utils/cn'
 import { icons } from '../config'
 import css from '../styles.module.css'
 import { IS_PRODUCTION } from '@/config/constants'
-import { HELP_CENTER_URL } from '@safe-global/utils/config/constants'
 import { trackEvent, OVERVIEW_EVENTS, MixpanelEventParams } from '@/services/analytics'
 import { Switch } from '@/components/ui/switch'
 import { Field, FieldLabel } from '@/components/ui/field'
@@ -15,16 +14,27 @@ import { ApiCtaSidebar } from '../ApiCtaSidebar'
 import { SidebarIndexingStatus } from '../SidebarIndexingStatus'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { LS_KEY } from '@/config/gateway'
+import HelpMenu from '@/components/common/HelpMenu'
 
 export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?: boolean }): ReactElement => {
   const dispatch = useAppDispatch()
   const isDarkMode = useDarkMode()
   const [isProdGateway = false, setIsProdGateway] = useLocalStorage<boolean>(LS_KEY)
+  const [helpMenuAnchor, setHelpMenuAnchor] = useState<HTMLElement | null>(null)
 
   const onToggleGateway = (checked: boolean) => {
     setIsProdGateway(checked)
     setTimeout(() => location.reload(), 300)
   }
+
+  const handleHelpClick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    trackEvent({ ...OVERVIEW_EVENTS.HELP_CENTER }, { [MixpanelEventParams.SIDEBAR_ELEMENT]: 'Help Center' })
+    setHelpMenuAnchor(event.currentTarget)
+  }, [])
+
+  const handleHelpMenuClose = useCallback(() => {
+    setHelpMenuAnchor(null)
+  }, [])
 
   return (
     <SidebarFooter data-testid="sidebar-common-footer">
@@ -54,11 +64,8 @@ export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?:
         <SidebarMenuItem className={css.footerHelpRow}>
           <SidebarMenuButton
             className={cn('h-9 min-w-0 flex-1 gap-3', css.sidebarInteractive, css.sidebarNavItem)}
-            render={<a href={HELP_CENTER_URL} target="_blank" rel="noopener noreferrer" />}
             data-testid="list-item-need-help"
-            onClick={() =>
-              trackEvent({ ...OVERVIEW_EVENTS.HELP_CENTER }, { [MixpanelEventParams.SIDEBAR_ELEMENT]: 'Help Center' })
-            }
+            onClick={handleHelpClick}
           >
             <icons.CircleHelp />
             <span>Help</span>
@@ -68,6 +75,8 @@ export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?:
           </div>
         </SidebarMenuItem>
       </SidebarMenu>
+
+      <HelpMenu anchorEl={helpMenuAnchor} onClose={handleHelpMenuClose} />
     </SidebarFooter>
   )
 }

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, type ReactElement } from 'react'
+import { Sparkles } from 'lucide-react'
 import { SidebarFooter, SidebarMenu, SidebarMenuItem, SidebarMenuButton } from '@/components/ui/sidebar'
 import { cn } from '@/utils/cn'
 import { icons } from '../config'
@@ -9,15 +10,20 @@ import { Switch } from '@/components/ui/switch'
 import { Field, FieldLabel } from '@/components/ui/field'
 import { setDarkMode } from '@/store/settingsSlice'
 import { useDarkMode } from '@/hooks/useDarkMode'
-import { useAppDispatch } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { CookieAndTermType, hasConsentFor } from '@/store/cookiesAndTermsSlice'
+import { openCookieBanner } from '@/store/popupSlice'
+import { BEAMER_SELECTOR } from '@/services/beamer'
 import { ApiCtaSidebar } from '../ApiCtaSidebar'
 import { SidebarIndexingStatus } from '../SidebarIndexingStatus'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { LS_KEY } from '@/config/gateway'
 import HelpMenu from '@/components/common/HelpMenu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?: boolean }): ReactElement => {
   const dispatch = useAppDispatch()
+  const hasBeamerConsent = useAppSelector((state) => hasConsentFor(state, CookieAndTermType.UPDATES))
   const isDarkMode = useDarkMode()
   const [isProdGateway = false, setIsProdGateway] = useLocalStorage<boolean>(LS_KEY)
   const [helpMenuAnchor, setHelpMenuAnchor] = useState<HTMLElement | null>(null)
@@ -35,6 +41,13 @@ export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?:
   const handleHelpMenuClose = useCallback(() => {
     setHelpMenuAnchor(null)
   }, [])
+
+  const handleBeamerClick = useCallback(() => {
+    trackEvent({ ...OVERVIEW_EVENTS.WHATS_NEW }, { [MixpanelEventParams.SIDEBAR_ELEMENT]: "What's New" })
+    if (!hasBeamerConsent) {
+      dispatch(openCookieBanner({ warningKey: CookieAndTermType.UPDATES }))
+    }
+  }, [dispatch, hasBeamerConsent])
 
   return (
     <SidebarFooter data-testid="sidebar-common-footer">
@@ -70,6 +83,28 @@ export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?:
             <icons.CircleHelp />
             <span>Help</span>
           </SidebarMenuButton>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <SidebarMenuButton
+                  type="button"
+                  id={BEAMER_SELECTOR}
+                  data-testid="list-item-whats-new"
+                  aria-label="What's new"
+                  className={cn(
+                    'h-9 w-9 min-w-9 shrink-0 gap-0 !px-0 !py-0 text-center !justify-center !overflow-visible',
+                    '[&_svg]:size-4 [&_svg]:shrink-0 [&_svg]:stroke-[1.25]',
+                    css.sidebarInteractive,
+                    css.footerBeamerButton,
+                  )}
+                  onClick={handleBeamerClick}
+                />
+              }
+            >
+              <Sparkles aria-hidden strokeWidth={1.25} />
+            </TooltipTrigger>
+            <TooltipContent side="top">What&apos;s new</TooltipContent>
+          </Tooltip>
           <div className={css.footerHelpStatus}>
             <SidebarIndexingStatus />
           </div>

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/__tests__/SidebarCommonFooter.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/__tests__/SidebarCommonFooter.test.tsx
@@ -1,19 +1,25 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import React, { type ReactNode } from 'react'
 import { SidebarCommonFooter } from '../SidebarCommonFooter'
 
 const mockUseAppDispatch = jest.fn()
 const mockUseDarkMode = jest.fn()
 const mockTrackEvent = jest.fn()
 
+let mockHasBeamerConsent = true
+
 jest.mock('@/services/analytics', () => ({
   trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
-  OVERVIEW_EVENTS: { HELP_CENTER: { action: 'Open Help Center' } },
+  OVERVIEW_EVENTS: {
+    HELP_CENTER: { action: 'Open Help Center' },
+    WHATS_NEW: { action: "Open What's New" },
+  },
   MixpanelEventParams: { SIDEBAR_ELEMENT: 'sidebarElement' },
 }))
 
 jest.mock('@/store', () => ({
   useAppDispatch: () => mockUseAppDispatch(),
+  useAppSelector: () => mockHasBeamerConsent,
 }))
 
 jest.mock('@/hooks/useDarkMode', () => ({
@@ -36,18 +42,36 @@ jest.mock('@/components/ui/sidebar', () => ({
   SidebarMenuButton: ({
     children,
     className,
+    id,
+    type = 'button',
     'data-testid': testId,
+    'aria-label': ariaLabel,
     onClick,
   }: {
-    children: ReactNode
+    children?: ReactNode
     className?: string
+    id?: string
+    type?: 'button' | 'submit' | 'reset'
     'data-testid'?: string
+    'aria-label'?: string
     onClick?: React.MouseEventHandler<HTMLButtonElement>
   }) => (
-    <button data-testid={testId} className={className} onClick={onClick}>
+    <button type={type} id={id} data-testid={testId} className={className} aria-label={ariaLabel} onClick={onClick}>
       {children}
     </button>
   ),
+}))
+
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    render,
+  }: {
+    children: ReactNode
+    render: React.ReactElement<{ children?: ReactNode }>
+  }) => React.cloneElement(render, {}, children),
+  TooltipContent: ({ children }: { children: ReactNode }) => <div role="tooltip">{children}</div>,
 }))
 
 jest.mock('@/components/ui/switch', () => ({
@@ -99,10 +123,15 @@ jest.mock('../../SidebarIndexingStatus', () => ({
   SidebarIndexingStatus: () => <div data-testid="indexing-status" />,
 }))
 
+jest.mock('@/services/beamer', () => ({
+  BEAMER_SELECTOR: 'whats-new-button',
+}))
+
 describe('SidebarCommonFooter', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     isProductionMock = true
+    mockHasBeamerConsent = true
     mockUseAppDispatch.mockReturnValue(jest.fn())
     mockUseDarkMode.mockReturnValue(false)
   })
@@ -117,11 +146,38 @@ describe('SidebarCommonFooter', () => {
     )
   })
 
+  it("fires WHATS_NEW tracking event when clicking What's new", () => {
+    render(<SidebarCommonFooter />)
+    fireEvent.click(screen.getByTestId('list-item-whats-new'))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "Open What's New" }),
+      expect.objectContaining({ sidebarElement: "What's New" }),
+    )
+  })
+
+  it("dispatches open cookie banner when What's new is clicked without Beamer consent", () => {
+    mockHasBeamerConsent = false
+    const mockDispatch = jest.fn()
+    mockUseAppDispatch.mockReturnValue(mockDispatch)
+
+    render(<SidebarCommonFooter />)
+    fireEvent.click(screen.getByTestId('list-item-whats-new'))
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: expect.stringMatching(/openCookieBanner/),
+        payload: { warningKey: 'updates' },
+      }),
+    )
+  })
+
   it('renders footer and help entry', () => {
     render(<SidebarCommonFooter />)
 
     expect(screen.getByTestId('sidebar-common-footer')).toBeInTheDocument()
     expect(screen.getByTestId('list-item-need-help')).toBeInTheDocument()
+    expect(screen.getByTestId('list-item-whats-new')).toBeInTheDocument()
     expect(screen.getByTestId('help-icon')).toBeInTheDocument()
     expect(screen.getByText('Help')).toBeInTheDocument()
   })

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/__tests__/SidebarCommonFooter.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/__tests__/SidebarCommonFooter.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import type { ReactElement, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { SidebarCommonFooter } from '../SidebarCommonFooter'
 
 const mockUseAppDispatch = jest.fn()
@@ -20,6 +20,12 @@ jest.mock('@/hooks/useDarkMode', () => ({
   useDarkMode: () => mockUseDarkMode(),
 }))
 
+jest.mock('@/components/common/HelpMenu', () => ({
+  __esModule: true,
+  default: ({ anchorEl, onClose }: { anchorEl: HTMLElement | null; onClose: () => void }) =>
+    anchorEl ? <div data-testid="help-menu" role="menu" onClick={onClose} /> : null,
+}))
+
 // Mock sidebar UI components
 jest.mock('@/components/ui/sidebar', () => ({
   SidebarFooter: ({ children, 'data-testid': testId }: { children: ReactNode; 'data-testid'?: string }) => (
@@ -29,33 +35,19 @@ jest.mock('@/components/ui/sidebar', () => ({
   SidebarMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarMenuButton: ({
     children,
-    render: renderProp,
     className,
     'data-testid': testId,
     onClick,
   }: {
     children: ReactNode
-    render?: ReactElement<{ href: string; target?: string; rel?: string }>
     className?: string
     'data-testid'?: string
-    onClick?: () => void
-  }) =>
-    renderProp ? (
-      <a
-        data-testid={testId}
-        className={className}
-        href={renderProp.props.href}
-        target={renderProp.props.target}
-        rel={renderProp.props.rel}
-        onClick={onClick}
-      >
-        {children}
-      </a>
-    ) : (
-      <button data-testid={testId} className={className} onClick={onClick}>
-        {children}
-      </button>
-    ),
+    onClick?: React.MouseEventHandler<HTMLButtonElement>
+  }) => (
+    <button data-testid={testId} className={className} onClick={onClick}>
+      {children}
+    </button>
+  ),
 }))
 
 jest.mock('@/components/ui/switch', () => ({
@@ -139,13 +131,22 @@ describe('SidebarCommonFooter', () => {
     expect(screen.getByTestId('indexing-status')).toBeInTheDocument()
   })
 
-  it('renders help link with correct attributes', () => {
+  it('opens help menu when Help button is clicked', () => {
     render(<SidebarCommonFooter />)
 
-    const helpLink = screen.getByRole('link', { name: /Help/i })
-    expect(helpLink).toHaveAttribute('href', 'https://help.safe.global')
-    expect(helpLink).toHaveAttribute('target', '_blank')
-    expect(helpLink).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(screen.queryByTestId('help-menu')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('list-item-need-help'))
+    expect(screen.getByTestId('help-menu')).toBeInTheDocument()
+  })
+
+  it('closes help menu when onClose is called', () => {
+    render(<SidebarCommonFooter />)
+
+    fireEvent.click(screen.getByTestId('list-item-need-help'))
+    expect(screen.getByTestId('help-menu')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('help-menu'))
+    expect(screen.queryByTestId('help-menu')).not.toBeInTheDocument()
   })
 
   it('does not render dev toggles in production', () => {

--- a/apps/web/src/features/spaces/components/Sidebar/styles.module.css
+++ b/apps/web/src/features/spaces/components/Sidebar/styles.module.css
@@ -224,6 +224,22 @@
   display: block;
 }
 
+/* Beamer unread count */
+.footerBeamerButton {
+  position: relative;
+  overflow: visible;
+}
+
+.footerBeamerButton :global(.beamer_icon) {
+  position: absolute;
+  right: 0.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 18px;
+  background-color: var(--color-success-background, #dcfce7) !important;
+  color: var(--accent-secondary-foreground) !important;
+}
+
 .sidebarGroup {
   padding-block: 0;
 }
@@ -276,6 +292,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  overflow: visible;
 }
 
 .footerHelpRow .footerHelp {

--- a/apps/web/src/features/support-chat/components/SupportChatDrawer.tsx
+++ b/apps/web/src/features/support-chat/components/SupportChatDrawer.tsx
@@ -229,30 +229,29 @@ function SupportChatDrawer({ open, onClose, config, user }: SupportChatDrawerPro
   if (!open) return null
 
   return (
-    <Box
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose()
-      }}
-      sx={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: 1300,
-        pointerEvents: 'none',
-      }}
-    >
+    <>
+      <Box
+        aria-hidden
+        onClick={onClose}
+        sx={{
+          position: 'fixed',
+          inset: 0,
+          zIndex: 1300,
+          bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'rgba(0, 0, 0, 0.4)' : 'rgba(0, 0, 0, 0.2)'),
+        }}
+      />
       <Box
         sx={{
           position: 'fixed',
           bottom: { xs: 0, sm: 72 },
-          right: { xs: 0, sm: 24 },
+          left: { xs: 0, sm: 24 },
           width: { xs: '100vw', sm: chatWidth },
           maxWidth: { xs: '100vw', sm: chatWidth },
           height: { xs: '100vh', sm: 'auto' },
           maxHeight: { xs: '100vh', sm: 'calc(100vh - 88px)' },
-          zIndex: 1300,
-          pointerEvents: 'auto',
+          zIndex: 1301,
           animation: 'supportChatOpen 150ms ease-out',
-          transformOrigin: 'bottom right',
+          transformOrigin: 'bottom left',
           '@keyframes supportChatOpen': {
             from: { opacity: 0, transform: 'scale(0.95) translateY(8px)' },
             to: { opacity: 1, transform: 'scale(1) translateY(0)' },
@@ -272,7 +271,7 @@ function SupportChatDrawer({ open, onClose, config, user }: SupportChatDrawerPro
             borderRadius: showPlaceholder ? { xs: 0, sm: 2 } : 0,
             overflow: 'visible',
             boxShadow: showPlaceholder ? { xs: 'none', sm: 8 } : 'none',
-            alignSelf: 'flex-end',
+            alignSelf: 'flex-start',
             flexShrink: 0,
             transition: 'background-color 120ms ease, box-shadow 120ms ease',
           }}
@@ -343,7 +342,7 @@ function SupportChatDrawer({ open, onClose, config, user }: SupportChatDrawerPro
           )}
         </Box>
       </Box>
-    </Box>
+    </>
   )
 }
 


### PR DESCRIPTION
> Help link blooms into a menu,
> Pylon chat opens on click,
> Beamer sparkles in the sidebar too.

## What it solves

Add the Beamer btn and the Contact Support menu to the sidebar.

Resolves: [WA-2149](https://linear.app/safe-global/issue/WA-2149/add-beamer-to-the-sidebar)
Resolves: [WA-2148](https://linear.app/safe-global/issue/WA-2148/restore-help-center-contact-modal-but-move-the-entry-to-the-sidebar)

## How this PR fixes it

Replaces the direct "Help" link in the sidebar footer with a dropdown `HelpMenu` component that exposes two actions:
- **Help center** — opens `help.safe.global` in a new tab (existing behaviour)
- **Contact support** — opens the Pylon `SupportChatDrawer` (only on official host, only when the `support-chat` feature is enabled)

Also adds a **"What's new" (Beamer)** icon button to the sidebar footer. If the user hasn't consented to the `UPDATES` cookie category, clicking it opens the cookie consent banner first.

## How to test it

The Contact Support feature is NOT testable on Staging without Feature Flag enabled.
1. Open the web app.
2. Click the **Help** button in the sidebar footer.
3. Verify a dropdown appears with "Help center" (and "Contact support" - this one will appear only on the official host and with a feature flag enabled). On unofficial hosts (like this branch) / when `support-chat` feature flag is disabled → "Contact support" item must not appear.
4. Click **Help center** → should open `help.safe.global` in a new tab.
6. Verify the **"What's new" ✨** icon appears next to Help.
7. If cookie consent is already granted → Beamer panel opens on click.
8. If cookie consent is NOT granted → cookie banner opens instead.


## Affected flows

- User opens Help → Help Center from sidebar footer
- User opens Help → Contact Support (Pylon chat) from sidebar footer
- User clicks "What's new" Beamer button in sidebar footer

## Blast radius

- `SidebarCommonFooter` (used in both `SafeSidebarVariant` and `SpacesSidebarVariant`) — any sidebar footer regression would affect all users
- `HelpMenu` is a new shared component under `components/common/`
- `SupportChatDrawer` is now also triggered from the sidebar (previously only from `Topbar`)
- Beamer consent gate reuses existing `openCookieBanner` / `CookieAndTermType.UPDATES` path

## Visual summary

```mermaid
flowchart LR
  A[Sidebar footer Help button] -->|click| B[HelpMenu dropdown]
  B --> C[Help center\nopens in new tab]
  B --> D{Official host\n& feature enabled?}
  D -->|Yes| E[Contact support\nPylon SupportChatDrawer]
  D -->|No| F[Item hidden]

  G[Sidebar footer ✨ Beamer button] -->|click| H{UPDATES consent?}
  H -->|Yes| I[Beamer panel opens]
  H -->|No| J[Cookie banner opens]
  ```
  
## CLA signature
With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
