### PR TITLE
fix(mobile): never auto-redirect to Settings on notification permission denial

### DIFF
--- a/apps/mobile/src/hooks/useNotificationManager.test.ts
+++ b/apps/mobile/src/hooks/useNotificationManager.test.ts
@@ -68,4 +68,43 @@ describe('useNotificationManager', () => {
       expect(success).toBe(false)
     })
   })
+
+  // Apple 5.1.1(iv): denial paths must surface the in-app explainer Alert (which has an explicit
+  // "Turn on" button) instead of auto-opening Settings. See WA-2238.
+  describe('Apple 5.1.1(iv) compliance', () => {
+    it('toggleNotificationState shows the in-app explainer when permission is denied', async () => {
+      jest.mocked(NotificationsService.isDeviceNotificationEnabled).mockResolvedValue(false)
+      jest.mocked(NotificationsService.getAllPermissions).mockResolvedValue({
+        permission: 'denied',
+        blockedNotifications: new Map(),
+      })
+      const stateUnsubscribed = {
+        ...mockState,
+        notifications: { ...mockState.notifications, isAppNotificationsEnabled: false },
+      } as unknown as RootState
+      const { result } = renderHook(() => useNotificationManager(), stateUnsubscribed)
+
+      await act(async () => {
+        await result.current.toggleNotificationState()
+      })
+
+      expect(NotificationsService.requestPushNotificationsPermission).toHaveBeenCalled()
+    })
+
+    it('enableNotification shows the in-app explainer once promptThreshold is reached', async () => {
+      jest.mocked(NotificationsService.isDeviceNotificationEnabled).mockResolvedValue(false)
+      const stateAtThreshold = {
+        ...mockState,
+        notifications: { ...mockState.notifications, promptAttempts: 5 },
+      } as unknown as RootState
+      const { result } = renderHook(() => useNotificationManager(), stateAtThreshold)
+
+      await act(async () => {
+        await result.current.enableNotification()
+      })
+
+      expect(NotificationsService.requestPushNotificationsPermission).toHaveBeenCalled()
+      expect(NotificationsService.getAllPermissions).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/apps/mobile/src/hooks/useNotificationManager.test.ts
+++ b/apps/mobile/src/hooks/useNotificationManager.test.ts
@@ -91,6 +91,28 @@ describe('useNotificationManager', () => {
       expect(NotificationsService.requestPushNotificationsPermission).toHaveBeenCalled()
     })
 
+    // Registration can fail with a granted permission (network, backend); pushing the user to
+    // Settings in that case is misleading and leaves pendingPermissionRequestRef stuck true.
+    it('toggleNotificationState does NOT show the explainer when registration fails with permission granted', async () => {
+      jest.mocked(NotificationsService.isDeviceNotificationEnabled).mockResolvedValue(false)
+      jest.mocked(NotificationsService.getAllPermissions).mockResolvedValue({
+        permission: 'granted',
+        blockedNotifications: new Map(),
+      })
+      mockRegisterForNotifications.mockResolvedValueOnce({ loading: false, error: new Error('network') })
+      const stateUnsubscribed = {
+        ...mockState,
+        notifications: { ...mockState.notifications, isAppNotificationsEnabled: false },
+      } as unknown as RootState
+      const { result } = renderHook(() => useNotificationManager(), stateUnsubscribed)
+
+      await act(async () => {
+        await result.current.toggleNotificationState()
+      })
+
+      expect(NotificationsService.requestPushNotificationsPermission).not.toHaveBeenCalled()
+    })
+
     it('enableNotification shows the in-app explainer once promptThreshold is reached', async () => {
       jest.mocked(NotificationsService.isDeviceNotificationEnabled).mockResolvedValue(false)
       const stateAtThreshold = {

--- a/apps/mobile/src/hooks/useNotificationManager.ts
+++ b/apps/mobile/src/hooks/useNotificationManager.ts
@@ -30,7 +30,7 @@ export const useNotificationManager = () => {
   const pendingPermissionRequestRef = useRef(false)
 
   const requestAndRegister = useCallback(
-    async (updateNotificationSettings = true, openSettingsOnDenied = false) => {
+    async (updateNotificationSettings = true) => {
       const { permission } = await NotificationsService.getAllPermissions()
 
       if (permission === 'granted') {
@@ -42,9 +42,6 @@ export const useNotificationManager = () => {
           dispatch(toggleDeviceNotifications(true))
           return true
         }
-      } else if (openSettingsOnDenied) {
-        pendingPermissionRequestRef.current = true
-        await NotificationsService.getAllPermissions(true)
       }
 
       return false
@@ -70,8 +67,10 @@ export const useNotificationManager = () => {
         dispatch(updatePromptAttempts(promptAttempts + 1))
         return await requestAndRegister()
       } else {
+        // Threshold reached — surface the in-app explainer Alert so the user can EXPLICITLY tap
+        // "Turn on" to open Settings. Never auto-redirect on denial (Apple 5.1.1(iv)).
         pendingPermissionRequestRef.current = true
-        await NotificationsService.getAllPermissions(true)
+        await NotificationsService.requestPushNotificationsPermission()
       }
     } catch (error) {
       pendingPermissionRequestRef.current = false
@@ -102,11 +101,14 @@ export const useNotificationManager = () => {
 
       if (!isSubscribed) {
         if (!deviceNotificationStatus) {
-          const success = await requestAndRegister(false, true)
+          const success = await requestAndRegister(false)
           if (success) {
             return true
           }
-          // Don't clear the flag here if not granted immediately
+          // Denied — show the in-app explainer Alert so the user can EXPLICITLY tap "Turn on"
+          // to open Settings. Never auto-redirect on denial (Apple 5.1.1(iv)).
+          pendingPermissionRequestRef.current = true
+          await NotificationsService.requestPushNotificationsPermission()
         } else {
           await registerForNotifications(false)
         }

--- a/apps/mobile/src/hooks/useNotificationManager.ts
+++ b/apps/mobile/src/hooks/useNotificationManager.ts
@@ -40,11 +40,11 @@ export const useNotificationManager = () => {
 
         if (!loading && !error) {
           dispatch(toggleDeviceNotifications(true))
-          return true
+          return { success: true, permission } as const
         }
       }
 
-      return false
+      return { success: false, permission } as const
     },
     [dispatch, registerForNotifications],
   )
@@ -65,7 +65,8 @@ export const useNotificationManager = () => {
         return false
       } else if (promptAttempts < promptThreshold) {
         dispatch(updatePromptAttempts(promptAttempts + 1))
-        return await requestAndRegister()
+        const { success } = await requestAndRegister()
+        return success
       } else {
         // Threshold reached — surface the in-app explainer Alert so the user can EXPLICITLY tap
         // "Turn on" to open Settings. Never auto-redirect on denial (Apple 5.1.1(iv)).
@@ -101,14 +102,19 @@ export const useNotificationManager = () => {
 
       if (!isSubscribed) {
         if (!deviceNotificationStatus) {
-          const success = await requestAndRegister(false)
+          const { success, permission } = await requestAndRegister(false)
           if (success) {
             return true
           }
-          // Denied — show the in-app explainer Alert so the user can EXPLICITLY tap "Turn on"
-          // to open Settings. Never auto-redirect on denial (Apple 5.1.1(iv)).
-          pendingPermissionRequestRef.current = true
-          await NotificationsService.requestPushNotificationsPermission()
+          // Only show the Settings explainer when the OS permission was actually denied.
+          // Registration failures with a granted permission (network, backend) must not push
+          // the user to Settings — Settings won't help and would leave pendingPermissionRequestRef
+          // stuck true. Apple 5.1.1(iv) compliance is unaffected: Settings is still only opened
+          // from an explicit "Turn on" tap inside the Alert.
+          if (permission === 'denied') {
+            pendingPermissionRequestRef.current = true
+            await NotificationsService.requestPushNotificationsPermission()
+          }
         } else {
           await registerForNotifications(false)
         }

--- a/apps/mobile/src/services/notifications/NotificationService.test.ts
+++ b/apps/mobile/src/services/notifications/NotificationService.test.ts
@@ -1,4 +1,5 @@
 import { AuthorizationStatus, EventType } from '@notifee/react-native'
+import { Linking, Platform } from 'react-native'
 import { ChannelId } from '@/src/utils/notifications'
 
 jest.mock('./notificationParser', () => ({
@@ -116,9 +117,30 @@ describe('NotificationsService', () => {
       })
       ;(notifee.getChannels as jest.Mock).mockResolvedValue([])
 
-      const result = await NotificationsService.getAllPermissions(false)
+      const result = await NotificationsService.getAllPermissions()
 
       expect(result.permission).toBe('denied')
+    })
+
+    // Apple App Store guideline 5.1.1(iv): denial of an OS permission prompt must NOT chain into a
+    // Settings redirect. See WA-2238 / WA-2229 (camera fix #7810).
+    it('does not open device Settings when permission is denied', async () => {
+      ;(notifee.createChannel as jest.Mock).mockResolvedValue('channel-id')
+      ;(notifee.requestPermission as jest.Mock).mockResolvedValue({ authorizationStatus: AuthorizationStatus.DENIED })
+      ;(notifee.getNotificationSettings as jest.Mock).mockResolvedValue({
+        authorizationStatus: AuthorizationStatus.DENIED,
+      })
+      ;(notifee.getChannels as jest.Mock).mockResolvedValue([])
+      const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true)
+      const openSettingsSpy = jest.spyOn(Linking, 'openSettings').mockResolvedValue(undefined)
+
+      await NotificationsService.getAllPermissions()
+
+      expect(openURLSpy).not.toHaveBeenCalled()
+      expect(openSettingsSpy).not.toHaveBeenCalled()
+
+      openURLSpy.mockRestore()
+      openSettingsSpy.mockRestore()
     })
 
     it('returns denied on error', async () => {
@@ -129,6 +151,41 @@ describe('NotificationsService', () => {
       const result = await NotificationsService.getAllPermissions()
 
       expect(result.permission).toBe('denied')
+    })
+  })
+
+  describe('openDeviceSettings', () => {
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    // Apple 5.1.1(iv): openDeviceSettings is a pure side-effect — it must not re-request the
+    // permission, otherwise a denial of that prompt would chain into a Settings redirect.
+    it('does not re-request notification permission', async () => {
+      Platform.OS = 'ios'
+      jest.spyOn(Linking, 'openURL').mockResolvedValue(true)
+
+      await NotificationsService.openDeviceSettings()
+
+      expect(notifee.requestPermission).not.toHaveBeenCalled()
+    })
+
+    it('opens iOS app settings via Linking.openURL', async () => {
+      Platform.OS = 'ios'
+      const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true)
+
+      await NotificationsService.openDeviceSettings()
+
+      expect(openURLSpy).toHaveBeenCalledWith('app-settings:')
+    })
+
+    it('opens Android settings via Linking.openSettings', async () => {
+      Platform.OS = 'android'
+      const openSettingsSpy = jest.spyOn(Linking, 'openSettings').mockResolvedValue(undefined)
+
+      await NotificationsService.openDeviceSettings()
+
+      expect(openSettingsSpy).toHaveBeenCalled()
     })
   })
 

--- a/apps/mobile/src/services/notifications/NotificationService.ts
+++ b/apps/mobile/src/services/notifications/NotificationService.ts
@@ -71,31 +71,17 @@ class NotificationsService {
     }
   }
 
-  async getAllPermissions(shouldOpenSettings = false) {
+  async getAllPermissions() {
     try {
       const promises: Promise<string>[] = notificationChannels.map((channel: AndroidChannel) =>
         withTimeout(this.createChannel(channel), 5000),
       )
       // 1 - Creates android's notifications channel
       await Promise.allSettled(promises)
-      const { authorizationStatus } = await notifee.requestPermission()
-      // 2 - Verifies blocked notifications
+      // 2 - Request OS permission (may show prompt; status only — never auto-redirects to Settings)
+      await notifee.requestPermission()
+      // 3 - Verifies blocked notifications
       const blockedNotifications = await withTimeout(this.getBlockedNotifications(), 5000)
-      /**
-       * 3 - If permission has not being granted already or blocked notifications are found, open device's settings
-       * so that user can enable DEVICE notifications, but ONLY if explicitly requested via shouldOpenSettings
-       **/
-      if (shouldOpenSettings && authorizationStatus === AuthorizationStatus.DENIED) {
-        const settings = await notifee.getNotificationSettings()
-
-        if (
-          settings.authorizationStatus === AuthorizationStatus.NOT_DETERMINED ||
-          settings.authorizationStatus === AuthorizationStatus.DENIED
-        ) {
-          await this.openDeviceSettings()
-        }
-      }
-
       // 4 - Check if the user has enabled device notifications
       const permission = await withTimeout(this.checkCurrentPermissions(), 5000)
 
@@ -132,8 +118,10 @@ class NotificationsService {
     return status === AuthorizationStatus.DENIED
   }
 
+  // Pure side-effect: opens OS Settings. Never re-requests permission, so denial of an OS prompt
+  // can never chain into a Settings redirect. Apple App Store guideline 5.1.1(iv): Settings may
+  // only be opened from an explicit user tap, never as a side effect of a permission denial.
   async openDeviceSettings() {
-    await notifee.requestPermission()
     try {
       if (Platform.OS === 'ios') {
         Linking.openURL('app-settings:')
@@ -141,7 +129,7 @@ class NotificationsService {
         Linking.openSettings()
       }
     } catch (error) {
-      Logger.error('Error checking if a user has push notifications permission', error)
+      Logger.error('Error opening device settings for notifications', error)
     }
   }
 


### PR DESCRIPTION
> Tap "Don't Allow",
> stay on screen, no redirect —
> Settings on user tap.

## What it solves

Resolves [WA-2238](https://linear.app/safe-global/issue/WA-2238).

Follow-up audit from the camera-permission rejection ([#7810](https://github.com/safe-global/safe-wallet-monorepo/pull/7810) / [WA-2229](https://linear.app/safe-global/issue/WA-2229)) found the same anti-pattern in the notification flow. Apple guideline **5.1.1(iv)** forbids auto-redirecting users to Settings as a side effect of denying a privacy permission, and notifications fall under the same category — Apple is likely to reject the next submission if we leave this in.

Two violations in [`NotificationService.ts`](apps/mobile/src/services/notifications/NotificationService.ts):

1. `openDeviceSettings` chained `notifee.requestPermission()` then unconditionally opened Settings — denying the OS prompt led straight into Settings.
2. `getAllPermissions(shouldOpenSettings = true)` opened Settings whenever the prompt resolved as `DENIED`. Reachable from `useNotificationManager.requestAndRegister` (toggle ON) and `useNotificationManager.enableNotification` (after `promptAttempts >= promptThreshold`).

## How this PR fixes it

Minimal, structural fix — every Settings open is now reachable only from an explicit user tap inside the existing native Alert ("Turn on" button in `defaultButtons`).

- **`NotificationService.openDeviceSettings`** is now a pure side-effect — drops the internal `await notifee.requestPermission()`. A denied prompt can no longer chain into a Settings redirect.
- **`NotificationService.getAllPermissions`** drops the `shouldOpenSettings` parameter and the auto-redirect branch. Returns status only.
- **`useNotificationManager.requestAndRegister`** drops the `openSettingsOnDenied` parameter. On denial it just returns `false`; the caller decides what to do.
- **`useNotificationManager.toggleNotificationState`**: when `requestAndRegister` returns `false` (denial), surfaces `requestPushNotificationsPermission()` (the existing native Alert) so the user must tap **"Turn on"** explicitly to open Settings.
- **`useNotificationManager.enableNotification`** (threshold-reached branch): replaces `getAllPermissions(true)` with `requestPushNotificationsPermission()` for the same reason.
- **`pendingPermissionRequestRef`** is still set before each Alert so the existing `AppState 'active'` listener (CASE 2) re-registers when the user returns from Settings with notifications enabled.

The `defaultButtons` "Turn on" handler is conceptually OK (explicit user tap) and now calls the cleaned-up `openDeviceSettings` (no internal re-request).

### Compliance test

New unit tests assert the core invariant: `requestPermission()` resolving `DENIED` never invokes `Linking.openURL('app-settings:')` or `Linking.openSettings()`, and `openDeviceSettings()` never re-requests permission.

## How to test it

1. Fresh-install on an iOS device or simulator.
2. Onboarding → **Enable notifications** → tap **Continue** → OS prompt → **"Don't Allow"**.
   - ✅ App stays on the current screen.
   - ❌ Pre-fix: app silently redirected to Settings.
3. Settings → App settings → toggle notifications ON with device-level notifications disabled.
   - ✅ Native Alert with "Maybe later" / **"Turn on"**.
   - Tap **"Turn on"** → iOS Settings opens (allowed: explicit user tap).
4. Toggle notifications ON in iOS Settings → return to app → AppState listener re-registers and reflects enabled state.
5. Repeat for Safe-level notifications toggle in `NotificationsSettings.container.tsx`.
6. Repeat steps 1–4 on Android emulator to confirm parity.
7. Verify `promptAttempts` increments correctly across denial cycles ("Maybe later" still works; redux state matches pre-fix counts).

## Affected flows

- **Onboarding opt-in** ([`apps/mobile/src/app/notifications-opt-in.tsx`](apps/mobile/src/app/notifications-opt-in.tsx))
- **App Settings → Notifications toggle** ([`AppSettings.container.tsx`](apps/mobile/src/features/Settings/components/AppSettings/AppSettings.container.tsx))
- **Safe-level notifications toggle** ([`NotificationsSettings.container.tsx`](apps/mobile/src/features/Notifications/NotificationsSettings.container.tsx))
- **Existing native Alert prompt** (`defaultButtons` "Maybe later" / "Turn on")

## Blast radius

- `apps/mobile/src/services/notifications/NotificationService.ts` — `getAllPermissions` signature change (drop `shouldOpenSettings`); `openDeviceSettings` no longer re-requests permission. Both are methods on a singleton — TS guarantees every caller is updated.
- `apps/mobile/src/hooks/useNotificationManager.ts` — `requestAndRegister` signature change (drop `openSettingsOnDenied`). The only consumer outside the hook is `useNotificationManager` itself.
- No shared package, no Redux slice, no RTK Query endpoint, no chain config, no feature flag touched.
- Web app unaffected.
- The Ledger flow uses its own `openDeviceSettings` in `bluetoothService` — separate concern, untouched.

## Risks / not checked

- Did not run an actual App Store submission; relies on guideline interpretation matching the camera fix that Apple already accepted.
- Did not exercise unrelated notification handlers (foreground / background message receipt, navigation handler) — out of scope.
- Android parity is structural; verified via unit tests but not on a physical Android device.
- The `pendingPermissionRequestRef` ref will remain `true` if the user taps "Maybe later" without going to Settings; this is harmless (CASE 2 only fires when device notifications become enabled) and matches existing behaviour.

## Visual summary

```mermaid
stateDiagram-v2
    [*] --> NotDetermined: first visit
    NotDetermined --> Granted: tap "Continue" → OS prompt → "Allow"
    NotDetermined --> Denied: tap "Continue" → OS prompt → "Don't Allow"

    Denied --> Alert: app surfaces in-app explainer
    Alert --> Settings: user taps "Turn on" (explicit)
    Alert --> Denied: user taps "Maybe later"
    Settings --> Granted: returns with permission ON (AppState listener)

    note right of Denied
      Pre-fix: auto-redirect to Settings here
      (Apple 5.1.1(iv) violation).

      Post-fix: stays on screen,
      Settings only via explicit "Turn on" tap.
    end note
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics change; `promptAttempts` semantics preserved
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — `NotificationService.test.ts` and `useNotificationManager.test.ts` cover the core invariant
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

---
[\![Safe Engineering](https://img.shields.io/badge/Safe-Engineering-12ff80)](https://github.com/5afe/safe-engineering-plugin) Generated with [Claude Code](https://claude.com/claude-code)