### PR TITLE
fix(web): show all deployed chains for current safe in selector dropdown

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSafeBarSafes.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSafeBarSafes.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import { useSafeBarSafes } from '../useSafeBarSafes'
-import type { SafeItem } from '@/hooks/safes'
+import type { SafeItem, MultiChainSafeItem } from '@/hooks/safes'
 import type { AllSafeItems } from '@/hooks/safes'
 
 // ── mocks ──────────────────────────────────────────────────────────────
@@ -32,12 +32,15 @@ jest.mock('@/hooks/useChainId', () => ({
 }))
 
 const mockAllSafes = jest.fn<SafeItem[] | undefined, []>(() => undefined)
-jest.mock('@/hooks/safes', () => ({
-  useAllSafes: () => mockAllSafes(),
-  useAllSafesGrouped: (items: SafeItem[]) => ({
+const mockGrouped = jest.fn<{ allMultiChainSafes: MultiChainSafeItem[]; allSingleSafes: SafeItem[] }, [SafeItem[]]>(
+  (items: SafeItem[]) => ({
     allMultiChainSafes: [],
     allSingleSafes: items,
   }),
+)
+jest.mock('@/hooks/safes', () => ({
+  useAllSafes: () => mockAllSafes(),
+  useAllSafesGrouped: (items: SafeItem[]) => mockGrouped(items),
 }))
 
 const mockIsSpaceRoute = jest.fn(() => false)
@@ -67,6 +70,11 @@ describe('useSafeBarSafes', () => {
     mockReduxSafeAddress.mockReturnValue('')
     mockChainId.mockReturnValue('1')
     mockAllSafes.mockReturnValue(undefined)
+    // Default: pass-through. Tests needing multi-chain grouping override per-case.
+    mockGrouped.mockImplementation((items: SafeItem[]) => ({
+      allMultiChainSafes: [],
+      allSingleSafes: items,
+    }))
   })
 
   it('returns empty lists when allSafes is undefined', () => {
@@ -255,5 +263,60 @@ describe('useSafeBarSafes', () => {
     const injected = result.current.dropdownSafes[0] as SafeItem
     expect(injected.name).toBe('Known Name')
     expect(injected.isReadOnly).toBe(false)
+  })
+
+  const groupByAddress = (items: SafeItem[]) => {
+    const byAddress: Record<string, SafeItem[]> = {}
+    for (const s of items) {
+      ;(byAddress[s.address] ??= []).push(s)
+    }
+    const allMultiChainSafes: MultiChainSafeItem[] = Object.entries(byAddress)
+      .filter(([, group]) => group.length > 1)
+      .map(([address, group]) => ({
+        address,
+        safes: group,
+        isPinned: group.some((s) => s.isPinned),
+        lastVisited: 0,
+        name: undefined,
+      }))
+    const multiAddresses = new Set(allMultiChainSafes.map((m) => m.address))
+    const allSingleSafes = items.filter((s) => !multiAddresses.has(s.address))
+    return { allMultiChainSafes, allSingleSafes }
+  }
+
+  // A wallet may own a safe on more chains than it has pinned; the current safe
+  // row must reflect all of them.
+  it('uses multi-chain representation of current safe even when only one chain is pinned', () => {
+    const sepoliaPinned = createSafe('0xMultiSafe', true, '11155111')
+    const mainnetOwned = createSafe('0xMultiSafe', false, '1')
+    mockAllSafes.mockReturnValue([sepoliaPinned, mainnetOwned])
+    mockSafeAddress.mockReturnValue('0xMultiSafe')
+    mockGrouped.mockImplementation(groupByAddress)
+
+    const { result } = renderHook(() => useSafeBarSafes())
+
+    // Current safe row should reflect both chains so the user can switch.
+    expect(result.current.dropdownSafes).toHaveLength(1)
+    const item = result.current.dropdownSafes[0] as MultiChainSafeItem
+    expect(item.address).toBe('0xMultiSafe')
+    expect('safes' in item).toBe(true)
+    expect(item.safes.map((s) => s.chainId).sort()).toEqual(['1', '11155111'])
+  })
+
+  it('keeps other pinned safes alongside the multi-chain current safe', () => {
+    const sepoliaPinned = createSafe('0xMultiSafe', true, '11155111')
+    const mainnetOwned = createSafe('0xMultiSafe', false, '1')
+    const otherPinned = createSafe('0xOtherPinned', true, '1')
+    mockAllSafes.mockReturnValue([sepoliaPinned, mainnetOwned, otherPinned])
+    mockSafeAddress.mockReturnValue('0xMultiSafe')
+    mockGrouped.mockImplementation(groupByAddress)
+
+    const { result } = renderHook(() => useSafeBarSafes())
+
+    expect(result.current.dropdownSafes).toHaveLength(2)
+    const current = result.current.dropdownSafes[0] as MultiChainSafeItem
+    expect(current.address).toBe('0xMultiSafe')
+    expect(current.safes).toHaveLength(2)
+    expect(result.current.dropdownSafes[1].address).toBe('0xOtherPinned')
   })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
@@ -63,13 +63,15 @@ export function useSafeBarSafes() {
     }
   }, [safeAddress, currentChainId])
 
-  // Inject the current safe into pinnedSafes if it's not already there.
+  // Current safe: pull from allKnownSafes so the dropdown sees every chain it's
+  // deployed on (pinned, owned, or counterfactual); other safes stay pinned-only.
+  // Pin state stays decoupled — bookmark drives it, navigating doesn't auto-pin.
   const dropdownSafes = useMemo<AllSafeItems>(() => {
     if (!safeAddress) return pinnedSafes
-    if (pinnedSafes.some((s) => sameAddress(s.address, safeAddress))) return pinnedSafes
     const current = allKnownSafes.find((s) => sameAddress(s.address, safeAddress)) ?? fallbackCurrentSafe
     if (!current) return pinnedSafes
-    return [current, ...pinnedSafes]
+    const otherPinned = pinnedSafes.filter((s) => !sameAddress(s.address, safeAddress))
+    return [current, ...otherPinned]
   }, [pinnedSafes, allKnownSafes, safeAddress, fallbackCurrentSafe])
 
   // Same for chain selector.

--- a/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
@@ -76,6 +76,10 @@ jest.mock('@/features/__core__', () => ({
 
 jest.mock('@/hooks/useSafeInfo', () => () => ({ safeAddress: '0xSafe1' }))
 
+jest.mock('@/hooks/useSafeAddressFromUrl', () => ({
+  useSafeAddressFromUrl: jest.fn(() => '0xSafe1'),
+}))
+
 jest.mock('@/hooks/useChainId', () => () => '1')
 
 jest.mock('@/hooks/safes', () => ({
@@ -106,11 +110,13 @@ jest.mock('./SpaceBackLink', () => {
 
 import { usePathname } from 'next/navigation'
 import { useIsQualifiedSafe } from '@/features/spaces'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { useSpaceSafeSelectorItems } from './hooks/useSpaceSafeSelectorItems'
 import { useSpaceBackLink } from './hooks/useSpaceBackLink'
 
 const mockUsePathname = usePathname as jest.Mock
 const mockUseIsQualifiedSafe = useIsQualifiedSafe as jest.Mock
+const mockUseSafeAddressFromUrl = useSafeAddressFromUrl as jest.Mock
 const mockUseSpaceSafeSelectorItems = useSpaceSafeSelectorItems as jest.Mock
 const mockUseSpaceBackLink = useSpaceBackLink as jest.Mock
 
@@ -118,6 +124,7 @@ describe('SpaceSafeBar', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     mockUsePathname.mockReturnValue('/home')
+    mockUseSafeAddressFromUrl.mockReturnValue('0xSafe1')
     mockUseSpaceSafeSelectorItems.mockReturnValue({
       items: mockItems,
       selectedItemId: '1:0xSafe1',
@@ -252,4 +259,36 @@ describe('SpaceSafeBar', () => {
       expect(queryByTestId('nested-safes-button')).not.toBeInTheDocument()
     },
   )
+
+  it.each([['/settings/notifications'], ['/settings/cookies'], ['/settings/appearance'], ['/settings']])(
+    'renders nothing on settings route %s when URL has no safe',
+    (pathname) => {
+      mockUsePathname.mockReturnValue(pathname)
+      mockUseSafeAddressFromUrl.mockReturnValue('')
+
+      const { queryByTestId } = render(<SpaceSafeBar />)
+      expect(queryByTestId('safe-selector-dropdown')).not.toBeInTheDocument()
+      expect(queryByTestId('space-chain-selector')).not.toBeInTheDocument()
+      expect(queryByTestId('nested-safes-button')).not.toBeInTheDocument()
+    },
+  )
+
+  it.each([['/settings/setup'], ['/settings/security'], ['/settings/notifications']])(
+    'renders normally on settings route %s when URL has a safe',
+    (pathname) => {
+      mockUsePathname.mockReturnValue(pathname)
+      mockUseSafeAddressFromUrl.mockReturnValue('0xSafe1')
+
+      const { getByTestId } = render(<SpaceSafeBar />)
+      expect(getByTestId('safe-selector-dropdown')).toBeInTheDocument()
+    },
+  )
+
+  it('still renders on non-settings routes when URL has no safe (Redux fallback path unchanged)', () => {
+    mockUsePathname.mockReturnValue('/home')
+    mockUseSafeAddressFromUrl.mockReturnValue('')
+
+    const { getByTestId } = render(<SpaceSafeBar />)
+    expect(getByTestId('safe-selector-dropdown')).toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -16,6 +16,7 @@ import useChainId from '@/hooks/useChainId'
 import useWallet from '@/hooks/wallets/useWallet'
 import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
 import { useAllSafes } from '@/hooks/safes'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useSpaceSafeSelectorItems } from './hooks/useSpaceSafeSelectorItems'
 import { useSpaceBackLink } from './hooks/useSpaceBackLink'
@@ -83,6 +84,7 @@ function ConnectWalletFooter({ onConnect, onClose }: { onConnect: () => void; on
 
 function SpaceSafeBar() {
   const pathname = usePathname()
+  const urlSafeAddress = useSafeAddressFromUrl()
   const dispatch = useAppDispatch()
   const isQualifiedSafe = useIsQualifiedSafe()
   const { items, selectedItemId, handleItemSelect, isLoading, isError, refetch } = useSpaceSafeSelectorItems()
@@ -97,6 +99,8 @@ function SpaceSafeBar() {
   const { txFlow } = useContext(TxModalContext)
 
   if (HIDDEN_ROUTES.includes(pathname ?? '')) return null
+  // /settings/* serves both per-safe (URL has ?safe=) and global pages — hide when no safe context.
+  if (pathname?.startsWith(AppRoutes.settings.index) && !urlSafeAddress) return null
 
   // Check if current safe is pinned on any chain
   const isPinned = Boolean(addedSafes[chainId]?.[safeAddress])

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
@@ -167,6 +167,46 @@ describe('SafeSelectorDropdown', () => {
      * useSpaceChainSelector, or the controlled value plumbing), this test catches the
      * second router.push. The two unit tests above only cover each branch in isolation.
      */
+    it('renders an error message when items are loaded but selectedItemId has no match', () => {
+      const itemA = createItem()
+      render(<SafeSelectorDropdown items={[itemA]} selectedItemId="999:0xnotfound" isLoading={false} />)
+
+      expect(screen.getByText('This Safe is not available on the selected network')).toBeInTheDocument()
+    })
+
+    it('keeps showing the skeleton while items are still loading and there is no match yet', () => {
+      const itemA = createItem()
+      render(<SafeSelectorDropdown items={[itemA]} selectedItemId="999:0xnotfound" isLoading={true} />)
+
+      expect(screen.queryByText('This Safe is not available on the selected network')).not.toBeInTheDocument()
+    })
+
+    it('shows the load error (not the no-match error) when isError is true', () => {
+      const itemA = createItem()
+      const onRetry = jest.fn()
+      render(
+        <SafeSelectorDropdown
+          items={[itemA]}
+          selectedItemId="999:0xnotfound"
+          isLoading={false}
+          isError={true}
+          onRetry={onRetry}
+        />,
+      )
+
+      expect(screen.getByText('Failed to load Safe data')).toBeInTheDocument()
+      expect(screen.queryByText('This Safe is not available on the selected network')).not.toBeInTheDocument()
+    })
+
+    it('shows the skeleton (not the no-match error) when items are empty', () => {
+      const { container } = render(<SafeSelectorDropdown items={[]} selectedItemId="1:0xa" isLoading={false} />)
+
+      expect(screen.queryByText('This Safe is not available on the selected network')).not.toBeInTheDocument()
+      // Skeleton renders a placeholder block; trigger content is not rendered yet
+      expect(screen.queryByTestId('safe-selector-trigger-content')).not.toBeInTheDocument()
+      expect(container.firstChild).toBeTruthy()
+    })
+
     it('performs exactly one router.push across pick → rerender → base-ui auto-reset', async () => {
       const mockPush = jest.fn()
       jest.mocked(useRouter).mockReturnValue({ push: mockPush } as unknown as ReturnType<typeof useRouter>)

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
@@ -55,6 +55,10 @@ function SafeSelectorDropdown({
 
   if (!selectedItem || !mounted) {
     if (isError && mounted) return <InlineRetryError message="Failed to load Safe data" onRetry={onRetry} />
+    // Mismatch (loaded, but no item for selectedItemId). No retry: refetch can't fix it.
+    if (mounted && !isLoading && items.length > 0) {
+      return <InlineRetryError message="This Safe is not available on the selected network" />
+    }
     return <SafeSelectorDropdownSkeleton />
   }
 


### PR DESCRIPTION
> Owned but unpinned chains
> left the dropdown stuck loading;
> safe-less settings did the same.
> Fix both, ship before launch.

## What it solves

Resolves:
- [WA-2216](https://linear.app/safe-global/issue/WA-2216/safe-selector-dropdown-stuck-loading-when-navigating-to-owned-but) — Safe selector dropdown stuck loading when navigating to an owned-but-unpinned chain
- [WA-2199](https://linear.app/safe-global/issue/WA-2199/empty-bar-of-spaces-and-safes-in-global-preferences) — Empty bar of spaces and safes in global preferences (and consequently the nested-safe modal stuck loading)

Both manifest as a perpetual loading skeleton in `SpaceSafeBar` but have different root causes — bundled here because they're going live together.

### WA-2216

When a safe was added via `new-safe/load` on only one chain (e.g. Sepolia) but the connected wallet was an owner on the same safe deployed to additional chains, the chain selector listed every deployed chain (correct) while the safe selector dropdown only carried the pinned chain. Navigating to a non-pinned chain via the chain selector left the safe selector dropdown stuck on its loading skeleton, because `selectedItemId` no longer matched any item.

### WA-2199

`SpaceSafeBar` rendered on `/settings/*` global pages (push-notification preferences, cookies, appearance) where there's no `?safe=` in the URL. With no safe context, `useSpaceSafeSelectorItems` returned `items: []` and `isLoading: true` indefinitely, leaving the bar stuck on the skeleton — and dragging the nested-safe button along with it.

## How this PR fixes it

**WA-2216** (data alignment between chain selector and dropdown):

1. **`useSafeBarSafes`**: For the **current safe row** in the dropdown, pull from `allKnownSafes` (which spans pinned + owned + counterfactual chains) instead of `pinnedSafes`. Other rows in the dropdown stay pinned-only. Pin state remains decoupled — the bookmark icon still drives `addedSafes`, navigating to an unpinned chain does **not** auto-pin it.
2. **`SafeSelectorDropdown`**: Defense-in-depth — when items have loaded but `selectedItem` is still undefined (i.e. a structural mismatch), render `InlineRetryError` ("This Safe is not available on the selected network") instead of looping in the skeleton. No retry button — refetch can't fix a structural mismatch.

**WA-2199** (hide bar where it's meaningless):

3. **`SpaceSafeBar`**: Hide on `/settings/*` routes when the URL has no `?safe=` (i.e. global settings pages). Per-safe settings pages still render the bar normally because their URL carries the safe. Other routes are untouched (Redux-fallback behavior preserved).

## How to test it

### WA-2216

1. Open `/new-safe/load` and add an existing safe on **only one** network (e.g. Sepolia) where the connected wallet is an owner.
2. Confirm the wallet is also an owner of the **same address** on at least one other chain (so CGW returns it via `allOwned`).
3. On the home page, open the **chain selector** — it should list every chain the safe is deployed on (the pinned chain plus the owned chains).
4. Click a chain other than the pinned one. URL should navigate (`safe=eth:0x...`).
5. **Before this PR**: the safe selector dropdown stayed on a loading skeleton indefinitely.
6. **After this PR**: the dropdown renders normally — the current safe row becomes a multi-chain row showing all deployed chains, and you can switch chains directly from the dropdown too.
7. Verify: clicking the bookmark icon to pin/unpin still works and is **not** triggered by chain switching.
8. Edge case: paste a URL like `eth:0xSafeOnlyOnSepolia` for a safe deployed only on Sepolia. Instead of looping skeleton, you should see "This Safe is not available on the selected network".

### WA-2199

1. Sign in with no trusted/pinned safes (clear `addedSafes` from local storage if needed).
2. Click the bell icon in the top right → "Push notifications settings". URL should be `/settings/notifications` with no `?safe=`.
3. **Before this PR**: the SpaceSafeBar at the top showed a perpetual skeleton; the nested-safe button next to it stayed in a loading state.
4. **After this PR**: the SpaceSafeBar is hidden entirely on this page.
5. Verify per-safe settings still work: navigate to a safe → open Settings → Setup. URL becomes `/settings/setup?safe=eth:0x...`. The bar should render normally with that safe selected.
6. Verify other global `/settings/*` pages (`/settings/cookies`, `/settings/appearance`) also hide the bar when no `?safe=`.
7. Verify non-settings routes still show the bar normally (regression check).

## Affected flows

- **Switching chains for the currently viewed safe via the chain selector** (WA-2216) — dropdown now stays consistent with the chain selector across all owned/deployed chains, not just pinned ones.
- **Switching chains via the safe selector dropdown** (WA-2216) — the current safe row now exposes all its deployed chains (multi-chain row), enabling chain switching directly from the dropdown.
- **Pinning / un-pinning safes** — unchanged. Bookmark icon still drives `addedSafes`. Navigation does not auto-pin.
- **Other safes in the dropdown** — unchanged. Still rendered from `pinnedSafes` only.
- **Visiting global settings pages with no safe context** (WA-2199) — bar is now hidden instead of rendering a perpetual skeleton; the nested-safe modal entry button is hidden too, so the secondary "modal stuck loading" symptom disappears.
- **Visiting per-safe settings pages** — unchanged. URL carries `?safe=`, bar renders normally.

## Blast radius

- `useSafeBarSafes` (shared hook): only direct consumer is `SpaceSafeBar`, which feeds `useSpaceSafeSelectorItems`. Both space and non-space contexts route through the same return shape; the change touches only the non-space `dropdownSafes` branch. The space branch (`isInSpaceContext ? spaceSafes : dropdownSafes`) is untouched.
- `SafeSelectorDropdown` (shared component): used by `SpaceSafeBar`. New error branch fires only when `mounted && !isLoading && items.length > 0 && !selectedItem`; happy-path render and existing skeleton/error paths are untouched.
- `SpaceSafeBar` (top-level layout component, rendered in `PageLayout`): added one `pathname.startsWith('/settings') && !urlSafeAddress` early return. Affects only `/settings/*` pages without `?safe=`. All other routes unchanged.
- `useSpaceSafeSelectorItems`: unchanged. Continues to build multi-chain item ids with `currentChainId` first, which now matches `selectedItemId` for the WA-2216 scenario.
- No RTK Query endpoint, feature flag, chain config, or persisted state touched.
- No mobile impact (web-only path under `apps/web/src/`).
- No routes / layouts changed.

## Risks / not checked

- Did not exercise the Spaces qualified-safe context end-to-end. The space branch in `useSafeBarSafes` is untouched, but the dropdown rendering path is shared.
- Did not verify behavior when `useGetMultipleSafeOverviewsQuery` returns `isError=true` while items are also loaded — covered by a new unit test (load error takes precedence over no-match) but not exercised manually in the running app.
- Did not check counterfactual-only chain edge case manually (safe is undeployed/counterfactual on the URL chain). Data path goes through `undeployedSafes` → `useAllSafes` → `allKnownSafes`, so the multi-chain item should include it; visual treatment of the chain row (status badges) wasn't manually exercised.
- Did not verify that the new "This Safe is not available on the selected network" copy is the final wording — happy to swap if product/design has a preference.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before"]
    direction LR
    A1[useSafeBarSafes] -->|pinnedSafes only| B1[dropdownSafes: Sepolia only]
    A1 -->|allKnownSafes| C1[chainSelectorSafes: Sepolia + Mainnet]
    B1 --> D1[items: id=11155111:0xSafe]
    C1 --> E1[Chain selector lists both]
    E1 -->|click Mainnet| F1[URL: eth:0xSafe]
    F1 --> G1[selectedItemId: 1:0xSafe]
    G1 -->|no match in items| H1[selectedItem = undefined]
    H1 --> I1[💀 SafeSelectorDropdownSkeleton forever]
    J1[/settings/notifications no safe/] --> K1[SpaceSafeBar renders] --> L1[items: empty, isLoading: true forever] --> M1[💀 Skeleton + nested-safe modal stuck]
  end

  subgraph After["After"]
    direction LR
    A2[useSafeBarSafes] -->|allKnownSafes for current safe| B2[dropdownSafes: multi-chain]
    A2 -->|allKnownSafes| C2[chainSelectorSafes: multi-chain]
    B2 --> D2[items: id=1:0xSafe, chains=Sepolia+Mainnet]
    C2 --> E2[Chain selector lists both]
    E2 -->|click Mainnet| F2[URL: eth:0xSafe]
    F2 --> G2[selectedItemId: 1:0xSafe]
    G2 -->|matches| H2[selectedItem = multi-chain item]
    H2 --> I2[✅ Dropdown renders, expandable]
    J2[/settings/notifications no safe/] --> K2[SpaceSafeBar returns null] --> L2[✅ Nothing to be stuck on]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).