### PR TITLE
fix(mobile): prevent crash on settings switch row tap

### DIFF
--- a/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
+++ b/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
@@ -4,6 +4,7 @@ import { router } from 'expo-router'
 
 import { Text, View } from 'tamagui'
 import { AppSettings } from './AppSettings'
+import { type SettingsSection } from './AppSettings.types'
 import { useTheme } from '@/src/theme/hooks/useTheme'
 import { SafeFontIcon as Icon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import { FloatingMenu } from '../FloatingMenu'
@@ -54,7 +55,7 @@ export const AppSettingsContainer = () => {
     )
   }
 
-  const settingsSections = [
+  const settingsSections: SettingsSection[] = [
     {
       sectionName: 'Preferences',
       items: [

--- a/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.tsx
+++ b/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.tsx
@@ -50,31 +50,29 @@ export const AppSettings = ({ sections }: AppSettingsProps) => {
                 {section.sectionName && <Text color="$colorSecondary">{section.sectionName}</Text>}
                 <View backgroundColor={'$background'} borderRadius={'$3'}>
                   {section.items.map((item, itemIndex) => {
-                    if (item.type === 'floating-menu') {
-                      return (
-                        <SafeListItem
-                          key={`item-${sectionIndex}-${itemIndex}`}
-                          label={item.label}
-                          leftNode={<Icon name={item.leftIcon as IconName} color={'$colorSecondary'} />}
-                          rightNode={item.rightNode ?? <Icon name={'chevron-right'} />}
-                          tag={item.tag}
-                        />
-                      )
+                    const key = `item-${sectionIndex}-${itemIndex}`
+                    const listItem = (
+                      <SafeListItem
+                        label={item.label}
+                        leftNode={<Icon name={item.leftIcon as IconName} color={'$colorSecondary'} />}
+                        rightNode={item.rightNode ?? <Icon name={'chevron-right'} />}
+                        tag={item.tag}
+                      />
+                    )
+
+                    const onPress = 'onPress' in item ? item.onPress : undefined
+                    if (!onPress) {
+                      return <View key={key}>{listItem}</View>
                     }
 
                     return (
                       <Pressable
-                        key={`item-${sectionIndex}-${itemIndex}`}
+                        key={key}
                         style={({ pressed }) => [{ opacity: pressed || item.disabled ? 0.5 : 1.0 }]}
-                        onPress={item.onPress}
+                        onPress={onPress}
                         disabled={item.disabled}
                       >
-                        <SafeListItem
-                          label={item.label}
-                          leftNode={<Icon name={item.leftIcon as IconName} color={'$colorSecondary'} />}
-                          rightNode={item.rightNode ?? <Icon name={'chevron-right'} />}
-                          tag={item.tag}
-                        />
+                        {listItem}
                       </Pressable>
                     )
                   })}

--- a/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.types.ts
+++ b/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.types.ts
@@ -1,14 +1,24 @@
 import { ReactNode } from 'react'
 
-export interface SettingsItem {
+interface BaseSettingsItem {
   label: string
   leftIcon: string
   rightNode?: ReactNode
-  onPress?: () => void
   disabled?: boolean
-  type?: string
   tag?: string
 }
+
+export interface StaticSettingsItem extends BaseSettingsItem {
+  type: 'switch' | 'floating-menu'
+  rightNode: ReactNode
+}
+
+export interface PressableSettingsItem extends BaseSettingsItem {
+  type?: 'menu' | 'external-link'
+  onPress: () => void
+}
+
+export type SettingsItem = StaticSettingsItem | PressableSettingsItem
 
 export interface SettingsSection {
   sectionName?: string


### PR DESCRIPTION
> Tap a switch in settings,
> wrapper called undefined,
> typed union locks the door.

## What it solves

Mobile app v1.0.11 crashed on `/app-settings` with `TypeError: undefined is not a function` when users tapped a switch row (biometrics, "Allow notifications") outside of the switch knob. The renderer wrapped every non-floating-menu item in a `Pressable` with `onPress={item.onPress}`, but switch rows intentionally have no `onPress` (the `LoadableSwitch` in `rightNode` handles taps), so tapping the row chrome called `undefined` and crashed.

Datadog crash report: https://app.datadoghq.eu/error-tracking/issue/964869a6-42a4-11f1-9dc1-da7ad0900005

Resolves: [WA-2194](https://linear.app/safe-global/issue/WA-2194/mobile-crash-on-app-settings-typeerror-undefined-is-not-a-function)

## How this PR fixes it

Three layers, so the same class of bug is harder to reintroduce:

1. **Renderer**: `'switch'` rows now render the same way as `'floating-menu'` (no outer `Pressable`). The interactive element lives in `rightNode`.
2. **Types**: `SettingsItem` is now a discriminated union — `'switch' | 'floating-menu'` requires `rightNode` and forbids `onPress`; `'menu' | 'external-link' | undefined` requires `onPress`. The compiler will reject any future drift.
3. **Defense-in-depth**: the renderer also falls back to a static row whenever `onPress` is missing (`'onPress' in item ? ... : undefined`), so even if the types are bypassed the runtime can't call undefined.

Why TypeScript didn't catch this originally: `onPress` was optional and `type` was a loose `string`, so a switch row with no `onPress` typechecked fine and `Pressable.onPress` accepted `undefined` without complaint.

## How to test it

1. Build mobile and open the app
2. Navigate to App settings (Settings tab → app settings)
3. Tap on the row containing the "Biometrics" or "Allow notifications" switch — specifically tap on the **label or icon area**, not the switch knob itself
4. Verify the app does not crash and the row is non-interactive (only the switch toggles)
5. Verify other rows (Currency, Address book, Clear pending transactions, About links) still navigate / fire on tap as before

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[Tap switch row chrome] --> B1[Pressable onPress=undefined]
    B1 --> C1[💥 TypeError: undefined is not a function]
  end
  subgraph After
    A2[Tap switch row chrome] --> B2{type === 'switch'?}
    B2 -->|Yes| D2[Static row, no Pressable]
    B2 -->|No| E2{onPress defined?}
    E2 -->|Yes| F2[Pressable fires onPress]
    E2 -->|No| D2
  end
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — follow-up

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).