### PR TITLE
Revert "chore(web): hide "Add Safe to space" sidebar button for this release"

### DIFF
--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
@@ -22,9 +22,12 @@ import Link from 'next/link'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ImplementationVersionState } from '@safe-global/store/gateway/types'
 import { isNonCriticalUpdate } from '@safe-global/utils/utils/chains'
+import { useIsCounterfactualSafe } from '@/features/counterfactual'
 import { useSidebarHydrated } from '../../hooks/useSidebarHydrated'
 import { useSafeQueryParam } from '@/hooks/useSafeAddressFromUrl'
 import { containerVariants, itemVariants } from '../../constants'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
 
 const MAIN_NAV_SKELETON_COUNT = 5
 const DEFI_GROUP_SKELETON_COUNT = 4
@@ -37,7 +40,9 @@ export const SafeSidebarVariant = ({
 }: SafeSidebarVariantProps): ReactElement => {
   const router = useRouter()
   const { safe } = useSafeInfo()
+  const isCounterfactualSafe = useIsCounterfactualSafe()
   const isHydrated = useSidebarHydrated()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
   const safeFromQuery = useSafeQueryParam()
   const safeAddress = isHydrated ? safeFromQuery || undefined : undefined
   const isOutdated =
@@ -50,9 +55,8 @@ export const SafeSidebarVariant = ({
   }
   const isSettingsActive = router.pathname.startsWith(AppRoutes.settings.index)
 
-  // The "Add Safe to space" entry point is intentionally hidden for this release.
-  // Re-enable by restoring the previous addToWorkspace condition.
-  const shouldRenderWorkspaceHeaderGroup = workspaceHeader.variant === 'backToSpace'
+  const shouldRenderWorkspaceHeaderGroup =
+    workspaceHeader.variant === 'backToSpace' || (isUserSignedIn && !(isHydrated && isCounterfactualSafe))
 
   // Use provided items or create placeholders for skeleton
   const displayMainNavItems = mainNavItems || Array(MAIN_NAV_SKELETON_COUNT).fill(null)

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
@@ -11,7 +11,13 @@ import { AppRoutes } from '@/config/routes'
 import { ImplementationVersionState } from '@safe-global/store/gateway/types'
 
 const mockUseSafeInfo = jest.fn()
+const mockUseIsCounterfactualSafe = jest.fn()
 const mockUseSidebarHydrated = jest.fn()
+const mockUseAppSelector = jest.fn()
+
+jest.mock('@/store', () => ({
+  useAppSelector: (...args: unknown[]) => mockUseAppSelector(...args),
+}))
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(() => ({
@@ -24,6 +30,10 @@ jest.mock('next/router', () => ({
 jest.mock('@/hooks/useSafeInfo', () => ({
   __esModule: true,
   default: () => mockUseSafeInfo(),
+}))
+
+jest.mock('@/features/counterfactual', () => ({
+  useIsCounterfactualSafe: () => mockUseIsCounterfactualSafe(),
 }))
 
 jest.mock('../../../hooks/useSidebarHydrated', () => ({
@@ -189,7 +199,9 @@ describe('SafeSidebarVariant', () => {
     mockUseSafeInfo.mockReturnValue({
       safe: { implementationVersionState: ImplementationVersionState.UP_TO_DATE, version: '1.3.0' },
     })
+    mockUseIsCounterfactualSafe.mockReturnValue(false)
     mockUseSidebarHydrated.mockReturnValue(true)
+    mockUseAppSelector.mockReturnValue(true)
   })
 
   it('renders all navigation sections', () => {
@@ -208,7 +220,9 @@ describe('SafeSidebarVariant', () => {
     expect(screen.getAllByText('Swap').length).toBeGreaterThan(0)
   })
 
-  it('does not render the addToWorkspace variant ("Add Safe to space" is hidden for this release)', () => {
+  it('hides workspace header group for counterfactual addToWorkspace (undeployed) Safes', () => {
+    mockUseIsCounterfactualSafe.mockReturnValue(true)
+
     render(
       <SafeSidebarVariant
         workspaceHeader={createAddHeader()}
@@ -219,6 +233,21 @@ describe('SafeSidebarVariant', () => {
 
     expect(screen.queryByTestId('add-safe-to-workspace-button')).not.toBeInTheDocument()
     expect(screen.queryByText('Add Safe to space')).not.toBeInTheDocument()
+  })
+
+  it('still renders backToSpace workspace header when Safe is counterfactual', () => {
+    mockUseIsCounterfactualSafe.mockReturnValue(true)
+
+    render(
+      <SafeSidebarVariant
+        workspaceHeader={createBackHeader({ spaceName: 'My Space', spaceId: '9' })}
+        mainNavItems={mockMainNavItems}
+        defiGroup={mockDefiGroup}
+      />,
+    )
+
+    expect(screen.getByTestId('back-to-space-button')).toBeInTheDocument()
+    expect(screen.getByText('My Space')).toBeInTheDocument()
   })
 
   it('renders all main navigation items', () => {
@@ -328,11 +357,67 @@ describe('SafeSidebarVariant', () => {
       expect(avatarFallback).toHaveTextContent('E')
     })
 
-    it('never renders the addToWorkspace variant trigger (hidden for this release)', () => {
+    it('renders the addToWorkspace variant with the trigger button', () => {
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createAddHeader({ spaces: [] })}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.getByTestId('add-safe-to-workspace-button')).toBeInTheDocument()
+    })
+
+    it('shows addToWorkspace when signed in and the Safe is deployed (not counterfactual)', () => {
+      mockUseAppSelector.mockReturnValue(true)
+      mockUseIsCounterfactualSafe.mockReturnValue(false)
+
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createAddHeader({ spaces: [] })}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.getByTestId('add-safe-to-workspace-button')).toBeInTheDocument()
+    })
+
+    it('passes spaces array to addToWorkspace variant', () => {
       const spaces = [
         { id: 1, name: 'Team', safeCount: 5 },
         { id: 2, name: 'Personal', safeCount: 2 },
       ]
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createAddHeader({ spaces })}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.getByTestId('add-safe-to-workspace-button')).toBeInTheDocument()
+    })
+
+    it('hides addToWorkspace when the user is not signed in (SIWE session)', () => {
+      mockUseAppSelector.mockReturnValue(false)
+
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createAddHeader({ spaces: [] })}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.queryByTestId('add-safe-to-workspace-button')).not.toBeInTheDocument()
+      expect(screen.queryByText('Add Safe to space')).not.toBeInTheDocument()
+    })
+
+    it('hides the addToWorkspace section entirely when Safe is counterfactual (undeployed)', () => {
+      mockUseIsCounterfactualSafe.mockReturnValue(true)
+      const spaces = [{ id: 1, name: 'Team', safeCount: 0 }]
 
       render(
         <SafeSidebarVariant
@@ -343,7 +428,39 @@ describe('SafeSidebarVariant', () => {
       )
 
       expect(screen.queryByTestId('add-safe-to-workspace-button')).not.toBeInTheDocument()
-      expect(screen.queryByText('Add Safe to space')).not.toBeInTheDocument()
+    })
+
+    it('keeps backToSpace header visible when Safe is counterfactual', () => {
+      mockUseIsCounterfactualSafe.mockReturnValue(true)
+
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createBackHeader({ spaceName: 'Shared Workspace', spaceId: '100' })}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.getByTestId('back-to-space-button')).toBeInTheDocument()
+      expect(screen.getByText('Shared Workspace')).toBeInTheDocument()
+    })
+
+    it('renders correct number of spaces in addToWorkspace when multiple spaces provided', () => {
+      const spaces = Array.from({ length: 5 }, (_, i) => ({
+        id: i + 1,
+        name: `Space ${i + 1}`,
+        safeCount: 0,
+      }))
+
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createAddHeader({ spaces })}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.getByTestId('add-safe-to-workspace-button')).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
Reverts safe-global/safe-wallet-monorepo#7818.
Reverting this PR as the Add Safe To Space button shound be visible in the UI again - the issue with the session expiration token is mitigated.