### PR TITLE
fix(test): e2e test flows for Spaces

### DIFF
--- a/apps/web/cypress/e2e/pages/spaces.page.js
+++ b/apps/web/cypress/e2e/pages/spaces.page.js
@@ -20,7 +20,7 @@ const spaceSaveBtn = '[data-testid="space-save-button"]'
 const spaceDeleteBtn = '[data-testid="space-delete-button"]'
 const spaceConfirmDeleteBtn = '[data-testid="space-confirm-delete-button"]'
 const spaceCard = '[data-testid="space-card"]'
-const spaceVertMenuIcon = '[data-testid="MoreVertIcon"]'
+const spaceCardContextMenuBtn = '[data-testid="space-card-context-menu-button"]'
 const contectMenuRemoveBtn = '[data-testid="remove-button"]'
 
 // -- Dashboard widgets --
@@ -427,42 +427,25 @@ export function deleteSpace(name) {
 
 const MAX_SPACES = 10
 
-function deleteAllSpaces() {
-  cy.get('body').then(($body) => {
-    if ($body.find(spaceCard).length > 0) {
-      cy.get(spaceCard)
-        .first()
-        .within(() => {
-          cy.get(spaceVertMenuIcon).click({ force: true })
-        })
-      cy.get(contectMenuRemoveBtn).click({ force: true })
-      cy.get(spaceConfirmDeleteBtn).click()
-      cy.wait(1000)
-      deleteAllSpaces()
-    }
-  })
-}
-
-function deleteOneSpace() {
-  cy.get(spaceCard)
-    .first()
-    .within(() => {
-      cy.get(spaceVertMenuIcon).click({ force: true })
-    })
-  cy.get(contectMenuRemoveBtn).click({ force: true })
-  cy.get(spaceConfirmDeleteBtn).click()
-  cy.get(spaceCard, { timeout: 10000 }).should('have.length.lessThan', MAX_SPACES)
-}
-
 export function ensureReadyToCreateSpace() {
-  cy.get('body').then(($body) => {
-    const count = $body.find(spaceCard).length
-    if (count >= MAX_SPACES) {
-      deleteOneSpace()
-    } else if (count > 0) {
-      deleteAllSpaces()
-    }
-  })
+  // Wait for the page to settle: either the spaces list or the create button must be visible
+  cy.get(`${orgList}, ${createSpaceBtn}`, { timeout: 30000 }).filter(':visible').should('have.length.at.least', 1)
+
+  // Use the live jQuery collection so the count reflects what's actually in the DOM now
+  cy.get('body')
+    .find(spaceCard)
+    .then(($cards) => {
+      if ($cards.length >= MAX_SPACES) {
+        // At the limit — delete one space to free a slot
+        cy.wrap($cards.first()).within(() => {
+          cy.get(spaceCardContextMenuBtn).click({ force: true })
+        })
+        cy.get(contectMenuRemoveBtn).click({ force: true })
+        cy.get(spaceConfirmDeleteBtn).click()
+        cy.get(spaceCard, { timeout: 10000 }).should('have.length.lessThan', MAX_SPACES)
+      }
+    })
+
   // Wait for either the create button or the create-space form to settle after deletion/redirect
   cy.get(`${createSpaceBtn}, ${orgSpaceInput}`, { timeout: 30000 }).filter(':visible').should('have.length.at.least', 1)
 }

--- a/apps/web/cypress/e2e/pages/spaces.page.js
+++ b/apps/web/cypress/e2e/pages/spaces.page.js
@@ -425,6 +425,8 @@ export function deleteSpace(name) {
   cy.contains(spaceCard, name).should('not.exist')
 }
 
+const MAX_SPACES = 10
+
 function deleteAllSpaces() {
   cy.get('body').then(($body) => {
     if ($body.find(spaceCard).length > 0) {
@@ -441,9 +443,23 @@ function deleteAllSpaces() {
   })
 }
 
+function deleteOneSpace() {
+  cy.get(spaceCard)
+    .first()
+    .within(() => {
+      cy.get(spaceVertMenuIcon).click({ force: true })
+    })
+  cy.get(contectMenuRemoveBtn).click({ force: true })
+  cy.get(spaceConfirmDeleteBtn).click()
+  cy.get(spaceCard, { timeout: 10000 }).should('have.length.lessThan', MAX_SPACES)
+}
+
 export function ensureReadyToCreateSpace() {
   cy.get('body').then(($body) => {
-    if ($body.find(spaceCard).length > 0) {
+    const count = $body.find(spaceCard).length
+    if (count >= MAX_SPACES) {
+      deleteOneSpace()
+    } else if (count > 0) {
       deleteAllSpaces()
     }
   })

--- a/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
+++ b/apps/web/cypress/e2e/regression/multichain_setup_new.cy.js
@@ -11,7 +11,6 @@ import * as create_wallet from '../pages/create_wallet.pages.js'
 import * as owner from '../pages/owners.pages.js'
 
 import { suspendOutreachModal } from '../pages/modals.page.js'
-import { isThisYear } from 'date-fns'
 
 let staticSafes = []
 
@@ -52,7 +51,7 @@ describe('Multichain setup tests', { defaultCommandTimeout: 60000 }, () => {
     cy.contains(sidebarNavItem, 'Apps').should('be.disabled')
   })
 
-  isThisYear('Verify notification if the owner set up was changed in original safe', () => {
+  it('Verify notification if the owner set up was changed in original safe', () => {
     const safeAddress = staticSafes.MATIC_STATIC_SAFE_28.split(':')[1]
     // Mock /v2/safes to return deviating owners across chains — triggers InconsistentSignerSetupWarning
     cy.intercept('GET', '**/v2/safes**', [

--- a/apps/web/src/features/spaces/components/SpaceCard/SpaceContextMenu.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCard/SpaceContextMenu.tsx
@@ -48,7 +48,12 @@ const SpaceContextMenu = ({ space }: { space: GetSpaceResponse }) => {
 
   return (
     <>
-      <IconButton className={css.spaceActions} size="small" onClick={handleOpenContextMenu} data-testid="MoreVertIcon">
+      <IconButton
+        className={css.spaceActions}
+        size="small"
+        onClick={handleOpenContextMenu}
+        data-testid="space-card-context-menu-button"
+      >
         <MoreVertIcon sx={({ palette }) => ({ color: palette.border.main })} />
       </IconButton>
       <ContextMenu anchorEl={anchorEl} open={!!anchorEl} onClose={handleCloseContextMenu}>


### PR DESCRIPTION
> E2E guards and test fixes,
> max spaces met — delete one, not all,
> relay clicks the right door.

## What it solves

Resolves a flaky E2E test issue:
- Spaces basic flow fails when the test user has reached the 10-space limit

## How this PR fixes it

- `ensureReadyToCreateSpace()` now waits for the spaces list to load, then deletes one space only when `N >= 10` (instead of deleting all spaces unconditionally)
- Adds `data-testid="space-card-context-menu-button"` to `SpaceContextMenu` replacing the generic `MoreVertIcon` test ID


## How to test it

1. Log in as a user with 10 spaces → run `spaces_basicflow.cy.js` → verify it deletes one space and proceeds


## Affected flows

- Spaces basic flow onboarding (create, rename, delete, add account, invite member)


## Blast radius

- `SpaceContextMenu.tsx`: `data-testid` rename from `MoreVertIcon` → `space-card-context-menu-button`. Any other test selecting `[data-testid="MoreVertIcon"]` on a space card will break.
- `spaces.page.js`: `deleteAllSpaces` removed — not used anywhere else


## Risks / not checked

- Did not verify spaces flow with `N < 10` (spaces are deleted by other test runs between CI jobs)


## Visual summary

```mermaid
flowchart TD
    A[ensureReadyToCreateSpace] --> B{Wait for orgList or createSpaceBtn}
    B --> C{count >= 10?}
    C -->|Yes| D[Delete one space]
    C -->|No| E[Proceed]
    D --> E
    E --> F[Wait for createSpaceBtn visible]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
