### PR TITLE
hotfix(web/Spaces): tooltips for the entire NavItem content for every Sidebar item

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Typography } from '@/components/ui/typography'
 import { SidebarMenuItem, SidebarMenuButton, useSidebar } from '@/components/ui/sidebar'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/utils/cn'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import css from '../styles.module.css'
@@ -28,14 +29,19 @@ export const ApiCtaSidebar = (): ReactElement => {
           aria-label="API"
           render={isIconCollapsed ? <a href={API_DOCS_URL} target="_blank" rel="noopener noreferrer" /> : undefined}
         >
-          <Image
-            src="/images/spaces/api-sidebar.svg"
-            alt="API"
-            width={16}
-            height={16}
-            className="dark:brightness-0 dark:invert"
-          />
-          <span className="min-w-0 flex-1 truncate group-data-[collapsible=icon]:hidden">API</span>
+          <Tooltip>
+            <TooltipTrigger className="flex min-w-0 items-center gap-3">
+              <Image
+                src="/images/spaces/api-sidebar.svg"
+                alt="API"
+                width={16}
+                height={16}
+                className="dark:brightness-0 dark:invert"
+              />
+              <span className="min-w-0 flex-1 truncate group-data-[collapsible=icon]:hidden">API</span>
+            </TooltipTrigger>
+            <TooltipContent side="right">API</TooltipContent>
+          </Tooltip>
         </SidebarMenuButton>
         <div
           className={cn(css.footerHelpStatus, !isIconCollapsed && 'cursor-pointer')}

--- a/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/__tests__/ApiCtaSidebar.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/__tests__/ApiCtaSidebar.test.tsx
@@ -2,6 +2,14 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { ApiCtaSidebar } from '../ApiCtaSidebar'
 
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  TooltipContent: () => null,
+}))
+
 const mockSetIsCollapsed = jest.fn()
 let mockIsCollapsed: boolean | undefined = undefined
 let mockSidebarState: 'expanded' | 'collapsed' = 'expanded'
@@ -197,6 +205,18 @@ describe('ApiCtaSidebar', () => {
       expect(link).toHaveAttribute('href', 'https://developer.safe.global/login')
       expect(link).toHaveAttribute('target', '_blank')
       expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+  })
+
+  describe('tooltip', () => {
+    it('wraps the icon and label together in a tooltip trigger on the collapsed button', () => {
+      mockIsCollapsed = true
+      render(<ApiCtaSidebar />)
+
+      const trigger = document.querySelector('.flex.items-center.gap-3')
+      expect(trigger).toBeInTheDocument()
+      expect(trigger).toHaveTextContent('API')
+      expect(trigger?.querySelector('img[alt="API"]')).toBeInTheDocument()
     })
   })
 })

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
@@ -80,8 +80,13 @@ export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?:
             data-testid="list-item-need-help"
             onClick={handleHelpClick}
           >
-            <icons.CircleHelp />
-            <span>Help</span>
+            <Tooltip>
+              <TooltipTrigger className="flex min-w-0 items-center gap-3">
+                <icons.CircleHelp />
+                <span className="truncate group-data-[collapsible=icon]:hidden">Help</span>
+              </TooltipTrigger>
+              <TooltipContent side="right">Help center</TooltipContent>
+            </Tooltip>
           </SidebarMenuButton>
           <Tooltip>
             <TooltipTrigger

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/__tests__/SidebarCommonFooter.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/__tests__/SidebarCommonFooter.test.tsx
@@ -67,10 +67,12 @@ jest.mock('@/components/ui/tooltip', () => ({
   TooltipTrigger: ({
     children,
     render,
+    className,
   }: {
     children: ReactNode
-    render: React.ReactElement<{ children?: ReactNode }>
-  }) => React.cloneElement(render, {}, children),
+    render?: React.ReactElement<{ children?: ReactNode }>
+    className?: string
+  }) => (render ? React.cloneElement(render, {}, children) : <div className={className}>{children}</div>),
   TooltipContent: ({ children }: { children: ReactNode }) => <div role="tooltip">{children}</div>,
 }))
 
@@ -185,6 +187,11 @@ describe('SidebarCommonFooter', () => {
   it('renders the indexing status next to Help', () => {
     render(<SidebarCommonFooter />)
     expect(screen.getByTestId('indexing-status')).toBeInTheDocument()
+  })
+
+  it('renders the Help center tooltip', () => {
+    render(<SidebarCommonFooter />)
+    expect(screen.getByRole('tooltip', { name: /Help center/i })).toBeInTheDocument()
   })
 
   it('opens help menu when Help button is clicked', () => {

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
@@ -85,14 +85,14 @@ export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: Na
       onClick={handleClick}
     >
       <Tooltip>
-        <TooltipTrigger>
+        <TooltipTrigger className="flex min-w-0 items-center gap-3">
           <div className={item.isActive ? css.activeIcon : undefined}>
             <item.icon />
           </div>
+          <span className="truncate group-data-[collapsible=icon]:hidden">{item.label}</span>
         </TooltipTrigger>
         <TooltipContent side="right">{item.label}</TooltipContent>
       </Tooltip>
-      <span>{item.label}</span>
     </SidebarMenuButton>
   )
 

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
@@ -104,15 +104,15 @@ export const SafeSidebarVariant = ({
                     data-testid="sidebar-settings-item"
                   >
                     <Tooltip>
-                      <TooltipTrigger>
+                      <TooltipTrigger className="flex min-w-0 items-center gap-3">
                         <span className="relative">
                           <Settings className="text-muted-foreground" />
                           {isOutdated && <span className={css.outdatedDot} aria-hidden />}
                         </span>
+                        <span className="truncate group-data-[collapsible=icon]:hidden">Settings</span>
                       </TooltipTrigger>
                       <TooltipContent side="right">Settings</TooltipContent>
                     </Tooltip>
-                    <span>Settings</span>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               </SidebarMenu>

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarVariant/__tests__/SpacesSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarVariant/__tests__/SpacesSidebarVariant.test.tsx
@@ -4,6 +4,14 @@ import type { ReactNode } from 'react'
 import { SpacesSidebarVariant } from '../SpacesSidebarVariant'
 import type { ResolvedSidebarItem, ResolvedSidebarGroup, SpaceItem } from '../../../types'
 
+jest.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  TooltipContent: () => null,
+}))
+
 jest.mock('@/components/ui/sidebar', () => ({
   SidebarContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,


### PR DESCRIPTION
> Tooltips wrap icon+label on sidebar nav items, footer API and Help buttons, and the Settings button; label hides when collapsed.

## What it solves

Tooltip on sidebar nav items only covered the icon, not the full item row. Also tooltips for the new footer items (Beamer, Help Center) were missing.
Resolves: [WA-2219](https://linear.app/safe-global/issue/WA-2219/tooltips-for-the-entire-content-of-the-sidebar-items)

## How this PR fixes it

Moved `TooltipTrigger` to wrap both the icon and the label `<span>` together. Added `group-data-[collapsible=icon]:hidden` directly on the label span so it still disappears in icon-only mode. Applied the same pattern to the API, Help, and Settings footer buttons. Updated unit tests accordingly.

## How to test it

1. Open the sidebar in expanded mode — hover any nav item, API, Help, or Settings; tooltip appears.
2. Collapse the sidebar to icon-only mode — labels disappear, tooltips still appear on hover.

## Affected flows

- Safe sidebar navigation items
- Spaces sidebar navigation items
- Footer: API CTA, Help, Settings

## Blast radius

- `NavItem.tsx` — used by both `SafeSidebarVariant` and `SpacesSidebarVariant`
- `SafeSidebarVariant.tsx` — Settings button only
- `ApiCtaSidebar.tsx` — collapsed button state only
- `SidebarCommonFooter.tsx` — Help button only

## Risks / not checked

- Not tested on mobile
- E2E tests not run locally (no DOM changes to test IDs)

## Visual summary

```mermaid
flowchart LR
  Before["TooltipTrigger wraps icon only\nLabel is sibling outside trigger"]
  After["TooltipTrigger wraps icon + label\nLabel hidden via CSS when collapsed"]
  Before --> After
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
