### PR TITLE
fix(web): adjust recovery modal corners and trim sidebar info

### DIFF
--- a/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
+++ b/apps/web/src/components/tx-flow/common/TxLayout/index.tsx
@@ -1,18 +1,7 @@
 import type { Transaction } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { type ComponentType, type ReactElement, type ReactNode, useContext } from 'react'
-import {
-  Box,
-  Container,
-  Grid2 as Grid,
-  Typography,
-  Button,
-  Paper,
-  SvgIcon,
-  useMediaQuery,
-  Card,
-  Stack,
-} from '@mui/material'
+import { Box, Container, Grid2 as Grid, Typography, Button, Paper, SvgIcon, useMediaQuery, Stack } from '@mui/material'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import { useTheme } from '@mui/material/styles'
 import classnames from 'classnames'
@@ -22,8 +11,6 @@ import { TxInfoProvider } from '@/components/tx-flow/TxInfoProvider'
 import TxNonce from '../TxNonce'
 import TxStatusWidget from '../TxStatusWidget'
 import css from './styles.module.css'
-import ChainIndicator from '@/components/common/ChainIndicator'
-import SafeInfo from '@/components/tx-flow/common/SafeInfo'
 import SafeShieldWidget from '@/features/safe-shield'
 import { SafeShieldProvider } from '@/features/safe-shield/SafeShieldContext'
 
@@ -111,10 +98,6 @@ const TxLayout = ({
               <Grid sx={{ width: 200 }} pt={5}>
                 <aside>
                   <Stack gap={3} position="fixed">
-                    <Card className={css.safeInfoCard}>
-                      <SafeInfo />
-                    </Card>
-
                     <TxStatusWidget
                       isLastStep={step === steps.length - 1}
                       txSummary={txSummary}
@@ -141,8 +124,6 @@ const TxLayout = ({
                       >
                         {title}
                       </Typography>
-
-                      <ChainIndicator inline />
                     </div>
 
                     <Paper

--- a/apps/web/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowSetup.tsx
+++ b/apps/web/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowSetup.tsx
@@ -86,7 +86,7 @@ export function RecoverAccountFlowSetup({
   return (
     <FormProvider {...formMethods}>
       <form onSubmit={formMethods.handleSubmit(onSubmit)} className={commonCss.form}>
-        <TxCard sx={{ mt: 0 }}>
+        <TxCard sx={{ mt: 0, borderTopLeftRadius: 0, borderTopRightRadius: 0 }}>
           <div>
             <Typography
               variant="h6"


### PR DESCRIPTION
> Recovery modal trimmed:
> Safe info card removed,
> top corners squared off.

## What it solves

Resolves: visual polish on the recovery modal. The setup card had rounded top corners that didn't sit flush against the modal header, and the side rail repeated information (Safe info card + inline chain indicator) that was already conveyed elsewhere in the flow.

## How this PR fixes it

- `TxLayout`: removes the `SafeInfo` card from the fixed side rail and the inline `ChainIndicator` from the step title area.
- `RecoverAccountFlowSetup`: zeroes out the top-left/top-right border radius on the first `TxCard` so it joins flush with the modal header.

## How to test it

1. `yarn workspace @safe-global/web dev`
2. Open a Safe with a recovery configured, trigger a recovery flow.
3. Confirm the setup step renders with square top corners on the first card and that the side rail no longer shows a duplicated Safe info card or inline chain pill.
4. Walk through other tx flows that use `TxLayout` (send, swap, settings changes) and confirm they still render correctly without the `SafeInfo` rail card.

## Affected flows

- Account recovery setup flow — primary visual change
- Any tx flow rendered inside `TxLayout` — side rail now lacks the `SafeInfo` card and inline chain indicator

## Blast radius

- `apps/web/src/components/tx-flow/common/TxLayout/index.tsx` — shared layout used by all tx flows (send, swap, recovery, settings, etc.). The removed `SafeInfo` card and inline `ChainIndicator` were rendered on every flow, so all consumers of `TxLayout` are visually affected.
- `apps/web/src/components/tx-flow/flows/RecoverAccount/RecoverAccountFlowSetup.tsx` — local change, only the recovery setup step.
- No store, API, hook, or selector contracts changed.
- No mobile impact (web-only files).

## Risks / not checked

- Did not visually verify every tx flow that consumes `TxLayout` (send, swap, settings, batch, etc.) — only the recovery flow was the design target. Reviewers may want to spot-check at least one non-recovery flow.
- Did not test on mobile viewport widths.
- Did not verify behavior with feature flags toggled off.

## Visual summary

\`\`\`mermaid
flowchart LR
  subgraph Before
    A1[TxLayout side rail]
    A1 --> S1[SafeInfo card]
    A1 --> W1[TxStatusWidget]
    T1[Step title row] --> CI[ChainIndicator inline]
    R1[RecoverAccountFlowSetup TxCard] --> RC1[Rounded top corners]
  end
  subgraph After
    A2[TxLayout side rail]
    A2 --> W2[TxStatusWidget]
    T2[Step title row]
    R2[RecoverAccountFlowSetup TxCard] --> RC2[Square top corners]
  end
\`\`\`

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)