### PR TITLE
Fix(web): safe selector on tx flow

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/SpaceNestedSafesButton.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceNestedSafesButton.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
+import { TxModalContext, type TxModalContextType } from '@/components/tx-flow'
 import SpaceNestedSafesButton from './SpaceNestedSafesButton'
 
 const mockStartFiltering = jest.fn()
@@ -189,5 +190,63 @@ describe('SpaceNestedSafesButton', () => {
     const track = screen.getByTestId('track')
     expect(track).toHaveAttribute('data-action', 'Open nested Safe list')
     expect(track).toHaveAttribute('data-label', 'space_safe_bar')
+  })
+
+  describe('disabled while a tx flow is active', () => {
+    const renderWithTxFlow = (txFlow: TxModalContextType['txFlow']) => {
+      const value: TxModalContextType = {
+        txFlow,
+        setTxFlow: jest.fn(),
+        setFullWidth: jest.fn(),
+      }
+      return render(
+        <TxModalContext.Provider value={value}>
+          <SpaceNestedSafesButton />
+        </TxModalContext.Provider>,
+      )
+    }
+
+    it('disables the button when a tx flow is open', () => {
+      renderWithTxFlow(<div data-testid="active-tx-flow" />)
+
+      const button = screen.getByTestId('nested-safes-button')
+      expect(button).toBeDisabled()
+    })
+
+    it('applies the disabled styling to the button when a tx flow is open', () => {
+      renderWithTxFlow(<div data-testid="active-tx-flow" />)
+
+      const button = screen.getByTestId('nested-safes-button')
+      expect(button.className).toMatch(/cursor-not-allowed/)
+      expect(button.className).toMatch(/opacity-50/)
+      expect(button.className).not.toMatch(/cursor-pointer/)
+    })
+
+    it('shows the explanatory tooltip text when a tx flow is open', () => {
+      renderWithTxFlow(<div data-testid="active-tx-flow" />)
+
+      expect(screen.getByText('Nested Safes are not allowed in this screen')).toBeInTheDocument()
+      expect(screen.queryByText('Nested Safes')).not.toBeInTheDocument()
+    })
+
+    it('does not open the popover or call startFiltering when clicked while disabled', () => {
+      renderWithTxFlow(<div data-testid="active-tx-flow" />)
+
+      fireEvent.click(screen.getByTestId('nested-safes-button'))
+
+      expect(mockStartFiltering).not.toHaveBeenCalled()
+      expect(screen.getByTestId('nested-safes-popover')).toHaveAttribute('data-open', 'false')
+    })
+
+    it('renders the original tooltip and remains enabled when no tx flow is active', () => {
+      renderWithTxFlow(undefined)
+
+      const button = screen.getByTestId('nested-safes-button')
+      expect(button).not.toBeDisabled()
+      expect(button.className).not.toMatch(/cursor-not-allowed/)
+      expect(button.className).not.toMatch(/opacity-50/)
+      expect(screen.getByText('Nested Safes')).toBeInTheDocument()
+      expect(screen.queryByText('Nested Safes are not allowed in this screen')).not.toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/SpaceNestedSafesButton.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceNestedSafesButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import type { ReactElement } from 'react'
 import { GitMerge } from 'lucide-react'
 
@@ -12,12 +12,16 @@ import Track from '@/components/common/Track'
 import { NESTED_SAFE_EVENTS, NESTED_SAFE_LABELS } from '@/services/analytics/events/nested-safes'
 import { MixpanelEventParams } from '@/services/analytics/mixpanel-events'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { TxModalContext } from '@/components/tx-flow'
+import { cn } from '@/utils/cn'
 
 function SpaceNestedSafesButton(): ReactElement | null {
   const { safe } = useSafeInfo()
   const { chainId } = safe
   const safeAddress = safe.address.value
   const isEnabled = useHasFeature(FEATURES.NESTED_SAFES)
+  const { txFlow } = useContext(TxModalContext)
+  const isDisabled = !!txFlow
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
 
   const { currentData: ownedSafes } = useOwnersGetSafesByOwnerV1Query(
@@ -50,8 +54,12 @@ function SpaceNestedSafesButton(): ReactElement | null {
           <TooltipTrigger
             render={
               <button
-                onClick={onClick}
-                className="relative flex items-center border-0 rounded-lg bg-transparent px-2 m-1 cursor-pointer hover:bg-muted/30 transition-colors"
+                onClick={isDisabled ? undefined : onClick}
+                disabled={isDisabled}
+                className={cn(
+                  'relative flex items-center border-0 rounded-lg bg-transparent px-2 m-1 transition-colors',
+                  isDisabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-muted/30',
+                )}
                 aria-label="Nested Safes"
                 data-testid="nested-safes-button"
               />
@@ -72,7 +80,7 @@ function SpaceNestedSafesButton(): ReactElement | null {
               </div>
             </Track>
           </TooltipTrigger>
-          <TooltipContent>Nested Safes</TooltipContent>
+          <TooltipContent>{isDisabled ? 'Nested Safes are not allowed in this screen' : 'Nested Safes'}</TooltipContent>
         </Tooltip>
       </div>
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/__tests__/SafeSelectorDropdown.test.tsx
@@ -3,11 +3,32 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
+import { TxModalContext, type TxModalContextType } from '@/components/tx-flow'
 import SafeSelectorDropdown from '../index'
 import type { SafeItemData } from '../types'
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
+}))
+
+jest.mock('@/components/ui/tooltip', () => ({
+  __esModule: true,
+  Tooltip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    render,
+  }: {
+    children?: React.ReactNode
+    render?: React.ReactElement<{ children?: React.ReactNode }>
+  }) => {
+    if (render) {
+      return React.cloneElement(render, undefined, children)
+    }
+    return <>{children}</>
+  },
+  TooltipContent: ({ children }: { children?: React.ReactNode }) => (
+    <span data-testid="tooltip-content">{children}</span>
+  ),
 }))
 
 jest.mock('../components/SafeSelectorTriggerContent', () => ({
@@ -40,12 +61,21 @@ jest.mock('@/components/ui/select', () => {
       children,
       value,
       onValueChange,
+      disabled,
+      open,
     }: {
       children?: React.ReactNode
       value?: string
       onValueChange?: (next: string | null, details: { reason: string; cancel: () => void }) => void
+      disabled?: boolean
+      open?: boolean
     }) => (
-      <div data-testid="mock-select-root" data-mock-controlled-value={value}>
+      <div
+        data-testid="mock-select-root"
+        data-mock-controlled-value={value}
+        data-mock-disabled={String(!!disabled)}
+        data-mock-open={String(!!open)}
+      >
         <button
           type="button"
           data-testid="simulate-user-pick-new"
@@ -240,6 +270,56 @@ describe('SafeSelectorDropdown', () => {
       await user.click(screen.getByTestId('simulate-base-ui-auto-reset'))
 
       expect(mockPush).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('disabled while a tx flow is active', () => {
+    const renderWithTxFlow = (txFlow: TxModalContextType['txFlow']) => {
+      const itemA = createItem()
+      const value: TxModalContextType = {
+        txFlow,
+        setTxFlow: jest.fn(),
+        setFullWidth: jest.fn(),
+      }
+      return render(
+        <TxModalContext.Provider value={value}>
+          <SafeSelectorDropdown items={[itemA]} selectedItemId={itemA.id} onItemSelect={jest.fn()} />
+        </TxModalContext.Provider>,
+      )
+    }
+
+    it('disables the Select and forces it closed when a tx flow is open', () => {
+      renderWithTxFlow(<div data-testid="active-tx-flow" />)
+
+      const selectRoot = screen.getByTestId('mock-select-root')
+      expect(selectRoot.getAttribute('data-mock-disabled')).toBe('true')
+      expect(selectRoot.getAttribute('data-mock-open')).toBe('false')
+    })
+
+    it('renders the explanatory tooltip when a tx flow is open', () => {
+      renderWithTxFlow(<div data-testid="active-tx-flow" />)
+
+      expect(screen.getByTestId('tooltip-content')).toHaveTextContent('Changing the Safe is not allowed in this screen')
+    })
+
+    it('applies the disabled styling to the trigger when a tx flow is open', () => {
+      renderWithTxFlow(<div data-testid="active-tx-flow" />)
+
+      const trigger = screen.getByTestId('open-safes-icon')
+      expect(trigger.className).toMatch(/cursor-not-allowed/)
+      expect(trigger.className).toMatch(/opacity-50/)
+    })
+
+    it('does not disable the Select or render the tooltip when no tx flow is active', () => {
+      renderWithTxFlow(undefined)
+
+      const selectRoot = screen.getByTestId('mock-select-root')
+      expect(selectRoot.getAttribute('data-mock-disabled')).toBe('false')
+      expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument()
+
+      const trigger = screen.getByTestId('open-safes-icon')
+      expect(trigger.className).not.toMatch(/cursor-not-allowed/)
+      expect(trigger.className).not.toMatch(/opacity-50/)
     })
   })
 })

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { Select, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
 import { cn } from '@/utils/cn'
@@ -8,6 +8,8 @@ import InlineRetryError from '@/components/common/InlineRetryError'
 import { useSafeSelectorState } from './hooks/useSafeSelectorState'
 import { getSafeSelectorClassVariants } from './utils/classVariants'
 import type { SafeSelectorDropdownProps } from './types'
+import { TxModalContext } from '@/components/tx-flow'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 
 function SafeSelectorDropdownSkeleton() {
   return (
@@ -36,6 +38,8 @@ function SafeSelectorDropdown({
   footer,
 }: SafeSelectorDropdownProps) {
   const hasDropdownContent = Boolean(header) || Boolean(footer) || isLoading || isError
+  const { txFlow } = useContext(TxModalContext)
+  const isDisabled = !!txFlow
   const {
     dropdownOpen,
     selectedChainId,
@@ -45,7 +49,6 @@ function SafeSelectorDropdown({
     handleSafeChange,
     closeDropdown,
   } = useSafeSelectorState({ items, selectedItemId, onItemSelect, forceOpenable: hasDropdownContent })
-
   const [mounted, setMounted] = useState(false)
   useEffect(() => setMounted(true), [])
 
@@ -62,47 +65,70 @@ function SafeSelectorDropdown({
     return <SafeSelectorDropdownSkeleton />
   }
 
-  return (
-    <div
-      data-testid="space-safes-navigation-block"
-      className={cn(
-        // TODO: change rounded-lg (8px) to rounded-2xl (16px) after migrating to the new design system
-        'group relative w-full sm:w-[430px] min-h-[calc(68px)] flex items-center shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)] rounded-lg p-2 overflow-hidden bg-card focus:ring-0',
-        variants.wrapperClass,
-      )}
+  const selectElement = (
+    <Select
+      value={safeSelectValue}
+      onValueChange={handleSafeChange}
+      open={variants.canOpen && !isDisabled ? dropdownOpen : false}
+      onOpenChange={isDisabled ? undefined : handleOpenChange}
+      disabled={isDisabled}
     >
-      <div className="pointer-events-none absolute inset-1 rounded-md bg-muted/30 opacity-0 group-hover:opacity-100" />
-      <Select
-        value={safeSelectValue}
-        onValueChange={handleSafeChange}
-        open={variants.canOpen ? dropdownOpen : false}
-        onOpenChange={handleOpenChange}
+      <SelectTrigger
+        className={cn(
+          '-m-4 flex-1 border-0 shadow-none bg-transparent dark:bg-transparent py-0 pl-6 hover:bg-transparent dark:hover:bg-transparent data-[state=open]:bg-transparent [&_[data-slot=select-value]]:pr-0 relative',
+          variants.triggerClass,
+          isDisabled && 'cursor-not-allowed opacity-50',
+        )}
+        size="default"
+        iconWrapperClassName={variants.iconWrapperClass}
+        data-testid="open-safes-icon"
       >
-        <SelectTrigger
-          className={cn(
-            '-m-4 flex-1 border-0 shadow-none bg-transparent dark:bg-transparent py-0 pl-6 hover:bg-transparent dark:hover:bg-transparent data-[state=open]:bg-transparent [&_[data-slot=select-value]]:pr-0 relative',
-            variants.triggerClass,
-          )}
-          size="default"
-          iconWrapperClassName={variants.iconWrapperClass}
-          data-testid="open-safes-icon"
-        >
-          <SelectValue>
-            <SafeSelectorTriggerContent selectedItem={selectedItem} selectedChainId={selectedChainId} />
-          </SelectValue>
-        </SelectTrigger>
-        <SafeDropdownContainer
-          items={items}
-          selectedItemId={safeSelectValue}
-          onItemSelect={safeItemSelect}
-          isLoading={isLoading}
-          isError={isError}
-          onRetry={onRetry}
-          header={header}
-          footer={footer}
-          closeDropdown={closeDropdown}
-        />
-      </Select>
+        <SelectValue>
+          <SafeSelectorTriggerContent selectedItem={selectedItem} selectedChainId={selectedChainId} />
+        </SelectValue>
+      </SelectTrigger>
+
+      <SafeDropdownContainer
+        items={items}
+        selectedItemId={safeSelectValue}
+        onItemSelect={safeItemSelect}
+        isLoading={isLoading}
+        isError={isError}
+        onRetry={onRetry}
+        header={header}
+        footer={footer}
+        closeDropdown={closeDropdown}
+      />
+    </Select>
+  )
+
+  // TODO: change rounded-lg (8px) to rounded-2xl (16px) after migrating to the new design system
+  const wrapperClassName = cn(
+    'group relative w-full sm:w-[430px] min-h-[calc(68px)] flex items-center shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)] rounded-lg p-2 overflow-hidden bg-card focus:ring-0',
+    variants.wrapperClass,
+  )
+
+  const innerContent = (
+    <>
+      <div className="pointer-events-none absolute inset-1 rounded-md bg-muted/30 opacity-0 group-hover:opacity-100" />
+      {selectElement}
+    </>
+  )
+
+  if (isDisabled) {
+    return (
+      <Tooltip>
+        <TooltipTrigger render={<div data-testid="space-safes-navigation-block" className={wrapperClassName} />}>
+          {innerContent}
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Changing the Safe is not allowed in this screen</TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <div data-testid="space-safes-navigation-block" className={wrapperClassName}>
+      {innerContent}
     </div>
   )
 }


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/EPD-481/disable-the-safe-dropdown-selector-in-the-transaction-modal-flow


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
