### PR TITLE
fix(mobile): never auto-redirect to Settings on camera permission denial

### DIFF
--- a/apps/mobile/src/components/Camera/QrCamera.test.tsx
+++ b/apps/mobile/src/components/Camera/QrCamera.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { fireEvent, render } from '@/src/tests/test-utils'
+import { QrCamera } from './QrCamera'
+
+jest.mock('react-native-vision-camera', () => ({
+  Camera: jest.fn(() => null),
+  useCodeScanner: jest.fn(() => ({})),
+  useCameraDevice: jest.fn(() => null),
+}))
+
+jest.mock('expo-blur', () => ({
+  BlurView: ({ children }: { children?: React.ReactNode }) => children,
+}))
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ back: jest.fn(), push: jest.fn() }),
+}))
+
+const renderQrCamera = (overrides: Partial<React.ComponentProps<typeof QrCamera>> = {}) =>
+  render(
+    <QrCamera
+      permission="denied"
+      isCameraActive={false}
+      onScan={jest.fn()}
+      onActivateCamera={jest.fn()}
+      onRequestPermission={jest.fn()}
+      onPressSettings={jest.fn()}
+      footer={null}
+      {...overrides}
+    />,
+  )
+
+describe('QrCamera', () => {
+  it('does NOT call onPressSettings when the user taps the lens wrapper while permission is denied', () => {
+    const onPressSettings = jest.fn()
+    const { getByTestId } = renderQrCamera({ permission: 'denied', onPressSettings })
+
+    fireEvent.press(getByTestId('camera-lens-wrapper'))
+
+    expect(onPressSettings).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call onPressSettings when the user taps the lens wrapper while permission is restricted', () => {
+    const onPressSettings = jest.fn()
+    const { getByTestId } = renderQrCamera({ permission: 'restricted', onPressSettings })
+
+    fireEvent.press(getByTestId('camera-lens-wrapper'))
+
+    expect(onPressSettings).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call onRequestPermission when the user taps the lens wrapper while permission is not-determined', () => {
+    const onRequestPermission = jest.fn()
+    const { getByTestId } = renderQrCamera({ permission: 'not-determined', onRequestPermission })
+
+    fireEvent.press(getByTestId('camera-lens-wrapper'))
+
+    expect(onRequestPermission).not.toHaveBeenCalled()
+  })
+
+  it('calls onPressSettings only when the explicit "Open Settings" button is tapped while denied', () => {
+    const onPressSettings = jest.fn()
+    const { getByTestId } = renderQrCamera({ permission: 'denied', onPressSettings })
+
+    fireEvent.press(getByTestId('camera-open-settings'))
+
+    expect(onPressSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onActivateCamera when the user taps the lens wrapper while permission is granted but camera inactive', () => {
+    const onActivateCamera = jest.fn()
+    const { getByTestId } = renderQrCamera({
+      permission: 'granted',
+      isCameraActive: false,
+      onActivateCamera,
+    })
+
+    fireEvent.press(getByTestId('camera-lens-wrapper'))
+
+    expect(onActivateCamera).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mobile/src/components/Camera/QrCamera.tsx
+++ b/apps/mobile/src/components/Camera/QrCamera.tsx
@@ -2,7 +2,7 @@ import { Camera, useCodeScanner, useCameraDevice, Code, CameraPermissionStatus }
 import { View, Theme, H3, getTokenValue } from 'tamagui'
 import { Dimensions, Pressable, StyleSheet, useWindowDimensions } from 'react-native'
 import { useTheme } from '@/src/theme/hooks/useTheme'
-import React, { useCallback } from 'react'
+import React from 'react'
 import { useRouter } from 'expo-router'
 
 const { width } = Dimensions.get('window')
@@ -116,17 +116,23 @@ function CameraLens({
     onPressSettings,
   })
 
-  const handlePressBox = useCallback(() => {
-    if (button) {
-      void button.onPress()
-    }
-  }, [button])
+  // Only let taps on the wrapper trigger the in-lens action when the camera is
+  // ready to activate. For 'not-determined' / 'denied' / 'restricted' the
+  // wrapper must be inert so that Settings (and the OS prompt) only ever fires
+  // from an explicit tap on the labeled SafeButton — Apple guideline 5.1.1(iv).
+  const wrapperPress =
+    permission === 'granted' && !isCameraActive
+      ? () => {
+          void onActivateCamera()
+        }
+      : undefined
 
   return (
     <Pressable
       style={[styles.transparentBox, denied && { backgroundColor: 'rgba(0, 0, 0, 0.8)' }]}
-      onPress={button ? handlePressBox : undefined}
-      disabled={!button}
+      onPress={wrapperPress}
+      disabled={!wrapperPress}
+      testID="camera-lens-wrapper"
     >
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.topLeft]} />
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.topRight]} />

--- a/apps/mobile/src/components/Camera/QrCamera.tsx
+++ b/apps/mobile/src/components/Camera/QrCamera.tsx
@@ -1,6 +1,6 @@
 import { Camera, useCodeScanner, useCameraDevice, Code, CameraPermissionStatus } from 'react-native-vision-camera'
 import { View, Theme, H3, getTokenValue } from 'tamagui'
-import { Dimensions, Linking, Pressable, StyleSheet, useWindowDimensions } from 'react-native'
+import { Dimensions, Pressable, StyleSheet, useWindowDimensions } from 'react-native'
 import { useTheme } from '@/src/theme/hooks/useTheme'
 import React, { useCallback } from 'react'
 import { useRouter } from 'expo-router'
@@ -17,8 +17,47 @@ type QrCameraProps = {
   onScan: (code: Code[]) => void
   isCameraActive: boolean
   permission: CameraPermissionStatus
-  hasPermission: boolean
   onActivateCamera: () => void
+  onRequestPermission: () => void | Promise<unknown>
+  onPressSettings: () => void
+}
+
+type LensButtonConfig = {
+  label: string
+  onPress: () => void | Promise<unknown>
+  testID?: string
+}
+
+// Returns the in-lens CTA for the current permission state, or null when the
+// camera is live and no button should render. The 'denied' branch must NOT
+// auto-redirect to Settings — it surfaces an explicit "Open Settings" button
+// that the user has to tap (Apple guideline 5.1.1(iv)).
+function getLensButtonConfig({
+  permission,
+  isCameraActive,
+  onActivateCamera,
+  onRequestPermission,
+  onPressSettings,
+}: {
+  permission: CameraPermissionStatus
+  isCameraActive: boolean
+  onActivateCamera: () => void
+  onRequestPermission: () => void | Promise<unknown>
+  onPressSettings: () => void
+}): LensButtonConfig | null {
+  if (permission === 'granted') {
+    if (isCameraActive) {
+      return null
+    }
+    return { label: 'Continue', onPress: onActivateCamera, testID: 'camera-continue' }
+  }
+
+  if (permission === 'not-determined') {
+    return { label: 'Continue', onPress: onRequestPermission, testID: 'camera-request-permission' }
+  }
+
+  // 'denied' or 'restricted'
+  return { label: 'Open Settings', onPress: onPressSettings, testID: 'camera-open-settings' }
 }
 
 function CameraHeader({ heading }: { heading: React.ReactNode }) {
@@ -53,55 +92,52 @@ function CameraFooter(props: { footer: React.ReactNode }) {
 }
 
 function CameraLens({
-  denied,
-  onPressSettings,
-  hasPermission,
-  onActivateCamera,
+  permission,
   isCameraActive,
+  onActivateCamera,
+  onRequestPermission,
+  onPressSettings,
 }: {
-  denied: boolean
-  onPressSettings: () => Promise<void>
-  hasPermission: boolean
-  onActivateCamera: () => void
+  permission: CameraPermissionStatus
   isCameraActive: boolean
+  onActivateCamera: () => void
+  onRequestPermission: () => void | Promise<unknown>
+  onPressSettings: () => void
 }) {
   const { isDark } = useTheme()
-
   const color = isDark ? getTokenValue('$color.textPrimaryDark') : getTokenValue('$color.textPrimaryLight')
 
-  const handleGrantOrActivatePress = useCallback(async () => {
-    if (!hasPermission) {
-      const permission = await Camera.requestCameraPermission()
+  const denied = permission === 'denied' || permission === 'restricted'
+  const button = getLensButtonConfig({
+    permission,
+    isCameraActive,
+    onActivateCamera,
+    onRequestPermission,
+    onPressSettings,
+  })
 
-      if (permission === 'denied') {
-        await onPressSettings()
-      }
-    } else if (hasPermission && !isCameraActive) {
-      onActivateCamera()
+  const handlePressBox = useCallback(() => {
+    if (button) {
+      void button.onPress()
     }
-  }, [hasPermission, isCameraActive, onActivateCamera, onPressSettings])
-
-  const buttonText = 'Continue'
-  const buttonAction = handleGrantOrActivatePress
+  }, [button])
 
   return (
     <Pressable
       style={[styles.transparentBox, denied && { backgroundColor: 'rgba(0, 0, 0, 0.8)' }]}
-      onPress={hasPermission && !isCameraActive ? handleGrantOrActivatePress : undefined}
-      disabled={denied || !hasPermission}
+      onPress={button ? handlePressBox : undefined}
+      disabled={!button}
     >
-      {/* Green corners */}
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.topLeft]} />
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.topRight]} />
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.bottomLeft]} />
       <View borderColor={denied ? '$error' : '$success'} style={[styles.corner, styles.bottomRight]} />
 
-      {/* Show button/icon only if permission denied, not granted, or granted but inactive */}
-      {(denied || !hasPermission || (hasPermission && !isCameraActive)) && (
+      {button && (
         <View style={styles.deniedCameraContainer}>
           <SafeFontIcon name={'camera'} size={40} color={denied ? '$error' : color} />
-          <SafeButton rounded secondary onPress={buttonAction} marginTop={20}>
-            {buttonText}
+          <SafeButton rounded secondary onPress={button.onPress} marginTop={20} testID={button.testID}>
+            {button.label}
           </SafeButton>
         </View>
       )}
@@ -115,8 +151,9 @@ export const QrCamera = ({
   onScan,
   isCameraActive,
   permission,
-  hasPermission,
   onActivateCamera,
+  onRequestPermission,
+  onPressSettings,
 }: QrCameraProps) => {
   const device = useCameraDevice('back')
   const { height } = useWindowDimensions()
@@ -125,22 +162,16 @@ export const QrCamera = ({
     onCodeScanned: onScan,
   })
 
-  const openSettings = useCallback(async () => {
-    await Linking.openSettings()
-  }, [])
-
-  const denied = permission === 'denied'
+  const denied = permission === 'denied' || permission === 'restricted'
   const granted = permission === 'granted'
 
   return (
     <Theme name={'dark'}>
       <View style={styles.container}>
-        {/* Only render Camera device is available */}
         {device && granted && (
           <Camera style={StyleSheet.absoluteFill} device={device} isActive={isCameraActive} codeScanner={codeScanner} />
         )}
 
-        {/* Overlay with blurred edges */}
         <View style={styles.overlay}>
           <View flex={1}>
             <BlurView
@@ -151,7 +182,6 @@ export const QrCamera = ({
               <CameraHeader heading={heading} />
             </BlurView>
 
-            {/* Middle with transparent center */}
             <View style={styles.transparentCenter}>
               <BlurView
                 style={[styles.sideBlur, denied && styles.deniedCameraBlur]}
@@ -160,11 +190,11 @@ export const QrCamera = ({
               />
 
               <CameraLens
-                denied={denied}
-                onPressSettings={openSettings}
-                hasPermission={hasPermission}
-                onActivateCamera={onActivateCamera}
+                permission={permission}
                 isCameraActive={isCameraActive}
+                onActivateCamera={onActivateCamera}
+                onRequestPermission={onRequestPermission}
+                onPressSettings={onPressSettings}
               />
               <BlurView
                 style={[styles.sideBlur, denied && styles.deniedCameraBlur]}
@@ -173,7 +203,6 @@ export const QrCamera = ({
               />
             </View>
 
-            {/* Bottom Blur */}
             <BlurView
               style={[styles.blur, denied && styles.deniedCameraBlur]}
               intensity={30}
@@ -188,8 +217,8 @@ export const QrCamera = ({
   )
 }
 
-const BOX_RADIUS = 5 // Rounded corners
-const CORNER_SIZE = 30 // Size of the green corners
+const BOX_RADIUS = 5
+const CORNER_SIZE = 30
 
 const styles = StyleSheet.create({
   container: {
@@ -200,11 +229,11 @@ const styles = StyleSheet.create({
   },
   blur: {
     flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.7)', // Simulates blur
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
   },
   blurTop: {
     flex: 0,
-    backgroundColor: 'rgba(0, 0, 0, 0.7)', // Simulates blur
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
   },
   topContainer: {
     flex: 1,
@@ -214,14 +243,14 @@ const styles = StyleSheet.create({
   },
   sideBlur: {
     flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.7)', // Simulates blur
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
   },
   transparentBox: {
     width: width * 0.6,
     height: width * 0.6,
-    borderRadius: BOX_RADIUS, // Rounded corners
-    overflow: 'hidden', // Prevents content leaking outside the corners
-    position: 'relative', // For positioning corners
+    borderRadius: BOX_RADIUS,
+    overflow: 'hidden',
+    position: 'relative',
     backgroundColor: 'transparent',
   },
   corner: {
@@ -234,7 +263,7 @@ const styles = StyleSheet.create({
     left: 0,
     borderTopWidth: 2,
     borderLeftWidth: 2,
-    borderTopLeftRadius: BOX_RADIUS, // Matches the box's radius
+    borderTopLeftRadius: BOX_RADIUS,
   },
   topRight: {
     top: 0,

--- a/apps/mobile/src/components/Camera/index.ts
+++ b/apps/mobile/src/components/Camera/index.ts
@@ -1,1 +1,2 @@
 export { QrCamera } from './QrCamera'
+export { useCameraPermissionFlow } from './useCameraPermissionFlow'

--- a/apps/mobile/src/components/Camera/useCameraPermissionFlow.test.ts
+++ b/apps/mobile/src/components/Camera/useCameraPermissionFlow.test.ts
@@ -1,0 +1,66 @@
+import { Linking } from 'react-native'
+import { Camera } from 'react-native-vision-camera'
+import { act, renderHook } from '@/src/tests/test-utils'
+import { useCameraPermissionFlow } from './useCameraPermissionFlow'
+
+jest.mock('react-native-vision-camera', () => ({
+  Camera: {
+    getCameraPermissionStatus: jest.fn(),
+    requestCameraPermission: jest.fn(),
+  },
+}))
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: jest.fn(),
+}))
+
+describe('useCameraPermissionFlow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(Linking, 'openSettings').mockResolvedValue(undefined)
+    jest.mocked(Camera.getCameraPermissionStatus).mockReturnValue('not-determined')
+  })
+
+  it('seeds permission from Camera.getCameraPermissionStatus on mount', () => {
+    jest.mocked(Camera.getCameraPermissionStatus).mockReturnValue('denied')
+
+    const { result } = renderHook(() => useCameraPermissionFlow())
+
+    expect(result.current.permission).toBe('denied')
+  })
+
+  it('updates permission state after requestPermission resolves', async () => {
+    jest.mocked(Camera.requestCameraPermission).mockResolvedValue('granted')
+
+    const { result } = renderHook(() => useCameraPermissionFlow())
+
+    await act(async () => {
+      await result.current.requestPermission()
+    })
+
+    expect(result.current.permission).toBe('granted')
+  })
+
+  it('does NOT call Linking.openSettings as a side effect of denial', async () => {
+    jest.mocked(Camera.requestCameraPermission).mockResolvedValue('denied')
+
+    const { result } = renderHook(() => useCameraPermissionFlow())
+
+    await act(async () => {
+      await result.current.requestPermission()
+    })
+
+    expect(result.current.permission).toBe('denied')
+    expect(Linking.openSettings).not.toHaveBeenCalled()
+  })
+
+  it('opens Settings only when openSettings is called explicitly', () => {
+    const { result } = renderHook(() => useCameraPermissionFlow())
+
+    act(() => {
+      result.current.openSettings()
+    })
+
+    expect(Linking.openSettings).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mobile/src/components/Camera/useCameraPermissionFlow.ts
+++ b/apps/mobile/src/components/Camera/useCameraPermissionFlow.ts
@@ -1,0 +1,33 @@
+import { useCallback, useState } from 'react'
+import { Linking } from 'react-native'
+import { useFocusEffect } from 'expo-router'
+import { Camera, CameraPermissionStatus } from 'react-native-vision-camera'
+
+/**
+ * Owns the camera permission state for a screen and exposes the only sanctioned
+ * paths to request permission and to open Settings. Callers must never invoke
+ * `openSettings` as a side effect of `requestPermission` resolving with
+ * `'denied'` — Apple guideline 5.1.1(iv) forbids redirecting the user to
+ * Settings immediately after they deny the OS prompt.
+ */
+export const useCameraPermissionFlow = () => {
+  const [permission, setPermission] = useState<CameraPermissionStatus>(() => Camera.getCameraPermissionStatus())
+
+  useFocusEffect(
+    useCallback(() => {
+      setPermission(Camera.getCameraPermissionStatus())
+    }, []),
+  )
+
+  const requestPermission = useCallback(async () => {
+    const next = await Camera.requestCameraPermission()
+    setPermission(next)
+    return next
+  }, [])
+
+  const openSettings = useCallback(() => {
+    void Linking.openSettings()
+  }, [])
+
+  return { permission, requestPermission, openSettings }
+}

--- a/apps/mobile/src/features/ImportReadOnly/ScanQrAccount.container.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/ScanQrAccount.container.tsx
@@ -1,14 +1,13 @@
-import { Camera, useCameraPermission } from 'react-native-vision-camera'
 import React, { useCallback } from 'react'
 import { useRouter } from 'expo-router'
 
 import { QrCameraView } from '@/src/features/ImportReadOnly/components/ScanQrAccountView'
 import { useScan } from '@/src/features/ImportReadOnly/hooks/useScan'
+import { useCameraPermissionFlow } from '@/src/components/Camera/useCameraPermissionFlow'
 
 export const ScanQrAccountContainer = () => {
   const router = useRouter()
-  const permission = Camera.getCameraPermissionStatus()
-  const { hasPermission } = useCameraPermission()
+  const { permission, requestPermission, openSettings } = useCameraPermissionFlow()
   const { onScan, isCameraActive, setIsCameraActive } = useScan()
 
   const onEnterManuallyPress = useCallback(async () => {
@@ -17,15 +16,16 @@ export const ScanQrAccountContainer = () => {
 
   const handleActivateCamera = useCallback(() => {
     setIsCameraActive(true)
-  }, [])
+  }, [setIsCameraActive])
 
   return (
     <QrCameraView
       permission={permission}
-      hasPermission={hasPermission}
       isCameraActive={isCameraActive}
       onScan={onScan}
       onActivateCamera={handleActivateCamera}
+      onRequestPermission={requestPermission}
+      onPressSettings={openSettings}
       onEnterManuallyPress={onEnterManuallyPress}
     />
   )

--- a/apps/mobile/src/features/ImportReadOnly/components/ScanQrAccountView.tsx
+++ b/apps/mobile/src/features/ImportReadOnly/components/ScanQrAccountView.tsx
@@ -11,8 +11,35 @@ type QrCameraViewProps = {
   isCameraActive: boolean
   onScan: (codes: Code[]) => void
   onEnterManuallyPress: () => void
-  hasPermission: boolean
   onActivateCamera: () => void
+  onRequestPermission: () => void | Promise<unknown>
+  onPressSettings: () => void
+}
+
+const headingForPermission = (permission: CameraPermissionStatus): string => {
+  switch (permission) {
+    case 'denied':
+      return 'Camera access is off'
+    case 'restricted':
+      return 'Camera access is restricted'
+    case 'not-determined':
+      return 'Allow camera access'
+    default:
+      return 'Scan a QR code'
+  }
+}
+
+const bodyForPermission = (permission: CameraPermissionStatus): string => {
+  switch (permission) {
+    case 'denied':
+      return 'Enable camera access to scan QR codes for adding Safe Accounts and connecting wallets. You can change this in Settings.'
+    case 'restricted':
+      return 'Camera access is disabled by a device restriction. If you manage this device, you can change it in Settings.'
+    case 'not-determined':
+      return 'Safe needs camera access to scan QR codes for adding Safe Accounts and connecting wallets.'
+    default:
+      return 'Scan the QR code of the account you want to import. You can find it under Receive or in the sidebar.'
+  }
 }
 
 export const QrCameraView = ({
@@ -20,24 +47,22 @@ export const QrCameraView = ({
   isCameraActive,
   onScan,
   onEnterManuallyPress,
-  hasPermission,
   onActivateCamera,
+  onRequestPermission,
+  onPressSettings,
 }: QrCameraViewProps) => (
   <>
     <QrCamera
       permission={permission}
-      hasPermission={hasPermission}
       isCameraActive={isCameraActive}
       onScan={onScan}
       onActivateCamera={onActivateCamera}
-      heading={permission === 'denied' ? 'Camera access disabled' : 'Scan a QR code'}
+      onRequestPermission={onRequestPermission}
+      onPressSettings={onPressSettings}
+      heading={headingForPermission(permission)}
       footer={
         <>
-          <Text textAlign={'center'}>
-            {permission === 'denied'
-              ? 'Enabling camera will allow you to scan QR codes to import existing Safe Accounts and join new ones with a mobile signer.'
-              : 'Scan the QR code of the account you want to import. You can find it under Receive or in the sidebar.'}
-          </Text>
+          <Text textAlign="center">{bodyForPermission(permission)}</Text>
           <View alignItems="center" marginTop="$5">
             <SafeButton
               secondary

--- a/apps/mobile/src/features/Send/ScanQrSend.container.tsx
+++ b/apps/mobile/src/features/Send/ScanQrSend.container.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react'
 import { Text } from 'tamagui'
-import { Camera, Code, useCameraPermission } from 'react-native-vision-camera'
+import { Code } from 'react-native-vision-camera'
 import { useRouter } from 'expo-router'
 import { useFocusEffect } from 'expo-router'
 import { parsePrefixedAddress } from '@safe-global/utils/utils/addresses'
@@ -8,6 +8,7 @@ import { isValidAddress } from '@safe-global/utils/utils/validation'
 import { useToastController } from '@tamagui/toast'
 import { ToastViewport } from '@tamagui/toast'
 import { QrCamera } from '@/src/components/Camera'
+import { useCameraPermissionFlow } from '@/src/components/Camera/useCameraPermissionFlow'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectActiveChain } from '@/src/store/chains'
 
@@ -15,10 +16,35 @@ function isChainMismatch(prefix: string | undefined, activeShortName: string | u
   return Boolean(prefix && activeShortName && prefix !== activeShortName)
 }
 
+const headingForPermission = (permission: ReturnType<typeof useCameraPermissionFlow>['permission']): string => {
+  switch (permission) {
+    case 'denied':
+      return 'Camera access is off'
+    case 'restricted':
+      return 'Camera access is restricted'
+    case 'not-determined':
+      return 'Allow camera access'
+    default:
+      return 'Scan an address'
+  }
+}
+
+const bodyForPermission = (permission: ReturnType<typeof useCameraPermissionFlow>['permission']): string => {
+  switch (permission) {
+    case 'denied':
+      return 'Enable camera access to scan an Ethereum wallet address. You can change this in Settings.'
+    case 'restricted':
+      return 'Camera access is disabled by a device restriction. If you manage this device, you can change it in Settings.'
+    case 'not-determined':
+      return 'Safe needs camera access to scan an Ethereum wallet address.'
+    default:
+      return 'Scan an Ethereum wallet address to continue'
+  }
+}
+
 export function ScanQrSendContainer() {
   const router = useRouter()
-  const permission = Camera.getCameraPermissionStatus()
-  const { hasPermission } = useCameraPermission()
+  const { permission, requestPermission, openSettings } = useCameraPermissionFlow()
   const hasScanned = useRef(false)
   const toastForValueShown = useRef<Set<string>>(new Set())
   const [isCameraActive, setIsCameraActive] = useState(false)
@@ -26,7 +52,7 @@ export function ScanQrSendContainer() {
   const activeChain = useAppSelector(selectActiveChain)
 
   const handleFocusEffect = useCallback(() => {
-    if (!hasPermission) {
+    if (permission !== 'granted') {
       return
     }
 
@@ -36,7 +62,7 @@ export function ScanQrSendContainer() {
     return () => {
       setIsCameraActive(false)
     }
-  }, [hasPermission])
+  }, [permission])
 
   useFocusEffect(handleFocusEffect)
 
@@ -108,12 +134,13 @@ export function ScanQrSendContainer() {
     <>
       <QrCamera
         permission={permission}
-        hasPermission={hasPermission}
         isCameraActive={isCameraActive}
         onScan={onScan}
         onActivateCamera={handleActivateCamera}
-        heading="Scan an address"
-        footer={<Text textAlign="center">Scan an Ethereum wallet address to continue</Text>}
+        onRequestPermission={requestPermission}
+        onPressSettings={openSettings}
+        heading={headingForPermission(permission)}
+        footer={<Text textAlign="center">{bodyForPermission(permission)}</Text>}
       />
       <ToastViewport multipleToasts={false} left={0} right={0} />
     </>


### PR DESCRIPTION
> Tap "Don't Allow",
> stay on screen, no redirect —
> Settings on user tap.

## What it solves

Resolves [WA-2229](https://linear.app/safe-global/issue/WA-2229) — App Store rejection of mobile build 1.0.12 (39) under guideline **5.1.1(iv) Privacy / Data Collection and Storage**.

After the user tapped **"Don't Allow"** on the iOS camera permission system prompt, the app immediately called `Linking.openSettings()`, redirecting them to Settings. Apple requires the denial to be respected in the moment; an "Open Settings" affordance is only allowed later, when the user actively tries to use a camera-gated feature, and only as an explicit, user-tapped button.


## How this PR fixes it

- **New** [`useCameraPermissionFlow`](apps/mobile/src/components/Camera/useCameraPermissionFlow.ts) hook owns permission state and exposes `requestPermission` and `openSettings` as **separate** callables. `openSettings` is never invoked as a side effect — only ever from a button `onPress`. Permission state refreshes via `useFocusEffect` so the Settings round-trip transitions naturally.
- **Refactor** [`QrCamera`](apps/mobile/src/components/Camera/QrCamera.tsx) so the in-lens button is permission-aware via a `getLensButtonConfig` helper:

  | Permission | Button label | Action |
  |---|---|---|
  | `not-determined` | Continue | `requestPermission()` (triggers OS prompt) |
  | `denied` / `restricted` | Open Settings | `openSettings()` (only path to `Linking.openSettings`) |
  | `granted` + inactive | Continue | activate camera |
  | `granted` + active | — | live scanner |

- **Update** both QR scan containers ([ImportReadOnly](apps/mobile/src/features/ImportReadOnly/ScanQrAccount.container.tsx), [Send](apps/mobile/src/features/Send/ScanQrSend.container.tsx)) to use the new hook, with per-state explainer copy.
- **Drop** redundant `hasPermission` prop; derive from `permission === 'granted'`.

The new test [`useCameraPermissionFlow.test.ts`](apps/mobile/src/components/Camera/useCameraPermissionFlow.test.ts) asserts the core compliance invariant: a `request → 'denied'` resolution **does not** call `Linking.openSettings`.

## How to test it

1. Fresh-install on an iOS device or simulator.
2. Navigate to **Add a Safe → Scan QR**. The pre-prompt explainer renders ("Allow camera access" + "Continue").
3. Tap **Continue** → OS permission prompt appears.
4. Tap **"Don't Allow"**.
   - ✅ App should remain on the QR camera screen, with copy updated to "Camera access is off" and a clearly labeled **"Open Settings"** button.
   - ❌ Pre-fix behaviour: app silently redirects to Settings.
5. Tap **Open Settings** → iOS Settings opens (this is allowed because it's an explicit user tap).
6. Toggle camera permission ON and return to the app.
   - The screen re-evaluates permission via `useFocusEffect` and transitions to the live camera.
7. Repeat for **Send → Scan QR address**.

## Affected flows

- **Add a Safe via QR scan** (Import Read-Only): pre-prompt → OS prompt → granted/denied/restricted UI.
- **Send → Scan an address**: same flow.

## Blast radius

- `apps/mobile/src/components/Camera/QrCamera.tsx` — props changed: `hasPermission` removed, `onRequestPermission` and `onPressSettings` added. Consumers updated in this PR (only two: `ScanQrAccount.container` via `ScanQrAccountView`, and `ScanQrSend.container`).
- `apps/mobile/src/components/Camera/index.ts` — re-exports the new hook.
- `useScan` is **not** modified — it consumes `useCameraPermission()` from `react-native-vision-camera` for camera-active gating, which is independent of the permission UI flow.
- No shared package, no Redux slice, no RTK Query endpoint, no chain config touched.
- Web app unaffected.


## Visual summary

Permission-state machine driving the in-lens button:

```mermaid
stateDiagram-v2
    [*] --> NotDetermined: first visit
    NotDetermined --> Granted: Continue → OS prompt → "OK"
    NotDetermined --> Denied: Continue → OS prompt → "Don't Allow"
    NotDetermined --> Restricted: device-level restriction

    Denied --> [*]: user taps "Open Settings"
    Restricted --> [*]: user taps "Open Settings"

    Granted --> Active: focus / Continue
    Active --> Granted: navigate away

    note right of Denied
      Pre-fix: auto-redirect to Settings here
      (Apple 5.1.1(iv) violation)

      Post-fix: stays on screen,
      explicit "Open Settings" button
    end note
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — `useCameraPermissionFlow.test.ts` covers the core invariant
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

---
[\![Safe Engineering](https://img.shields.io/badge/Safe-Engineering-12ff80)](https://github.com/5afe/safe-engineering-plugin) Generated with [Claude Code](https://claude.com/claude-code)