### PR TITLE
feat(web/Spaces): unify buttons styles for Spaces pages

### DIFF
--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -51,6 +51,10 @@
   /* we need it in order to have higher importance than the .main class */
   && {
     padding-top: var(--topbar-height);
+
+    @media (max-width: 640px) {
+      padding-top: 0;
+    }
   }
 }
 

--- a/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
+++ b/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
@@ -109,14 +109,14 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
 
   return (
     <div className={cn('shadcn-scope', isDarkMode && 'dark')}>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Wallet>
           {(isOk) => {
             const sendDisabled = !isOk || isBlockedCountry || noAssets
             return (
               <Tooltip title={sendTooltip} arrow placement="top">
                 <span className={cn('inline-flex', { 'cursor-not-allowed': sendDisabled })}>
-                  <Button variant="default" className="px-6 font-bold" onClick={handleOnSend} disabled={sendDisabled}>
+                  <Button variant="default" className="px-6" onClick={handleOnSend} disabled={sendDisabled}>
                     <ArrowUpRight className="size-5 text-green-400" />
                     Send
                   </Button>
@@ -130,7 +130,7 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
           {isSpace ? (
             <Button
               variant={secondaryVariant}
-              className={cn('px-6 font-bold hover:bg-border')}
+              className={cn('px-6 hover:bg-border')}
               onClick={handleOnReceive}
               disabled={noAssets}
             >
@@ -158,7 +158,7 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
                       {isSpace ? (
                         <Button
                           variant={secondaryVariant}
-                          className={cn('px-6 font-bold hover:bg-border')}
+                          className={cn('px-6 hover:bg-border')}
                           data-testid="overview-swap-btn"
                           disabled={swapDisabled}
                           onClick={handleOnSwap}
@@ -195,7 +195,7 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
             const buildTxButton = isSpace ? (
               <Button
                 variant={secondaryVariant}
-                className="px-6 font-bold hover:bg-border"
+                className="px-6 hover:bg-border"
                 disabled={!isOk || noAssets}
                 onClick={handleOnBuildTx}
                 aria-label="Transaction builder"

--- a/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
+++ b/apps/web/src/features/actions-tray/components/ActionsTray/ActionsTray.tsx
@@ -116,7 +116,7 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
             return (
               <Tooltip title={sendTooltip} arrow placement="top">
                 <span className={cn('inline-flex', { 'cursor-not-allowed': sendDisabled })}>
-                  <Button variant="default" className="px-6" onClick={handleOnSend} disabled={sendDisabled}>
+                  <Button variant="default" className="px-6 font-bold" onClick={handleOnSend} disabled={sendDisabled}>
                     <ArrowUpRight className="size-5 text-green-400" />
                     Send
                   </Button>
@@ -130,7 +130,7 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
           {isSpace ? (
             <Button
               variant={secondaryVariant}
-              className={cn('px-6 hover:bg-border')}
+              className={cn('px-6 font-bold hover:bg-border')}
               onClick={handleOnReceive}
               disabled={noAssets}
             >
@@ -158,7 +158,7 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
                       {isSpace ? (
                         <Button
                           variant={secondaryVariant}
-                          className={cn('px-6 hover:bg-border')}
+                          className={cn('px-6 font-bold hover:bg-border')}
                           data-testid="overview-swap-btn"
                           disabled={swapDisabled}
                           onClick={handleOnSwap}
@@ -195,7 +195,7 @@ const ActionsTray = ({ noAssets, variant = 'safe' }: ActionsTrayProps): ReactEle
             const buildTxButton = isSpace ? (
               <Button
                 variant={secondaryVariant}
-                className="px-6 hover:bg-border"
+                className="px-6 font-bold hover:bg-border"
                 disabled={!isOk || noAssets}
                 onClick={handleOnBuildTx}
                 aria-label="Transaction builder"

--- a/apps/web/src/features/spaces/components/Members/index.tsx
+++ b/apps/web/src/features/spaces/components/Members/index.tsx
@@ -1,82 +1,57 @@
-import PlusIcon from '@/public/images/common/plus.svg'
-import { Button, Stack, Typography } from '@mui/material'
+import { Button as ShadcnButton } from '@/components/ui/button'
+import { Plus } from 'lucide-react'
+import { Typography } from '@/components/ui/typography'
 import AddMemberModal from 'src/features/spaces/components/AddMemberModal'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import MembersList from '../MembersList'
-import { useMembersSearch, useIsInvited, useSpaceMembersByStatus, useIsAdmin } from '@/features/spaces'
+import { useIsInvited, useSpaceMembersByStatus, useIsAdmin } from '@/features/spaces'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import { SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
-import { trackEvent } from '@/services/analytics'
-import SearchInput from '../SearchInput'
 
 const SpaceMembers = () => {
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
-  const [searchQuery, setSearchQuery] = useState('')
   const { activeMembers, invitedMembers } = useSpaceMembersByStatus()
   const isAdmin = useIsAdmin()
   const isInvited = useIsInvited()
 
-  const filteredMembers = useMembersSearch(activeMembers, searchQuery)
-  const filteredInvites = useMembersSearch(invitedMembers, searchQuery)
-
-  useEffect(() => {
-    if (searchQuery) {
-      trackEvent({ ...SPACE_EVENTS.SEARCH_MEMBERS })
-    }
-  }, [searchQuery])
-
   return (
     <>
       {isInvited && <PreviewInvite />}
-      <Typography variant="h1" mb={3}>
-        Members
-      </Typography>
-      <Stack
-        direction="row"
-        justifyContent="space-between"
-        alignItems="flex-start"
-        mb={3}
-        flexWrap="nowrap"
-        gap={2}
-        flexDirection={{ xs: 'column-reverse', sm: 'row' }}
-      >
-        <SearchInput onSearch={setSearchQuery} />
+      <div className="mb-6 flex flex-col gap-6">
+        <Typography variant="h2" className="font-bold leading-[1] tracking-tight">
+          Members
+        </Typography>
         {isAdmin && (
           <Track {...SPACE_EVENTS.ADD_MEMBER_MODAL} label={SPACE_LABELS.members_page}>
-            <Button
+            <ShadcnButton
               data-testid="add-member-button"
-              variant="contained"
-              startIcon={<PlusIcon />}
+              size="lg"
+              className="font-bold px-4 py-0"
               onClick={() => setOpenAddMembersModal(true)}
-              sx={{ whiteSpace: 'nowrap' }}
             >
+              <Plus className="size-4 mr-1 text-green-500" />
               Add member
-            </Button>
+            </ShadcnButton>
           </Track>
         )}
-      </Stack>
+      </div>
       <>
-        {searchQuery && !filteredMembers.length && !filteredInvites.length && (
-          <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">
-            Found 0 results
-          </Typography>
-        )}
-        {filteredInvites.length > 0 && (
+        {invitedMembers.length > 0 && (
           <>
-            <Typography variant="h5" fontWeight={700} mb={2}>
-              Pending invitations ({filteredInvites.length})
+            <Typography variant="paragraph-bold" className="font-bold mb-4">
+              Pending invitations ({invitedMembers.length})
             </Typography>
-            <MembersList members={filteredInvites} />
+            <MembersList members={invitedMembers} />
           </>
         )}
-        {filteredMembers.length > 0 && (
+        {activeMembers.length > 0 && (
           <>
-            <Typography variant="h5" fontWeight={700} mb={2} mt={1}>
-              All members ({filteredMembers.length})
+            <Typography variant="paragraph-bold" className="font-bold mt-2 mb-4">
+              All members ({activeMembers.length})
             </Typography>
-            <MembersList members={filteredMembers} />
+            <MembersList members={activeMembers} />
           </>
         )}
       </>

--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -1,6 +1,7 @@
 import AddAccounts from '../AddAccounts'
 import EmptySafeAccounts from './EmptySafeAccounts'
-import { Stack, Typography } from '@mui/material'
+import { Stack } from '@mui/material'
+import { Typography } from '@/components/ui/typography'
 import { useMemo } from 'react'
 import { useAppSelector } from '@/store'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
@@ -75,16 +76,18 @@ const SpaceSafeAccounts = () => {
   return (
     <>
       {isInvited && <PreviewInvite />}
-      <Typography variant="h1" mb={3}>
-        Safe Accounts
-      </Typography>
-      {isAdmin && (
-        <Stack direction="row" justifyContent="flex-end" mt={-3} mb={3}>
-          <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>
-            <AddAccounts />
-          </Track>
-        </Stack>
-      )}
+      <div className="mb-6 flex flex-col gap-6">
+        <Typography variant="h2" className="font-bold leading-[1] tracking-tight">
+          Safe Accounts
+        </Typography>
+        {isAdmin && (
+          <Stack direction="row" justifyContent="flex-start">
+            <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>
+              <AddAccounts buttonVariant="default" />
+            </Track>
+          </Stack>
+        )}
+      </div>
 
       {isSpaceSafesError ? (
         <div className="flex items-center gap-3 rounded-2xl border border-destructive/30 bg-destructive/5 px-5 py-4">

--- a/apps/web/src/features/spaces/components/SetupWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/index.tsx
@@ -171,7 +171,7 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
             >
               <div
                 className={cn('flex flex-col gap-2 px-2 pb-2', {
-                  'flex-row': horizontal,
+                  'sm:flex-row': horizontal,
                 })}
               >
                 {sortedSteps.map(({ key, label, icon: Icon, activeFn }, index) => {
@@ -191,7 +191,7 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
                       className={cn(
                         'flex items-center gap-4 rounded-3xl p-4 transition-colors',
                         isCompleted ? 'cursor-not-allowed bg-muted/50' : 'cursor-pointer bg-muted hover:bg-muted/70',
-                        { 'flex-1': horizontal },
+                        { 'sm:flex-1': horizontal },
                       )}
                     >
                       <div

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContact.tsx
@@ -1,6 +1,6 @@
 import { Alert, DialogActions, Stack, Button, DialogContent, Typography, CircularProgress, Box } from '@mui/material'
 import { Button as ShadcnButton } from '@/components/ui/button'
-import PlusIcon from '@/public/images/common/plus.svg'
+import { Plus } from 'lucide-react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
 import ModalDialog from '@/components/common/ModalDialog'
 import { useState } from 'react'
@@ -105,8 +105,8 @@ const AddContact = () => {
 
   return (
     <>
-      <ShadcnButton size="sm" onClick={handleOpen}>
-        <PlusIcon />
+      <ShadcnButton size="lg" className="font-bold px-4 py-0" onClick={handleOpen}>
+        <Plus className="size-4 mr-1 text-green-500" />
         Add contact
       </ShadcnButton>
       <ModalDialog open={open} onClose={handleClose} dialogTitle="Add contact" hideChainIndicator>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/Import/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/Import/index.tsx
@@ -9,7 +9,7 @@ const ImportAddressBook = () => {
 
   return (
     <>
-      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+      <Button variant="outline" size="lg" className="font-bold px-4 py-0" onClick={() => setOpen(true)}>
         <SvgIcon component={ImportIcon} inheritViewBox fontSize="small" />
         Import
       </Button>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Typography } from '@mui/material'
+import { Typography } from '@/components/ui/typography'
 import { useIsInvited, useIsAdmin, useAddressBookSearch, useGetSpaceAddressBook } from '@/features/spaces'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
@@ -87,18 +87,17 @@ const SpaceAddressBook = () => {
       {isInvited && <PreviewInvite />}
 
       <div className={cn('shadcn-scope', isDarkMode && 'dark')}>
-        {/* Header row: title + subtitle left, buttons right */}
-        <div className="mt-6 mb-6 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <Typography variant="h1">Address book</Typography>
-          </div>
+        <div className="mb-6 flex flex-col gap-6">
+          <Typography variant="h2" className="font-bold leading-[1] tracking-tight">
+            Address book
+          </Typography>
 
           {isAdmin && (
-            <div className="flex shrink-0 gap-2">
-              <ImportAddressBook />
+            <div className="flex gap-2">
               <Track {...SPACE_EVENTS.ADD_ADDRESS}>
                 <AddContact />
               </Track>
+              <ImportAddressBook />
             </div>
           )}
         </div>

--- a/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
@@ -1,5 +1,6 @@
 import { useAppSelector } from '@/store'
-import { Button, Card, Grid2, Stack, Tooltip, Typography } from '@mui/material'
+import { Button, Card, Grid2, Stack, Tooltip } from '@mui/material'
+import { Typography } from '@/components/ui/typography'
 import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useState } from 'react'
 import { useCurrentSpaceId, useIsAdmin, useIsInvited, useIsActiveMember } from '@/features/spaces'
@@ -28,16 +29,16 @@ const SpaceSettings = () => {
   return (
     <div>
       {isInvited && <PreviewInvite />}
-      <Typography variant="h2" mb={3}>
+      <Typography variant="h2" className="font-bold leading-[1] tracking-tight mb-6">
         Settings
       </Typography>
       <Card>
         <Grid2 container p={4} spacing={2}>
           <Grid2 size={{ xs: 12, md: 4 }}>
-            <Typography fontWeight="bold">General</Typography>
+            <Typography variant="paragraph-bold">General</Typography>
           </Grid2>
           <Grid2 size={{ xs: 12, md: 8 }}>
-            <Typography mb={2}>
+            <Typography className="mb-4">
               The space name is visible in the sidebar menu, headings to all its members. Usually it&apos;s a name of
               the company or a business. <ExternalLink href={AppRoutes.privacy}>How is this data stored?</ExternalLink>
             </Typography>
@@ -48,10 +49,10 @@ const SpaceSettings = () => {
 
         <Grid2 container p={4} spacing={2}>
           <Grid2 size={{ xs: 12, md: 4 }}>
-            <Typography fontWeight="bold">Danger Zone</Typography>
+            <Typography variant="paragraph-bold">Danger Zone</Typography>
           </Grid2>
           <Grid2 size={{ xs: 12, md: 8 }}>
-            <Typography mb={2}>This action cannot be undone.</Typography>
+            <Typography className="mb-4">This action cannot be undone.</Typography>
 
             <Stack direction="row" spacing={2}>
               <Tooltip title={isLastActiveAdmin ? 'You are the last active admin and cannot leave the space.' : ''}>


### PR DESCRIPTION
> Titles align, buttons bold and left,
> spaces pages dressed to match the rest.

## What it solves

UI inconsistency across Spaces pages — page titles had different fonts/positions and action buttons were misaligned.
Resolves: [WA-2002](https://linear.app/safe-global/issue/WA-2002/design-qa-unify-font-size-of-page-headers)

## How this PR fixes it

- Replaced MUI `Typography` page titles on Accounts, Address Book, Members, and Settings pages with shadcn `Typography variant="h2"` to match the Home page's Total Value heading style
- Moved action buttons (Add Accounts, Add Member, Add Contact, Import) from the right side to below the title on the left, matching the ActionsTray layout on Home
- Made Add Accounts button primary (`variant="default"`) on the Accounts page; outline on the Dashboard widget
- Swapped Add Contact / Import button order; made both bold and consistent size (`size="lg"`)
- Replaced SVG `PlusIcon` with lucide `Plus` (green) on Add Contact and Add Member buttons
- Removed search input from Members page header
- On small screens (mobile), the UI was broken - made items in the Actions Tray and Onboarding Tray responsive.

## How to test it

1. In Spaces, navigate to Accounts, Address Book, Members, Settings via the sidebar — confirm titles are visually identical in size and font to Home
2. On Accounts: verify "Add Accounts" button is primary and sits below the title on the left
3. On Address Book: verify "Add contact" (primary, green plus) comes before "Import" (outline), both below the title
4. On Members: verify "Add member" button is below the title with green plus icon; no search bar in header; tables have rounded corners
5. On Settings: confirm text styles look correct

## Affected flows

- Spaces Accounts page — title style, Add Accounts button position and variant
- Spaces Address Book page — title style, button order and position
- Spaces Members page — title style, Add Member button style, removed search, table border-radius
- Spaces Settings page — title style, Typography props

## Blast radius

- `AddAccounts` component is used on Dashboard widget and Accounts page — `font-bold` now conditional on `buttonVariant="default"`
- `EnhancedTable` is untouched — border-radius applied via wrapper div in `MembersList` only
- No shared hooks, slices, or API endpoints modified

## Risks / not checked

- Did not run full test suite

## Visual summary

Before:
<img width="1500" height="760" alt="image" src="https://github.com/user-attachments/assets/bb4c17d8-e6d9-4f10-9090-86fad3491933" />
<img width="1497" height="743" alt="image" src="https://github.com/user-attachments/assets/9662100d-4ea3-4d81-84d1-7088f465e170" />
<img width="1500" height="740" alt="image" src="https://github.com/user-attachments/assets/82c1c1c2-2774-438f-88e7-0d74be1608a8" />


After:
<img width="1509" height="755" alt="image" src="https://github.com/user-attachments/assets/00dba2e8-1773-4b35-a97f-d74e2720a97d" />
<img width="1495" height="754" alt="image" src="https://github.com/user-attachments/assets/90d11c15-80fd-449e-853d-1a4381f2cec8" />
<img width="1485" height="756" alt="image" src="https://github.com/user-attachments/assets/2983a76f-e4c3-4a09-beb2-d932a7d820f7" />



```mermaid
flowchart TB
  subgraph Before
    A1[MUI h1/h2 title — varying size] --> B1[Button pushed right]
  end
  subgraph After
    A2[shadcn h2 title — consistent 30px bold] --> B2[Button below title, left-aligned]
  end
```


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
