### PR TITLE
fix: drop console- and report-sourced errors from Datadog RUM

### DIFF
--- a/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
+++ b/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
@@ -288,7 +288,16 @@ describe('DatadogProvider', () => {
       expect(filterRumEvent(event, {} as any)).toBe(false)
     })
 
-    it('keeps errors from sources other than console (e.g. unhandled exceptions, network)', async () => {
+    it('drops errors auto-captured from the Browser Reporting API (source=report)', async () => {
+      const { filterRumEvent } = await import('../datadog')
+      const event = buildErrorEvent({
+        source: 'report',
+        message: "csp_violation: 'eval' blocked by 'script-src' directive",
+      })
+      expect(filterRumEvent(event, {} as any)).toBe(false)
+    })
+
+    it('keeps errors from user-impacting sources (unhandled exceptions, network, custom)', async () => {
       const { filterRumEvent } = await import('../datadog')
       for (const source of ['source', 'network', 'custom', undefined]) {
         const event = buildErrorEvent({

--- a/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
+++ b/apps/web/src/services/observability/providers/__tests__/datadog.test.ts
@@ -277,5 +277,27 @@ describe('DatadogProvider', () => {
         expect(filterRumEvent(buildErrorEvent({ message }), {} as any)).toBe(false)
       }
     })
+
+    it('drops errors auto-captured from console.error (source=console)', async () => {
+      const { filterRumEvent } = await import('../datadog')
+      const event = buildErrorEvent({
+        source: 'console',
+        message: 'Failed to copy address: PermissionDenied',
+        stack: 'at copy (https://app.safe.global/_next/static/chunks/main.js:1:1)',
+      })
+      expect(filterRumEvent(event, {} as any)).toBe(false)
+    })
+
+    it('keeps errors from sources other than console (e.g. unhandled exceptions, network)', async () => {
+      const { filterRumEvent } = await import('../datadog')
+      for (const source of ['source', 'network', 'custom', undefined]) {
+        const event = buildErrorEvent({
+          source,
+          message: 'Boom',
+          stack: 'at handler (https://app.safe.global/_next/static/chunks/main.js:1:1)',
+        })
+        expect(filterRumEvent(event, {} as any)).toBe(true)
+      }
+    })
   })
 })

--- a/apps/web/src/services/observability/providers/datadog.ts
+++ b/apps/web/src/services/observability/providers/datadog.ts
@@ -66,23 +66,33 @@ const isKnownNoise = (message: string | undefined): boolean => {
   return KNOWN_NOISE_PATTERNS.some((pattern) => message.includes(pattern))
 }
 
+const NON_USER_IMPACTING_SOURCES = new Set(['console', 'report'])
+
 /**
  * Drop RUM error events that are demonstrably not caused by user-impacting
  * failures so the Error-Free Views SLO reflects real breakage. Non-error events
  * (views, actions, resources) pass through untouched.
  *
- * Note on console-sourced errors: the RUM SDK auto-instruments `console.error`
- * via `trackConsoleError` (no init flag exists to disable it). The codebase has
- * many `console.error` catch blocks for non-blocking failures (clipboard denial,
- * RPC retries, third-party widget init, observability self-recovery in
- * `composite.ts`, etc.) that are not user-impacting. We drop them here; surface
- * genuine user failures via `trackError` (→ `addError`) instead.
+ * Sources we drop:
+ * - `console`: the RUM SDK auto-instruments `console.error` via
+ *   `trackConsoleError` (no init flag exists to disable it). The codebase has
+ *   many `console.error` catch blocks for non-blocking failures (clipboard
+ *   denial, RPC retries, third-party widget init, observability self-recovery
+ *   in `composite.ts`, etc.) that are not user-impacting.
+ * - `report`: Browser Reporting API events (CSP violations, deprecation,
+ *   intervention, permissions-policy). Useful as a security/policy signal but
+ *   not indicative of user-blocking failure; CSP visibility belongs on a
+ *   `report-uri`/`report-to` endpoint, not the SLO.
+ *
+ * Genuine user failures continue to flow through `trackError` /
+ * `captureException` (source: `custom`), unhandled exceptions (`source`), and
+ * network failures (`network`).
  */
 export const filterRumEvent = (event: RumEvent, context: RumEventDomainContext): boolean => {
   if (event.type !== 'error') return true
 
   const errorEvent = event as RumErrorEvent
-  if (errorEvent.error.source === 'console') return false
+  if (NON_USER_IMPACTING_SOURCES.has(errorEvent.error.source)) return false
   if (isKnownNoise(errorEvent.error.message)) return false
   if (originatesFromExtension(errorEvent.error.stack)) return false
 

--- a/apps/web/src/services/observability/providers/datadog.ts
+++ b/apps/web/src/services/observability/providers/datadog.ts
@@ -67,14 +67,22 @@ const isKnownNoise = (message: string | undefined): boolean => {
 }
 
 /**
- * Drop RUM error events that are demonstrably not caused by our code so the
- * Error-Free Views SLO reflects real user-impacting failures. Non-error events
+ * Drop RUM error events that are demonstrably not caused by user-impacting
+ * failures so the Error-Free Views SLO reflects real breakage. Non-error events
  * (views, actions, resources) pass through untouched.
+ *
+ * Note on console-sourced errors: the RUM SDK auto-instruments `console.error`
+ * via `trackConsoleError` (no init flag exists to disable it). The codebase has
+ * many `console.error` catch blocks for non-blocking failures (clipboard denial,
+ * RPC retries, third-party widget init, observability self-recovery in
+ * `composite.ts`, etc.) that are not user-impacting. We drop them here; surface
+ * genuine user failures via `trackError` (→ `addError`) instead.
  */
 export const filterRumEvent = (event: RumEvent, context: RumEventDomainContext): boolean => {
   if (event.type !== 'error') return true
 
   const errorEvent = event as RumErrorEvent
+  if (errorEvent.error.source === 'console') return false
   if (isKnownNoise(errorEvent.error.message)) return false
   if (originatesFromExtension(errorEvent.error.stack)) return false
 


### PR DESCRIPTION
> RUM auto-grabs console.error and Reporting API,
> CSP eval blocks alone are 82% of errors,
> filter cuts noise at the source — SLO breathes.

## What it solves

The Error-Free Views SLO is still burning despite [#7674](https://github.com/safe-global/safe-wallet-monorepo/pull/7674) shipping ~3 weeks ago (deployed; filter strings verified live in `_app-593833c9c072ef97.js`). Both burn-rate monitors are firing in production:

- Fast burn (>14.4×, priority:1) — ALERT
- Slow burn (>6×) — ALERT

The 30-min `View Error Rate > 60%` monitor is OK, so the rate isn't spiking — it's a sustained low-level burn against the 30-day budget.

### Root cause — the headline

A 7h production sample of 5000 RUM error events (2026-05-06 01:14–08:36 UTC) breaks down by `error.source` as follows:

| Source | Count | % | Notes |
|---|---:|---:|---|
| **`report`** (Browser Reporting API) | **4095** | **82%** | 4091 are `csp_violation: 'eval' blocked by 'script-src'`, concentrated on `/welcome` (3648 hits) — third-party scripts (Beamer / Hubspot / Calendly / GTM / Cloudflare) calling `eval()` / `new Function()` |
| `console` | 542 | 11% | viem ENS reverse-resolution reverts (243), RPC HTTP failures (108), BigInt-from-non-integer (46), WalletConnect "No matching key" (44), …  — exactly the catch-block noise PR #7674 aimed to silence |
| `source` | 316 | 6% | Unhandled exceptions: Ledger `SendApduTimeoutError` (221), minified React errors (44), service-worker `updatefound` (14), … |
| `custom` | 47 | 1% | Real `trackError` from tx flows — correctly counted |

Two systemic noise sources are dwarfing real failures by 50–100×.

#### Why `console` slipped past PR #7674

`@datadog/browser-rum-core` auto-instruments `console.error` via [`trackConsoleError`](https://github.com/DataDog/browser-sdk/blob/main/packages/rum-core/src/domain/error/trackConsoleError.ts) and there is **no `init`-time flag to disable it**. PR #7674 fixed `logError` (now warn-level → `addAction`), but didn't account for **29 direct `console.error` call sites across 24 files**:

| File | Why noisy |
|---|---|
| `services/observability/providers/composite.ts` (×6) | `'Logger error:'` self-recovery — fires when the observability stack itself hiccups; risks recursive amplification |
| `hooks/useGasPrice.ts` | Every gas-price RPC failure (chain switches / RPC retries) |
| `features/safe-shield/{ShowAllAddress,AnalysisIssuesDisplay,useReportFalseResult}` | Clipboard-permission denials and false-result reports |
| `features/hypernative/*` (×4) | OAuth + Calendly third-party init failures |
| `features/spaces/{SpaceSettings,AddMemberModal}` (×4) | Backend-error catch blocks |
| `services/{push-notifications/firebase,analytics/mixpanel,ls-migration/common}`, `utils/url`, `pages/hypernative/oauth-callback`, `features/{multichain,batching,counterfactual}/*`, `components/{tx-flow/.../ExecuteThroughRole/hooks,safe-apps/SafeAppsErrorBoundary,new-safe/.../ReviewStep}` | Various background catch blocks |

#### Why `report` is even bigger

The same SDK auto-instruments `ReportingObserver`, so every CSP / Permissions-Policy / deprecation / intervention report becomes a RUM error. Today's CSP allows `'unsafe-inline'` and `'wasm-unsafe-eval'` but blocks `eval()`; one or more allow-listed third-party vendors call `eval()` / `new Function()` and trigger thousands of violations per hour.

CSP visibility is a **security/policy** signal that belongs on a `report-uri`/`report-to` endpoint — it was never a user-impacting failure and shouldn't burn an Error-Free Views budget. The deployed CSP currently has no `report-uri`/`report-to` set, so violations are *only* surfacing via RUM today; that's a follow-up for the security team to wire up properly.

## How this PR fixes it

Two source-level filters added to the existing `beforeSend` in `apps/web/src/services/observability/providers/datadog.ts`:

```ts
const NON_USER_IMPACTING_SOURCES = new Set(['console', 'report'])
// …
if (NON_USER_IMPACTING_SOURCES.has(errorEvent.error.source)) return false
```

Combined effect on the 7h sample: **~93% of current RUM error volume drops**, leaving only `source` (unhandled exceptions, 6%) and `custom` (real `trackError`, 1%) — which is exactly what Error-Free Views should reflect.

What's preserved:
- `trackError(...)` → `captureException` → `datadogRum.addError` (source: `custom`) — sign / execute / propose / recover / cancel-recovery / speedup / counterfactual flows
- React `ErrorBoundary` → `captureException` → `datadogRum.addError` (source: `custom`)
- Native unhandled exceptions / unhandled rejections (source: `source`)
- Failed network requests RUM auto-captures (source: `network`)
- Existing PR #7674 filters: extension URLs + known noise messages

## Visual summary

```mermaid
flowchart LR
  subgraph Before["Before — auto-instrumented sources flood the SLO"]
    B1["console.error(...)"] --> B2["error.source = 'console'"]
    B3["CSP / Reporting API"] --> B4["error.source = 'report'"]
    B5["unhandled / trackError"] --> B6["error.source = source / custom"]
    B2 --> B7["beforeSend (extension URLs, noise msgs)"]
    B4 --> B7
    B6 --> B7
    B7 -->|"only drops extension stacks<br/>+ known-noise msgs"| B8["✅ 93% pass through"]
    B8 --> B9["❌ all count vs<br/>Error-Free Views"]
  end

  subgraph After["After — drop non-user-impacting sources at the boundary"]
    A1["console.error(...)"] --> A2["source = 'console'"]
    A3["CSP / Reporting API"] --> A4["source = 'report'"]
    A5["unhandled / trackError"] --> A6["source = source / custom"]
    A2 --> A7["beforeSend filter"]
    A4 --> A7
    A6 --> A7
    A7 -->|"new: source ∈ {console, report}"| A8["❌ dropped (93%)"]
    A7 -->|"source / custom"| A9["✅ counted in SLO (real failures)"]
  end
```

## How to test it

**Unit tests (included):**

- `apps/web/src/services/observability/providers/__tests__/datadog.test.ts`:
  - drops events with `error.source === 'console'`
  - drops events with `error.source === 'report'`
  - keeps events from sources `source` / `network` / `custom` / `undefined`

Run: `yarn workspace @safe-global/web jest src/services/observability/providers`

**Manual verification post-deploy:**

1. In Datadog RUM: filter `@type:error @error.source:console` over 24h — should drop to ~0.
2. Same for `@type:error @error.source:report` — should drop to ~0.
3. Filter `@type:error @error.source:custom` — should still see the genuine `trackError` / `captureException` events from the tx flows.
4. Sign a transaction that legitimately fails (bad nonce, revert) — must still appear as a RUM error.
5. Burn-rate monitors should fall below threshold within ~hours; SLO should recover toward 99% over the next 30-day rolling window.

## Follow-ups (not in this PR)

1. **Ledger `SendApduTimeoutError` (221/7h, source=`source`)** — should be caught at the Ledger integration layer and surfaced as a UX hint ("Re-connect your device") rather than thrown. If untouchable upstream, add to the noise-message list. After this PR lands, this becomes the single largest remaining error source.
2. **CSP visibility** — wire up `report-uri` / `report-to` directives if the security team wants visibility into CSP violations (the right channel for them, instead of RUM).
3. **Identify the eval source** — separately investigate which whitelisted vendor (Beamer / Hubspot / Calendly / GTM / Cloudflare Turnstile) is calling `eval()` on `/welcome`. Vendor upgrade or replacement, not a CSP relaxation.
4. **Observability hygiene** — replace remaining `console.error` catch blocks with `logError(code, e)` so they're queryable in Datadog Logs by code (`@code:611`, etc.). Lower priority — once this filter is in, the SLO impact is gone whether the call sites use `console.error` or `logError`. The 6 sites in `composite.ts` should stay as raw `console.error` regardless (recursion risk if observability itself is the thing failing — the new source filter handles those too).

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only change)
- [x] I've documented how it affects the analytics (if at all) 📊 — `@error.source:console` and `@error.source:report` events are no longer recorded in RUM; `@error.source:custom`, `@error.source:source`, and `@error.source:network` are unaffected
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)