### PR TITLE
fix(web): redirect user if his session is expired

### DIFF
--- a/apps/mobile/src/store/utils/cookieHandling.test.ts
+++ b/apps/mobile/src/store/utils/cookieHandling.test.ts
@@ -65,6 +65,86 @@ describe('formatCookieHeader', () => {
   })
 })
 
+describe('setupMobileCookieHandling', () => {
+  const mockAddHandleResponseHook = jest.fn()
+  const mockSetPrepareHeadersHook = jest.fn()
+  const mockIsIpOrLocalhostUrl = jest.fn()
+  const mockIsHttpsUrl = jest.fn()
+
+  beforeEach(() => {
+    jest.resetModules()
+    mockAddHandleResponseHook.mockReset()
+    mockSetPrepareHeadersHook.mockReset()
+    mockIsIpOrLocalhostUrl.mockReset()
+    mockIsHttpsUrl.mockReset()
+
+    jest.doMock('@safe-global/store/gateway/cgwClient', () => ({
+      __esModule: true,
+      setPrepareHeadersHook: mockSetPrepareHeadersHook,
+      addHandleResponseHook: mockAddHandleResponseHook,
+      isCredentialRoute: (url: string) => url.includes('/api/'),
+    }))
+
+    jest.doMock('@/src/utils/url', () => ({
+      __esModule: true,
+      isIpOrLocalhostUrl: mockIsIpOrLocalhostUrl,
+      isHttpsUrl: mockIsHttpsUrl,
+    }))
+  })
+
+  it('does not register hooks for HTTPS gateway URLs', () => {
+    mockIsIpOrLocalhostUrl.mockReturnValue(true)
+    mockIsHttpsUrl.mockReturnValue(true)
+
+    const { setupMobileCookieHandling: setup } = require('./cookieHandling')
+    setup()
+
+    expect(mockAddHandleResponseHook).not.toHaveBeenCalled()
+    expect(mockSetPrepareHeadersHook).not.toHaveBeenCalled()
+  })
+
+  it('does not register hooks for non-localhost gateway URLs', () => {
+    mockIsIpOrLocalhostUrl.mockReturnValue(false)
+    mockIsHttpsUrl.mockReturnValue(false)
+
+    const { setupMobileCookieHandling: setup } = require('./cookieHandling')
+    setup()
+
+    expect(mockAddHandleResponseHook).not.toHaveBeenCalled()
+    expect(mockSetPrepareHeadersHook).not.toHaveBeenCalled()
+  })
+
+  it('registers hooks for HTTP localhost/IP gateway URLs', () => {
+    mockIsIpOrLocalhostUrl.mockReturnValue(true)
+    mockIsHttpsUrl.mockReturnValue(false)
+    mockAddHandleResponseHook.mockReturnValue(jest.fn())
+
+    const { setupMobileCookieHandling: setup } = require('./cookieHandling')
+    setup()
+
+    expect(mockSetPrepareHeadersHook).toHaveBeenCalledTimes(1)
+    expect(mockAddHandleResponseHook).toHaveBeenCalledTimes(1)
+  })
+
+  it('deregisters the previous response hook before re-registering on repeated calls', () => {
+    mockIsIpOrLocalhostUrl.mockReturnValue(true)
+    mockIsHttpsUrl.mockReturnValue(false)
+
+    const firstDeregister = jest.fn()
+    const secondDeregister = jest.fn()
+    mockAddHandleResponseHook.mockReturnValueOnce(firstDeregister).mockReturnValueOnce(secondDeregister)
+
+    const { setupMobileCookieHandling: setup } = require('./cookieHandling')
+
+    setup()
+    expect(firstDeregister).not.toHaveBeenCalled()
+
+    setup()
+    expect(firstDeregister).toHaveBeenCalledTimes(1)
+    expect(mockAddHandleResponseHook).toHaveBeenCalledTimes(2)
+  })
+})
+
 describe('Cookie Handling', () => {
   beforeEach(() => {
     jest.resetModules()

--- a/apps/mobile/src/store/utils/cookieHandling.ts
+++ b/apps/mobile/src/store/utils/cookieHandling.ts
@@ -73,6 +73,8 @@ export const handleCookieResponse = (
   return updatedCookies
 }
 
+let deregisterResponseHook: (() => void) | undefined
+
 /**
  * Sets up mobile-specific cookie handling for API requests.
  * This ensures cookies are properly stored and forwarded for credential routes.
@@ -88,6 +90,10 @@ export const setupMobileCookieHandling = () => {
     return
   }
 
+  // Deregister any previously registered response hook (e.g. during Fast Refresh)
+  // to prevent duplicate hook accumulation in the responseHooks array.
+  deregisterResponseHook?.()
+
   // Reset cookies object
   cookies = {}
 
@@ -97,7 +103,7 @@ export const setupMobileCookieHandling = () => {
   })
 
   // Set up the custom response hook
-  addHandleResponseHook((response, url) => {
+  deregisterResponseHook = addHandleResponseHook((response, url) => {
     cookies = handleCookieResponse(response, url, cookies)
   })
 }

--- a/apps/mobile/src/store/utils/cookieHandling.ts
+++ b/apps/mobile/src/store/utils/cookieHandling.ts
@@ -1,4 +1,4 @@
-import { setPrepareHeadersHook, setHandleResponseHook, isCredentialRoute } from '@safe-global/store/gateway/cgwClient'
+import { setPrepareHeadersHook, addHandleResponseHook, isCredentialRoute } from '@safe-global/store/gateway/cgwClient'
 import { GATEWAY_URL } from '@/src/config/constants'
 import { isIpOrLocalhostUrl, isHttpsUrl } from '@/src/utils/url'
 // Store for parsed cookies
@@ -97,7 +97,7 @@ export const setupMobileCookieHandling = () => {
   })
 
   // Set up the custom response hook
-  setHandleResponseHook((response, url) => {
+  addHandleResponseHook((response, url) => {
     cookies = handleCookieResponse(response, url, cookies)
   })
 }

--- a/apps/web/src/components/common/Captcha/__tests__/captchaHeadersInit.test.ts
+++ b/apps/web/src/components/common/Captcha/__tests__/captchaHeadersInit.test.ts
@@ -9,7 +9,7 @@ describe('captchaHeadersInit', () => {
   let isCaptchaActivated: () => boolean
   let isProtectedEndpoint: (url: string) => boolean
   let mockSetPrepareHeadersHook: jest.Mock
-  let mockSetHandleResponseHook: jest.Mock
+  let mockAddHandleResponseHook: jest.Mock
 
   const PROTECTED_URL = '/v2/owners/0xABC123/safes'
   const NON_PROTECTED_URL = '/v1/chains/1/safes'
@@ -18,7 +18,7 @@ describe('captchaHeadersInit', () => {
     jest.resetModules()
     jest.doMock('@safe-global/store/gateway/cgwClient', () => ({
       setPrepareHeadersHook: jest.fn(),
-      setHandleResponseHook: jest.fn(),
+      addHandleResponseHook: jest.fn(),
     }))
     jest.doMock('@safe-global/utils/config/constants', () => ({
       TURNSTILE_SITE_KEY: 'test-site-key',
@@ -35,7 +35,7 @@ describe('captchaHeadersInit', () => {
     } = require('@/components/common/Captcha/captchaHeadersInit'))
     ;({
       setPrepareHeadersHook: mockSetPrepareHeadersHook,
-      setHandleResponseHook: mockSetHandleResponseHook,
+      addHandleResponseHook: mockAddHandleResponseHook,
     } = require('@safe-global/store/gateway/cgwClient'))
   })
 
@@ -130,14 +130,14 @@ describe('captchaHeadersInit', () => {
 
     it('registers a handle-response hook', () => {
       initializeCaptchaHeaders()
-      expect(mockSetHandleResponseHook).toHaveBeenCalledTimes(1)
+      expect(mockAddHandleResponseHook).toHaveBeenCalledTimes(1)
     })
 
     it('is idempotent — registers hooks only once', () => {
       initializeCaptchaHeaders()
       initializeCaptchaHeaders()
       expect(mockSetPrepareHeadersHook).toHaveBeenCalledTimes(1)
-      expect(mockSetHandleResponseHook).toHaveBeenCalledTimes(1)
+      expect(mockAddHandleResponseHook).toHaveBeenCalledTimes(1)
     })
 
     it('adds X-Captcha-Token header when token is set', async () => {
@@ -371,7 +371,7 @@ describe('captchaHeadersInit', () => {
       sharedTokenRef.current = 'old-token'
       initializeCaptchaHeaders()
 
-      const hook = mockSetHandleResponseHook.mock.calls[0][0]
+      const hook = mockAddHandleResponseHook.mock.calls[0][0]
       await hook(makeResponse(401, { message: 'Invalid CAPTCHA token' }), PROTECTED_URL)
 
       expect(sharedTokenRef.current).toBeNull()
@@ -386,7 +386,7 @@ describe('captchaHeadersInit', () => {
       sharedTokenRef.current = 'old-token'
       initializeCaptchaHeaders()
 
-      const hook = mockSetHandleResponseHook.mock.calls[0][0]
+      const hook = mockAddHandleResponseHook.mock.calls[0][0]
       await hook(makeResponse(401, { message: 'Invalid CAPTCHA token' }), NON_PROTECTED_URL)
 
       expect(sharedTokenRef.current).toBe('old-token')
@@ -399,7 +399,7 @@ describe('captchaHeadersInit', () => {
       sharedTokenRef.current = 'token'
       initializeCaptchaHeaders()
 
-      const hook = mockSetHandleResponseHook.mock.calls[0][0]
+      const hook = mockAddHandleResponseHook.mock.calls[0][0]
       await hook(makeResponse(200, { message: 'Invalid CAPTCHA token' }), PROTECTED_URL)
 
       expect(sharedTokenRef.current).toBe('token')
@@ -412,7 +412,7 @@ describe('captchaHeadersInit', () => {
       sharedTokenRef.current = 'token'
       initializeCaptchaHeaders()
 
-      const hook = mockSetHandleResponseHook.mock.calls[0][0]
+      const hook = mockAddHandleResponseHook.mock.calls[0][0]
       await hook(makeResponse(401, { message: 'Unauthorized' }), PROTECTED_URL)
 
       expect(sharedTokenRef.current).toBe('token')
@@ -421,7 +421,7 @@ describe('captchaHeadersInit', () => {
 
     it('does not throw when the response body is not JSON', async () => {
       initializeCaptchaHeaders()
-      const hook = mockSetHandleResponseHook.mock.calls[0][0]
+      const hook = mockAddHandleResponseHook.mock.calls[0][0]
       await expect(hook(makeUnreadableResponse(401), PROTECTED_URL)).resolves.not.toThrow()
     })
   })

--- a/apps/web/src/components/common/Captcha/captchaHeadersInit.ts
+++ b/apps/web/src/components/common/Captcha/captchaHeadersInit.ts
@@ -1,4 +1,4 @@
-import { setPrepareHeadersHook, setHandleResponseHook } from '@safe-global/store/gateway/cgwClient'
+import { setPrepareHeadersHook, addHandleResponseHook } from '@safe-global/store/gateway/cgwClient'
 import { TURNSTILE_SITE_KEY } from '@safe-global/utils/config/constants'
 
 export const sharedTokenRef: { current: string | null } = { current: null }
@@ -118,7 +118,7 @@ export function initializeCaptchaHeaders() {
     }
   })
 
-  setHandleResponseHook(async (response: Response, url: string) => {
+  addHandleResponseHook(async (response: Response, url: string) => {
     // Only handle 401 responses
     if (response.status !== 401) return
     // Only captcha-protected endpoints can return captcha 401s

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
@@ -438,7 +438,7 @@ describe('SafeSidebarVariant', () => {
       )
 
       expect(screen.queryByTestId('add-safe-to-workspace-button')).not.toBeInTheDocument()
-      expect(screen.queryByText('Add Safe to workspace')).not.toBeInTheDocument()
+      expect(screen.queryByText('Add Safe to space')).not.toBeInTheDocument()
     })
 
     it('shows addToWorkspace when sessionExpiresAt is still in the future (token valid)', () => {

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
@@ -415,6 +415,54 @@ describe('SafeSidebarVariant', () => {
       expect(screen.queryByText('Add Safe to workspace')).not.toBeInTheDocument()
     })
 
+    it('hides addToWorkspace when the SIWE session token has expired (sessionExpiresAt in the past)', () => {
+      // Drive the real isAuthenticated selector logic: sessionExpiresAt > Date.now() ? signed-in : not.
+      // Each call returns whatever the mocked selector function (passed in) computes against this state.
+      const expiredAuthState = { auth: { sessionExpiresAt: Date.now() - 1_000 } }
+      mockUseAppSelector.mockImplementation((selector: (s: typeof expiredAuthState) => unknown) =>
+        selector(expiredAuthState),
+      )
+
+      jest.isolateModules(() => {
+        // Use the real selector so the regression surface is "expired token" not "selector returned false".
+        const { isAuthenticated } = jest.requireActual('@/store/authSlice')
+        expect(isAuthenticated(expiredAuthState)).toBe(false)
+      })
+
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createAddHeader({ spaces: [] })}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.queryByTestId('add-safe-to-workspace-button')).not.toBeInTheDocument()
+      expect(screen.queryByText('Add Safe to workspace')).not.toBeInTheDocument()
+    })
+
+    it('shows addToWorkspace when sessionExpiresAt is still in the future (token valid)', () => {
+      const validAuthState = { auth: { sessionExpiresAt: Date.now() + 60_000 } }
+      mockUseAppSelector.mockImplementation((selector: (s: typeof validAuthState) => unknown) =>
+        selector(validAuthState),
+      )
+
+      jest.isolateModules(() => {
+        const { isAuthenticated } = jest.requireActual('@/store/authSlice')
+        expect(isAuthenticated(validAuthState)).toBe(true)
+      })
+
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createAddHeader({ spaces: [] })}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.getByTestId('add-safe-to-workspace-button')).toBeInTheDocument()
+    })
+
     it('hides the addToWorkspace section entirely when Safe is counterfactual (undeployed)', () => {
       mockUseIsCounterfactualSafe.mockReturnValue(true)
       const spaces = [{ id: 1, name: 'Team', safeCount: 0 }]

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import SpacesList from '../index'
+
+const mockUseAppSelector = jest.fn()
+const mockUseSpacesGetV1Query = jest.fn()
+const mockUseUsersGetWithWalletsV1Query = jest.fn()
+const mockUseSignInRedirect = jest.fn()
+
+jest.mock('@/store', () => ({
+  useAppSelector: (selector: unknown) => mockUseAppSelector(selector),
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: jest.fn(() => 'isAuthenticated'),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useSpacesGetV1Query: (...args: unknown[]) => mockUseSpacesGetV1Query(...args),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/users', () => ({
+  useUsersGetWithWalletsV1Query: (...args: unknown[]) => mockUseUsersGetWithWalletsV1Query(...args),
+}))
+
+jest.mock('@/components/welcome/WelcomeLogin/hooks/useSignInRedirect', () => ({
+  useSignInRedirect: (...args: unknown[]) => mockUseSignInRedirect(...args),
+}))
+
+jest.mock('@/features/__core__', () => ({
+  useLoadFeature: () => ({ AccountsNavigation: () => <nav data-testid="accounts-nav" /> }),
+  createFeatureHandle: () => ({}),
+}))
+
+jest.mock('@/features/myAccounts', () => ({
+  MyAccountsFeature: { name: 'MyAccountsFeature' },
+}))
+
+jest.mock('@/features/spaces', () => ({
+  MemberStatus: { ACTIVE: 'ACTIVE', INVITED: 'INVITED', DECLINED: 'DECLINED' },
+}))
+
+jest.mock('@/features/spaces/utils', () => ({
+  filterSpacesByStatus: (_user: unknown, spaces: unknown[], status: string) =>
+    status === 'INVITED' ? [] : ((spaces as Array<{ name: string; status?: string }>) ?? []),
+}))
+
+jest.mock('../../SignInOptions', () => ({
+  __esModule: true,
+  default: () => <div data-testid="sign-in-options" />,
+}))
+
+jest.mock('../../SpaceCard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="space-card" />,
+}))
+
+jest.mock('../../InviteBanner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="invite-banner" />,
+}))
+
+jest.mock('../../SpaceInfoModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+}))
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+describe('SpacesList — auth/expiry state rendering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseSpacesGetV1Query.mockReturnValue({ currentData: undefined, isFetching: false, error: undefined })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: undefined })
+    mockUseSignInRedirect.mockReturnValue({ setHasSignedIn: jest.fn(), redirectLoading: false })
+  })
+
+  it('renders the Sign in card (not Create space) when the user is unauthenticated — i.e. after a session expiry redirect', () => {
+    // After sessionExpired() runs, setUnauthenticated clears sessionExpiresAt → isAuthenticated returns false.
+    mockUseAppSelector.mockReturnValue(false)
+
+    render(<SpacesList />)
+
+    // The signed-out card with Sign in heading + SignInOptions must render…
+    expect(screen.getByRole('heading', { name: /sign in/i })).toBeInTheDocument()
+    expect(screen.getByTestId('sign-in-options')).toBeInTheDocument()
+
+    // …and the Create space CTA / no-spaces empty state must NOT.
+    expect(screen.queryByText(/^create space$/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/no spaces found/i)).not.toBeInTheDocument()
+  })
+
+  it('renders the No-spaces empty state with Create space CTA when the user is authenticated and has no spaces', () => {
+    mockUseAppSelector.mockReturnValue(true)
+    mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    expect(screen.getByText(/no spaces found/i)).toBeInTheDocument()
+    // The "Create space" CTA link is rendered (Button + NextLink composition).
+    expect(screen.getByRole('link', { name: /create space/i })).toBeInTheDocument()
+
+    // Sign in card must NOT render in this branch.
+    expect(screen.queryByTestId('sign-in-options')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/hooks/__tests__/useLogout.test.ts
+++ b/apps/web/src/hooks/__tests__/useLogout.test.ts
@@ -1,9 +1,15 @@
 import { renderHook, act } from '@testing-library/react'
 import useLogout from '@/hooks/useLogout'
 import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
+import { setUnauthenticated } from '@/store/authSlice'
 
 jest.mock('@/config/gateway', () => ({
   GATEWAY_URL: 'https://safe-client.safe.global',
+}))
+
+const mockDispatch = jest.fn()
+jest.mock('@/store', () => ({
+  useAppDispatch: () => mockDispatch,
 }))
 
 describe('useLogout', () => {
@@ -15,6 +21,7 @@ describe('useLogout', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockDispatch.mockReset()
     sessionStorage.clear()
     capturedForm = null
 
@@ -49,6 +56,21 @@ describe('useLogout', () => {
 
     expect(sessionStorage.getItem(LOGGING_OUT_KEY)).toBe('1')
     expect(submitSpy).toHaveBeenCalled()
+  })
+
+  it('should dispatch setUnauthenticated before submitting the form', () => {
+    const { result } = renderHook(() => useLogout())
+
+    const callOrder: string[] = []
+    mockDispatch.mockImplementation(() => callOrder.push('dispatch'))
+    submitSpy.mockImplementation(() => callOrder.push('submit'))
+
+    act(() => {
+      result.current.logout()
+    })
+
+    expect(mockDispatch).toHaveBeenCalledWith(setUnauthenticated())
+    expect(callOrder).toEqual(['dispatch', 'submit'])
   })
 
   it('should submit a form POST to the logout redirect endpoint', () => {

--- a/apps/web/src/hooks/useLogout.ts
+++ b/apps/web/src/hooks/useLogout.ts
@@ -1,6 +1,8 @@
 import { useCallback } from 'react'
 import { GATEWAY_URL } from '@/config/gateway'
 import { AppRoutes } from '@/config/routes'
+import { useAppDispatch } from '@/store'
+import { setUnauthenticated } from '@/store/authSlice'
 import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
 
 const LOGOUT_REDIRECT_PATH = '/v1/auth/logout/redirect'
@@ -14,9 +16,16 @@ const LOGOUT_REDIRECT_PATH = '/v1/auth/logout/redirect'
  *
  * Sets a transient flag in sessionStorage so that after the redirect lands back in the app,
  * `useLogoutCallback` can reconcile with the backend via /v1/auth/me.
+ *
+ * Dispatches setUnauthenticated() before the form submit so that any 403s from in-flight
+ * credentialed requests during the redirect window find sessionExpiresAt already cleared
+ * and do not trigger the "session expired" toast on a deliberate logout.
  */
 const useLogout = () => {
+  const dispatch = useAppDispatch()
+
   const logout = useCallback(() => {
+    dispatch(setUnauthenticated())
     sessionStorage.setItem(LOGGING_OUT_KEY, '1')
 
     const redirectUrl = new URL(AppRoutes.welcome.spaces, window.location.origin).toString()
@@ -36,7 +45,7 @@ const useLogout = () => {
     document.body.appendChild(form)
     form.submit()
     document.body.removeChild(form)
-  }, [])
+  }, [dispatch])
 
   return { logout }
 }

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -95,6 +95,8 @@ import { useOidcLoginCallback } from '@/features/oidc-auth'
 import { useLogoutCallback } from '@/hooks/useLogoutCallback'
 import ObservabilityErrorBoundary from '@/components/common/ObservabilityErrorBoundary'
 import { ShadcnProvider } from '@/components/ui/ShadcnProvider'
+import { initializeSessionExpiry } from '@/services/sessionExpiry/sessionExpiryInit'
+import { useSessionExpiryGuard } from '@/services/sessionExpiry/useSessionExpiryGuard'
 
 // Initialize observability before React rendering starts
 // This ensures we capture early page metrics (FCP, LCP, TTI) and errors during hydration
@@ -104,6 +106,11 @@ if (typeof window !== 'undefined') {
 
 const reduxStore = makeStore()
 setStoreInstance(reduxStore)
+
+// Register the global 403-on-credentialed-route → session-expired interceptor.
+// Must run after setStoreInstance (so getStoreInstance() works) and before any
+// RTK Query requests fire.
+initializeSessionExpiry()
 
 const InitApp = (): null => {
   useHydrateStore(reduxStore)
@@ -128,6 +135,7 @@ const InitApp = (): null => {
   useSafeLabsTerms() // Automatically disconnect wallets if terms not accepted and feature is enabled
   useOidcLoginCallback()
   useLogoutCallback()
+  useSessionExpiryGuard()
 
   return null
 }

--- a/apps/web/src/services/sessionExpiry/__tests__/sessionExpiry.integration.test.ts
+++ b/apps/web/src/services/sessionExpiry/__tests__/sessionExpiry.integration.test.ts
@@ -1,0 +1,130 @@
+import { AppRoutes } from '@/config/routes'
+
+// Capture the registered hook so we can fire it like the real cgwClient would.
+let registeredHook: ((response: Response, url: string) => void | Promise<void>) | undefined
+
+jest.mock('@safe-global/store/gateway/cgwClient', () => {
+  const CREDENTIAL_ROUTES = [/\/v1\/users/, /\/v1\/spaces/, /\/v1\/auth/]
+  return {
+    addHandleResponseHook: (fn: typeof registeredHook) => {
+      registeredHook = fn
+    },
+    isCredentialRoute: (url: string) => CREDENTIAL_ROUTES.some((r) => r.test(url)),
+  }
+})
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  default: { replace: jest.fn() },
+}))
+
+const dispatched: Array<{ type: string; payload?: unknown }> = []
+let mockState: { auth: { sessionExpiresAt: number | null } } = { auth: { sessionExpiresAt: null } }
+
+jest.mock('@/store', () => ({
+  getStoreInstance: () => ({
+    dispatch: (action: unknown) => {
+      // showNotification returns a thunk — execute it so the enqueueNotification action lands.
+      if (typeof action === 'function') {
+        return (action as (d: typeof dispatch, gs: typeof getState) => unknown)(dispatch, getState)
+      }
+      dispatched.push(action as { type: string; payload?: unknown })
+      // Mirror the real reducer effect for setUnauthenticated.
+      if ((action as { type: string }).type === 'auth/setUnauthenticated') {
+        mockState = { auth: { sessionExpiresAt: null } }
+      }
+      return action
+    },
+    getState: () => mockState,
+  }),
+}))
+
+const dispatch = (action: unknown) => {
+  if (typeof action === 'function') {
+    return (action as (d: typeof dispatch, gs: typeof getState) => unknown)(dispatch, getState)
+  }
+  dispatched.push(action as { type: string; payload?: unknown })
+  if ((action as { type: string }).type === 'auth/setUnauthenticated') {
+    mockState = { auth: { sessionExpiresAt: null } }
+  }
+  return action
+}
+const getState = () => mockState
+
+// We deliberately do NOT mock @/store/sessionExpired or @/store/notificationsSlice —
+// this test exercises the real thunk chain end-to-end.
+
+jest.mock('@/store/authSlice', () => ({
+  setUnauthenticated: () => ({ type: 'auth/setUnauthenticated' }),
+}))
+
+const makeResponse = (status: number): Response => ({ status }) as Response
+
+describe('sessionExpiry integration — 403 on credentialed routes triggers full redirect + toast chain', () => {
+  let routerReplace: jest.Mock
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+    registeredHook = undefined
+    dispatched.length = 0
+    mockState = { auth: { sessionExpiresAt: Date.now() + 60_000 } }
+    // After resetModules, re-acquire the mocked router so we read the post-reset jest.fn().
+    routerReplace = require('next/router').default.replace as jest.Mock
+    routerReplace.mockClear()
+  })
+
+  const initAndFire = async (status: number, url: string) => {
+    const { initializeSessionExpiry } = require('../sessionExpiryInit')
+    initializeSessionExpiry()
+    expect(registeredHook).toBeDefined()
+    await registeredHook!(makeResponse(status), url)
+  }
+
+  it('dispatches the full chain (setUnauthenticated + enqueueNotification + Router.replace) on 403 to /v1/spaces/*', async () => {
+    await initAndFire(403, '/v1/spaces/123/safes')
+
+    // setUnauthenticated dispatched first
+    expect(dispatched.find((a) => a.type === 'auth/setUnauthenticated')).toBeDefined()
+
+    // showNotification thunk ran → enqueueNotification action with our error message + groupKey landed
+    const notification = dispatched.find((a) => a.type === 'notifications/enqueueNotification') as
+      | { type: string; payload: { message: string; variant: string; groupKey: string } }
+      | undefined
+    expect(notification).toBeDefined()
+    expect(notification?.payload.message).toMatch(/session has expired.*sign in/i)
+    expect(notification?.payload.variant).toBe('error')
+    expect(notification?.payload.groupKey).toBe('session-expired')
+
+    // Router.replace was called with welcome.spaces
+    expect(routerReplace).toHaveBeenCalledWith(AppRoutes.welcome.spaces)
+  })
+
+  it('does not redirect on 403 to /v1/auth/me (excluded probe route)', async () => {
+    await initAndFire(403, '/v1/auth/me')
+
+    expect(dispatched).toHaveLength(0)
+    expect(routerReplace).not.toHaveBeenCalled()
+  })
+
+  it('does not redirect on 403 to a non-credentialed route (e.g. /v1/chains/...)', async () => {
+    await initAndFire(403, '/v1/chains/1/safes/0xabc')
+
+    expect(dispatched).toHaveLength(0)
+    expect(routerReplace).not.toHaveBeenCalled()
+  })
+
+  it('does not redirect on a 200 response to a credentialed route', async () => {
+    await initAndFire(200, '/v1/spaces/123/safes')
+
+    expect(dispatched).toHaveLength(0)
+    expect(routerReplace).not.toHaveBeenCalled()
+  })
+
+  it('redirects on 403 to /v1/users/* (also a credentialed route)', async () => {
+    await initAndFire(403, '/v1/users/me')
+
+    expect(dispatched.find((a) => a.type === 'auth/setUnauthenticated')).toBeDefined()
+    expect(routerReplace).toHaveBeenCalledWith(AppRoutes.welcome.spaces)
+  })
+})

--- a/apps/web/src/services/sessionExpiry/__tests__/sessionExpiryInit.test.ts
+++ b/apps/web/src/services/sessionExpiry/__tests__/sessionExpiryInit.test.ts
@@ -1,0 +1,118 @@
+import { shouldTriggerSessionExpiry, isSessionExpiryExcluded } from '../sessionExpiryInit'
+
+describe('sessionExpiry — URL filter', () => {
+  describe('isSessionExpiryExcluded', () => {
+    it.each([
+      ['/v1/auth/me', true],
+      ['/v1/auth/verify', true],
+      ['/v1/auth/logout', true],
+      ['/v1/auth/logout/redirect', true],
+      ['/v1/auth/nonce', false],
+      ['/v1/spaces', false],
+      ['/v1/users', false],
+    ])('%s -> %s', (url, expected) => {
+      expect(isSessionExpiryExcluded(url)).toBe(expected)
+    })
+  })
+
+  describe('shouldTriggerSessionExpiry', () => {
+    it.each([
+      // Triggers: 403 on credentialed routes that are NOT in the exclusion list
+      [403, '/v1/spaces', true],
+      [403, '/v1/spaces/123/safes', true],
+      [403, '/v1/users', true],
+      [403, '/v1/users/me', true],
+      [403, '/v1/auth/nonce', true],
+
+      // Does NOT trigger: excluded auth probe routes
+      [403, '/v1/auth/me', false],
+      [403, '/v1/auth/verify', false],
+      [403, '/v1/auth/logout', false],
+      [403, '/v1/auth/logout/redirect', false],
+
+      // Does NOT trigger: 403 on non-credentialed routes
+      [403, '/v1/chains/1/safes', false],
+      [403, '/v1/some/random/path', false],
+
+      // Does NOT trigger: non-403 statuses
+      [200, '/v1/spaces', false],
+      [401, '/v1/spaces', false],
+      [404, '/v1/spaces', false],
+      [500, '/v1/spaces', false],
+    ])('status=%s url=%s -> trigger=%s', (status, url, expected) => {
+      expect(shouldTriggerSessionExpiry(status, url)).toBe(expected)
+    })
+  })
+})
+
+describe('sessionExpiry — initialization side effects', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('registers exactly one response hook on first call and is idempotent', () => {
+    const addHandleResponseHook = jest.fn()
+    jest.doMock('@safe-global/store/gateway/cgwClient', () => ({
+      addHandleResponseHook,
+      isCredentialRoute: () => true,
+    }))
+    jest.doMock('@/store', () => ({ getStoreInstance: jest.fn() }))
+    jest.doMock('@/store/sessionExpired', () => ({ sessionExpired: jest.fn() }))
+
+    const { initializeSessionExpiry } = require('../sessionExpiryInit')
+
+    initializeSessionExpiry()
+    initializeSessionExpiry()
+    initializeSessionExpiry()
+
+    expect(addHandleResponseHook).toHaveBeenCalledTimes(1)
+  })
+
+  it('dispatches sessionExpired on a credentialed 403 outside the exclusion list', () => {
+    const dispatch = jest.fn()
+    const sessionExpiredAction = { type: 'sessionExpired' }
+    const sessionExpired = jest.fn(() => sessionExpiredAction)
+    let hookFn: ((response: Response, url: string) => void) | undefined
+
+    jest.doMock('@safe-global/store/gateway/cgwClient', () => ({
+      addHandleResponseHook: (fn: typeof hookFn) => {
+        hookFn = fn
+      },
+      isCredentialRoute: (url: string) => /\/v1\/(spaces|users|auth)/.test(url),
+    }))
+    jest.doMock('@/store', () => ({ getStoreInstance: () => ({ dispatch }) }))
+    jest.doMock('@/store/sessionExpired', () => ({ sessionExpired }))
+
+    const { initializeSessionExpiry } = require('../sessionExpiryInit')
+    initializeSessionExpiry()
+
+    hookFn?.({ status: 403 } as Response, '/v1/spaces/123')
+    expect(sessionExpired).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenCalledWith(sessionExpiredAction)
+  })
+
+  it('does not dispatch sessionExpired on excluded auth probe routes', () => {
+    const dispatch = jest.fn()
+    const sessionExpired = jest.fn()
+    let hookFn: ((response: Response, url: string) => void) | undefined
+
+    jest.doMock('@safe-global/store/gateway/cgwClient', () => ({
+      addHandleResponseHook: (fn: typeof hookFn) => {
+        hookFn = fn
+      },
+      isCredentialRoute: () => true,
+    }))
+    jest.doMock('@/store', () => ({ getStoreInstance: () => ({ dispatch }) }))
+    jest.doMock('@/store/sessionExpired', () => ({ sessionExpired }))
+
+    const { initializeSessionExpiry } = require('../sessionExpiryInit')
+    initializeSessionExpiry()
+
+    hookFn?.({ status: 403 } as Response, '/v1/auth/me')
+    hookFn?.({ status: 403 } as Response, '/v1/auth/verify')
+    hookFn?.({ status: 403 } as Response, '/v1/auth/logout')
+
+    expect(sessionExpired).not.toHaveBeenCalled()
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
+++ b/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
@@ -1,5 +1,7 @@
-import { renderHook } from '@/tests/test-utils'
+import { act, renderHook } from '@/tests/test-utils'
 import { useSessionExpiryGuard } from '../useSessionExpiryGuard'
+import { setAuthenticated } from '@/store/authSlice'
+import { useAppDispatch } from '@/store'
 import type { RootState } from '@/store'
 
 const mockSessionExpiredAction = { type: 'sessionExpired' }
@@ -26,6 +28,7 @@ describe('useSessionExpiryGuard', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers().setSystemTime(new Date('2026-05-05T12:00:00Z'))
+    window.localStorage.clear()
   })
 
   afterEach(() => {
@@ -59,6 +62,26 @@ describe('useSessionExpiryGuard', () => {
     })
 
     expect(mockSessionExpired).not.toHaveBeenCalled()
+  })
+
+  it('dispatches when sessionExpiresAt becomes stale after store hydration', () => {
+    const { result } = renderHook(
+      () => {
+        useSessionExpiryGuard()
+        return useAppDispatch()
+      },
+      { initialReduxState: buildState(null) },
+    )
+
+    // No dispatch yet — initial render saw null (pre-hydration state).
+    expect(mockSessionExpired).not.toHaveBeenCalled()
+
+    // Simulate the persisted, already-expired value arriving via HYDRATE_ACTION.
+    act(() => {
+      result.current(setAuthenticated(Date.now() - 1_000))
+    })
+
+    expect(mockSessionExpired).toHaveBeenCalledTimes(1)
   })
 
   it('dispatches when routeChangeStart fires after the session has expired', () => {

--- a/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
+++ b/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
@@ -1,0 +1,105 @@
+import { renderHook } from '@/tests/test-utils'
+import { useSessionExpiryGuard } from '../useSessionExpiryGuard'
+import type { RootState } from '@/store'
+
+const mockSessionExpiredAction = { type: 'sessionExpired' }
+const mockSessionExpired = jest.fn(() => mockSessionExpiredAction)
+jest.mock('@/store/sessionExpired', () => ({
+  sessionExpired: () => mockSessionExpired(),
+}))
+
+const routerEvents = {
+  on: jest.fn(),
+  off: jest.fn(),
+}
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ events: routerEvents }),
+}))
+
+const buildState = (sessionExpiresAt: number | null): Partial<RootState> =>
+  ({
+    auth: { sessionExpiresAt, lastUsedSpace: null, isStoreHydrated: true, isOidcLoginPending: false },
+  }) as Partial<RootState>
+
+describe('useSessionExpiryGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-05T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const getRouteChangeHandler = (): (() => void) | undefined => {
+    const call = routerEvents.on.mock.calls.find(([event]) => event === 'routeChangeStart')
+    return call?.[1] as (() => void) | undefined
+  }
+
+  it('dispatches sessionExpired on mount when sessionExpiresAt is in the past', () => {
+    renderHook(() => useSessionExpiryGuard(), {
+      initialReduxState: buildState(Date.now() - 1_000),
+    })
+
+    expect(mockSessionExpired).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dispatch on mount when sessionExpiresAt is in the future', () => {
+    renderHook(() => useSessionExpiryGuard(), {
+      initialReduxState: buildState(Date.now() + 60_000),
+    })
+
+    expect(mockSessionExpired).not.toHaveBeenCalled()
+  })
+
+  it('does not dispatch on mount when sessionExpiresAt is null (logged out)', () => {
+    renderHook(() => useSessionExpiryGuard(), {
+      initialReduxState: buildState(null),
+    })
+
+    expect(mockSessionExpired).not.toHaveBeenCalled()
+  })
+
+  it('dispatches when routeChangeStart fires after the session has expired', () => {
+    renderHook(() => useSessionExpiryGuard(), {
+      initialReduxState: buildState(Date.now() + 60_000),
+    })
+
+    // No dispatch yet — session is valid.
+    expect(mockSessionExpired).not.toHaveBeenCalled()
+
+    // Move past the expiry window before triggering navigation.
+    jest.advanceTimersByTime(120_000)
+
+    const handler = getRouteChangeHandler()
+    expect(handler).toBeDefined()
+    handler?.()
+
+    expect(mockSessionExpired).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dispatch on routeChangeStart when sessionExpiresAt is still in the future', () => {
+    renderHook(() => useSessionExpiryGuard(), {
+      initialReduxState: buildState(Date.now() + 60_000),
+    })
+
+    const handler = getRouteChangeHandler()
+    handler?.()
+
+    expect(mockSessionExpired).not.toHaveBeenCalled()
+  })
+
+  it('cleans up the routeChangeStart listener on unmount', () => {
+    const { unmount } = renderHook(() => useSessionExpiryGuard(), {
+      initialReduxState: buildState(Date.now() + 60_000),
+    })
+
+    expect(routerEvents.on).toHaveBeenCalledWith('routeChangeStart', expect.any(Function))
+    const handler = routerEvents.on.mock.calls[0][1]
+
+    unmount()
+
+    expect(routerEvents.off).toHaveBeenCalledWith('routeChangeStart', handler)
+  })
+})

--- a/apps/web/src/services/sessionExpiry/sessionExpiryInit.ts
+++ b/apps/web/src/services/sessionExpiry/sessionExpiryInit.ts
@@ -1,0 +1,34 @@
+import { addHandleResponseHook, isCredentialRoute } from '@safe-global/store/gateway/cgwClient'
+import { getStoreInstance } from '@/store'
+import { sessionExpired } from '@/store/sessionExpired'
+
+// Routes that legitimately return 403 without meaning "the session expired":
+//   - /v1/auth/me      → reconcileAuth uses this as a probe; logout/OIDC flows
+//                        depend on a 403 here meaning "unauthenticated", not "expired"
+//   - /v1/auth/verify  → SIWE sign-in failure; handled locally by SignInButton
+//   - /v1/auth/logout  → expected to be hit while logging out
+const SESSION_EXPIRY_EXCLUDED_ROUTES = [/\/v1\/auth\/me$/, /\/v1\/auth\/verify$/, /\/v1\/auth\/logout(\/redirect)?$/]
+
+export const isSessionExpiryExcluded = (url: string): boolean =>
+  SESSION_EXPIRY_EXCLUDED_ROUTES.some((pattern) => pattern.test(url))
+
+export const shouldTriggerSessionExpiry = (status: number, url: string): boolean =>
+  status === 403 && isCredentialRoute(url) && !isSessionExpiryExcluded(url)
+
+let initialized = false
+
+/**
+ * Registers a response hook that detects 403s on credentialed Spaces/Users/Auth
+ * routes and dispatches the sessionExpired thunk (toast + redirect + cleanup).
+ *
+ * Idempotent: safe to call once at app startup.
+ */
+export const initializeSessionExpiry = (): void => {
+  if (initialized) return
+  initialized = true
+
+  addHandleResponseHook((response: Response, url: string) => {
+    if (!shouldTriggerSessionExpiry(response.status, url)) return
+    getStoreInstance().dispatch(sessionExpired())
+  })
+}

--- a/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
+++ b/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
@@ -21,18 +21,14 @@ export const useSessionExpiryGuard = (): void => {
   const router = useRouter()
   const sessionExpiresAt = useAppSelector((state) => state.auth.sessionExpiresAt)
 
-  // Mount-time check: if we boot up with an already-expired session,
-  // clean it up before any pages render data.
+  // Runs on mount, after store hydration populates a persisted sessionExpiresAt,
+  // and on every Next.js route change. The thunk is idempotent so duplicate
+  // dispatches across the mount/hydrate/route paths are safe.
   useEffect(() => {
     if (isExpired(sessionExpiresAt)) {
       dispatch(sessionExpired())
     }
-    // Intentionally only on first mount — the routeChangeStart listener below
-    // covers all subsequent transitions.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
-  useEffect(() => {
     const handleRouteChange = () => {
       if (isExpired(sessionExpiresAt)) {
         dispatch(sessionExpired())

--- a/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
+++ b/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { sessionExpired } from '@/store/sessionExpired'
+
+const isExpired = (sessionExpiresAt: number | null): boolean =>
+  sessionExpiresAt !== null && sessionExpiresAt <= Date.now()
+
+/**
+ * Preemptive client-side session-expiry guard.
+ *
+ * Runs on app mount and on every Next.js route change. If the locally-stored
+ * sessionExpiresAt has elapsed, dispatches the sessionExpired thunk before the
+ * destination page issues any backend calls — saving a needless 403 round-trip.
+ *
+ * The thunk is idempotent (early-exits when sessionExpiresAt is already null),
+ * so this composes safely with the response-hook safety net.
+ */
+export const useSessionExpiryGuard = (): void => {
+  const dispatch = useAppDispatch()
+  const router = useRouter()
+  const sessionExpiresAt = useAppSelector((state) => state.auth.sessionExpiresAt)
+
+  // Mount-time check: if we boot up with an already-expired session,
+  // clean it up before any pages render data.
+  useEffect(() => {
+    if (isExpired(sessionExpiresAt)) {
+      dispatch(sessionExpired())
+    }
+    // Intentionally only on first mount — the routeChangeStart listener below
+    // covers all subsequent transitions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      if (isExpired(sessionExpiresAt)) {
+        dispatch(sessionExpired())
+      }
+    }
+
+    router.events.on('routeChangeStart', handleRouteChange)
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange)
+    }
+  }, [dispatch, router.events, sessionExpiresAt])
+}

--- a/apps/web/src/store/__tests__/sessionExpired.test.ts
+++ b/apps/web/src/store/__tests__/sessionExpired.test.ts
@@ -1,0 +1,77 @@
+import Router from 'next/router'
+import type { AppDispatch, RootState } from '@/store'
+import { sessionExpired, SESSION_EXPIRED_GROUP_KEY } from '@/store/sessionExpired'
+import { AppRoutes } from '@/config/routes'
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  default: { replace: jest.fn() },
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  setUnauthenticated: () => ({ type: 'auth/setUnauthenticated' }),
+}))
+
+jest.mock('@/store/notificationsSlice', () => ({
+  showNotification: (payload: unknown) => ({ type: 'notifications/show', payload }),
+}))
+
+const makeState = (sessionExpiresAt: number | null): RootState =>
+  ({ auth: { sessionExpiresAt } }) as unknown as RootState
+
+const setup = (state: RootState) => {
+  const dispatch = jest.fn((action) => action) as unknown as AppDispatch & jest.Mock
+  const getState = jest.fn(() => state)
+  return { dispatch, getState }
+}
+
+describe('sessionExpired', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('clears auth, queues a session-expired toast, and replaces to welcome.spaces when authenticated', () => {
+    const { dispatch, getState } = setup(makeState(Date.now() + 60_000))
+
+    sessionExpired()(dispatch, getState, undefined)
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'auth/setUnauthenticated' })
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'notifications/show',
+      payload: expect.objectContaining({
+        groupKey: SESSION_EXPIRED_GROUP_KEY,
+        variant: 'error',
+      }),
+    })
+    expect(Router.replace).toHaveBeenCalledWith(AppRoutes.welcome.spaces)
+  })
+
+  it('is a no-op when sessionExpiresAt is null (already logged out / already handled)', () => {
+    const { dispatch, getState } = setup(makeState(null))
+
+    sessionExpired()(dispatch, getState, undefined)
+
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(Router.replace).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent across parallel calls — only the first gets through before state clears', () => {
+    let sessionExpiresAt: number | null = Date.now() + 60_000
+    const dispatch = jest.fn((action) => {
+      if (typeof action === 'object' && action.type === 'auth/setUnauthenticated') {
+        sessionExpiresAt = null
+      }
+      return action
+    }) as unknown as AppDispatch & jest.Mock
+    const getState = jest.fn(() => makeState(sessionExpiresAt))
+
+    sessionExpired()(dispatch, getState, undefined)
+    sessionExpired()(dispatch, getState, undefined)
+    sessionExpired()(dispatch, getState, undefined)
+
+    expect(Router.replace).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenCalledWith({ type: 'auth/setUnauthenticated' })
+    const showCalls = dispatch.mock.calls.filter(([a]) => typeof a === 'object' && a.type === 'notifications/show')
+    expect(showCalls).toHaveLength(1)
+  })
+})

--- a/apps/web/src/store/sessionExpired.ts
+++ b/apps/web/src/store/sessionExpired.ts
@@ -1,0 +1,35 @@
+import Router from 'next/router'
+import { AppRoutes } from '@/config/routes'
+import type { AppThunk } from '@/store'
+import { setUnauthenticated } from '@/store/authSlice'
+import { showNotification } from '@/store/notificationsSlice'
+
+export const SESSION_EXPIRED_GROUP_KEY = 'session-expired'
+const SESSION_EXPIRED_MESSAGE = 'Your session has expired. Please sign in again.'
+
+/**
+ * Thunk fired when an authenticated session is detected as no longer valid —
+ * either preemptively (client-side timestamp check) or reactively (a 403 from
+ * a credentialed endpoint).
+ *
+ * Idempotent: when no session is present, this is a no-op. The auth slice's
+ * sessionExpiresAt field doubles as the de-dupe key — once cleared, parallel
+ * 403s landing afterwards will short-circuit here without re-toasting or
+ * re-navigating.
+ */
+export const sessionExpired = (): AppThunk => (dispatch, getState) => {
+  const { sessionExpiresAt } = getState().auth
+  if (sessionExpiresAt === null) return
+
+  dispatch(setUnauthenticated())
+
+  dispatch(
+    showNotification({
+      message: SESSION_EXPIRED_MESSAGE,
+      variant: 'error',
+      groupKey: SESSION_EXPIRED_GROUP_KEY,
+    }),
+  )
+
+  Router.replace(AppRoutes.welcome.spaces)
+}

--- a/packages/store/src/gateway/cgwClient-hooks.test.ts
+++ b/packages/store/src/gateway/cgwClient-hooks.test.ts
@@ -71,4 +71,61 @@ describe('cgwClient hooks', () => {
     expect(mockResponseFunction).toHaveBeenCalled()
     expect(mockResponseFunction).toHaveBeenCalledWith(expect.any(Response), '/test-response')
   })
+
+  it('runs every registered response hook in registration order', async () => {
+    const callOrder: string[] = []
+    const hookA = jest.fn(() => {
+      callOrder.push('A')
+    })
+    const hookB = jest.fn(() => {
+      callOrder.push('B')
+    })
+
+    cgwClient.addHandleResponseHook(hookA)
+    cgwClient.addHandleResponseHook(hookB)
+
+    await cgwClient.dynamicBaseQuery('/test-multi-hook', testApi, {})
+
+    expect(hookA).toHaveBeenCalledTimes(1)
+    expect(hookB).toHaveBeenCalledTimes(1)
+    expect(callOrder).toEqual(['A', 'B'])
+  })
+
+  it('continues invoking subsequent hooks when an earlier one throws', async () => {
+    const failing = jest.fn(() => {
+      throw new Error('hook failed')
+    })
+    const succeeding = jest.fn()
+
+    cgwClient.addHandleResponseHook(failing)
+    cgwClient.addHandleResponseHook(succeeding)
+
+    await cgwClient.dynamicBaseQuery('/test-hook-isolation', testApi, {})
+
+    expect(failing).toHaveBeenCalled()
+    expect(succeeding).toHaveBeenCalled()
+  })
+
+  it('addHandleResponseHook returns a deregistration function', async () => {
+    const hook = jest.fn()
+    const deregister = cgwClient.addHandleResponseHook(hook)
+
+    deregister()
+
+    await cgwClient.dynamicBaseQuery('/test-deregister', testApi, {})
+    expect(hook).not.toHaveBeenCalled()
+  })
+
+  it('setHandleResponseHook still replaces previously registered hooks (back-compat)', async () => {
+    const previous = jest.fn()
+    const replacement = jest.fn()
+
+    cgwClient.addHandleResponseHook(previous)
+    cgwClient.setHandleResponseHook(replacement)
+
+    await cgwClient.dynamicBaseQuery('/test-replace', testApi, {})
+
+    expect(previous).not.toHaveBeenCalled()
+    expect(replacement).toHaveBeenCalled()
+  })
 })

--- a/packages/store/src/gateway/cgwClient-hooks.test.ts
+++ b/packages/store/src/gateway/cgwClient-hooks.test.ts
@@ -8,6 +8,15 @@ import * as cgwClient from './cgwClient'
 describe('cgwClient hooks', () => {
   let testApi: BaseQueryApi
   let originalFetch: typeof global.fetch
+  const responseHookDeregisters: Array<() => void> = []
+
+  // Wraps addHandleResponseHook so per-test registrations are torn down in afterEach.
+  // This keeps each test isolated now that there's no reset-style setter.
+  const registerResponseHook = (hook: Parameters<typeof cgwClient.addHandleResponseHook>[0]) => {
+    const deregister = cgwClient.addHandleResponseHook(hook)
+    responseHookDeregisters.push(deregister)
+    return deregister
+  }
 
   beforeAll(() => {
     cgwClient.setBaseUrl('https://test.com')
@@ -21,9 +30,8 @@ describe('cgwClient hooks', () => {
       new Response('{}', { status: 200, headers: new Headers() }), // Headers need to be mutable for set
     )
 
-    // Reset hooks to default implementations
+    // Reset prepareHeaders hook to a passthrough; response hooks are deregistered in afterEach.
     cgwClient.setPrepareHeadersHook((headers) => headers)
-    cgwClient.setHandleResponseHook(() => {})
 
     testApi = {
       dispatch: jest.fn(),
@@ -39,6 +47,10 @@ describe('cgwClient hooks', () => {
   afterEach(() => {
     // Restore original fetch
     global.fetch = originalFetch
+    // Tear down any response hooks registered by the test
+    while (responseHookDeregisters.length > 0) {
+      responseHookDeregisters.pop()?.()
+    }
   })
 
   it('should call custom prepareHeadersHook and set header when fetchBaseQuery is used', async () => {
@@ -59,9 +71,9 @@ describe('cgwClient hooks', () => {
     expect(request.headers.get('X-Test-Header')).toBe('test-value')
   })
 
-  it('should call custom handleResponseHook when fetchBaseQuery is used', async () => {
+  it('should call a registered handleResponseHook when fetchBaseQuery is used', async () => {
     const mockResponseFunction = jest.fn()
-    cgwClient.setHandleResponseHook(mockResponseFunction)
+    registerResponseHook(mockResponseFunction)
 
     await cgwClient.dynamicBaseQuery('/test-response', testApi, {})
 
@@ -81,8 +93,8 @@ describe('cgwClient hooks', () => {
       callOrder.push('B')
     })
 
-    cgwClient.addHandleResponseHook(hookA)
-    cgwClient.addHandleResponseHook(hookB)
+    registerResponseHook(hookA)
+    registerResponseHook(hookB)
 
     await cgwClient.dynamicBaseQuery('/test-multi-hook', testApi, {})
 
@@ -97,8 +109,8 @@ describe('cgwClient hooks', () => {
     })
     const succeeding = jest.fn()
 
-    cgwClient.addHandleResponseHook(failing)
-    cgwClient.addHandleResponseHook(succeeding)
+    registerResponseHook(failing)
+    registerResponseHook(succeeding)
 
     await cgwClient.dynamicBaseQuery('/test-hook-isolation', testApi, {})
 
@@ -108,24 +120,11 @@ describe('cgwClient hooks', () => {
 
   it('addHandleResponseHook returns a deregistration function', async () => {
     const hook = jest.fn()
-    const deregister = cgwClient.addHandleResponseHook(hook)
+    const deregister = registerResponseHook(hook)
 
     deregister()
 
     await cgwClient.dynamicBaseQuery('/test-deregister', testApi, {})
     expect(hook).not.toHaveBeenCalled()
-  })
-
-  it('setHandleResponseHook still replaces previously registered hooks (back-compat)', async () => {
-    const previous = jest.fn()
-    const replacement = jest.fn()
-
-    cgwClient.addHandleResponseHook(previous)
-    cgwClient.setHandleResponseHook(replacement)
-
-    await cgwClient.dynamicBaseQuery('/test-replace', testApi, {})
-
-    expect(previous).not.toHaveBeenCalled()
-    expect(replacement).toHaveBeenCalled()
   })
 })

--- a/packages/store/src/gateway/cgwClient.ts
+++ b/packages/store/src/gateway/cgwClient.ts
@@ -39,15 +39,29 @@ export const setPrepareHeadersHook = (hook: PrepareHeadersHook) => {
   customPrepareHeaders = hook
 }
 
-// Hook for handling response - this can be overridden by platform-specific code
+// Hook for handling response - platform-specific code can register one or more.
+// Hooks run in registration order; failures in one hook do not abort the others.
 type HandleResponseHook = (response: Response, url: string) => void | Promise<void>
 
-// Default implementation (does nothing)
-let customHandleResponse: HandleResponseHook = () => {}
+const responseHooks: HandleResponseHook[] = []
 
-// Setter for the custom hook
-export const setHandleResponseHook = (hook: HandleResponseHook) => {
-  customHandleResponse = hook
+// Register a response hook. Returns a deregistration function.
+export const addHandleResponseHook = (hook: HandleResponseHook): (() => void) => {
+  responseHooks.push(hook)
+  return () => {
+    const index = responseHooks.indexOf(hook)
+    if (index !== -1) responseHooks.splice(index, 1)
+  }
+}
+
+/**
+ * @deprecated Prefer addHandleResponseHook, which composes with other registrations.
+ * This setter REPLACES all previously registered response hooks, matching the
+ * pre-multi-hook contract — useful primarily for test isolation.
+ */
+export const setHandleResponseHook = (hook: HandleResponseHook): (() => void) => {
+  responseHooks.length = 0
+  return addHandleResponseHook(hook)
 }
 
 export const rawBaseQuery = fetchBaseQuery({
@@ -108,9 +122,16 @@ export const dynamicBaseQuery: BaseQueryFn<string | FetchArgs, unknown, FetchBas
 
   const response = await rawBaseQuery(adjustedArgs, api, extraOptions)
 
-  // Apply platform-specific response handling
+  // Apply platform-specific response handling. Run hooks sequentially in
+  // registration order; one hook's failure must not block the others.
   if (response.meta?.response) {
-    await customHandleResponse(response.meta.response, urlEnd)
+    for (const hook of responseHooks) {
+      try {
+        await hook(response.meta.response, urlEnd)
+      } catch {
+        // Swallow hook errors — a misbehaving hook must not break the request flow
+      }
+    }
   }
 
   return response

--- a/packages/store/src/gateway/cgwClient.ts
+++ b/packages/store/src/gateway/cgwClient.ts
@@ -54,16 +54,6 @@ export const addHandleResponseHook = (hook: HandleResponseHook): (() => void) =>
   }
 }
 
-/**
- * @deprecated Prefer addHandleResponseHook, which composes with other registrations.
- * This setter REPLACES all previously registered response hooks, matching the
- * pre-multi-hook contract — useful primarily for test isolation.
- */
-export const setHandleResponseHook = (hook: HandleResponseHook): (() => void) => {
-  responseHooks.length = 0
-  return addHandleResponseHook(hook)
-}
-
 export const rawBaseQuery = fetchBaseQuery({
   baseUrl: '/',
   headers: {


### PR DESCRIPTION
Resolves: [WA-2209](https://linear.app/safe-global/issue/WA-2235/redirect-to-login-when-auth-token-expires)

It fixes the 403 forbiden errors we have under space onboarding flow by redirecting the user to welcome page if his session has expired. It also shows a toast on top of the screen saying the user session has expired.


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
