### PR TITLE
fix(mobile): stop eager api.web3modal.org requests on launch

### DIFF
--- a/apps/mobile/src/features/WalletConnect/appKit.ts
+++ b/apps/mobile/src/features/WalletConnect/appKit.ts
@@ -87,6 +87,9 @@ export function createAppKitInstance(networks: [Network, ...Network[]], defaultN
     themeVariables: {
       accent: '#12FF80',
     },
+    // Reown SDK fires telemetry to api.web3modal.org when this is undefined.
+    // We have our own opt-in analytics; never send data to Reown.
+    enableAnalytics: false,
     debug: __DEV__,
   })
 }

--- a/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.tsx
+++ b/apps/mobile/src/features/WalletConnect/context/WalletConnectContext.tsx
@@ -1,5 +1,13 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
-import { AppKit, AppKitProvider, useAccount, useAppKit, useProvider, useWalletInfo } from '@reown/appkit-react-native'
+import {
+  AppKit,
+  AppKitProvider,
+  useAccount,
+  useAppKit,
+  useAppKitState,
+  useProvider,
+  useWalletInfo,
+} from '@reown/appkit-react-native'
 import type { Provider } from '@reown/appkit-common-react-native'
 import { Platform } from 'react-native'
 import { FullWindowOverlay } from 'react-native-screens'
@@ -50,7 +58,13 @@ export function useOptionalWalletConnectContext(): WalletConnectContextValue | n
  * Mounts all WalletConnect hooks once and pushes the combined API into
  * the given callback. Must be rendered inside AppKitProvider.
  */
-function WalletConnectContextBridge({ onContextReady }: { onContextReady: (v: WalletConnectContextValue) => void }) {
+function WalletConnectContextBridge({
+  onContextReady,
+  requestModalMount,
+}: {
+  onContextReady: (v: WalletConnectContextValue) => void
+  requestModalMount: () => void
+}) {
   const { initiateConnection } = useImportSignerFlow()
   const { reconnect } = useReconnectFlow()
   const { switchNetwork, switchNetworkIfNeeded, isWrongNetwork } = useSwitchNetwork()
@@ -60,6 +74,7 @@ function WalletConnectContextBridge({ onContextReady }: { onContextReady: (v: Wa
   const appKitHook = useAppKit()
   const { address, chainId, isConnected } = useAccount()
   const { walletInfo } = useWalletInfo()
+  const { isOpen } = useAppKitState()
   const signers = useAppSelector(selectSigners)
 
   const isWalletConnectSigner = useCallback(
@@ -73,6 +88,13 @@ function WalletConnectContextBridge({ onContextReady }: { onContextReady: (v: Wa
   // bridge/provider cycle.
   const appKitRef = useRef(appKitHook)
   appKitRef.current = appKitHook
+
+  // Lazy-mount <AppKit /> the first time anything opens the modal
+  useEffect(() => {
+    if (isOpen) {
+      requestModalMount()
+    }
+  }, [isOpen, requestModalMount])
 
   const disconnect = useCallback(() => appKitRef.current.disconnect(), [])
   const open = useCallback((...args: Parameters<typeof appKitHook.open>) => appKitRef.current.open(...args), [])
@@ -135,16 +157,27 @@ interface WalletConnectProviderProps {
  * Children always occupy the same tree position so React never remounts
  * them when AppKit initializes (which would cause a visible flash).
  * The AppKit bridge and modal are rendered as siblings above children.
+ *
+ * The `<AppKit />` modal is lazy-mounted the first time anything sets
+ * `ModalController.state.open` to true (i.e. any caller of
+ * `useAppKit().open()`). Mounting `<AppKit />` eagerly triggers
+ * `ApiController.prefetch()` inside the SDK, which fires `/getWallets`,
+ * network image requests to api.web3modal.org on cold start — which is not desired.
+ * The first open() sets the modal state synchronously; the bridge observes that,
+ * mounts `<AppKit />`, and the modal renders visible on the next paint.
  */
 export function WalletConnectProvider({ children, instance }: WalletConnectProviderProps) {
   const [contextValue, setContextValue] = useState<WalletConnectContextValue | null>(null)
+  const [modalMounted, setModalMounted] = useState(false)
+
+  const requestModalMount = useCallback(() => setModalMounted(true), [])
 
   return (
     <WalletConnectContext.Provider value={contextValue}>
       {instance && (
         <AppKitProvider instance={instance}>
-          <WalletConnectContextBridge onContextReady={setContextValue} />
-          <AppKit modalContentWrapper={Platform.OS === 'ios' ? FullWindowOverlay : undefined} />
+          <WalletConnectContextBridge onContextReady={setContextValue} requestModalMount={requestModalMount} />
+          {modalMounted && <AppKit modalContentWrapper={Platform.OS === 'ios' ? FullWindowOverlay : undefined} />}
         </AppKitProvider>
       )}
       {children}

--- a/apps/mobile/src/features/WalletConnect/context/__tests__/WalletConnectContext.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/context/__tests__/WalletConnectContext.test.tsx
@@ -51,6 +51,8 @@ const mockAppKit = { open: mockOpen, disconnect: mockDisconnect }
 const mockAccount = { address: mockAddress, chainId: 1, isConnected: true }
 const mockWalletInfoResult = { walletInfo: { name: 'MetaMask' } }
 
+const mockAppKitState = { isOpen: false, isLoading: false, isConnected: false, chain: undefined }
+
 jest.mock('@reown/appkit-react-native', () => ({
   AppKit: () => null,
   AppKitProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -58,6 +60,7 @@ jest.mock('@reown/appkit-react-native', () => ({
   useAccount: () => mockAccount,
   useWalletInfo: () => mockWalletInfoResult,
   useProvider: () => ({ provider: undefined }),
+  useAppKitState: () => mockAppKitState,
 }))
 
 const mockInstance = {} as NonNullable<React.ComponentProps<typeof WalletConnectProvider>['instance']>
@@ -135,9 +138,9 @@ describe('WalletConnectContext', () => {
     it('delegates open to useAppKit', async () => {
       const { result } = await renderWithProvider()
 
-      result.current?.open()
+      result.current?.open({ view: 'Connect' })
 
-      expect(mockOpen).toHaveBeenCalled()
+      expect(mockOpen).toHaveBeenCalledWith({ view: 'Connect' })
     })
 
     it('delegates disconnect to useAppKit', async () => {


### PR DESCRIPTION
> Reown wakes at boot,
> fetching wallets we don't need —
> mount the modal late.

## What it solves

On every mobile cold start the Reown AppKit SDK fired requests to `api.web3modal.org` (`/getWallets`, `/getNetworkImages`, `/getAnalyticsConfig`, plus `INITIALIZE` / `MODAL_LOADED` track events) before the user had taken any wallet-connect action. This violates our opt-in privacy posture and wastes network/battery on every launch.

Resolves: https://linear.app/safe-global/issue/WA-2195/investigate-eager-apiweb3modalorg-requests-on-mobile-app-launch

## How this PR fixes it

Two independent levers:

1. Pass `enableAnalytics: false` to `createAppKit`. The SDK was leaving this `undefined`, which causes it to fetch analytics config and emit `INITIALIZE` / `MODAL_LOADED` track events.
2. Lazy-mount the `<AppKit />` modal component. The eager `ApiController.prefetch()` (wallet list, network images) runs from `<AppKit />`'s mount-time `useEffect`, *not* from `createAppKit()` itself. We keep `AppKitProvider` mounted from boot so signing and session restoration still work, but defer mounting the modal until anything sets `ModalController.state.open` to true.

Gotchas:

- We watch `ModalController` via the public `useAppKitState()` hook rather than wrapping our own `open()`. Internal hooks like `useConnect` call `useAppKit().open()` directly, so a wrapper would have been bypassed (the picker silently no-oped on the first attempt — that's how I caught it).
- `ModalController.open()` does `await ApiController.state.prefetchPromise` before flipping state. While the modal is unmounted, `prefetchPromise` is `undefined`, so `await undefined` resolves immediately — no missed-event window.
- Reown's `createAppKit` is a global singleton (`Symbol.for('__REOWN_APPKIT_INSTANCE__')`), so this whole approach has to coexist with the existing one-shot init pattern in `appKit.ts`. It does.

## How to test it

1. Cold-launch the mobile app with the network panel open. Confirm zero requests to `api.web3modal.org` until you tap "Connect wallet".
2. Tap "Connect wallet" in the signers / import-signer flow. Modal should open and show the wallet picker as before.
3. With an existing WalletConnect signer already imported, sign a transaction. Verify it works without ever opening the modal (exercises `useProvider` / `EthersAdapter` while the modal is unmounted).
4. Reconnect an existing WC signer (modal-based reconnect flow) and confirm it still works.

## Screenshots

N/A — no UI changes.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).