### PR TITLE
fix: fix top bar ui and disable ens name as fallback

### DIFF
--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -3,7 +3,6 @@
 .topbar {
   @apply absolute top-0 right-0 z-[1];
   left: 230px;
-  transition: left 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
 }
 
 .topbarCollapsed {
@@ -24,6 +23,14 @@
   header {
     padding-left: 230px;
   }
+}
+
+.topbarElevated:not(.topbarNoSidebar) header {
+  padding-left: calc(230px + 1.5rem);
+}
+
+.topbarElevated.topbarNoSidebar header {
+  padding-left: 1.5rem;
 }
 
 @media (max-width: 899.95px) {

--- a/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react'
 import SpaceSafeBar from './index'
+import { TxModalContext } from '@/components/tx-flow'
 
 const mockItems = [
   {
@@ -219,6 +220,25 @@ describe('SpaceSafeBar', () => {
     const { getByTestId } = render(<SpaceSafeBar />)
     expect(getByTestId('space-back-link')).toBeInTheDocument()
     expect(getByTestId('safe-selector-dropdown')).toBeInTheDocument()
+  })
+
+  it('hides SpaceBackLink while a tx-flow modal is open', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+    mockUseSpaceBackLink.mockReturnValue({
+      space: { id: 1, name: 'Test Space' },
+      handleBackToSpace: jest.fn(),
+    })
+
+    const { queryByTestId, getByTestId } = render(
+      <TxModalContext.Provider value={{ txFlow: <div />, setTxFlow: jest.fn(), setFullWidth: jest.fn() }}>
+        <SpaceSafeBar />
+      </TxModalContext.Provider>,
+    )
+
+    expect(queryByTestId('space-back-link')).not.toBeInTheDocument()
+    // Other elements still render — only the back link is hidden
+    expect(getByTestId('safe-selector-dropdown')).toBeInTheDocument()
+    expect(getByTestId('space-chain-selector')).toBeInTheDocument()
   })
 
   it.each([['/welcome/accounts'], ['/welcome/spaces'], ['/new-safe/create'], ['/new-safe/load']])(

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import { usePathname } from 'next/navigation'
+import { TxModalContext } from '@/components/tx-flow'
 import { Bookmark, ChevronRight, Wallet } from 'lucide-react'
 import { AppRoutes } from '@/config/routes'
 import { useIsQualifiedSafe } from '@/features/spaces'
@@ -92,6 +93,7 @@ function SpaceSafeBar() {
   const allSafeItems = useAllSafes()
   const wallet = useWallet()
   const connectWallet = useConnectWallet()
+  const { txFlow } = useContext(TxModalContext)
 
   if (HIDDEN_ROUTES.includes(pathname ?? '')) return null
 
@@ -153,7 +155,7 @@ function SpaceSafeBar() {
 
   return (
     <div data-testid="safe-level-navigation" className="flex flex-wrap items-center gap-2">
-      {isQualifiedSafe && space && <SpaceBackLink space={space} onClick={handleBackToSpace} />}
+      {isQualifiedSafe && space && !txFlow && <SpaceBackLink space={space} onClick={handleBackToSpace} />}
       <SpaceChainSelector isLoading={isLoading} />
       <SpaceNestedSafesButton />
       <SafeSelectorDropdown

--- a/apps/web/src/hooks/useSafeDisplayName.ts
+++ b/apps/web/src/hooks/useSafeDisplayName.ts
@@ -1,16 +1,11 @@
 import { useAddressBookItem } from '@/hooks/useAllAddressBooks'
-import { useAddressResolver } from '@/hooks/useAddressResolver'
 
 /**
  * Resolves the display name for a Safe address.
- * Priority: preferredName > address book > ENS name
- *
- * ENS results are cached in-memory per chain+address by useAddressResolver,
- * so each address is only resolved once per session.
+ * Priority: preferredName > address book
  */
 export const useSafeDisplayName = (address: string, chainId: string, preferredName?: string): string => {
   const addressBookItem = useAddressBookItem(address, chainId)
-  const { ens } = useAddressResolver(address)
 
-  return preferredName || addressBookItem?.name || ens || ''
+  return preferredName || addressBookItem?.name || ''
 }


### PR DESCRIPTION
> Topbar stops flying in,
> back link bows to tx-flow,
> ENS sits this one out.

## What it solves
https://linear.app/safe-global/issue/WA-2176/fix-ui-issues-with-selector-positioning-and-behavior
Resolves several topbar polish issues introduced by the recent topbar/elevation rework:

1. **Recovery page**: topbar content (chain selector pill) sat flush against the sidebar with no breathing room — content started at 230px (sidebar edge) instead of the 254px the non-elevated state uses.
2. **Tx-flow modal (e.g. New transaction)**: topbar inherited the elevated rule's `padding-left: 230px`, leaving the chain selector hovering inside the page rather than flush left like on the Tx Builder (`/apps/open`) page.
3. **Page load / refresh**: chain selector visibly "flew in from the left" because the `.topbar` transition fired during initial render.
4. **Tx-flow modal**: the "back to space" arrow next to the chain selector remained visible during transaction creation, which is noisy and not actionable inside a modal.
5. **`useSafeDisplayName`**: the ENS fallback is being deferred to a later milestone — removing it now keeps behavior predictable in the meantime.

## How this PR fixes it

**`PageLayout/styles.module.css`**

- Drop `transition: left 225ms` from `.topbar`. The transition only mattered for sidebar collapse/expand, but it also fired on initial mount, causing the "flying in" effect.
- Split the elevated header padding into two scoped rules instead of one global override:
  - `.topbarElevated:not(.topbarNoSidebar) header` → `calc(230px + 1.5rem)` (recovery: matches the non-elevated state's 254px content offset).
  - `.topbarElevated.topbarNoSidebar header` → `1.5rem` (tx-flow: matches the Tx Builder layout where the topbar is flush left with only `px-6` of padding).

**`SpaceSafeBar/index.tsx`**

- Read `txFlow` from `TxModalContext` and hide `SpaceBackLink` while any tx-flow modal is open.

**`useSafeDisplayName.ts`**

- Remove the ENS fallback and `useAddressResolver` dependency. Priority is now `preferredName > addressBookItem?.name > ''`. The hook signature is unchanged so all 6 consumers compile without edits.

**Test**

- Added a regression test in `SpaceSafeBar/index.test.tsx` covering the new "hide back link during tx-flow" branch.

## How to test it

1. **Recovery page** (chain on which you have a Safe with recovery enabled):
   - Trigger the recovery modal — the chain selector pill should sit ~24px away from the sidebar edge, matching the spacing on every other Safe page.
2. **Tx-flow flush-left**:
   - Click "New transaction" on any Safe. The topbar's chain selector should snap to the left edge of the screen (matching `/apps/open` Tx Builder).
3. **Initial-load animation**:
   - Hard-refresh any Safe page. The chain selector should appear in place — no visible left-to-right slide.
4. **Back-to-space hiding**:
   - On a space-qualified Safe, confirm the back-to-space arrow is visible on `/home`.
   - Open New transaction → arrow disappears. Close modal → arrow returns.
   - Confirm the arrow is still visible on `/transactions/queue` and `/transactions/history` (those are list pages, not modals).
5. **`useSafeDisplayName`**:
   - For a Safe with no preferred name and no address-book entry, the hook should return `''` (caller renders truncated address). Previously it would return ENS; that path is intentionally gone.

## Affected flows

- Recovery: viewing the Recover This Account banner on a Safe with recovery enabled.
- New transaction (and every other tx-flow modal: Send, Add Owner, Replace Owner, Change Threshold, etc.) — topbar layout while modal is open.
- Page load / refresh on any sidebar-bearing Safe route — first-paint animation.
- Space-qualified Safe header — back-to-space affordance during tx-flow.
- Any UI rendering a Safe display name via `useSafeDisplayName` (Safe selector dropdown trigger, multi-chain rows, accounts modal cards).

## Blast radius

- **`PageLayout/styles.module.css`** — global topbar styling. The new selectors are scoped to the two `.topbarElevated` cases (recovery vs tx-flow) and a no-op for non-elevated states. Removing the `.topbar` transition affects all sidebar collapse/expand animations (Spaces collapse, mobile breakpoint resize) — these now snap rather than slide.
- **`SpaceSafeBar`** — consumed by the topbar on every Safe and Space route via `Topbar/index.tsx`. The new condition only affects the back-link branch.
- **`TxModalContext`** — read-only consumption; no provider or context shape change.
- **`useSafeDisplayName`** — 6 consumers in `features/spaces/components/SafeSelectorDropdown/*` and `components/common/SpaceSafeBar/AccountsModal/*`. Signature unchanged, so call sites are untouched. Any Safe without a preferred name or address-book entry that previously displayed an ENS name will now display the truncated address until ENS is re-added.
- **Mobile**: shared packages are not touched. `useSafeDisplayName` is web-only.

## Risks / not checked

- **Mobile breakpoint**: the elevated `.topbarElevated.topbarNoSidebar header` rule sets `padding-left: 1.5rem` unconditionally. The `@media (max-width: 899.95px)` block was not re-tested with both modals open — historically the elevated padding was already misaligned on mobile (sidebar absent but padding assumed it). This PR doesn't make that worse but doesn't fix it either.
- **Sidebar transition removal**: removing `transition: left 225ms` from `.topbar` means Spaces sidebar collapse/expand and mobile breakpoint resize no longer animate the topbar. Verified visually as acceptable, but no formal designer sign-off.
- **Recovery + tx-flow simultaneously**: not exercised. Both register under `useTopbarElevation`, but only one modal is expected to be visible at a time.
- **Chromatic**: visual regression for the topbar across light/dark themes will be picked up automatically; no manual cross-theme audit performed.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    direction LR
    B1[".topbar"] -->|"transition: left 225ms"| B2["fly-in on load"]
    B3[".topbarElevated header<br/>padding-left: 230px"] --> B4["recovery: content kisses sidebar (230px)"]
    B3 --> B5["tx-flow: content stuck at 230px<br/>not flush left like Tx Builder"]
    B6["SpaceSafeBar"] --> B7["back link visible during tx-flow"]
    B8["useSafeDisplayName"] --> B9["preferredName → addressBook → <b>ENS</b> → ''"]
  end

  subgraph After
    direction LR
    A1[".topbar"] --> A2["snap to position (no transition on load)"]
    A3[".topbarElevated:not(.topbarNoSidebar)<br/>padding-left: calc(230px + 1.5rem)"] --> A4["recovery: 254px (aligned with non-elevated)"]
    A5[".topbarElevated.topbarNoSidebar<br/>padding-left: 1.5rem"] --> A6["tx-flow: flush left @ 24px<br/>matches /apps/open"]
    A7["SpaceSafeBar checks txFlow"] --> A8["back link hidden during tx-flow"]
    A9["useSafeDisplayName"] --> A10["preferredName → addressBook → ''<br/>(ENS deferred to next milestone)"]
  end
```