### PR TITLE
fix(mobile): surface WalletConnect connect errors without paging on expiry

### DIFF
--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
@@ -1,14 +1,17 @@
+import { Alert } from 'react-native'
 import { renderHook, act } from '@/src/tests/test-utils'
-import {
-  useConnect,
-  ConnectError,
-  ProposalExpiredError,
-  UnsupportedChainError,
-  UserRejectedError,
-  isProposalExpiredMessage,
-} from '../useConnect'
+import { useConnect, ConnectError, isProposalExpiredMessage } from '../useConnect'
+import Logger from '@/src/utils/logger'
+
+jest.spyOn(Alert, 'alert').mockImplementation(() => undefined)
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}))
 
 const mockOpen = jest.fn()
+const mockClose = jest.fn()
 const mockDisconnect = jest.fn().mockResolvedValue(undefined)
 const mockSwitchNetwork = jest.fn().mockResolvedValue(undefined)
 
@@ -20,7 +23,12 @@ const mockWalletState = {
 }
 
 jest.mock('@reown/appkit-react-native', () => ({
-  useAppKit: () => ({ open: mockOpen, disconnect: mockDisconnect, switchNetwork: mockSwitchNetwork }),
+  useAppKit: () => ({
+    open: mockOpen,
+    close: mockClose,
+    disconnect: mockDisconnect,
+    switchNetwork: mockSwitchNetwork,
+  }),
   useAccount: () => ({
     isConnected: mockWalletState.isConnected,
     address: mockWalletState.address,
@@ -39,6 +47,9 @@ jest.mock('../useStableAppKitEvent', () => ({
     eventCallbacks[event] = callback
   },
 }))
+
+const renderUseConnect = (initialStore?: Record<string, unknown>) =>
+  renderHook(() => useConnect({ flow: 'test' }), initialStore)
 
 const setConnected = (
   address: string,
@@ -70,7 +81,7 @@ describe('useConnect', () => {
   })
 
   it('calls open with Connect view when connect is called', () => {
-    const { result } = renderHook(() => useConnect())
+    const { result } = renderUseConnect()
 
     act(() => {
       result.current()
@@ -80,7 +91,7 @@ describe('useConnect', () => {
   })
 
   it('resolves with address, walletName, and walletIcon on successful connection', async () => {
-    const { result, rerender } = renderHook(() => useConnect())
+    const { result, rerender } = renderUseConnect()
 
     let resolved: unknown
     act(() => {
@@ -103,8 +114,8 @@ describe('useConnect', () => {
     })
   })
 
-  it('rejects on CONNECT_ERROR with the AppKit message preserved', async () => {
-    const { result } = renderHook(() => useConnect())
+  it('rejects on CONNECT_ERROR with the AppKit message preserved (catastrophic case)', async () => {
+    const { result } = renderUseConnect()
 
     let rejected: Error | undefined
     act(() => {
@@ -124,74 +135,11 @@ describe('useConnect', () => {
     })
 
     expect(rejected).toBeInstanceOf(ConnectError)
-    expect(rejected).not.toBeInstanceOf(ProposalExpiredError)
     expect(rejected?.message).toBe('WalletConnect signing failed')
   })
 
-  it('upgrades CONNECT_ERROR with "Proposal expired" message to ProposalExpiredError', async () => {
-    const { result } = renderHook(() => useConnect())
-
-    let rejected: Error | undefined
-    act(() => {
-      result.current().catch((e: Error) => {
-        rejected = e
-      })
-    })
-
-    act(() => {
-      eventCallbacks['CONNECT_ERROR']?.({
-        data: { properties: { message: 'Proposal expired' } },
-      })
-    })
-
-    await act(async () => {
-      await Promise.resolve()
-    })
-
-    expect(rejected).toBeInstanceOf(ProposalExpiredError)
-    // ProposalExpiredError extends ConnectError so consumers catching the
-    // generic class still match.
-    expect(rejected).toBeInstanceOf(ConnectError)
-    expect(rejected?.message).toBe('Proposal expired')
-  })
-
-  it('upgrades wrapped "Proposal expired" messages to ProposalExpiredError', async () => {
-    const { result } = renderHook(() => useConnect())
-
-    let rejected: Error | undefined
-    act(() => {
-      result.current().catch((e: Error) => {
-        rejected = e
-      })
-    })
-
-    act(() => {
-      eventCallbacks['CONNECT_ERROR']?.({
-        data: { properties: { message: 'Pairing already exists: Proposal expired' } },
-      })
-    })
-
-    await act(async () => {
-      await Promise.resolve()
-    })
-
-    expect(rejected).toBeInstanceOf(ProposalExpiredError)
-  })
-
-  it('isProposalExpiredMessage matches wrapped messages and rejects unrelated substrings', () => {
-    // Realistic wrapped form from SignClient when a pairing already exists.
-    expect(isProposalExpiredMessage('Pairing already exists: Proposal expired')).toBe(true)
-    // Whitespace tolerance.
-    expect(isProposalExpiredMessage('Proposal  expired')).toBe(true)
-    // Word boundaries prevent matches on substrings inside other words.
-    expect(isProposalExpiredMessage('subproposal expired-ish')).toBe(false)
-    // Empty / unrelated.
-    expect(isProposalExpiredMessage('')).toBe(false)
-    expect(isProposalExpiredMessage('Connection failed')).toBe(false)
-  })
-
   it('falls back to a generic message when AppKit emits CONNECT_ERROR without one', async () => {
-    const { result } = renderHook(() => useConnect())
+    const { result } = renderUseConnect()
 
     let rejected: Error | undefined
     act(() => {
@@ -212,29 +160,142 @@ describe('useConnect', () => {
     expect(rejected?.message).toBe('Connection failed')
   })
 
-  it('rejects on USER_REJECTED', async () => {
-    const { result } = renderHook(() => useConnect())
+  describe('proposal expired (transparent retry)', () => {
+    it('reopens the connect modal and keeps the promise pending', async () => {
+      const { result } = renderUseConnect()
 
-    let rejected: Error | undefined
-    act(() => {
-      result.current().catch((e: Error) => {
-        rejected = e
+      let resolved: unknown
+      let rejected: Error | undefined
+      act(() => {
+        result.current().then(
+          (r) => {
+            resolved = r
+          },
+          (e: Error) => {
+            rejected = e
+          },
+        )
       })
+
+      expect(mockOpen).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        eventCallbacks['CONNECT_ERROR']?.({
+          data: { properties: { message: 'Proposal expired' } },
+        })
+      })
+
+      // Allow the IIFE (await disconnect → re-open) to flush.
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(Logger.warn).toHaveBeenCalledWith('WalletConnect proposal expired during test, reopening connect modal')
+      expect(mockDisconnect).toHaveBeenCalled()
+      expect(mockOpen).toHaveBeenCalledTimes(2)
+      expect(mockOpen).toHaveBeenLastCalledWith({ view: 'Connect' })
+      expect(resolved).toBeUndefined()
+      expect(rejected).toBeUndefined()
+      expect(Alert.alert).not.toHaveBeenCalled()
     })
 
-    act(() => {
-      eventCallbacks['USER_REJECTED']?.()
+    it('reopens for wrapped "Proposal expired" messages too', async () => {
+      const { result } = renderUseConnect()
+
+      act(() => {
+        result.current().then(
+          () => undefined,
+          () => undefined,
+        )
+      })
+
+      act(() => {
+        eventCallbacks['CONNECT_ERROR']?.({
+          data: { properties: { message: 'Pairing already exists: Proposal expired' } },
+        })
+      })
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(mockOpen).toHaveBeenCalledTimes(2)
+      expect(Alert.alert).not.toHaveBeenCalled()
     })
 
-    await act(async () => {
-      await Promise.resolve()
-    })
+    it('does not reopen if the consumer unmounted between the error and the cleanup', async () => {
+      const { result, unmount } = renderUseConnect()
 
-    expect(rejected).toBeInstanceOf(UserRejectedError)
+      act(() => {
+        result.current().then(
+          () => undefined,
+          () => undefined,
+        )
+      })
+
+      act(() => {
+        eventCallbacks['CONNECT_ERROR']?.({
+          data: { properties: { message: 'Proposal expired' } },
+        })
+      })
+
+      // Unmount before the IIFE finishes its disconnect → reopen sequence.
+      unmount()
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(mockOpen).toHaveBeenCalledTimes(1) // initial only — no reopen
+    })
+  })
+
+  it('isProposalExpiredMessage matches wrapped messages and rejects unrelated substrings', () => {
+    expect(isProposalExpiredMessage('Pairing already exists: Proposal expired')).toBe(true)
+    expect(isProposalExpiredMessage('Proposal  expired')).toBe(true)
+    expect(isProposalExpiredMessage('subproposal expired-ish')).toBe(false)
+    expect(isProposalExpiredMessage('')).toBe(false)
+    expect(isProposalExpiredMessage('Connection failed')).toBe(false)
+  })
+
+  describe('USER_REJECTED', () => {
+    it('resolves with null, closes the modal, logs at info level, does not alert', async () => {
+      const { result } = renderUseConnect()
+
+      let resolved: unknown
+      let rejected: Error | undefined
+      act(() => {
+        result.current().then(
+          (r) => {
+            resolved = r
+          },
+          (e: Error) => {
+            rejected = e
+          },
+        )
+      })
+
+      act(() => {
+        eventCallbacks['USER_REJECTED']?.()
+      })
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
+      expect(resolved).toBeNull()
+      expect(rejected).toBeUndefined()
+      expect(mockClose).toHaveBeenCalledTimes(1)
+      expect(Logger.info).toHaveBeenCalledWith('User rejected WC connect during test')
+      expect(Alert.alert).not.toHaveBeenCalled()
+    })
   })
 
   it('does not resolve when walletInfo fields are incomplete', async () => {
-    const { result, rerender } = renderHook(() => useConnect())
+    const { result, rerender } = renderUseConnect()
 
     let resolved = false
     act(() => {
@@ -267,7 +328,7 @@ describe('useConnect', () => {
   })
 
   it('does not resolve when no connect is pending', () => {
-    const { rerender } = renderHook(() => useConnect())
+    const { rerender } = renderUseConnect()
 
     setConnected('0xABC')
     rerender({})
@@ -277,17 +338,20 @@ describe('useConnect', () => {
   })
 
   it('ignores error events when no connect is pending', () => {
-    renderHook(() => useConnect())
+    renderUseConnect()
 
     // Should not throw
     act(() => {
       eventCallbacks['CONNECT_ERROR']?.({ data: { properties: { message: 'Proposal expired' } } })
       eventCallbacks['USER_REJECTED']?.()
     })
+
+    expect(mockClose).not.toHaveBeenCalled()
+    expect(mockDisconnect).not.toHaveBeenCalled()
   })
 
   it('clears pending promise on unmount', async () => {
-    const { result, unmount } = renderHook(() => useConnect())
+    const { result, unmount } = renderUseConnect()
 
     let settled = false
     act(() => {
@@ -311,13 +375,13 @@ describe('useConnect', () => {
   })
 
   it('handles sequential connect calls', async () => {
-    const { result, rerender } = renderHook(() => useConnect())
+    const { result, rerender } = renderUseConnect()
 
-    // First connect — reject it
-    let firstRejected = false
+    // First connect — user rejects, resolves null.
+    let firstResolved: unknown = 'unset'
     act(() => {
-      result.current().catch(() => {
-        firstRejected = true
+      result.current().then((r) => {
+        firstResolved = r
       })
     })
 
@@ -329,9 +393,9 @@ describe('useConnect', () => {
       await Promise.resolve()
     })
 
-    expect(firstRejected).toBe(true)
+    expect(firstResolved).toBeNull()
 
-    // Second connect — resolve it
+    // Second connect — resolve via state update.
     let secondResolved: unknown
     act(() => {
       result.current().then((r) => {
@@ -363,7 +427,7 @@ describe('useConnect', () => {
     })
 
     it('attempts to switch network when caipNetworkId does not match the active Safe chain', async () => {
-      const { result } = renderHook(() => useConnect(), activeSafeStore)
+      const { result } = renderUseConnect(activeSafeStore)
 
       let rejected: Error | undefined
       act(() => {
@@ -383,16 +447,22 @@ describe('useConnect', () => {
       expect(mockDisconnect).not.toHaveBeenCalled()
     })
 
-    it('rejects with UnsupportedChainError when switchNetwork throws', async () => {
+    it('resolves null and alerts when switchNetwork throws (unsupported chain)', async () => {
       mockSwitchNetwork.mockRejectedValueOnce(new Error('Chain not supported'))
 
-      const { result } = renderHook(() => useConnect(), activeSafeStore)
+      const { result } = renderUseConnect(activeSafeStore)
 
+      let resolved: unknown = 'unset'
       let rejected: Error | undefined
       act(() => {
-        result.current().catch((e: Error) => {
-          rejected = e
-        })
+        result.current().then(
+          (r) => {
+            resolved = r
+          },
+          (e: Error) => {
+            rejected = e
+          },
+        )
       })
 
       await act(async () => {
@@ -401,20 +471,34 @@ describe('useConnect', () => {
         })
       })
 
-      expect(rejected).toBeInstanceOf(UnsupportedChainError)
+      // Allow the IIFE disconnect to settle.
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(resolved).toBeNull()
+      expect(rejected).toBeUndefined()
       expect(mockDisconnect).toHaveBeenCalled()
+      expect(Alert.alert).toHaveBeenCalledWith('Unsupported network', expect.any(String), expect.any(Array))
     })
 
-    it('rejects via timeout when switchNetwork resolves but chain never settles', async () => {
+    it('resolves null and alerts via timeout when switchNetwork resolves but chain never settles', async () => {
       jest.useFakeTimers()
 
-      const { result } = renderHook(() => useConnect(), activeSafeStore)
+      const { result } = renderUseConnect(activeSafeStore)
 
+      let resolved: unknown = 'unset'
       let rejected: Error | undefined
       act(() => {
-        result.current().catch((e: Error) => {
-          rejected = e
-        })
+        result.current().then(
+          (r) => {
+            resolved = r
+          },
+          (e: Error) => {
+            rejected = e
+          },
+        )
       })
 
       await act(async () => {
@@ -424,20 +508,28 @@ describe('useConnect', () => {
       })
 
       expect(mockSwitchNetwork).toHaveBeenCalledWith('eip155:1')
-      expect(rejected).toBeUndefined()
+      expect(resolved).toBe('unset')
 
       await act(async () => {
         jest.advanceTimersByTime(8000)
       })
 
-      expect(rejected).toBeInstanceOf(UnsupportedChainError)
+      // Allow the IIFE disconnect to settle.
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      expect(resolved).toBeNull()
+      expect(rejected).toBeUndefined()
       expect(mockDisconnect).toHaveBeenCalled()
+      expect(Alert.alert).toHaveBeenCalledWith('Unsupported network', expect.any(String), expect.any(Array))
 
       jest.useRealTimers()
     })
 
     it('resolves after switchNetwork succeeds and state settles on the correct chain', async () => {
-      const { result, rerender } = renderHook(() => useConnect(), activeSafeStore)
+      const { result, rerender } = renderUseConnect(activeSafeStore)
 
       let resolved: unknown
       let rejected: Error | undefined
@@ -474,7 +566,7 @@ describe('useConnect', () => {
     })
 
     it('resolver does not resolve while wallet state is on the wrong chain', async () => {
-      const { result, rerender } = renderHook(() => useConnect(), activeSafeStore)
+      const { result, rerender } = renderUseConnect(activeSafeStore)
 
       let resolved: unknown
       let rejected: Error | undefined
@@ -503,7 +595,7 @@ describe('useConnect', () => {
     })
 
     it('does not attempt to switch when caipNetworkId matches and address is present', async () => {
-      const { result } = renderHook(() => useConnect(), activeSafeStore)
+      const { result } = renderUseConnect(activeSafeStore)
 
       let rejected: Error | undefined
       act(() => {
@@ -524,7 +616,7 @@ describe('useConnect', () => {
     })
 
     it('ignores CONNECT_SUCCESS when no active Safe is set', async () => {
-      const { result } = renderHook(() => useConnect())
+      const { result } = renderUseConnect()
 
       let rejected: Error | undefined
       act(() => {
@@ -545,7 +637,7 @@ describe('useConnect', () => {
     })
 
     it('does not switch when address is present and caipNetworkId is missing', async () => {
-      const { result } = renderHook(() => useConnect(), activeSafeStore)
+      const { result } = renderUseConnect(activeSafeStore)
 
       let rejected: Error | undefined
       act(() => {

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
@@ -1,5 +1,11 @@
 import { renderHook, act } from '@/src/tests/test-utils'
-import { useConnect, ConnectError, UnsupportedChainError, UserRejectedError } from '../useConnect'
+import {
+  useConnect,
+  ConnectError,
+  UnsupportedChainError,
+  UserRejectedError,
+  isProposalExpiredError,
+} from '../useConnect'
 
 const mockOpen = jest.fn()
 const mockDisconnect = jest.fn().mockResolvedValue(undefined)
@@ -22,7 +28,9 @@ jest.mock('@reown/appkit-react-native', () => ({
   useWalletInfo: () => ({ walletInfo: mockWalletState.walletInfo }),
 }))
 
-type EventCallback = (state?: { data: { address?: string; properties: { caipNetworkId?: string } } }) => void
+type EventCallback = (state?: {
+  data: { address?: string; properties: { caipNetworkId?: string; message?: string } }
+}) => void
 const eventCallbacks: Record<string, EventCallback | undefined> = {}
 
 jest.mock('../useStableAppKitEvent', () => ({
@@ -94,7 +102,7 @@ describe('useConnect', () => {
     })
   })
 
-  it('rejects on CONNECT_ERROR', async () => {
+  it('rejects on CONNECT_ERROR with the AppKit message preserved', async () => {
     const { result } = renderHook(() => useConnect())
 
     let rejected: Error | undefined
@@ -105,7 +113,9 @@ describe('useConnect', () => {
     })
 
     act(() => {
-      eventCallbacks['CONNECT_ERROR']?.()
+      eventCallbacks['CONNECT_ERROR']?.({
+        data: { properties: { message: 'WalletConnect signing failed' } },
+      })
     })
 
     await act(async () => {
@@ -113,6 +123,54 @@ describe('useConnect', () => {
     })
 
     expect(rejected).toBeInstanceOf(ConnectError)
+    expect(rejected?.message).toBe('WalletConnect signing failed')
+    expect(isProposalExpiredError(rejected)).toBe(false)
+  })
+
+  it('preserves "Proposal expired" message so callers can downgrade log level', async () => {
+    const { result } = renderHook(() => useConnect())
+
+    let rejected: Error | undefined
+    act(() => {
+      result.current().catch((e: Error) => {
+        rejected = e
+      })
+    })
+
+    act(() => {
+      eventCallbacks['CONNECT_ERROR']?.({
+        data: { properties: { message: 'Proposal expired' } },
+      })
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(rejected).toBeInstanceOf(ConnectError)
+    expect(isProposalExpiredError(rejected)).toBe(true)
+  })
+
+  it('falls back to a generic message when AppKit emits CONNECT_ERROR without one', async () => {
+    const { result } = renderHook(() => useConnect())
+
+    let rejected: Error | undefined
+    act(() => {
+      result.current().catch((e: Error) => {
+        rejected = e
+      })
+    })
+
+    act(() => {
+      eventCallbacks['CONNECT_ERROR']?.({ data: { properties: {} } })
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(rejected).toBeInstanceOf(ConnectError)
+    expect(rejected?.message).toBe('Connection failed')
   })
 
   it('rejects on USER_REJECTED', async () => {
@@ -184,7 +242,7 @@ describe('useConnect', () => {
 
     // Should not throw
     act(() => {
-      eventCallbacks['CONNECT_ERROR']?.()
+      eventCallbacks['CONNECT_ERROR']?.({ data: { properties: { message: 'Proposal expired' } } })
       eventCallbacks['USER_REJECTED']?.()
     })
   })

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
@@ -2,9 +2,10 @@ import { renderHook, act } from '@/src/tests/test-utils'
 import {
   useConnect,
   ConnectError,
+  ProposalExpiredError,
   UnsupportedChainError,
   UserRejectedError,
-  isProposalExpiredError,
+  isProposalExpiredMessage,
 } from '../useConnect'
 
 const mockOpen = jest.fn()
@@ -123,11 +124,11 @@ describe('useConnect', () => {
     })
 
     expect(rejected).toBeInstanceOf(ConnectError)
+    expect(rejected).not.toBeInstanceOf(ProposalExpiredError)
     expect(rejected?.message).toBe('WalletConnect signing failed')
-    expect(isProposalExpiredError(rejected)).toBe(false)
   })
 
-  it('preserves "Proposal expired" message so callers can downgrade log level', async () => {
+  it('upgrades CONNECT_ERROR with "Proposal expired" message to ProposalExpiredError', async () => {
     const { result } = renderHook(() => useConnect())
 
     let rejected: Error | undefined
@@ -147,20 +148,46 @@ describe('useConnect', () => {
       await Promise.resolve()
     })
 
+    expect(rejected).toBeInstanceOf(ProposalExpiredError)
+    // ProposalExpiredError extends ConnectError so consumers catching the
+    // generic class still match.
     expect(rejected).toBeInstanceOf(ConnectError)
-    expect(isProposalExpiredError(rejected)).toBe(true)
+    expect(rejected?.message).toBe('Proposal expired')
   })
 
-  it('isProposalExpiredError matches wrapped messages and rejects unrelated substrings', () => {
+  it('upgrades wrapped "Proposal expired" messages to ProposalExpiredError', async () => {
+    const { result } = renderHook(() => useConnect())
+
+    let rejected: Error | undefined
+    act(() => {
+      result.current().catch((e: Error) => {
+        rejected = e
+      })
+    })
+
+    act(() => {
+      eventCallbacks['CONNECT_ERROR']?.({
+        data: { properties: { message: 'Pairing already exists: Proposal expired' } },
+      })
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(rejected).toBeInstanceOf(ProposalExpiredError)
+  })
+
+  it('isProposalExpiredMessage matches wrapped messages and rejects unrelated substrings', () => {
     // Realistic wrapped form from SignClient when a pairing already exists.
-    expect(isProposalExpiredError(new Error('Pairing already exists: Proposal expired'))).toBe(true)
+    expect(isProposalExpiredMessage('Pairing already exists: Proposal expired')).toBe(true)
     // Whitespace tolerance.
-    expect(isProposalExpiredError(new Error('Proposal  expired'))).toBe(true)
+    expect(isProposalExpiredMessage('Proposal  expired')).toBe(true)
     // Word boundaries prevent matches on substrings inside other words.
-    expect(isProposalExpiredError(new Error('subproposal expired-ish'))).toBe(false)
-    // Non-Error inputs are rejected.
-    expect(isProposalExpiredError('Proposal expired')).toBe(false)
-    expect(isProposalExpiredError(undefined)).toBe(false)
+    expect(isProposalExpiredMessage('subproposal expired-ish')).toBe(false)
+    // Empty / unrelated.
+    expect(isProposalExpiredMessage('')).toBe(false)
+    expect(isProposalExpiredMessage('Connection failed')).toBe(false)
   })
 
   it('falls back to a generic message when AppKit emits CONNECT_ERROR without one', async () => {

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useConnect.test.ts
@@ -151,6 +151,18 @@ describe('useConnect', () => {
     expect(isProposalExpiredError(rejected)).toBe(true)
   })
 
+  it('isProposalExpiredError matches wrapped messages and rejects unrelated substrings', () => {
+    // Realistic wrapped form from SignClient when a pairing already exists.
+    expect(isProposalExpiredError(new Error('Pairing already exists: Proposal expired'))).toBe(true)
+    // Whitespace tolerance.
+    expect(isProposalExpiredError(new Error('Proposal  expired'))).toBe(true)
+    // Word boundaries prevent matches on substrings inside other words.
+    expect(isProposalExpiredError(new Error('subproposal expired-ish'))).toBe(false)
+    // Non-Error inputs are rejected.
+    expect(isProposalExpiredError('Proposal expired')).toBe(false)
+    expect(isProposalExpiredError(undefined)).toBe(false)
+  })
+
   it('falls back to a generic message when AppKit emits CONNECT_ERROR without one', async () => {
     const { result } = renderHook(() => useConnect())
 

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -220,7 +220,7 @@ describe('useImportSignerFlow', () => {
     expect(closeOrder).toBeLessThan(alertOrder)
   })
 
-  it('downgrades to Logger.warn and still cleans up when connect fails with a ProposalExpiredError', async () => {
+  it('reopens the QR via connect() on ProposalExpiredError instead of alerting', async () => {
     const { result } = renderImportFlow()
     const expiredError = new ProposalExpiredError('Proposal expired')
 
@@ -228,18 +228,25 @@ describe('useImportSignerFlow', () => {
       result.current.initiateConnection()
     })
 
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+
     await act(async () => {
       mockConnectReject(expiredError)
     })
 
+    // Helper awaits disconnect cleanup, signals retry; flow re-calls connect.
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Error during signer import', expect.any(String), expect.any(Array))
+      expect(mockConnect).toHaveBeenCalledTimes(2)
     })
 
-    expect(Logger.warn).toHaveBeenCalledWith('WalletConnect proposal expired during signer import:', expiredError)
+    expect(Logger.warn).toHaveBeenCalledWith(
+      'WalletConnect proposal expired during signer import, reopening connect modal:',
+      expiredError,
+    )
     expect(Logger.error).not.toHaveBeenCalled()
     expect(mockDisconnect).toHaveBeenCalled()
-    expect(mockClose).toHaveBeenCalled()
+    expect(mockClose).not.toHaveBeenCalled()
+    expect(Alert.alert).not.toHaveBeenCalled()
   })
 
   it('captures async rejection from disconnect() during error cleanup without dropping close/alert', async () => {

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useImportSignerFlow } from '../useImportSignerFlow'
-import { ConnectError, UnsupportedChainError, UserRejectedError } from '../useConnect'
+import { ConnectError, ProposalExpiredError, UnsupportedChainError, UserRejectedError } from '../useConnect'
 import Logger from '@/src/utils/logger'
 import type { ConnectResult } from '../useConnect'
 import type { Signer } from '@/src/store/signersSlice'
@@ -220,9 +220,9 @@ describe('useImportSignerFlow', () => {
     expect(closeOrder).toBeLessThan(alertOrder)
   })
 
-  it('downgrades to Logger.warn and still cleans up when connect fails with a "Proposal expired" ConnectError', async () => {
+  it('downgrades to Logger.warn and still cleans up when connect fails with a ProposalExpiredError', async () => {
     const { result } = renderImportFlow()
-    const expiredError = new ConnectError('Proposal expired')
+    const expiredError = new ProposalExpiredError('Proposal expired')
 
     act(() => {
       result.current.initiateConnection()

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useImportSignerFlow } from '../useImportSignerFlow'
-import { ConnectError, ProposalExpiredError, UnsupportedChainError, UserRejectedError } from '../useConnect'
+import { ConnectError } from '../useConnect'
 import Logger from '@/src/utils/logger'
 import type { ConnectResult } from '../useConnect'
 import type { Signer } from '@/src/store/signersSlice'
@@ -24,12 +24,12 @@ const mockClose = jest.fn()
 const mockValidateAddressOwnership = jest.fn()
 const mockSwitchNetworkIfNeeded = jest.fn().mockResolvedValue(undefined)
 
-let mockConnectResolve: (result: ConnectResult) => void
+let mockConnectResolve: (result: ConnectResult | null) => void
 let mockConnectReject: (error: Error) => void
 
 const mockConnect = jest.fn(
   () =>
-    new Promise<ConnectResult>((resolve, reject) => {
+    new Promise<ConnectResult | null>((resolve, reject) => {
       mockConnectResolve = resolve
       mockConnectReject = reject
     }),
@@ -66,7 +66,7 @@ describe('useImportSignerFlow', () => {
     jest.clearAllMocks()
   })
 
-  it('calls connect when initiateConnection is called', async () => {
+  it('calls connect when initiateConnection is called', () => {
     const { result } = renderImportFlow()
 
     act(() => {
@@ -131,9 +131,7 @@ describe('useImportSignerFlow', () => {
     })
   })
 
-  it('navigates to error when validation throws', async () => {
-    mockValidateAddressOwnership.mockRejectedValue(new Error('Network error'))
-
+  it('short-circuits silently when connect resolves null (useConnect handled the cancel/unsupported case)', async () => {
     const { result } = renderImportFlow()
 
     act(() => {
@@ -141,57 +139,18 @@ describe('useImportSignerFlow', () => {
     })
 
     await act(async () => {
-      mockConnectResolve({ address: mockAddress, walletName: 'MetaMask', walletIcon: 'icon' })
-    })
-
-    await waitFor(() => {
-      expect(mockRouterPush).not.toHaveBeenCalled()
-    })
-  })
-
-  it('closes the modal on UserRejectedError without alerting and emits info-level telemetry', async () => {
-    const { result } = renderImportFlow()
-
-    act(() => {
-      result.current.initiateConnection()
-    })
-
-    await act(async () => {
-      mockConnectReject(new UserRejectedError())
+      mockConnectResolve(null)
     })
 
     expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
-    expect(Alert.alert).not.toHaveBeenCalled()
-    expect(Logger.error).not.toHaveBeenCalled()
-    expect(Logger.warn).not.toHaveBeenCalled()
-    expect(Logger.info).toHaveBeenCalledWith('User rejected WC connect during signer import')
     expect(mockDisconnect).not.toHaveBeenCalled()
-    expect(mockClose).toHaveBeenCalled()
-  })
-
-  it('shows an alert when wallet does not support the active Safe chain', async () => {
-    const { result } = renderImportFlow()
-
-    act(() => {
-      result.current.initiateConnection()
-    })
-
-    await act(async () => {
-      mockConnectReject(new UnsupportedChainError())
-    })
-
-    await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Unsupported network', expect.any(String), expect.any(Array))
-    })
-
-    expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
-    expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(Alert.alert).not.toHaveBeenCalled()
+    // The flow's catch must not run for the null path — no fallback log either.
     expect(Logger.error).not.toHaveBeenCalled()
-    expect(mockClose).not.toHaveBeenCalled()
   })
 
-  it('disconnects, closes the modal, then alerts when connect fails with a non-expiry ConnectError', async () => {
+  it('disconnects, closes the modal, then alerts when connect rejects with a catastrophic ConnectError', async () => {
     const { result } = renderImportFlow()
     const connectError = new ConnectError('Connection failed')
 
@@ -208,7 +167,6 @@ describe('useImportSignerFlow', () => {
     })
 
     expect(Logger.error).toHaveBeenCalledWith('Error during signer import:', connectError)
-    expect(Logger.warn).not.toHaveBeenCalled()
     expect(mockDisconnect).toHaveBeenCalled()
     expect(mockClose).toHaveBeenCalled()
     expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
@@ -220,36 +178,7 @@ describe('useImportSignerFlow', () => {
     expect(closeOrder).toBeLessThan(alertOrder)
   })
 
-  it('reopens the QR via connect() on ProposalExpiredError instead of alerting', async () => {
-    const { result } = renderImportFlow()
-    const expiredError = new ProposalExpiredError('Proposal expired')
-
-    act(() => {
-      result.current.initiateConnection()
-    })
-
-    expect(mockConnect).toHaveBeenCalledTimes(1)
-
-    await act(async () => {
-      mockConnectReject(expiredError)
-    })
-
-    // Helper awaits disconnect cleanup, signals retry; flow re-calls connect.
-    await waitFor(() => {
-      expect(mockConnect).toHaveBeenCalledTimes(2)
-    })
-
-    expect(Logger.warn).toHaveBeenCalledWith(
-      'WalletConnect proposal expired during signer import, reopening connect modal:',
-      expiredError,
-    )
-    expect(Logger.error).not.toHaveBeenCalled()
-    expect(mockDisconnect).toHaveBeenCalled()
-    expect(mockClose).not.toHaveBeenCalled()
-    expect(Alert.alert).not.toHaveBeenCalled()
-  })
-
-  it('captures async rejection from disconnect() during error cleanup without dropping close/alert', async () => {
+  it('captures async rejection from disconnect() during fallback cleanup without dropping close/alert', async () => {
     const { result } = renderImportFlow()
     const connectError = new ConnectError('Connection failed')
     const disconnectRejection = new Error('relay teardown failed')
@@ -273,6 +202,28 @@ describe('useImportSignerFlow', () => {
     expect(mockDisconnect).toHaveBeenCalled()
     expect(mockClose).toHaveBeenCalled()
     expect(Alert.alert).toHaveBeenCalledWith('Error during signer import', expect.any(String), expect.any(Array))
+  })
+
+  it('runs the fallback alert when validation throws after a successful connect', async () => {
+    const validationError = new Error('Network error')
+    mockValidateAddressOwnership.mockRejectedValue(validationError)
+
+    const { result } = renderImportFlow()
+
+    act(() => {
+      result.current.initiateConnection()
+    })
+
+    await act(async () => {
+      mockConnectResolve({ address: mockAddress, walletName: 'MetaMask', walletIcon: 'icon' })
+    })
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Error during signer import', expect.any(String), expect.any(Array))
+    })
+
+    expect(Logger.error).toHaveBeenCalledWith('Error during signer import:', validationError)
+    expect(mockRouterPush).not.toHaveBeenCalled()
   })
 
   it('disconnects and shows alert when a different-type signer exists for the address', async () => {

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -242,6 +242,32 @@ describe('useImportSignerFlow', () => {
     expect(mockClose).toHaveBeenCalled()
   })
 
+  it('captures async rejection from disconnect() during error cleanup without dropping close/alert', async () => {
+    const { result } = renderImportFlow()
+    const connectError = new ConnectError('Connection failed')
+    const disconnectRejection = new Error('relay teardown failed')
+    mockDisconnect.mockRejectedValueOnce(disconnectRejection)
+
+    act(() => {
+      result.current.initiateConnection()
+    })
+
+    await act(async () => {
+      mockConnectReject(connectError)
+    })
+
+    await waitFor(() => {
+      expect(Logger.warn).toHaveBeenCalledWith(
+        'Failed to disconnect WC session after import error:',
+        disconnectRejection,
+      )
+    })
+
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(mockClose).toHaveBeenCalled()
+    expect(Alert.alert).toHaveBeenCalledWith('Error during signer import', expect.any(String), expect.any(Array))
+  })
+
   it('disconnects and shows alert when a different-type signer exists for the address', async () => {
     mockValidateAddressOwnership.mockResolvedValue({ isOwner: true })
 

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -258,7 +258,7 @@ describe('useImportSignerFlow', () => {
 
     await waitFor(() => {
       expect(Logger.warn).toHaveBeenCalledWith(
-        'Failed to disconnect WC session after import error:',
+        'Failed to disconnect WC session after signer import error:',
         disconnectRejection,
       )
     })

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useImportSignerFlow.test.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useImportSignerFlow } from '../useImportSignerFlow'
-import { UnsupportedChainError, UserRejectedError } from '../useConnect'
+import { ConnectError, UnsupportedChainError, UserRejectedError } from '../useConnect'
 import Logger from '@/src/utils/logger'
 import type { ConnectResult } from '../useConnect'
 import type { Signer } from '@/src/store/signersSlice'
@@ -20,6 +20,7 @@ const checksumAddress = getAddress(mockAddress)
 
 const mockRouterPush = jest.fn()
 const mockDisconnect = jest.fn()
+const mockClose = jest.fn()
 const mockValidateAddressOwnership = jest.fn()
 const mockSwitchNetworkIfNeeded = jest.fn().mockResolvedValue(undefined)
 
@@ -41,7 +42,7 @@ jest.mock('expo-router', () => ({
 }))
 
 jest.mock('@reown/appkit-react-native', () => ({
-  useAppKit: () => ({ disconnect: mockDisconnect }),
+  useAppKit: () => ({ disconnect: mockDisconnect, close: mockClose }),
 }))
 
 jest.mock('@/src/hooks/useAddressOwnershipValidation', () => ({
@@ -148,7 +149,7 @@ describe('useImportSignerFlow', () => {
     })
   })
 
-  it('does nothing when connect is rejected (user rejected)', async () => {
+  it('closes the modal on UserRejectedError without alerting and emits info-level telemetry', async () => {
     const { result } = renderImportFlow()
 
     act(() => {
@@ -161,6 +162,12 @@ describe('useImportSignerFlow', () => {
 
     expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(Alert.alert).not.toHaveBeenCalled()
+    expect(Logger.error).not.toHaveBeenCalled()
+    expect(Logger.warn).not.toHaveBeenCalled()
+    expect(Logger.info).toHaveBeenCalledWith('User rejected WC connect during signer import')
+    expect(mockDisconnect).not.toHaveBeenCalled()
+    expect(mockClose).toHaveBeenCalled()
   })
 
   it('shows an alert when wallet does not support the active Safe chain', async () => {
@@ -181,21 +188,58 @@ describe('useImportSignerFlow', () => {
     expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
     expect(Logger.error).not.toHaveBeenCalled()
+    expect(mockClose).not.toHaveBeenCalled()
   })
 
-  it('does nothing when connect fails (connection error)', async () => {
+  it('disconnects, closes the modal, then alerts when connect fails with a non-expiry ConnectError', async () => {
     const { result } = renderImportFlow()
+    const connectError = new ConnectError('Connection failed')
 
     act(() => {
       result.current.initiateConnection()
     })
 
     await act(async () => {
-      mockConnectReject(new Error('Connection failed'))
+      mockConnectReject(connectError)
     })
 
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Error during signer import', expect.any(String), expect.any(Array))
+    })
+
+    expect(Logger.error).toHaveBeenCalledWith('Error during signer import:', connectError)
+    expect(Logger.warn).not.toHaveBeenCalled()
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(mockClose).toHaveBeenCalled()
     expect(mockValidateAddressOwnership).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
+    // Modal must dismiss before the alert renders so the alert isn't hosted by
+    // the dismissing modal on iOS.
+    const closeOrder = mockClose.mock.invocationCallOrder[0]
+    const alertOrder = (Alert.alert as jest.Mock).mock.invocationCallOrder[0]
+    expect(closeOrder).toBeLessThan(alertOrder)
+  })
+
+  it('downgrades to Logger.warn and still cleans up when connect fails with a "Proposal expired" ConnectError', async () => {
+    const { result } = renderImportFlow()
+    const expiredError = new ConnectError('Proposal expired')
+
+    act(() => {
+      result.current.initiateConnection()
+    })
+
+    await act(async () => {
+      mockConnectReject(expiredError)
+    })
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Error during signer import', expect.any(String), expect.any(Array))
+    })
+
+    expect(Logger.warn).toHaveBeenCalledWith('WalletConnect proposal expired during signer import:', expiredError)
+    expect(Logger.error).not.toHaveBeenCalled()
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(mockClose).toHaveBeenCalled()
   })
 
   it('disconnects and shows alert when a different-type signer exists for the address', async () => {

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
@@ -178,7 +178,7 @@ describe('useReconnectFlow', () => {
     expect(closeOrder).toBeLessThan(alertOrder)
   })
 
-  it('downgrades to Logger.warn and still cleans up when connect fails with a ProposalExpiredError', async () => {
+  it('reopens the QR via connect() on ProposalExpiredError instead of alerting', async () => {
     const { result } = renderReconnectFlow()
     const expiredError = new ProposalExpiredError('Proposal expired')
 
@@ -186,18 +186,25 @@ describe('useReconnectFlow', () => {
       result.current.reconnect(mockAddress)
     })
 
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+
     await act(async () => {
       mockConnectReject(expiredError)
     })
 
+    // Helper awaits disconnect cleanup, signals retry; flow re-calls connect.
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Error during reconnect', expect.any(String), expect.any(Array))
+      expect(mockConnect).toHaveBeenCalledTimes(2)
     })
 
-    expect(Logger.warn).toHaveBeenCalledWith('WalletConnect proposal expired during reconnect:', expiredError)
+    expect(Logger.warn).toHaveBeenCalledWith(
+      'WalletConnect proposal expired during reconnect, reopening connect modal:',
+      expiredError,
+    )
     expect(Logger.error).not.toHaveBeenCalled()
     expect(mockDisconnect).toHaveBeenCalled()
-    expect(mockClose).toHaveBeenCalled()
+    expect(mockClose).not.toHaveBeenCalled()
+    expect(Alert.alert).not.toHaveBeenCalled()
   })
 
   it('captures async rejection from disconnect() during error cleanup without dropping close/alert', async () => {

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
@@ -3,8 +3,14 @@ import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useReconnectFlow } from '../useReconnectFlow'
-import { UnsupportedChainError, UserRejectedError } from '../useConnect'
+import { ConnectError, UnsupportedChainError, UserRejectedError } from '../useConnect'
 import type { ConnectResult } from '../useConnect'
+import Logger from '@/src/utils/logger'
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}))
 
 jest.spyOn(Alert, 'alert').mockImplementation(() => undefined)
 
@@ -13,6 +19,7 @@ const mockOtherAddress = faker.finance.ethereumAddress() as `0x${string}`
 
 const mockRouterPush = jest.fn()
 const mockDisconnect = jest.fn()
+const mockClose = jest.fn()
 const mockSwitchNetworkIfNeeded = jest.fn().mockResolvedValue(undefined)
 
 let mockConnectResolve: (result: ConnectResult) => void
@@ -33,7 +40,7 @@ jest.mock('expo-router', () => ({
 }))
 
 jest.mock('@reown/appkit-react-native', () => ({
-  useAppKit: () => ({ disconnect: mockDisconnect }),
+  useAppKit: () => ({ disconnect: mockDisconnect, close: mockClose }),
 }))
 
 jest.mock('../useSwitchNetwork', () => ({
@@ -120,9 +127,10 @@ describe('useReconnectFlow', () => {
     expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
     expect(mockDisconnect).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(mockClose).not.toHaveBeenCalled()
   })
 
-  it('does nothing when connect is rejected', async () => {
+  it('closes the modal on UserRejectedError without alerting and emits info-level telemetry', async () => {
     const { result } = renderReconnectFlow()
 
     act(() => {
@@ -136,5 +144,59 @@ describe('useReconnectFlow', () => {
     expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
     expect(mockDisconnect).not.toHaveBeenCalled()
     expect(mockRouterPush).not.toHaveBeenCalled()
+    expect(Alert.alert).not.toHaveBeenCalled()
+    expect(Logger.error).not.toHaveBeenCalled()
+    expect(Logger.warn).not.toHaveBeenCalled()
+    expect(Logger.info).toHaveBeenCalledWith('User rejected WC connect during reconnect')
+    expect(mockClose).toHaveBeenCalled()
+  })
+
+  it('disconnects, closes the modal, then alerts when connect fails with a non-expiry ConnectError', async () => {
+    const { result } = renderReconnectFlow()
+    const connectError = new ConnectError('Connection failed')
+
+    act(() => {
+      result.current.reconnect(mockAddress)
+    })
+
+    await act(async () => {
+      mockConnectReject(connectError)
+    })
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Error during reconnect', expect.any(String), expect.any(Array))
+    })
+
+    expect(Logger.error).toHaveBeenCalledWith('Error during reconnect:', connectError)
+    expect(Logger.warn).not.toHaveBeenCalled()
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(mockClose).toHaveBeenCalled()
+    // Modal must dismiss before the alert renders so the alert isn't hosted by
+    // the dismissing modal on iOS.
+    const closeOrder = mockClose.mock.invocationCallOrder[0]
+    const alertOrder = (Alert.alert as jest.Mock).mock.invocationCallOrder[0]
+    expect(closeOrder).toBeLessThan(alertOrder)
+  })
+
+  it('downgrades to Logger.warn and still cleans up when connect fails with a "Proposal expired" ConnectError', async () => {
+    const { result } = renderReconnectFlow()
+    const expiredError = new ConnectError('Proposal expired')
+
+    act(() => {
+      result.current.reconnect(mockAddress)
+    })
+
+    await act(async () => {
+      mockConnectReject(expiredError)
+    })
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith('Error during reconnect', expect.any(String), expect.any(Array))
+    })
+
+    expect(Logger.warn).toHaveBeenCalledWith('WalletConnect proposal expired during reconnect:', expiredError)
+    expect(Logger.error).not.toHaveBeenCalled()
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(mockClose).toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useReconnectFlow } from '../useReconnectFlow'
-import { ConnectError, UnsupportedChainError, UserRejectedError } from '../useConnect'
+import { ConnectError, ProposalExpiredError, UnsupportedChainError, UserRejectedError } from '../useConnect'
 import type { ConnectResult } from '../useConnect'
 import Logger from '@/src/utils/logger'
 
@@ -178,9 +178,9 @@ describe('useReconnectFlow', () => {
     expect(closeOrder).toBeLessThan(alertOrder)
   })
 
-  it('downgrades to Logger.warn and still cleans up when connect fails with a "Proposal expired" ConnectError', async () => {
+  it('downgrades to Logger.warn and still cleans up when connect fails with a ProposalExpiredError', async () => {
     const { result } = renderReconnectFlow()
-    const expiredError = new ConnectError('Proposal expired')
+    const expiredError = new ProposalExpiredError('Proposal expired')
 
     act(() => {
       result.current.reconnect(mockAddress)

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
@@ -199,4 +199,30 @@ describe('useReconnectFlow', () => {
     expect(mockDisconnect).toHaveBeenCalled()
     expect(mockClose).toHaveBeenCalled()
   })
+
+  it('captures async rejection from disconnect() during error cleanup without dropping close/alert', async () => {
+    const { result } = renderReconnectFlow()
+    const connectError = new ConnectError('Connection failed')
+    const disconnectRejection = new Error('relay teardown failed')
+    mockDisconnect.mockRejectedValueOnce(disconnectRejection)
+
+    act(() => {
+      result.current.reconnect(mockAddress)
+    })
+
+    await act(async () => {
+      mockConnectReject(connectError)
+    })
+
+    await waitFor(() => {
+      expect(Logger.warn).toHaveBeenCalledWith(
+        'Failed to disconnect WC session after reconnect error:',
+        disconnectRejection,
+      )
+    })
+
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(mockClose).toHaveBeenCalled()
+    expect(Alert.alert).toHaveBeenCalledWith('Error during reconnect', expect.any(String), expect.any(Array))
+  })
 })

--- a/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/__tests__/useReconnectFlow.test.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { getAddress } from 'ethers'
 import { renderHook, act, waitFor } from '@/src/tests/test-utils'
 import { useReconnectFlow } from '../useReconnectFlow'
-import { ConnectError, ProposalExpiredError, UnsupportedChainError, UserRejectedError } from '../useConnect'
+import { ConnectError } from '../useConnect'
 import type { ConnectResult } from '../useConnect'
 import Logger from '@/src/utils/logger'
 
@@ -22,12 +22,12 @@ const mockDisconnect = jest.fn()
 const mockClose = jest.fn()
 const mockSwitchNetworkIfNeeded = jest.fn().mockResolvedValue(undefined)
 
-let mockConnectResolve: (result: ConnectResult) => void
+let mockConnectResolve: (result: ConnectResult | null) => void
 let mockConnectReject: (error: Error) => void
 
 const mockConnect = jest.fn(
   () =>
-    new Promise<ConnectResult>((resolve, reject) => {
+    new Promise<ConnectResult | null>((resolve, reject) => {
       mockConnectResolve = resolve
       mockConnectReject = reject
     }),
@@ -109,7 +109,7 @@ describe('useReconnectFlow', () => {
     })
   })
 
-  it('shows an alert when wallet does not support the active Safe chain', async () => {
+  it('short-circuits silently when connect resolves null (useConnect handled the cancel/unsupported case)', async () => {
     const { result } = renderReconnectFlow()
 
     act(() => {
@@ -117,28 +117,7 @@ describe('useReconnectFlow', () => {
     })
 
     await act(async () => {
-      mockConnectReject(new UnsupportedChainError())
-    })
-
-    await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Unsupported network', expect.any(String), expect.any(Array))
-    })
-
-    expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
-    expect(mockDisconnect).not.toHaveBeenCalled()
-    expect(mockRouterPush).not.toHaveBeenCalled()
-    expect(mockClose).not.toHaveBeenCalled()
-  })
-
-  it('closes the modal on UserRejectedError without alerting and emits info-level telemetry', async () => {
-    const { result } = renderReconnectFlow()
-
-    act(() => {
-      result.current.reconnect(mockAddress)
-    })
-
-    await act(async () => {
-      mockConnectReject(new UserRejectedError())
+      mockConnectResolve(null)
     })
 
     expect(mockSwitchNetworkIfNeeded).not.toHaveBeenCalled()
@@ -146,12 +125,9 @@ describe('useReconnectFlow', () => {
     expect(mockRouterPush).not.toHaveBeenCalled()
     expect(Alert.alert).not.toHaveBeenCalled()
     expect(Logger.error).not.toHaveBeenCalled()
-    expect(Logger.warn).not.toHaveBeenCalled()
-    expect(Logger.info).toHaveBeenCalledWith('User rejected WC connect during reconnect')
-    expect(mockClose).toHaveBeenCalled()
   })
 
-  it('disconnects, closes the modal, then alerts when connect fails with a non-expiry ConnectError', async () => {
+  it('disconnects, closes the modal, then alerts when connect rejects with a catastrophic ConnectError', async () => {
     const { result } = renderReconnectFlow()
     const connectError = new ConnectError('Connection failed')
 
@@ -168,7 +144,6 @@ describe('useReconnectFlow', () => {
     })
 
     expect(Logger.error).toHaveBeenCalledWith('Error during reconnect:', connectError)
-    expect(Logger.warn).not.toHaveBeenCalled()
     expect(mockDisconnect).toHaveBeenCalled()
     expect(mockClose).toHaveBeenCalled()
     // Modal must dismiss before the alert renders so the alert isn't hosted by
@@ -178,36 +153,7 @@ describe('useReconnectFlow', () => {
     expect(closeOrder).toBeLessThan(alertOrder)
   })
 
-  it('reopens the QR via connect() on ProposalExpiredError instead of alerting', async () => {
-    const { result } = renderReconnectFlow()
-    const expiredError = new ProposalExpiredError('Proposal expired')
-
-    act(() => {
-      result.current.reconnect(mockAddress)
-    })
-
-    expect(mockConnect).toHaveBeenCalledTimes(1)
-
-    await act(async () => {
-      mockConnectReject(expiredError)
-    })
-
-    // Helper awaits disconnect cleanup, signals retry; flow re-calls connect.
-    await waitFor(() => {
-      expect(mockConnect).toHaveBeenCalledTimes(2)
-    })
-
-    expect(Logger.warn).toHaveBeenCalledWith(
-      'WalletConnect proposal expired during reconnect, reopening connect modal:',
-      expiredError,
-    )
-    expect(Logger.error).not.toHaveBeenCalled()
-    expect(mockDisconnect).toHaveBeenCalled()
-    expect(mockClose).not.toHaveBeenCalled()
-    expect(Alert.alert).not.toHaveBeenCalled()
-  })
-
-  it('captures async rejection from disconnect() during error cleanup without dropping close/alert', async () => {
+  it('captures async rejection from disconnect() during fallback cleanup without dropping close/alert', async () => {
     const { result } = renderReconnectFlow()
     const connectError = new ConnectError('Connection failed')
     const disconnectRejection = new Error('relay teardown failed')

--- a/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
@@ -46,6 +46,17 @@ export const showUnsupportedChainAlert = () => {
   )
 }
 
+// AppKit forwards the underlying SignClient/Universal Provider message verbatim
+// in CONNECT_ERROR. The QR-code pairing proposal expires (~5 min default) before
+// the wallet completes pairing, surfacing as "Proposal expired". We don't want
+// these to page on-call as Logger.error.
+//
+// TODO(WA-2198): pin to `PROPOSAL_EXPIRY_MESSAGE` from `@walletconnect/sign-client`
+// once it becomes a direct dep (today it's only transitive via @reown/appkit-react-native).
+// Until then, the anchored regex tolerates whitespace/case drift.
+export const isProposalExpiredError = (error: unknown): boolean =>
+  error instanceof Error && /proposal\s+expired/i.test(error.message)
+
 interface PendingConnect {
   resolve: (result: ConnectResult) => void
   reject: (error: Error) => void
@@ -157,14 +168,14 @@ export function useConnect() {
       })
   })
 
-  useStableAppKitEvent('CONNECT_ERROR', () => {
+  useStableAppKitEvent('CONNECT_ERROR', ({ data }) => {
     if (!pendingRef.current) {
       return
     }
     const { reject } = pendingRef.current
     pendingRef.current = null
     clearSwitchTimeout()
-    reject(new ConnectError('Connection failed'))
+    reject(new ConnectError(data.properties?.message || 'Connection failed'))
   })
 
   useStableAppKitEvent('USER_REJECTED', () => {

--- a/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
@@ -51,9 +51,6 @@ export const showUnsupportedChainAlert = () => {
 // the wallet completes pairing, surfacing as "Proposal expired". We don't want
 // these to page on-call as Logger.error.
 //
-// TODO(WA-2198): pin to `PROPOSAL_EXPIRY_MESSAGE` from `@walletconnect/sign-client`
-// once it becomes a direct dep (today it's only transitive via @reown/appkit-react-native).
-// Until then, the anchored regex tolerates whitespace/case drift.
 export const isProposalExpiredError = (error: unknown): boolean =>
   error instanceof Error && /proposal\s+expired/i.test(error.message)
 

--- a/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
@@ -48,11 +48,12 @@ export const showUnsupportedChainAlert = () => {
 
 // AppKit forwards the underlying SignClient/Universal Provider message verbatim
 // in CONNECT_ERROR. The QR-code pairing proposal expires (~5 min default) before
-// the wallet completes pairing, surfacing as "Proposal expired". We don't want
-// these to page on-call as Logger.error.
-//
+// the wallet completes pairing, surfacing as "Proposal expired" — sometimes
+// wrapped (e.g. "Pairing already exists: Proposal expired"). Word boundaries
+// keep the match tight enough to avoid downgrading non-WC errors that happen
+// to contain the substring.
 export const isProposalExpiredError = (error: unknown): boolean =>
-  error instanceof Error && /proposal\s+expired/i.test(error.message)
+  error instanceof Error && /\bproposal\s+expired\b/i.test(error.message)
 
 interface PendingConnect {
   resolve: (result: ConnectResult) => void
@@ -144,7 +145,7 @@ export function useConnect() {
       return
     }
 
-    const wrongChain = caipNetworkId && caipNetworkId !== expectedCaipId
+    const wrongChain = caipNetworkId !== expectedCaipId
 
     // Wallet connected on the right chain with an account — resolver will handle it.
     if (data.address && !wrongChain) {

--- a/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
@@ -138,6 +138,12 @@ export function useConnect() {
     }
 
     const { caipNetworkId } = data.properties
+
+    // If the wallet is not connected, we don't need to switch network
+    if (!caipNetworkId) {
+      return
+    }
+
     const wrongChain = caipNetworkId && caipNetworkId !== expectedCaipId
 
     // Wallet connected on the right chain with an account — resolver will handle it.

--- a/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
@@ -55,6 +55,69 @@ export const showUnsupportedChainAlert = () => {
 export const isProposalExpiredError = (error: unknown): boolean =>
   error instanceof Error && /\bproposal\s+expired\b/i.test(error.message)
 
+export interface WalletConnectErrorContext {
+  /** Slug used in log messages, e.g. 'signer import' → "during signer import". */
+  flow: string
+  /** Title shown in the user-facing alert for unhandled errors. */
+  alertTitle: string
+  /** Body shown alongside `alertTitle`. */
+  alertBody: string
+  /** From `useAppKit()` — closes the modal sheet. */
+  close: () => void
+  /** From `useAppKit()` — typed `() => void` but returns a Promise at runtime. */
+  disconnect: () => void
+}
+
+/**
+ * Centralizes WalletConnect-flow error handling so logging, modal cleanup,
+ * and user alerts stay consistent across consumers of `useConnect`.
+ *
+ * Behaviour by error class:
+ * - `UnsupportedChainError` → `showUnsupportedChainAlert` (disconnect already
+ *   handled inside `useConnect.rejectUnsupported`).
+ * - `UserRejectedError` → `Logger.info` + `close()`. No alert (intentional
+ *   cancellation).
+ * - `Proposal expired` `ConnectError` → `Logger.warn` + cleanup + alert.
+ * - Any other error → `Logger.error` + cleanup + alert.
+ *
+ * Cleanup runs `disconnect()` inside an awaited IIFE so async rejections from
+ * AppKit don't escape as unhandled rejections. `close()` is called before
+ * `Alert.alert` so the alert isn't hosted by a dismissing modal on iOS.
+ */
+export const handleWalletConnectError = (error: unknown, ctx: WalletConnectErrorContext): void => {
+  if (error instanceof UnsupportedChainError) {
+    showUnsupportedChainAlert()
+    return
+  }
+
+  if (error instanceof UserRejectedError) {
+    Logger.info(`User rejected WC connect during ${ctx.flow}`)
+    ctx.close()
+    return
+  }
+
+  if (isProposalExpiredError(error)) {
+    Logger.warn(`WalletConnect proposal expired during ${ctx.flow}:`, error)
+  } else {
+    Logger.error(`Error during ${ctx.flow}:`, error)
+  }
+
+  // Tear down any half-formed pairing before dismissing the modal so we
+  // don't leak relay subscriptions or ghost sessions on retry. AppKit's
+  // useAppKit narrows disconnect to () => void, but the underlying call
+  // returns a Promise — await inside an IIFE so async rejections are
+  // captured rather than escaping as unhandled rejections.
+  void (async () => {
+    try {
+      await ctx.disconnect()
+    } catch (disconnectError) {
+      Logger.warn(`Failed to disconnect WC session after ${ctx.flow} error:`, disconnectError)
+    }
+  })()
+  ctx.close()
+  Alert.alert(ctx.alertTitle, ctx.alertBody, [{ text: 'OK' }])
+}
+
 interface PendingConnect {
   resolve: (result: ConnectResult) => void
   reject: (error: Error) => void

--- a/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
@@ -12,6 +12,12 @@ export interface ConnectResult {
   walletIcon: string
 }
 
+/**
+ * Catastrophic / unknown CONNECT_ERROR rejected to consumers. The known
+ * benign cases (`UnsupportedChain`, `UserRejected`, `ProposalExpired`) are
+ * handled inside `useConnect` itself and surfaced as `connect()` resolving
+ * to `null` (handled cancellations) or transparently retrying.
+ */
 export class ConnectError extends Error {
   constructor(message: string) {
     super(message)
@@ -19,40 +25,7 @@ export class ConnectError extends Error {
   }
 }
 
-/**
- * QR-code pairing proposal expired before the wallet completed pairing
- * (default ~5 min). Treated as a benign, expected failure mode (downgraded
- * log severity, lighter cleanup messaging) but still requires the same
- * teardown as a generic ConnectError. Extends ConnectError so consumers
- * who only care about "any connect failure" still match via `instanceof`.
- */
-export class ProposalExpiredError extends ConnectError {
-  constructor(message: string) {
-    super(message)
-    this.name = 'ProposalExpiredError'
-  }
-}
-
-export class UserRejectedError extends Error {
-  constructor() {
-    super('User rejected the connection request')
-    this.name = 'UserRejectedError'
-  }
-}
-
-export class UnsupportedChainError extends Error {
-  constructor() {
-    super('Wallet does not support the active chain')
-    this.name = 'UnsupportedChainError'
-  }
-}
-
-/**
- * Shared alert shown when a WalletConnect flow fails with
- * UnsupportedChainError. Colocated with the error class so the
- * copy stays in sync across consumers.
- */
-export const showUnsupportedChainAlert = () => {
+const showUnsupportedChainAlert = () => {
   Alert.alert(
     'Unsupported network',
     "The connected wallet doesn't support the network of the active Safe. Please connect a wallet that supports it, or switch to a different Safe.",
@@ -64,97 +37,12 @@ export const showUnsupportedChainAlert = () => {
 // in CONNECT_ERROR. The QR-code pairing proposal expires (~5 min default) before
 // the wallet completes pairing, surfacing as "Proposal expired" — sometimes
 // wrapped (e.g. "Pairing already exists: Proposal expired"). Word boundaries
-// keep the match tight enough to avoid promoting non-WC errors that happen
-// to contain the substring. Used at the CONNECT_ERROR rejection site to
-// upgrade plain ConnectError to ProposalExpiredError.
+// keep the match tight enough to avoid false positives on non-WC errors that
+// happen to contain the substring.
 export const isProposalExpiredMessage = (message: string): boolean => /\bproposal\s+expired\b/i.test(message)
 
-export interface WalletConnectErrorContext {
-  /** Slug used in log messages, e.g. 'signer import' → "during signer import". */
-  flow: string
-  /** Title shown in the user-facing alert for unhandled errors. */
-  alertTitle: string
-  /** Body shown alongside `alertTitle`. */
-  alertBody: string
-  /** From `useAppKit()` — closes the modal sheet. */
-  close: () => void
-  /** From `useAppKit()` — typed `() => void` but returns a Promise at runtime. */
-  disconnect: () => void
-}
-
-/**
- * Outcome of `handleWalletConnectError`. Callers loop on `'retry'` to give
- * the user a fresh QR after a benign expiry; `'handled'` means the helper
- * has already shown the appropriate UI and the caller should stop.
- */
-export type WalletConnectErrorOutcome = 'handled' | 'retry'
-
-/**
- * Centralizes WalletConnect-flow error handling so logging, modal cleanup,
- * and user alerts stay consistent across consumers of `useConnect`.
- *
- * Behaviour by error class:
- * - `UnsupportedChainError` → `showUnsupportedChainAlert` (disconnect already
- *   handled inside `useConnect.rejectUnsupported`); returns `'handled'`.
- * - `UserRejectedError` → `Logger.info` + `close()`; returns `'handled'`.
- * - `ProposalExpiredError` → `Logger.warn` + awaited disconnect, then
- *   returns `'retry'` so the caller can re-call `connect()` and present a
- *   fresh QR. No alert — proposal expiry is benign and recoverable.
- * - Any other error → `Logger.error` + cleanup + alert; returns `'handled'`.
- *
- * Cleanup is awaited on the retry path (so the next `connect()` doesn't
- * pick up the dead pairing), and runs inside a fire-and-forget IIFE on the
- * alert path (so the alert renders promptly). `close()` is called before
- * `Alert.alert` so the alert isn't hosted by a dismissing modal on iOS.
- */
-export const handleWalletConnectError = async (
-  error: unknown,
-  ctx: WalletConnectErrorContext,
-): Promise<WalletConnectErrorOutcome> => {
-  if (error instanceof UnsupportedChainError) {
-    showUnsupportedChainAlert()
-    return 'handled'
-  }
-
-  if (error instanceof UserRejectedError) {
-    Logger.info(`User rejected WC connect during ${ctx.flow}`)
-    ctx.close()
-    return 'handled'
-  }
-
-  if (error instanceof ProposalExpiredError) {
-    Logger.warn(`WalletConnect proposal expired during ${ctx.flow}, reopening connect modal:`, error)
-    // Tear down the stale pairing before reopening so the next connect()
-    // doesn't pick up a dead session. Awaited (vs. fire-and-forget) so the
-    // retry can't race the cleanup.
-    try {
-      await ctx.disconnect()
-    } catch (disconnectError) {
-      Logger.warn(`Failed to disconnect WC session after ${ctx.flow} error:`, disconnectError)
-    }
-    return 'retry'
-  }
-
-  Logger.error(`Error during ${ctx.flow}:`, error)
-  // Tear down any half-formed pairing before dismissing the modal so we
-  // don't leak relay subscriptions or ghost sessions on retry. AppKit's
-  // useAppKit narrows disconnect to () => void, but the underlying call
-  // returns a Promise — await inside an IIFE so async rejections are
-  // captured rather than escaping as unhandled rejections.
-  void (async () => {
-    try {
-      await ctx.disconnect()
-    } catch (disconnectError) {
-      Logger.warn(`Failed to disconnect WC session after ${ctx.flow} error:`, disconnectError)
-    }
-  })()
-  ctx.close()
-  Alert.alert(ctx.alertTitle, ctx.alertBody, [{ text: 'OK' }])
-  return 'handled'
-}
-
 interface PendingConnect {
-  resolve: (result: ConnectResult) => void
+  resolve: (result: ConnectResult | null) => void
   reject: (error: Error) => void
 }
 
@@ -164,14 +52,28 @@ interface PendingConnect {
 // connection state is stale.
 const SWITCH_SETTLE_TIMEOUT_MS = 8000
 
+export interface UseConnectOptions {
+  /** Slug used in internal log messages, e.g. 'signer import'. */
+  flow: string
+}
+
 /**
- * Returns a `connect()` function that opens the AppKit modal and
- * returns a promise resolving with the connected wallet's address
- * and name. Rejects on CONNECT_ERROR, USER_REJECTED, or when the
- * wallet cannot honor the active Safe's chain (UnsupportedChainError).
+ * Returns a `connect()` function that opens the AppKit modal and resolves
+ * with the connected wallet's address and name. The known benign failure
+ * modes are handled inside this hook:
+ *
+ * - **Unsupported chain**: shows "Unsupported network" alert, disconnects,
+ *   resolves to `null`.
+ * - **User rejection**: logs at info level, closes the modal, resolves to `null`.
+ * - **Proposal expired**: logs at warn level, disconnects, transparently
+ *   reopens the modal with a fresh proposal — promise stays pending until
+ *   the user either succeeds or hits one of the other paths.
+ *
+ * Only catastrophic / unrecognised CONNECT_ERROR cases reject (with
+ * `ConnectError`); consumers handle those via `showConnectFallbackAlert`.
  */
-export function useConnect() {
-  const { open, disconnect, switchNetwork } = useAppKit()
+export function useConnect({ flow }: UseConnectOptions) {
+  const { open, close, disconnect, switchNetwork } = useAppKit()
   const { address, isConnected, chain } = useAccount()
   const { walletInfo } = useWalletInfo()
   const activeSafe = useAppSelector(selectActiveSafe)
@@ -190,21 +92,22 @@ export function useConnect() {
     }
   }
 
-  const rejectUnsupported = () => {
+  const resolveUnsupported = () => {
     if (!pendingRef.current) {
       return
     }
-    const { reject } = pendingRef.current
+    const { resolve } = pendingRef.current
     pendingRef.current = null
     clearSwitchTimeout()
     void (async () => {
       try {
         await disconnect()
       } catch (error) {
-        Logger.warn('Failed to disconnect after unsupported-chain connection:', error)
+        Logger.warn(`Failed to disconnect after unsupported-chain connection during ${flow}:`, error)
       }
     })()
-    reject(new UnsupportedChainError())
+    showUnsupportedChainAlert()
+    resolve(null)
   }
 
   // Resolver: only resolve when state is fully connected AND the wallet is on
@@ -251,9 +154,9 @@ export function useConnect() {
     }
 
     // Wallet is on a different chain but has an account. Try to switch; if the
-    // switch throws, reject. If it resolves, the resolver useEffect handles
-    // success — with a timeout safety net for wallets that resolve without
-    // actually switching.
+    // switch throws, mark unsupported. If it resolves, the resolver useEffect
+    // handles success — with a timeout safety net for wallets that resolve
+    // without actually switching.
     switchNetwork(expectedCaipId)
       .then(() => {
         if (!pendingRef.current) {
@@ -261,12 +164,12 @@ export function useConnect() {
         }
         switchTimeoutRef.current = setTimeout(() => {
           Logger.warn('switchNetwork resolved but chain did not settle in time')
-          rejectUnsupported()
+          resolveUnsupported()
         }, SWITCH_SETTLE_TIMEOUT_MS)
       })
       .catch((switchError) => {
         Logger.warn('Failed to switch network after unsupported-chain connection:', switchError)
-        rejectUnsupported()
+        resolveUnsupported()
       })
   })
 
@@ -274,25 +177,47 @@ export function useConnect() {
     if (!pendingRef.current) {
       return
     }
+    const message = data.properties?.message || 'Connection failed'
+
+    // Proposal expiry is benign and recoverable: tear down the stale pairing
+    // and reopen the modal with a fresh proposal. pendingRef stays set so
+    // the same promise can resolve once the user successfully scans.
+    if (isProposalExpiredMessage(message)) {
+      Logger.warn(`WalletConnect proposal expired during ${flow}, reopening connect modal`)
+      void (async () => {
+        try {
+          await disconnect()
+        } catch (disconnectError) {
+          Logger.warn(`Failed to disconnect WC session after ${flow} error:`, disconnectError)
+        }
+        if (pendingRef.current) {
+          open({ view: 'Connect' })
+        }
+      })()
+      return
+    }
+
+    // Catastrophic / unrecognised error — surface to caller.
     const { reject } = pendingRef.current
     pendingRef.current = null
     clearSwitchTimeout()
-    const message = data.properties?.message || 'Connection failed'
-    reject(isProposalExpiredMessage(message) ? new ProposalExpiredError(message) : new ConnectError(message))
+    reject(new ConnectError(message))
   })
 
   useStableAppKitEvent('USER_REJECTED', () => {
     if (!pendingRef.current) {
       return
     }
-    const { reject } = pendingRef.current
+    Logger.info(`User rejected WC connect during ${flow}`)
+    close()
+    const { resolve } = pendingRef.current
     pendingRef.current = null
     clearSwitchTimeout()
-    reject(new UserRejectedError())
+    resolve(null)
   })
 
-  const connect = useCallback(() => {
-    return new Promise<ConnectResult>((resolve, reject) => {
+  const connect = useCallback((): Promise<ConnectResult | null> => {
+    return new Promise<ConnectResult | null>((resolve, reject) => {
       pendingRef.current = { resolve, reject }
       open({ view: 'Connect' })
     })

--- a/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
@@ -19,6 +19,20 @@ export class ConnectError extends Error {
   }
 }
 
+/**
+ * QR-code pairing proposal expired before the wallet completed pairing
+ * (default ~5 min). Treated as a benign, expected failure mode (downgraded
+ * log severity, lighter cleanup messaging) but still requires the same
+ * teardown as a generic ConnectError. Extends ConnectError so consumers
+ * who only care about "any connect failure" still match via `instanceof`.
+ */
+export class ProposalExpiredError extends ConnectError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ProposalExpiredError'
+  }
+}
+
 export class UserRejectedError extends Error {
   constructor() {
     super('User rejected the connection request')
@@ -50,10 +64,10 @@ export const showUnsupportedChainAlert = () => {
 // in CONNECT_ERROR. The QR-code pairing proposal expires (~5 min default) before
 // the wallet completes pairing, surfacing as "Proposal expired" — sometimes
 // wrapped (e.g. "Pairing already exists: Proposal expired"). Word boundaries
-// keep the match tight enough to avoid downgrading non-WC errors that happen
-// to contain the substring.
-export const isProposalExpiredError = (error: unknown): boolean =>
-  error instanceof Error && /\bproposal\s+expired\b/i.test(error.message)
+// keep the match tight enough to avoid promoting non-WC errors that happen
+// to contain the substring. Used at the CONNECT_ERROR rejection site to
+// upgrade plain ConnectError to ProposalExpiredError.
+export const isProposalExpiredMessage = (message: string): boolean => /\bproposal\s+expired\b/i.test(message)
 
 export interface WalletConnectErrorContext {
   /** Slug used in log messages, e.g. 'signer import' → "during signer import". */
@@ -77,7 +91,7 @@ export interface WalletConnectErrorContext {
  *   handled inside `useConnect.rejectUnsupported`).
  * - `UserRejectedError` → `Logger.info` + `close()`. No alert (intentional
  *   cancellation).
- * - `Proposal expired` `ConnectError` → `Logger.warn` + cleanup + alert.
+ * - `ProposalExpiredError` → `Logger.warn` + cleanup + alert.
  * - Any other error → `Logger.error` + cleanup + alert.
  *
  * Cleanup runs `disconnect()` inside an awaited IIFE so async rejections from
@@ -96,7 +110,7 @@ export const handleWalletConnectError = (error: unknown, ctx: WalletConnectError
     return
   }
 
-  if (isProposalExpiredError(error)) {
+  if (error instanceof ProposalExpiredError) {
     Logger.warn(`WalletConnect proposal expired during ${ctx.flow}:`, error)
   } else {
     Logger.error(`Error during ${ctx.flow}:`, error)
@@ -242,7 +256,8 @@ export function useConnect() {
     const { reject } = pendingRef.current
     pendingRef.current = null
     clearSwitchTimeout()
-    reject(new ConnectError(data.properties?.message || 'Connection failed'))
+    const message = data.properties?.message || 'Connection failed'
+    reject(isProposalExpiredMessage(message) ? new ProposalExpiredError(message) : new ConnectError(message))
   })
 
   useStableAppKitEvent('USER_REJECTED', () => {

--- a/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useConnect.ts
@@ -83,39 +83,59 @@ export interface WalletConnectErrorContext {
 }
 
 /**
+ * Outcome of `handleWalletConnectError`. Callers loop on `'retry'` to give
+ * the user a fresh QR after a benign expiry; `'handled'` means the helper
+ * has already shown the appropriate UI and the caller should stop.
+ */
+export type WalletConnectErrorOutcome = 'handled' | 'retry'
+
+/**
  * Centralizes WalletConnect-flow error handling so logging, modal cleanup,
  * and user alerts stay consistent across consumers of `useConnect`.
  *
  * Behaviour by error class:
  * - `UnsupportedChainError` → `showUnsupportedChainAlert` (disconnect already
- *   handled inside `useConnect.rejectUnsupported`).
- * - `UserRejectedError` → `Logger.info` + `close()`. No alert (intentional
- *   cancellation).
- * - `ProposalExpiredError` → `Logger.warn` + cleanup + alert.
- * - Any other error → `Logger.error` + cleanup + alert.
+ *   handled inside `useConnect.rejectUnsupported`); returns `'handled'`.
+ * - `UserRejectedError` → `Logger.info` + `close()`; returns `'handled'`.
+ * - `ProposalExpiredError` → `Logger.warn` + awaited disconnect, then
+ *   returns `'retry'` so the caller can re-call `connect()` and present a
+ *   fresh QR. No alert — proposal expiry is benign and recoverable.
+ * - Any other error → `Logger.error` + cleanup + alert; returns `'handled'`.
  *
- * Cleanup runs `disconnect()` inside an awaited IIFE so async rejections from
- * AppKit don't escape as unhandled rejections. `close()` is called before
+ * Cleanup is awaited on the retry path (so the next `connect()` doesn't
+ * pick up the dead pairing), and runs inside a fire-and-forget IIFE on the
+ * alert path (so the alert renders promptly). `close()` is called before
  * `Alert.alert` so the alert isn't hosted by a dismissing modal on iOS.
  */
-export const handleWalletConnectError = (error: unknown, ctx: WalletConnectErrorContext): void => {
+export const handleWalletConnectError = async (
+  error: unknown,
+  ctx: WalletConnectErrorContext,
+): Promise<WalletConnectErrorOutcome> => {
   if (error instanceof UnsupportedChainError) {
     showUnsupportedChainAlert()
-    return
+    return 'handled'
   }
 
   if (error instanceof UserRejectedError) {
     Logger.info(`User rejected WC connect during ${ctx.flow}`)
     ctx.close()
-    return
+    return 'handled'
   }
 
   if (error instanceof ProposalExpiredError) {
-    Logger.warn(`WalletConnect proposal expired during ${ctx.flow}:`, error)
-  } else {
-    Logger.error(`Error during ${ctx.flow}:`, error)
+    Logger.warn(`WalletConnect proposal expired during ${ctx.flow}, reopening connect modal:`, error)
+    // Tear down the stale pairing before reopening so the next connect()
+    // doesn't pick up a dead session. Awaited (vs. fire-and-forget) so the
+    // retry can't race the cleanup.
+    try {
+      await ctx.disconnect()
+    } catch (disconnectError) {
+      Logger.warn(`Failed to disconnect WC session after ${ctx.flow} error:`, disconnectError)
+    }
+    return 'retry'
   }
 
+  Logger.error(`Error during ${ctx.flow}:`, error)
   // Tear down any half-formed pairing before dismissing the modal so we
   // don't leak relay subscriptions or ghost sessions on retry. AppKit's
   // useAppKit narrows disconnect to () => void, but the underlying call
@@ -130,6 +150,7 @@ export const handleWalletConnectError = (error: unknown, ctx: WalletConnectError
   })()
   ctx.close()
   Alert.alert(ctx.alertTitle, ctx.alertBody, [{ text: 'OK' }])
+  return 'handled'
 }
 
 interface PendingConnect {

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -6,14 +6,21 @@ import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipVa
 import { useSignerCollisionGuard } from '@/src/features/ImportSigner/hooks/useSignerCollisionGuard'
 import Logger from '@/src/utils/logger'
 import { useSwitchNetwork } from './useSwitchNetwork'
-import { useConnect, UnsupportedChainError, UserRejectedError, showUnsupportedChainAlert } from './useConnect'
+import {
+  useConnect,
+  UnsupportedChainError,
+  UserRejectedError,
+  showUnsupportedChainAlert,
+  isProposalExpiredError,
+} from './useConnect'
+import { Alert } from 'react-native'
 
 /**
  * Handles the signer import flow: ownership validation and navigation
  * after a new wallet connects via WalletConnect.
  */
 export function useImportSignerFlow() {
-  const { disconnect } = useAppKit()
+  const { disconnect, close } = useAppKit()
   const { switchNetworkIfNeeded } = useSwitchNetwork()
   const { validateAddressOwnership } = useAddressOwnershipValidation()
   const { guardAgainstCollision } = useSignerCollisionGuard()
@@ -54,11 +61,32 @@ export function useImportSignerFlow() {
         showUnsupportedChainAlert()
         return
       }
-      if (!(error instanceof UserRejectedError)) {
+
+      if (error instanceof UserRejectedError) {
+        Logger.info('User rejected WC connect during signer import')
+        close()
+        return
+      }
+
+      if (isProposalExpiredError(error)) {
+        Logger.warn('WalletConnect proposal expired during signer import:', error)
+      } else {
         Logger.error('Error during signer import:', error)
       }
+
+      // Tear down any half-formed pairing before dismissing the modal so we
+      // don't leak relay subscriptions or ghost sessions on retry.
+      try {
+        disconnect()
+      } catch (disconnectError) {
+        Logger.warn('Failed to disconnect WC session after import error:', disconnectError)
+      }
+      close()
+      Alert.alert('Error during signer import', 'Something went wrong while importing the signer. Please try again.', [
+        { text: 'OK' },
+      ])
     }
-  }, [connect, validateAddressOwnership, switchNetworkIfNeeded, disconnect, guardAgainstCollision])
+  }, [connect, validateAddressOwnership, switchNetworkIfNeeded, disconnect, guardAgainstCollision, close])
 
   return { initiateConnection }
 }

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -75,12 +75,17 @@ export function useImportSignerFlow() {
       }
 
       // Tear down any half-formed pairing before dismissing the modal so we
-      // don't leak relay subscriptions or ghost sessions on retry.
-      try {
-        disconnect()
-      } catch (disconnectError) {
-        Logger.warn('Failed to disconnect WC session after import error:', disconnectError)
-      }
+      // don't leak relay subscriptions or ghost sessions on retry. AppKit's
+      // useAppKit narrows disconnect to () => void, but the underlying call
+      // returns a Promise — await inside an IIFE so async rejections are
+      // captured rather than escaping as unhandled rejections.
+      void (async () => {
+        try {
+          await disconnect()
+        } catch (disconnectError) {
+          Logger.warn('Failed to disconnect WC session after import error:', disconnectError)
+        }
+      })()
       close()
       Alert.alert('Error during signer import', 'Something went wrong while importing the signer. Please try again.', [
         { text: 'OK' },

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -20,43 +20,54 @@ export function useImportSignerFlow() {
   const connect = useConnect()
 
   const initiateConnection = useCallback(async () => {
-    try {
-      const { address, walletName, walletIcon } = await connect()
-      const checksumAddress = getAddress(address)
-      const result = await validateAddressOwnership(checksumAddress)
+    // Loop so a ProposalExpiredError (benign QR expiry) transparently
+    // reopens the connect modal with a fresh proposal. Any other error
+    // exits the loop via handleWalletConnectError returning 'handled'.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        const { address, walletName, walletIcon } = await connect()
+        const checksumAddress = getAddress(address)
+        const result = await validateAddressOwnership(checksumAddress)
 
-      if (result.isOwner) {
-        if (guardAgainstCollision(checksumAddress, 'walletconnect')) {
-          try {
-            await disconnect()
-          } catch (disconnectError) {
-            Logger.error('Failed to disconnect WC session after collision:', disconnectError)
+        if (result.isOwner) {
+          if (guardAgainstCollision(checksumAddress, 'walletconnect')) {
+            try {
+              await disconnect()
+            } catch (disconnectError) {
+              Logger.error('Failed to disconnect WC session after collision:', disconnectError)
+            }
+            return
           }
-          return
+
+          await switchNetworkIfNeeded()
+
+          router.push({
+            pathname: '/import-signers/name-signer',
+            params: { address: checksumAddress, walletName },
+          })
+        } else {
+          disconnect()
+
+          router.push({
+            pathname: '/import-signers/connect-signer-error',
+            params: { address: checksumAddress, walletIcon },
+          })
         }
-
-        await switchNetworkIfNeeded()
-
-        router.push({
-          pathname: '/import-signers/name-signer',
-          params: { address: checksumAddress, walletName },
+        return
+      } catch (error) {
+        const outcome = await handleWalletConnectError(error, {
+          flow: 'signer import',
+          alertTitle: 'Error during signer import',
+          alertBody: 'Something went wrong while importing the signer. Please try again.',
+          close,
+          disconnect,
         })
-      } else {
-        disconnect()
-
-        router.push({
-          pathname: '/import-signers/connect-signer-error',
-          params: { address: checksumAddress, walletIcon },
-        })
+        if (outcome === 'retry') {
+          continue
+        }
+        return
       }
-    } catch (error) {
-      handleWalletConnectError(error, {
-        flow: 'signer import',
-        alertTitle: 'Error during signer import',
-        alertBody: 'Something went wrong while importing the signer. Please try again.',
-        close,
-        disconnect,
-      })
     }
   }, [connect, validateAddressOwnership, switchNetworkIfNeeded, disconnect, guardAgainstCollision, close])
 

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -6,14 +6,7 @@ import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipVa
 import { useSignerCollisionGuard } from '@/src/features/ImportSigner/hooks/useSignerCollisionGuard'
 import Logger from '@/src/utils/logger'
 import { useSwitchNetwork } from './useSwitchNetwork'
-import {
-  useConnect,
-  UnsupportedChainError,
-  UserRejectedError,
-  showUnsupportedChainAlert,
-  isProposalExpiredError,
-} from './useConnect'
-import { Alert } from 'react-native'
+import { useConnect, handleWalletConnectError } from './useConnect'
 
 /**
  * Handles the signer import flow: ownership validation and navigation
@@ -57,39 +50,13 @@ export function useImportSignerFlow() {
         })
       }
     } catch (error) {
-      if (error instanceof UnsupportedChainError) {
-        showUnsupportedChainAlert()
-        return
-      }
-
-      if (error instanceof UserRejectedError) {
-        Logger.info('User rejected WC connect during signer import')
-        close()
-        return
-      }
-
-      if (isProposalExpiredError(error)) {
-        Logger.warn('WalletConnect proposal expired during signer import:', error)
-      } else {
-        Logger.error('Error during signer import:', error)
-      }
-
-      // Tear down any half-formed pairing before dismissing the modal so we
-      // don't leak relay subscriptions or ghost sessions on retry. AppKit's
-      // useAppKit narrows disconnect to () => void, but the underlying call
-      // returns a Promise — await inside an IIFE so async rejections are
-      // captured rather than escaping as unhandled rejections.
-      void (async () => {
-        try {
-          await disconnect()
-        } catch (disconnectError) {
-          Logger.warn('Failed to disconnect WC session after import error:', disconnectError)
-        }
-      })()
-      close()
-      Alert.alert('Error during signer import', 'Something went wrong while importing the signer. Please try again.', [
-        { text: 'OK' },
-      ])
+      handleWalletConnectError(error, {
+        flow: 'signer import',
+        alertTitle: 'Error during signer import',
+        alertBody: 'Something went wrong while importing the signer. Please try again.',
+        close,
+        disconnect,
+      })
     }
   }, [connect, validateAddressOwnership, switchNetworkIfNeeded, disconnect, guardAgainstCollision, close])
 

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -48,7 +48,15 @@ export function useImportSignerFlow() {
           params: { address: checksumAddress, walletName },
         })
       } else {
-        disconnect()
+        // disconnect() is typed () => void but returns a Promise at runtime;
+        // wrap in an awaited IIFE so async rejections don't escape unhandled.
+        void (async () => {
+          try {
+            await disconnect()
+          } catch (disconnectError) {
+            Logger.warn('Failed to disconnect WC session after non-owner connect:', disconnectError)
+          }
+        })()
 
         router.push({
           pathname: '/import-signers/connect-signer-error',

--- a/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useImportSignerFlow.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { Alert } from 'react-native'
 import { router } from 'expo-router'
 import { getAddress } from 'ethers'
 import { useAppKit } from '@reown/appkit-react-native'
@@ -6,7 +7,7 @@ import { useAddressOwnershipValidation } from '@/src/hooks/useAddressOwnershipVa
 import { useSignerCollisionGuard } from '@/src/features/ImportSigner/hooks/useSignerCollisionGuard'
 import Logger from '@/src/utils/logger'
 import { useSwitchNetwork } from './useSwitchNetwork'
-import { useConnect, handleWalletConnectError } from './useConnect'
+import { useConnect } from './useConnect'
 
 /**
  * Handles the signer import flow: ownership validation and navigation
@@ -17,57 +18,61 @@ export function useImportSignerFlow() {
   const { switchNetworkIfNeeded } = useSwitchNetwork()
   const { validateAddressOwnership } = useAddressOwnershipValidation()
   const { guardAgainstCollision } = useSignerCollisionGuard()
-  const connect = useConnect()
+  const connect = useConnect({ flow: 'signer import' })
 
   const initiateConnection = useCallback(async () => {
-    // Loop so a ProposalExpiredError (benign QR expiry) transparently
-    // reopens the connect modal with a fresh proposal. Any other error
-    // exits the loop via handleWalletConnectError returning 'handled'.
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      try {
-        const { address, walletName, walletIcon } = await connect()
-        const checksumAddress = getAddress(address)
-        const result = await validateAddressOwnership(checksumAddress)
-
-        if (result.isOwner) {
-          if (guardAgainstCollision(checksumAddress, 'walletconnect')) {
-            try {
-              await disconnect()
-            } catch (disconnectError) {
-              Logger.error('Failed to disconnect WC session after collision:', disconnectError)
-            }
-            return
-          }
-
-          await switchNetworkIfNeeded()
-
-          router.push({
-            pathname: '/import-signers/name-signer',
-            params: { address: checksumAddress, walletName },
-          })
-        } else {
-          disconnect()
-
-          router.push({
-            pathname: '/import-signers/connect-signer-error',
-            params: { address: checksumAddress, walletIcon },
-          })
-        }
-        return
-      } catch (error) {
-        const outcome = await handleWalletConnectError(error, {
-          flow: 'signer import',
-          alertTitle: 'Error during signer import',
-          alertBody: 'Something went wrong while importing the signer. Please try again.',
-          close,
-          disconnect,
-        })
-        if (outcome === 'retry') {
-          continue
-        }
+    try {
+      const result = await connect()
+      // useConnect handled cancel / unsupported-chain internally.
+      if (!result) {
         return
       }
+      const { address, walletName, walletIcon } = result
+      const checksumAddress = getAddress(address)
+      const ownership = await validateAddressOwnership(checksumAddress)
+
+      if (ownership.isOwner) {
+        if (guardAgainstCollision(checksumAddress, 'walletconnect')) {
+          try {
+            await disconnect()
+          } catch (disconnectError) {
+            Logger.error('Failed to disconnect WC session after collision:', disconnectError)
+          }
+          return
+        }
+
+        await switchNetworkIfNeeded()
+
+        router.push({
+          pathname: '/import-signers/name-signer',
+          params: { address: checksumAddress, walletName },
+        })
+      } else {
+        disconnect()
+
+        router.push({
+          pathname: '/import-signers/connect-signer-error',
+          params: { address: checksumAddress, walletIcon },
+        })
+      }
+    } catch (error) {
+      Logger.error('Error during signer import:', error)
+      // Tear down any half-formed pairing before dismissing the modal so we
+      // don't leak relay subscriptions or ghost sessions on retry. AppKit's
+      // useAppKit narrows disconnect to () => void, but the underlying call
+      // returns a Promise — await inside an IIFE so async rejections are
+      // captured rather than escaping as unhandled rejections.
+      void (async () => {
+        try {
+          await disconnect()
+        } catch (disconnectError) {
+          Logger.warn('Failed to disconnect WC session after signer import error:', disconnectError)
+        }
+      })()
+      close()
+      Alert.alert('Error during signer import', 'Something went wrong while importing the signer. Please try again.', [
+        { text: 'OK' },
+      ])
     }
   }, [connect, validateAddressOwnership, switchNetworkIfNeeded, disconnect, guardAgainstCollision, close])
 

--- a/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
@@ -1,10 +1,12 @@
 import { useCallback } from 'react'
+import { Alert } from 'react-native'
 import { router } from 'expo-router'
 import { useAppKit } from '@reown/appkit-react-native'
 import { getAddress } from 'ethers'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+import Logger from '@/src/utils/logger'
 import { useSwitchNetwork } from './useSwitchNetwork'
-import { useConnect, handleWalletConnectError } from './useConnect'
+import { useConnect } from './useConnect'
 
 /**
  * Handles the first WalletConnect reconnection attempt for existing signers.
@@ -13,45 +15,48 @@ import { useConnect, handleWalletConnectError } from './useConnect'
 export function useReconnectFlow() {
   const { disconnect, close } = useAppKit()
   const { switchNetworkIfNeeded } = useSwitchNetwork()
-  const connect = useConnect()
+  const connect = useConnect({ flow: 'reconnect' })
 
   const reconnect = useCallback(
     async (signerAddress: string) => {
-      // Loop so a ProposalExpiredError (benign QR expiry) transparently
-      // reopens the connect modal with a fresh proposal. Any other error
-      // exits the loop via handleWalletConnectError returning 'handled'.
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        try {
-          const { address } = await connect()
-          const reconnectAddress = getAddress(signerAddress)
-
-          if (!sameAddress(reconnectAddress, address)) {
-            disconnect()
-
-            router.push({
-              pathname: '/import-signers/reconnect-error',
-              params: { address: reconnectAddress },
-            })
-
-            return
-          }
-
-          switchNetworkIfNeeded()
-          return
-        } catch (error) {
-          const outcome = await handleWalletConnectError(error, {
-            flow: 'reconnect',
-            alertTitle: 'Error during reconnect',
-            alertBody: 'Something went wrong while reconnecting the signer. Please try again.',
-            close,
-            disconnect,
-          })
-          if (outcome === 'retry') {
-            continue
-          }
+      try {
+        const result = await connect()
+        // useConnect handled cancel / unsupported-chain internally.
+        if (!result) {
           return
         }
+        const reconnectAddress = getAddress(signerAddress)
+
+        if (!sameAddress(reconnectAddress, result.address)) {
+          disconnect()
+
+          router.push({
+            pathname: '/import-signers/reconnect-error',
+            params: { address: reconnectAddress },
+          })
+
+          return
+        }
+
+        switchNetworkIfNeeded()
+      } catch (error) {
+        Logger.error('Error during reconnect:', error)
+        // Tear down any half-formed pairing before dismissing the modal so we
+        // don't leak relay subscriptions or ghost sessions on retry. AppKit's
+        // useAppKit narrows disconnect to () => void, but the underlying call
+        // returns a Promise — await inside an IIFE so async rejections are
+        // captured rather than escaping as unhandled rejections.
+        void (async () => {
+          try {
+            await disconnect()
+          } catch (disconnectError) {
+            Logger.warn('Failed to disconnect WC session after reconnect error:', disconnectError)
+          }
+        })()
+        close()
+        Alert.alert('Error during reconnect', 'Something went wrong while reconnecting the signer. Please try again.', [
+          { text: 'OK' },
+        ])
       }
     },
     [connect, disconnect, switchNetworkIfNeeded, close],

--- a/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
@@ -4,14 +4,22 @@ import { useAppKit } from '@reown/appkit-react-native'
 import { getAddress } from 'ethers'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useSwitchNetwork } from './useSwitchNetwork'
-import { useConnect, UnsupportedChainError, showUnsupportedChainAlert } from './useConnect'
+import {
+  useConnect,
+  UnsupportedChainError,
+  showUnsupportedChainAlert,
+  UserRejectedError,
+  isProposalExpiredError,
+} from './useConnect'
+import { Alert } from 'react-native'
+import Logger from '@/src/utils/logger'
 
 /**
  * Handles the first WalletConnect reconnection attempt for existing signers.
  * On address mismatch, navigates to ReconnectError which owns subsequent retries.
  */
 export function useReconnectFlow() {
-  const { disconnect } = useAppKit()
+  const { disconnect, close } = useAppKit()
   const { switchNetworkIfNeeded } = useSwitchNetwork()
   const connect = useConnect()
 
@@ -38,10 +46,33 @@ export function useReconnectFlow() {
           showUnsupportedChainAlert()
           return
         }
-        // CONNECT_ERROR or USER_REJECTED — no action needed
+
+        if (error instanceof UserRejectedError) {
+          Logger.info('User rejected WC connect during reconnect')
+          close()
+          return
+        }
+
+        if (isProposalExpiredError(error)) {
+          Logger.warn('WalletConnect proposal expired during reconnect:', error)
+        } else {
+          Logger.error('Error during reconnect:', error)
+        }
+
+        // Tear down any half-formed pairing before dismissing the modal so we
+        // don't leak relay subscriptions or ghost sessions on retry.
+        try {
+          disconnect()
+        } catch (disconnectError) {
+          Logger.warn('Failed to disconnect WC session after reconnect error:', disconnectError)
+        }
+        close()
+        Alert.alert('Error during reconnect', 'Something went wrong while reconnecting the signer. Please try again.', [
+          { text: 'OK' },
+        ])
       }
     },
-    [connect, disconnect, switchNetworkIfNeeded],
+    [connect, disconnect, switchNetworkIfNeeded, close],
   )
 
   return { reconnect }

--- a/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
@@ -60,12 +60,17 @@ export function useReconnectFlow() {
         }
 
         // Tear down any half-formed pairing before dismissing the modal so we
-        // don't leak relay subscriptions or ghost sessions on retry.
-        try {
-          disconnect()
-        } catch (disconnectError) {
-          Logger.warn('Failed to disconnect WC session after reconnect error:', disconnectError)
-        }
+        // don't leak relay subscriptions or ghost sessions on retry. AppKit's
+        // useAppKit narrows disconnect to () => void, but the underlying call
+        // returns a Promise — await inside an IIFE so async rejections are
+        // captured rather than escaping as unhandled rejections.
+        void (async () => {
+          try {
+            await disconnect()
+          } catch (disconnectError) {
+            Logger.warn('Failed to disconnect WC session after reconnect error:', disconnectError)
+          }
+        })()
         close()
         Alert.alert('Error during reconnect', 'Something went wrong while reconnecting the signer. Please try again.', [
           { text: 'OK' },

--- a/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
@@ -28,7 +28,15 @@ export function useReconnectFlow() {
         const reconnectAddress = getAddress(signerAddress)
 
         if (!sameAddress(reconnectAddress, result.address)) {
-          disconnect()
+          // disconnect() is typed () => void but returns a Promise at runtime;
+          // wrap in an awaited IIFE so async rejections don't escape unhandled.
+          void (async () => {
+            try {
+              await disconnect()
+            } catch (disconnectError) {
+              Logger.warn('Failed to disconnect WC session after address mismatch:', disconnectError)
+            }
+          })()
 
           router.push({
             pathname: '/import-signers/reconnect-error',

--- a/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
@@ -17,30 +17,41 @@ export function useReconnectFlow() {
 
   const reconnect = useCallback(
     async (signerAddress: string) => {
-      try {
-        const { address } = await connect()
-        const reconnectAddress = getAddress(signerAddress)
+      // Loop so a ProposalExpiredError (benign QR expiry) transparently
+      // reopens the connect modal with a fresh proposal. Any other error
+      // exits the loop via handleWalletConnectError returning 'handled'.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        try {
+          const { address } = await connect()
+          const reconnectAddress = getAddress(signerAddress)
 
-        if (!sameAddress(reconnectAddress, address)) {
-          disconnect()
+          if (!sameAddress(reconnectAddress, address)) {
+            disconnect()
 
-          router.push({
-            pathname: '/import-signers/reconnect-error',
-            params: { address: reconnectAddress },
+            router.push({
+              pathname: '/import-signers/reconnect-error',
+              params: { address: reconnectAddress },
+            })
+
+            return
+          }
+
+          switchNetworkIfNeeded()
+          return
+        } catch (error) {
+          const outcome = await handleWalletConnectError(error, {
+            flow: 'reconnect',
+            alertTitle: 'Error during reconnect',
+            alertBody: 'Something went wrong while reconnecting the signer. Please try again.',
+            close,
+            disconnect,
           })
-
+          if (outcome === 'retry') {
+            continue
+          }
           return
         }
-
-        switchNetworkIfNeeded()
-      } catch (error) {
-        handleWalletConnectError(error, {
-          flow: 'reconnect',
-          alertTitle: 'Error during reconnect',
-          alertBody: 'Something went wrong while reconnecting the signer. Please try again.',
-          close,
-          disconnect,
-        })
       }
     },
     [connect, disconnect, switchNetworkIfNeeded, close],

--- a/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
+++ b/apps/mobile/src/features/WalletConnect/hooks/useReconnectFlow.ts
@@ -4,15 +4,7 @@ import { useAppKit } from '@reown/appkit-react-native'
 import { getAddress } from 'ethers'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { useSwitchNetwork } from './useSwitchNetwork'
-import {
-  useConnect,
-  UnsupportedChainError,
-  showUnsupportedChainAlert,
-  UserRejectedError,
-  isProposalExpiredError,
-} from './useConnect'
-import { Alert } from 'react-native'
-import Logger from '@/src/utils/logger'
+import { useConnect, handleWalletConnectError } from './useConnect'
 
 /**
  * Handles the first WalletConnect reconnection attempt for existing signers.
@@ -42,39 +34,13 @@ export function useReconnectFlow() {
 
         switchNetworkIfNeeded()
       } catch (error) {
-        if (error instanceof UnsupportedChainError) {
-          showUnsupportedChainAlert()
-          return
-        }
-
-        if (error instanceof UserRejectedError) {
-          Logger.info('User rejected WC connect during reconnect')
-          close()
-          return
-        }
-
-        if (isProposalExpiredError(error)) {
-          Logger.warn('WalletConnect proposal expired during reconnect:', error)
-        } else {
-          Logger.error('Error during reconnect:', error)
-        }
-
-        // Tear down any half-formed pairing before dismissing the modal so we
-        // don't leak relay subscriptions or ghost sessions on retry. AppKit's
-        // useAppKit narrows disconnect to () => void, but the underlying call
-        // returns a Promise — await inside an IIFE so async rejections are
-        // captured rather than escaping as unhandled rejections.
-        void (async () => {
-          try {
-            await disconnect()
-          } catch (disconnectError) {
-            Logger.warn('Failed to disconnect WC session after reconnect error:', disconnectError)
-          }
-        })()
-        close()
-        Alert.alert('Error during reconnect', 'Something went wrong while reconnecting the signer. Please try again.', [
-          { text: 'OK' },
-        ])
+        handleWalletConnectError(error, {
+          flow: 'reconnect',
+          alertTitle: 'Error during reconnect',
+          alertBody: 'Something went wrong while reconnecting the signer. Please try again.',
+          close,
+          disconnect,
+        })
       }
     },
     [connect, disconnect, switchNetworkIfNeeded, close],


### PR DESCRIPTION
> WC errors now live in `useConnect`,
> proposal expired silently retries,
> consumers do `if (\!result) return`.

## What it solves

`@reown/appkit-react-native`'s `CONNECT_ERROR` was being surfaced as a generic `Logger.error('Error during signer import', ...)` (and equivalent for reconnect) every time the QR-pairing 5-min timeout fired — paging on-call for what is a routine "user didn't scan in time" event. The user also got no signal that anything had gone wrong: no alert, and any half-formed pairing was left behind because only the modal UI was dismissed. On top of that, the catch sites duplicated `instanceof` ladders for every WalletConnect error class, and the cleanup `disconnect()` was un-`await`ed despite returning a `Promise` at runtime — an unhandled-rejection of exactly the class this PR was supposed to suppress.

Resolves: https://linear.app/safe-global/issue/WA-2198

## How this PR fixes it

All known WalletConnect failure modes are now handled inside `useConnect` itself. The hook returns `Promise<ConnectResult | null>`:

- **Success** → resolves with `{ address, walletName, walletIcon }`.
- **User rejected** → `Logger.info` + `close()` + resolves `null`.
- **Unsupported chain** → `Alert.alert('Unsupported network', …)` + `disconnect()` + resolves `null`.
- **Proposal expired** → `Logger.warn` + `disconnect()` + `open({ view: 'Connect' })`. `pendingRef` stays set so the same promise resolves once the user actually scans. Transparent retry, no consumer involvement.
- **Catastrophic / unrecognised `CONNECT_ERROR`** → rejects with `ConnectError`.

Consumers become trivial:

```ts
const connect = useConnect({ flow: 'signer import' })

try {
  const result = await connect()
  if (\!result) return                       // useConnect handled cancel/unsupported
  const { address, walletName, walletIcon } = result
  // happy path
} catch (error) {
  // Fallback for unrecognised errors only — log + IIFE-disconnect + close + Alert.
}
```

A few non-obvious decisions:

- **`disconnect()` runs inside an awaited async IIFE.** AppKit's `useAppKit` hook narrows the `disconnect` return type to `() => void`, but the implementation returns the underlying `Promise<void>`. A bare `try { disconnect() } catch {}` only catches synchronous throws — async rejections become unhandled. The IIFE awaits inside the try so cleanup errors land in `Logger.warn` instead of escaping.
- **`close()` runs before `Alert.alert(...)`** in the fallback path. On iOS the alert can otherwise be hosted by the dismissing AppKit modal and disappear with it. Both flows have a unit test pinning `close → alert` invocation order.
- **`isProposalExpiredMessage` uses `\bproposal\s+expired\b`.** Word boundaries are tight enough to skip substring matches inside other words but lax enough to match the canonical SignClient string and the wrapped form `"Pairing already exists: Proposal expired"`.
- **No retry counter on proposal-expired.** Each retry hands the user another 5 minutes; if they keep walking away, we keep regenerating QRs. Bounded retries felt like overengineering until we see the failure mode in the wild.

Behaviour summary by failure class:

| Trigger | Log | Cleanup | Modal | Promise |
|---|---|---|---|---|
| Success | — | — | (auto) | resolves with result |
| User rejected | `Logger.info` | — | `close()` | resolves `null` |
| Unsupported chain | `Logger.warn` (on switch failure) | `disconnect()` | (auto) + alert | resolves `null` |
| Proposal expired | `Logger.warn` | `disconnect()` | reopen | stays pending |
| Catastrophic `ConnectError` | `Logger.error` (in flow) | `disconnect()` | `close()` + alert | rejects |

## How to test it

1. **Proposal expiry (transparent retry)**: open the import-signer flow and scan a WC QR with a wallet, then wait >5 min before approving on the wallet side. Confirm: the appkit modal refreshes silently (no alert, no error toast) and you can complete the pairing on the next scan. `Logger.warn` records the event in the dev console.
2. **User rejection**: open the import-signer flow and reject the connection in the wallet. Confirm: modal closes cleanly, no alert.
3. **Unsupported chain**: connect a wallet that doesn't support the active Safe's chain. Confirm: "Unsupported network" alert renders, modal stays out of the way, no orphaned session.
4. **Catastrophic error**: trigger a non-expiry connect error (e.g. force-quit the wallet mid-handshake). Confirm: the alert renders cleanly *after* the AppKit sheet dismisses (not behind it), and a fresh QR scan works on retry without "already paired" errors.
5. Repeat (1)–(4) on the reconnect flow (existing signer, signers tab → "Reconnect").

## Visual summary

```mermaid
flowchart TB
    A[connect] --> B{event}
    B -->|CONNECT_SUCCESS<br/>right chain| R[resolve&#40;result&#41;]
    B -->|CONNECT_SUCCESS<br/>wrong chain| S[switchNetwork]
    S -->|ok + chain settles| R
    S -->|throws or timeout| U[disconnect + showUnsupportedChainAlert]
    U --> N[resolve&#40;null&#41;]
    B -->|USER_REJECTED| L1[Logger.info + close]
    L1 --> N
    B -->|CONNECT_ERROR<br/>proposal expired| W[Logger.warn + disconnect + open]
    W -.transparent retry.-> A
    B -->|CONNECT_ERROR<br/>other| RJ[reject ConnectError]
    RJ --> F[caller: Logger.error<br/>+ disconnect + close + alert]
```

## Screenshots

N/A — no UI changes beyond:
- The new "Unsupported network" / generic-error alerts, both stock RN `Alert.alert`.
- Proposal-expired no longer surfaces a user-visible alert at all (transparent retry).

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

Tests added/updated:

`useConnect.test.ts`:
- AppKit message preserved through `ConnectError` (catastrophic case)
- Proposal-expired transparently reopens the modal (asserts second `open({view:'Connect'})` call, no alert, promise stays pending)
- Wrapped proposal-expired (`"Pairing already exists: Proposal expired"`) also reopens
- Proposal-expired post-unmount does not reopen (no orphan `open` calls)
- `isProposalExpiredMessage` matrix: wrapped form, whitespace tolerance, word-boundary negation
- Generic `CONNECT_ERROR` falls back to `'Connection failed'`
- `USER_REJECTED` resolves `null` + closes modal + `Logger.info` + no alert
- Unsupported-chain (switchNetwork throws or times out) resolves `null` + disconnects + shows alert
- Sequential `connect` calls reuse the same hook correctly
- Pending promise cleared on unmount

Flow tests (`useImportSignerFlow.test.ts`, `useReconnectFlow.test.ts`):
- Short-circuits silently when `connect` resolves `null` (covers all cancel/unsupported paths in one assertion since the flow can't tell them apart)
- Fallback alert path (with `close → alert` order assertion)
- Async rejection from `disconnect()` during fallback cleanup is captured to `Logger.warn`, doesn't drop `close`/`Alert`
- Validation errors during the happy path route through the fallback alert
- Collision-guard path: alerts on duplicate signer, captures `disconnect` async rejection

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).