### PR TITLE
fix(web): show Safe logo in Topbar on settings without a safe

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/index.test.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.test.tsx
@@ -50,6 +50,11 @@ jest.mock('@/hooks/useSafeAddress', () => ({
   default: () => '',
 }))
 
+const mockUseSafeAddressFromUrl = jest.fn<string, []>(() => '')
+jest.mock('@/hooks/useSafeAddressFromUrl', () => ({
+  useSafeAddressFromUrl: () => mockUseSafeAddressFromUrl(),
+}))
+
 jest.mock('@/hooks/useIsSafeOwner', () => ({
   __esModule: true,
   default: () => false,
@@ -129,6 +134,7 @@ describe('Topbar', () => {
     mockUseIsMobile.mockReturnValue(false)
     mockIsSpaceRoute.mockReturnValue(true)
     mockUsePathname.mockReturnValue('/home')
+    mockUseSafeAddressFromUrl.mockReturnValue('')
     mockUseLoadFeature.mockReturnValue({
       WalletPopover: () => null,
       GlobalSearchModal: () => null,
@@ -193,6 +199,29 @@ describe('Topbar', () => {
         </TxModalContext.Provider>,
       )
       expect(screen.getByTestId('space-safe-bar')).toBeInTheDocument()
+    })
+
+    it('renders SafeLogo on settings routes when no safe address is in the URL', () => {
+      mockIsSpaceRoute.mockReturnValue(false)
+      mockUsePathname.mockReturnValue('/settings/setup')
+      mockUseSafeAddressFromUrl.mockReturnValue('')
+      const { container } = render(<Topbar />)
+      expect(screen.queryByTestId('space-safe-bar')).not.toBeInTheDocument()
+      expect(screen.getByTestId('logo-image')).toBeInTheDocument()
+      // Logo row is short — header centers items vertically so the logo aligns with the right-side button group
+      expect(container.querySelector('header')?.className).toMatch(/items-center/)
+      expect(container.querySelector('header')?.className).not.toMatch(/items-start/)
+    })
+
+    it('renders SpaceSafeBar on settings routes when a safe address is in the URL', () => {
+      mockIsSpaceRoute.mockReturnValue(false)
+      mockUsePathname.mockReturnValue('/settings/setup')
+      mockUseSafeAddressFromUrl.mockReturnValue('0x1234567890abcdef1234567890abcdef12345678')
+      const { container } = render(<Topbar />)
+      expect(screen.getByTestId('space-safe-bar')).toBeInTheDocument()
+      expect(screen.queryByTestId('logo-image')).not.toBeInTheDocument()
+      // Default top alignment is preserved when the SpaceSafeBar is shown
+      expect(container.querySelector('header')?.className).toMatch(/items-start/)
     })
   })
 

--- a/apps/web/src/components/common/Header/Topbar/index.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.tsx
@@ -16,6 +16,7 @@ import { useAppDispatch, useAppSelector } from '@/store'
 import { selectNotifications } from '@/store/notificationsSlice'
 import { openGlobalSearch } from '@/features/global-search/store/globalSearchSlice'
 import useSafeAddress from '@/hooks/useSafeAddress'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import useIsSafeOwner from '@/hooks/useIsSafeOwner'
 import { useIsWalletProposer } from '@/hooks/useProposers'
 import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
@@ -23,6 +24,7 @@ import NotificationsPopover, { type NotificationsPopoverRef } from './Notificati
 import { useCurrentSpaceId } from '@/features/spaces'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import SafeLogo from '@/components/common/SafeLogo'
 import SpaceSafeBar from '@/components/common/SpaceSafeBar'
 import SafenetStakingButton from './SafenetStakingButton'
 import { useSafeTokenEnabled } from '@/hooks/useSafeTokenEnabled'
@@ -57,6 +59,8 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
   const isSpaceRoute = useIsSpaceRoute()
   const pathname = usePathname()
   const isWelcomeListRoute = pathname === AppRoutes.welcome.accounts || pathname === AppRoutes.welcome.spaces
+  const urlSafeAddress = useSafeAddressFromUrl()
+  const isSettingsWithoutSafe = pathname?.startsWith(AppRoutes.settings.index) === true && !urlSafeAddress
   const safeAddress = useSafeAddress()
   const isProposer = useIsWalletProposer()
   const isSafeOwner = useIsSafeOwner()
@@ -87,7 +91,7 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
   return (
     <>
       <header
-        className={`flex flex-wrap items-start gap-y-2 px-6 py-4 bg-secondary dark:bg-background ${
+        className={`flex flex-wrap ${isSettingsWithoutSafe ? 'items-center' : 'items-start'} gap-y-2 px-6 py-4 bg-secondary dark:bg-background ${
           showMenuButton ? 'justify-between pl-2' : 'justify-between'
         }`}
       >
@@ -104,7 +108,13 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
 
         {/* Left content: SpaceSafeBar must not shrink so its children stay on one line */}
         <div className="shrink-0 max-md:order-last flex items-center max-md:basis-full max-md:mt-2">
-          {showSpaceSafeBar ? <SpaceSafeBar /> : <GlobalSearchInput className="w-64 md:w-80" />}
+          {isSettingsWithoutSafe ? (
+            <SafeLogo />
+          ) : showSpaceSafeBar ? (
+            <SpaceSafeBar />
+          ) : (
+            <GlobalSearchInput className="w-64 md:w-80" />
+          )}
         </div>
 
         {/* Right content: navigation buttons — wraps to next row when viewport is narrow */}

--- a/apps/web/src/components/common/PageLayout/index.test.tsx
+++ b/apps/web/src/components/common/PageLayout/index.test.tsx
@@ -66,6 +66,11 @@ jest.mock('@/hooks/useTopbarElevation', () => ({
   useIsTopbarElevated: jest.fn(() => false),
 }))
 
+const mockUseSafeAddressFromUrl = jest.fn<string, []>(() => '')
+jest.mock('@/hooks/useSafeAddressFromUrl', () => ({
+  useSafeAddressFromUrl: () => mockUseSafeAddressFromUrl(),
+}))
+
 jest.mock('@/features/__core__', () => ({
   useLoadFeature: jest.fn(() => ({
     BatchSidebar: () => null,
@@ -81,6 +86,10 @@ const STATIC_ROUTES = [AppRoutes.terms, AppRoutes.privacy, AppRoutes.licenses, A
 const NON_STATIC_ROUTES = ['/home', '/balances', '/settings/setup', '/welcome/accounts']
 
 describe('PageLayout', () => {
+  beforeEach(() => {
+    mockUseSafeAddressFromUrl.mockReturnValue('')
+  })
+
   const renderLayout = (pathname: string) =>
     render(
       <PageLayout pathname={pathname}>
@@ -119,5 +128,28 @@ describe('PageLayout', () => {
         expect(screen.getByTestId('topbar')).toBeInTheDocument()
       },
     )
+  })
+
+  describe('settings route padding-top', () => {
+    it('applies the compact main class on settings without a safe address', () => {
+      mockUseSafeAddressFromUrl.mockReturnValue('')
+      const { container } = renderLayout('/settings/notifications')
+      const main = container.querySelector('main, [class*="main"]')
+      expect(main?.className).toMatch(/mainSpaceCompact/)
+    })
+
+    it('does not apply the compact main class on settings with a safe address', () => {
+      mockUseSafeAddressFromUrl.mockReturnValue('0x1234567890abcdef1234567890abcdef12345678')
+      const { container } = renderLayout('/settings/notifications')
+      const main = container.querySelector('main, [class*="main"]')
+      expect(main?.className).not.toMatch(/mainSpaceCompact/)
+    })
+
+    it('does not apply the compact main class on non-settings routes', () => {
+      mockUseSafeAddressFromUrl.mockReturnValue('')
+      const { container } = renderLayout('/home')
+      const main = container.querySelector('main, [class*="main"]')
+      expect(main?.className).not.toMatch(/mainSpaceCompact/)
+    })
   })
 })

--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -20,6 +20,7 @@ import { useRouterGuard } from '@/hooks/useRouterGuard'
 import { useFlowActivationGuard } from '@/hooks/useRouterGuard/activationGuards/useFlowActivationGuard'
 import { useKeyboardObserver } from '@/hooks/useKeyboardObserver'
 import { useIsTopbarElevated } from '@/hooks/useTopbarElevation'
+import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 
 const ONBOARDING_ROUTES = [
   AppRoutes.welcome.createSpace,
@@ -52,6 +53,8 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
   const hideHeader = NO_HEADER_ROUTES.includes(pathname)
   const isOnboardingRoute = ONBOARDING_ROUTES.includes(pathname)
   const isSpaceRoute = useIsSpaceRoute()
+  const urlSafeAddress = useSafeAddressFromUrl()
+  const isSettingsWithoutSafe = pathname.startsWith(AppRoutes.settings.index) && !urlSafeAddress
   const parentSafe = useParentSafe()
   const menuToggleHandler = isSidebarRoute ? setSidebarOpen : undefined
 
@@ -100,6 +103,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
           [css.mainAnimated]: isSidebarRoute && isAnimated,
           [css.mainNoHeader]: hideHeader,
           [css.mainSpace]: !hideHeader,
+          [css.mainSpaceCompact]: isSettingsWithoutSafe,
           [css.mainSpaceCollapsed]: isSpaceRoute && !isSpacesSidebarExpanded,
         })}
       >

--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -58,6 +58,16 @@
   }
 }
 
+/* Compact variant: settings page without an active safe — topbar collapses
+   to a single row (logo only) so we shrink the reserved space accordingly.
+   The topbar is ~76px tall (header --header-height plus the wallet button row),
+   so we leave one space-3 of breathing room below it. */
+@media (min-width: 900px) {
+  .mainSpace.mainSpaceCompact {
+    padding-top: calc(var(--header-height) + var(--space-3));
+  }
+}
+
 .main {
   background-color: var(--color-background-main);
   padding-left: 230px;


### PR DESCRIPTION
> Settings, no safe in URL —
> empty header gets a logo,
> tabs no longer drift.

Resolves: [WA-2233 — Hide top bar on settings page](https://linear.app/safe-global/issue/WA-2233/hide-top-bar-on-settings-page)

## What it solves

When opening `/settings/*` without a `?safe=` query param, the `SpaceSafeBar` was already hiding itself but the Topbar's left slot was left empty — there was no way to navigate back to `/welcome/accounts` from the header. After landing the empty state, two layout side-effects became visible: (1) the page content sat far below the header because `.mainSpace` reserved 100px of `padding-top` for a SafeBar row that no longer renders, and (2) when the small logo was added the right-side button group dwarfed it because the header was top-aligned.

## How this PR fixes it

- **Topbar** (`apps/web/src/components/common/Header/Topbar/index.tsx`):
  Detect `isSettingsWithoutSafe = pathname.startsWith('/settings') && !urlSafeAddress`. When true, render `<SafeLogo />` in the left slot (defaults to `href = /welcome/accounts`) and switch the header's cross-axis from `items-start` to `items-center` so the 24px logo aligns with the ~44px button group on the right.
- **PageLayout** (`apps/web/src/components/common/PageLayout/index.tsx` + `styles.module.css`):
  Mirror the same `isSettingsWithoutSafe` detection and add a `mainSpaceCompact` class that overrides `.mainSpace` `padding-top` from `var(--topbar-height)` (100px, sized for full topbar+SafeBar) to `calc(var(--header-height) + var(--space-3))` (~80px), enough to clear the single-row topbar with a small breathing gap. Wrapped in `@media (min-width: 900px)` so the existing mobile `padding-top: 0` rule is untouched.

## How to test it

1. Open the web app and navigate to `/settings/notifications` (or any other `/settings/*` page) **without** a `?safe=` query string in the URL — e.g. via the user-settings entry point.
2. Verify the header shows the Safe logo on the far left, vertically centered with the search/notifications/wallet buttons on the right.
3. Click the logo and confirm it routes to `/welcome/accounts`.
4. Toggle dark mode — the gap between the header bottom and the settings tabs should still feel breathing-room comfortable, not cramped.
5. Navigate to a `/settings/*` page **with** a safe in the URL (e.g. via the sidebar's Settings entry on a connected Safe). Confirm the original `SpaceSafeBar` renders and the page content keeps the original 100px top padding (no regression).
6. Sanity-check other routes (`/home`, `/balances`, `/welcome/accounts`, a space route) — none should pick up the new compact spacing.

## Affected flows

- Settings pages without a Safe context (no `?safe=` in URL): Topbar now renders the Safe logo as the only left-side element, and the layout uses the compact top-padding.
- Settings pages with a Safe context: unchanged — `SpaceSafeBar` continues to render in the Topbar's left slot.

## Blast radius

- **`Topbar`** consumers: every non-`NO_HEADER_ROUTES` page renders this. The change is gated by `isSettingsWithoutSafe`; non-settings pages keep `items-start` and the SpaceSafeBar/GlobalSearchInput branches.
- **`PageLayout`** consumers: every page in the app. The new `mainSpaceCompact` class is only applied when `isSettingsWithoutSafe`; specificity is `(0,2,0)` matching the existing `.mainSpace.mainSpace`, source order ensures the compact rule wins at `min-width: 900px` only.
- **Hooks reused (no new state):** `useSafeAddressFromUrl` (already used by `SpaceSafeBar`).
- **No changes to:** Redux slices, RTK Query endpoints, feature flags, persistence, mobile, shared packages.

## Risks / not checked

- I did not run Cypress E2E or Chromatic — relying on the unit tests added for the rendering branches plus manual review of the screenshots in the PR conversation.
- I did not test the elevated topbar (`isTopbarElevated`) interaction explicitly; the absolute→fixed switch should still respect `padding-top` because the reservation lives on `.main`, not the topbar element.
- I did not verify mobile narrow viewports (<900px) end-to-end, but the new `padding-top` rule is wrapped in `min-width: 900px`, so existing `padding-top: 0` mobile behavior is preserved.
- I did not exercise the SSR/hydration path manually; `useSafeAddressFromUrl` already returns `''` server-side and resolves on the client (same pattern `SpaceSafeBar` uses today).

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1["Topbar (no safe)\nleft: empty"] --> B1["main padding-top: 100px"]
    B1 --> C1["~44px gap looked too wide"]
  end
  subgraph After
    A2["Topbar (no safe)\nleft: SafeLogo (centered)"] --> B2["main padding-top: 80px\n(header-height + space-3)"]
    B2 --> C2["compact gap; logo links to /welcome/accounts"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics surface touched
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — Topbar and PageLayout unit tests cover the new branches
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)