### PR TITLE
chore(web): rename sidebar "Add Safe to workspace" trigger to "Add Sa…

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/styles.module.css
+++ b/apps/web/src/features/spaces/components/Sidebar/styles.module.css
@@ -45,7 +45,7 @@
   cursor: pointer;
 }
 
-/* "Add Safe to workspace" (opens space selector) */
+/* "Add Safe to space" (opens space selector) */
 .addSafeToWorkspaceTrigger {
   display: flex;
   align-items: center;

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
@@ -138,7 +138,7 @@ jest.mock('../../SpaceSelectorDropdown', () => ({
   SpaceSelectorDropdown: ({ triggerVariant }: { triggerVariant?: 'default' | 'addToWorkspace' }) =>
     triggerVariant === 'addToWorkspace' ? (
       <button type="button" data-testid="add-safe-to-workspace-button">
-        Add Safe to workspace
+        Add Safe to space
       </button>
     ) : (
       <div data-testid="space-selector-default">Space selector</div>
@@ -232,7 +232,7 @@ describe('SafeSidebarVariant', () => {
     )
 
     expect(screen.queryByTestId('add-safe-to-workspace-button')).not.toBeInTheDocument()
-    expect(screen.queryByText('Add Safe to workspace')).not.toBeInTheDocument()
+    expect(screen.queryByText('Add Safe to space')).not.toBeInTheDocument()
   })
 
   it('still renders backToSpace workspace header when Safe is counterfactual', () => {
@@ -412,7 +412,7 @@ describe('SafeSidebarVariant', () => {
       )
 
       expect(screen.queryByTestId('add-safe-to-workspace-button')).not.toBeInTheDocument()
-      expect(screen.queryByText('Add Safe to workspace')).not.toBeInTheDocument()
+      expect(screen.queryByText('Add Safe to space')).not.toBeInTheDocument()
     })
 
     it('hides the addToWorkspace section entirely when Safe is counterfactual (undeployed)', () => {

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarWorkspaceHeader/SafeSidebarWorkspaceHeader.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarWorkspaceHeader/SafeSidebarWorkspaceHeader.tsx
@@ -50,7 +50,7 @@ export const SafeSidebarWorkspaceHeader = ({ workspaceHeader }: SafeSidebarWorks
                 size="lg"
                 className={css.addSafeToWorkspaceTrigger}
                 data-testid="add-safe-to-workspace-button"
-                aria-label="Add Safe to workspace"
+                aria-label="Add Safe to space"
                 aria-haspopup="dialog"
               />
             }
@@ -58,7 +58,7 @@ export const SafeSidebarWorkspaceHeader = ({ workspaceHeader }: SafeSidebarWorks
             <span className={css.addSafeToWorkspaceRing}>
               <CircleFadingPlus className={css.addSafeToWorkspacePlusIcon} strokeWidth={2.5} />
             </span>
-            <span className={css.addSafeToWorkspaceLabel}>Add Safe to workspace</span>
+            <span className={css.addSafeToWorkspaceLabel}>Add Safe to space</span>
           </DialogTrigger>
           <DialogContent className="max-w-[420px] p-0" showCloseButton={false}>
             <AddToSpacePopupModal />

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarWorkspaceHeader/__tests__/SafeSidebarWorkspaceHeader.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarWorkspaceHeader/__tests__/SafeSidebarWorkspaceHeader.test.tsx
@@ -106,7 +106,7 @@ jest.mock('../../SpaceSelectorDropdown', () => ({
     spaceSelectorDropdownMock(props)
     return props.triggerVariant === 'addToWorkspace' ? (
       <button type="button" data-testid="add-safe-to-workspace-button">
-        Add Safe to workspace
+        Add Safe to space
       </button>
     ) : (
       <div data-testid="space-selector-default">Space selector</div>
@@ -286,12 +286,12 @@ describe('SafeSidebarWorkspaceHeader', () => {
       expect(spaceSelectorDropdownMock).toHaveBeenCalled()
     })
 
-    it('renders Add Safe to workspace trigger and popup inside Dialog when not in a Space', () => {
+    it('renders Add Safe to space trigger and popup inside Dialog when not in a Space', () => {
       render(<SafeSidebarWorkspaceHeader workspaceHeader={createAddHeader()} />)
 
       expect(screen.queryByText('ChevronLeft')).not.toBeInTheDocument()
       expect(screen.getByTestId('dialog-root')).toBeInTheDocument()
-      expect(screen.getByText('Add Safe to workspace')).toBeInTheDocument()
+      expect(screen.getByText('Add Safe to space')).toBeInTheDocument()
       expect(screen.getByTestId('add-to-space-popup-modal')).toBeInTheDocument()
     })
   })

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/SpaceSelectorDropdown.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/SpaceSelectorDropdown.tsx
@@ -46,7 +46,7 @@ export const SpaceSelectorDropdown = ({
   const displayName = truncateSpaceName(spaceName, SPACE_SELECTOR_NAME_MAX_LENGTH)
   const initial = spaceName.charAt(0).toUpperCase()
   const selectedSpaceColor = spaceName ? getDeterministicColor(spaceName) : undefined
-  const triggerAriaLabel = triggerVariant === 'addToWorkspace' ? 'Add Safe to workspace' : 'Open workspace selector'
+  const triggerAriaLabel = triggerVariant === 'addToWorkspace' ? 'Add Safe to space' : 'Open workspace selector'
   const safe = useSafeQueryParam() || undefined
 
   const { addToSpace, loadingSpaceId } = useAddSafeToSpace({ spaces, onSpaceAdded })
@@ -159,7 +159,7 @@ export const SpaceSelectorDropdown = ({
             <span className={css.addSafeToWorkspaceRing}>
               <CircleFadingPlus className={css.addSafeToWorkspacePlusIcon} strokeWidth={2.5} />
             </span>
-            <span className={css.addSafeToWorkspaceLabel}>Add Safe to workspace</span>
+            <span className={css.addSafeToWorkspaceLabel}>Add Safe to space</span>
           </>
         ) : (
           <>

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/__tests__/SpaceSelectorDropdown.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/__tests__/SpaceSelectorDropdown.test.tsx
@@ -281,7 +281,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
 
       const fullButton = screen
         .getAllByRole('button')
@@ -298,7 +298,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ id: 1, name: 'Full Space', safeCount: LIMIT }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
 
       expect(screen.getByText(/You can have up to /)).toBeInTheDocument()
     })
@@ -307,7 +307,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ id: 1, name: 'Space', safeCount: LIMIT - 1 }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
 
       expect(screen.queryByText(/You can have up to /)).not.toBeInTheDocument()
     })
@@ -328,7 +328,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ id: 1, name: 'Full Space', safeCount: LIMIT }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
 
       expect(screen.getByText(`You can have up to ${LIMIT} Safes per workspace`)).toBeInTheDocument()
     })
@@ -357,7 +357,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ id: 1, name: 'Alpha', safeCount: 0 }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
       expect(screen.getByText('Alpha')).toBeInTheDocument()
 
       const alphaButton = screen
@@ -388,7 +388,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
 
       const alphaButton = screen
         .getAllByRole('button')
@@ -411,7 +411,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ id: 1, name: 'Alpha', safeCount: 0 }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
 
       const alphaButton = screen
         .getAllByRole('button')
@@ -430,7 +430,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ id: 1, name: 'Alpha', safeCount: 0 }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
       expect(screen.getByText('Alpha')).toBeInTheDocument()
 
       const alphaButton = screen
@@ -524,7 +524,7 @@ describe('SpaceSelectorDropdown', () => {
       ]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
 
       const full1 = screen.getAllByRole('button').find((btn) => btn.querySelector('span')?.textContent === 'Full1')
       const full2 = screen.getAllByRole('button').find((btn) => btn.querySelector('span')?.textContent === 'Full2')
@@ -542,7 +542,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ id: 1, name: 'AlmostFull', safeCount: LIMIT - 1 }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
 
       const button = screen
         .getAllByRole('button')
@@ -602,7 +602,7 @@ describe('SpaceSelectorDropdown', () => {
       const spaces = [{ id: 1, name: 'Alpha', safeCount: 0 }]
       render(<SpaceSelectorDropdown triggerVariant="addToWorkspace" spaces={spaces} />)
 
-      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to workspace' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Add Safe to space' }))
 
       const alphaButton = screen
         .getAllByRole('button')


### PR DESCRIPTION
> Workspace word retired in the trigger,
> "Add Safe to space" reads cleaner;
> aria-label, span, six tests realigned.

## What it solves
Resolves: https://linear.app/safe-global/issue/WA-2236/rename-add-to-workspace-to-add-to-space
Inconsistent terminology in the Safe-page sidebar — the trigger button said "Add Safe to workspace" while the rest of the product (and the modal it opens) talks about "spaces". This aligns the visible label and the accessible name on that trigger.

## How this PR fixes it

Renames the visible text and `aria-label` on the two places that render the
"Add Safe to space" trigger in the Safe-page sidebar:

- [`SafeSidebarWorkspaceHeader.tsx`](apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarWorkspaceHeader/SafeSidebarWorkspaceHeader.tsx) — workspace-header slot when the active Safe is not in any space
- [`SpaceSelectorDropdown.tsx`](apps/web/src/features/spaces/components/Sidebar/variants/SpaceSelectorDropdown/SpaceSelectorDropdown.tsx) — `triggerVariant === 'addToWorkspace'` branch only

Internal identifiers stay the same to keep the diff minimal:

- `data-testid="add-safe-to-workspace-button"`
- CSS classes `addSafeToWorkspaceTrigger`, `addSafeToWorkspaceLabel`, `addSafeToWorkspaceRing`, `addSafeToWorkspacePlusIcon`
- `triggerVariant === 'addToWorkspace'`

The other branch of `SpaceSelectorDropdown` (the workspace switcher inside an existing space) keeps `aria-label="Open workspace selector"` — out of scope.

## How to test it

1. `yarn workspace @safe-global/web dev`
2. Open a Safe that is not yet in any space (the sidebar shows the dashed CTA in the workspace-header slot).
3. The visible label should read **"Add Safe to space"**.
4. Inspect the button — `aria-label` is also **"Add Safe to space"**, `data-testid` unchanged (`add-safe-to-workspace-button`).
5. Click the button — the existing "Add to space" popup/dialog opens unchanged.
6. Switch to a Safe that already belongs to a space → the workspace switcher trigger keeps its existing label (unchanged).

Unit tests: `yarn workspace @safe-global/web jest src/features/spaces/components/Sidebar` — 20 suites / 234 tests pass.

## Affected flows

- Adding a Safe to a space from the sidebar trigger (visible label + a11y name only — behavior unchanged).

## Blast radius

- Two production files: `SafeSidebarWorkspaceHeader.tsx`, `SpaceSelectorDropdown.tsx` (visible label + aria-label only).
- Three unit-test files updated for the new copy: `SafeSidebarVariant.test.tsx`, `SafeSidebarWorkspaceHeader.test.tsx`, `SpaceSelectorDropdown.test.tsx`.
- One CSS comment updated for accuracy in `Sidebar/styles.module.css`.
- No public API, no Redux state, no RTK Query endpoint, no feature flag, no route, no shared package, no mobile impact.
- No Cypress E2E references the old text or the related `data-testid` (verified across `cypress/{smoke,regression,happypath,visual,prodhealthcheck,safe-apps,pages}`).
- No Storybook story hardcodes the old copy.

## Risks / not checked

- Did not run Chromatic locally — visual-regression baselines that include this trigger will diff (expected, intended).
- Did not test on mobile (web-only string; mobile sidebar is a separate codebase).
- Did not run the full `yarn workspace @safe-global/web test` suite — scoped to the Sidebar tree where the change lives.
- Internal identifiers (`addToWorkspace`, `addSafeToWorkspaceLabel`, `add-safe-to-workspace-button`) intentionally not renamed; if product wants full terminology consistency a follow-up can rename them.

## Visual summary

```mermaid
flowchart LR
  A[Sidebar workspace-header slot] --> B{Active Safe in a space?}
  B -- No --> C["Trigger:<br/>label = 'Add Safe to space'<br/>aria-label = 'Add Safe to space'"]
  B -- Yes --> D["Workspace switcher<br/>aria-label = 'Open workspace selector'<br/>(unchanged)"]
  C -- click --> E[AddToSpacePopupModal]
```

Before / after copy:

| Surface | Before | After |
| --- | --- | --- |
| Visible label | `Add Safe to workspace` | `Add Safe to space` |
| `aria-label` | `Add Safe to workspace` | `Add Safe to space` |
| `data-testid` | `add-safe-to-workspace-button` | unchanged |
| CSS classes | `addSafeToWorkspace*` | unchanged |

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A, web-only string.
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics events touch this string.
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — existing unit tests updated; no E2E impact.
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯.

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

