### PR TITLE
fix(web): guard against expired session at boot and on a timer

### DIFF
--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -93,6 +93,7 @@ import { CaptchaProvider } from '@/components/common/Captcha'
 import { HnQueueAssessmentProvider } from '@/features/hypernative'
 import { useOidcLoginCallback } from '@/features/oidc-auth'
 import { useLogoutCallback } from '@/hooks/useLogoutCallback'
+import { useSessionExpiryGuard } from '@/services/sessionExpiry/useSessionExpiryGuard'
 import ObservabilityErrorBoundary from '@/components/common/ObservabilityErrorBoundary'
 import { ShadcnProvider } from '@/components/ui/ShadcnProvider'
 
@@ -128,6 +129,7 @@ const InitApp = (): null => {
   useSafeLabsTerms() // Automatically disconnect wallets if terms not accepted and feature is enabled
   useOidcLoginCallback()
   useLogoutCallback()
+  useSessionExpiryGuard()
 
   return null
 }

--- a/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
+++ b/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
@@ -1,0 +1,290 @@
+import { useStore } from 'react-redux'
+import { act, renderHook, waitFor } from '@/tests/test-utils'
+import type { AppStore, RootState } from '@/store'
+import { useSessionExpiryGuard, SESSION_EXPIRED_GROUP_KEY, SESSION_EXPIRED_MESSAGE } from '../useSessionExpiryGuard'
+import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
+
+const mockUnwrap = jest.fn()
+const mockUnsubscribe = jest.fn()
+const mockInitiate = jest.fn()
+
+// Real RTK Query's `endpoint.initiate()` returns a thunk; dispatching it returns a
+// QueryActionCreatorResult with .unwrap()/.unsubscribe(). We mirror that shape:
+// initiate() → thunk fn → dispatch invokes it → resolves to { unwrap, unsubscribe }.
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/auth', () => ({
+  cgwApi: {
+    endpoints: {
+      authGetMeV1: {
+        initiate: () => mockInitiate(),
+      },
+    },
+  },
+}))
+
+const buildState = (sessionExpiresAt: number | null, isStoreHydrated = true): Partial<RootState> =>
+  ({
+    auth: {
+      sessionExpiresAt,
+      lastUsedSpace: null,
+      isStoreHydrated,
+      isOidcLoginPending: false,
+    },
+  }) as Partial<RootState>
+
+const findNotification = (store: AppStore) =>
+  store.getState().notifications.find((n) => n.groupKey === SESSION_EXPIRED_GROUP_KEY)
+
+const flushMicrotasks = () => act(async () => Promise.resolve())
+
+const renderGuardWithStore = (sessionExpiresAt: number | null) => {
+  let capturedStore: AppStore | undefined
+  const result = renderHook(
+    () => {
+      capturedStore = useStore() as AppStore
+      useSessionExpiryGuard()
+    },
+    { initialReduxState: buildState(sessionExpiresAt) },
+  )
+  if (!capturedStore) throw new Error('store not captured')
+  return { ...result, store: capturedStore }
+}
+
+describe('useSessionExpiryGuard', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-07T12:00:00Z'))
+    mockUnwrap.mockReset()
+    mockUnsubscribe.mockReset()
+    mockInitiate.mockReset()
+    // Default: dispatching the thunk yields the QueryActionCreatorResult shape.
+    mockInitiate.mockImplementation(() => () => ({ unwrap: mockUnwrap, unsubscribe: mockUnsubscribe }))
+    sessionStorage.clear()
+    // Load-bearing: the auth slice is persisted (apps/web/src/store/index.ts
+    // persistedSlices), so a prior test's dispatched setUnauthenticated would
+    // be replayed into this test's store via useHydrateStore's HYDRATE_ACTION
+    // and clobber initialReduxState.auth.sessionExpiresAt. Do not remove.
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('does nothing when the user is not signed in (sessionExpiresAt is null)', async () => {
+    const { store } = renderGuardWithStore(null)
+    await flushMicrotasks()
+
+    expect(mockInitiate).not.toHaveBeenCalled()
+    expect(findNotification(store)).toBeUndefined()
+  })
+
+  it('clears auth and shows a toast when sessionExpiresAt has already passed — without firing /v1/auth/me', async () => {
+    const { store } = renderGuardWithStore(Date.now() - 1_000)
+    await flushMicrotasks()
+
+    expect(mockInitiate).not.toHaveBeenCalled()
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toMatchObject({
+      message: SESSION_EXPIRED_MESSAGE,
+      variant: 'error',
+      groupKey: SESSION_EXPIRED_GROUP_KEY,
+    })
+  })
+
+  it('fires exactly one /v1/auth/me probe when sessionExpiresAt is in the future', async () => {
+    mockUnwrap.mockResolvedValue({ id: 'user-1' })
+
+    const { rerender } = renderGuardWithStore(Date.now() + 60_000)
+    await flushMicrotasks()
+    rerender()
+    rerender()
+    await flushMicrotasks()
+
+    expect(mockInitiate).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps Redux auth state when /v1/auth/me returns 200', async () => {
+    mockUnwrap.mockResolvedValue({ id: 'user-1' })
+    const expiresAt = Date.now() + 60_000
+
+    const { store } = renderGuardWithStore(expiresAt)
+    await flushMicrotasks()
+
+    expect(store.getState().auth.sessionExpiresAt).toBe(expiresAt)
+    expect(findNotification(store)).toBeUndefined()
+  })
+
+  it('clears auth and shows a toast when /v1/auth/me returns 403', async () => {
+    mockUnwrap.mockRejectedValue({ status: 403, data: 'Forbidden' })
+
+    const { store } = renderGuardWithStore(Date.now() + 60_000)
+    await flushMicrotasks()
+
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toMatchObject({
+      message: SESSION_EXPIRED_MESSAGE,
+      variant: 'error',
+      groupKey: SESSION_EXPIRED_GROUP_KEY,
+    })
+  })
+
+  it('leaves auth state untouched on transient errors but still schedules the local-expiry timer', async () => {
+    mockUnwrap.mockRejectedValue({ status: 500, data: 'oops' })
+    const expiresAt = Date.now() + 60_000
+
+    const { store } = renderGuardWithStore(expiresAt)
+    await flushMicrotasks()
+
+    // Immediately: no clear, no toast — we don't have proof the cookie is bad.
+    expect(store.getState().auth.sessionExpiresAt).toBe(expiresAt)
+    expect(findNotification(store)).toBeUndefined()
+
+    // After local expiry passes, the timer must fire so we don't leak past expiry.
+    await act(async () => {
+      jest.advanceTimersByTime(60_001)
+      await Promise.resolve()
+    })
+
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toMatchObject({
+      message: SESSION_EXPIRED_MESSAGE,
+      groupKey: SESSION_EXPIRED_GROUP_KEY,
+    })
+  })
+
+  it('schedules a timer that clears auth and toasts when the session expires mid-tab', async () => {
+    mockUnwrap.mockResolvedValue({ id: 'user-1' })
+    const expiresAt = Date.now() + 60_000
+
+    const { store } = renderGuardWithStore(expiresAt)
+    await flushMicrotasks()
+
+    expect(store.getState().auth.sessionExpiresAt).toBe(expiresAt)
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_001)
+      await Promise.resolve()
+    })
+
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toMatchObject({
+      message: SESSION_EXPIRED_MESSAGE,
+      groupKey: SESSION_EXPIRED_GROUP_KEY,
+    })
+  })
+
+  it('suppresses the /me probe but still arms the local-expiry timer when LOGGING_OUT_KEY is set', async () => {
+    sessionStorage.setItem(LOGGING_OUT_KEY, '1')
+
+    const { store } = renderGuardWithStore(Date.now() + 60_000)
+    await flushMicrotasks()
+
+    // No probe — useLogoutCallback owns /me during this flow.
+    expect(mockInitiate).not.toHaveBeenCalled()
+    expect(findNotification(store)).toBeUndefined()
+
+    // …but the local timer must still fire so a flow that finishes silently
+    // (callback crashes, dispatch never lands) doesn't leave sessionExpiresAt
+    // unenforced.
+    await act(async () => {
+      jest.advanceTimersByTime(60_001)
+      await Promise.resolve()
+    })
+
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toMatchObject({
+      message: SESSION_EXPIRED_MESSAGE,
+      groupKey: SESSION_EXPIRED_GROUP_KEY,
+    })
+  })
+
+  it('suppresses the /me probe but still arms the local-expiry timer when oidc_auth_pending is set', async () => {
+    sessionStorage.setItem('oidc_auth_pending', '1')
+
+    const { store } = renderGuardWithStore(Date.now() + 60_000)
+    await flushMicrotasks()
+
+    expect(mockInitiate).not.toHaveBeenCalled()
+    expect(findNotification(store)).toBeUndefined()
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_001)
+      await Promise.resolve()
+    })
+
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toMatchObject({
+      message: SESSION_EXPIRED_MESSAGE,
+      groupKey: SESSION_EXPIRED_GROUP_KEY,
+    })
+  })
+
+  it('clears auth at sessionExpiresAt even if the /me probe is still pending', async () => {
+    // Probe never resolves — simulates a slow/hung gateway.
+    mockUnwrap.mockReturnValue(new Promise(() => {}))
+    const expiresAt = Date.now() + 60_000
+
+    const { store } = renderGuardWithStore(expiresAt)
+    await flushMicrotasks()
+
+    expect(mockInitiate).toHaveBeenCalledTimes(1)
+    expect(store.getState().auth.sessionExpiresAt).toBe(expiresAt)
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_001)
+      await Promise.resolve()
+    })
+
+    expect(store.getState().auth.sessionExpiresAt).toBeNull()
+    expect(findNotification(store)).toMatchObject({
+      message: SESSION_EXPIRED_MESSAGE,
+      groupKey: SESSION_EXPIRED_GROUP_KEY,
+    })
+  })
+
+  it('does not re-fire the /me probe across re-renders that keep sessionExpiresAt unchanged', async () => {
+    mockUnwrap.mockResolvedValue({ id: 'u' })
+
+    const { rerender } = renderGuardWithStore(Date.now() + 60_000)
+    await flushMicrotasks()
+    rerender()
+    rerender()
+    await flushMicrotasks()
+
+    expect(mockInitiate).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires a fresh /me probe after the user logs out and signs back in within the same tab', async () => {
+    mockUnwrap.mockResolvedValue({ id: 'u' })
+
+    // First mount: signed in.
+    const first = renderGuardWithStore(Date.now() + 60_000)
+    await flushMicrotasks()
+    expect(mockInitiate).toHaveBeenCalledTimes(1)
+    first.unmount()
+
+    // Second mount: same tab, signed out (preloaded null).
+    const middle = renderGuardWithStore(null)
+    await flushMicrotasks()
+    expect(mockInitiate).toHaveBeenCalledTimes(1)
+    middle.unmount()
+
+    // Third mount: signed in again with a new expiry — a fresh probe must fire.
+    renderGuardWithStore(Date.now() + 120_000)
+    await flushMicrotasks()
+    expect(mockInitiate).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs once after the store hydrates from a partial preloaded state', async () => {
+    mockUnwrap.mockResolvedValue({ id: 'user-1' })
+
+    // Mark hydration explicitly false in preloaded state; the test harness'
+    // useHydrateStore flips it to true on mount.
+    renderHook(() => useSessionExpiryGuard(), {
+      initialReduxState: buildState(Date.now() + 60_000, false),
+    })
+
+    await waitFor(() => {
+      expect(mockInitiate).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
+++ b/apps/web/src/services/sessionExpiry/__tests__/useSessionExpiryGuard.test.tsx
@@ -1,7 +1,13 @@
 import { useStore } from 'react-redux'
 import { act, renderHook, waitFor } from '@/tests/test-utils'
 import type { AppStore, RootState } from '@/store'
-import { useSessionExpiryGuard, SESSION_EXPIRED_GROUP_KEY, SESSION_EXPIRED_MESSAGE } from '../useSessionExpiryGuard'
+import {
+  useSessionExpiryGuard,
+  SESSION_EXPIRED_GROUP_KEY,
+  SESSION_EXPIRED_MESSAGE,
+  SESSION_EXPIRED_SIGN_IN_LABEL,
+} from '../useSessionExpiryGuard'
+import { setAuthenticated } from '@/store/authSlice'
 import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
 
 const mockUnwrap = jest.fn()
@@ -272,6 +278,36 @@ describe('useSessionExpiryGuard', () => {
     renderGuardWithStore(Date.now() + 120_000)
     await flushMicrotasks()
     expect(mockInitiate).toHaveBeenCalledTimes(2)
+  })
+
+  it('dismisses a lingering session-expired toast when the user signs back in within the same tab', async () => {
+    mockUnwrap.mockResolvedValue({ id: 'u' })
+
+    // Reproduce the bug: prior expiry left a toast in the store, then the user
+    // signs in again. The toast must not hang on screen.
+    const { store } = renderGuardWithStore(Date.now() - 1_000)
+    await flushMicrotasks()
+    const toast = findNotification(store)
+    expect(toast).toBeDefined()
+    expect(toast?.isDismissed).not.toBe(true)
+
+    await act(async () => {
+      store.dispatch(setAuthenticated(Date.now() + 60_000))
+      await Promise.resolve()
+    })
+
+    expect(findNotification(store)?.isDismissed).toBe(true)
+  })
+
+  it('shows a Spaces sign-in link in the toast that points at /welcome/spaces', async () => {
+    const { store } = renderGuardWithStore(Date.now() - 1_000)
+    await flushMicrotasks()
+
+    expect(findNotification(store)).toMatchObject({
+      message: SESSION_EXPIRED_MESSAGE,
+      link: { href: '/welcome/spaces', title: SESSION_EXPIRED_SIGN_IN_LABEL },
+    })
+    expect(SESSION_EXPIRED_MESSAGE).toBe('Your session has expired. Please sign in to Spaces again.')
   })
 
   it('runs once after the store hydrates from a partial preloaded state', async () => {

--- a/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
+++ b/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react'
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import { cgwApi as authApi } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { selectIsStoreHydrated, setUnauthenticated } from '@/store/authSlice'
+import { showNotification } from '@/store/notificationsSlice'
+import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
+
+// Mirrors apps/web/src/features/oidc-auth/constants.ts. The constant is not
+// exported from the feature's public API; duplicating the literal here avoids
+// pulling the (lazy-loaded) feature module into the boot path.
+const OIDC_AUTH_PENDING_KEY = 'oidc_auth_pending'
+
+export const SESSION_EXPIRED_GROUP_KEY = 'session-expired'
+export const SESSION_EXPIRED_MESSAGE = 'Your session has expired. Please sign in again.'
+
+const isForbidden = (error: unknown): error is FetchBaseQueryError =>
+  typeof error === 'object' && error !== null && 'status' in error && error.status === 403
+
+/**
+ * Detects an expired session and clears Redux auth state so components stop
+ * issuing credentialed requests that would otherwise 403.
+ *
+ * On boot (after store hydration), when the persisted state says the user is
+ * signed in:
+ *  1. If `sessionExpiresAt` has already passed → clear auth + toast immediately,
+ *     no /v1/auth/me round-trip.
+ *  2. Otherwise → arm a local-expiry timer for the remaining lifetime so a
+ *     session that crosses `sessionExpiresAt` mid-tab is cleared without any
+ *     further network request, even if the probe is slow or skipped.
+ *  3. In parallel, fire exactly one /v1/auth/me probe to detect cookies that
+ *     expired earlier than the persisted hint suggests. 403 → clear auth + toast
+ *     immediately (overrides the timer); 200 / transient error → leave the timer
+ *     to fire when local expiry passes.
+ *
+ * The /me probe is suppressed while OIDC login or logout callback flows are
+ * processing — those hooks already call /me themselves. The local timer is
+ * **not** suppressed: we still want sessionExpiresAt enforced even if the
+ * surrounding flow finishes silently without dispatching an auth-state change.
+ */
+export const useSessionExpiryGuard = (): void => {
+  const dispatch = useAppDispatch()
+  const isHydrated = useAppSelector(selectIsStoreHydrated)
+  const sessionExpiresAt = useAppSelector((state) => state.auth.sessionExpiresAt)
+
+  // Track which sessionExpiresAt value we've already processed so that
+  // unrelated re-renders (e.g. dispatch identity churn under React Strict Mode)
+  // don't re-fire the /me probe. Cleared when the user signs out so a
+  // subsequent sign-in within the same tab is processed afresh.
+  const lastProcessedRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!isHydrated) return
+    if (sessionExpiresAt === null) {
+      lastProcessedRef.current = null
+      return
+    }
+    if (lastProcessedRef.current === sessionExpiresAt) return
+    lastProcessedRef.current = sessionExpiresAt
+
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const expireNow = () => {
+      dispatch(setUnauthenticated())
+      dispatch(
+        showNotification({
+          message: SESSION_EXPIRED_MESSAGE,
+          variant: 'error',
+          groupKey: SESSION_EXPIRED_GROUP_KEY,
+        }),
+      )
+    }
+
+    // Pre-flight: cookie is already past local expiry → no point arming the
+    // timer or probing /me, just clear immediately.
+    if (sessionExpiresAt <= Date.now()) {
+      expireNow()
+      return
+    }
+
+    // Arm the local-expiry timer up front. This is the floor on cleanup
+    // latency: even if the /me probe hangs or is suppressed (OIDC/logout flow
+    // owns /me), the session is guaranteed to be cleared at sessionExpiresAt.
+    timer = setTimeout(expireNow, sessionExpiresAt - Date.now())
+
+    // Suppress the probe while OIDC login or logout callback flows are
+    // processing. Both flags are set *synchronously before a full-page redirect*
+    // (useLogout.ts / useOidcLogin.ts), so on the return load they're guaranteed
+    // to be present. They're cleared only after the callback's async /me
+    // resolves and dispatches an auth-state change, which triggers this effect
+    // to re-run via the sessionExpiresAt dep.
+    const inFlow = sessionStorage.getItem(LOGGING_OUT_KEY) || sessionStorage.getItem(OIDC_AUTH_PENDING_KEY)
+    if (inFlow) {
+      return () => {
+        cancelled = true
+        if (timer !== undefined) clearTimeout(timer)
+      }
+    }
+
+    const probe = dispatch(authApi.endpoints.authGetMeV1.initiate())
+    probe
+      .unwrap()
+      .catch((error: unknown) => {
+        if (cancelled) return
+        // 403 → cookie is gone; expire now (the timer is also cleared in
+        // cleanup, but expireNow's setUnauthenticated triggers a re-render
+        // with sessionExpiresAt=null which will run the cleanup anyway).
+        if (isForbidden(error)) expireNow()
+        // Transient (5xx / network): we have no proof the cookie is invalid;
+        // fall through and let the timer enforce local expiry.
+      })
+      .finally(() => {
+        probe.unsubscribe()
+      })
+
+    return () => {
+      cancelled = true
+      if (timer !== undefined) clearTimeout(timer)
+    }
+  }, [dispatch, isHydrated, sessionExpiresAt])
+}

--- a/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
+++ b/apps/web/src/services/sessionExpiry/useSessionExpiryGuard.ts
@@ -3,8 +3,9 @@ import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { cgwApi as authApi } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
 import { useAppDispatch, useAppSelector } from '@/store'
 import { selectIsStoreHydrated, setUnauthenticated } from '@/store/authSlice'
-import { showNotification } from '@/store/notificationsSlice'
+import { closeByGroupKey, showNotification } from '@/store/notificationsSlice'
 import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
+import { AppRoutes } from '@/config/routes'
 
 // Mirrors apps/web/src/features/oidc-auth/constants.ts. The constant is not
 // exported from the feature's public API; duplicating the literal here avoids
@@ -12,7 +13,8 @@ import { LOGGING_OUT_KEY } from '@/hooks/useLogoutCallback'
 const OIDC_AUTH_PENDING_KEY = 'oidc_auth_pending'
 
 export const SESSION_EXPIRED_GROUP_KEY = 'session-expired'
-export const SESSION_EXPIRED_MESSAGE = 'Your session has expired. Please sign in again.'
+export const SESSION_EXPIRED_MESSAGE = 'Your session has expired. Please sign in to Spaces again.'
+export const SESSION_EXPIRED_SIGN_IN_LABEL = 'Sign in to Spaces'
 
 const isForbidden = (error: unknown): error is FetchBaseQueryError =>
   typeof error === 'object' && error !== null && 'status' in error && error.status === 403
@@ -68,6 +70,7 @@ export const useSessionExpiryGuard = (): void => {
           message: SESSION_EXPIRED_MESSAGE,
           variant: 'error',
           groupKey: SESSION_EXPIRED_GROUP_KEY,
+          link: { href: AppRoutes.welcome.spaces, title: SESSION_EXPIRED_SIGN_IN_LABEL },
         }),
       )
     }
@@ -78,6 +81,11 @@ export const useSessionExpiryGuard = (): void => {
       expireNow()
       return
     }
+
+    // We have a fresh, future expiry — meaning the user is (re-)authenticated.
+    // Dismiss any lingering session-expired toast left over from a prior expiry
+    // in the same tab so it doesn't hang around after the user signs back in.
+    dispatch(closeByGroupKey({ groupKey: SESSION_EXPIRED_GROUP_KEY }))
 
     // Arm the local-expiry timer up front. This is the floor on cleanup
     // latency: even if the /me probe hangs or is suppressed (OIDC/logout flow

--- a/apps/web/src/store/notificationsSlice.ts
+++ b/apps/web/src/store/notificationsSlice.ts
@@ -54,7 +54,8 @@ export const notificationsSlice = createSlice({
   },
 })
 
-export const { closeNotification, deleteAllNotifications, readNotification } = notificationsSlice.actions
+export const { closeNotification, closeByGroupKey, deleteAllNotifications, readNotification } =
+  notificationsSlice.actions
 
 export const showNotification = (payload: Omit<Notification, 'id' | 'timestamp'>): AppThunk<string> => {
   return (dispatch) => {


### PR DESCRIPTION
> Cookie expires, Redux still says authenticated,
> components flood the gateway with credentialed 403s.
> One /me probe at boot — and a timer for the rest.

## What it solves

Resolves: when the JWT session cookie expires, the browser stops sending it but Redux's \`sessionExpiresAt\` still says the user is signed in. Components keep firing credentialed requests against the gateway, every one of which 403s.

## How this PR fixes it

New \`useSessionExpiryGuard\` hook, registered once in \`InitApp\`. After store hydration, when the persisted state says the user is signed in:

1. If \`sessionExpiresAt\` has already passed → clear auth + toast immediately, no \`/v1/auth/me\` round-trip.
2. Else fire **one** \`/v1/auth/me\` probe; on 403 clear auth + toast, on 200 keep state.
3. Schedule a timer to clear auth + toast at \`sessionExpiresAt\` so a session that expires mid-tab is cleared without further credentialed requests.

Skipped while \`useLogoutCallback\`/\`useOidcLoginCallback\` are processing — those hooks already own \`/me\` for those flows.

**Backend behaviour confirmed unchanged.** \`auth.controller.ts:134-138\` already sets the cookie's \`Max-Age\` from the JWT \`exp\` claim, so the browser auto-deletes it on time. No backend change needed.

**Why this differs from the reverted #7807.** That PR added a global RTK Query 403 interceptor that conflated two unrelated 403s — \"cookie missing/invalid\" vs \"authenticated but not authorized\" (e.g. trying to delete a space you don't own). The backend \`AuthGuard\` returns identical 403s for both, so the interceptor false-positived on space deletion. This PR never inspects component-route 403s; only \`/v1/auth/me\` is consulted, where 403 unambiguously means \"no valid session.\"

## How to test it

1. Sign in to Spaces.
2. In DevTools → Application → Cookies, delete the \`access_token\` cookie (simulates expiry).
3. Reload the page. Expected: a single \`/v1/auth/me\` request returns 403, the \"Session expired\" toast appears, and no further credentialed requests fire (Network tab should not show a flood of 403s on \`/v1/spaces\`, \`/v1/users\`, etc.).
4. Negative test: sign in, leave the cookie alone, reload. Expected: a single \`/v1/auth/me\` returns 200, no toast, normal session continues.
5. Permission denial sanity check: as a non-owner, attempt an action that should 403 server-side. Expected: that action's 403 is **not** treated as session expiry — no toast, no logout.

## Affected flows

- App boot when a persisted SIWE/OIDC session is present.
- Mid-session expiry while the tab stays open (timer path).
- OIDC login callback and SIWE logout — guard intentionally yields to those.

## Blast radius

- New hook in \`apps/web/src/services/sessionExpiry/\`.
- One call site: \`apps/web/src/pages/_app.tsx\` (\`InitApp\`).
- Reads \`state.auth.sessionExpiresAt\`, \`selectIsStoreHydrated\`.
- Uses \`cgwApi.endpoints.authGetMeV1\` — same endpoint already used by \`reconcileAuth\` (\`useLogoutCallback\`, \`useOidcLoginCallback\`); RTK Query deduplicates concurrent calls.
- Coordinates with \`LOGGING_OUT_KEY\` (\`useLogoutCallback\`) and \`oidc_auth_pending\` (\`useOidcLoginCallback\`) sessionStorage flags.
- No mobile changes.
- No 403 interceptor: untouched downstream — does **not** affect Turnstile (returns 401, different code), space-deletion permission denials, or any other credentialed-route 403.

## Risks / not checked

- Did not run the mobile build (web-only fix).
- Did not exercise on a live staging session — verified in jsdom only.
- The post-sign-in \`sessionExpiresAt\` is still hardcoded to \`Date.now() + 24h\` in \`SignInButton\`. If the gateway's \`AUTH_VALIDITY_PERIOD_SECONDS\` is shorter, the timer fires too late; this PR catches that case via the boot-time \`/me\` probe but not for mid-session drift on the first session. Aligning the value belongs to a follow-up.

## Visual summary

\`\`\`mermaid
flowchart TD
  A[App boots / InitApp mounts] --> B{Store hydrated?}
  B -- no --> A
  B -- yes --> C{sessionExpiresAt}
  C -- null --> Z[no-op]
  C -- past --> D[setUnauthenticated + toast]
  C -- future --> E{LOGGING_OUT_KEY or oidc_auth_pending?}
  E -- yes --> Z
  E -- no --> F[GET /v1/auth/me]
  F -- 200 --> G[schedule timer for sessionExpiresAt]
  G -- timer fires --> D
  F -- 403 --> D
  F -- 5xx/network --> H[leave state untouched]
\`\`\`

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)