### PR TITLE
fix(web/Spaces): smoke test

### DIFF
--- a/apps/web/cypress/e2e/pages/import_export.pages.js
+++ b/apps/web/cypress/e2e/pages/import_export.pages.js
@@ -169,7 +169,8 @@ export function clickOnDataTab() {
 
 export function verifyCheckboxes(checkboxes, checked = false) {
   checkboxes.forEach((checkbox) => {
-    cy.contains('label', checkbox)
+    cy.get('main')
+      .contains('label', checkbox)
       .find('input[type="checkbox"]')
       .should(checked ? 'be.checked' : 'not.be.checked')
   })


### PR DESCRIPTION
## What it solves

Resolves: Smoke test for Import-export was flaky. It was doing a global cy.contains('label', 'Dark mode'). After reload, Cypress can match the sidebar footer label first, and that label does not wrap the settings-page checkbox input, so `.find('input[type="checkbox"]')` timed out.

## How this PR fixes it
 Patched the helper to scope the lookup to `main`, so it only searches the appearance form.

## How to test it

All smoke tests should pass.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
