### PR TITLE
fix(web): hide global search button on welcome list pages

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/index.test.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.test.tsx
@@ -64,6 +64,12 @@ jest.mock('@/hooks/useIsSpaceRoute', () => ({
   useIsSpaceRoute: () => mockIsSpaceRoute(),
 }))
 
+const mockUsePathname = jest.fn<string, []>(() => '/home')
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'),
+  usePathname: () => mockUsePathname(),
+}))
+
 jest.mock('@/components/common/SpaceSafeBar', () => {
   const MockSpaceSafeBar = () => <div data-testid="space-safe-bar" />
   MockSpaceSafeBar.displayName = 'SpaceSafeBar'
@@ -122,6 +128,7 @@ describe('Topbar', () => {
     jest.clearAllMocks()
     mockUseIsMobile.mockReturnValue(false)
     mockIsSpaceRoute.mockReturnValue(true)
+    mockUsePathname.mockReturnValue('/home')
     mockUseLoadFeature.mockReturnValue({
       WalletPopover: () => null,
       GlobalSearchModal: () => null,
@@ -186,6 +193,36 @@ describe('Topbar', () => {
         </TxModalContext.Provider>,
       )
       expect(screen.getByTestId('space-safe-bar')).toBeInTheDocument()
+    })
+  })
+
+  describe('search button visibility', () => {
+    it('shows the search button on non-space, non-welcome routes', () => {
+      mockIsSpaceRoute.mockReturnValue(false)
+      mockUsePathname.mockReturnValue('/home')
+      render(<Topbar />)
+      expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument()
+    })
+
+    it('hides the search button on /welcome/accounts', () => {
+      mockIsSpaceRoute.mockReturnValue(false)
+      mockUsePathname.mockReturnValue('/welcome/accounts')
+      render(<Topbar />)
+      expect(screen.queryByRole('button', { name: /search/i })).not.toBeInTheDocument()
+    })
+
+    it('hides the search button on /welcome/spaces', () => {
+      mockIsSpaceRoute.mockReturnValue(false)
+      mockUsePathname.mockReturnValue('/welcome/spaces')
+      render(<Topbar />)
+      expect(screen.queryByRole('button', { name: /search/i })).not.toBeInTheDocument()
+    })
+
+    it('shows the search button on other welcome subpaths', () => {
+      mockIsSpaceRoute.mockReturnValue(false)
+      mockUsePathname.mockReturnValue('/welcome')
+      render(<Topbar />)
+      expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/components/common/Header/Topbar/index.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.tsx
@@ -1,8 +1,10 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { useContext, useMemo, useRef, type ReactElement } from 'react'
 import { Menu } from 'lucide-react'
+import { usePathname } from 'next/navigation'
 
 import { Button } from '@/components/ui/button'
+import { AppRoutes } from '@/config/routes'
 import { HeaderNavigation } from '@/features/spaces/components/HeaderNavigation'
 import { useLoadFeature } from '@/features/__core__'
 import { WalletFeature, useWalletPopover } from '@/features/wallet'
@@ -54,6 +56,8 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
   const notifications = useAppSelector(selectNotifications)
   const spaceId = useCurrentSpaceId()
   const isSpaceRoute = useIsSpaceRoute()
+  const pathname = usePathname()
+  const isWelcomeListRoute = pathname === AppRoutes.welcome.accounts || pathname === AppRoutes.welcome.spaces
   const safeAddress = useSafeAddress()
   const isProposer = useIsWalletProposer()
   const isSafeOwner = useIsSafeOwner()
@@ -120,7 +124,7 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
             walletLabel={wallet?.label}
             walletOpen={walletOpen}
             messages={unreadCount}
-            showSearch={!isSpaceRoute}
+            showSearch={!isSpaceRoute && !isWelcomeListRoute}
             onSearchClick={() => dispatch(openGlobalSearch())}
             onNotificationsClick={(e) => notificationsRef.current?.handleClick(e)}
             onWalletClick={handleWalletClick}


### PR DESCRIPTION
> Welcome accounts and welcome spaces,
> hide the search — nothing to find here yet,
> tests assert the icon stays away.

## What it solves

Resolves: the global search button shows in the Topbar on `/welcome/accounts` and `/welcome/spaces` even though there is nothing meaningful to search at that point in the journey (the user has not yet entered a Safe or Space context).

## How this PR fixes it

`Topbar` now reads the current pathname via `usePathname()` and computes `isWelcomeListRoute` for `AppRoutes.welcome.accounts` and `AppRoutes.welcome.spaces`. The `showSearch` prop passed to `HeaderNavigation` is gated on `!isSpaceRoute && !isWelcomeListRoute`, so the search button is suppressed on those two pages while remaining visible on every other non-space route (including `/welcome` itself).

## How to test it

1. `yarn workspace @safe-global/web dev`
2. Visit `/welcome` — search button is **visible**.
3. Visit `/welcome/accounts` — search button is **hidden**.
4. Visit `/welcome/spaces` — search button is **hidden**.
5. Visit any Safe dashboard (non-space route) — search button is **visible**.
6. Visit a `/spaces/...` route — search button stays hidden as before.

Or run the unit tests: `yarn workspace @safe-global/web test apps/web/src/components/common/Header/Topbar/index.test.tsx`.

## Affected flows

- Topbar render on `/welcome/accounts` (account list landing page)
- Topbar render on `/welcome/spaces` (spaces list landing page)

## Blast radius

- `apps/web/src/components/common/Header/Topbar/index.tsx` — only consumer of the new `isWelcomeListRoute` flag; `HeaderNavigation` already supports `showSearch` toggling.
- No changes to shared hooks, slices, RTK Query endpoints, feature flags, or routes.
- No mobile impact — change is web-only inside `apps/web`.

## Risks / not checked

- Did not verify on a physical mobile viewport — relied on existing breakpoint logic which is unchanged.
- Did not exercise feature-flag-disabled variants of `GlobalSearchFeature` (out of scope; the search button is the same one already gated by `isSpaceRoute`).

## Visual summary

```mermaid
flowchart LR
  A[Topbar render] --> B{isSpaceRoute?}
  B -- yes --> H[hide search]
  B -- no --> C{pathname == /welcome/accounts<br/>or /welcome/spaces?}
  C -- yes --> H
  C -- no --> S[show search]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)