### PR TITLE
hotfix(web/Spaces): add missing data-testId for multichain tests; fix hydration errors

### DIFF
--- a/apps/web/cypress/e2e/pages/network.pages.js
+++ b/apps/web/cypress/e2e/pages/network.pages.js
@@ -10,6 +10,7 @@ const chainNavigationButton = '[data-testid="space-chain-navigation-button"]'
 export const createSafeMsg = (network) => `Successfully added your account on ${network}`
 
 export function clickChainNavigationButton() {
+  cy.wait(1000)
   cy.get(chainNavigationButton).should('be.visible').click()
   cy.get(allNetworksAccordion).should('be.visible')
 }
@@ -25,7 +26,7 @@ export function clickAddNetworkBtn(chainName) {
 }
 
 export function clickModalAddNetworkBtn() {
-  cy.get(modalAddNetworkBtn).should('be.visible').click()
+  cy.get(modalAddNetworkBtn).should('be.visible').and('not.be.disabled').click()
 }
 
 export function verifyModalAddNetworkBtnDisabled() {

--- a/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useCallback } from 'react'
+import { useContext, useEffect, useState, useCallback } from 'react'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import ChainSelectorBlock from '@/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock'
@@ -22,6 +22,11 @@ function SpaceChainSelector({ isLoading }: { isLoading?: boolean }) {
   const isDisabled = !!txFlow
 
   const [addNetworkChainId, setAddNetworkChainId] = useState<string>()
+  const [isHydrated, setIsHydrated] = useState(false)
+
+  useEffect(() => {
+    setIsHydrated(true)
+  }, [])
 
   const handleAddNetwork = useCallback((chainId: string) => {
     setAddNetworkChainId(chainId)
@@ -39,6 +44,8 @@ function SpaceChainSelector({ isLoading }: { isLoading?: boolean }) {
   const handleCloseDialog = useCallback(() => {
     setAddNetworkChainId(undefined)
   }, [])
+
+  if (!isHydrated) return <SpaceChainSelectorSkeleton />
 
   if (!deployedChains.length) {
     if (isLoading) return <SpaceChainSelectorSkeleton />

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AllNetworksSection.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/AllNetworksSection.tsx
@@ -82,7 +82,7 @@ function AllNetworksSection({ safeAddress, deployedChainIds, onAddNetwork }: All
   }
 
   return (
-    <Accordion defaultValue={[]} onValueChange={handleAccordionChange}>
+    <Accordion defaultValue={[]} onValueChange={handleAccordionChange} data-testid="all-networks-accordion">
       <AccordionItem value="all-networks" className="border-0">
         <AccordionTrigger className="rounded-lg pl-4 pr-2 py-2 hover:no-underline hover:bg-muted/30 text-muted-foreground cursor-pointer">
           <Typography variant="paragraph-small-medium" className="text-muted-foreground">
@@ -99,6 +99,7 @@ function AllNetworksSection({ safeAddress, deployedChainIds, onAddNetwork }: All
                   onClick={() => !disabled && handleChainClick(chainItem.chainId)}
                   disabled={disabled}
                   className="flex items-center justify-between px-2 py-2 rounded-lg w-full cursor-pointer hover:bg-muted/30 text-left disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                  data-testid="add-network-btn"
                   aria-label={`Add ${chainItem.chainName}`}
                 >
                   <div className="flex items-center gap-4">


### PR DESCRIPTION
> Hydrate-gate the chain bar,
> add testids for accordion,
> wait, then click — green tests.

## What it solves

E2E test flake on the multichain Add Network flow + a hydration mismatch in `SpaceChainSelector`.

## How this PR fixes it

- `SpaceChainSelector`: render the skeleton until `useEffect` mounts, so server and first client render match (root cause: `useSafeAddressFromUrl` reads `location.search`).
- `AllNetworksSection`: add `data-testid` for the accordion and add-network buttons.
- Cypress `network.pages.js`: wait for the chain nav button before clicking; assert `modal-add-network-btn` is enabled before submit.

## How to test it

1. Open a Safe page — chain selector renders without a hydration warning in the console.
2. Run `yarn workspace @safe-global/web cypress:run --spec '**/regression/add_network*'` (or the relevant smoke spec) — passes consistently.

## Affected flows

- Multichain "Add network" from the safe-bar chain selector.
- Initial render of the safe-bar on any Safe route.

## Blast radius

- `SpaceChainSelector` is rendered on every Safe route via the safe-bar — first paint now shows a skeleton instead of nothing.
- `AllNetworksSection` testids are additive; no behavior change.
- Page-object changes are scoped to `network.pages.js`.

## Risks / not checked

- Did not fix the underlying SSR/CSR divergence in `useSafeAddressFromUrl` — only masked it at this consumer.
- Did not verify on mobile.
- Did not run the full E2E suite, only the network-related specs.

## Visual summary

​```mermaid
flowchart LR
  A[SSR render] --> S[Skeleton]
  B[Client render #1] --> S
  S --> C[useEffect: isHydrated=true]
  C --> D[Real ChainSelector]
​```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
