### PR TITLE
hotfix(web/Spaces): frozen scroll after chain selection; styles for sidebar items

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock.tsx
@@ -49,6 +49,7 @@ function ChainSelectorBlock({
     ? 'w-16 flex items-center justify-between px-2 m-1 rounded-lg shrink-0 cursor-not-allowed opacity-50 focus:outline-none'
     : 'w-16 flex items-center justify-between px-2 m-1 rounded-lg shrink-0 cursor-pointer hover:bg-muted/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
 
+  // modal=false in DropdownMenu below: this props avoids Base UI's body scroll-lock that can leave the page frozen
   return (
     <DropdownMenu open={open} onOpenChange={handleOpenChange} modal={false}>
       <DropdownMenuTrigger

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/ChainSelectorBlock.tsx
@@ -50,7 +50,7 @@ function ChainSelectorBlock({
     : 'w-16 flex items-center justify-between px-2 m-1 rounded-lg shrink-0 cursor-pointer hover:bg-muted/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
 
   return (
-    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+    <DropdownMenu open={open} onOpenChange={handleOpenChange} modal={false}>
       <DropdownMenuTrigger
         disabled={disabled}
         render={

--- a/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
@@ -30,7 +30,7 @@ export const ApiCtaSidebar = (): ReactElement => {
           render={isIconCollapsed ? <a href={API_DOCS_URL} target="_blank" rel="noopener noreferrer" /> : undefined}
         >
           <Tooltip>
-            <TooltipTrigger className="flex min-w-0 items-center gap-3">
+            <TooltipTrigger className="flex min-w-0 cursor-pointer items-center gap-3">
               <Image
                 src="/images/spaces/api-sidebar.svg"
                 alt="API"

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
@@ -81,7 +81,7 @@ export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?:
             onClick={handleHelpClick}
           >
             <Tooltip>
-              <TooltipTrigger className="flex min-w-0 items-center gap-3">
+              <TooltipTrigger className="flex min-w-0 cursor-pointer items-center gap-3">
                 <icons.CircleHelp />
                 <span className="truncate group-data-[collapsible=icon]:hidden">Help</span>
               </TooltipTrigger>

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
@@ -85,7 +85,7 @@ export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: Na
       onClick={handleClick}
     >
       <Tooltip>
-        <TooltipTrigger className="flex min-w-0 items-center gap-3">
+        <TooltipTrigger className="flex min-w-0 cursor-pointer items-center gap-3">
           <div className={item.isActive ? css.activeIcon : undefined}>
             <item.icon />
           </div>

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
@@ -104,7 +104,7 @@ export const SafeSidebarVariant = ({
                     data-testid="sidebar-settings-item"
                   >
                     <Tooltip>
-                      <TooltipTrigger className="flex min-w-0 items-center gap-3">
+                      <TooltipTrigger className="flex min-w-0 cursor-pointer items-center gap-3">
                         <span className="relative">
                           <Settings className="text-muted-foreground" />
                           {isOutdated && <span className={css.outdatedDot} aria-hidden />}


### PR DESCRIPTION
> Drop the modal scroll lock,
> chain switch frees the body,
> page breathes again.

## What it solves

- Page sometimes freezes (cannot scroll) after switching networks via the chain selector dropdown.
Resolves: [WA-2220](https://linear.app/safe-global/issue/WA-2220/scrollbar-disappears-after-adding-or-changing-networks)
- UI fixes: `cursor: pointer` for all SIdebar items disappeared after adding new tooltips


## How this PR fixes it

Sets `modal={false}` on the chain-selector `DropdownMenu` in `ChainSelectorBlock.tsx`. Base UI's `Menu.Root` defaults to `modal: true`, which engages a body scroll lock that mutates `<html>`/`<body>` inline styles (`overflow: hidden`, `position: relative`, `height: 100dvh`). When chain selection triggers a `router.push()`, the heavy re-render races the scroll-lock cleanup (deferred via `setTimeout(0)`, using module-level globals to remember original styles), occasionally leaving the page locked. Disabling modal mode removes the lock entirely — no race, no freeze.

Also adds `cursor: pointer` to all sidebar items.

## How to test it

1. Open a multi-chain Safe.
2. From the chain selector in the Safe bar, switch networks **several times in a row**.
3. Confirm the page remains scrollable to the bottom after each switch.
4. Confirm the dropdown still closes on outside click and on Esc.
5. Now hover over all items in both sidebars - cursor should be pointer

## Affected flows

- Switching networks via the chain selector dropdown in the Safe bar (multi-chain Safes).

## Blast radius

- `ChainSelectorBlock` only — local one-line prop change.
- Other `DropdownMenu` consumers (`SpaceSelectorDropdown`, `SpaceContextMenuNew`, `PinnedSafeContextMenu`) are unchanged.
- Outside-click dismissal is wired via Floating UI's `useDismiss` in `MenuRoot`, called unconditionally regardless of `modal` — not affected.
- No persistence, API, feature-flag, or mobile-shared-package surfaces touched.

## Risks / not checked

- Did not test with a screen reader; aria roles and focus order are unchanged but not re-validated.
- Did not verify on touch devices specifically (Base UI already disables the scroll lock on touch, so behavior should be unchanged there).

## Visual summary

```mermaid
flowchart LR
  A[Click chain in dropdown] --> B[setOpen false + router.push]
  B --> C{modal=true?}
  C -->|before| D[Scroll lock cleanup races re-render]
  D --> E[Body left with overflow:hidden — page frozen]
  C -->|after| F[No scroll lock acquired]
  F --> G[Page stays scrollable]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
