### PR TITLE
hotfix: prevent safe-bar flicker and wrong-safe push in the Safe selector

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceChainSelector.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceChainSelector.test.ts
@@ -36,6 +36,9 @@ jest.mock('@/hooks/useSafeInfo', () => ({
   __esModule: true,
   default: jest.fn(),
 }))
+jest.mock('@/hooks/useSafeAddressFromUrl', () => ({
+  useSafeAddressFromUrl: jest.fn(),
+}))
 jest.mock('@/hooks/useChainId', () => ({
   __esModule: true,
   default: jest.fn(),
@@ -57,6 +60,7 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MixpanelEventParams } from '@/services/analytics/mixpanel-events'
 import useSafeInfo from '@/hooks/useSafeInfo'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import useChainId from '@/hooks/useChainId'
 import useChains from '@/hooks/useChains'
 import { useRouter } from 'next/router'
@@ -103,6 +107,7 @@ function setupDefaults(
   ;(useSafeBarSafes as jest.Mock).mockReturnValue({ chainSelectorSafes: allSafes })
   ;(useCurrentSpaceId as jest.Mock).mockReturnValue('42')
   ;(useSafeInfo as jest.Mock).mockReturnValue({ safeAddress: overrides.safeAddress ?? '0xSafe1' })
+  ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('')
   ;(useChainId as jest.Mock).mockReturnValue(overrides.currentChainId ?? '1')
   ;(useChains as jest.Mock).mockReturnValue({ configs: chainConfigs })
   ;(useRouter as jest.Mock).mockReturnValue({ push: mockPush })
@@ -184,6 +189,63 @@ describe('useSpaceChainSelector', () => {
     expect(result.current.deployedChains).toHaveLength(1)
   })
 
+  it('prefers the URL safe address when Redux still points to the previous safe', () => {
+    setupDefaults({
+      allSafes: [singleChainSafe, multiChainSafe],
+      safeAddress: '0xSafe1',
+      currentChainId: '137',
+    })
+    ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('0xSafe2')
+
+    const { result } = renderHook(() => useSpaceChainSelector())
+
+    expect(result.current.safeAddress).toBe('0xSafe2')
+    expect(result.current.deployedChainIds).toEqual(['1', '137'])
+    expect(result.current.safeName).toBe('Multi Safe')
+  })
+
+  // Regression guard: when the user just navigated to a new safe, the URL updates synchronously
+  // but Redux's safeAddress lags behind. handleChainChange must push the URL safe, not the
+  // Redux one — otherwise the chain switcher rewrites the URL with the previous safe's address.
+  it('navigates with the URL safe address when Redux is stale (handleChainChange uses URL, not Redux)', () => {
+    setupDefaults({
+      allSafes: [singleChainSafe, multiChainSafe],
+      safeAddress: '0xSafe1',
+      currentChainId: '137',
+    })
+    ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('0xSafe2')
+
+    const { result } = renderHook(() => useSpaceChainSelector())
+
+    act(() => {
+      result.current.handleChainChange('1')
+    })
+
+    expect(mockPush).toHaveBeenCalledTimes(1)
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: '/home',
+      query: { safe: 'eth:0xSafe2' },
+    })
+  })
+
+  it('recomputes deployedChains/safeName when only urlSafeAddress changes between renders', () => {
+    setupDefaults({
+      allSafes: [singleChainSafe, multiChainSafe],
+      safeAddress: '0xSafe1',
+    })
+    ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('0xSafe1')
+
+    const { result, rerender } = renderHook(() => useSpaceChainSelector())
+
+    expect(result.current.safeName).toBe('My Safe')
+    expect(result.current.deployedChainIds).toEqual(['1'])
+    ;(useSafeAddressFromUrl as jest.Mock).mockReturnValue('0xSafe2')
+    rerender()
+
+    expect(result.current.safeName).toBe('Multi Safe')
+    expect(result.current.deployedChainIds).toEqual(['1', '137'])
+  })
+
   it('falls back to null for chainLogoUri when chain config exists but chainLogoUri is missing', () => {
     ;(useChains as jest.Mock).mockReturnValue({
       configs: [{ chainId: '1', chainName: 'Ethereum', shortName: 'eth' }],
@@ -218,7 +280,7 @@ describe('useSpaceChainSelector', () => {
     })
   })
 
-  it('returns safeAddress from useSafeInfo', () => {
+  it('returns safeAddress from Redux when URL is empty', () => {
     const { result } = renderHook(() => useSpaceChainSelector())
     expect(result.current.safeAddress).toBe('0xSafe1')
   })

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceChainSelector.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceChainSelector.ts
@@ -4,6 +4,7 @@ import { isMultiChainSafeItem } from '@/hooks/safes'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useChainId from '@/hooks/useChainId'
 import useChains from '@/hooks/useChains'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { AppRoutes } from '@/config/routes'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
@@ -15,7 +16,9 @@ import { useSafeBarSafes } from './useSafeBarSafes'
 
 export function useSpaceChainSelector() {
   const { chainSelectorSafes: allSafes } = useSafeBarSafes()
-  const { safeAddress } = useSafeInfo()
+  const { safeAddress: reduxSafeAddress } = useSafeInfo()
+  const urlSafeAddress = useSafeAddressFromUrl()
+  const safeAddress = urlSafeAddress || reduxSafeAddress
   const selectedChainId = useChainId()
   const { configs: chainConfigs } = useChains()
   const router = useRouter()

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
@@ -29,6 +29,11 @@ jest.mock('@/components/ui/select', () => {
   const NEW_ID = '2:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
   const PREV_ID = '1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
+  // Avoid fallbacks to the previous value when the registered SelectItem set changes.
+  const itemPressDetails = () => ({ reason: 'item-press' as const, cancel: () => {} })
+  // 'none' is base-ui's reason when it auto-corrects after the registered SelectItem set changes
+  const noneDetails = () => ({ reason: 'none' as const, cancel: () => {} })
+
   return {
     __esModule: true,
     Select: ({
@@ -38,18 +43,26 @@ jest.mock('@/components/ui/select', () => {
     }: {
       children?: React.ReactNode
       value?: string
-      onValueChange?: (next: string | null) => void
+      onValueChange?: (next: string | null, details: { reason: string; cancel: () => void }) => void
     }) => (
       <div data-testid="mock-select-root" data-mock-controlled-value={value}>
         <button
           type="button"
-          data-testid="simulate-double-onvaluechange"
+          data-testid="simulate-user-pick-new"
           onClick={() => {
-            onValueChange?.(NEW_ID)
-            onValueChange?.(PREV_ID)
+            onValueChange?.(NEW_ID, itemPressDetails())
           }}
         >
-          simulate double onValueChange
+          simulate user pick new
+        </button>
+        <button
+          type="button"
+          data-testid="simulate-base-ui-auto-reset"
+          onClick={() => {
+            onValueChange?.(PREV_ID, noneDetails())
+          }}
+        >
+          simulate base-ui auto-reset to initial value
         </button>
         {children}
       </div>
@@ -98,8 +111,8 @@ function SafeSelectorWithSpaceSafeBarNavigation({
 }
 
 describe('SafeSelectorDropdown', () => {
-  describe('controlled Select double onValueChange', () => {
-    it('calls onItemSelect once when Select fires new id then snap-back to the previous id', async () => {
+  describe('onValueChange filtering by reason', () => {
+    it('forwards user item-press picks to onItemSelect', async () => {
       const user = userEvent.setup()
       const onItemSelect = jest.fn()
       const itemA = createItem()
@@ -112,16 +125,19 @@ describe('SafeSelectorDropdown', () => {
 
       render(<SafeSelectorDropdown items={[itemA, itemB]} selectedItemId={itemA.id} onItemSelect={onItemSelect} />)
 
-      await user.click(screen.getByTestId('simulate-double-onvaluechange'))
+      await user.click(screen.getByTestId('simulate-user-pick-new'))
 
       expect(onItemSelect).toHaveBeenCalledTimes(1)
       expect(onItemSelect).toHaveBeenCalledWith(itemB.id)
     })
 
     /**
-     * One navigation per selection — snap-back to the previous id must not trigger a second push.
+     * base-ui's Select fires onValueChange with reason='none' when its registered SelectItem set
+     * changes (e.g. expanding/collapsing a multi-chain row) and the controlled value stops matching
+     * any registered item — it then resets to its captured initial value. This must NOT trigger
+     * navigation, otherwise the user gets bounced back to whichever safe was selected on first mount.
      */
-    it('performs one router.push when onItemSelect is wired like SpaceSafeBar and Select double-fires', async () => {
+    it('ignores base-ui auto-reset (reason=none) and does not navigate', async () => {
       const mockPush = jest.fn()
       jest.mocked(useRouter).mockReturnValue({ push: mockPush } as unknown as ReturnType<typeof useRouter>)
 
@@ -134,15 +150,56 @@ describe('SafeSelectorDropdown', () => {
         chains: [{ chainId: '2', chainName: 'Another', chainLogoUri: null, shortName: 'oeth' }],
       })
 
-      render(<SafeSelectorWithSpaceSafeBarNavigation items={[itemA, itemB]} selectedItemId={itemA.id} />)
+      render(<SafeSelectorWithSpaceSafeBarNavigation items={[itemA, itemB]} selectedItemId={itemB.id} />)
 
-      await user.click(screen.getByTestId('simulate-double-onvaluechange'))
+      await user.click(screen.getByTestId('simulate-base-ui-auto-reset'))
+
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    /**
+     * The realistic regression sequence: user picks a new safe → router.push fires once →
+     * parent re-renders with the new selectedItemId → base-ui's registered SelectItem set
+     * shifts (e.g. multi-chain row collapses around the previous selection) → onValueChange
+     * fires again with reason='none' resetting to the captured initial value.
+     *
+     * If either guard regresses (the reason filter, the URL-aware safeAddress in
+     * useSpaceChainSelector, or the controlled value plumbing), this test catches the
+     * second router.push. The two unit tests above only cover each branch in isolation.
+     */
+    it('performs exactly one router.push across pick → rerender → base-ui auto-reset', async () => {
+      const mockPush = jest.fn()
+      jest.mocked(useRouter).mockReturnValue({ push: mockPush } as unknown as ReturnType<typeof useRouter>)
+
+      const user = userEvent.setup()
+      const itemA = createItem()
+      const itemB = createItem({
+        id: '2:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        name: 'Safe B',
+        address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        chains: [{ chainId: '2', chainName: 'Another', chainLogoUri: null, shortName: 'oeth' }],
+      })
+
+      const { rerender } = render(
+        <SafeSelectorWithSpaceSafeBarNavigation items={[itemA, itemB]} selectedItemId={itemA.id} />,
+      )
+
+      await user.click(screen.getByTestId('simulate-user-pick-new'))
 
       expect(mockPush).toHaveBeenCalledTimes(1)
       expect(mockPush).toHaveBeenCalledWith({
         pathname: AppRoutes.home,
         query: { safe: `oeth:${itemB.address}` },
       })
+
+      // Parent re-renders after the URL/Redux update propagates: selectedItemId moves to itemB.
+      rerender(<SafeSelectorWithSpaceSafeBarNavigation items={[itemA, itemB]} selectedItemId={itemB.id} />)
+
+      // base-ui then fires an auto-reset (reason='none') as its registered items shift around the
+      // now-current value. This must NOT produce a second push.
+      await user.click(screen.getByTestId('simulate-base-ui-auto-reset'))
+
+      expect(mockPush).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.test.ts
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.test.ts
@@ -77,11 +77,11 @@ describe('useSafeSelectorState', () => {
     expect(result.current.selectedItem).toBeUndefined()
   })
 
-  /**
-   * When a controlled Select emits onValueChange twice (new id, then snap-back to the previous id
-   * before the URL updates), only the first call is forwarded — the second matches currentSelectionId.
-   */
-  it('ignores handleSafeChange when the value matches the current selection (revert snap-back)', () => {
+  // Minimal stub of base-ui's SelectRootChangeEventDetails — only what handleSafeChange reads.
+  const itemPress = () => ({ reason: 'item-press', cancel: () => {} }) as any
+  const noneReason = () => ({ reason: 'none', cancel: () => {} }) as any
+
+  it('forwards user item-press picks to onItemSelect', () => {
     const onItemSelect = jest.fn()
     const { result } = renderHook(() =>
       useSafeSelectorState({
@@ -92,11 +92,112 @@ describe('useSafeSelectorState', () => {
     )
 
     act(() => {
-      result.current.handleSafeChange('2:0xB')
-      result.current.handleSafeChange('1:0xA')
+      result.current.handleSafeChange('2:0xB', itemPress())
     })
 
     expect(onItemSelect).toHaveBeenCalledTimes(1)
     expect(onItemSelect).toHaveBeenCalledWith('2:0xB')
+  })
+
+  /**
+   * base-ui's Select calls onValueChange with reason='none' when its registered SelectItem set
+   * changes and the controlled value no longer matches — e.g. expanding/collapsing a multi-chain
+   * row, where the row's per-chain SelectItems mount/unmount. Forwarding these would navigate
+   * back to base-ui's captured initial value (the safe selected on first mount).
+   */
+  it('ignores onValueChange when reason is not item-press (base-ui auto-reset)', () => {
+    const onItemSelect = jest.fn()
+    const { result } = renderHook(() =>
+      useSafeSelectorState({
+        items: [createItem('1:0xA'), createItem('2:0xB')],
+        selectedItemId: '2:0xB',
+        onItemSelect,
+      }),
+    )
+
+    act(() => {
+      result.current.handleSafeChange('1:0xA', noneReason())
+    })
+
+    expect(onItemSelect).not.toHaveBeenCalled()
+  })
+
+  it('ignores handleSafeChange when the picked value matches the current selection', () => {
+    const onItemSelect = jest.fn()
+    const { result } = renderHook(() =>
+      useSafeSelectorState({
+        items: [createItem('1:0xA'), createItem('2:0xB')],
+        selectedItemId: '1:0xA',
+        onItemSelect,
+      }),
+    )
+
+    act(() => {
+      result.current.handleSafeChange('1:0xA', itemPress())
+    })
+
+    expect(onItemSelect).not.toHaveBeenCalled()
+  })
+
+  // base-ui's setValue (SelectRoot.js) honors `eventDetails.isCanceled` and skips its internal
+  // setValueUnwrapped when canceled. Without cancel(), base-ui briefly overwrites
+  // its own state with `initialValueRef.current` before our props re-stabilise.
+  it.each([
+    ['none', 'auto-reset when registered SelectItems change'],
+    ['cancel-open', 'open canceled by user / library'],
+    ['list-navigation', 'keyboard arrow navigation'],
+    ['outside-press', 'click outside the popup'],
+  ])('calls eventDetails.cancel() and skips onItemSelect for reason=%s (%s)', (reason) => {
+    const onItemSelect = jest.fn()
+    const cancel = jest.fn()
+    const { result } = renderHook(() =>
+      useSafeSelectorState({
+        items: [createItem('1:0xA'), createItem('2:0xB')],
+        selectedItemId: '2:0xB',
+        onItemSelect,
+      }),
+    )
+
+    act(() => {
+      result.current.handleSafeChange('1:0xA', { reason, cancel } as any)
+    })
+
+    expect(cancel).toHaveBeenCalledTimes(1)
+    expect(onItemSelect).not.toHaveBeenCalled()
+  })
+
+  it('coerces null value to empty string and skips onItemSelect when current selection is also empty', () => {
+    const onItemSelect = jest.fn()
+    const { result } = renderHook(() =>
+      useSafeSelectorState({
+        items: [createItem('1:0xA'), createItem('2:0xB')],
+        selectedItemId: '',
+        onItemSelect,
+      }),
+    )
+
+    act(() => {
+      result.current.handleSafeChange(null, itemPress())
+    })
+
+    expect(onItemSelect).not.toHaveBeenCalled()
+  })
+
+  it('forwards null as empty string to onItemSelect when current selection is non-empty', () => {
+    const onItemSelect = jest.fn()
+    const { result } = renderHook(() =>
+      useSafeSelectorState({
+        items: [createItem('1:0xA'), createItem('2:0xB')],
+        selectedItemId: '1:0xA',
+        onItemSelect,
+      }),
+    )
+
+    act(() => {
+      result.current.handleSafeChange(null, itemPress())
+    })
+
+    expect(onItemSelect).toHaveBeenCalledTimes(1)
+    expect(onItemSelect).toHaveBeenCalledWith('')
   })
 })

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.ts
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/hooks/useSafeSelectorState.ts
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from 'react'
+import type { SelectRootChangeEventDetails } from '@base-ui/react/select'
 import type { SafeItemData } from '../types'
 
 interface UseSafeSelectorStateProps {
@@ -44,15 +45,24 @@ export const useSafeSelectorState = ({
     [isSingleSafe],
   )
 
+  // Prevents the dropdown from snapping back to the safe selected on first mount whenever
+  // a multi-chain row expands/collapses or items load async. base-ui fires `onValueChange`
+  // and then resets to its captured initial value (SelectPositioner
+  // `onMapChange`). We only forward 'item-press' picks and cancel() everything
+  // else to avoid unwanted fallbacks.
   const handleSafeChange = useCallback(
-    (value: string | null) => {
+    (value: string | null, eventDetails: SelectRootChangeEventDetails) => {
+      if (eventDetails.reason !== 'item-press') {
+        eventDetails.cancel()
+        return
+      }
+
       const itemId = value ?? ''
-      // Skip reselecting the previous id before the URL updates
-      const currentSelectionId = selectedItemId ?? selectedItem?.id ?? ''
-      if (itemId === currentSelectionId) return
+      if (itemId === (selectedItemId ?? '')) return
+
       onItemSelect?.(itemId)
     },
-    [onItemSelect, selectedItemId, selectedItem],
+    [onItemSelect, selectedItemId],
   )
 
   const closeDropdown = useCallback(() => {


### PR DESCRIPTION
## What it solves

Resolves: [WA-2212](https://linear.app/safe-global/issue/WA-2212/safe-selector-jumps-back-to-first-account)
Flickering and wrong-safe navigation in the Spaces safe bar after switching safes.

Two related bugs:
1. **Chain switcher pushed the previous safe's address into the URL.** After `router.push` to a new safe, Redux's `safeAddress` lags one render behind the URL. `useSpaceChainSelector` was reading from Redux, so the chain dropdown briefly showed the previous safe's data, and clicking a chain pushed the *previous* safe's address.
2. **Safe dropdown snapped back to the safe selected on first mount.** base-ui's `Select` fires `onValueChange` with `reason='none'` whenever its registered `<SelectItem>` set changes (multi-chain row expand/collapse, async items load) and the controlled value no longer matches — it then resets to the value captured on first render. The handler was forwarding these to `onItemSelect` → `router.push`, bouncing the user back to a stale safe.

## How this PR fixes it

- `useSpaceChainSelector` now prefers `useSafeAddressFromUrl()` and falls back to Redux only when the URL has no safe param. The URL is the source of truth post-`router.push`.
- `useSafeSelectorState.handleSafeChange` filters by `eventDetails.reason`: only `'item-press'` is forwarded; everything else calls `eventDetails.cancel()` so base-ui also skips its internal `setValueUnwrapped` (keeps the Select fully controlled).

## How to test it

1. Open a space with multiple safes (mix of single- and multi-chain).
2. Switch between safes from the dropdown — confirm no flicker, no fallback to a previous safe.
3. With a multi-chain safe selected, expand/collapse the chain row in the dropdown — confirm the selection doesn't jump back.
4. Use the chain switcher to change networks for the current safe — confirm the URL keeps the *current* safe's address.

## Affected flows

- Spaces > safe bar: switching the active safe
- Spaces > safe bar: switching chain on a multi-chain safe
- Safe selector dropdown: expanding/collapsing multi-chain rows

## Blast radius

- `useSpaceChainSelector` (consumed by `SpaceChainSelector`, `SpaceSafeBar`)
- `useSafeSelectorState` (consumed by `SafeSelectorDropdown` — used in space safe bar and account modal)
- New consumer of `useSafeAddressFromUrl` — pure read of `router.query.safe`, no other surfaces affected
- No API/store/feature-flag changes

## Risks / not checked

- Did not test on mobile (web-only changes)
- Did not exercise the SSR/hydration path explicitly — relied on `useSafeAddressFromUrl`'s existing `location.search` fallback
- Did not verify behavior with `reason='cancel-open' | 'list-navigation' | 'outside-press'` manually in browser; covered by unit tests only

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    A1[useSpaceChainSelector] -->|reads| R1[Redux safeAddress<br/>stale after router.push]
    R1 --> P1[router.push wrong safe]
    S1[base-ui Select<br/>onValueChange reason=none] --> H1[handleSafeChange]
    H1 --> P2[router.push initial safe]
  end
  subgraph After
    A2[useSpaceChainSelector] -->|reads| U2[URL safeAddress]
    U2 -->|fallback| R2[Redux safeAddress]
    A2 --> P3[router.push current safe]
    S2[base-ui Select<br/>onValueChange] --> F[reason filter]
    F -->|item-press| H2[onItemSelect]
    F -->|else| C[cancel + ignore]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
