### PR TITLE
fix(web): drive topbar safe selector from URL not Redux

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSafeBarSafes.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSafeBarSafes.test.ts
@@ -15,9 +15,8 @@ jest.mock('@/features/spaces', () => ({
 }))
 
 const mockSafeAddress = jest.fn(() => '0xCurrentSafe')
-jest.mock('@/hooks/useSafeInfo', () => ({
-  __esModule: true,
-  default: () => ({ safeAddress: mockSafeAddress() }),
+jest.mock('@/hooks/useSafeAddressFromUrl', () => ({
+  useSafeAddressFromUrl: () => mockSafeAddress(),
 }))
 
 const mockChainId = jest.fn(() => '1')
@@ -73,10 +72,11 @@ describe('useSafeBarSafes', () => {
     expect(result.current.dropdownSafes[0].address).toBe('0xCurrentSafe')
   })
 
-  it('returns space safes when in space context', () => {
+  it('returns space safes when in space context and the URL safe is in the space', () => {
     mockUseIsQualifiedSafe.mockReturnValue(true)
     const spaceSafe = createSafe('0xSpaceSafe', true)
     mockUseSpaceSafes.mockReturnValue({ allSafes: [spaceSafe] })
+    mockSafeAddress.mockReturnValue('0xSpaceSafe')
 
     const { result } = renderHook(() => useSafeBarSafes())
 
@@ -89,6 +89,7 @@ describe('useSafeBarSafes', () => {
     mockIsSpaceRoute.mockReturnValue(true)
     const spaceSafe = createSafe('0xSpaceSafe', true)
     mockUseSpaceSafes.mockReturnValue({ allSafes: [spaceSafe] })
+    mockSafeAddress.mockReturnValue('0xSpaceSafe')
 
     const { result } = renderHook(() => useSafeBarSafes())
 
@@ -149,6 +150,21 @@ describe('useSafeBarSafes', () => {
     expect(fallback.chainId).toBe('11155111')
     expect(fallback.isReadOnly).toBe(true)
     expect(fallback.isPinned).toBe(false)
+  })
+
+  it('keeps URL fallback at index 0 even when other pinned safes exist', () => {
+    const pinnedA = createSafe('0xPinnedA', true)
+    const pinnedB = createSafe('0xPinnedB', true)
+    mockAllSafes.mockReturnValue([pinnedA, pinnedB])
+    mockSafeAddress.mockReturnValue('0xNestedChild')
+    mockChainId.mockReturnValue('11155111')
+
+    const { result } = renderHook(() => useSafeBarSafes())
+
+    expect(result.current.dropdownSafes).toHaveLength(3)
+    expect(result.current.dropdownSafes[0].address).toBe('0xNestedChild')
+    expect(result.current.dropdownSafes[1].address).toBe('0xPinnedA')
+    expect(result.current.dropdownSafes[2].address).toBe('0xPinnedB')
   })
 
   it('injects fallback into chainSelectorSafes when not in allKnownSafes', () => {

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSafeBarSafes.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSafeBarSafes.test.ts
@@ -19,6 +19,12 @@ jest.mock('@/hooks/useSafeAddressFromUrl', () => ({
   useSafeAddressFromUrl: () => mockSafeAddress(),
 }))
 
+const mockReduxSafeAddress = jest.fn(() => '')
+jest.mock('@/hooks/useSafeInfo', () => ({
+  __esModule: true,
+  default: () => ({ safeAddress: mockReduxSafeAddress() }),
+}))
+
 const mockChainId = jest.fn(() => '1')
 jest.mock('@/hooks/useChainId', () => ({
   __esModule: true,
@@ -58,6 +64,7 @@ describe('useSafeBarSafes', () => {
     mockUseIsQualifiedSafe.mockReturnValue(false)
     mockIsSpaceRoute.mockReturnValue(false)
     mockSafeAddress.mockReturnValue('0xCurrentSafe')
+    mockReduxSafeAddress.mockReturnValue('')
     mockChainId.mockReturnValue('1')
     mockAllSafes.mockReturnValue(undefined)
   })
@@ -199,15 +206,41 @@ describe('useSafeBarSafes', () => {
     expect(result.current.chainSelectorSafes).toHaveLength(1)
   })
 
-  it('returns pinnedSafes as-is when safeAddress is empty', () => {
+  it('returns pinnedSafes as-is when both URL and Redux are empty', () => {
     const pinned = createSafe('0xPinned', true)
     mockAllSafes.mockReturnValue([pinned])
     mockSafeAddress.mockReturnValue('')
+    mockReduxSafeAddress.mockReturnValue('')
 
     const { result } = renderHook(() => useSafeBarSafes())
 
     expect(result.current.dropdownSafes).toHaveLength(1)
     expect(result.current.dropdownSafes[0].address).toBe('0xPinned')
+  })
+
+  it('falls back to Redux safeAddress when URL has no safe param', () => {
+    const pinned = createSafe('0xPinned', true)
+    mockAllSafes.mockReturnValue([pinned])
+    mockSafeAddress.mockReturnValue('')
+    mockReduxSafeAddress.mockReturnValue('0xFromRedux')
+    mockChainId.mockReturnValue('1')
+
+    const { result } = renderHook(() => useSafeBarSafes())
+
+    expect(result.current.dropdownSafes).toHaveLength(2)
+    expect(result.current.dropdownSafes[0].address).toBe('0xFromRedux')
+    expect(result.current.dropdownSafes[1].address).toBe('0xPinned')
+  })
+
+  it('prefers URL safeAddress over Redux when both are present', () => {
+    const pinned = createSafe('0xPinned', true)
+    mockAllSafes.mockReturnValue([pinned])
+    mockSafeAddress.mockReturnValue('0xFromUrl')
+    mockReduxSafeAddress.mockReturnValue('0xFromRedux')
+
+    const { result } = renderHook(() => useSafeBarSafes())
+
+    expect(result.current.dropdownSafes[0].address).toBe('0xFromUrl')
   })
 
   it('prefers allKnownSafes entry over fallback for injection', () => {

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
@@ -20,6 +20,9 @@ jest.mock('@/hooks/useSafeInfo', () => ({
   __esModule: true,
   default: jest.fn(),
 }))
+jest.mock('@/hooks/useSafeAddressFromUrl', () => ({
+  useSafeAddressFromUrl: jest.fn(),
+}))
 jest.mock('@/hooks/useChainId', () => ({
   __esModule: true,
   default: jest.fn(),
@@ -64,6 +67,7 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MixpanelEventParams } from '@/services/analytics/mixpanel-events'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import useChainId from '@/hooks/useChainId'
 import useChains from '@/hooks/useChains'
 import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
@@ -131,9 +135,14 @@ function setupDefaults(
   })
   ;(useCurrentSpaceId as jest.Mock).mockReturnValue(overrides.spaceId ?? '42')
   ;(useSafeInfo as jest.Mock).mockReturnValue({
-    safe: { threshold: 2, owners: [{ value: '0xOwner1' }, { value: '0xOwner2' }] },
+    safe: {
+      address: { value: overrides.safeAddress ?? '0xSafe1' },
+      threshold: 2,
+      owners: [{ value: '0xOwner1' }, { value: '0xOwner2' }],
+    },
     safeAddress: overrides.safeAddress ?? '0xSafe1',
   })
+  ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue(overrides.safeAddress ?? '0xSafe1')
   ;(useChainId as jest.Mock).mockReturnValue(overrides.currentChainId ?? '1')
   ;(useChains as jest.Mock).mockReturnValue({ configs: chainConfigs })
   ;(useGetMultipleSafeOverviewsQuery as jest.Mock).mockReturnValue({
@@ -495,7 +504,7 @@ describe('useSpaceSafeSelectorItems', () => {
 
   // ── case-insensitive address matching ──
 
-  it('matches the current safe using case-insensitive address comparison', () => {
+  it('matches the current safe using case-insensitive address comparison against the URL', () => {
     const mixedCaseSafe: SafeItem = {
       chainId: '1',
       address: '0xAbCdEf',
@@ -506,15 +515,41 @@ describe('useSpaceSafeSelectorItems', () => {
     }
 
     ;(useSafeInfo as jest.Mock).mockReturnValue({
-      safe: { threshold: 3, owners: [{ value: '0x1' }, { value: '0x2' }, { value: '0x3' }] },
-      safeAddress: '0xabcdef', // lowercase vs mixed-case in item
+      safe: {
+        address: { value: '0xAbCdEf' },
+        threshold: 3,
+        owners: [{ value: '0x1' }, { value: '0x2' }, { value: '0x3' }],
+      },
+      safeAddress: '0xAbCdEf',
     })
+    ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('0xabcdef') // lowercase vs mixed-case in item
     ;(useSafeBarSafes as jest.Mock).mockReturnValue({ dropdownSafes: [mixedCaseSafe] })
 
     const { result } = renderHook(() => useSpaceSafeSelectorItems())
     // Should use live safe.threshold (3) not overview, proving case-insensitive match worked
     expect(result.current.items[0].threshold).toBe(3)
     expect(result.current.items[0].owners).toBe(3)
+  })
+
+  // ── URL drives selectedItemId even when Redux lags ──
+
+  it('uses the URL safe address for selectedItemId even when Redux still holds the previous safe', () => {
+    setupDefaults({
+      allSafes: [singleChainSafe],
+      safeAddress: '0xSafe1',
+    })
+    ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('0xNewSafeFromUrl')
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.selectedItemId).toBe('1:0xNewSafeFromUrl')
+  })
+
+  it('returns empty selectedItemId when no safe is in the URL', () => {
+    setupDefaults()
+    ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('')
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.selectedItemId).toBe('')
   })
 
   // ── tracking:
@@ -562,5 +597,22 @@ describe('useSpaceSafeSelectorItems', () => {
     const { result } = renderHook(() => useSpaceSafeSelectorItems())
     // id should start with currentChainId (137), not first chain in safes array (1)
     expect(result.current.items[0].id).toBe('137:0xSafe2')
+  })
+
+  it('places URL chainId first in multi-chain id even when Redux holds a different safe', () => {
+    setupDefaults({
+      allSafes: [multiChainSafe],
+      safeAddress: '0xPreviousSafe',
+      currentChainId: '137',
+      overviews: [
+        { address: { value: '0xSafe2' }, chainId: '1', fiatTotal: '100', threshold: 1, owners: [{ value: '0xO' }] },
+        { address: { value: '0xSafe2' }, chainId: '137', fiatTotal: '200', threshold: 1, owners: [{ value: '0xO' }] },
+      ],
+    })
+    ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('0xSafe2')
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.items[0].id).toBe('137:0xSafe2')
+    expect(result.current.selectedItemId).toBe('137:0xSafe2')
   })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
@@ -544,9 +544,25 @@ describe('useSpaceSafeSelectorItems', () => {
     expect(result.current.selectedItemId).toBe('1:0xNewSafeFromUrl')
   })
 
-  it('returns empty selectedItemId when no safe is in the URL', () => {
+  it('falls back to Redux safeAddress for selectedItemId when URL has no safe', () => {
     setupDefaults()
     ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('')
+    ;(useSafeInfo as jest.Mock).mockReturnValue({
+      safe: { address: { value: '0xFromRedux' }, threshold: 2, owners: [] },
+      safeAddress: '0xFromRedux',
+    })
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.selectedItemId).toBe('1:0xFromRedux')
+  })
+
+  it('returns empty selectedItemId when both URL and Redux are empty', () => {
+    setupDefaults()
+    ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('')
+    ;(useSafeInfo as jest.Mock).mockReturnValue({
+      safe: { address: { value: '' }, threshold: 0, owners: [] },
+      safeAddress: '',
+    })
 
     const { result } = renderHook(() => useSpaceSafeSelectorItems())
     expect(result.current.selectedItemId).toBe('')

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
@@ -2,9 +2,9 @@ import { useMemo } from 'react'
 import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
 import { useAllSafes, useAllSafesGrouped, type AllSafeItems } from '@/hooks/safes'
 import type { SafeItem } from '@/hooks/safes'
-import useSafeInfo from '@/hooks/useSafeInfo'
 import useChainId from '@/hooks/useChainId'
 import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 
 /**
@@ -22,7 +22,7 @@ export function useSafeBarSafes() {
   const isSpaceRoute = useIsSpaceRoute()
   const isInSpaceContext = isQualifiedSafe || isSpaceRoute
   const { allSafes: spaceSafes } = useSpaceSafes()
-  const { safeAddress } = useSafeInfo()
+  const safeAddress = useSafeAddressFromUrl()
   const currentChainId = useChainId()
 
   const allSafeItems = useAllSafes()

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
@@ -3,6 +3,7 @@ import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
 import { useAllSafes, useAllSafesGrouped, type AllSafeItems } from '@/hooks/safes'
 import type { SafeItem } from '@/hooks/safes'
 import useChainId from '@/hooks/useChainId'
+import useSafeInfo from '@/hooks/useSafeInfo'
 import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
 import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
@@ -22,7 +23,9 @@ export function useSafeBarSafes() {
   const isSpaceRoute = useIsSpaceRoute()
   const isInSpaceContext = isQualifiedSafe || isSpaceRoute
   const { allSafes: spaceSafes } = useSpaceSafes()
-  const safeAddress = useSafeAddressFromUrl()
+  const urlSafeAddress = useSafeAddressFromUrl()
+  const { safeAddress: reduxSafeAddress } = useSafeInfo()
+  const safeAddress = urlSafeAddress || reduxSafeAddress
   const currentChainId = useChainId()
 
   const allSafeItems = useAllSafes()

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
@@ -127,8 +127,9 @@ function buildSingleChainItem(
 
 export function useSpaceSafeSelectorItems() {
   const { dropdownSafes: allSafes } = useSafeBarSafes()
-  const { safe } = useSafeInfo()
+  const { safe, safeAddress: reduxSafeAddress } = useSafeInfo()
   const urlSafeAddress = useSafeAddressFromUrl()
+  const effectiveSafeAddress = urlSafeAddress || reduxSafeAddress
   const currentChainId = useChainId()
   const { configs: chainConfigs } = useChains()
   const router = useRouter()
@@ -148,7 +149,7 @@ export function useSpaceSafeSelectorItems() {
 
   const items: SafeItemData[] = useMemo(() => {
     return allSafes.map((item) => {
-      const isCurrentSafe = sameAddress(item.address, urlSafeAddress)
+      const isCurrentSafe = sameAddress(item.address, effectiveSafeAddress)
 
       if (isMultiChainSafeItem(item)) {
         return buildMultiChainItem(
@@ -165,9 +166,9 @@ export function useSpaceSafeSelectorItems() {
 
       return buildSingleChainItem(item, isCurrentSafe, overviews, overviewsLoading, safe, chainConfigs)
     })
-  }, [allSafes, urlSafeAddress, currentChainId, safe, overviews, overviewsLoading, chainConfigs, undeployedSafes])
+  }, [allSafes, effectiveSafeAddress, currentChainId, safe, overviews, overviewsLoading, chainConfigs, undeployedSafes])
 
-  const selectedItemId = urlSafeAddress ? `${currentChainId}:${urlSafeAddress}` : ''
+  const selectedItemId = effectiveSafeAddress ? `${currentChainId}:${effectiveSafeAddress}` : ''
 
   const handleItemSelect = useCallback(
     (itemId: string) => {

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
@@ -6,6 +6,7 @@ import type { SafeItem, MultiChainSafeItem } from '@/hooks/safes'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useChainId from '@/hooks/useChainId'
 import useChains from '@/hooks/useChains'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
 import { useAppSelector } from '@/store'
 import { selectCurrency } from '@/store/settingsSlice'
@@ -126,7 +127,8 @@ function buildSingleChainItem(
 
 export function useSpaceSafeSelectorItems() {
   const { dropdownSafes: allSafes } = useSafeBarSafes()
-  const { safe, safeAddress } = useSafeInfo()
+  const { safe } = useSafeInfo()
+  const urlSafeAddress = useSafeAddressFromUrl()
   const currentChainId = useChainId()
   const { configs: chainConfigs } = useChains()
   const router = useRouter()
@@ -146,7 +148,7 @@ export function useSpaceSafeSelectorItems() {
 
   const items: SafeItemData[] = useMemo(() => {
     return allSafes.map((item) => {
-      const isCurrentSafe = item.address.toLowerCase() === safeAddress.toLowerCase()
+      const isCurrentSafe = sameAddress(item.address, urlSafeAddress)
 
       if (isMultiChainSafeItem(item)) {
         return buildMultiChainItem(
@@ -163,9 +165,9 @@ export function useSpaceSafeSelectorItems() {
 
       return buildSingleChainItem(item, isCurrentSafe, overviews, overviewsLoading, safe, chainConfigs)
     })
-  }, [allSafes, safeAddress, currentChainId, safe, overviews, overviewsLoading, chainConfigs, undeployedSafes])
+  }, [allSafes, urlSafeAddress, currentChainId, safe, overviews, overviewsLoading, chainConfigs, undeployedSafes])
 
-  const selectedItemId = `${currentChainId}:${safeAddress}`
+  const selectedItemId = urlSafeAddress ? `${currentChainId}:${urlSafeAddress}` : ''
 
   const handleItemSelect = useCallback(
     (itemId: string) => {

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.test.ts
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.test.ts
@@ -61,6 +61,22 @@ describe('useSafeSelectorState', () => {
     expect(result.current.dropdownOpen).toBe(false)
   })
 
+  it('returns undefined selectedItem when selectedItemId does not match any item', () => {
+    const { result } = renderHook(() =>
+      useSafeSelectorState({ items: [createItem('1'), createItem('2')], selectedItemId: 'unknown' }),
+    )
+
+    expect(result.current.selectedItem).toBeUndefined()
+  })
+
+  it('returns undefined selectedItem when selectedItemId is empty', () => {
+    const { result } = renderHook(() =>
+      useSafeSelectorState({ items: [createItem('1'), createItem('2')], selectedItemId: '' }),
+    )
+
+    expect(result.current.selectedItem).toBeUndefined()
+  })
+
   /**
    * When a controlled Select emits onValueChange twice (new id, then snap-back to the previous id
    * before the URL updates), only the first call is forwarded — the second matches currentSelectionId.

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.ts
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.ts
@@ -9,8 +9,11 @@ interface UseSafeSelectorStateProps {
   forceOpenable?: boolean
 }
 
+// No items[0] fallback on miss — surfaces regressions instead of silently
+// snapping to the wrong safe.
 const getSelectedItem = (items: SafeItemData[], selectedItemId?: string) => {
-  return items.find((item) => item.id === selectedItemId) ?? items[0]
+  if (!selectedItemId) return undefined
+  return items.find((item) => item.id === selectedItemId)
 }
 
 const getFirstChainId = (item: SafeItemData | undefined) => {


### PR DESCRIPTION
> Read the URL, not Redux.
> Inject by URL, not Redux.
> No more snap to items[0].

## What it solves

Resolves: [WA-2192](https://linear.app/safe-global/issue/WA-2192/safe-from-url-loads-wrong-safe-in-navigation)

The topbar `SafeSelectorDropdown` was showing the **wrong safe** in two scenarios:

- **Case 1** — Switching safes via the dropdown briefly displayed the first safe in the list before settling on the clicked one.
- **Case 2** — Opening a nested safe (parent in space, child outside it) showed the first safe in the list **persistently**, with a 404 in the console. URL was correct but the navigation contradicted it.

## How this PR fixes it

The dropdown's "selected" state was derived from `useSafeInfo()` (Redux), which lags the URL by a CGW round-trip — and on a 404 (nested safes) the slice never updates. With `selectedItemId` constructed from a stale Redux address, `items.find(...)` missed and the dropdown silently fell back to `items[0]`.

Three coordinated changes:

1. **`useSpaceSafeSelectorItems.ts`** — `selectedItemId` and `isCurrentSafe` now read `useSafeAddressFromUrl()`. The URL match is explicit, and for multi-chain safes `orderedChainIds[0]` correctly puts the URL chain first so `item.id` lines up with `selectedItemId`.

2. **`useSafeBarSafes.ts`** — `safeAddress` (driving `fallbackCurrentSafe` and the dropdown injection) reads from the URL instead of Redux. The URL safe is always present in `items` — even when CGW returns 404 — so the `find()` succeeds.

3. **`useSafeSelectorState.ts`** — `getSelectedItem` no longer falls back to `items[0]` on a miss. Returns `undefined` so any future regression surfaces as "no selection" instead of silently displaying the wrong safe.

`useIsQualifiedSafe()` was already URL-driven, so when navigating from a space-qualified parent to a nested child outside the space, `isInSpaceContext` flips to `false` immediately and the non-space fallback path takes over. No `spaceSafesWithFallback`-style hack was needed.

## How to test it

Use the staging deployment for the Linear ticket: `https://epicspacesm2--walletweb.review.5afe.dev/`

**Case 1 — Switch between safes**
1. Open the app, sign in to a space with multiple safes
2. Click the dropdown, scroll to a safe you haven't visited yet (away from the top)
3. Select it
4. ✅ Topbar updates instantly to the selected safe — no flash of the first safe

**Case 2 — Nested safe**
1. Navigate to a safe with nested safes (e.g. `?safe=sep:0x2a73e61bd15b25B6958b4DA3bfc759ca4db249b9`)
2. Click the **Nested Safes** icon (GitMerge) in the topbar
3. Pick a nested child safe from the popover
4. URL changes to the child address; console may still show a CGW 404 (separate backend concern)
5. ✅ Topbar dropdown displays the child safe (placeholder name / zero balance is OK), **not** the first safe in the list

**Direct URL test (original repro)**
1. Open `https://epicspacesm2--walletweb.review.5afe.dev/home?safe=sep:0xC4934eA242Bf292CA59A2aF85ED116506F8f2d03` from a fresh tab
2. ✅ Topbar shows the safe from the URL, not whichever safe happens to be first in your pinned/space list

**Regression check**
1. Open the dropdown on a safe-less route (e.g. `/welcome/accounts`)
2. ✅ Topbar/SpaceSafeBar is hidden (existing `HIDDEN_ROUTES` behavior, unchanged)

## Affected flows

- Topbar safe selector dropdown — switching to any pinned, owned, or URL-only safe
- Nested safe navigation via the GitMerge popover in the topbar
- Multi-chain safe identity in the dropdown (URL chain becomes the leading chain on selection)
- Topbar chain selector and "Nested Safes" button (indirect — they co-render in `SpaceSafeBar`)

## Blast radius

**Hooks changed**
- `useSafeBarSafes` — consumed by `SpaceSafeBar` (topbar). Returns `dropdownSafes` / `chainSelectorSafes` to `useSpaceSafeSelectorItems`, `SpaceChainSelector`, and `AccountsModal`. Switched dependency from `useSafeInfo` (Redux) to `useSafeAddressFromUrl` (URL).
- `useSpaceSafeSelectorItems` — consumed by `SpaceSafeBar`. `selectedItemId` shape unchanged (`${chainId}:${address}`); only its source flipped to URL.
- `useSafeSelectorState` — consumed by `SafeSelectorDropdown` (the shadcn dropdown wrapper). `selectedItem` may now legitimately be `undefined`; the component already handles that by rendering an `InlineRetryError`, `SafeSelectorDropdownSkeleton`, or `null`.

**Not touched**
- RTK Query endpoints / CGW contracts — no API changes
- Feature flags / chain configs — none added or modified
- Persistence / Redux schema — no migration; `safeInfoSlice` shape unchanged, just no longer the source of truth for the selector
- Routes / layouts — no changes
- Mobile / shared packages — web-only feature; `packages/` untouched

## Risks / not checked

- **CGW 404 root cause for nested safes** — out of scope. This PR ensures the UI no longer misleads when the API 404s, but the underlying backend issue (why `/safes/{chainId}/{nestedAddr}` returns 404) is not addressed.
- **Threshold / owners briefly stale** — for the URL-matched item, `resolveThresholdAndOwners` still pulls from Redux when `isCurrentSafe = true`. During the ~1s Redux-lag window the trigger may show the previous safe's threshold/owners. Visually subtle, accepted as a trade-off vs. wrong safe identity.
- **`SpaceChainSelector` in nested-safe scenario** — when the URL safe is unknown, the chain selector falls back to a single chain (the URL chain). Functional but doesn't expose multi-chain options for the unknown safe. Same behavior as a freshly visited URL safe pre-fix.
- **Mobile** — not tested. Files changed are web-only (`apps/web/src/...`); no shared-package code touched, so no mobile impact expected.
- **Redux address-format mismatch** — `item.id === selectedItemId` is exact string equality. If a future change causes `useSafeAddressFromUrl` and `SafeItem.address` to use different formats (case, checksum), the match fails and the dropdown shows nothing (loud failure, by design — Fix 3).

## Visual summary

```mermaid
sequenceDiagram
    autonumber
    participant U as User
    participant URL as URL
    participant H as Topbar hooks
    participant R as Redux / CGW
    participant D as Dropdown

    rect rgba(255, 200, 200, 0.3)
    Note over U,D: Before — case 2 (nested safe, CGW 404)
    U->>URL: click nested → ?safe=sep:0xChild
    URL-->>H: useSafeAddressFromUrl = 0xChild
    URL-->>R: useLoadSafeInfo fetch → 404
    R-->>R: safeInfo data: undefined
    H->>D: selectedItemId = "sep:" (Redux empty)
    D->>D: items.find(...) = undefined
    D->>D: ?? items[0] (silent fallback)
    D-->>U: ❌ first safe in list shown
    end

    rect rgba(200, 255, 200, 0.3)
    Note over U,D: After
    U->>URL: click nested → ?safe=sep:0xChild
    URL-->>H: useSafeAddressFromUrl = 0xChild
    H->>H: fallbackCurrentSafe injected into items
    H->>D: selectedItemId = "sep:0xChild" (URL)
    D->>D: items.find(...) → match ✓
    D-->>U: ✅ child safe shown
    end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — 4 new regression tests, 133/133 passing
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).