### PR TITLE
fix(mobile): never auto-redirect to Settings on biometrics toggle (WA-2239)

### DIFF
--- a/apps/mobile/src/app/biometrics-opt-in.tsx
+++ b/apps/mobile/src/app/biometrics-opt-in.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react'
-import { Platform } from 'react-native'
+import { Alert, Platform } from 'react-native'
 import { useTheme } from '@/src/theme/hooks/useTheme'
 import { OptIn } from '@/src/components/OptIn'
 import { router, useLocalSearchParams } from 'expo-router'
@@ -10,7 +10,8 @@ import { View } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 function BiometricsOptIn() {
-  const { toggleBiometrics, getBiometricsUIInfo, isBiometricsEnabled, isLoading } = useBiometrics()
+  const { toggleBiometrics, openBiometricSettings, getBiometricsUIInfo, isBiometricsEnabled, isLoading } =
+    useBiometrics()
   const { bottom } = useSafeAreaInsets()
   const local = useLocalSearchParams<{
     txId: string
@@ -57,7 +58,20 @@ function BiometricsOptIn() {
 
   const handleAccept = async () => {
     try {
-      await toggleBiometrics(true)
+      const result = await toggleBiometrics(true)
+      if (result.status === 'os-not-configured') {
+        Alert.alert(
+          'Set up biometrics',
+          Platform.OS === 'ios'
+            ? 'Set up Face ID or Touch ID in iOS Settings to enable biometrics in Safe.'
+            : 'Set up fingerprint in your device Settings to enable biometrics in Safe.',
+          [
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'Open Settings', onPress: openBiometricSettings },
+          ],
+          { cancelable: true },
+        )
+      }
     } catch (error) {
       Logger.error('Error enabling biometrics', error)
       toast.show('Error enabling biometrics', {

--- a/apps/mobile/src/app/biometrics-opt-in.tsx
+++ b/apps/mobile/src/app/biometrics-opt-in.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react'
-import { Alert, Platform } from 'react-native'
+import { Platform } from 'react-native'
 import { useTheme } from '@/src/theme/hooks/useTheme'
 import { OptIn } from '@/src/components/OptIn'
 import { router, useLocalSearchParams } from 'expo-router'
@@ -10,7 +10,7 @@ import { View } from 'tamagui'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 function BiometricsOptIn() {
-  const { toggleBiometrics, openBiometricSettings, getBiometricsUIInfo, isBiometricsEnabled, isLoading } =
+  const { toggleBiometrics, promptBiometricsSetup, getBiometricsUIInfo, isBiometricsEnabled, isLoading } =
     useBiometrics()
   const { bottom } = useSafeAreaInsets()
   const local = useLocalSearchParams<{
@@ -60,17 +60,13 @@ function BiometricsOptIn() {
     try {
       const result = await toggleBiometrics(true)
       if (result.status === 'os-not-configured') {
-        Alert.alert(
-          'Set up biometrics',
-          Platform.OS === 'ios'
-            ? 'Set up Face ID or Touch ID in iOS Settings to enable biometrics in Safe.'
-            : 'Set up fingerprint in your device Settings to enable biometrics in Safe.',
-          [
-            { text: 'Cancel', style: 'cancel' },
-            { text: 'Open Settings', onPress: openBiometricSettings },
-          ],
-          { cancelable: true },
-        )
+        promptBiometricsSetup()
+      } else if (result.status === 'error') {
+        Logger.error('Error enabling biometrics:', result.error)
+        toast.show('Error enabling biometrics', {
+          native: false,
+          duration: 2000,
+        })
       }
     } catch (error) {
       Logger.error('Error enabling biometrics', error)

--- a/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
+++ b/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
@@ -10,6 +10,7 @@ import { SafeFontIcon as Icon } from '@/src/components/SafeFontIcon/SafeFontIcon
 import { FloatingMenu } from '../FloatingMenu'
 import { LoadableSwitch } from '@/src/components/LoadableSwitch'
 import { useBiometrics } from '@/src/hooks/useBiometrics'
+import Logger from '@/src/utils/logger'
 import { useNotificationManager } from '@/src/hooks/useNotificationManager'
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks'
 import { selectAppNotificationStatus } from '@/src/store/notificationsSlice'
@@ -22,7 +23,7 @@ export const AppSettingsContainer = () => {
   const dispatch = useAppDispatch()
   const {
     toggleBiometrics,
-    openBiometricSettings,
+    promptBiometricsSetup,
     isBiometricsEnabled,
     isLoading: isBiometricsLoading,
     getBiometricsUIInfo,
@@ -43,17 +44,10 @@ export const AppSettingsContainer = () => {
   const handleToggleBiometrics = async () => {
     const result = await toggleBiometrics(!isBiometricsEnabled)
     if (result.status === 'os-not-configured') {
-      Alert.alert(
-        'Set up biometrics',
-        Platform.OS === 'ios'
-          ? 'Set up Face ID or Touch ID in iOS Settings to enable biometrics in Safe.'
-          : 'Set up fingerprint in your device Settings to enable biometrics in Safe.',
-        [
-          { text: 'Cancel', style: 'cancel' },
-          { text: 'Open Settings', onPress: openBiometricSettings },
-        ],
-        { cancelable: true },
-      )
+      promptBiometricsSetup()
+    } else if (result.status === 'error') {
+      Logger.error('Biometrics toggle failed:', result.error)
+      Alert.alert('Biometrics error', 'Something went wrong. Please try again.', [{ text: 'OK' }])
     }
   }
 

--- a/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
+++ b/apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx
@@ -20,7 +20,13 @@ import { clearAllPendingTxs } from '@/src/store/pendingTxsSlice'
 
 export const AppSettingsContainer = () => {
   const dispatch = useAppDispatch()
-  const { toggleBiometrics, isBiometricsEnabled, isLoading: isBiometricsLoading, getBiometricsUIInfo } = useBiometrics()
+  const {
+    toggleBiometrics,
+    openBiometricSettings,
+    isBiometricsEnabled,
+    isLoading: isBiometricsLoading,
+    getBiometricsUIInfo,
+  } = useBiometrics()
   const { enableNotification, disableNotification, isLoading: isNotificationsLoading } = useNotificationManager()
   const isAppNotificationEnabled = useAppSelector(selectAppNotificationStatus)
   const currency = useAppSelector(selectCurrency)
@@ -31,6 +37,23 @@ export const AppSettingsContainer = () => {
       disableNotification()
     } else {
       enableNotification()
+    }
+  }
+
+  const handleToggleBiometrics = async () => {
+    const result = await toggleBiometrics(!isBiometricsEnabled)
+    if (result.status === 'os-not-configured') {
+      Alert.alert(
+        'Set up biometrics',
+        Platform.OS === 'ios'
+          ? 'Set up Face ID or Touch ID in iOS Settings to enable biometrics in Safe.'
+          : 'Set up fingerprint in your device Settings to enable biometrics in Safe.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Open Settings', onPress: openBiometricSettings },
+        ],
+        { cancelable: true },
+      )
     }
   }
 
@@ -116,7 +139,7 @@ export const AppSettingsContainer = () => {
           rightNode: (
             <LoadableSwitch
               testID="toggle-app-biometrics"
-              onChange={() => toggleBiometrics(!isBiometricsEnabled)}
+              onChange={handleToggleBiometrics}
               value={isBiometricsEnabled}
               isLoading={isBiometricsLoading}
               trackColor={{ true: '$primary' }}

--- a/apps/mobile/src/hooks/useBiometrics.test.ts
+++ b/apps/mobile/src/hooks/useBiometrics.test.ts
@@ -2,7 +2,7 @@ import { act, waitFor } from '@testing-library/react-native'
 import { renderHook, type TestStore } from '@/src/tests/test-utils'
 import { useBiometrics } from './useBiometrics'
 import * as Keychain from 'react-native-keychain'
-import { Linking } from 'react-native'
+import { Alert, Linking } from 'react-native'
 
 const mockGetSupportedBiometryType = Keychain.getSupportedBiometryType as jest.Mock
 const mockSetGenericPassword = Keychain.setGenericPassword as jest.Mock
@@ -236,7 +236,8 @@ describe('useBiometrics', () => {
 
     it('handles unexpected errors during biometrics setup', async () => {
       mockGetSupportedBiometryType.mockResolvedValue(Keychain.BIOMETRY_TYPE.FACE_ID)
-      mockSetGenericPassword.mockRejectedValue(new Error('Unexpected storage error'))
+      const thrown = new Error('Unexpected storage error')
+      mockSetGenericPassword.mockRejectedValue(thrown)
       mockResetGenericPassword.mockResolvedValue(true)
 
       const hookResult = renderHook(() => useBiometrics())
@@ -244,7 +245,7 @@ describe('useBiometrics', () => {
 
       await act(async () => {
         const returnValue = await hookResult.result.current.toggleBiometrics(true)
-        expect(returnValue).toMatchObject({ status: 'error' })
+        expect(returnValue).toEqual({ status: 'error', error: thrown })
       })
 
       expect(store.getState().biometrics.isEnabled).toBe(false)
@@ -261,8 +262,65 @@ describe('useBiometrics', () => {
 
       await act(async () => {
         const returnValue = await result.current.toggleBiometrics(true)
-        expect(returnValue).toMatchObject({ status: 'error' })
+        expect(returnValue).toEqual({
+          status: 'error',
+          error: expect.objectContaining({ message: 'Failed to verify biometrics setup' }),
+        })
       })
+    })
+
+    it('returns error when disable fails to reset the keychain', async () => {
+      const resetError = new Error('Keychain unavailable')
+      mockResetGenericPassword.mockRejectedValue(resetError)
+
+      const hookResult = renderHook(() => useBiometrics(), {
+        biometrics: { isEnabled: true, isSupported: true, type: 'FACE_ID', userAttempts: 0 },
+      })
+      const store = hookResult.store as TestStore
+
+      await act(async () => {
+        const returnValue = await hookResult.result.current.toggleBiometrics(false)
+        expect(returnValue).toEqual({ status: 'error', error: resetError })
+      })
+
+      // Redux still flips to disabled to match user intent.
+      expect(store.getState().biometrics.isEnabled).toBe(false)
+    })
+  })
+
+  describe('promptBiometricsSetup', () => {
+    it('shows an Alert with explicit Cancel and Open Settings buttons', () => {
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn())
+      const { result } = renderHook(() => useBiometrics())
+
+      result.current.promptBiometricsSetup()
+
+      expect(alertSpy).toHaveBeenCalledTimes(1)
+      const [, , buttons] = alertSpy.mock.calls[0]
+      expect(buttons).toEqual([
+        expect.objectContaining({ text: 'Cancel', style: 'cancel' }),
+        expect.objectContaining({ text: 'Open Settings' }),
+      ])
+
+      alertSpy.mockRestore()
+    })
+
+    it('only invokes Linking when the user taps Open Settings', () => {
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn())
+      const openURLSpy = jest.spyOn(Linking, 'openURL').mockImplementation(jest.fn())
+      const { result } = renderHook(() => useBiometrics())
+
+      result.current.promptBiometricsSetup()
+      expect(openURLSpy).not.toHaveBeenCalled()
+
+      // Simulate the user tapping the Open Settings button.
+      const buttons = alertSpy.mock.calls[0][2] as { text: string; onPress?: () => void }[]
+      buttons.find((b) => b.text === 'Open Settings')?.onPress?.()
+
+      expect(openURLSpy).toHaveBeenCalledWith('app-settings:')
+
+      alertSpy.mockRestore()
+      openURLSpy.mockRestore()
     })
   })
 

--- a/apps/mobile/src/hooks/useBiometrics.test.ts
+++ b/apps/mobile/src/hooks/useBiometrics.test.ts
@@ -113,7 +113,8 @@ describe('useBiometrics', () => {
       const store = hookResult.store as TestStore
 
       await act(async () => {
-        await hookResult.result.current.toggleBiometrics(true)
+        const returnValue = await hookResult.result.current.toggleBiometrics(true)
+        expect(returnValue).toEqual({ status: 'enabled' })
       })
 
       await waitFor(() => {
@@ -130,7 +131,8 @@ describe('useBiometrics', () => {
       const store = hookResult.store as TestStore
 
       await act(async () => {
-        await hookResult.result.current.toggleBiometrics(false)
+        const returnValue = await hookResult.result.current.toggleBiometrics(false)
+        expect(returnValue).toEqual({ status: 'disabled' })
       })
 
       await waitFor(() => {
@@ -152,7 +154,7 @@ describe('useBiometrics', () => {
 
       await act(async () => {
         const returnValue = await hookResult.result.current.toggleBiometrics(true)
-        expect(returnValue).toBe(false)
+        expect(returnValue).toEqual({ status: 'cancelled' })
       })
 
       await waitFor(() => {
@@ -172,7 +174,7 @@ describe('useBiometrics', () => {
 
       await act(async () => {
         const returnValue = await result.current.toggleBiometrics(true)
-        expect(returnValue).toBe(false)
+        expect(returnValue).toEqual({ status: 'cancelled' })
       })
     })
 
@@ -188,7 +190,7 @@ describe('useBiometrics', () => {
 
       await act(async () => {
         const returnValue = await result.current.toggleBiometrics(true)
-        expect(returnValue).toBe(false)
+        expect(returnValue).toEqual({ status: 'cancelled' })
       })
     })
 
@@ -204,21 +206,32 @@ describe('useBiometrics', () => {
 
       await act(async () => {
         const returnValue = await result.current.toggleBiometrics(true)
-        expect(returnValue).toBe(false)
+        expect(returnValue).toEqual({ status: 'cancelled' })
       })
     })
 
-    it('does not enable when biometrics is not supported', async () => {
+    it('returns os-not-configured when biometrics is not available, without redirecting to Settings', async () => {
+      // Compliance invariant: enabling biometrics must NEVER call Linking.openURL or
+      // Linking.openSettings as a side effect. The caller renders an in-app explainer
+      // with an explicit "Open Settings" button.
       mockGetSupportedBiometryType.mockResolvedValue(null)
+      const openURLSpy = jest.spyOn(Linking, 'openURL').mockImplementation(jest.fn())
+      const openSettingsSpy = jest.spyOn(Linking, 'openSettings').mockImplementation(jest.fn())
 
       const hookResult = renderHook(() => useBiometrics())
       const store = hookResult.store as TestStore
 
       await act(async () => {
-        await hookResult.result.current.toggleBiometrics(true)
+        const returnValue = await hookResult.result.current.toggleBiometrics(true)
+        expect(returnValue).toEqual({ status: 'os-not-configured' })
       })
 
       expect(store.getState().biometrics.isEnabled).toBe(false)
+      expect(openURLSpy).not.toHaveBeenCalled()
+      expect(openSettingsSpy).not.toHaveBeenCalled()
+
+      openURLSpy.mockRestore()
+      openSettingsSpy.mockRestore()
     })
 
     it('handles unexpected errors during biometrics setup', async () => {
@@ -231,7 +244,7 @@ describe('useBiometrics', () => {
 
       await act(async () => {
         const returnValue = await hookResult.result.current.toggleBiometrics(true)
-        expect(returnValue).toBe(false)
+        expect(returnValue).toMatchObject({ status: 'error' })
       })
 
       expect(store.getState().biometrics.isEnabled).toBe(false)
@@ -248,7 +261,7 @@ describe('useBiometrics', () => {
 
       await act(async () => {
         const returnValue = await result.current.toggleBiometrics(true)
-        expect(returnValue).toBe(false)
+        expect(returnValue).toMatchObject({ status: 'error' })
       })
     })
   })
@@ -278,6 +291,27 @@ describe('useBiometrics', () => {
       await waitFor(() => {
         expect(store.getState().biometrics.isEnabled).toBe(false)
       })
+    })
+
+    it('does not redirect to Settings when OS-level biometrics is disabled on mount', async () => {
+      // Background re-evaluation must not auto-redirect either.
+      mockGetSupportedBiometryType.mockResolvedValue(null)
+      mockResetGenericPassword.mockResolvedValue(true)
+      const openURLSpy = jest.spyOn(Linking, 'openURL').mockImplementation(jest.fn())
+      const openSettingsSpy = jest.spyOn(Linking, 'openSettings').mockImplementation(jest.fn())
+
+      renderHook(() => useBiometrics(), {
+        biometrics: { isEnabled: true, isSupported: true, type: 'FACE_ID', userAttempts: 0 },
+      })
+
+      await waitFor(() => {
+        expect(mockResetGenericPassword).toHaveBeenCalled()
+      })
+      expect(openURLSpy).not.toHaveBeenCalled()
+      expect(openSettingsSpy).not.toHaveBeenCalled()
+
+      openURLSpy.mockRestore()
+      openSettingsSpy.mockRestore()
     })
   })
 })

--- a/apps/mobile/src/hooks/useBiometrics.ts
+++ b/apps/mobile/src/hooks/useBiometrics.ts
@@ -13,6 +13,14 @@ import { RootState } from '../store'
 
 const BIOMETRICS_KEY = 'SAFE_WALLET_BIOMETRICS'
 
+export type EnableBiometricsResult =
+  | { status: 'enabled' }
+  | { status: 'os-not-configured' }
+  | { status: 'cancelled' }
+  | { status: 'error'; error: unknown }
+
+export type ToggleBiometricsResult = EnableBiometricsResult | { status: 'disabled' }
+
 export function useBiometrics() {
   const dispatch = useAppDispatch()
   const [isLoading, setIsLoading] = useState(false)
@@ -84,7 +92,7 @@ export function useBiometrics() {
     }
   }, [])
 
-  const disableBiometrics = useCallback(async () => {
+  const disableBiometrics = useCallback(async (): Promise<{ status: 'disabled' }> => {
     setIsLoading(true)
     try {
       await Keychain.resetGenericPassword()
@@ -94,87 +102,78 @@ export function useBiometrics() {
     } finally {
       setIsLoading(false)
     }
+    return { status: 'disabled' }
   }, [])
 
-  const enableBiometrics = useCallback(
-    async (fromInteraction?: boolean) => {
-      setIsLoading(true)
+  const enableBiometrics = useCallback(async (): Promise<EnableBiometricsResult> => {
+    setIsLoading(true)
+
+    try {
+      const isSupported = await checkBiometricsSupport()
+      const { biometricsEnabled: isEnabledAtOSLevel } = await checkBiometricsOSSettingsStatus()
+
+      // Biometrics not available at OS level (no hardware or not enrolled).
+      // Surface the outcome to the caller — never auto-redirect to system Settings here.
+      // The caller decides whether to show an explainer with an explicit "Open Settings" button.
+      if (!isSupported || !isEnabledAtOSLevel) {
+        dispatch(setBiometricsEnabled(false))
+        return { status: 'os-not-configured' }
+      }
 
       try {
-        const isSupported = await checkBiometricsSupport()
-        const { biometricsEnabled: isEnabledAtOSLevel } = await checkBiometricsOSSettingsStatus()
+        // Wrap the biometrics operations in a nested try-catch to allow for user cancellation
+        const setGenericPasswordResult = await Keychain.setGenericPassword(BIOMETRICS_KEY, 'biometrics-enabled', {
+          accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_ANY,
+          accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED,
+        })
 
-        if (!isSupported || !isEnabledAtOSLevel) {
-          dispatch(setBiometricsEnabled(false))
-
-          if (fromInteraction) {
-            return openBiometricSettings()
-          }
-        }
-
-        try {
-          // Wrap the biometrics operations in a nested try-catch to allow for user cancellation
-          const setGenericPasswordResult = await Keychain.setGenericPassword(BIOMETRICS_KEY, 'biometrics-enabled', {
+        if (setGenericPasswordResult) {
+          const getGenericPasswordResult = await Keychain.getGenericPassword({
             accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_ANY,
-            accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED,
           })
 
-          if (setGenericPasswordResult) {
-            const getGenericPasswordResult = await Keychain.getGenericPassword({
-              accessControl: Keychain.ACCESS_CONTROL.BIOMETRY_ANY,
-            })
-
-            if (getGenericPasswordResult) {
-              dispatch(setBiometricsEnabled(true))
-              dispatch(setUserAttempts(0))
-              return true
-            }
+          if (getGenericPasswordResult) {
+            dispatch(setBiometricsEnabled(true))
+            dispatch(setUserAttempts(0))
+            return { status: 'enabled' }
           }
-
-          // If we get here, something went wrong with setting or getting the password
-          throw new Error('Failed to verify biometrics setup')
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (biometricsError: any) {
-          // Handle user cancellation specifically
-          if (
-            biometricsError.code === '-128' || // User pressed Cancel
-            biometricsError.code === 'AuthenticationFailed' ||
-            biometricsError.message.includes('cancel') ||
-            biometricsError.message.includes('user name or passphrase')
-          ) {
-            Keychain.resetGenericPassword().then(() => {
-              dispatch(setUserAttempts(userAttempts + 1))
-            })
-            dispatch(setBiometricsEnabled(false))
-            return false
-          }
-          // Re-throw other errors
-          throw biometricsError
         }
-      } catch (error) {
-        Logger.error('Unexpected error in biometrics setup:', error)
-        await Keychain.resetGenericPassword()
-        dispatch(setBiometricsEnabled(false))
-        return false
-      } finally {
-        setIsLoading(false)
+
+        // If we get here, something went wrong with setting or getting the password
+        throw new Error('Failed to verify biometrics setup')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (biometricsError: any) {
+        // Handle user cancellation specifically
+        if (
+          biometricsError.code === '-128' || // User pressed Cancel
+          biometricsError.code === 'AuthenticationFailed' ||
+          biometricsError.message.includes('cancel') ||
+          biometricsError.message.includes('user name or passphrase')
+        ) {
+          Keychain.resetGenericPassword().then(() => {
+            dispatch(setUserAttempts(userAttempts + 1))
+          })
+          dispatch(setBiometricsEnabled(false))
+          return { status: 'cancelled' }
+        }
+        // Re-throw other errors
+        throw biometricsError
       }
-    },
-    [checkBiometricsSupport, userAttempts],
-  )
+    } catch (error) {
+      Logger.error('Unexpected error in biometrics setup:', error)
+      await Keychain.resetGenericPassword()
+      dispatch(setBiometricsEnabled(false))
+      return { status: 'error', error }
+    } finally {
+      setIsLoading(false)
+    }
+  }, [checkBiometricsSupport, checkBiometricsOSSettingsStatus, userAttempts])
 
   const toggleBiometrics = useCallback(
-    async (newValue: boolean, fromInteraction: boolean) => {
-      return newValue ? enableBiometrics(fromInteraction) : disableBiometrics()
+    async (newValue: boolean): Promise<ToggleBiometricsResult> => {
+      return newValue ? enableBiometrics() : disableBiometrics()
     },
     [enableBiometrics, disableBiometrics],
-  )
-
-  const toggleBiometricsFromUser = useCallback(
-    async (newValue: boolean) => {
-      return toggleBiometrics(newValue, true)
-    },
-    [toggleBiometrics],
   )
 
   const getBiometricsUIInfo = useCallback(() => {
@@ -202,7 +201,7 @@ export function useBiometrics() {
   }, [])
 
   return {
-    toggleBiometrics: toggleBiometricsFromUser,
+    toggleBiometrics,
     openBiometricSettings,
     isBiometricsEnabled: isEnabled,
     biometricsType,

--- a/apps/mobile/src/hooks/useBiometrics.ts
+++ b/apps/mobile/src/hooks/useBiometrics.ts
@@ -27,10 +27,6 @@ export function useBiometrics() {
   const dispatch = useAppDispatch()
   const [isLoading, setIsLoading] = useState(false)
 
-  // This hasInteracted ref is used to prevent the biometrics from being enabled/disabled
-  // even when the app is in background then comes back to foreground
-  // with biometrics enabled and the app settings was disabled
-  // and the user has not interacted with config
   const isEnabled = useAppSelector((state: RootState) => state.biometrics.isEnabled)
   const biometricsType = useAppSelector((state: RootState) => state.biometrics.type)
   const userAttempts = useAppSelector((state: RootState) => state.biometrics.userAttempts)

--- a/apps/mobile/src/hooks/useBiometrics.ts
+++ b/apps/mobile/src/hooks/useBiometrics.ts
@@ -7,7 +7,7 @@ import {
   setBiometricsType,
   setUserAttempts,
 } from '@/src/store/biometricsSlice'
-import { Platform, Linking } from 'react-native'
+import { Alert, Platform, Linking } from 'react-native'
 import Logger from '@/src/utils/logger'
 import { RootState } from '../store'
 
@@ -19,7 +19,9 @@ export type EnableBiometricsResult =
   | { status: 'cancelled' }
   | { status: 'error'; error: unknown }
 
-export type ToggleBiometricsResult = EnableBiometricsResult | { status: 'disabled' }
+export type DisableBiometricsResult = { status: 'disabled' } | { status: 'error'; error: unknown }
+
+export type ToggleBiometricsResult = EnableBiometricsResult | DisableBiometricsResult
 
 export function useBiometrics() {
   const dispatch = useAppDispatch()
@@ -40,6 +42,20 @@ export function useBiometrics() {
       Linking.openSettings()
     }
   }
+
+  const promptBiometricsSetup = useCallback(() => {
+    Alert.alert(
+      'Set up biometrics',
+      Platform.OS === 'ios'
+        ? 'Set up Face ID or Touch ID in iOS Settings to enable biometrics in Safe.'
+        : 'Set up fingerprint in your device Settings to enable biometrics in Safe.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Open Settings', onPress: openBiometricSettings },
+      ],
+      { cancelable: true },
+    )
+  }, [])
 
   const checkBiometricsSupport = useCallback(async () => {
     try {
@@ -92,17 +108,21 @@ export function useBiometrics() {
     }
   }, [])
 
-  const disableBiometrics = useCallback(async (): Promise<{ status: 'disabled' }> => {
+  const disableBiometrics = useCallback(async (): Promise<DisableBiometricsResult> => {
     setIsLoading(true)
     try {
       await Keychain.resetGenericPassword()
       dispatch(setBiometricsEnabled(false))
+      return { status: 'disabled' }
     } catch (error) {
       Logger.error('Error disabling biometrics:', error)
+      // Keep Redux in sync with user intent so the toggle reflects 'off', but signal
+      // the keychain failure to callers — the credential may still be present.
+      dispatch(setBiometricsEnabled(false))
+      return { status: 'error', error }
     } finally {
       setIsLoading(false)
     }
-    return { status: 'disabled' }
   }, [])
 
   const enableBiometrics = useCallback(async (): Promise<EnableBiometricsResult> => {
@@ -150,9 +170,12 @@ export function useBiometrics() {
           biometricsError.message.includes('cancel') ||
           biometricsError.message.includes('user name or passphrase')
         ) {
-          Keychain.resetGenericPassword().then(() => {
-            dispatch(setUserAttempts(userAttempts + 1))
-          })
+          try {
+            await Keychain.resetGenericPassword()
+          } catch (resetError) {
+            Logger.error('Failed to reset keychain after cancellation:', resetError)
+          }
+          dispatch(setUserAttempts(userAttempts + 1))
           dispatch(setBiometricsEnabled(false))
           return { status: 'cancelled' }
         }
@@ -194,15 +217,16 @@ export function useBiometrics() {
       const { biometricsEnabled: isEnabledAtOSLevel } = await checkBiometricsOSSettingsStatus()
 
       if (!isEnabledAtOSLevel) {
-        disableBiometrics()
+        await disableBiometrics()
       }
     }
-    checkBiometrics()
-  }, [])
+    checkBiometrics().catch((error) => Logger.error('Error in biometrics OS-status check:', error))
+  }, [checkBiometricsOSSettingsStatus, disableBiometrics])
 
   return {
     toggleBiometrics,
     openBiometricSettings,
+    promptBiometricsSetup,
     isBiometricsEnabled: isEnabled,
     biometricsType,
     isLoading,


### PR DESCRIPTION
> Toggle Face ID, OS off,
> stay in app, no shove to Settings —
> button on user tap.

## What it solves

Resolves: [WA-2239](https://linear.app/safe-global/issue/WA-2239) — audit follow-up to the camera permission rejection ([WA-2229](https://linear.app/safe-global/issue/WA-2229) / #7810).

The biometrics toggle has a softer version of the same anti-pattern: when the user taps "Enable biometrics" and Face ID / Touch ID is not configured at the OS level, the app **silently** calls `Linking.openURL('app-settings:')` as a side effect. Per the camera fix house pattern, system Settings should only be opened from an explicit user-tapped button.

## How this PR fixes it

- **Hook contract change** in `apps/mobile/src/hooks/useBiometrics.ts`: `enableBiometrics` no longer calls `openBiometricSettings()` itself. It returns a discriminated `EnableBiometricsResult`:

  ```ts
  type EnableBiometricsResult =
    | { status: 'enabled' }
    | { status: 'os-not-configured' }
    | { status: 'cancelled' }
    | { status: 'error'; error: unknown }
  ```

  The `fromInteraction` parameter and the `toggleBiometricsFromUser` wrapper are removed — the only side effect they ever produced was the redirect we are removing.

- **Settings switch** (`AppSettings.container.tsx`): on `os-not-configured`, render a native `Alert.alert` with "Cancel" / "Open Settings". Tapping "Open Settings" — and only that — calls `openBiometricSettings()`. Same primitive already in use a few lines above for "Clear pending transactions", so zero new dependencies.

- **Biometrics opt-in screen** (`biometrics-opt-in.tsx`): same alert; user remains on the screen.

- **`useLayoutEffect` cleanup**: unchanged — still disables biometrics on mount when OS-level Face ID was turned off, no redirect (already correct, kept for symmetry with the camera PR).

- **Test**: new compliance invariant in `useBiometrics.test.ts` — `toggleBiometrics(true)` with `getSupportedBiometryType() → null` returns `{ status: 'os-not-configured' }` and does **not** call `Linking.openURL` or `Linking.openSettings`. Existing cancellation / error tests updated to assert on the new outcome shape.

## How to test it

1. iOS: Settings → Face ID & Passcode → turn Face ID **off**. Open Safe.
2. Settings → Security → tap "Enable biometrics".
3. Expect: app stays on the screen, alert appears with "Set up Face ID or Touch ID in iOS Settings to enable biometrics in Safe." and "Cancel" / "Open Settings".
4. Tap "Open Settings" → iOS Settings opens.
5. Re-enable Face ID, return to Safe. The toggle stays off (existing cleanup behavior). Tap again → keychain prompt → success.
6. Repeat steps 2-4 from the opt-in screen via Import signers (private key) → biometrics-opt-in.
7. Android: turn off fingerprint at OS level, repeat. `Linking.openSettings()` only fires on explicit "Open Settings" tap.
8. Pre-fix behaviour (for reference): tapping the toggle in step 3 silently jumps to Settings.

## Affected flows

- **Settings → Security → Enable biometrics** (toggle): primary flow changed.
- **Biometrics opt-in modal** during:
  - Import signers (private key) → `/import-signers/signer`
  - Review & confirm tx → `/review-and-confirm`
  - Review & execute tx → `/review-and-execute`
- **Disable path** (toggle off): unchanged.

## Blast radius

- `apps/mobile/src/hooks/useBiometrics.ts` — public API change: `toggleBiometrics` returns `ToggleBiometricsResult` instead of `Promise<boolean | undefined>`; `fromInteraction` parameter removed. Only two consumers branched on the return value (the two surfaces in this PR); other consumers (`ConfirmTx`, `ExecuteTx`, `ImportSigners`, `NavigationGuardHOC`) only read `isBiometricsEnabled` and are unaffected.
- `apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx` — toggle handler now async and branches on the result.
- `apps/mobile/src/app/biometrics-opt-in.tsx` — same pattern in `handleAccept`.
- No shared package, Redux slice, RTK Query endpoint, or chain config touched.
- Web app unaffected.
- Analytics: existing `biometricsEnabled` event in `SettingsStrategy.ts` still fires (we still dispatch `setBiometricsEnabled(false)` on the os-not-configured path).

## Risks / not checked

- **Distinguishing "no biometric hardware" from "not enrolled"** — `Keychain.getSupportedBiometryType()` returns `null` for both cases, so the hook collapses them into `os-not-configured`. On modern iOS/Android devices all hardware supports either Face ID, Touch ID, or fingerprint; on a hypothetical hardware-less device the user would open Settings, not see Face ID, and return. Acceptable degradation. Distinguishing via `LAContext` is out of scope for this fix.
- **Auto-retry on focus** — unlike the camera flow, biometrics state is not refreshed via `useFocusEffect`. Existing `useLayoutEffect`-on-mount handles app foregrounding in practice. If product wants the toggle to flip back to "enabled" after the user enables Face ID in Settings and returns, that is a follow-up.
- **e2e** — biometrics flows are not covered by Maestro today (would require simulator biometric stubs); this PR does not add e2e.
- **Mobile manual QA** — not run in this environment; needs human verification on a device per "How to test it" above.

## Visual summary

```mermaid
stateDiagram-v2
    [*] --> ToggleTapped: user taps biometrics switch / opt-in CTA
    ToggleTapped --> CheckOS: enableBiometrics()

    CheckOS --> OSConfigured: getSupportedBiometryType \!== null
    CheckOS --> OSNotConfigured: getSupportedBiometryType === null

    OSConfigured --> KeychainPrompt
    KeychainPrompt --> Enabled: setGenericPassword + getGenericPassword OK
    KeychainPrompt --> Cancelled: error -128 / "cancel"

    OSNotConfigured --> ShowAlert: dispatch setBiometricsEnabled(false)
    ShowAlert --> [*]: "Cancel"
    ShowAlert --> SystemSettings: "Open Settings" → openBiometricSettings()

    note right of OSNotConfigured
      Pre-fix: openBiometricSettings()
      called as a side effect.

      Post-fix: stays on screen,
      explicit "Open Settings" button.
    end note
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — needs human QA per the steps above
- [x] I've documented how it affects the analytics (if at all) 📊 — existing `biometricsEnabled` event preserved, no new event
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — new compliance invariant test in `useBiometrics.test.ts`
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

---
[\![Safe Engineering](https://img.shields.io/badge/Safe-Engineering-12ff80)](https://github.com/5afe/safe-engineering-plugin) Generated with [Claude Code](https://claude.com/claude-code)
