### PR TITLE
fix(mobile): prevent invalid hook call in NFTItem on FlatList renderItem

### DIFF
--- a/apps/mobile/src/features/Assets/components/NFTs/NFTs.container.tsx
+++ b/apps/mobile/src/features/Assets/components/NFTs/NFTs.container.tsx
@@ -44,6 +44,8 @@ export function NFTsContainer() {
     }
   }
 
+  const renderItem = React.useCallback(({ item }: { item: Collectible }) => <NFTItem item={item} />, [])
+
   if (error) {
     return (
       <Fallback loading={isFetching}>
@@ -64,7 +66,7 @@ export function NFTsContainer() {
     <SafeTab.FlatList<Collectible>
       onEndReached={onEndReached}
       data={allCollectibles}
-      renderItem={NFTItem}
+      renderItem={renderItem}
       ListFooterComponent={isFetching ? <Loader size={24} /> : undefined}
       keyExtractor={(item, index) => `${item.address}-${index}`}
       contentContainerStyle={{ paddingHorizontal: getTokenValue('$4'), gap: getTokenValue('$2') }}


### PR DESCRIPTION
> Wrap the NFT row renderer,
> hooks dispatcher stays alive,
> iOS list stops crying.

## What it solves

Datadog Error Tracking issue [`15468432-424a-11f1-817b-da7ad0900005`](https://app.datadoghq.eu/error-tracking/issue/15468432-424a-11f1-817b-da7ad0900005) — `Invalid hook call. Hooks can only be called inside of the body of a function component.` thrown from `NFTItem` on iOS (safe-mobile 1.0.11). 7 sessions affected so far, all on the Assets/NFTs view.

Resolves: [WA-2196](https://linear.app/safe-global/issue/WA-2196/fix-invalid-hook-call-in-nftitem-when-rendered-via-flatlist-renderitem)

## How this PR fixes it

`SafeTab.FlatList` resolves to `Tabs.FlatList` from `react-native-collapsible-tab-view`, whose class-based `CellRenderer` invokes `renderItem` as a plain function (visible in the stack: `renderProp` → `_renderElement` → `render` → `finishClassComponent`). Passing `NFTItem` directly as `renderItem` therefore evaluated `NFTItem`'s descendants (`AssetsCard` → `TokenIcon` → `Logo` with `useState`) outside React's hook dispatcher, throwing `Invalid hook call`.

Wrapping the call in a memoized `({ item }) => <NFTItem item={item} />` lets React render it as a real element with its own fiber, restoring normal hook semantics.

## How to test it

1. Run the mobile app on an iOS simulator (ideally iOS 26 to match the original report) against a Safe that owns NFTs.
2. Navigate to the Safe's Assets tab and switch to the NFTs sub-tab.
3. Confirm the NFT list renders without errors and that no `Invalid hook call` is logged in the Metro/Datadog console.
4. Scroll to trigger the FlatList's cell recycling and confirm there are still no errors.

## Screenshots

N/A — no UI changes.

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).