### PR TITLE
feat(security): scan + feature-redirect hooks

### DIFF
--- a/apps/web/src/features/security/contract.ts
+++ b/apps/web/src/features/security/contract.ts
@@ -22,7 +22,7 @@ import type { isKnownModuleByName } from './data/scanners/modules'
 import type { getStrengthLevel, getStrengthColor } from './data/securityScoring'
 import type { CHECK_DEFS } from './data/securityChecks'
 import type { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
-import type { getScanResultsCache, evictScanCache } from './hooks/useSecurityScan'
+import type { getCachedScan, setCachedScan } from './data/scanResultsCache'
 
 export interface SecurityContract {
   // Scanner registry
@@ -39,9 +39,9 @@ export interface SecurityContract {
   isKnownModuleByName: typeof isKnownModuleByName
   getStrengthLevel: typeof getStrengthLevel
   getStrengthColor: typeof getStrengthColor
-  // Module-level scan-result cache accessors
-  getScanResultsCache: typeof getScanResultsCache
-  evictScanCache: typeof evictScanCache
+  // Module-level scan-result cache accessors (the cache itself stays private)
+  getCachedScan: typeof getCachedScan
+  setCachedScan: typeof setCachedScan
   // Shared constants
   zeroAddress: typeof ZERO_ADDRESS
 }

--- a/apps/web/src/features/security/data/scanResultsCache.ts
+++ b/apps/web/src/features/security/data/scanResultsCache.ts
@@ -1,0 +1,62 @@
+/**
+ * Module-level cache shared by `useSecurityScan` (drawer) and `useAutoScan`
+ * (queue). Both writers compute results for the same `scanKey(address, chainId)`;
+ * the cache keeps the most recent write so consumers see the freshest data.
+ *
+ * The Map is intentionally private — consumers go through `getCachedScan` /
+ * `setCachedScan` so the map can't be mutated by reference from outside.
+ */
+import type { ScanResult, ScannerId } from './scanners/types'
+
+const CACHE_TTL_MS = 3_600_000
+const MAX_CACHE_SIZE = 50
+
+type CacheEntry = {
+  results: Partial<Record<ScannerId, ScanResult>>
+  timestamp: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+const evictOldest = (): void => {
+  if (cache.size <= MAX_CACHE_SIZE) return
+  let oldestKey: string | null = null
+  let oldestTs = Infinity
+  for (const [k, v] of cache) {
+    if (v.timestamp < oldestTs) {
+      oldestTs = v.timestamp
+      oldestKey = k
+    }
+  }
+  if (oldestKey) cache.delete(oldestKey)
+}
+
+/** Returns the cached entry if it exists and is still within TTL, else null. */
+export const getCachedScan = (key: string): CacheEntry | null => {
+  const entry = cache.get(key)
+  if (!entry) return null
+  if (Date.now() - entry.timestamp >= CACHE_TTL_MS) return null
+  return entry
+}
+
+/**
+ * Writes a result. Concurrent scans for the same key can race; we prefer the
+ * newer timestamp so a slow-completing scan never overwrites a faster, fresher one.
+ */
+export const setCachedScan = (
+  key: string,
+  results: Partial<Record<ScannerId, ScanResult>>,
+  timestamp: number,
+): void => {
+  const existing = cache.get(key)
+  if (existing && existing.timestamp >= timestamp) return
+  cache.set(key, { results, timestamp })
+  evictOldest()
+}
+
+/** Test-only escape hatch — clears the entire cache. */
+export const clearScanCache = (): void => {
+  cache.clear()
+}
+
+export { CACHE_TTL_MS, MAX_CACHE_SIZE }

--- a/apps/web/src/features/security/data/scanners/constants.ts
+++ b/apps/web/src/features/security/data/scanners/constants.ts
@@ -1,6 +1,7 @@
 import { IS_PRODUCTION } from '@/config/constants'
 import type { SafeVersion } from '@safe-global/types-kit'
 import type { SecurityGrade } from '../securityTypes'
+import type { SafeGrade } from './types'
 
 /** Maximum time a single scanner is allowed to run before being rejected. */
 export const SCANNER_TIMEOUT_MS = 15_000
@@ -17,6 +18,18 @@ export const SEVERITY_RANK: Record<SecurityGrade, number> = {
   High: 1,
   Medium: 2,
   Low: 3,
+}
+
+/**
+ * Sort order for SafeGrade — overall per-Safe assessment. Distinct from `SEVERITY_RANK`,
+ * which ranks per-check `SecurityGrade`. Lower number = worse, so a "worst-grade-first"
+ * scan picks the smallest rank across a multichain Safe's chain entries.
+ */
+export const SAFE_GRADE_RANK: Record<SafeGrade, number> = {
+  critical: 0,
+  at_risk: 1,
+  needs_attention: 2,
+  passing: 3,
 }
 
 /** Score thresholds that bucket a numeric score into a SecurityGrade. */

--- a/apps/web/src/features/security/data/scanners/types.ts
+++ b/apps/web/src/features/security/data/scanners/types.ts
@@ -45,8 +45,21 @@ export type ScanResult = {
   partner?: 'hypernative'
 }
 
+export type ScannerId =
+  | 'account_setup'
+  | 'multichain_setup'
+  | 'contract_version'
+  | 'modules'
+  | 'guard'
+  | 'pending_tx'
+  | 'recovery'
+  | 'transaction_scanning'
+  | 'fallback_handler'
+  | 'factory_validation'
+  | 'signer_integrity'
+
 export type SecurityScanner = {
-  id: string
+  id: ScannerId
   scan: (ctx: ScanContext) => Promise<ScanResult>
 }
 

--- a/apps/web/src/features/security/feature.ts
+++ b/apps/web/src/features/security/feature.ts
@@ -24,7 +24,7 @@ import {
 } from './data/scanners/utils'
 import { getStrengthLevel, getStrengthColor } from './data/securityScoring'
 import { isKnownModuleByName } from './data/scanners/modules'
-import { getScanResultsCache, evictScanCache } from './hooks/useSecurityScan'
+import { getCachedScan, setCachedScan } from './data/scanResultsCache'
 
 const feature: SecurityContract = {
   // Scanner registry + UI metadata
@@ -41,8 +41,8 @@ const feature: SecurityContract = {
   getStrengthLevel,
   getStrengthColor,
   // Module-level cache accessors
-  getScanResultsCache,
-  evictScanCache,
+  getCachedScan,
+  setCachedScan,
   // Shared constants
   zeroAddress: ZERO_ADDRESS,
 }

--- a/apps/web/src/features/security/hooks/__tests__/useSecurityHubFeatureRedirect.test.ts
+++ b/apps/web/src/features/security/hooks/__tests__/useSecurityHubFeatureRedirect.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react'
+import useSecurityHubFeatureRedirect from '../useSecurityHubFeatureRedirect'
+import { AppRoutes } from '@/config/routes'
+
+const mockPush = jest.fn()
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+const mockUseHasFeature = jest.fn()
+jest.mock('@/hooks/useChains', () => ({
+  useHasFeature: () => mockUseHasFeature(),
+}))
+
+describe('useSecurityHubFeatureRedirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('redirects to the spaces home when the SECURITY_HUB flag is explicitly off', () => {
+    mockUseHasFeature.mockReturnValue(false)
+
+    renderHook(() => useSecurityHubFeatureRedirect())
+
+    expect(mockPush).toHaveBeenCalledWith({ pathname: AppRoutes.spaces.index })
+  })
+
+  it('does not redirect while the chain config is still loading (flag === undefined)', () => {
+    mockUseHasFeature.mockReturnValue(undefined)
+
+    renderHook(() => useSecurityHubFeatureRedirect())
+
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+  it('does not redirect when the SECURITY_HUB flag is enabled', () => {
+    mockUseHasFeature.mockReturnValue(true)
+
+    renderHook(() => useSecurityHubFeatureRedirect())
+
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/security/hooks/__tests__/useSecurityScan.test.ts
+++ b/apps/web/src/features/security/hooks/__tests__/useSecurityScan.test.ts
@@ -1,9 +1,10 @@
 import { renderHook, act, waitFor } from '@testing-library/react'
 import useSecurityScan from '../useSecurityScan'
-import type { ScanContext, ScanResult, SecurityScanner } from '../../data/scanners/types'
+import type { ScanContext, ScanResult, ScannerId, SecurityScanner } from '../../data/scanners/types'
 import { createMockContext } from '../../data/scanners/test-helpers'
+import { clearScanCache } from '../../data/scanResultsCache'
 
-const makeScanner = (id: string, result?: Partial<ScanResult>, delayMs = 0): SecurityScanner => ({
+const makeScanner = (id: ScannerId, result?: Partial<ScanResult>, delayMs = 0): SecurityScanner => ({
   id,
   scan: () =>
     new Promise((resolve) =>
@@ -23,7 +24,10 @@ const makeScanner = (id: string, result?: Partial<ScanResult>, delayMs = 0): Sec
     ),
 })
 
-const mockScanners = [makeScanner('test_a'), makeScanner('test_b')]
+const ID_A: ScannerId = 'account_setup'
+const ID_B: ScannerId = 'modules'
+
+const mockScanners = [makeScanner(ID_A), makeScanner(ID_B)]
 
 jest.mock('../../data/scanners/registry', () => ({
   get SCANNERS() {
@@ -33,8 +37,9 @@ jest.mock('../../data/scanners/registry', () => ({
 
 describe('useSecurityScan', () => {
   beforeEach(() => {
+    clearScanCache()
     mockScanners.length = 0
-    mockScanners.push(makeScanner('test_a'), makeScanner('test_b'))
+    mockScanners.push(makeScanner(ID_A), makeScanner(ID_B))
   })
 
   it('auto-scans when context is provided', async () => {
@@ -45,8 +50,8 @@ describe('useSecurityScan', () => {
       expect(result.current.isComplete).toBe(true)
     })
 
-    expect(result.current.results.test_a).toBeDefined()
-    expect(result.current.results.test_b).toBeDefined()
+    expect(result.current.results[ID_A]).toBeDefined()
+    expect(result.current.results[ID_B]).toBeDefined()
     expect(result.current.lastScannedAt).not.toBeNull()
   })
 
@@ -102,8 +107,8 @@ describe('useSecurityScan', () => {
     // First scanner resolves slowly, second resolves instantly
     mockScanners.length = 0
     mockScanners.push(
-      makeScanner('slow', { status: 'issue', severity: 'High', score: 30 }, 200),
-      makeScanner('fast', { status: 'clear', severity: 'Low', score: 100 }, 0),
+      makeScanner(ID_A, { status: 'issue', severity: 'High', score: 30 }, 200),
+      makeScanner(ID_B, { status: 'clear', severity: 'Low', score: 100 }, 0),
     )
 
     const ctx1 = createMockContext({ chainId: '1', safeAddress: '0xSafe1' })
@@ -159,9 +164,9 @@ describe('useSecurityScan', () => {
       unmount()
 
       // Second: new hook instance should use cached results without scanning
-      const scanSpy = jest.fn().mockResolvedValue(makeScanner('test_a').scan(ctx))
+      const scanSpy = jest.fn().mockResolvedValue(makeScanner(ID_A).scan(ctx))
       mockScanners.length = 0
-      mockScanners.push({ id: 'test_a', scan: scanSpy })
+      mockScanners.push({ id: ID_A, scan: scanSpy })
 
       const { result: result2 } = renderHook(() => useSecurityScan(ctx))
 
@@ -170,7 +175,7 @@ describe('useSecurityScan', () => {
       })
 
       expect(scanSpy).not.toHaveBeenCalled()
-      expect(result2.current.results.test_a).toBeDefined()
+      expect(result2.current.results[ID_A]).toBeDefined()
       expect(result2.current.isComplete).toBe(true)
     })
 
@@ -200,7 +205,7 @@ describe('useSecurityScan', () => {
 
   it('reports progress correctly', async () => {
     mockScanners.length = 0
-    mockScanners.push(makeScanner('fast', {}, 0), makeScanner('slow', {}, 100))
+    mockScanners.push(makeScanner(ID_A, {}, 0), makeScanner(ID_B, {}, 100))
 
     const ctx = createMockContext()
     const { result } = renderHook(() => useSecurityScan(ctx))

--- a/apps/web/src/features/security/hooks/__tests__/useSecurityScan.test.ts
+++ b/apps/web/src/features/security/hooks/__tests__/useSecurityScan.test.ts
@@ -1,0 +1,216 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import useSecurityScan from '../useSecurityScan'
+import type { ScanContext, ScanResult, SecurityScanner } from '../../data/scanners/types'
+import { createMockContext } from '../../data/scanners/test-helpers'
+
+const makeScanner = (id: string, result?: Partial<ScanResult>, delayMs = 0): SecurityScanner => ({
+  id,
+  scan: () =>
+    new Promise((resolve) =>
+      setTimeout(
+        () =>
+          resolve({
+            status: 'clear',
+            severity: 'Low',
+            score: 100,
+            evidence: [],
+            remediation: '',
+            lastChecked: new Date().toISOString(),
+            ...result,
+          }),
+        delayMs,
+      ),
+    ),
+})
+
+const mockScanners = [makeScanner('test_a'), makeScanner('test_b')]
+
+jest.mock('../../data/scanners/registry', () => ({
+  get SCANNERS() {
+    return mockScanners
+  },
+}))
+
+describe('useSecurityScan', () => {
+  beforeEach(() => {
+    mockScanners.length = 0
+    mockScanners.push(makeScanner('test_a'), makeScanner('test_b'))
+  })
+
+  it('auto-scans when context is provided', async () => {
+    const ctx = createMockContext()
+    const { result } = renderHook(() => useSecurityScan(ctx))
+
+    await waitFor(() => {
+      expect(result.current.isComplete).toBe(true)
+    })
+
+    expect(result.current.results.test_a).toBeDefined()
+    expect(result.current.results.test_b).toBeDefined()
+    expect(result.current.lastScannedAt).not.toBeNull()
+  })
+
+  it('does not scan when context is null', () => {
+    const { result } = renderHook(() => useSecurityScan(null))
+
+    expect(result.current.isComplete).toBe(false)
+    expect(result.current.results).toEqual({})
+    expect(result.current.lastScannedAt).toBeNull()
+  })
+
+  it('clears results when context goes null', async () => {
+    const ctx = createMockContext()
+    const { result, rerender } = renderHook(({ c }: { c: ScanContext | null }) => useSecurityScan(c), {
+      initialProps: { c: ctx } as { c: ScanContext | null },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isComplete).toBe(true)
+    })
+    expect(Object.keys(result.current.results).length).toBe(2)
+
+    // Switch to null (Safe transition)
+    rerender({ c: null })
+
+    expect(result.current.results).toEqual({})
+    expect(result.current.lastScannedAt).toBeNull()
+  })
+
+  it('rescans when ctxKey changes', async () => {
+    const ctx1 = createMockContext({ chainId: '1', safeAddress: '0xSafe1' })
+    const { result, rerender } = renderHook(({ c }: { c: ScanContext | null }) => useSecurityScan(c), {
+      initialProps: { c: ctx1 },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isComplete).toBe(true)
+    })
+
+    const firstScannedAt = result.current.lastScannedAt
+
+    // Switch to different Safe
+    const ctx2 = createMockContext({ chainId: '1', safeAddress: '0xSafe2' })
+    rerender({ c: ctx2 })
+
+    await waitFor(() => {
+      expect(result.current.isComplete).toBe(true)
+      expect(result.current.lastScannedAt).not.toBe(firstScannedAt)
+    })
+  })
+
+  it('rejects stale in-flight results after context change', async () => {
+    // First scanner resolves slowly, second resolves instantly
+    mockScanners.length = 0
+    mockScanners.push(
+      makeScanner('slow', { status: 'issue', severity: 'High', score: 30 }, 200),
+      makeScanner('fast', { status: 'clear', severity: 'Low', score: 100 }, 0),
+    )
+
+    const ctx1 = createMockContext({ chainId: '1', safeAddress: '0xSafe1' })
+    const { result, rerender } = renderHook(({ c }: { c: ScanContext | null }) => useSecurityScan(c), {
+      initialProps: { c: ctx1 } as { c: ScanContext | null },
+    })
+
+    // Switch context before slow scanner resolves
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+    rerender({ c: null })
+
+    // Wait for the slow scanner to resolve (it should be rejected)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 300))
+    })
+
+    // Results should be cleared, not contain stale data
+    expect(result.current.results).toEqual({})
+  })
+
+  it('rescan function triggers a new scan', async () => {
+    const ctx = createMockContext()
+    const { result } = renderHook(() => useSecurityScan(ctx))
+
+    await waitFor(() => {
+      expect(result.current.isComplete).toBe(true)
+    })
+
+    const firstScannedAt = result.current.lastScannedAt
+
+    // Wait a tick so Date.now() differs
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+      result.current.rescan()
+    })
+
+    await waitFor(() => {
+      expect(result.current.lastScannedAt).not.toBe(firstScannedAt)
+    })
+  })
+
+  describe('scan cache', () => {
+    it('skips auto-scan when fresh cache exists', async () => {
+      // First: run a scan to populate the cache
+      const ctx = createMockContext({ chainId: '1', safeAddress: '0xCached' })
+      const { result, unmount } = renderHook(() => useSecurityScan(ctx))
+
+      await waitFor(() => {
+        expect(result.current.isComplete).toBe(true)
+      })
+      unmount()
+
+      // Second: new hook instance should use cached results without scanning
+      const scanSpy = jest.fn().mockResolvedValue(makeScanner('test_a').scan(ctx))
+      mockScanners.length = 0
+      mockScanners.push({ id: 'test_a', scan: scanSpy })
+
+      const { result: result2 } = renderHook(() => useSecurityScan(ctx))
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 50))
+      })
+
+      expect(scanSpy).not.toHaveBeenCalled()
+      expect(result2.current.results.test_a).toBeDefined()
+      expect(result2.current.isComplete).toBe(true)
+    })
+
+    it('rescan works after cache hit', async () => {
+      const ctx = createMockContext({ chainId: '1', safeAddress: '0xRescan' })
+      const { result, unmount } = renderHook(() => useSecurityScan(ctx))
+
+      await waitFor(() => {
+        expect(result.current.isComplete).toBe(true)
+      })
+      unmount()
+
+      // New instance uses cache
+      const { result: result2 } = renderHook(() => useSecurityScan(ctx))
+
+      // Trigger manual rescan
+      act(() => {
+        result2.current.rescan()
+      })
+
+      await waitFor(() => {
+        expect(result2.current.isComplete).toBe(true)
+        expect(result2.current.lastScannedAt).not.toBeNull()
+      })
+    })
+  })
+
+  it('reports progress correctly', async () => {
+    mockScanners.length = 0
+    mockScanners.push(makeScanner('fast', {}, 0), makeScanner('slow', {}, 100))
+
+    const ctx = createMockContext()
+    const { result } = renderHook(() => useSecurityScan(ctx))
+
+    // Initially 0% progress
+    expect(result.current.progress).toBeLessThanOrEqual(100)
+
+    await waitFor(() => {
+      expect(result.current.isComplete).toBe(true)
+      expect(result.current.progress).toBe(100)
+    })
+  })
+})

--- a/apps/web/src/features/security/hooks/useSecurityHubFeatureRedirect.ts
+++ b/apps/web/src/features/security/hooks/useSecurityHubFeatureRedirect.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { AppRoutes } from '@/config/routes'
+
+/**
+ * Redirect away from the Security Hub page when `FEATURES.SECURITY_HUB` is disabled
+ * on the current chain. The broader Spaces UI may still be enabled — in that case
+ * we land the user back on the Space home rather than ejecting to welcome.
+ *
+ * Mirrors `apps/web/src/features/spaces/hooks/useFeatureFlagRedirect.ts`.
+ */
+const useSecurityHubFeatureRedirect = () => {
+  const router = useRouter()
+  const isSecurityHubEnabled = useHasFeature(FEATURES.SECURITY_HUB)
+
+  useEffect(() => {
+    if (isSecurityHubEnabled === false) {
+      router.push({ pathname: AppRoutes.spaces.index })
+    }
+  }, [isSecurityHubEnabled, router])
+}
+
+export default useSecurityHubFeatureRedirect

--- a/apps/web/src/features/security/hooks/useSecurityScan.ts
+++ b/apps/web/src/features/security/hooks/useSecurityScan.ts
@@ -1,0 +1,152 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+import type { ScanContext, ScanResult } from '../data/scanners/types'
+import { SCANNERS } from '../data/scanners/registry'
+import { scanKey, withScannerTimeout } from '../data/scanners/utils'
+
+/**
+ * Module-level cache so multiple hook instances sharing the same ctxKey
+ * reuse results instead of running duplicate scans. TTL: 1 hour.
+ */
+const CACHE_TTL_MS = 3_600_000
+const MAX_CACHE_SIZE = 50
+const scanResultsCache = new Map<string, { results: Record<string, ScanResult>; timestamp: number }>()
+
+/** Evict the oldest entry if the cache exceeds the size limit. */
+const evictIfNeeded = () => {
+  if (scanResultsCache.size <= MAX_CACHE_SIZE) return
+  let oldestKey: string | null = null
+  let oldestTs = Infinity
+  for (const [k, v] of scanResultsCache) {
+    if (v.timestamp < oldestTs) {
+      oldestTs = v.timestamp
+      oldestKey = k
+    }
+  }
+  if (oldestKey) scanResultsCache.delete(oldestKey)
+}
+
+export const getScanResultsCache = () => scanResultsCache
+export { evictIfNeeded as evictScanCache }
+
+export type ScanState = {
+  results: Record<string, ScanResult>
+  loading: Record<string, boolean>
+  errors: Record<string, string>
+  isComplete: boolean
+  lastScannedAt: number | null
+  progress: number
+  rescan: () => void
+}
+
+const useSecurityScan = (ctx: ScanContext | null): ScanState => {
+  const ctxKey = ctx ? scanKey(ctx.safeAddress, ctx.chainId) : null
+
+  const [results, setResults] = useState<Record<string, ScanResult>>({})
+  const [loading, setLoading] = useState<Record<string, boolean>>({})
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [lastScannedAt, setLastScannedAt] = useState<number | null>(null)
+  const scanIdRef = useRef(0)
+  const ctxRef = useRef(ctx)
+  ctxRef.current = ctx
+
+  const executeScan = useCallback(
+    async (scannerId: string, scanFn: () => Promise<ScanResult>, guardId?: number, onAllComplete?: () => void) => {
+      setLoading((prev) => ({ ...prev, [scannerId]: true }))
+
+      try {
+        const result = await scanFn()
+        if (guardId !== undefined && scanIdRef.current !== guardId) return
+        setResults((prev) => ({ ...prev, [scannerId]: result }))
+      } catch (err: any) {
+        if (guardId !== undefined && scanIdRef.current !== guardId) return
+        setErrors((prev) => ({ ...prev, [scannerId]: err instanceof Error ? err.message : 'Scan failed' }))
+      } finally {
+        if (guardId !== undefined && scanIdRef.current !== guardId) return
+        setLoading((prev) => ({ ...prev, [scannerId]: false }))
+        onAllComplete?.()
+      }
+    },
+    [],
+  )
+
+  const runScan = useCallback(() => {
+    const currentCtx = ctxRef.current
+    if (!currentCtx) return
+
+    const currentScanId = ++scanIdRef.current
+    const total = SCANNERS.length
+    let completedCount = 0
+    // Local accumulator — avoids reading state from inside a setState updater
+    // (which would violate React's purity contract and double-fire under StrictMode).
+    const accumulatedResults: Record<string, ScanResult> = {}
+
+    setResults({})
+    setErrors({})
+    setLastScannedAt(null)
+
+    SCANNERS.forEach((scanner) => {
+      executeScan(
+        scanner.id,
+        async () => {
+          const result = await withScannerTimeout(scanner.scan(currentCtx))
+          // Capture into the local accumulator before returning so the completion
+          // callback can write the cache without reading from setState.
+          accumulatedResults[scanner.id] = result
+          return result
+        },
+        currentScanId,
+        () => {
+          completedCount++
+          if (completedCount === total) {
+            const now = Date.now()
+            setLastScannedAt(now)
+            // Write to module-level cache so other hook instances (sidebar) reuse results.
+            const key = ctxRef.current ? scanKey(ctxRef.current.safeAddress, ctxRef.current.chainId) : null
+            if (key) {
+              scanResultsCache.set(key, { results: accumulatedResults, timestamp: now })
+              evictIfNeeded()
+            }
+          }
+        },
+      )
+    })
+  }, [executeScan])
+
+  useEffect(() => {
+    if (ctxKey) {
+      // Check cache when ctxKey first becomes available — not just on mount.
+      // When the drawer opens, ctx starts as null (queries loading) so the mount-time
+      // cache check misses. By the time ctx resolves, we need to check again here.
+      const freshCached = scanResultsCache.get(ctxKey)
+      const freshResolved = freshCached && Date.now() - freshCached.timestamp < CACHE_TTL_MS ? freshCached : null
+      if (freshResolved) {
+        setResults(freshResolved.results)
+        setLastScannedAt(freshResolved.timestamp)
+        return
+      }
+      runScan()
+    } else {
+      // Context went null (Safe switching) — clear stale results and reject in-flight scans
+      scanIdRef.current++
+      setResults({})
+      setErrors({})
+      setLastScannedAt(null)
+    }
+  }, [ctxKey, runScan])
+
+  const loadingCount = Object.values(loading).filter(Boolean).length
+  const total = SCANNERS.length
+  const progress = total > 0 ? Math.round(((total - loadingCount) / total) * 100) : 0
+
+  return {
+    results,
+    loading,
+    errors,
+    isComplete: loadingCount === 0 && Object.keys(results).length > 0,
+    lastScannedAt,
+    progress,
+    rescan: runScan,
+  }
+}
+
+export default useSecurityScan

--- a/apps/web/src/features/security/hooks/useSecurityScan.ts
+++ b/apps/web/src/features/security/hooks/useSecurityScan.ts
@@ -1,37 +1,13 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
-import type { ScanContext, ScanResult } from '../data/scanners/types'
+import type { ScanContext, ScanResult, ScannerId } from '../data/scanners/types'
 import { SCANNERS } from '../data/scanners/registry'
 import { scanKey, withScannerTimeout } from '../data/scanners/utils'
-
-/**
- * Module-level cache so multiple hook instances sharing the same ctxKey
- * reuse results instead of running duplicate scans. TTL: 1 hour.
- */
-const CACHE_TTL_MS = 3_600_000
-const MAX_CACHE_SIZE = 50
-const scanResultsCache = new Map<string, { results: Record<string, ScanResult>; timestamp: number }>()
-
-/** Evict the oldest entry if the cache exceeds the size limit. */
-const evictIfNeeded = () => {
-  if (scanResultsCache.size <= MAX_CACHE_SIZE) return
-  let oldestKey: string | null = null
-  let oldestTs = Infinity
-  for (const [k, v] of scanResultsCache) {
-    if (v.timestamp < oldestTs) {
-      oldestTs = v.timestamp
-      oldestKey = k
-    }
-  }
-  if (oldestKey) scanResultsCache.delete(oldestKey)
-}
-
-export const getScanResultsCache = () => scanResultsCache
-export { evictIfNeeded as evictScanCache }
+import { getCachedScan, setCachedScan } from '../data/scanResultsCache'
 
 export type ScanState = {
-  results: Record<string, ScanResult>
-  loading: Record<string, boolean>
-  errors: Record<string, string>
+  results: Partial<Record<ScannerId, ScanResult>>
+  loading: Partial<Record<ScannerId, boolean>>
+  errors: Partial<Record<ScannerId, string>>
   isComplete: boolean
   lastScannedAt: number | null
   progress: number
@@ -41,23 +17,23 @@ export type ScanState = {
 const useSecurityScan = (ctx: ScanContext | null): ScanState => {
   const ctxKey = ctx ? scanKey(ctx.safeAddress, ctx.chainId) : null
 
-  const [results, setResults] = useState<Record<string, ScanResult>>({})
-  const [loading, setLoading] = useState<Record<string, boolean>>({})
-  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [results, setResults] = useState<Partial<Record<ScannerId, ScanResult>>>({})
+  const [loading, setLoading] = useState<Partial<Record<ScannerId, boolean>>>({})
+  const [errors, setErrors] = useState<Partial<Record<ScannerId, string>>>({})
   const [lastScannedAt, setLastScannedAt] = useState<number | null>(null)
   const scanIdRef = useRef(0)
   const ctxRef = useRef(ctx)
   ctxRef.current = ctx
 
   const executeScan = useCallback(
-    async (scannerId: string, scanFn: () => Promise<ScanResult>, guardId?: number, onAllComplete?: () => void) => {
+    async (scannerId: ScannerId, scanFn: () => Promise<ScanResult>, guardId?: number, onAllComplete?: () => void) => {
       setLoading((prev) => ({ ...prev, [scannerId]: true }))
 
       try {
         const result = await scanFn()
         if (guardId !== undefined && scanIdRef.current !== guardId) return
         setResults((prev) => ({ ...prev, [scannerId]: result }))
-      } catch (err: any) {
+      } catch (err: unknown) {
         if (guardId !== undefined && scanIdRef.current !== guardId) return
         setErrors((prev) => ({ ...prev, [scannerId]: err instanceof Error ? err.message : 'Scan failed' }))
       } finally {
@@ -78,7 +54,7 @@ const useSecurityScan = (ctx: ScanContext | null): ScanState => {
     let completedCount = 0
     // Local accumulator — avoids reading state from inside a setState updater
     // (which would violate React's purity contract and double-fire under StrictMode).
-    const accumulatedResults: Record<string, ScanResult> = {}
+    const accumulatedResults: Partial<Record<ScannerId, ScanResult>> = {}
 
     setResults({})
     setErrors({})
@@ -100,12 +76,9 @@ const useSecurityScan = (ctx: ScanContext | null): ScanState => {
           if (completedCount === total) {
             const now = Date.now()
             setLastScannedAt(now)
-            // Write to module-level cache so other hook instances (sidebar) reuse results.
+            // Share results with module-level cache so other hook instances (sidebar) reuse them.
             const key = ctxRef.current ? scanKey(ctxRef.current.safeAddress, ctxRef.current.chainId) : null
-            if (key) {
-              scanResultsCache.set(key, { results: accumulatedResults, timestamp: now })
-              evictIfNeeded()
-            }
+            if (key) setCachedScan(key, accumulatedResults, now)
           }
         },
       )
@@ -117,11 +90,10 @@ const useSecurityScan = (ctx: ScanContext | null): ScanState => {
       // Check cache when ctxKey first becomes available — not just on mount.
       // When the drawer opens, ctx starts as null (queries loading) so the mount-time
       // cache check misses. By the time ctx resolves, we need to check again here.
-      const freshCached = scanResultsCache.get(ctxKey)
-      const freshResolved = freshCached && Date.now() - freshCached.timestamp < CACHE_TTL_MS ? freshCached : null
-      if (freshResolved) {
-        setResults(freshResolved.results)
-        setLastScannedAt(freshResolved.timestamp)
+      const cached = getCachedScan(ctxKey)
+      if (cached) {
+        setResults(cached.results)
+        setLastScannedAt(cached.timestamp)
         return
       }
       runScan()
@@ -136,7 +108,10 @@ const useSecurityScan = (ctx: ScanContext | null): ScanState => {
 
   const loadingCount = Object.values(loading).filter(Boolean).length
   const total = SCANNERS.length
-  const progress = total > 0 ? Math.round(((total - loadingCount) / total) * 100) : 0
+  // Use settled count, not (total - loadingCount): loading starts empty so loadingCount
+  // is 0 before any scanner has started, which would incorrectly report 100% progress.
+  const settledCount = Object.keys(results).length + Object.keys(errors).length
+  const progress = total > 0 ? Math.round((settledCount / total) * 100) : 0
 
   return {
     results,

--- a/apps/web/src/features/security/index.ts
+++ b/apps/web/src/features/security/index.ts
@@ -38,6 +38,9 @@ export const SecurityFeature = createFeatureHandle<SecurityContract>('security',
 // Contract type (for explicit annotations if needed)
 export type { SecurityContract } from './contract'
 
+// Pure data constants — eagerly available, no need to go through the feature handle
+export { SEVERITY_RANK, SAFE_GRADE_RANK } from './data/scanners/constants'
+
 // Hooks exported directly — always loaded, not lazy
 export { default as useSecurityScan } from './hooks/useSecurityScan'
 export { default as useSecurityHubFeatureRedirect } from './hooks/useSecurityHubFeatureRedirect'

--- a/apps/web/src/features/security/types.ts
+++ b/apps/web/src/features/security/types.ts
@@ -5,7 +5,14 @@
  * and incur zero runtime cost.
  */
 
-export type { ScanContext, ScanResult, EvidenceItem, SecurityScanner, SafeGrade } from './data/scanners/types'
+export type {
+  ScanContext,
+  ScanResult,
+  EvidenceItem,
+  SecurityScanner,
+  ScannerId,
+  SafeGrade,
+} from './data/scanners/types'
 export type { GradeSummary } from './data/scanners/utils'
 export type { StrengthLevel } from './data/securityScoring'
 export type { SecurityGrade, CheckStatus, CheckResult } from './data/securityTypes'

--- a/apps/web/src/features/spaces/components/SecurityHub/Page.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/Page.tsx
@@ -1,0 +1,13 @@
+import { AddressBookSourceProvider } from '@/components/common/AddressBookSourceProvider'
+import AuthState from '../AuthState'
+import SecurityHub from './index'
+
+export default function SecurityHubPage({ spaceId }: { spaceId: string }) {
+  return (
+    <AuthState spaceId={spaceId}>
+      <AddressBookSourceProvider source="spaceOnly">
+        <SecurityHub />
+      </AddressBookSourceProvider>
+    </AuthState>
+  )
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecurityPanelView.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecurityPanelView.test.tsx
@@ -1,0 +1,324 @@
+import type { ReactNode } from 'react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { createMockContext } from '@/features/security/testing'
+import type { ScanResult } from '@/features/security/types'
+import SecurityPanelView from '../components/SecurityPanelView/SecurityPanelView'
+
+// next/link isn't meaningful in a jsdom render; pass through to a plain anchor.
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href, ...rest }: { children: ReactNode; href: string } & Record<string, unknown>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  )
+  MockLink.displayName = 'MockLink'
+  return { __esModule: true, default: MockLink }
+})
+
+// useLoadFeature depends on Redux/chain context which isn't wired in this unit test.
+// Return the resolved feature synchronously so components see $isReady=true.
+// require() inside the factory since jest.mock is hoisted above ES imports.
+jest.mock('@/features/__core__', () => {
+  const securityFeatureImpl = require('@/features/security/feature').default
+  return {
+    ...jest.requireActual('@/features/__core__'),
+    useLoadFeature: () => ({
+      ...securityFeatureImpl,
+      $isReady: true,
+      $isDisabled: false,
+      $error: undefined,
+    }),
+  }
+})
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+type PartialResult = Partial<ScanResult> & Pick<ScanResult, 'status' | 'severity'>
+
+const mkResult = (r: PartialResult): ScanResult => ({
+  score: r.status === 'clear' ? 100 : 30,
+  evidence: [],
+  remediation: '',
+  lastChecked: new Date().toISOString(),
+  ...r,
+})
+
+const allClearResults: Record<string, ScanResult> = {
+  account_setup: mkResult({ status: 'clear', severity: 'Low' }),
+  recovery: mkResult({ status: 'clear', severity: 'Low' }),
+  contract_version: mkResult({ status: 'clear', severity: 'Low' }),
+  factory_validation: mkResult({ status: 'clear', severity: 'Low' }),
+  guard: mkResult({ status: 'clear', severity: 'Low' }),
+  fallback_handler: mkResult({
+    status: 'clear',
+    severity: 'Low',
+    evidence: [{ label: 'Status', value: 'Official Safe fallback handler' }],
+  }),
+  modules: mkResult({ status: 'clear', severity: 'Low' }),
+  transaction_scanning: mkResult({ status: 'clear', severity: 'Low' }),
+  pending_tx: mkResult({ status: 'clear', severity: 'Low' }),
+  multichain_setup: mkResult({ status: 'not_applicable', severity: 'Low' }),
+  signer_integrity: mkResult({ status: 'clear', severity: 'Low' }),
+}
+
+const SAFE_QUERY_PARAM = 'eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6'
+
+/**
+ * Renders SecurityPanelView with sensible defaults. Explicitly setting a key
+ * to `undefined` DOES override the default — use this to test missing-prop cases.
+ */
+const renderPanel = (overrides: Partial<React.ComponentProps<typeof SecurityPanelView>> = {}) => {
+  const defaults: React.ComponentProps<typeof SecurityPanelView> = {
+    scanContext: createMockContext(),
+    results: allClearResults,
+    isComplete: true,
+    safeQueryParam: SAFE_QUERY_PARAM,
+  }
+  return render(<SecurityPanelView {...defaults} {...overrides} />)
+}
+
+/** Find the "N checks passing" accordion summary (distinct from the header's "All checks passing."). */
+const getChecksAccordion = () => screen.getByText(/^\d+ checks? passing$/)
+const getSignersAccordion = () => screen.getByText(/signers? not blocklisted$/)
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('SecurityPanelView', () => {
+  describe('loading / empty states', () => {
+    it('renders skeletons when scanContext is null', () => {
+      const { container } = renderPanel({ scanContext: null, results: {}, isComplete: false })
+      expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThan(0)
+    })
+
+    it('renders skeletons when no results have arrived and scan is still running', () => {
+      const { container } = renderPanel({ results: {}, isComplete: false })
+      expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('header', () => {
+    it('renders strength level and "all checks passing" copy when everything clears', () => {
+      renderPanel()
+      expect(screen.getByText('Strong')).toBeInTheDocument()
+      expect(screen.getByText('All checks passing.')).toBeInTheDocument()
+    })
+
+    it('renders a failure count when checks fail', () => {
+      renderPanel({
+        results: {
+          ...allClearResults,
+          contract_version: mkResult({ status: 'issue', severity: 'High', remediation: 'Update.' }),
+        },
+      })
+      expect(screen.getByText(/\d+ issues? need attention/)).toBeInTheDocument()
+    })
+  })
+
+  describe('Security checks bucketing', () => {
+    it('surfaces failing checks at the top and shows a passing-accordion summary', () => {
+      renderPanel({
+        results: {
+          ...allClearResults,
+          contract_version: mkResult({ status: 'issue', severity: 'High', remediation: 'Update.' }),
+        },
+      })
+      // Failing check visible by its non-OK title
+      expect(screen.getByText('Contract version is outdated')).toBeInTheDocument()
+      // Accordion summary for the remaining passing checks
+      expect(getChecksAccordion()).toBeInTheDocument()
+    })
+
+    it('reveals passing rows inside the accordion when it is toggled open', () => {
+      renderPanel()
+      // Everything passes — accordion holds all rows. Open it.
+      fireEvent.click(getChecksAccordion())
+      // Declarative titles for passing checks should now be in the DOM
+      expect(screen.getByText('Signing threshold is strong')).toBeInTheDocument()
+      expect(screen.getByText('Contract version is up to date')).toBeInTheDocument()
+      expect(screen.getByText('Deployed via official Safe factory')).toBeInTheDocument()
+    })
+
+    it('sorts failing rows by severity (Critical → High → Medium)', () => {
+      renderPanel({
+        scanContext: createMockContext({ threshold: 1 }),
+        results: {
+          ...allClearResults,
+          pending_tx: mkResult({ status: 'partial', severity: 'Medium', remediation: 'x' }),
+          contract_version: mkResult({ status: 'issue', severity: 'High', remediation: 'x' }),
+          account_setup: mkResult({ status: 'issue', severity: 'Critical', remediation: 'x' }),
+        },
+      })
+      const criticalEl = screen.getByText('Single signer controls this Safe')
+      const highEl = screen.getByText('Contract version is outdated')
+      const mediumEl = screen.getByText('Pending transactions are stale')
+
+      // Critical before High in DOM order
+      expect(criticalEl.compareDocumentPosition(highEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      // High before Medium in DOM order
+      expect(highEl.compareDocumentPosition(mediumEl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
+
+  describe('failing-row CTA', () => {
+    it("renders a CTA link pointing to the scanner's fix route", () => {
+      renderPanel({
+        results: {
+          ...allClearResults,
+          contract_version: mkResult({ status: 'issue', severity: 'High', remediation: 'Update.' }),
+        },
+      })
+      // Expand the failing row
+      fireEvent.click(screen.getByText('Contract version is outdated'))
+      const link = screen.getByRole('link', { name: /update/i })
+      expect(link).toHaveAttribute('href', expect.stringContaining('safe='))
+    })
+
+    it('honors ScanResult.ctaLabelOverride over the CHECK_DEFS default', () => {
+      renderPanel({
+        results: {
+          ...allClearResults,
+          guard: mkResult({
+            status: 'partial',
+            severity: 'Medium',
+            remediation: 'Guard recommended.',
+            ctaLabelOverride: 'Review modules',
+          }),
+        },
+      })
+      fireEvent.click(screen.getByText('Transaction guard is recommended'))
+      expect(screen.getByRole('link', { name: /review modules/i })).toBeInTheDocument()
+    })
+
+    it('does not render a CTA when safeQueryParam is missing', () => {
+      renderPanel({
+        safeQueryParam: undefined,
+        results: {
+          ...allClearResults,
+          contract_version: mkResult({ status: 'issue', severity: 'High', remediation: 'Update.' }),
+        },
+      })
+      fireEvent.click(screen.getByText('Contract version is outdated'))
+      expect(screen.queryByRole('link', { name: /update/i })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('signers section', () => {
+    it('renders one row per owner (visible after opening the signers accordion)', () => {
+      renderPanel({
+        scanContext: createMockContext({
+          owners: [
+            { value: '0x1111111111111111111111111111111111111111', name: 'Alice' },
+            { value: '0x2222222222222222222222222222222222222222' },
+          ],
+        }),
+      })
+      fireEvent.click(getSignersAccordion())
+      expect(screen.getByText('Alice')).toBeInTheDocument()
+      expect(screen.getByText('0x2222...2222')).toBeInTheDocument()
+    })
+
+    it('shows "N signers not blocklisted" accordion for passing signers', () => {
+      renderPanel({
+        scanContext: createMockContext({
+          owners: [
+            { value: '0x1111111111111111111111111111111111111111' },
+            { value: '0x2222222222222222222222222222222222222222' },
+            { value: '0x3333333333333333333333333333333333333333' },
+          ],
+        }),
+      })
+      expect(screen.getByText(/3 signers not blocklisted/)).toBeInTheDocument()
+    })
+
+    it('uses the singular label for a single owner', () => {
+      renderPanel({
+        scanContext: createMockContext({
+          owners: [{ value: '0x1111111111111111111111111111111111111111' }],
+        }),
+      })
+      expect(screen.getByText(/1 signer not blocklisted/)).toBeInTheDocument()
+    })
+  })
+
+  describe('multichain row', () => {
+    it('promotes a failing multichain check into the top "needs attention" area', () => {
+      renderPanel({
+        results: {
+          ...allClearResults,
+          multichain_setup: mkResult({ status: 'partial', severity: 'Medium', remediation: 'Align signers.' }),
+        },
+      })
+      expect(screen.getByText('Signers differ across networks')).toBeInTheDocument()
+    })
+
+    it('renders a passing multichain row as a visible footer outside the signers accordion', () => {
+      renderPanel({
+        results: { ...allClearResults, multichain_setup: mkResult({ status: 'clear', severity: 'Low' }) },
+      })
+      expect(screen.getByText('Signers are consistent across networks')).toBeInTheDocument()
+    })
+  })
+
+  describe('fallback handler', () => {
+    it('uses the scanner-emitted Status label as the title when passing', () => {
+      renderPanel()
+      fireEvent.click(getChecksAccordion())
+      // Title + evidence both contain this label; assert at least one match exists.
+      expect(screen.getAllByText('Official Safe fallback handler').length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('modules', () => {
+    it('collapses to a summary row when more than 2 modules are installed', () => {
+      renderPanel({
+        scanContext: createMockContext({
+          modules: [
+            { value: '0xaaaa000000000000000000000000000000000001', name: 'Delay Module' },
+            { value: '0xaaaa000000000000000000000000000000000002', name: 'Allowance Module' },
+            { value: '0xaaaa000000000000000000000000000000000003', name: 'Scope Guard' },
+          ],
+        }),
+      })
+      fireEvent.click(getChecksAccordion())
+      expect(screen.getByText(/Modules & Extensions · 3 installed/)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /view all/i })).toBeInTheDocument()
+    })
+
+    it('shows unrecognized modules as failing rows (visible without expanding accordion)', () => {
+      renderPanel({
+        scanContext: createMockContext({
+          modules: [{ value: '0xbbbb000000000000000000000000000000000002', name: 'Mystery Module' }],
+        }),
+      })
+      // Unrecognized module → failing → visible at top. Title + evidence both render the name;
+      // assert at least one match exists and that it's a body2 title element.
+      const matches = screen.getAllByText('Mystery Module')
+      expect(matches.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('row expansion', () => {
+    it('reveals evidence + remediation when a failing row is clicked', () => {
+      renderPanel({
+        scanContext: createMockContext({ threshold: 1 }),
+        results: {
+          ...allClearResults,
+          account_setup: mkResult({
+            status: 'issue',
+            severity: 'Critical',
+            remediation: 'Raise the threshold.',
+            evidence: [
+              { label: 'Signers', value: '3' },
+              { label: 'Threshold', value: '1 of 3' },
+            ],
+          }),
+        },
+      })
+      const row = screen.getByText('Single signer controls this Safe')
+      fireEvent.click(row)
+      const paper = row.closest('.MuiPaper-root')!
+      expect(within(paper as HTMLElement).getByText('Raise the threshold.')).toBeInTheDocument()
+      expect(within(paper as HTMLElement).getByText('1 of 3')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecuritySafesTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecuritySafesTable.test.tsx
@@ -1,0 +1,257 @@
+import type { ReactNode } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import SecuritySafesTable from '../components/SecuritySafesTable/SecuritySafesTable'
+import type { SpaceSafeEntry, SelectedSafe } from '../types'
+import type { ScanResult } from '@/features/security/types'
+// Helper: mirrors security.scanKey exactly (address.toLowerCase() + chainId). Inlined to
+// avoid a feature-handle mock setup in tests that don't exercise the security feature directly.
+const scanKey = (address: string, chainId: string) => `${address.toLowerCase()}:${chainId}`
+
+// ─── mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('next/link', () => {
+  const MockLink = ({ children, href, ...rest }: { children: ReactNode; href: string } & Record<string, unknown>) => (
+    <a href={typeof href === 'string' ? href : ''} {...rest}>
+      {children}
+    </a>
+  )
+  MockLink.displayName = 'MockLink'
+  return { __esModule: true, default: MockLink }
+})
+
+jest.mock('@/components/common/ChainIndicator', () => {
+  const MockCI = ({ chainId }: { chainId: string }) => <span data-testid={`chain-${chainId}`} />
+  MockCI.displayName = 'MockChainIndicator'
+  return { __esModule: true, default: MockCI }
+})
+
+jest.mock('@/features/multichain', () => ({
+  NetworkLogosList: ({ networks }: { networks: { chainId: string }[] }) => (
+    <span data-testid="network-logos">{networks.length}</span>
+  ),
+}))
+
+jest.mock('@/components/common/Identicon', () => {
+  const MockId = ({ address }: { address: string }) => <span data-testid={`identicon-${address.slice(0, 6)}`} />
+  MockId.displayName = 'MockIdenticon'
+  return { __esModule: true, default: MockId }
+})
+
+// Mock only the query hook, not the entire gateway module (avoids breaking Redux store bootstrap)
+jest.mock('@safe-global/store/gateway', () => ({
+  ...jest.requireActual('@safe-global/store/gateway'),
+  useGetChainsConfigV2Query: () => ({
+    data: {
+      ids: ['1', '137'],
+      entities: {
+        '1': { chainId: '1', shortName: 'eth' },
+        '137': { chainId: '137', shortName: 'matic' },
+      },
+    },
+  }),
+}))
+
+jest.mock('@/store/api/gateway', () => ({
+  useGetMultipleSafeOverviewsQuery: () => ({ data: [] }),
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: () => 'usd',
+}))
+
+// useLoadFeature needs Redux/chain context; return the resolved feature synchronously.
+jest.mock('@/features/__core__', () => {
+  const securityFeatureImpl = require('@/features/security/feature').default
+  return {
+    ...jest.requireActual('@/features/__core__'),
+    useLoadFeature: () => ({
+      ...securityFeatureImpl,
+      $isReady: true,
+      $isDisabled: false,
+      $error: undefined,
+    }),
+  }
+})
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const mkResult = (status: ScanResult['status'] = 'clear'): ScanResult => ({
+  status,
+  severity: status === 'clear' ? 'Low' : 'High',
+  score: status === 'clear' ? 100 : 30,
+  evidence: [],
+  remediation: '',
+  lastChecked: new Date().toISOString(),
+})
+
+const singleSafe: SpaceSafeEntry = {
+  address: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+  chainId: '1',
+  name: 'My Vault',
+  isMultichain: false,
+  chainEntries: [{ chainId: '1', isDeployed: true }],
+}
+
+const multiSafe: SpaceSafeEntry = {
+  address: '0x1111111111111111111111111111111111111111',
+  chainId: '1',
+  name: 'Multi Safe',
+  isMultichain: true,
+  chainEntries: [
+    { chainId: '1', isDeployed: true },
+    { chainId: '137', isDeployed: true },
+  ],
+}
+
+const buildScanResults = (
+  entries: { address: string; chainId: string }[],
+  resultOverrides: Record<string, Partial<ScanResult>> = {},
+) => {
+  const all: Record<string, Record<string, ScanResult>> = {}
+  for (const e of entries) {
+    const key = scanKey(e.address, e.chainId)
+    all[key] = {
+      account_setup: mkResult(),
+      contract_version: mkResult(),
+      recovery: mkResult(),
+      factory_validation: mkResult(),
+      guard: mkResult(),
+      fallback_handler: mkResult(),
+      modules: mkResult(),
+      pending_tx: mkResult(),
+      transaction_scanning: mkResult(),
+      multichain_setup: mkResult('not_applicable'),
+      signer_integrity: mkResult(),
+      ...resultOverrides,
+    }
+  }
+  return all
+}
+
+type Props = React.ComponentProps<typeof SecuritySafesTable>
+const renderTable = (overrides: Partial<Props> = {}) => {
+  const defaults: Props = {
+    safes: [singleSafe],
+    onViewReport: jest.fn(),
+    selectedSafe: null,
+    scanResults: buildScanResults([{ address: singleSafe.address, chainId: singleSafe.chainId }]),
+    balanceMap: {},
+  }
+  return render(<SecuritySafesTable {...defaults} {...overrides} />)
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('SecuritySafesTable', () => {
+  it('renders a single-chain safe row with name and network icon', () => {
+    renderTable()
+    expect(screen.getByText('My Vault')).toBeInTheDocument()
+    expect(screen.getByTestId('chain-1')).toBeInTheDocument()
+  })
+
+  it('calls onViewReport when a deployed row is clicked', () => {
+    const onViewReport = jest.fn()
+    renderTable({ onViewReport })
+    fireEvent.click(screen.getByText('My Vault').closest('tr')!)
+    expect(onViewReport).toHaveBeenCalledWith(singleSafe.address, singleSafe.chainId)
+  })
+
+  it('does not fire onViewReport for an undeployed safe', () => {
+    const onViewReport = jest.fn()
+    const undeployed: SpaceSafeEntry = {
+      ...singleSafe,
+      chainEntries: [{ chainId: '1', isDeployed: false }],
+    }
+    renderTable({ safes: [undeployed], onViewReport, scanResults: {} })
+    fireEvent.click(screen.getByText('My Vault').closest('tr')!)
+    expect(onViewReport).not.toHaveBeenCalled()
+    expect(screen.getByText('Not deployed')).toBeInTheDocument()
+  })
+
+  it('shows a dash when no scan results are available', () => {
+    renderTable({ scanResults: {} })
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows a spinner for a safe that is currently scanning', () => {
+    const key = scanKey(singleSafe.address, singleSafe.chainId)
+    const { container } = renderTable({
+      scanningKeys: new Set([key]),
+      scanResults: {},
+    })
+    expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders scan data even when the key is still in scanningKeys', () => {
+    // Regression: the drawer (or a parallel consumer) can populate scanResults for a Safe
+    // before useAutoScan's sequential queue reaches it. Cells must prefer data over the
+    // scanning flag so the row shows real values immediately instead of stale skeletons.
+    const key = scanKey(singleSafe.address, singleSafe.chainId)
+    const scanResults = buildScanResults([{ address: singleSafe.address, chainId: singleSafe.chainId }], {
+      account_setup: {
+        ...mkResult(),
+        evidence: [{ label: 'Threshold', value: '2 of 3' }],
+      } as ScanResult,
+      contract_version: {
+        ...mkResult(),
+        evidence: [{ label: 'Current version', value: '1.4.1' }],
+      } as ScanResult,
+    })
+    const { container } = renderTable({
+      scanningKeys: new Set([key]),
+      scanResults,
+      balanceMap: { [key]: '1000' },
+    })
+    expect(screen.getByText('2 of 3')).toBeInTheDocument()
+    expect(screen.getByText('1.4.1')).toBeInTheDocument()
+    expect(container.querySelectorAll('.MuiSkeleton-root').length).toBe(0)
+  })
+
+  describe('multichain safes', () => {
+    const scanResults = buildScanResults([
+      { address: multiSafe.address, chainId: '1' },
+      { address: multiSafe.address, chainId: '137' },
+    ])
+
+    it('renders a parent row with network logos and an expand caret', () => {
+      renderTable({ safes: [multiSafe], scanResults })
+      // Parent + child rows both contain the name; assert at least one exists.
+      expect(screen.getAllByText('Multi Safe').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByTestId('network-logos')).toBeInTheDocument()
+      expect(screen.getByTestId('ExpandMoreRoundedIcon')).toBeInTheDocument()
+    })
+
+    it('reveals per-chain child rows when the parent is expanded', () => {
+      const onViewReport = jest.fn()
+      renderTable({ safes: [multiSafe], scanResults, onViewReport })
+      // Expand the multichain row — click the parent (first match)
+      const parentRow = screen.getAllByText('Multi Safe')[0].closest('tr')!
+      fireEvent.click(parentRow)
+      // After expand, child chain rows become visible — each has a chain indicator
+      expect(screen.getByTestId('chain-1')).toBeInTheDocument()
+      expect(screen.getByTestId('chain-137')).toBeInTheDocument()
+      // Click a child row — should fire onViewReport with that chain
+      fireEvent.click(screen.getByTestId('chain-137').closest('tr')!)
+      expect(onViewReport).toHaveBeenCalledWith(multiSafe.address, '137')
+    })
+
+    it('shows multichain warning icon when multichain_setup scanner reports a problem', () => {
+      const warnResults = buildScanResults(
+        [
+          { address: multiSafe.address, chainId: '1' },
+          { address: multiSafe.address, chainId: '137' },
+        ],
+        { multichain_setup: { status: 'partial', severity: 'Medium' } as ScanResult },
+      )
+      renderTable({ safes: [multiSafe], scanResults: warnResults })
+      expect(screen.getByTestId('WarningAmberRoundedIcon')).toBeInTheDocument()
+    })
+  })
+
+  it('highlights the selected safe row', () => {
+    const selected: SelectedSafe = { address: singleSafe.address, chainId: '1' }
+    renderTable({ selectedSafe: selected })
+    const row = screen.getByText('My Vault').closest('tr')!
+    expect(row).toHaveClass('Mui-selected')
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/__tests__/utils.test.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/__tests__/utils.test.ts
@@ -1,0 +1,95 @@
+import { reconcileDeployedSafes, getDeployedEntries } from '../utils'
+import type { SpaceSafeEntry } from '../types'
+
+const scanKey = (address: string, chainId: string) => `${address}:${chainId}`
+
+const SAFE_A = '0xAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAa'
+const SAFE_B = '0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb'
+
+const mkMultichain = (address: string, entries: Array<{ chainId: string; isDeployed: boolean }>): SpaceSafeEntry => ({
+  address,
+  chainId: entries[0]?.chainId ?? '1',
+  name: 'Multi',
+  isMultichain: true,
+  chainEntries: entries,
+})
+
+const mkSingle = (address: string, chainId: string, isDeployed = true): SpaceSafeEntry => ({
+  address,
+  chainId,
+  name: 'Single',
+  isMultichain: false,
+  chainEntries: [{ chainId, isDeployed }],
+})
+
+describe('reconcileDeployedSafes', () => {
+  it('returns the input unchanged when confirmedDeployedKeys is null (still loading)', () => {
+    const safes = [mkMultichain(SAFE_A, [{ chainId: '1', isDeployed: true }])]
+    const result = reconcileDeployedSafes(safes, null, scanKey)
+    expect(result).toBe(safes)
+  })
+
+  it('leaves safes alone when every locally-deployed chain is confirmed by CGW', () => {
+    const safes = [
+      mkMultichain(SAFE_A, [
+        { chainId: '1', isDeployed: true },
+        { chainId: '137', isDeployed: true },
+      ]),
+    ]
+    const confirmed = new Set([scanKey(SAFE_A, '1'), scanKey(SAFE_A, '137')])
+    const result = reconcileDeployedSafes(safes, confirmed, scanKey)
+    // Identity preserved when nothing changes — lets downstream memoisation stay stable.
+    expect(result[0]).toBe(safes[0])
+  })
+
+  it('flips a ghost-deployed multichain entry to isDeployed=false', () => {
+    const safes = [
+      mkMultichain(SAFE_A, [
+        { chainId: '1', isDeployed: true },
+        { chainId: '137', isDeployed: true }, // ghost: not returned by CGW
+      ]),
+    ]
+    const confirmed = new Set([scanKey(SAFE_A, '1')])
+    const result = reconcileDeployedSafes(safes, confirmed, scanKey)
+    expect(result[0].chainEntries[0]).toEqual({ chainId: '1', isDeployed: true })
+    expect(result[0].chainEntries[1]).toEqual({ chainId: '137', isDeployed: false })
+  })
+
+  it('leaves already-undeployed chains untouched (no spurious flips)', () => {
+    const safes = [
+      mkMultichain(SAFE_A, [
+        { chainId: '1', isDeployed: true },
+        { chainId: '137', isDeployed: false }, // locally known-counterfactual
+      ]),
+    ]
+    const confirmed = new Set([scanKey(SAFE_A, '1')])
+    const result = reconcileDeployedSafes(safes, confirmed, scanKey)
+    expect(result[0].chainEntries[1]).toEqual({ chainId: '137', isDeployed: false })
+  })
+
+  it('handles single-chain safes', () => {
+    const safes = [mkSingle(SAFE_B, '10', true)]
+    const confirmed = new Set<string>() // response returned data for other safes but not this one
+    // Guard note: caller passes null for the "empty response" case, so receiving an empty set
+    // here means CGW responded with other safes but not this one — i.e. this Safe is a ghost.
+    const result = reconcileDeployedSafes(safes, confirmed, scanKey)
+    expect(result[0].chainEntries[0]).toEqual({ chainId: '10', isDeployed: false })
+  })
+})
+
+describe('getDeployedEntries', () => {
+  it('excludes chain entries flagged not-deployed after reconciliation', () => {
+    const safes = [
+      mkMultichain(SAFE_A, [
+        { chainId: '1', isDeployed: true },
+        { chainId: '137', isDeployed: false },
+      ]),
+      mkSingle(SAFE_B, '10', true),
+    ]
+    const entries = getDeployedEntries(safes)
+    expect(entries).toEqual([
+      { address: SAFE_A, chainId: '1' },
+      { address: SAFE_B, chainId: '10' },
+    ])
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SafeGradeChip/SafeGradeChip.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SafeGradeChip/SafeGradeChip.tsx
@@ -1,0 +1,66 @@
+import { Chip, type ChipProps } from '@mui/material'
+import type { SafeGrade } from '@/features/security/types'
+
+/** Human-readable label per SafeGrade. Shared by every chip in the SecurityHub UI. */
+export const SAFE_GRADE_LABEL: Record<SafeGrade, string> = {
+  critical: 'Critical',
+  at_risk: 'At risk',
+  needs_attention: 'Needs review',
+  passing: 'Healthy',
+}
+
+/**
+ * Color tokens per SafeGrade.
+ * - `accent` is the strong color (foreground text when soft, background when active).
+ * - `bg`     is the paired soft background (chip fill in the default soft variant).
+ *
+ * Both static "status" chips (StatusCell) and the interactive filter chips
+ * (WorkspaceHealthCard) compose their styling from this pair.
+ */
+export const SAFE_GRADE_PALETTE: Record<SafeGrade, { accent: string; bg: string }> = {
+  critical: { accent: 'error.dark', bg: 'error.background' },
+  at_risk: { accent: 'error.main', bg: 'error.background' },
+  needs_attention: { accent: 'warning.main', bg: 'warning.background' },
+  passing: { accent: 'success.main', bg: 'success.background' },
+}
+
+export type SafeGradeChipProps = Omit<ChipProps, 'color'> & {
+  grade: SafeGrade
+  /** When true, render filled (accent background, paper text). Default is soft (bg + accent text). */
+  active?: boolean
+  /** Override the default grade label (e.g. prefix a count like "3 Critical"). */
+  label?: string
+}
+
+/**
+ * Single visual primitive for SafeGrade chips. Encapsulates label/palette lookup,
+ * size/weight, and the soft-vs-active variant; consumers add their own `sx` overrides
+ * (height, transition, hover) for context-specific tweaks.
+ */
+const SafeGradeChip = ({ grade, active = false, label, onClick, sx, ...chipProps }: SafeGradeChipProps) => {
+  const { accent, bg } = SAFE_GRADE_PALETTE[grade]
+  const backgroundColor = active ? accent : bg
+  const color = active ? 'background.paper' : accent
+  return (
+    <Chip
+      label={label ?? SAFE_GRADE_LABEL[grade]}
+      size="small"
+      onClick={onClick}
+      sx={{
+        backgroundColor,
+        color,
+        fontWeight: 700,
+        '& .MuiChip-label': { px: 1 },
+        ...(onClick && {
+          cursor: 'pointer',
+          transition: 'background-color 0.15s, color 0.15s',
+          '&:hover': { backgroundColor, color, opacity: 0.8 },
+        }),
+        ...sx,
+      }}
+      {...chipProps}
+    />
+  )
+}
+
+export default SafeGradeChip

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/PanelHeader.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/PanelHeader.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from 'react'
+import { Box, CircularProgress, Paper, Skeleton, Stack, Typography } from '@mui/material'
+import type { ScanResult } from '@/features/security/types'
+import { GRADE_BG_BY_STRENGTH, STRENGTH_DESCRIPTIONS } from './constants'
+import { usePanelHeader } from './hooks/usePanelHeader'
+
+export type PanelHeaderProps = {
+  results: Record<string, ScanResult>
+  isComplete: boolean
+}
+
+/** Score gauge + strength level chip + action line at the top of the panel. */
+const PanelHeader = ({ results, isComplete }: PanelHeaderProps): ReactElement | null => {
+  const state = usePanelHeader(results, isComplete)
+
+  if (state.status === 'loading') {
+    return <Skeleton variant="rectangular" height={120} sx={{ borderRadius: '12px', mb: 3 }} />
+  }
+  if (state.status === 'empty') return null
+
+  const { score, level, color, actionLine } = state
+
+  return (
+    <Paper sx={{ p: 2.5, borderRadius: '12px', mb: 3, backgroundColor: GRADE_BG_BY_STRENGTH[level] }} elevation={0}>
+      <Stack direction="row" spacing={2.5} alignItems="center">
+        <Box sx={{ position: 'relative', display: 'inline-flex', flexShrink: 0 }}>
+          <CircularProgress variant="determinate" value={100} size={80} thickness={4} sx={{ color: 'border.light' }} />
+          <CircularProgress
+            variant="determinate"
+            value={score}
+            size={80}
+            thickness={4}
+            sx={{
+              color,
+              position: 'absolute',
+              left: 0,
+              '& .MuiCircularProgress-circle': { strokeLinecap: 'round' },
+            }}
+          />
+          <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Typography variant="h4" fontWeight={700} sx={{ lineHeight: 1 }}>
+              {score}
+            </Typography>
+          </Box>
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="h5" fontWeight={700} mb={0.5}>
+            {level}
+          </Typography>
+          <Typography variant="body2" color="text.primary" sx={{ lineHeight: 1.5, mb: 0.5 }}>
+            {STRENGTH_DESCRIPTIONS[level]}
+          </Typography>
+          <Typography variant="caption" color="text.secondary" fontWeight={600}>
+            {actionLine}
+          </Typography>
+        </Box>
+      </Stack>
+    </Paper>
+  )
+}
+
+export default PanelHeader

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SectionPanel.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SectionPanel.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement, ReactNode } from 'react'
+import { Box, Divider, Paper, Typography } from '@mui/material'
+import { motion } from 'framer-motion'
+import { ROW_STAGGER } from './constants'
+
+const MotionBox = motion.create(Box)
+
+export type SectionPanelProps = {
+  title: string
+  rows: { key: string; node: ReactNode }[]
+  footer?: ReactNode
+  /** Base delay offset so sections appearing later start their stagger later. */
+  baseDelay?: number
+}
+
+/**
+ * Animated section container used by every panel section (signers + checks).
+ * Renders nothing when there are no rows and no footer so empty sections collapse.
+ */
+const SectionPanel = ({ title, rows, footer, baseDelay = 0 }: SectionPanelProps): ReactElement | null => {
+  if (rows.length === 0 && !footer) return null
+  return (
+    <MotionBox
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ type: 'spring', stiffness: 400, damping: 30, delay: baseDelay }}
+      sx={{ mb: 3 }}
+    >
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{
+          textTransform: 'uppercase',
+          letterSpacing: '0.5px',
+          fontWeight: 700,
+          display: 'block',
+          mb: 1,
+        }}
+      >
+        {title}
+      </Typography>
+      <Paper
+        elevation={0}
+        sx={{
+          borderRadius: '12px',
+          overflow: 'hidden',
+          border: '1px solid',
+          borderColor: 'divider',
+        }}
+      >
+        {rows.map((r, idx) => (
+          <MotionBox
+            key={r.key}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.15, delay: baseDelay + (idx + 1) * ROW_STAGGER }}
+          >
+            {idx > 0 && <Divider />}
+            {r.node}
+          </MotionBox>
+        ))}
+        {footer && (
+          <MotionBox
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.15, delay: baseDelay + (rows.length + 1) * ROW_STAGGER }}
+          >
+            {footer}
+          </MotionBox>
+        )}
+      </Paper>
+    </MotionBox>
+  )
+}
+
+export default SectionPanel

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityChecksSection.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityChecksSection.tsx
@@ -1,0 +1,69 @@
+import { type ReactElement, useState } from 'react'
+import { Box, Collapse, Divider, Typography } from '@mui/material'
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
+import UnfoldLessRoundedIcon from '@mui/icons-material/UnfoldLessRounded'
+import UnfoldMoreRoundedIcon from '@mui/icons-material/UnfoldMoreRounded'
+import { maybePlural } from '@safe-global/utils/utils/formatters'
+import type { ScanContext, ScanResult } from '@/features/security/types'
+import SectionPanel from './SectionPanel'
+import { useSecurityChecks } from './hooks/useSecurityChecks'
+
+export type SecurityChecksSectionProps = {
+  scanContext: ScanContext
+  results: Record<string, ScanResult>
+  safeQueryParam?: string
+}
+
+const SecurityChecksSection = ({
+  scanContext,
+  results,
+  safeQueryParam,
+}: SecurityChecksSectionProps): ReactElement | null => {
+  const { isReady, failingRows, passingRows } = useSecurityChecks(scanContext, results, safeQueryParam)
+  const [passingExpanded, setPassingExpanded] = useState(false)
+
+  // Feature not yet loaded — render nothing; the panel skeleton covers this state.
+  if (!isReady) return null
+
+  const footer =
+    passingRows.length > 0 ? (
+      <>
+        {failingRows.length > 0 && <Divider />}
+        <Box
+          onClick={() => setPassingExpanded((v) => !v)}
+          sx={{
+            px: 2,
+            py: 1.25,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.25,
+            '&:hover': { backgroundColor: 'action.hover' },
+          }}
+        >
+          <CheckCircleRoundedIcon sx={{ color: 'success.main', fontSize: 18 }} />
+          <Typography variant="body2" fontWeight={600} sx={{ flex: 1 }}>
+            {`${passingRows.length} check${maybePlural(passingRows)} passing`}
+          </Typography>
+          {/* UnfoldMore/Less signals a *group* expansion, distinct from the single-row chevron. */}
+          {passingExpanded ? (
+            <UnfoldLessRoundedIcon sx={{ color: 'text.secondary', fontSize: 18 }} />
+          ) : (
+            <UnfoldMoreRoundedIcon sx={{ color: 'text.secondary', fontSize: 18 }} />
+          )}
+        </Box>
+        <Collapse in={passingExpanded}>
+          {passingRows.map((r) => (
+            <Box key={r.key}>
+              <Divider />
+              {r.node}
+            </Box>
+          ))}
+        </Collapse>
+      </>
+    ) : undefined
+
+  return <SectionPanel title="Security checks" rows={failingRows} footer={footer} baseDelay={0.08} />
+}
+
+export default SecurityChecksSection

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityPanelView.stories.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityPanelView.stories.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Auto-generated snapshot tests for Storybook stories
+ * Run "yarn generate:storybook-tests" to regenerate
+ */
+import '../../../../../../tests/storybook-setup'
+import { composeStories } from '@storybook/react'
+import { render } from '@testing-library/react'
+import type { ComponentType } from 'react'
+
+import * as stories from '../../components/SecurityPanelView/SecurityPanelView.stories'
+
+const composedStories = composeStories(stories)
+
+describe('./SecurityPanelView.stories', () => {
+  Object.entries(composedStories).forEach(([storyName, Story]) => {
+    test(storyName, () => {
+      const StoryComponent = Story as ComponentType
+      const { container } = render(<StoryComponent />)
+      expect(container.firstChild).toMatchSnapshot()
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityPanelView.stories.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityPanelView.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SecurityPanelView from './SecurityPanelView'
+import { createMockStory } from '@/stories/mocks'
+import { createMockContext } from '@/features/security/testing'
+import type { ScanResult } from '@/features/security/types'
+
+const mkResult = (overrides: Partial<ScanResult> = {}): ScanResult => ({
+  status: 'clear',
+  severity: 'Low',
+  score: 100,
+  evidence: [],
+  remediation: '',
+  lastChecked: new Date().toISOString(),
+  ...overrides,
+})
+
+const allPassing: Record<string, ScanResult> = {
+  account_setup: mkResult(),
+  contract_version: mkResult({ evidence: [{ label: 'Current version', value: '1.4.1' }] }),
+  factory_validation: mkResult(),
+  guard: mkResult(),
+  fallback_handler: mkResult(),
+  modules: mkResult({ status: 'not_applicable' }),
+  pending_tx: mkResult(),
+  transaction_scanning: mkResult(),
+  recovery: mkResult({ status: 'not_applicable' }),
+  multichain_setup: mkResult({ status: 'not_applicable' }),
+  signer_integrity: mkResult(),
+}
+
+const withIssues: Record<string, ScanResult> = {
+  ...allPassing,
+  contract_version: mkResult({
+    status: 'issue',
+    severity: 'High',
+    evidence: [
+      { label: 'Current version', value: '1.3.0' },
+      { label: 'Latest version', value: '1.4.1' },
+    ],
+    remediation: 'Update to the latest version.',
+  }),
+  guard: mkResult({
+    status: 'partial',
+    severity: 'Medium',
+    remediation: 'No transaction guard is configured.',
+  }),
+  modules: mkResult({
+    status: 'issue',
+    severity: 'High',
+    evidence: [{ label: 'Modules', value: '1 unrecognized module' }],
+    remediation: 'Review and remove unrecognized modules.',
+  }),
+}
+
+const critical: Record<string, ScanResult> = {
+  ...withIssues,
+  account_setup: mkResult({
+    status: 'issue',
+    severity: 'Critical',
+    evidence: [{ label: 'Threshold', value: '1 of 1' }],
+    remediation: 'Increase the signer threshold to avoid single-signer risk.',
+  }),
+}
+
+const setup = createMockStory({ features: { spaces: true }, layout: 'paper' })
+
+const meta = {
+  title: 'Features/SecurityHub/SecurityPanelView',
+  component: SecurityPanelView,
+  decorators: [setup.decorator],
+  parameters: {
+    ...setup.parameters,
+    chromatic: { disableSnapshot: true },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SecurityPanelView>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const AllPassing: Story = {
+  args: {
+    scanContext: createMockContext(),
+    results: allPassing,
+    isComplete: true,
+    safeQueryParam: 'eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+  },
+}
+
+export const WithIssues: Story = {
+  args: {
+    scanContext: createMockContext(),
+    results: withIssues,
+    isComplete: true,
+    safeQueryParam: 'eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+  },
+}
+
+export const CriticalIssue: Story = {
+  args: {
+    scanContext: createMockContext({ threshold: 1, owners: [{ value: '0x1111111111111111111111111111111111111111' }] }),
+    results: critical,
+    isComplete: true,
+    safeQueryParam: 'eth:0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6',
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    scanContext: null,
+    results: {},
+    isComplete: false,
+  },
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityPanelView.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityPanelView.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react'
+import { Box, Skeleton } from '@mui/material'
+import { motion } from 'framer-motion'
+import type { ScanContext, ScanResult } from '@/features/security/types'
+import PanelHeader from './PanelHeader'
+import SecurityChecksSection from './SecurityChecksSection'
+import SignersSection from './SignersSection'
+
+type SecurityPanelViewProps = {
+  scanContext: ScanContext | null
+  results: Record<string, ScanResult>
+  isComplete: boolean
+  /** The `shortName:address` param used to deep-link a CTA to the correct Safe (e.g., "eth:0x..."). */
+  safeQueryParam?: string
+}
+
+const MotionBox = motion.create(Box)
+
+/**
+ * Top-level layout for the per-Safe security panel. Composes the three
+ * sub-sections (header / security checks / signers). All derivation lives in
+ * the per-section hooks under `./hooks/`; this component only wires them up
+ * and handles the global skeleton state.
+ */
+const SecurityPanelView = ({
+  scanContext,
+  results,
+  isComplete,
+  safeQueryParam,
+}: SecurityPanelViewProps): ReactElement => {
+  const hasResults = Object.keys(results).length > 0
+
+  if (!scanContext || (!hasResults && !isComplete)) {
+    return (
+      <Box>
+        <Skeleton variant="rectangular" height={120} sx={{ borderRadius: '12px', mb: 3 }} />
+        <Skeleton variant="rectangular" height={200} sx={{ borderRadius: '12px', mb: 3 }} />
+        <Skeleton variant="rectangular" height={150} sx={{ borderRadius: '12px' }} />
+      </Box>
+    )
+  }
+
+  return (
+    <Box>
+      <MotionBox
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+      >
+        <PanelHeader results={results} isComplete={isComplete} />
+      </MotionBox>
+      <SecurityChecksSection scanContext={scanContext} results={results} safeQueryParam={safeQueryParam} />
+      <SignersSection scanContext={scanContext} results={results} safeQueryParam={safeQueryParam} />
+    </Box>
+  )
+}
+
+export default SecurityPanelView

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SignersSection.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SignersSection.tsx
@@ -1,0 +1,78 @@
+import { type ReactElement, useState } from 'react'
+import { Box, Collapse, Divider, Typography } from '@mui/material'
+import CheckCircleRoundedIcon from '@mui/icons-material/CheckCircleRounded'
+import UnfoldLessRoundedIcon from '@mui/icons-material/UnfoldLessRounded'
+import UnfoldMoreRoundedIcon from '@mui/icons-material/UnfoldMoreRounded'
+import { maybePlural } from '@safe-global/utils/utils/formatters'
+import type { ScanContext, ScanResult } from '@/features/security/types'
+import SectionPanel from './SectionPanel'
+import { useSignerRows } from './hooks/useSignerRows'
+
+export type SignersSectionProps = {
+  scanContext: ScanContext
+  results: Record<string, ScanResult>
+  safeQueryParam?: string
+}
+
+const SignersSection = ({ scanContext, results, safeQueryParam }: SignersSectionProps): ReactElement | null => {
+  const { isReady, failingRows, passingSigners, passingMultichainRow } = useSignerRows(
+    scanContext,
+    results,
+    safeQueryParam,
+  )
+  const [passingExpanded, setPassingExpanded] = useState(false)
+
+  if (!isReady) return null
+
+  const hasPassingContent = passingSigners.length > 0 || passingMultichainRow !== null
+
+  const footer = hasPassingContent ? (
+    <>
+      {passingSigners.length > 0 && (
+        <>
+          {failingRows.length > 0 && <Divider />}
+          <Box
+            onClick={() => setPassingExpanded((v) => !v)}
+            sx={{
+              px: 2,
+              py: 1.25,
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.25,
+              '&:hover': { backgroundColor: 'action.hover' },
+            }}
+          >
+            <CheckCircleRoundedIcon sx={{ color: 'success.main', fontSize: 18 }} />
+            <Typography variant="body2" fontWeight={600} sx={{ flex: 1 }}>
+              {`${passingSigners.length} signer${maybePlural(passingSigners)} not blocklisted`}
+            </Typography>
+            {passingExpanded ? (
+              <UnfoldLessRoundedIcon sx={{ color: 'text.secondary', fontSize: 18 }} />
+            ) : (
+              <UnfoldMoreRoundedIcon sx={{ color: 'text.secondary', fontSize: 18 }} />
+            )}
+          </Box>
+          <Collapse in={passingExpanded}>
+            {passingSigners.map((r) => (
+              <Box key={r.key}>
+                <Divider />
+                {r.node}
+              </Box>
+            ))}
+          </Collapse>
+        </>
+      )}
+      {passingMultichainRow && (
+        <>
+          {(failingRows.length > 0 || passingSigners.length > 0) && <Divider />}
+          {passingMultichainRow.node}
+        </>
+      )}
+    </>
+  ) : undefined
+
+  return <SectionPanel title="Your signers" rows={failingRows} footer={footer} baseDelay={0.16} />
+}
+
+export default SignersSection

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/__snapshots__/SecurityPanelView.stories.test.tsx.snap
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/__snapshots__/SecurityPanelView.stories.test.tsx.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`./SecurityPanelView.stories AllPassing 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <div
+      class="MuiBox-root mui-style-0"
+    >
+      <div
+        class="MuiBox-root mui-style-0"
+        style="opacity: 0;"
+      >
+        <span
+          class="MuiSkeleton-root MuiSkeleton-rectangular MuiSkeleton-pulse mui-style-63k1qp-MuiSkeleton-root"
+          style="height: 120px;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`./SecurityPanelView.stories CriticalIssue 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <div
+      class="MuiBox-root mui-style-0"
+    >
+      <div
+        class="MuiBox-root mui-style-0"
+        style="opacity: 0;"
+      >
+        <span
+          class="MuiSkeleton-root MuiSkeleton-rectangular MuiSkeleton-pulse mui-style-63k1qp-MuiSkeleton-root"
+          style="height: 120px;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`./SecurityPanelView.stories Loading 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <div
+      class="MuiBox-root mui-style-0"
+    >
+      <span
+        class="MuiSkeleton-root MuiSkeleton-rectangular MuiSkeleton-pulse mui-style-63k1qp-MuiSkeleton-root"
+        style="height: 120px;"
+      />
+      <span
+        class="MuiSkeleton-root MuiSkeleton-rectangular MuiSkeleton-pulse mui-style-63k1qp-MuiSkeleton-root"
+        style="height: 200px;"
+      />
+      <span
+        class="MuiSkeleton-root MuiSkeleton-rectangular MuiSkeleton-pulse mui-style-13wwyig-MuiSkeleton-root"
+        style="height: 150px;"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`./SecurityPanelView.stories WithIssues 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <div
+      class="MuiBox-root mui-style-0"
+    >
+      <div
+        class="MuiBox-root mui-style-0"
+        style="opacity: 0;"
+      >
+        <span
+          class="MuiSkeleton-root MuiSkeleton-rectangular MuiSkeleton-pulse mui-style-63k1qp-MuiSkeleton-root"
+          style="height: 120px;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/constants.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/constants.ts
@@ -1,0 +1,20 @@
+import type { StrengthLevel } from '@/features/security/types'
+
+/** Sentence beneath the header score for each strength level. */
+export const STRENGTH_DESCRIPTIONS: Record<StrengthLevel, string> = {
+  Strong: 'Your account is well configured.',
+  Moderate: 'Your account has room for improvement.',
+  Weak: 'Your account has security gaps that should be addressed.',
+  Critical: 'Your account has critical issues that need immediate attention.',
+}
+
+/** Header panel background color per strength level. */
+export const GRADE_BG_BY_STRENGTH: Record<StrengthLevel, string> = {
+  Strong: 'success.background',
+  Moderate: 'warning.background',
+  Weak: 'error.background',
+  Critical: 'error.background',
+}
+
+/** Stagger delay per row within a section (seconds) — used by SectionPanel. */
+export const ROW_STAGGER = 0.04

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/usePanelHeader.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/usePanelHeader.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react'
+import { maybePlural } from '@safe-global/utils/utils/formatters'
+import type { ScanResult, StrengthLevel } from '@/features/security/types'
+import { SecurityFeature } from '@/features/security'
+import { useLoadFeature } from '@/features/__core__'
+
+/**
+ * Three states the header can be in:
+ * - `loading`  — feature still resolving, or no summary yet and scan not complete.
+ * - `empty`    — feature ready but `computeSummary` returned nothing (nothing applicable to score).
+ * - `ready`    — derived header viewmodel (score / level / color / action line).
+ */
+export type PanelHeaderState =
+  | { status: 'loading' }
+  | { status: 'empty' }
+  | {
+      status: 'ready'
+      score: number
+      level: StrengthLevel
+      color: string
+      actionLine: string
+    }
+
+/**
+ * Computes the score, strength level, color, and action line for the panel header
+ * from raw scan results. Keeps the math + feature-handle plumbing out of the view
+ * component so the header is a pure render of the viewmodel.
+ */
+export const usePanelHeader = (results: Record<string, ScanResult>, isComplete: boolean): PanelHeaderState => {
+  const security = useLoadFeature(SecurityFeature)
+  const summary = useMemo(
+    () => (security.$isReady ? security.computeSummary(results) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [results, security.$isReady, security.computeSummary],
+  )
+
+  if (!security.$isReady || (!isComplete && !summary)) return { status: 'loading' }
+  if (!summary) return { status: 'empty' }
+
+  const clearRatio = summary.applicableCount > 0 ? summary.passing / summary.applicableCount : 0
+  const score = Math.round(clearRatio * 100)
+  const level = security.getStrengthLevel(clearRatio, summary.hasCriticalIssue)
+  const color = security.getStrengthColor(level)
+  const failureCount = summary.applicableCount - summary.passing
+  const actionLine =
+    failureCount === 0 ? 'All checks passing.' : `${failureCount} issue${maybePlural(failureCount)} need attention.`
+
+  return { status: 'ready', score, level, color, actionLine }
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/useSecurityChecks.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/useSecurityChecks.tsx
@@ -1,0 +1,335 @@
+import { type ReactNode, useMemo, useState } from 'react'
+import { Button } from '@mui/material'
+import type { EvidenceItem, ScanContext, ScanResult, SecurityGrade } from '@/features/security/types'
+import { SecurityFeature } from '@/features/security'
+import { useLoadFeature } from '@/features/__core__'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import {
+  EvidenceList,
+  Row,
+  StatusIcon,
+  buildExpanded,
+  isPassingStatus,
+  makeBuildCta,
+  sortBySeverity,
+  type SectionRow,
+} from '../primitives'
+
+export type UseSecurityChecksResult = {
+  isReady: boolean
+  failingRows: { key: string; node: ReactNode }[]
+  passingRows: { key: string; node: ReactNode }[]
+}
+
+/**
+ * Derives the rows rendered by `SecurityChecksSection` from raw scan results.
+ *
+ * Owns the `modulesExpanded` UI state because it directly affects which rows
+ * are produced (collapsed summary vs. one row per module). The footer's
+ * `passingExpanded` state stays in the rendering component since it only
+ * toggles visibility of an already-built list.
+ */
+export const useSecurityChecks = (
+  scanContext: ScanContext,
+  results: Record<string, ScanResult>,
+  safeQueryParam: string | undefined,
+): UseSecurityChecksResult => {
+  const security = useLoadFeature(SecurityFeature)
+  const [modulesExpanded, setModulesExpanded] = useState(false)
+
+  const buildCta = useMemo(
+    () => (security.$isReady ? makeBuildCta(security.checkDefs) : null),
+    [security.$isReady, security.checkDefs],
+  )
+
+  const isKnownModuleByName = security.$isReady ? security.isKnownModuleByName : null
+  const zeroAddress = security.$isReady ? security.zeroAddress : null
+
+  const { failingRows, passingRows } = useMemo(() => {
+    if (!buildCta || !isKnownModuleByName || !zeroAddress) {
+      return {
+        failingRows: [] as { key: string; node: ReactNode }[],
+        passingRows: [] as { key: string; node: ReactNode }[],
+      }
+    }
+
+    const hasGuard = scanContext.guard !== null && scanContext.guard.value !== zeroAddress
+    const hasFallback = scanContext.fallbackHandler !== null && scanContext.fallbackHandler.value !== zeroAddress
+    const activeModules = (scanContext.modules ?? []).filter((m) => m.value !== zeroAddress)
+    const showModuleSummary = activeModules.length > 2 && !modulesExpanded
+
+    const items: SectionRow[] = []
+    const iconFor = (r: ScanResult) => <StatusIcon status={r.status} />
+
+    const accountSetupResult = results['account_setup']
+    if (accountSetupResult) {
+      const ok = isPassingStatus(accountSetupResult.status)
+      const title = ok
+        ? 'Signing threshold is strong'
+        : scanContext.threshold === 1
+          ? 'Single signer controls this Safe'
+          : 'Signing threshold is low'
+      items.push({
+        key: 'threshold',
+        severity: accountSetupResult.severity,
+        isPassing: ok,
+        node: (
+          <Row
+            leadIcon={iconFor(accountSetupResult)}
+            title={title}
+            expandedContent={buildExpanded(
+              accountSetupResult,
+              buildCta('account_setup', accountSetupResult, safeQueryParam),
+            )}
+          />
+        ),
+      })
+    }
+
+    const recoveryResult = results['recovery']
+    if (recoveryResult) {
+      const ok = isPassingStatus(recoveryResult.status)
+      const title =
+        recoveryResult.status === 'clear'
+          ? 'Recovery is configured'
+          : recoveryResult.status === 'not_applicable'
+            ? 'Recovery not available on this network'
+            : 'Recovery is not configured'
+      items.push({
+        key: 'recovery',
+        severity: recoveryResult.severity,
+        isPassing: ok,
+        node: (
+          <Row
+            leadIcon={iconFor(recoveryResult)}
+            title={title}
+            expandedContent={buildExpanded(recoveryResult, buildCta('recovery', recoveryResult, safeQueryParam))}
+          />
+        ),
+      })
+    }
+
+    const versionResult = results['contract_version']
+    if (versionResult) {
+      const ok = isPassingStatus(versionResult.status)
+      const title = ok ? 'Contract version is up to date' : 'Contract version is outdated'
+      items.push({
+        key: 'version',
+        severity: versionResult.severity,
+        isPassing: ok,
+        node: (
+          <Row
+            leadIcon={iconFor(versionResult)}
+            title={title}
+            expandedContent={buildExpanded(versionResult, buildCta('contract_version', versionResult, safeQueryParam))}
+          />
+        ),
+      })
+    }
+
+    const factoryResult = results['factory_validation']
+    if (factoryResult) {
+      const ok = isPassingStatus(factoryResult.status)
+      const title = ok ? 'Deployed via official Safe factory' : 'Deployed from an unrecognized source'
+      items.push({
+        key: 'factory',
+        severity: factoryResult.severity,
+        isPassing: ok,
+        node: (
+          <Row
+            leadIcon={iconFor(factoryResult)}
+            title={title}
+            expandedContent={buildExpanded(
+              factoryResult,
+              buildCta('factory_validation', factoryResult, safeQueryParam),
+            )}
+          />
+        ),
+      })
+    }
+
+    const guardResult = results['guard']
+    if (guardResult) {
+      const ok = isPassingStatus(guardResult.status)
+      const title = ok
+        ? hasGuard
+          ? 'Transaction guard is active'
+          : 'No transaction guard in use'
+        : hasGuard
+          ? 'Transaction guard is unverified'
+          : 'Transaction guard is recommended'
+      items.push({
+        key: 'guard',
+        severity: guardResult.severity,
+        isPassing: ok,
+        node: (
+          <Row
+            leadIcon={iconFor(guardResult)}
+            title={title}
+            expandedContent={buildExpanded(guardResult, buildCta('guard', guardResult, safeQueryParam))}
+          />
+        ),
+      })
+    }
+
+    const fallbackResult = results['fallback_handler']
+    if (fallbackResult) {
+      const ok = isPassingStatus(fallbackResult.status)
+      // Scanner emits a human label like "Official Safe fallback handler" / "CoW Protocol TWAP handler"
+      // in evidence — reuse it directly so the title auto-matches each variant.
+      const handlerLabel = fallbackResult.evidence?.find(
+        (e): e is { label: string; value: string } => typeof e !== 'string' && e.label === 'Status',
+      )?.value
+      const title = ok
+        ? hasFallback
+          ? handlerLabel || 'Fallback handler is active'
+          : 'No fallback handler in use'
+        : 'Fallback handler is unverified'
+      items.push({
+        key: 'fallback',
+        severity: fallbackResult.severity,
+        isPassing: ok,
+        node: (
+          <Row
+            leadIcon={iconFor(fallbackResult)}
+            title={title}
+            expandedContent={buildExpanded(
+              fallbackResult,
+              buildCta('fallback_handler', fallbackResult, safeQueryParam),
+            )}
+          />
+        ),
+      })
+    }
+
+    const modulesResult = results['modules']
+    if (modulesResult) {
+      if (activeModules.length === 0) {
+        items.push({
+          key: 'modules-empty',
+          severity: modulesResult.severity,
+          isPassing: isPassingStatus(modulesResult.status),
+          node: (
+            <Row
+              leadIcon={iconFor(modulesResult)}
+              title="No modules installed"
+              expandedContent={buildExpanded(modulesResult, buildCta('modules', modulesResult, safeQueryParam))}
+            />
+          ),
+        })
+      } else if (showModuleSummary) {
+        // Collapsed summary row — not expandable, acts as a gateway to per-module rows.
+        items.push({
+          key: 'modules-summary',
+          severity: modulesResult.severity,
+          isPassing: isPassingStatus(modulesResult.status),
+          node: (
+            <Row
+              leadIcon={iconFor(modulesResult)}
+              title={`Modules & Extensions · ${activeModules.length} installed`}
+              trailing={
+                <Button
+                  size="small"
+                  variant="text"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setModulesExpanded(true)
+                  }}
+                  sx={{ fontSize: '0.7rem', p: 0, minWidth: 0, textTransform: 'none', fontWeight: 600 }}
+                >
+                  View all
+                </Button>
+              }
+            />
+          ),
+        })
+      } else {
+        const modulesCta = buildCta('modules', modulesResult, safeQueryParam)
+        activeModules.forEach((mod) => {
+          const trusted = isKnownModuleByName(mod.name)
+          const severity: SecurityGrade = trusted ? 'Low' : 'High'
+          const status: ScanResult['status'] = trusted ? 'clear' : 'issue'
+          // Show the module's name as the title for both trusted and unrecognized modules — users
+          // need to identify *which* module when it's flagged. The icon + intro convey the verdict.
+          const title = mod.name || shortenAddress(mod.value)
+          const perModuleEvidence: EvidenceItem[] = [
+            { label: 'Address', value: mod.value },
+            ...(mod.name ? [{ label: 'Name', value: mod.name }] : []),
+          ]
+          const intro = trusted
+            ? 'Recognized Safe ecosystem module.'
+            : "Unrecognized module — not in the known Safe ecosystem deployments. Review carefully and remove if you don't recognize it."
+          items.push({
+            key: `module-${mod.value}`,
+            severity,
+            isPassing: trusted,
+            node: (
+              <Row
+                leadIcon={<StatusIcon status={status} />}
+                title={title}
+                expandedContent={
+                  <EvidenceList intro={intro} evidence={perModuleEvidence} cta={trusted ? null : modulesCta} />
+                }
+              />
+            ),
+          })
+        })
+      }
+    }
+
+    const scanningResult = results['transaction_scanning']
+    if (scanningResult) {
+      const ok = isPassingStatus(scanningResult.status)
+      const title = ok ? 'Transaction scanning is enabled' : 'Transaction scanning is disabled'
+      items.push({
+        key: 'scanning',
+        severity: scanningResult.severity,
+        isPassing: ok,
+        node: (
+          <Row
+            leadIcon={iconFor(scanningResult)}
+            title={title}
+            expandedContent={buildExpanded(
+              scanningResult,
+              buildCta('transaction_scanning', scanningResult, safeQueryParam),
+            )}
+          />
+        ),
+      })
+    }
+
+    const pendingResult = results['pending_tx']
+    if (pendingResult) {
+      const ok = isPassingStatus(pendingResult.status)
+      const queued = scanContext.queuedTxCount
+      const title = ok
+        ? queued > 0
+          ? 'Queue is up to date'
+          : 'No pending transactions'
+        : 'Pending transactions are stale'
+      items.push({
+        key: 'pending',
+        severity: pendingResult.severity,
+        isPassing: ok,
+        node: (
+          <Row
+            leadIcon={iconFor(pendingResult)}
+            title={title}
+            expandedContent={buildExpanded(pendingResult, buildCta('pending_tx', pendingResult, safeQueryParam))}
+          />
+        ),
+      })
+    }
+
+    return {
+      failingRows: sortBySeverity(items.filter((i) => !i.isPassing)).map(({ key, node }) => ({ key, node })),
+      passingRows: items.filter((i) => i.isPassing).map(({ key, node }) => ({ key, node })),
+    }
+  }, [buildCta, isKnownModuleByName, zeroAddress, scanContext, results, safeQueryParam, modulesExpanded])
+
+  if (!security.$isReady || !buildCta) {
+    return { isReady: false, failingRows: [], passingRows: [] }
+  }
+
+  return { isReady: true, failingRows, passingRows }
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/useSignerRows.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/useSignerRows.tsx
@@ -1,0 +1,116 @@
+import { type ReactNode, useMemo } from 'react'
+import type { EvidenceItem, ScanContext, ScanResult, SecurityGrade } from '@/features/security/types'
+import { SecurityFeature } from '@/features/security'
+import { useLoadFeature } from '@/features/__core__'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import {
+  EvidenceList,
+  Row,
+  StatusIcon,
+  buildExpanded,
+  isPassingStatus,
+  makeBuildCta,
+  sortBySeverity,
+  type SectionRow,
+} from '../primitives'
+
+type RenderedRow = { key: string; node: ReactNode }
+
+export type UseSignerRowsResult = {
+  isReady: boolean
+  /** Flagged signers + (if failing) the multichain row, sorted worst-first. */
+  failingRows: RenderedRow[]
+  /** Signers with `isPassingStatus` results — collapsed under the accordion. */
+  passingSigners: RenderedRow[]
+  /** Multichain row rendered separately when it passes (it isn't a signer per se). */
+  passingMultichainRow: RenderedRow | null
+}
+
+const introForSigner = (status: ScanResult['status'], severity: SecurityGrade): string | undefined => {
+  if (status === 'inconclusive') return 'Screening service unavailable. Manually verify this signer.'
+  if (severity === 'Critical')
+    return 'This address appears on a sanctions or block list. Consider replacing this signer.'
+  if (status !== 'clear') return 'This address has elevated risk exposure (transactions linked to flagged sources).'
+  return undefined
+}
+
+/**
+ * Builds the rows rendered by `SignersSection` from a Safe's `signer_integrity` and
+ * `multichain_setup` results.
+ *
+ * The multichain row is treated specially: failing ones are bucketed with the flagged
+ * signers (so severity ranking applies), but a passing multichain row stays outside the
+ * passing-signers accordion since it isn't a signer — it's a property of the signer set.
+ */
+export const useSignerRows = (
+  scanContext: ScanContext,
+  results: Record<string, ScanResult>,
+  safeQueryParam: string | undefined,
+): UseSignerRowsResult => {
+  const security = useLoadFeature(SecurityFeature)
+  const buildCta = useMemo(
+    () => (security.$isReady ? makeBuildCta(security.checkDefs) : null),
+    [security.$isReady, security.checkDefs],
+  )
+
+  if (!security.$isReady || !buildCta) {
+    return { isReady: false, failingRows: [], passingSigners: [], passingMultichainRow: null }
+  }
+
+  const signerIntegrityResult = results['signer_integrity']
+  const multichainResult = results['multichain_setup']
+
+  // All signer rows route back to the signer_integrity remediation page.
+  const signerCta = buildCta('signer_integrity', signerIntegrityResult, safeQueryParam)
+
+  const signerItems: SectionRow[] = scanContext.owners.map((owner) => {
+    const severity: SecurityGrade = signerIntegrityResult?.severity ?? 'Low'
+    const status: ScanResult['status'] = signerIntegrityResult?.status ?? 'clear'
+    const title = owner.name || shortenAddress(owner.value)
+    const intro = introForSigner(status, severity)
+    const signerEvidence: EvidenceItem[] = [{ label: 'Address', value: owner.value }]
+    const rowCta = isPassingStatus(status) ? null : signerCta
+
+    return {
+      key: `signer-${owner.value}`,
+      severity,
+      isPassing: isPassingStatus(status),
+      node: (
+        <Row
+          leadIcon={<StatusIcon status={status} />}
+          title={title}
+          expandedContent={<EvidenceList intro={intro} evidence={signerEvidence} cta={rowCta} />}
+        />
+      ),
+    }
+  })
+
+  let multichainItem: SectionRow | null = null
+  if (multichainResult && multichainResult.status !== 'not_applicable') {
+    const ok = multichainResult.status === 'clear'
+    const title = ok ? 'Signers are consistent across networks' : 'Signers differ across networks'
+    const multichainCta = buildCta('multichain_setup', multichainResult, safeQueryParam)
+    multichainItem = {
+      key: 'multichain',
+      severity: multichainResult.severity,
+      isPassing: isPassingStatus(multichainResult.status),
+      node: (
+        <Row
+          leadIcon={<StatusIcon status={multichainResult.status} />}
+          title={title}
+          expandedContent={buildExpanded(multichainResult, multichainCta)}
+        />
+      ),
+    }
+  }
+
+  const failingItems = signerItems.filter((i) => !i.isPassing)
+  if (multichainItem && !multichainItem.isPassing) failingItems.push(multichainItem)
+
+  const failingRows = sortBySeverity(failingItems).map(({ key, node }) => ({ key, node }))
+  const passingSigners = signerItems.filter((i) => i.isPassing).map(({ key, node }) => ({ key, node }))
+  const passingMultichainRow =
+    multichainItem && multichainItem.isPassing ? { key: multichainItem.key, node: multichainItem.node } : null
+
+  return { isReady: true, failingRows, passingSigners, passingMultichainRow }
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/primitives.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/primitives.tsx
@@ -1,0 +1,223 @@
+import { type ReactElement, type ReactNode, useState } from 'react'
+import { Box, Collapse, Stack, Typography } from '@mui/material'
+import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded'
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded'
+import ErrorOutlineRoundedIcon from '@mui/icons-material/ErrorOutlineRounded'
+import HelpOutlineRoundedIcon from '@mui/icons-material/HelpOutlineRounded'
+import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded'
+import RemoveCircleOutlineRoundedIcon from '@mui/icons-material/RemoveCircleOutlineRounded'
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded'
+import Link from 'next/link'
+import type { EvidenceItem, ScanResult, SecurityGrade } from '@/features/security/types'
+import { SEVERITY_RANK, type SecurityContract } from '@/features/security'
+
+export type SectionRow = { key: string; severity: SecurityGrade; isPassing: boolean; node: ReactNode }
+
+export type Cta = { label: string; href: string }
+
+/**
+ * A row is considered "passing" (bucketed into the accordion) when the user has no action to take.
+ * `inconclusive` means "we couldn't determine" (e.g. 3rd-party screening API unavailable) — treating
+ * it as passing avoids false alarm; the row is still expandable with its distinct grey icon.
+ */
+export const isPassingStatus = (s: ScanResult['status']) =>
+  s === 'clear' || s === 'not_applicable' || s === 'inconclusive'
+
+/** Sort row entries with most severe first, falling back to original order. */
+export const sortBySeverity = <T extends { severity: SecurityGrade }>(items: T[]): T[] =>
+  [...items].sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity])
+
+/** Leading icon reflecting a check's status. Sized & colored to match the accordion summary icon. */
+export const StatusIcon = ({ status }: { status: ScanResult['status'] }): ReactElement => {
+  const sx = { fontSize: 18, flexShrink: 0 } as const
+  if (status === 'clear') return <CheckCircleOutlineRoundedIcon sx={{ ...sx, color: 'success.main' }} />
+  if (status === 'not_applicable') return <RemoveCircleOutlineRoundedIcon sx={{ ...sx, color: 'text.secondary' }} />
+  if (status === 'inconclusive') return <HelpOutlineRoundedIcon sx={{ ...sx, color: 'text.disabled' }} />
+  if (status === 'partial') return <WarningAmberRoundedIcon sx={{ ...sx, color: 'warning.main' }} />
+  // issue
+  return <ErrorOutlineRoundedIcon sx={{ ...sx, color: 'error.main' }} />
+}
+
+type RowProps = {
+  /** Leading status icon (same visual weight as accordion summary icon) */
+  leadIcon?: ReactNode
+  title: string
+  /** Trailing action node (used by modules summary's "View N" button) */
+  trailing?: ReactNode
+  /** Reveal additional content on click */
+  expandedContent?: ReactNode
+}
+
+export const Row = ({ leadIcon, title, trailing, expandedContent }: RowProps): ReactElement => {
+  const [expanded, setExpanded] = useState(false)
+  const expandable = !!expandedContent
+
+  return (
+    <Box
+      sx={{
+        px: 2,
+        cursor: expandable ? 'pointer' : 'default',
+        '&:hover': expandable ? { backgroundColor: 'action.hover' } : {},
+      }}
+      onClick={expandable ? () => setExpanded((v) => !v) : undefined}
+    >
+      <Stack direction="row" spacing={1.25} alignItems="center" sx={{ py: 1.25 }}>
+        {leadIcon && <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>{leadIcon}</Box>}
+        <Typography
+          variant="body2"
+          fontWeight={600}
+          sx={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}
+          noWrap
+          title={title}
+        >
+          {title}
+        </Typography>
+        {trailing}
+        {expandable && (
+          <KeyboardArrowDownRoundedIcon
+            sx={{
+              color: 'text.secondary',
+              fontSize: 18,
+              flexShrink: 0,
+              transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+              transition: 'transform 0.2s',
+            }}
+          />
+        )}
+      </Stack>
+      {expandable && (
+        <Collapse in={expanded}>
+          {/* Align expanded body's left edge with the title (icon 18px + gap 1.25 = 3.5 spacing units). */}
+          <Box sx={{ pb: 1.5, pl: leadIcon ? 3.5 : 0 }} onClick={(e) => e.stopPropagation()}>
+            {typeof expandedContent === 'string' ? (
+              <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.5, display: 'block' }}>
+                {expandedContent}
+              </Typography>
+            ) : (
+              expandedContent
+            )}
+          </Box>
+        </Collapse>
+      )}
+    </Box>
+  )
+}
+
+/**
+ * Factory that binds `checkDefs` to a CTA builder. Consumers obtain `checkDefs`
+ * via useLoadFeature and pass it once; the returned function is then used at
+ * each render site.
+ *
+ * The returned CTA builder returns null when:
+ *  - the row is passing (no action needed),
+ *  - we don't yet have a `safeQueryParam` (chain metadata still loading), or
+ *  - there's no checkDefs entry for this check id.
+ * Label precedence: `ScanResult.ctaLabelOverride` → `checkDefs[id].ctaLabel`.
+ */
+export const makeBuildCta =
+  (checkDefs: SecurityContract['checkDefs']) =>
+  (checkId: string, result: ScanResult | undefined, safeQueryParam: string | undefined): Cta | null => {
+    if (!safeQueryParam) return null
+    const def = checkDefs[checkId]
+    if (!def) return null
+    if (result && isPassingStatus(result.status)) return null
+    const label = result?.ctaLabelOverride || def.ctaLabel
+    return { label, href: `${def.fixRoute}?safe=${encodeURIComponent(safeQueryParam)}` }
+  }
+
+const CtaLink = ({ cta }: { cta: Cta }): ReactElement => (
+  <Link
+    href={cta.href}
+    onClick={(e) => e.stopPropagation()}
+    style={{ textDecoration: 'none', alignSelf: 'flex-start', borderRadius: 4 }}
+    className="security-cta-link"
+  >
+    <Stack
+      direction="row"
+      spacing={0.75}
+      alignItems="center"
+      sx={{
+        color: 'primary.main',
+        cursor: 'pointer',
+        transition: 'color 0.15s',
+        '& .cta-icon': { transition: 'transform 0.15s' },
+        '&:hover': { color: 'primary.dark' },
+        '&:hover .cta-label': { textDecoration: 'underline' },
+        '&:hover .cta-icon': { transform: 'translateX(2px)' },
+        '.security-cta-link:focus-visible &': {
+          outline: '2px solid',
+          outlineColor: 'primary.main',
+          outlineOffset: 2,
+          borderRadius: 4,
+        },
+      }}
+    >
+      <Typography className="cta-label" variant="caption" fontWeight={700} sx={{ color: 'inherit', lineHeight: 1.5 }}>
+        {cta.label}
+      </Typography>
+      <ArrowForwardRoundedIcon className="cta-icon" sx={{ fontSize: 14, color: 'inherit' }} />
+    </Stack>
+  </Link>
+)
+
+/** Expanded-row body: optional intro paragraph + evidence key/value list + optional CTA. */
+export const EvidenceList = ({
+  intro,
+  evidence,
+  cta,
+}: {
+  intro?: string
+  evidence?: EvidenceItem[]
+  cta?: Cta | null
+}): ReactElement | null => {
+  const hasEvidence = !!evidence && evidence.length > 0
+  if (!intro && !hasEvidence && !cta) return null
+  return (
+    <Stack spacing={0.75}>
+      {intro && (
+        <Typography variant="caption" color="text.primary" sx={{ lineHeight: 1.5, display: 'block' }}>
+          {intro}
+        </Typography>
+      )}
+      {hasEvidence && (
+        <Stack spacing={0.25}>
+          {evidence!.map((item, idx) =>
+            typeof item === 'string' ? (
+              <Typography
+                key={idx}
+                variant="caption"
+                color="text.secondary"
+                sx={{ lineHeight: 1.5, display: 'block', wordBreak: 'break-word' }}
+              >
+                {item}
+              </Typography>
+            ) : (
+              <Stack key={idx} direction="row" spacing={1} alignItems="baseline">
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ minWidth: 96, flexShrink: 0, lineHeight: 1.5 }}
+                >
+                  {item.label}
+                </Typography>
+                <Typography variant="caption" color="text.primary" sx={{ lineHeight: 1.5, wordBreak: 'break-word' }}>
+                  {item.value}
+                </Typography>
+              </Stack>
+            ),
+          )}
+        </Stack>
+      )}
+      {cta && <CtaLink cta={cta} />}
+    </Stack>
+  )
+}
+
+/** Build expanded body for a row backed by a ScanResult. Returns undefined when there's nothing to show. */
+export const buildExpanded = (result: ScanResult | undefined, cta?: Cta | null): ReactNode => {
+  if (!result) return cta ? <EvidenceList cta={cta} /> : undefined
+  const intro = !isPassingStatus(result.status) && result.remediation ? result.remediation : undefined
+  const hasEvidence = result.evidence && result.evidence.length > 0
+  if (!intro && !hasEvidence && !cta) return undefined
+  return <EvidenceList intro={intro} evidence={result.evidence} cta={cta} />
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.stories.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.stories.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Auto-generated snapshot tests for Storybook stories
+ * Run "yarn generate:storybook-tests" to regenerate
+ */
+import '../../../../../../tests/storybook-setup'
+import { composeStories } from '@storybook/react'
+import { render } from '@testing-library/react'
+import type { ComponentType } from 'react'
+
+import * as stories from './SecurityReportDrawer.stories'
+
+const composedStories = composeStories(stories)
+
+describe('./SecurityReportDrawer.stories', () => {
+  Object.entries(composedStories).forEach(([storyName, Story]) => {
+    test(storyName, () => {
+      const StoryComponent = Story as ComponentType
+      const { container } = render(<StoryComponent />)
+      expect(container.firstChild).toMatchSnapshot()
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.stories.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SecurityReportDrawer from './SecurityReportDrawer'
+import { createMockStory } from '@/stories/mocks'
+import { createMockContext } from '@/features/security/testing'
+import type { SpaceSafeEntry } from '../../types'
+
+const SAFE_A = '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6'
+
+const safeEntry: SpaceSafeEntry = {
+  address: SAFE_A,
+  chainId: '1',
+  name: 'Operations Vault',
+  isMultichain: false,
+  chainEntries: [{ chainId: '1', isDeployed: true }],
+}
+
+const setup = createMockStory({ features: { spaces: true } })
+
+const meta = {
+  title: 'Features/SecurityHub/SecurityReportDrawer',
+  component: SecurityReportDrawer,
+  decorators: [setup.decorator],
+  parameters: {
+    ...setup.parameters,
+    layout: 'fullscreen',
+    // Drawer is open on the right side; the main content area is intentionally empty.
+    chromatic: { disableSnapshot: true },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SecurityReportDrawer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const OpenWithContext: Story = {
+  args: {
+    selectedSafe: { address: SAFE_A, chainId: '1' },
+    selectedEntry: safeEntry,
+    scanContext: createMockContext({ safeAddress: SAFE_A }),
+    onClose: () => {},
+    onScanComplete: () => {},
+  },
+}
+
+export const Closed: Story = {
+  args: {
+    selectedSafe: null,
+    selectedEntry: undefined,
+    scanContext: null,
+    onClose: () => {},
+    onScanComplete: () => {},
+  },
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.tsx
@@ -1,0 +1,184 @@
+import { type ReactElement, useCallback, useEffect, useRef, useState } from 'react'
+import { Box, Drawer, IconButton, Stack, Tooltip, Typography } from '@mui/material'
+import { motion, AnimatePresence } from 'framer-motion'
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
+import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded'
+import type { ScanContext, ScanResult } from '@/features/security/types'
+import Identicon from '@/components/common/Identicon'
+import { useSecurityScan } from '@/features/security'
+import { useChain } from '@/hooks/useChains'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import SecurityPanelView from '../SecurityPanelView/SecurityPanelView'
+import type { SelectedSafe, SpaceSafeEntry } from '../../types'
+
+const MotionBox = motion.create(Box)
+
+type SecurityReportDrawerProps = {
+  selectedSafe: SelectedSafe | null
+  selectedEntry: SpaceSafeEntry | undefined
+  scanContext: ScanContext | null
+  onClose: () => void
+  onScanComplete: (address: string, chainId: string, timestamp: number, results: Record<string, ScanResult>) => void
+}
+
+const SecurityReportDrawer = ({
+  selectedSafe,
+  selectedEntry,
+  scanContext,
+  onClose,
+  onScanComplete,
+}: SecurityReportDrawerProps): ReactElement => {
+  const { results, isComplete, lastScannedAt, rescan } = useSecurityScan(scanContext)
+  const chain = useChain(selectedSafe?.chainId ?? '')
+  const scanContextRef = useRef(scanContext)
+  scanContextRef.current = scanContext
+
+  // Bump animationKey to replay the entrance animation on rescan.
+  const [animationKey, setAnimationKey] = useState(0)
+  const handleRescan = useCallback(() => {
+    rescan()
+    setAnimationKey((k) => k + 1)
+  }, [rescan])
+
+  // Forward scan completion to parent
+  useEffect(() => {
+    if (isComplete && lastScannedAt && onScanComplete && scanContextRef.current) {
+      onScanComplete(scanContextRef.current.safeAddress, scanContextRef.current.chainId, lastScannedAt, results)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isComplete, lastScannedAt])
+
+  return (
+    <Drawer
+      anchor="right"
+      open={!!selectedSafe}
+      onClose={onClose}
+      variant="temporary"
+      transitionDuration={250}
+      sx={{ zIndex: (theme) => theme.zIndex.modal }}
+      PaperProps={{
+        sx: {
+          width: 520,
+          maxWidth: '100vw',
+          borderRadius: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        },
+      }}
+    >
+      <AnimatePresence mode="wait">
+        {selectedSafe && (
+          <MotionBox
+            key={`${selectedSafe.address}:${selectedSafe.chainId}`}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            sx={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}
+          >
+            {/* Docked header */}
+            <MotionBox
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ type: 'spring', stiffness: 400, damping: 30, delay: 0.05 }}
+              sx={{
+                px: 3,
+                py: 2,
+                borderBottom: 1,
+                borderColor: 'border.light',
+                backgroundColor: 'background.paper',
+                flexShrink: 0,
+              }}
+            >
+              <Stack direction="row" alignItems="center" justifyContent="space-between" mb={1.5} spacing={1}>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ textTransform: 'uppercase', letterSpacing: '0.5px', fontWeight: 700 }}
+                >
+                  Security report
+                </Typography>
+                <Stack direction="row" spacing={0.5}>
+                  <Tooltip title="Re-scan this Safe">
+                    <span>
+                      <IconButton onClick={handleRescan} size="small" disabled={!isComplete} aria-label="Re-scan">
+                        <RefreshRoundedIcon fontSize="small" />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <IconButton onClick={onClose} size="small" aria-label="Close security report">
+                    <CloseRoundedIcon fontSize="small" />
+                  </IconButton>
+                </Stack>
+              </Stack>
+
+              <Stack direction="row" alignItems="center" spacing={1.25} sx={{ minWidth: 0 }}>
+                <Identicon address={selectedSafe.address} size={24} />
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography
+                    variant="caption"
+                    fontWeight={600}
+                    noWrap
+                    sx={{ display: 'block', lineHeight: 1.2 }}
+                    title={selectedEntry?.name || selectedSafe.address}
+                  >
+                    {selectedEntry?.name || shortenAddress(selectedSafe.address)}
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    noWrap
+                    sx={{ display: 'block', lineHeight: 1.2 }}
+                  >
+                    {chain?.shortName ? `${chain.shortName}:` : ''}
+                    {shortenAddress(selectedSafe.address)}
+                  </Typography>
+                </Box>
+                {lastScannedAt && (
+                  <Box sx={{ flexShrink: 0, textAlign: 'right' }}>
+                    <Typography
+                      variant="caption"
+                      fontWeight={600}
+                      sx={{ display: 'block', lineHeight: 1.2, whiteSpace: 'nowrap' }}
+                      title={new Date(lastScannedAt).toLocaleString()}
+                    >
+                      {new Date(lastScannedAt).toLocaleString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: 'numeric',
+                        minute: '2-digit',
+                      })}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', lineHeight: 1.2 }}>
+                      Last scanned
+                    </Typography>
+                  </Box>
+                )}
+              </Stack>
+            </MotionBox>
+
+            {/* Scrollable content — animationKey replays entrance on rescan */}
+            <MotionBox
+              key={animationKey}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.15 }}
+              sx={{ flex: 1, overflowY: 'auto', px: 3, pt: 2, pb: 3 }}
+            >
+              <SecurityPanelView
+                key={`${selectedSafe.address}:${selectedSafe.chainId}`}
+                scanContext={scanContext}
+                results={results}
+                isComplete={isComplete}
+                safeQueryParam={chain?.shortName ? `${chain.shortName}:${selectedSafe.address}` : undefined}
+              />
+            </MotionBox>
+          </MotionBox>
+        )}
+      </AnimatePresence>
+    </Drawer>
+  )
+}
+
+export default SecurityReportDrawer

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/__snapshots__/SecurityReportDrawer.stories.test.tsx.snap
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/__snapshots__/SecurityReportDrawer.stories.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`./SecurityReportDrawer.stories Closed 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 0px;"
+>
+  <div
+    class="MuiBox-root mui-style-111477h"
+  >
+    <main />
+  </div>
+</div>
+`;
+
+exports[`./SecurityReportDrawer.stories OpenWithContext 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 0px;"
+>
+  <div
+    class="MuiBox-root mui-style-111477h"
+  >
+    <main />
+  </div>
+</div>
+`;

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/MultichainSafeRow.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/MultichainSafeRow.tsx
@@ -1,0 +1,309 @@
+import { Fragment } from 'react'
+import { IconButton, Stack, TableCell, Tooltip, Typography } from '@mui/material'
+import Link from 'next/link'
+import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded'
+import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded'
+import type { ScanResult } from '@/features/security/types'
+import Identicon from '@/components/common/Identicon'
+import ChainIndicator from '@/components/common/ChainIndicator'
+import { NetworkLogosList } from '@/features/multichain'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import StatusCell from '../StatusCell/StatusCell'
+import { BalanceCell, ScoreCell, ThresholdCell, VersionCell } from './cells'
+import { DASH, MotionTableRow, ROW_VARIANTS } from './constants'
+import {
+  formatBalance,
+  getAggregateSafeGrade,
+  getAggregateSummary,
+  hasMultichainWarning,
+  isAnyChainScanning,
+  type GetSafeSecurityHref,
+  type RowSecurity,
+} from './utils'
+import type { ChainEntry, SelectedSafe, SpaceSafeEntry } from '../../types'
+
+export type MultichainSafeRowProps = {
+  safe: SpaceSafeEntry
+  safeIdx: number
+  hasAnimated: boolean
+  isExpanded: boolean
+  onToggleExpand: (address: string) => void
+  selectedSafe: SelectedSafe | null
+  onViewReport: (address: string, chainId: string) => void
+  scanResults: Record<string, Record<string, ScanResult>>
+  scanTimestamps?: Record<string, number>
+  scanningKeys?: Set<string>
+  balanceMap: Record<string, string | undefined>
+  security: RowSecurity
+  getSafeSecurityHref: GetSafeSecurityHref
+}
+
+type ChildRowProps = {
+  safe: SpaceSafeEntry
+  chain: ChainEntry
+  childIdx: number
+  selectedSafe: SelectedSafe | null
+  onViewReport: (address: string, chainId: string) => void
+  scanResults: Record<string, Record<string, ScanResult>>
+  scanTimestamps?: Record<string, number>
+  scanningKeys?: Set<string>
+  balanceMap: Record<string, string | undefined>
+  security: RowSecurity
+  getSafeSecurityHref: GetSafeSecurityHref
+}
+
+/** Per-chain row rendered under an expanded multichain parent. */
+const MultichainChildRow = ({
+  safe,
+  chain,
+  childIdx,
+  selectedSafe,
+  onViewReport,
+  scanResults,
+  scanTimestamps,
+  scanningKeys,
+  balanceMap,
+  security,
+  getSafeSecurityHref,
+}: ChildRowProps) => {
+  const { scanKey, computeSummary, formatTimestamp, getStrengthLevel, getStrengthColor, getSafeGrade } = security
+  const key = scanKey(safe.address, chain.chainId)
+  const results = scanResults[key]
+  const summary = results ? computeSummary(results) : null
+  const childGrade = results ? getSafeGrade(results) : null
+  const isSelected = sameAddress(selectedSafe?.address, safe.address) && selectedSafe?.chainId === chain.chainId
+  const isScanning = scanningKeys?.has(key)
+  const childHref = getSafeSecurityHref(safe.address, chain.chainId)
+
+  return (
+    <MotionTableRow
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.15, delay: childIdx * 0.03 }}
+      selected={isSelected}
+      hover={chain.isDeployed}
+      onClick={chain.isDeployed ? () => onViewReport(safe.address, chain.chainId) : undefined}
+      sx={{
+        backgroundColor: 'background.paper',
+        cursor: chain.isDeployed ? 'pointer' : 'default',
+      }}
+    >
+      <TableCell>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          component={childHref ? Link : 'span'}
+          {...(childHref ? { href: childHref } : {})}
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+          sx={{
+            pl: 5.5,
+            textDecoration: 'none',
+            color: 'text.secondary',
+            '&:hover': childHref ? { textDecoration: 'underline' } : {},
+          }}
+        >
+          {safe.name || shortenAddress(safe.address)}
+        </Typography>
+      </TableCell>
+      <TableCell>
+        <ChainIndicator chainId={chain.chainId} onlyLogo />
+      </TableCell>
+      <TableCell>
+        <BalanceCell value={balanceMap[key]} isScanning={isScanning} />
+      </TableCell>
+      <TableCell>
+        <ThresholdCell results={results} isScanning={isScanning} />
+      </TableCell>
+      <TableCell>
+        <VersionCell results={results} isScanning={isScanning} />
+      </TableCell>
+      <TableCell>
+        <StatusCell grade={childGrade} isScanning={isScanning} />
+      </TableCell>
+      <TableCell>
+        <ScoreCell
+          summary={summary}
+          isScanning={isScanning}
+          getStrengthLevel={getStrengthLevel}
+          getStrengthColor={getStrengthColor}
+        />
+      </TableCell>
+      <TableCell>
+        <Typography variant="caption" color="text.secondary">
+          {scanTimestamps?.[key] ? formatTimestamp(scanTimestamps[key]) : DASH}
+        </Typography>
+      </TableCell>
+      <TableCell align="right">
+        {chain.isDeployed ? (
+          <ChevronRightRoundedIcon
+            sx={{
+              color: isSelected ? 'primary.main' : 'text.secondary',
+              verticalAlign: 'middle',
+            }}
+          />
+        ) : (
+          <Tooltip title="Safe not yet deployed on this network">
+            <Typography variant="caption" color="text.disabled" noWrap sx={{ fontSize: '0.65rem' }}>
+              Not deployed
+            </Typography>
+          </Tooltip>
+        )}
+      </TableCell>
+    </MotionTableRow>
+  )
+}
+
+/**
+ * Collapsed parent row for a multichain Safe + the child rows for each chain
+ * when expanded. The parent aggregates balance/score/grade/scan-state across
+ * all chain entries; clicking the row toggles expansion.
+ */
+const MultichainSafeRow = ({
+  safe,
+  safeIdx,
+  hasAnimated,
+  isExpanded,
+  onToggleExpand,
+  selectedSafe,
+  onViewReport,
+  scanResults,
+  scanTimestamps,
+  scanningKeys,
+  balanceMap,
+  security,
+  getSafeSecurityHref,
+}: MultichainSafeRowProps) => {
+  const { scanKey, formatTimestamp, getStrengthLevel, getStrengthColor, getSafeGrade } = security
+  const aggregateSummary = getAggregateSummary(safe, scanResults, security)
+  const aggregateGrade = getAggregateSafeGrade(safe, scanResults, scanKey, getSafeGrade)
+  const aggregateScanning = isAnyChainScanning(safe, scanningKeys, scanKey)
+  const showMultichainWarning = hasMultichainWarning(safe, scanResults, scanKey)
+  const totalBalance = safe.chainEntries.reduce(
+    (sum, c) => sum + (Number(balanceMap[scanKey(safe.address, c.chainId)]) || 0),
+    0,
+  )
+  const chainTimestamps = safe.chainEntries
+    .map((c) => scanTimestamps?.[scanKey(safe.address, c.chainId)])
+    .filter((t): t is number => !!t)
+  const oldestTimestamp = chainTimestamps.length > 0 ? Math.min(...chainTimestamps) : null
+
+  return (
+    <Fragment>
+      <MotionTableRow
+        variants={ROW_VARIANTS}
+        initial={hasAnimated ? false : 'hidden'}
+        animate="visible"
+        transition={{ duration: 0.2, delay: hasAnimated ? 0 : safeIdx * 0.03 }}
+        hover
+        sx={{ cursor: 'pointer', '& > *': { borderBottom: isExpanded ? 0 : undefined } }}
+        onClick={() => onToggleExpand(safe.address)}
+      >
+        <TableCell>
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <Identicon address={safe.address} size={40} />
+            <Stack sx={{ minWidth: 0, gap: '6px' }}>
+              <Stack direction="row" alignItems="center" spacing={0.75}>
+                <Typography
+                  variant="body2"
+                  noWrap
+                  title={safe.name || safe.address}
+                  sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+                >
+                  {safe.name || shortenAddress(safe.address)}
+                </Typography>
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onToggleExpand(safe.address)
+                  }}
+                  sx={{ p: 0.25 }}
+                >
+                  <ExpandMoreRoundedIcon
+                    sx={{
+                      fontSize: 18,
+                      transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                      transition: 'transform 0.2s',
+                    }}
+                  />
+                </IconButton>
+                {showMultichainWarning && (
+                  <Tooltip title="Signer setup differs across networks">
+                    <WarningAmberRoundedIcon sx={{ fontSize: 18, color: 'warning.main' }} />
+                  </Tooltip>
+                )}
+              </Stack>
+              <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary', lineHeight: 1 }}>
+                {shortenAddress(safe.address)}
+              </Typography>
+            </Stack>
+          </Stack>
+        </TableCell>
+        <TableCell>
+          <Stack direction="row" alignItems="center" spacing={0.5} sx={{ ml: '6px' }}>
+            <NetworkLogosList networks={safe.chainEntries.slice(0, 3).map((c) => ({ chainId: c.chainId }))} />
+            {safe.chainEntries.length > 3 && (
+              <Typography variant="caption" color="text.secondary">
+                +{safe.chainEntries.length - 3}
+              </Typography>
+            )}
+          </Stack>
+        </TableCell>
+        <TableCell>
+          <Typography variant="body2" color="text.primary">
+            {formatBalance(String(totalBalance))}
+          </Typography>
+        </TableCell>
+        <TableCell>
+          <Typography variant="body2" color="text.secondary">
+            {DASH}
+          </Typography>
+        </TableCell>
+        <TableCell>
+          <Typography variant="body2" color="text.secondary">
+            {DASH}
+          </Typography>
+        </TableCell>
+        <TableCell>
+          <StatusCell grade={aggregateGrade} isScanning={aggregateScanning} />
+        </TableCell>
+        <TableCell>
+          <ScoreCell
+            summary={aggregateSummary}
+            isScanning={aggregateScanning}
+            getStrengthLevel={getStrengthLevel}
+            getStrengthColor={getStrengthColor}
+          />
+        </TableCell>
+        <TableCell>
+          <Typography variant="caption" color="text.secondary">
+            {oldestTimestamp ? formatTimestamp(oldestTimestamp) : DASH}
+          </Typography>
+        </TableCell>
+        <TableCell align="right" />
+      </MotionTableRow>
+
+      {isExpanded &&
+        safe.chainEntries.map((chain, childIdx) => (
+          <MultichainChildRow
+            key={scanKey(safe.address, chain.chainId)}
+            safe={safe}
+            chain={chain}
+            childIdx={childIdx}
+            selectedSafe={selectedSafe}
+            onViewReport={onViewReport}
+            scanResults={scanResults}
+            scanTimestamps={scanTimestamps}
+            scanningKeys={scanningKeys}
+            balanceMap={balanceMap}
+            security={security}
+            getSafeSecurityHref={getSafeSecurityHref}
+          />
+        ))}
+    </Fragment>
+  )
+}
+
+export default MultichainSafeRow

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.stories.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.stories.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Auto-generated snapshot tests for Storybook stories
+ * Run "yarn generate:storybook-tests" to regenerate
+ */
+import '../../../../../../tests/storybook-setup'
+import { composeStories } from '@storybook/react'
+import { render } from '@testing-library/react'
+import type { ComponentType } from 'react'
+
+import * as stories from './SecuritySafesTable.stories'
+
+const composedStories = composeStories(stories)
+
+describe('./SecuritySafesTable.stories', () => {
+  Object.entries(composedStories).forEach(([storyName, Story]) => {
+    test(storyName, () => {
+      const StoryComponent = Story as ComponentType
+      const { container } = render(<StoryComponent />)
+      expect(container.firstChild).toMatchSnapshot()
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.stories.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import SecuritySafesTable from './SecuritySafesTable'
+import { createMockStory } from '@/stories/mocks'
+import type { ScanResult } from '@/features/security/types'
+import type { SpaceSafeEntry } from '../../types'
+
+const mkResult = (overrides: Partial<ScanResult> = {}): ScanResult => ({
+  status: 'clear',
+  severity: 'Low',
+  score: 100,
+  evidence: [],
+  remediation: '',
+  lastChecked: new Date().toISOString(),
+  ...overrides,
+})
+
+const SAFE_A = '0xA000000000000000000000000000000000000000'
+const SAFE_B = '0xB000000000000000000000000000000000000000'
+const SAFE_MC = '0xC000000000000000000000000000000000000000'
+
+const single = (address: string, name: string): SpaceSafeEntry => ({
+  address,
+  chainId: '1',
+  name,
+  isMultichain: false,
+  chainEntries: [{ chainId: '1', isDeployed: true }],
+})
+
+const multichain = (address: string, name: string): SpaceSafeEntry => ({
+  address,
+  chainId: '1',
+  name,
+  isMultichain: true,
+  chainEntries: [
+    { chainId: '1', isDeployed: true },
+    { chainId: '137', isDeployed: true },
+  ],
+})
+
+const allClear = {
+  account_setup: mkResult({
+    status: 'clear',
+    evidence: [{ label: 'Threshold', value: '2 of 3' }],
+  }),
+  contract_version: mkResult({
+    status: 'clear',
+    evidence: [{ label: 'Current version', value: '1.4.1' }],
+  }),
+  guard: mkResult(),
+  fallback_handler: mkResult(),
+  pending_tx: mkResult(),
+}
+
+const mixedResults = {
+  account_setup: mkResult({
+    status: 'clear',
+    evidence: [{ label: 'Threshold', value: '1 of 2' }],
+  }),
+  contract_version: mkResult({
+    status: 'issue',
+    severity: 'High',
+    evidence: [{ label: 'Current version', value: '1.3.0' }],
+  }),
+  guard: mkResult({ status: 'partial', severity: 'Medium' }),
+  fallback_handler: mkResult(),
+  pending_tx: mkResult(),
+}
+
+const setup = createMockStory({ features: { spaces: true }, layout: 'paper' })
+
+const meta = {
+  title: 'Features/SecurityHub/SecuritySafesTable',
+  component: SecuritySafesTable,
+  decorators: [setup.decorator],
+  parameters: {
+    ...setup.parameters,
+    layout: 'fullscreen',
+    chromatic: { disableSnapshot: true },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SecuritySafesTable>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const SingleChainSafes: Story = {
+  args: {
+    safes: [single(SAFE_A, 'Operations Vault'), single(SAFE_B, 'Treasury')],
+    scanResults: {
+      [`${SAFE_A}:1`]: allClear,
+      [`${SAFE_B}:1`]: mixedResults,
+    },
+    scanTimestamps: {
+      [`${SAFE_A}:1`]: Date.now() - 90_000,
+      [`${SAFE_B}:1`]: Date.now() - 90_000,
+    },
+    scanningKeys: new Set(),
+    selectedSafe: null,
+    onViewReport: () => {},
+    gradeFilter: null,
+    balanceMap: {
+      [`${SAFE_A}:1`]: '1250000',
+      [`${SAFE_B}:1`]: '45200',
+    },
+  },
+}
+
+export const MultichainSafe: Story = {
+  args: {
+    safes: [multichain(SAFE_MC, 'Multichain Vault')],
+    scanResults: {
+      [`${SAFE_MC}:1`]: allClear,
+      [`${SAFE_MC}:137`]: mixedResults,
+    },
+    scanTimestamps: {
+      [`${SAFE_MC}:1`]: Date.now() - 120_000,
+      [`${SAFE_MC}:137`]: Date.now() - 120_000,
+    },
+    scanningKeys: new Set(),
+    selectedSafe: null,
+    onViewReport: () => {},
+    gradeFilter: null,
+    balanceMap: {
+      [`${SAFE_MC}:1`]: '850000',
+      [`${SAFE_MC}:137`]: '15300',
+    },
+  },
+}
+
+export const Scanning: Story = {
+  args: {
+    safes: [single(SAFE_A, 'Operations Vault'), single(SAFE_B, 'Treasury')],
+    scanResults: {},
+    scanningKeys: new Set([`${SAFE_A}:1`, `${SAFE_B}:1`]),
+    selectedSafe: null,
+    onViewReport: () => {},
+    gradeFilter: null,
+    balanceMap: {},
+  },
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.tsx
@@ -1,0 +1,148 @@
+import { type ReactElement, useState, useCallback, useEffect, useMemo, useRef } from 'react'
+import { Table, TableCell, TableHead, TableRow } from '@mui/material'
+import { AnimatePresence } from 'framer-motion'
+import type { ScanResult, SafeGrade } from '@/features/security/types'
+import { SecurityFeature } from '@/features/security'
+import { useLoadFeature } from '@/features/__core__'
+import { useGetChainsConfigV2Query } from '@safe-global/store/gateway'
+import { CONFIG_SERVICE_KEY } from '@/config/constants'
+import { AppRoutes } from '@/config/routes'
+import type { SelectedSafe, SpaceSafeEntry } from '../../types'
+import { COLUMNS, MotionTbody, TABLE_SX } from './constants'
+import SingleSafeRow from './SingleSafeRow'
+import MultichainSafeRow from './MultichainSafeRow'
+import type { GetSafeSecurityHref } from './utils'
+
+type SecuritySafesTableProps = {
+  safes: SpaceSafeEntry[]
+  onViewReport: (address: string, chainId: string) => void
+  selectedSafe: SelectedSafe | null
+  scanResults: Record<string, Record<string, ScanResult>>
+  scanTimestamps?: Record<string, number>
+  scanningKeys?: Set<string>
+  gradeFilter?: SafeGrade | null
+  balanceMap: Record<string, string | undefined>
+}
+
+const SecuritySafesTable = ({
+  safes,
+  onViewReport,
+  selectedSafe,
+  scanResults,
+  scanTimestamps,
+  scanningKeys,
+  gradeFilter,
+  balanceMap,
+}: SecuritySafesTableProps): ReactElement => {
+  const security = useLoadFeature(SecurityFeature)
+  const { data: chainsData } = useGetChainsConfigV2Query(CONFIG_SERVICE_KEY)
+  const chainShortNames = useMemo(() => {
+    if (!chainsData) return {}
+    const map: Record<string, string> = {}
+    for (const id of chainsData.ids) {
+      const chain = chainsData.entities[id]
+      if (chain) map[chain.chainId] = chain.shortName
+    }
+    return map
+  }, [chainsData])
+
+  // Link the Safe name to that Safe's home dashboard. The per-Safe security view
+  // now lives entirely inside this hub's drawer — clicking the row still opens it.
+  const getSafeSecurityHref = useCallback<GetSafeSecurityHref>(
+    (address, chainId) => {
+      const shortName = chainShortNames[chainId]
+      if (!shortName) return undefined
+      return { pathname: AppRoutes.home, query: { safe: `${shortName}:${address}` } }
+    },
+    [chainShortNames],
+  )
+
+  const [expandedAddresses, setExpandedAddresses] = useState<Set<string>>(new Set())
+
+  const toggleExpand = useCallback((address: string) => {
+    setExpandedAddresses((prev) => {
+      const next = new Set(prev)
+      if (next.has(address)) next.delete(address)
+      else next.add(address)
+      return next
+    })
+  }, [])
+
+  // Skip initial-load stagger after the first render — filter transitions should be instant
+  const hasAnimatedRef = useRef(false)
+  useEffect(() => {
+    hasAnimatedRef.current = true
+  }, [])
+
+  // Filter safes by grade when a chip filter is active
+  const filteredSafes = useMemo(() => {
+    if (!gradeFilter) return safes
+    if (!security.$isReady) return safes
+    return safes.filter((safe) => {
+      // For multichain Safes, match if ANY chain matches the grade
+      for (const chain of safe.chainEntries) {
+        const key = security.scanKey(safe.address, chain.chainId)
+        const results = scanResults[key]
+        if (results && security.getSafeGrade(results) === gradeFilter) return true
+      }
+      return false
+    })
+  }, [safes, scanResults, gradeFilter, security.$isReady, security.scanKey, security.getSafeGrade])
+
+  // Gate remaining render on feature load. Utilities are synchronous call-site primitives —
+  // pulling them via useLoadFeature means we must wait for the module to resolve.
+  // Since FEATURES.SPACES is already enabled on this page, this is a very brief state.
+  if (!security.$isReady) return <></>
+
+  return (
+    <Table sx={TABLE_SX}>
+      <TableHead>
+        <TableRow>
+          {COLUMNS.map((c, i) => (
+            <TableCell key={c.label || `col-${i}`} sx={{ width: c.width }}>
+              {c.label}
+            </TableCell>
+          ))}
+        </TableRow>
+      </TableHead>
+      <AnimatePresence mode="wait">
+        <MotionTbody
+          key={gradeFilter ?? 'all'}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          {filteredSafes.map((safe, safeIdx) => {
+            const isMultichain = safe.isMultichain && safe.chainEntries.length > 1
+            const sharedProps = {
+              safe,
+              safeIdx,
+              hasAnimated: hasAnimatedRef.current,
+              selectedSafe,
+              onViewReport,
+              scanResults,
+              scanTimestamps,
+              scanningKeys,
+              balanceMap,
+              security,
+              getSafeSecurityHref,
+            }
+            return isMultichain ? (
+              <MultichainSafeRow
+                key={safe.address}
+                {...sharedProps}
+                isExpanded={expandedAddresses.has(safe.address)}
+                onToggleExpand={toggleExpand}
+              />
+            ) : (
+              <SingleSafeRow key={security.scanKey(safe.address, safe.chainId)} {...sharedProps} />
+            )
+          })}
+        </MotionTbody>
+      </AnimatePresence>
+    </Table>
+  )
+}
+
+export default SecuritySafesTable

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SingleSafeRow.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SingleSafeRow.tsx
@@ -1,0 +1,139 @@
+import { Stack, TableCell, Tooltip, Typography } from '@mui/material'
+import Link from 'next/link'
+import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded'
+import type { ScanResult } from '@/features/security/types'
+import Identicon from '@/components/common/Identicon'
+import ChainIndicator from '@/components/common/ChainIndicator'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import StatusCell from '../StatusCell/StatusCell'
+import { BalanceCell, ScoreCell, ThresholdCell, VersionCell } from './cells'
+import { DASH, MotionTableRow, ROW_VARIANTS } from './constants'
+import type { GetSafeSecurityHref, RowSecurity } from './utils'
+import type { SelectedSafe, SpaceSafeEntry } from '../../types'
+
+export type SingleSafeRowProps = {
+  safe: SpaceSafeEntry
+  safeIdx: number
+  hasAnimated: boolean
+  selectedSafe: SelectedSafe | null
+  onViewReport: (address: string, chainId: string) => void
+  scanResults: Record<string, Record<string, ScanResult>>
+  scanTimestamps?: Record<string, number>
+  scanningKeys?: Set<string>
+  balanceMap: Record<string, string | undefined>
+  security: RowSecurity
+  getSafeSecurityHref: GetSafeSecurityHref
+}
+
+/** Row for a Safe deployed on exactly one chain. */
+const SingleSafeRow = ({
+  safe,
+  safeIdx,
+  hasAnimated,
+  selectedSafe,
+  onViewReport,
+  scanResults,
+  scanTimestamps,
+  scanningKeys,
+  balanceMap,
+  security,
+  getSafeSecurityHref,
+}: SingleSafeRowProps) => {
+  const { scanKey, computeSummary, formatTimestamp, getStrengthLevel, getStrengthColor, getSafeGrade } = security
+  const key = scanKey(safe.address, safe.chainId)
+  const results = scanResults[key]
+  const summary = results ? computeSummary(results) : null
+  const grade = results ? getSafeGrade(results) : null
+  const isSelected = selectedSafe?.address === safe.address && selectedSafe?.chainId === safe.chainId
+  const isScanning = scanningKeys?.has(key)
+  const safeHref = getSafeSecurityHref(safe.address, safe.chainId)
+  const isDeployed = safe.chainEntries[0]?.isDeployed !== false
+
+  return (
+    <MotionTableRow
+      variants={ROW_VARIANTS}
+      initial={hasAnimated ? false : 'hidden'}
+      animate="visible"
+      transition={{ duration: 0.2, delay: hasAnimated ? 0 : safeIdx * 0.03 }}
+      selected={isSelected}
+      hover={isDeployed}
+      onClick={isDeployed ? () => onViewReport(safe.address, safe.chainId) : undefined}
+      sx={isDeployed ? { cursor: 'pointer' } : {}}
+    >
+      <TableCell>
+        <Stack direction="row" alignItems="center" spacing={2}>
+          <Identicon address={safe.address} size={40} />
+          <Stack sx={{ minWidth: 0, gap: '6px' }}>
+            <Typography
+              variant="body2"
+              noWrap
+              component={safeHref ? Link : 'span'}
+              {...(safeHref ? { href: safeHref } : {})}
+              title={safe.name || safe.address}
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+              sx={{
+                display: 'block',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                textDecoration: 'none',
+                color: 'inherit',
+                '&:hover': safeHref ? { textDecoration: 'underline' } : {},
+              }}
+            >
+              {safe.name || shortenAddress(safe.address)}
+            </Typography>
+            <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary', lineHeight: 1 }}>
+              {shortenAddress(safe.address)}
+            </Typography>
+          </Stack>
+        </Stack>
+      </TableCell>
+      <TableCell>
+        <ChainIndicator chainId={safe.chainId} onlyLogo />
+      </TableCell>
+      <TableCell>
+        <BalanceCell value={balanceMap[key]} isScanning={isScanning} />
+      </TableCell>
+      <TableCell>
+        <ThresholdCell results={results} isScanning={isScanning} />
+      </TableCell>
+      <TableCell>
+        <VersionCell results={results} isScanning={isScanning} />
+      </TableCell>
+      <TableCell>
+        <StatusCell grade={grade} isScanning={isScanning} />
+      </TableCell>
+      <TableCell>
+        <ScoreCell
+          summary={summary}
+          isScanning={isScanning}
+          getStrengthLevel={getStrengthLevel}
+          getStrengthColor={getStrengthColor}
+        />
+      </TableCell>
+      <TableCell>
+        <Typography variant="caption" color="text.secondary">
+          {scanTimestamps?.[key] ? formatTimestamp(scanTimestamps[key]) : DASH}
+        </Typography>
+      </TableCell>
+      <TableCell align="right">
+        {isDeployed ? (
+          <ChevronRightRoundedIcon
+            sx={{
+              color: isSelected ? 'primary.main' : 'text.secondary',
+              verticalAlign: 'middle',
+            }}
+          />
+        ) : (
+          <Tooltip title="Safe not yet deployed on this network">
+            <Typography variant="caption" color="text.disabled" noWrap>
+              Not deployed
+            </Typography>
+          </Tooltip>
+        )}
+      </TableCell>
+    </MotionTableRow>
+  )
+}
+
+export default SingleSafeRow

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/__snapshots__/SecuritySafesTable.stories.test.tsx.snap
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/__snapshots__/SecuritySafesTable.stories.test.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`./SecuritySafesTable.stories MultichainSafe 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 0px;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  />
+</div>
+`;
+
+exports[`./SecuritySafesTable.stories Scanning 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 0px;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  />
+</div>
+`;
+
+exports[`./SecuritySafesTable.stories SingleChainSafes 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 0px;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  />
+</div>
+`;

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/cells.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/cells.tsx
@@ -1,0 +1,79 @@
+import { Box, Skeleton, Stack, Typography } from '@mui/material'
+import type { GradeSummary, ScanResult } from '@/features/security/types'
+import type { SecurityContract } from '@/features/security'
+import { DASH } from './constants'
+import { formatBalance, getEvidence } from './utils'
+
+type ScoreCellProps = {
+  summary: GradeSummary | null
+  isScanning?: boolean
+  getStrengthLevel: SecurityContract['getStrengthLevel']
+  getStrengthColor: SecurityContract['getStrengthColor']
+}
+
+/** Numeric score (0–100) + colored dot reflecting the strength level. */
+export const ScoreCell = ({ summary, isScanning, getStrengthLevel, getStrengthColor }: ScoreCellProps) => {
+  if (!summary) {
+    if (isScanning) return <Skeleton variant="rounded" width={60} height={20} />
+    return (
+      <Typography variant="body2" color="text.secondary">
+        {DASH}
+      </Typography>
+    )
+  }
+  const clearRatio = summary.applicableCount > 0 ? summary.passing / summary.applicableCount : 0
+  const score = Math.round(clearRatio * 100)
+  const level = getStrengthLevel(clearRatio, summary.hasCriticalIssue)
+  const color = getStrengthColor(level)
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={0.75}>
+      <Box
+        sx={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          backgroundColor: color,
+          flexShrink: 0,
+        }}
+      />
+      <Typography variant="body2" fontWeight={600}>
+        {score}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        / 100
+      </Typography>
+    </Stack>
+  )
+}
+
+type ResultsCellProps = { results?: Record<string, ScanResult>; isScanning?: boolean }
+
+/** Threshold from `account_setup` scanner evidence (e.g. "2 of 3"). */
+export const ThresholdCell = ({ results, isScanning }: ResultsCellProps) => {
+  if (!results && isScanning) return <Skeleton variant="rounded" width={50} height={20} />
+  const threshold = getEvidence(results, 'account_setup', 'Threshold')
+  return (
+    <Typography variant="body2" color="text.primary">
+      {threshold ?? DASH}
+    </Typography>
+  )
+}
+
+/** Contract version from `contract_version` scanner evidence (e.g. "1.4.1"). */
+export const VersionCell = ({ results, isScanning }: ResultsCellProps) => {
+  if (!results && isScanning) return <Skeleton variant="rounded" width={50} height={20} />
+  const version = getEvidence(results, 'contract_version', 'Current version')
+  return (
+    <Typography variant="body2" color="text.primary">
+      {version ?? DASH}
+    </Typography>
+  )
+}
+
+/** Compact fiat balance ($1.2K / $3.4M / dash when zero or missing). */
+export const BalanceCell = ({ value, isScanning }: { value?: string; isScanning?: boolean }) => (
+  <Typography variant="body2" color="text.primary">
+    {!value && isScanning ? <Skeleton variant="rounded" width={50} height={20} /> : formatBalance(value)}
+  </Typography>
+)

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/constants.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/constants.tsx
@@ -1,0 +1,81 @@
+import { forwardRef } from 'react'
+import { TableRow } from '@mui/material'
+import type { SxProps, Theme } from '@mui/material'
+import { motion } from 'framer-motion'
+
+/** Em-dash glyph used wherever a cell has no value to display. */
+export const DASH = '—'
+
+/** Row enter animation used by the table body. */
+export const ROW_VARIANTS = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 },
+}
+
+/**
+ * `motion.create` on TableRow + tbody. Wrapping TableRow in a forwardRef is required
+ * for framer-motion to attach its imperative animation refs to the underlying DOM node.
+ */
+export const MotionTableRow = motion.create(
+  forwardRef<HTMLTableRowElement, React.ComponentProps<typeof TableRow>>(function MotionTableRowInner(props, ref) {
+    return <TableRow ref={ref} {...props} />
+  }),
+)
+
+export const MotionTbody = motion.create('tbody')
+
+/**
+ * Top-level `sx` for the Safes table — column borders, rounded row corners,
+ * hover background, and inline typography overrides. Lives here so the main
+ * file isn't dominated by inline style config.
+ */
+export const TABLE_SX: SxProps<Theme> = {
+  tableLayout: 'fixed',
+  borderCollapse: 'separate',
+  borderSpacing: '0 6px',
+  '& th': {
+    border: 'none',
+    borderBottom: 'none !important',
+    py: 0.5,
+    px: 2.5,
+    fontSize: '0.65rem',
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+    color: 'text.primary',
+    opacity: 0.6,
+  },
+  '& td': {
+    border: 'none',
+    height: 72,
+    py: 0,
+    px: 2.5,
+    backgroundColor: 'background.paper',
+    transition: 'background-color 0.12s',
+    verticalAlign: 'middle',
+    '& .MuiTypography-body2': { fontWeight: 500, fontSize: '0.875rem' },
+    '& .MuiTypography-caption': { fontSize: '0.75rem' },
+  },
+  '& tbody tr:hover td': {
+    backgroundColor: 'success.background',
+  },
+  '& th:first-of-type': { pl: 0 },
+  '& td:first-of-type': { borderTopLeftRadius: 12, borderBottomLeftRadius: 12, pl: 3 },
+  '& td:last-of-type': { borderTopRightRadius: 12, borderBottomRightRadius: 12, pr: 3, overflow: 'hidden' },
+}
+
+/**
+ * Column widths for the Safes table header, in display order. Lives next to
+ * `TABLE_SX` so the column layout config is colocated.
+ */
+export const COLUMNS: { label: string; width: string }[] = [
+  { label: 'Account', width: '22%' },
+  { label: 'Network', width: '11%' },
+  { label: 'Balance', width: '9%' },
+  { label: 'Threshold', width: '9%' },
+  { label: 'Version', width: '8%' },
+  { label: 'Status', width: '11%' },
+  { label: 'Score', width: '10%' },
+  { label: 'Last scanned', width: '12%' },
+  { label: '', width: '8%' },
+]

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/utils.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/utils.ts
@@ -1,0 +1,146 @@
+import type { GradeSummary, SafeGrade, ScanResult } from '@/features/security/types'
+import type { SecurityGrade } from '@/features/security/types'
+import { SAFE_GRADE_RANK, SEVERITY_RANK, type SecurityContract } from '@/features/security'
+import { DASH } from './constants'
+import type { SpaceSafeEntry } from '../../types'
+
+/** Inverse of `SEVERITY_RANK` — rank index → SecurityGrade. Single source of truth for ordering. */
+const SEVERITY_BY_RANK = (Object.entries(SEVERITY_RANK) as Array<[SecurityGrade, number]>)
+  .sort(([, a], [, b]) => a - b)
+  .map(([grade]) => grade)
+
+/**
+ * The subset of the security feature handle that the table's pure helpers need.
+ * Threaded in via params instead of imported so the helpers stay testable and
+ * don't reach into the feature directly — callers obtain these from useLoadFeature.
+ */
+export type SecurityUtils = Pick<SecurityContract, 'scanKey' | 'computeSummary' | 'severityRank'>
+
+/** Superset used by row components: SecurityUtils + the formatters/grade helpers they render. */
+export type RowSecurity = SecurityUtils &
+  Pick<SecurityContract, 'formatTimestamp' | 'getStrengthLevel' | 'getStrengthColor' | 'getSafeGrade'>
+
+/** Builder returning a Safe's home URL for a given (address, chainId), or undefined if the chain has no short name. */
+export type GetSafeSecurityHref = (
+  address: string,
+  chainId: string,
+) => { pathname: string; query: { safe: string } } | undefined
+
+/** Extract a specific evidence label's value from a ScanResult. */
+export const getEvidence = (
+  results: Record<string, ScanResult> | undefined,
+  scannerId: string,
+  label: string,
+): string | null => {
+  const evidence = results?.[scannerId]?.evidence
+  if (!evidence) return null
+  for (const item of evidence) {
+    if (typeof item !== 'string' && item.label === label) return item.value
+  }
+  return null
+}
+
+/** Format a fiat total into a compact dollar string ($1.2K / $3.4M). */
+export const formatBalance = (fiatTotal?: string | null): string => {
+  const value = Number(fiatTotal)
+  if (!fiatTotal || !Number.isFinite(value) || value === 0) return DASH
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`
+  return `$${value.toFixed(0)}`
+}
+
+/**
+ * Aggregate the per-chain summaries of a multichain Safe into a single
+ * GradeSummary used for the collapsed parent row's Score cell.
+ */
+export const getAggregateSummary = (
+  safe: SpaceSafeEntry,
+  scanResults: Record<string, Record<string, ScanResult>>,
+  utils: SecurityUtils,
+): GradeSummary | null => {
+  let totalPassing = 0
+  let totalApplicable = 0
+  let worstGradeRank = 4
+  let hasCriticalIssue = false
+  let hasAny = false
+
+  for (const chain of safe.chainEntries) {
+    const key = utils.scanKey(safe.address, chain.chainId)
+    const results = scanResults[key]
+    if (!results) continue
+    const summary = utils.computeSummary(results)
+    if (!summary) continue
+    hasAny = true
+    totalPassing += summary.passing
+    totalApplicable += summary.applicableCount
+    if (summary.hasCriticalIssue) hasCriticalIssue = true
+    const rank = utils.severityRank(summary.grade)
+    if (rank < worstGradeRank) worstGradeRank = rank
+  }
+
+  if (!hasAny) return null
+  return {
+    passing: totalPassing,
+    applicableCount: totalApplicable,
+    grade: SEVERITY_BY_RANK[worstGradeRank] ?? 'Low',
+    hasCriticalIssue,
+  }
+}
+
+/**
+ * Worst SafeGrade across a multichain Safe's chain entries. Used for the collapsed
+ * parent row's Status cell so it reflects the most severe chain (matching the badge
+ * counting semantics in WorkspaceHealthCard).
+ */
+export const getAggregateSafeGrade = (
+  safe: SpaceSafeEntry,
+  scanResults: Record<string, Record<string, ScanResult>>,
+  scanKey: SecurityContract['scanKey'],
+  getSafeGrade: SecurityContract['getSafeGrade'],
+): SafeGrade | null => {
+  let worstRank = SAFE_GRADE_RANK.passing + 1
+  let worstGrade: SafeGrade | null = null
+  for (const chain of safe.chainEntries) {
+    const key = scanKey(safe.address, chain.chainId)
+    const results = scanResults[key]
+    if (!results) continue
+    const grade = getSafeGrade(results)
+    const rank = SAFE_GRADE_RANK[grade]
+    if (rank < worstRank) {
+      worstRank = rank
+      worstGrade = grade
+    }
+  }
+  return worstGrade
+}
+
+/**
+ * Any chain in a multichain Safe reporting a non-clear/non-N-A `multichain_setup`
+ * result triggers the warning badge on the collapsed parent row.
+ */
+export const hasMultichainWarning = (
+  safe: SpaceSafeEntry,
+  scanResults: Record<string, Record<string, ScanResult>>,
+  scanKey: SecurityContract['scanKey'],
+): boolean => {
+  for (const chain of safe.chainEntries) {
+    const key = scanKey(safe.address, chain.chainId)
+    const results = scanResults[key]
+    if (!results) continue
+    const multichainResult = results['multichain_setup']
+    if (multichainResult && multichainResult.status !== 'clear' && multichainResult.status !== 'not_applicable') {
+      return true
+    }
+  }
+  return false
+}
+
+/** True when any of the multichain Safe's chains is currently being scanned. */
+export const isAnyChainScanning = (
+  safe: SpaceSafeEntry,
+  scanningKeys: Set<string> | undefined,
+  scanKey: SecurityContract['scanKey'],
+): boolean => {
+  if (!scanningKeys) return false
+  return safe.chainEntries.some((c) => scanningKeys.has(scanKey(safe.address, c.chainId)))
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/StatusCell/StatusCell.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/StatusCell/StatusCell.tsx
@@ -1,0 +1,24 @@
+import { Skeleton, Typography } from '@mui/material'
+import type { SafeGrade } from '@/features/security/types'
+import SafeGradeChip from '../SafeGradeChip/SafeGradeChip'
+
+const DASH = '—'
+
+export type StatusCellProps = {
+  grade: SafeGrade | null
+  isScanning?: boolean
+}
+
+const StatusCell = ({ grade, isScanning }: StatusCellProps) => {
+  if (!grade) {
+    if (isScanning) return <Skeleton variant="rounded" width={70} height={20} />
+    return (
+      <Typography variant="body2" color="text.secondary">
+        {DASH}
+      </Typography>
+    )
+  }
+  return <SafeGradeChip grade={grade} sx={{ height: 22 }} />
+}
+
+export default StatusCell

--- a/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.stories.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.stories.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * Auto-generated snapshot tests for Storybook stories
+ * Run "yarn generate:storybook-tests" to regenerate
+ */
+import '../../../../../../tests/storybook-setup'
+import { composeStories } from '@storybook/react'
+import { render } from '@testing-library/react'
+import type { ComponentType } from 'react'
+
+import * as stories from '../../components/WorkspaceHealthCard/WorkspaceHealthCard.stories'
+
+const composedStories = composeStories(stories)
+
+describe('./WorkspaceHealthCard.stories', () => {
+  Object.entries(composedStories).forEach(([storyName, Story]) => {
+    test(storyName, () => {
+      const StoryComponent = Story as ComponentType
+      const { container } = render(<StoryComponent />)
+      expect(container.firstChild).toMatchSnapshot()
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.stories.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import WorkspaceHealthCard from './WorkspaceHealthCard'
+import { createMockStory } from '@/stories/mocks'
+import type { ScanResult } from '@/features/security/types'
+import type { SpaceSafeEntry } from '../../types'
+
+const mkResult = (overrides: Partial<ScanResult> = {}): ScanResult => ({
+  status: 'clear',
+  severity: 'Low',
+  score: 100,
+  evidence: [],
+  remediation: '',
+  lastChecked: new Date().toISOString(),
+  ...overrides,
+})
+
+const SAFE_A = '0xA000000000000000000000000000000000000000'
+const SAFE_B = '0xB000000000000000000000000000000000000000'
+const SAFE_C = '0xC000000000000000000000000000000000000000'
+
+const singleChain = (address: string): SpaceSafeEntry => ({
+  address,
+  chainId: '1',
+  name: `Safe ${address.slice(0, 6)}`,
+  isMultichain: false,
+  chainEntries: [{ chainId: '1', isDeployed: true }],
+})
+
+const allClear = {
+  account_setup: mkResult(),
+  contract_version: mkResult(),
+  guard: mkResult(),
+  fallback_handler: mkResult(),
+  pending_tx: mkResult(),
+}
+
+const mixedResults = {
+  account_setup: mkResult({ status: 'clear' }),
+  contract_version: mkResult({ status: 'issue', severity: 'High' }),
+  guard: mkResult({ status: 'partial', severity: 'Medium' }),
+  fallback_handler: mkResult({ status: 'clear' }),
+  pending_tx: mkResult({ status: 'clear' }),
+}
+
+const criticalResults = {
+  account_setup: mkResult({ status: 'issue', severity: 'Critical' }),
+  contract_version: mkResult({ status: 'issue', severity: 'High' }),
+  guard: mkResult({ status: 'partial', severity: 'Medium' }),
+  fallback_handler: mkResult({ status: 'clear' }),
+  pending_tx: mkResult({ status: 'clear' }),
+}
+
+const setup = createMockStory({ features: { spaces: true }, layout: 'paper' })
+
+const meta = {
+  title: 'Features/SecurityHub/WorkspaceHealthCard',
+  component: WorkspaceHealthCard,
+  decorators: [setup.decorator],
+  parameters: {
+    ...setup.parameters,
+    // Feature loads async in Storybook — snapshots can be flaky
+    chromatic: { disableSnapshot: true },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof WorkspaceHealthCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Healthy: Story = {
+  args: {
+    safes: [singleChain(SAFE_A), singleChain(SAFE_B), singleChain(SAFE_C)],
+    scanResults: {
+      [`${SAFE_A}:1`]: allClear,
+      [`${SAFE_B}:1`]: allClear,
+      [`${SAFE_C}:1`]: allClear,
+    },
+    isScanning: false,
+    activeFilter: null,
+    onFilterChange: () => {},
+    lastScannedAt: Date.now() - 120_000,
+    onRescan: () => {},
+  },
+}
+
+export const MixedGrades: Story = {
+  args: {
+    safes: [singleChain(SAFE_A), singleChain(SAFE_B), singleChain(SAFE_C)],
+    scanResults: {
+      [`${SAFE_A}:1`]: allClear,
+      [`${SAFE_B}:1`]: mixedResults,
+      [`${SAFE_C}:1`]: criticalResults,
+    },
+    isScanning: false,
+    activeFilter: null,
+    onFilterChange: () => {},
+    lastScannedAt: Date.now() - 60_000,
+    onRescan: () => {},
+  },
+}
+
+export const Scanning: Story = {
+  args: {
+    safes: [singleChain(SAFE_A)],
+    scanResults: {},
+    isScanning: true,
+    activeFilter: null,
+    onFilterChange: () => {},
+    lastScannedAt: null,
+    onRescan: () => {},
+  },
+}
+
+export const CriticalFilterActive: Story = {
+  args: {
+    safes: [singleChain(SAFE_A), singleChain(SAFE_B), singleChain(SAFE_C)],
+    scanResults: {
+      [`${SAFE_A}:1`]: allClear,
+      [`${SAFE_B}:1`]: mixedResults,
+      [`${SAFE_C}:1`]: criticalResults,
+    },
+    isScanning: false,
+    activeFilter: 'critical',
+    onFilterChange: () => {},
+    lastScannedAt: Date.now() - 60_000,
+    onRescan: () => {},
+  },
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.tsx
@@ -1,0 +1,238 @@
+import { type ReactElement, useMemo } from 'react'
+import { Box, Chip, CircularProgress, Paper, Skeleton, Stack, Typography } from '@mui/material'
+import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded'
+import type { ScanResult, SafeGrade, StrengthLevel } from '@/features/security/types'
+import { SecurityFeature } from '@/features/security'
+import { useLoadFeature } from '@/features/__core__'
+import SafeGradeChip, { SAFE_GRADE_LABEL } from '../SafeGradeChip/SafeGradeChip'
+import type { SpaceSafeEntry } from '../../types'
+
+const FILTER_GRADES: SafeGrade[] = ['critical', 'at_risk', 'needs_attention', 'passing']
+
+type WorkspaceHealthCardProps = {
+  safes: SpaceSafeEntry[]
+  scanResults: Record<string, Record<string, ScanResult>>
+  isScanning: boolean
+  activeFilter: SafeGrade | null
+  onFilterChange: (grade: SafeGrade) => void
+  lastScannedAt: number | null
+  onRescan: () => void
+}
+
+type AggregateCounts = {
+  passing: number
+  applicableCount: number
+  criticalCount: number
+  needsAttentionCount: number
+  atRiskCount: number
+  hasCriticalIssue: boolean
+}
+
+type Aggregate = AggregateCounts & {
+  level: StrengthLevel
+  color: string
+  scorePct: number
+}
+
+// Pure reducer — no feature-service calls. The strength level/color are derived
+// inside the component where useLoadFeature gives access to the scoring utils.
+const computeCounts = (scanResults: Record<string, Record<string, ScanResult>>): AggregateCounts | null => {
+  let passing = 0
+  let applicableCount = 0
+  let criticalCount = 0
+  let needsAttentionCount = 0
+  let atRiskCount = 0
+  let hasCriticalIssue = false
+  let hasAny = false
+
+  for (const safeResults of Object.values(scanResults)) {
+    for (const result of Object.values(safeResults)) {
+      if (result.status === 'not_applicable' || result.status === 'inconclusive') continue
+      hasAny = true
+      applicableCount++
+      if (result.status === 'clear') passing++
+      if (result.status === 'partial') needsAttentionCount++
+      if (result.status === 'issue') atRiskCount++
+      if (result.severity === 'Critical') {
+        hasCriticalIssue = true
+        criticalCount++
+      }
+    }
+  }
+
+  if (!hasAny) return null
+
+  return { passing, applicableCount, criticalCount, needsAttentionCount, atRiskCount, hasCriticalIssue }
+}
+
+const ScoreGauge = ({ scorePct, color }: { scorePct: number; color: string }) => (
+  <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+    <CircularProgress variant="determinate" value={100} size={120} thickness={4} sx={{ color: 'border.light' }} />
+    <CircularProgress
+      variant="determinate"
+      value={scorePct}
+      size={120}
+      thickness={4}
+      sx={{
+        color,
+        position: 'absolute',
+        left: 0,
+        '& .MuiCircularProgress-circle': { strokeLinecap: 'round' },
+      }}
+    />
+    <Box
+      sx={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+      }}
+    >
+      <Typography variant="h3" fontWeight={700} sx={{ lineHeight: 1 }}>
+        {scorePct}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        / 100
+      </Typography>
+    </Box>
+  </Box>
+)
+
+const WorkspaceHealthCard = ({
+  safes,
+  scanResults,
+  isScanning,
+  activeFilter,
+  onFilterChange,
+  lastScannedAt,
+  onRescan,
+}: WorkspaceHealthCardProps): ReactElement => {
+  const security = useLoadFeature(SecurityFeature)
+
+  const aggregate = useMemo<Aggregate | null>(() => {
+    const counts = computeCounts(scanResults)
+    if (!counts || !security.$isReady) return null
+    const clearRatio = counts.applicableCount > 0 ? counts.passing / counts.applicableCount : 0
+    const level = security.getStrengthLevel(clearRatio, counts.hasCriticalIssue)
+    const color = security.getStrengthColor(level)
+    return { ...counts, level, color, scorePct: Math.round(clearRatio * 100) }
+  }, [scanResults, security.$isReady, security.getStrengthLevel, security.getStrengthColor])
+
+  // Per-Safe grade counts for the filter chips.
+  // Iterate over `safes` (not scanResults) so multichain safes are counted once per
+  // distinct grade — not once per chain entry. This keeps chip counts consistent with
+  // the table's filter semantics ("show safes where ANY chain matches this grade").
+  const gradeCounts = useMemo(() => {
+    const counts: Record<SafeGrade, number> = { critical: 0, at_risk: 0, needs_attention: 0, passing: 0 }
+    if (!security.$isReady) return counts
+    for (const safe of safes) {
+      const gradesFound = new Set<SafeGrade>()
+      for (const chain of safe.chainEntries) {
+        const key = security.scanKey(safe.address, chain.chainId)
+        const results = scanResults[key]
+        if (!results) continue
+        gradesFound.add(security.getSafeGrade(results))
+      }
+      for (const grade of gradesFound) counts[grade]++
+    }
+    return counts
+  }, [safes, scanResults, security.$isReady, security.scanKey, security.getSafeGrade])
+
+  // Show skeleton only when we have no data at all. Once any Safe has completed, render the
+  // aggregate incrementally — it updates as more results arrive. The re-scan row below
+  // surfaces the in-progress state via its "Scanning..." label.
+  if (!aggregate) {
+    return (
+      <Paper sx={{ p: 3, borderRadius: '12px', mb: 3 }}>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={3} alignItems={{ xs: 'flex-start', md: 'center' }}>
+          <Skeleton variant="circular" width={120} height={120} />
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Skeleton variant="rounded" width={180} height={24} sx={{ mb: 1 }} />
+            <Skeleton variant="rounded" width={320} height={16} sx={{ mb: 0.5 }} />
+            <Skeleton variant="rounded" width={260} height={16} sx={{ mb: 2 }} />
+            <Stack direction="row" spacing={1}>
+              <Skeleton variant="rounded" width={80} height={20} sx={{ borderRadius: '10px' }} />
+              <Skeleton variant="rounded" width={100} height={20} sx={{ borderRadius: '10px' }} />
+            </Stack>
+          </Box>
+        </Stack>
+      </Paper>
+    )
+  }
+
+  const { color, level, scorePct } = aggregate
+
+  return (
+    <Paper sx={{ p: 3, borderRadius: '12px', mb: 3 }}>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={3} alignItems={{ xs: 'flex-start', md: 'center' }}>
+        <ScoreGauge scorePct={scorePct} color={color} />
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Stack direction="row" alignItems="center" spacing={1.5} mb={0.5} flexWrap="wrap">
+            <Typography variant="h5" fontWeight={700}>
+              Security score
+            </Typography>
+            <Chip
+              label={level}
+              size="small"
+              sx={{
+                backgroundColor: color,
+                color: 'background.paper',
+                fontWeight: 700,
+                letterSpacing: '0.5px',
+                height: 18,
+                fontSize: '0.65rem',
+                '& .MuiChip-label': { px: 0.75 },
+              }}
+            />
+          </Stack>
+          <Typography variant="body2" color="text.secondary" mb={2}>
+            Combined score from all security checks across your accounts.
+          </Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            {FILTER_GRADES.filter((grade) => gradeCounts[grade] > 0).map((grade) => (
+              <SafeGradeChip
+                key={grade}
+                grade={grade}
+                active={activeFilter === grade}
+                label={`${gradeCounts[grade]} ${SAFE_GRADE_LABEL[grade]}`}
+                onClick={() => onFilterChange(grade)}
+                sx={{ '& .MuiChip-root:active, & .MuiTouchRipple-root': { display: 'none' } }}
+              />
+            ))}
+          </Stack>
+
+          {lastScannedAt && (
+            <Stack direction="row" alignItems="center" spacing={0.5} mt={2}>
+              <Typography variant="caption" color="text.secondary">
+                Last scanned {security.$isReady ? security.formatTimestamp(lastScannedAt) : ''}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                ·
+              </Typography>
+              <Stack
+                direction="row"
+                spacing={0.5}
+                alignItems="center"
+                onClick={isScanning ? undefined : onRescan}
+                sx={{
+                  cursor: isScanning ? 'default' : 'pointer',
+                  color: isScanning ? 'text.disabled' : 'primary.main',
+                  '&:hover': isScanning ? {} : { color: 'primary.dark' },
+                }}
+              >
+                <RefreshRoundedIcon sx={{ fontSize: 14 }} />
+                <Typography variant="caption" fontWeight={700} sx={{ color: 'inherit' }}>
+                  {isScanning ? 'Scanning...' : 'Re-scan'}
+                </Typography>
+              </Stack>
+            </Stack>
+          )}
+        </Box>
+      </Stack>
+    </Paper>
+  )
+}
+
+export default WorkspaceHealthCard

--- a/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/__snapshots__/WorkspaceHealthCard.stories.test.tsx.snap
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/__snapshots__/WorkspaceHealthCard.stories.test.tsx.snap
@@ -1,0 +1,213 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`./WorkspaceHealthCard.stories CriticalFilterActive 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-a6mz0g-MuiPaper-root"
+      style="--Paper-shadow: none;"
+    >
+      <div
+        class="MuiStack-root mui-style-19f0b8n-MuiStack-root"
+      >
+        <span
+          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse mui-style-143xw5x-MuiSkeleton-root"
+          style="width: 120px; height: 120px;"
+        />
+        <div
+          class="MuiBox-root mui-style-1fjtzvx"
+        >
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-fxtlyh-MuiSkeleton-root"
+            style="width: 180px; height: 24px;"
+          />
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-53wl0q-MuiSkeleton-root"
+            style="width: 320px; height: 16px;"
+          />
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-1x7xl34-MuiSkeleton-root"
+            style="width: 260px; height: 16px;"
+          />
+          <div
+            class="MuiStack-root mui-style-niqf4j-MuiStack-root"
+          >
+            <span
+              class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-m4f463-MuiSkeleton-root"
+              style="width: 80px; height: 20px;"
+            />
+            <span
+              class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-m4f463-MuiSkeleton-root"
+              style="width: 100px; height: 20px;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`./WorkspaceHealthCard.stories Healthy 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-a6mz0g-MuiPaper-root"
+      style="--Paper-shadow: none;"
+    >
+      <div
+        class="MuiStack-root mui-style-19f0b8n-MuiStack-root"
+      >
+        <span
+          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse mui-style-143xw5x-MuiSkeleton-root"
+          style="width: 120px; height: 120px;"
+        />
+        <div
+          class="MuiBox-root mui-style-1fjtzvx"
+        >
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-fxtlyh-MuiSkeleton-root"
+            style="width: 180px; height: 24px;"
+          />
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-53wl0q-MuiSkeleton-root"
+            style="width: 320px; height: 16px;"
+          />
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-1x7xl34-MuiSkeleton-root"
+            style="width: 260px; height: 16px;"
+          />
+          <div
+            class="MuiStack-root mui-style-niqf4j-MuiStack-root"
+          >
+            <span
+              class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-m4f463-MuiSkeleton-root"
+              style="width: 80px; height: 20px;"
+            />
+            <span
+              class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-m4f463-MuiSkeleton-root"
+              style="width: 100px; height: 20px;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`./WorkspaceHealthCard.stories MixedGrades 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-a6mz0g-MuiPaper-root"
+      style="--Paper-shadow: none;"
+    >
+      <div
+        class="MuiStack-root mui-style-19f0b8n-MuiStack-root"
+      >
+        <span
+          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse mui-style-143xw5x-MuiSkeleton-root"
+          style="width: 120px; height: 120px;"
+        />
+        <div
+          class="MuiBox-root mui-style-1fjtzvx"
+        >
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-fxtlyh-MuiSkeleton-root"
+            style="width: 180px; height: 24px;"
+          />
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-53wl0q-MuiSkeleton-root"
+            style="width: 320px; height: 16px;"
+          />
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-1x7xl34-MuiSkeleton-root"
+            style="width: 260px; height: 16px;"
+          />
+          <div
+            class="MuiStack-root mui-style-niqf4j-MuiStack-root"
+          >
+            <span
+              class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-m4f463-MuiSkeleton-root"
+              style="width: 80px; height: 20px;"
+            />
+            <span
+              class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-m4f463-MuiSkeleton-root"
+              style="width: 100px; height: 20px;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`./WorkspaceHealthCard.stories Scanning 1`] = `
+<div
+  style="background-color: rgb(255, 255, 255); padding: 1rem;"
+>
+  <div
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-l2lphb-MuiPaper-root"
+    style="--Paper-shadow: none;"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 mui-style-a6mz0g-MuiPaper-root"
+      style="--Paper-shadow: none;"
+    >
+      <div
+        class="MuiStack-root mui-style-19f0b8n-MuiStack-root"
+      >
+        <span
+          class="MuiSkeleton-root MuiSkeleton-circular MuiSkeleton-pulse mui-style-143xw5x-MuiSkeleton-root"
+          style="width: 120px; height: 120px;"
+        />
+        <div
+          class="MuiBox-root mui-style-1fjtzvx"
+        >
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-fxtlyh-MuiSkeleton-root"
+            style="width: 180px; height: 24px;"
+          />
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-53wl0q-MuiSkeleton-root"
+            style="width: 320px; height: 16px;"
+          />
+          <span
+            class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-1x7xl34-MuiSkeleton-root"
+            style="width: 260px; height: 16px;"
+          />
+          <div
+            class="MuiStack-root mui-style-niqf4j-MuiStack-root"
+          >
+            <span
+              class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-m4f463-MuiSkeleton-root"
+              style="width: 80px; height: 20px;"
+            />
+            <span
+              class="MuiSkeleton-root MuiSkeleton-rounded MuiSkeleton-pulse mui-style-m4f463-MuiSkeleton-root"
+              style="width: 100px; height: 20px;"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/apps/web/src/features/spaces/components/SecurityHub/hooks/__tests__/useAutoScanOrchestrator.test.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/hooks/__tests__/useAutoScanOrchestrator.test.ts
@@ -1,0 +1,253 @@
+import { renderHook } from '@testing-library/react'
+import useAutoScanOrchestrator from '../useAutoScanOrchestrator'
+import type { OverviewMap, SelectedSafe, SpaceSafeEntry } from '../../types'
+
+const autoScanMock = jest.fn()
+let lastServices: unknown = null
+
+jest.mock('@/features/spaces/hooks/useAutoScan', () => ({
+  __esModule: true,
+  default: (
+    queue: SelectedSafe[],
+    safes: SpaceSafeEntry[],
+    overviewMap: OverviewMap,
+    services: unknown,
+    onComplete: unknown,
+  ) => {
+    lastServices = services
+    return autoScanMock(queue, safes, overviewMap, services, onComplete)
+  },
+}))
+
+const useCurrentSpaceIdMock = jest.fn<string | null, []>()
+jest.mock('@/features/spaces/hooks/useCurrentSpaceId', () => ({
+  useCurrentSpaceId: () => useCurrentSpaceIdMock(),
+}))
+
+const SAFE_A = '0xA000000000000000000000000000000000000000'
+const SAFE_B = '0xB000000000000000000000000000000000000000'
+const CHAIN = '1'
+
+const mkSafe = (address: string): SpaceSafeEntry => ({
+  address,
+  chainId: CHAIN,
+  name: `Safe ${address.slice(0, 6)}`,
+  isMultichain: false,
+  chainEntries: [{ chainId: CHAIN, isDeployed: true }],
+})
+
+const mkSelected = (address: string): SelectedSafe => ({ address, chainId: CHAIN })
+
+const startScanFn = jest.fn()
+
+const mkSecurity = (isReady = true) =>
+  ({
+    $isReady: isReady,
+    scanners: [{ id: 'account_setup', scan: jest.fn() }],
+    scanKey: (address: string, chainId: string) => `${address}:${chainId}`,
+    setCachedScan: jest.fn(),
+    withScannerTimeout: jest.fn(),
+  }) as unknown as Parameters<typeof useAutoScanOrchestrator>[0]['security']
+
+describe('useAutoScanOrchestrator', () => {
+  beforeEach(() => {
+    autoScanMock.mockReset()
+    useCurrentSpaceIdMock.mockReset()
+    useCurrentSpaceIdMock.mockReturnValue('space-1')
+    startScanFn.mockReset()
+    lastServices = null
+    autoScanMock.mockReturnValue({
+      scanningKeys: new Set<string>(),
+      isRunning: false,
+      justCompleted: false,
+      startScan: startScanFn,
+    })
+  })
+
+  it('builds an AutoScanServices bundle from the security handle when ready', () => {
+    const security = mkSecurity()
+
+    renderHook(() =>
+      useAutoScanOrchestrator({
+        security,
+        deployedEntries: [],
+        safes: [],
+        overviewMap: {},
+        isLoadingSpacesSafes: false,
+        onScanComplete: jest.fn(),
+      }),
+    )
+
+    expect(lastServices).toMatchObject({
+      scanners: security.scanners,
+      scanKey: security.scanKey,
+      setCachedScan: security.setCachedScan,
+      withScannerTimeout: security.withScannerTimeout,
+    })
+  })
+
+  it('passes null services when the feature is not ready', () => {
+    renderHook(() =>
+      useAutoScanOrchestrator({
+        security: mkSecurity(false),
+        deployedEntries: [mkSelected(SAFE_A)],
+        safes: [mkSafe(SAFE_A)],
+        overviewMap: {},
+        isLoadingSpacesSafes: false,
+        onScanComplete: jest.fn(),
+      }),
+    )
+
+    expect(lastServices).toBeNull()
+  })
+
+  it('calls startScan once when Safes appear', () => {
+    const { rerender } = renderHook(
+      (props: Parameters<typeof useAutoScanOrchestrator>[0]) => useAutoScanOrchestrator(props),
+      {
+        initialProps: {
+          security: mkSecurity(),
+          deployedEntries: [] as SelectedSafe[],
+          safes: [] as SpaceSafeEntry[],
+          overviewMap: {} as OverviewMap,
+          isLoadingSpacesSafes: false,
+          onScanComplete: jest.fn(),
+        },
+      },
+    )
+
+    expect(startScanFn).not.toHaveBeenCalled()
+
+    rerender({
+      security: mkSecurity(),
+      deployedEntries: [mkSelected(SAFE_A)],
+      safes: [mkSafe(SAFE_A)],
+      overviewMap: {},
+      isLoadingSpacesSafes: false,
+      onScanComplete: jest.fn(),
+    })
+
+    expect(startScanFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-call startScan when the queue identity is unchanged', () => {
+    const security = mkSecurity()
+    const props = {
+      security,
+      deployedEntries: [mkSelected(SAFE_A)],
+      safes: [mkSafe(SAFE_A)],
+      overviewMap: {} as OverviewMap,
+      isLoadingSpacesSafes: false,
+      onScanComplete: jest.fn(),
+    }
+    const { rerender } = renderHook((p: typeof props) => useAutoScanOrchestrator(p), { initialProps: props })
+
+    expect(startScanFn).toHaveBeenCalledTimes(1)
+    startScanFn.mockClear()
+
+    // Different array references with the same content should not retrigger.
+    rerender({ ...props, deployedEntries: [mkSelected(SAFE_A)], safes: [mkSafe(SAFE_A)] })
+
+    expect(startScanFn).not.toHaveBeenCalled()
+  })
+
+  it('re-triggers startScan when the queue identity changes', () => {
+    const security = mkSecurity()
+    const props = {
+      security,
+      deployedEntries: [mkSelected(SAFE_A)],
+      safes: [mkSafe(SAFE_A)],
+      overviewMap: {} as OverviewMap,
+      isLoadingSpacesSafes: false,
+      onScanComplete: jest.fn(),
+    }
+    const { rerender } = renderHook((p: typeof props) => useAutoScanOrchestrator(p), { initialProps: props })
+
+    startScanFn.mockClear()
+
+    rerender({
+      ...props,
+      deployedEntries: [mkSelected(SAFE_A), mkSelected(SAFE_B)],
+      safes: [mkSafe(SAFE_A), mkSafe(SAFE_B)],
+    })
+
+    expect(startScanFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call startScan while loading', () => {
+    renderHook(() =>
+      useAutoScanOrchestrator({
+        security: mkSecurity(),
+        deployedEntries: [mkSelected(SAFE_A)],
+        safes: [mkSafe(SAFE_A)],
+        overviewMap: {},
+        isLoadingSpacesSafes: true,
+        onScanComplete: jest.fn(),
+      }),
+    )
+
+    expect(startScanFn).not.toHaveBeenCalled()
+  })
+
+  it('does not call startScan when the feature is not ready', () => {
+    renderHook(() =>
+      useAutoScanOrchestrator({
+        security: mkSecurity(false),
+        deployedEntries: [mkSelected(SAFE_A)],
+        safes: [mkSafe(SAFE_A)],
+        overviewMap: {},
+        isLoadingSpacesSafes: false,
+        onScanComplete: jest.fn(),
+      }),
+    )
+
+    expect(startScanFn).not.toHaveBeenCalled()
+  })
+
+  it('retriggers startScan when the current space changes even if Safe keys overlap', () => {
+    const security = mkSecurity()
+    const props = {
+      security,
+      deployedEntries: [mkSelected(SAFE_A)],
+      safes: [mkSafe(SAFE_A)],
+      overviewMap: {} as OverviewMap,
+      isLoadingSpacesSafes: false,
+      onScanComplete: jest.fn(),
+    }
+    const { rerender } = renderHook((p: typeof props) => useAutoScanOrchestrator(p), { initialProps: props })
+
+    expect(startScanFn).toHaveBeenCalledTimes(1)
+    startScanFn.mockClear()
+
+    // Same Safe set, different space — must still re-scan.
+    useCurrentSpaceIdMock.mockReturnValue('space-2')
+    rerender({ ...props, deployedEntries: [mkSelected(SAFE_A)], safes: [mkSafe(SAFE_A)] })
+
+    expect(startScanFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the AutoScanState passed back from useAutoScan', () => {
+    const scanningKeys = new Set([`${SAFE_A}:${CHAIN}`])
+    autoScanMock.mockReturnValue({
+      scanningKeys,
+      isRunning: true,
+      justCompleted: false,
+      startScan: startScanFn,
+    })
+
+    const { result } = renderHook(() =>
+      useAutoScanOrchestrator({
+        security: mkSecurity(),
+        deployedEntries: [],
+        safes: [],
+        overviewMap: {},
+        isLoadingSpacesSafes: false,
+        onScanComplete: jest.fn(),
+      }),
+    )
+
+    expect(result.current.scanningKeys).toBe(scanningKeys)
+    expect(result.current.isRunning).toBe(true)
+    expect(result.current.startScan).toBe(startScanFn)
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/hooks/__tests__/useReconciledSpaceSafes.test.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/hooks/__tests__/useReconciledSpaceSafes.test.ts
@@ -1,0 +1,197 @@
+import { renderHook } from '@testing-library/react'
+import useReconciledSpaceSafes from '../useReconciledSpaceSafes'
+
+const useSpaceSafesMock = jest.fn()
+const useGetMultipleSafeOverviewsQueryMock = jest.fn()
+const useAppSelectorMock = jest.fn()
+
+jest.mock('@/features/spaces', () => ({
+  useSpaceSafes: () => useSpaceSafesMock(),
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: (selector: unknown) => useAppSelectorMock(selector),
+}))
+
+jest.mock('@/store/slices', () => ({
+  selectUndeployedSafes: 'selectUndeployedSafes',
+  selectCurrency: 'selectCurrency',
+}))
+
+jest.mock('@/store/api/gateway', () => ({
+  useGetMultipleSafeOverviewsQuery: (...args: unknown[]) => useGetMultipleSafeOverviewsQueryMock(...args),
+}))
+
+const SAFE_A = '0xA000000000000000000000000000000000000000'
+const SAFE_B = '0xB000000000000000000000000000000000000000'
+const MAINNET = '1'
+const POLYGON = '137'
+
+const mkSecurity = (isReady = true) =>
+  ({
+    $isReady: isReady,
+    scanKey: (address: string, chainId: string) => `${address}:${chainId}`,
+  }) as unknown as Parameters<typeof useReconciledSpaceSafes>[0]
+
+const mkOverview = (address: string, chainId: string, fiatTotal = '1000', queued = 0) => ({
+  address: { value: address },
+  chainId,
+  fiatTotal,
+  queued,
+})
+
+const setSelectors = ({ undeployed = {}, currency = 'usd' } = {}) => {
+  useAppSelectorMock.mockImplementation((selector: string) => {
+    if (selector === 'selectUndeployedSafes') return undeployed
+    if (selector === 'selectCurrency') return currency
+    return undefined
+  })
+}
+
+describe('useReconciledSpaceSafes', () => {
+  beforeEach(() => {
+    useSpaceSafesMock.mockReset()
+    useGetMultipleSafeOverviewsQueryMock.mockReset()
+    useAppSelectorMock.mockReset()
+
+    useSpaceSafesMock.mockReturnValue({ allSafes: [], isLoading: false })
+    useGetMultipleSafeOverviewsQueryMock.mockReturnValue({ data: undefined })
+    setSelectors()
+  })
+
+  it('returns empty result when no Safes are present', () => {
+    const { result } = renderHook(() => useReconciledSpaceSafes(mkSecurity()))
+
+    expect(result.current.safes).toEqual([])
+    expect(result.current.deployedEntries).toEqual([])
+    expect(result.current.balanceMap).toEqual({})
+    expect(result.current.overviewMap).toEqual({})
+  })
+
+  it('skips the batch overview query when there are no deployed Safes to fetch', () => {
+    renderHook(() => useReconciledSpaceSafes(mkSecurity()))
+
+    expect(useGetMultipleSafeOverviewsQueryMock).toHaveBeenCalledWith(expect.anything(), { skip: true })
+  })
+
+  it('builds balanceMap and overviewMap from the batch overview response', () => {
+    useSpaceSafesMock.mockReturnValue({
+      allSafes: [{ chainId: MAINNET, address: SAFE_A, name: 'A' }],
+      isLoading: false,
+    })
+    useGetMultipleSafeOverviewsQueryMock.mockReturnValue({
+      data: [mkOverview(SAFE_A, MAINNET, '1234', 5)],
+    })
+
+    const { result } = renderHook(() => useReconciledSpaceSafes(mkSecurity()))
+
+    const key = `${SAFE_A}:${MAINNET}`
+    expect(result.current.balanceMap).toEqual({ [key]: '1234' })
+    expect(result.current.overviewMap).toEqual({ [key]: { balanceUsd: 1234, queuedTxCount: 5 } })
+  })
+
+  it('keeps an undeployed single-chain Safe out of deployedEntries but in safes', () => {
+    setSelectors({ undeployed: { [MAINNET]: { [SAFE_A]: { props: {} } } } })
+    useSpaceSafesMock.mockReturnValue({
+      allSafes: [{ chainId: MAINNET, address: SAFE_A, name: 'A' }],
+      isLoading: false,
+    })
+    useGetMultipleSafeOverviewsQueryMock.mockReturnValue({ data: [] })
+
+    const { result } = renderHook(() => useReconciledSpaceSafes(mkSecurity()))
+
+    expect(result.current.safes).toHaveLength(1)
+    expect(result.current.safes[0].chainEntries[0].isDeployed).toBe(false)
+    expect(result.current.deployedEntries).toEqual([])
+  })
+
+  it('demotes ghost-deployed multichain entries when CGW does not confirm them', () => {
+    useSpaceSafesMock.mockReturnValue({
+      allSafes: [
+        {
+          address: SAFE_A,
+          safes: [
+            { chainId: MAINNET, address: SAFE_A },
+            { chainId: POLYGON, address: SAFE_A },
+          ],
+          isPinned: false,
+          lastVisited: 0,
+          name: 'Multi A',
+        },
+      ],
+      isLoading: false,
+    })
+    // CGW only returns Mainnet — Polygon is ghost-deployed.
+    useGetMultipleSafeOverviewsQueryMock.mockReturnValue({
+      data: [mkOverview(SAFE_A, MAINNET)],
+    })
+
+    const { result } = renderHook(() => useReconciledSpaceSafes(mkSecurity()))
+
+    const reconciled = result.current.safes[0]
+    const mainnetEntry = reconciled.chainEntries.find((c) => c.chainId === MAINNET)
+    const polygonEntry = reconciled.chainEntries.find((c) => c.chainId === POLYGON)
+    expect(mainnetEntry?.isDeployed).toBe(true)
+    expect(polygonEntry?.isDeployed).toBe(false)
+    expect(result.current.deployedEntries).toEqual([{ address: SAFE_A, chainId: MAINNET }])
+  })
+
+  it('does not reconcile while CGW response is still loading (null confirmedDeployedKeys)', () => {
+    useSpaceSafesMock.mockReturnValue({
+      allSafes: [{ chainId: MAINNET, address: SAFE_A, name: 'A' }],
+      isLoading: false,
+    })
+    useGetMultipleSafeOverviewsQueryMock.mockReturnValue({ data: undefined })
+
+    const { result } = renderHook(() => useReconciledSpaceSafes(mkSecurity()))
+
+    // Optimistic: Safe stays deployed since reconciliation is inconclusive.
+    expect(result.current.safes[0].chainEntries[0].isDeployed).toBe(true)
+    expect(result.current.deployedEntries).toEqual([{ address: SAFE_A, chainId: MAINNET }])
+  })
+
+  it('returns rawSafes unchanged when the security feature is not ready', () => {
+    useSpaceSafesMock.mockReturnValue({
+      allSafes: [{ chainId: MAINNET, address: SAFE_A, name: 'A' }],
+      isLoading: false,
+    })
+    useGetMultipleSafeOverviewsQueryMock.mockReturnValue({
+      data: [mkOverview(SAFE_A, MAINNET)],
+    })
+
+    const { result } = renderHook(() => useReconciledSpaceSafes(mkSecurity(false)))
+
+    expect(result.current.balanceMap).toEqual({})
+    expect(result.current.overviewMap).toEqual({})
+    expect(result.current.safes[0].chainEntries[0].isDeployed).toBe(true)
+  })
+
+  it('forwards isLoadingSpacesSafes from useSpaceSafes', () => {
+    useSpaceSafesMock.mockReturnValue({ allSafes: [], isLoading: true })
+
+    const { result } = renderHook(() => useReconciledSpaceSafes(mkSecurity()))
+
+    expect(result.current.isLoadingSpacesSafes).toBe(true)
+  })
+
+  it('ignores overview entries with missing address or chainId', () => {
+    useSpaceSafesMock.mockReturnValue({
+      allSafes: [
+        { chainId: MAINNET, address: SAFE_A, name: 'A' },
+        { chainId: MAINNET, address: SAFE_B, name: 'B' },
+      ],
+      isLoading: false,
+    })
+    useGetMultipleSafeOverviewsQueryMock.mockReturnValue({
+      data: [
+        mkOverview(SAFE_A, MAINNET, '500'),
+        { address: undefined, chainId: MAINNET, fiatTotal: '999', queued: 0 },
+        { address: { value: SAFE_B }, chainId: undefined, fiatTotal: '888', queued: 0 },
+      ],
+    })
+
+    const { result } = renderHook(() => useReconciledSpaceSafes(mkSecurity()))
+
+    expect(result.current.balanceMap).toEqual({ [`${SAFE_A}:${MAINNET}`]: '500' })
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/hooks/__tests__/useReportDrawer.test.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/hooks/__tests__/useReportDrawer.test.ts
@@ -1,0 +1,123 @@
+import { act, renderHook } from '@testing-library/react'
+import useReportDrawer from '../useReportDrawer'
+import type { ScanContext } from '@/features/security/types'
+import type { OverviewMap, SpaceSafeEntry } from '../../types'
+
+let mockScanContext: ScanContext | null = null
+const safeScanContextMock = jest.fn()
+
+jest.mock('@/features/spaces/hooks/useSafeScanContext', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => {
+    safeScanContextMock(...args)
+    return mockScanContext
+  },
+}))
+
+const SAFE_A = '0xA000000000000000000000000000000000000000'
+const SAFE_B = '0xB000000000000000000000000000000000000000'
+const CHAIN = '1'
+
+const mkSafe = (address: string): SpaceSafeEntry => ({
+  address,
+  chainId: CHAIN,
+  name: `Safe ${address.slice(0, 6)}`,
+  isMultichain: false,
+  chainEntries: [{ chainId: CHAIN, isDeployed: true }],
+})
+
+const mkSecurity = (isReady = true) =>
+  ({
+    $isReady: isReady,
+    scanKey: (address: string, chainId: string) => `${address}:${chainId}`,
+  }) as unknown as Parameters<typeof useReportDrawer>[0]['security']
+
+describe('useReportDrawer', () => {
+  beforeEach(() => {
+    mockScanContext = null
+    safeScanContextMock.mockReset()
+  })
+
+  it('starts with no Safe selected', () => {
+    const { result } = renderHook(() => useReportDrawer({ security: mkSecurity(), safes: [], overviewMap: {} }))
+
+    expect(result.current.selectedSafe).toBeNull()
+    expect(result.current.selectedEntry).toBeUndefined()
+  })
+
+  it('openReport selects a Safe', () => {
+    const safes = [mkSafe(SAFE_A), mkSafe(SAFE_B)]
+    const { result } = renderHook(() => useReportDrawer({ security: mkSecurity(), safes, overviewMap: {} }))
+
+    act(() => result.current.openReport(SAFE_A, CHAIN))
+
+    expect(result.current.selectedSafe).toEqual({ address: SAFE_A, chainId: CHAIN })
+    expect(result.current.selectedEntry).toBe(safes[0])
+  })
+
+  it('openReport on the same Safe twice toggles the selection off', () => {
+    const safes = [mkSafe(SAFE_A)]
+    const { result } = renderHook(() => useReportDrawer({ security: mkSecurity(), safes, overviewMap: {} }))
+
+    act(() => result.current.openReport(SAFE_A, CHAIN))
+    expect(result.current.selectedSafe).not.toBeNull()
+
+    act(() => result.current.openReport(SAFE_A, CHAIN))
+    expect(result.current.selectedSafe).toBeNull()
+  })
+
+  it('openReport on a different Safe replaces the selection', () => {
+    const safes = [mkSafe(SAFE_A), mkSafe(SAFE_B)]
+    const { result } = renderHook(() => useReportDrawer({ security: mkSecurity(), safes, overviewMap: {} }))
+
+    act(() => result.current.openReport(SAFE_A, CHAIN))
+    act(() => result.current.openReport(SAFE_B, CHAIN))
+
+    expect(result.current.selectedSafe).toEqual({ address: SAFE_B, chainId: CHAIN })
+    expect(result.current.selectedEntry).toBe(safes[1])
+  })
+
+  it('closeReport clears the selection', () => {
+    const safes = [mkSafe(SAFE_A)]
+    const { result } = renderHook(() => useReportDrawer({ security: mkSecurity(), safes, overviewMap: {} }))
+
+    act(() => result.current.openReport(SAFE_A, CHAIN))
+    act(() => result.current.closeReport())
+
+    expect(result.current.selectedSafe).toBeNull()
+  })
+
+  it('passes the pre-fetched overview from overviewMap to useSafeScanContext', () => {
+    const safes = [mkSafe(SAFE_A)]
+    const overviewMap: OverviewMap = { [`${SAFE_A}:${CHAIN}`]: { balanceUsd: 1234, queuedTxCount: 2 } }
+    const { result } = renderHook(() => useReportDrawer({ security: mkSecurity(), safes, overviewMap }))
+
+    act(() => result.current.openReport(SAFE_A, CHAIN))
+
+    expect(safeScanContextMock).toHaveBeenLastCalledWith({ address: SAFE_A, chainId: CHAIN }, safes[0], {
+      balanceUsd: 1234,
+      queuedTxCount: 2,
+    })
+  })
+
+  it('passes undefined when the security feature is not ready', () => {
+    const safes = [mkSafe(SAFE_A)]
+    const overviewMap: OverviewMap = { [`${SAFE_A}:${CHAIN}`]: { balanceUsd: 1234, queuedTxCount: 2 } }
+    const { result } = renderHook(() => useReportDrawer({ security: mkSecurity(false), safes, overviewMap }))
+
+    act(() => result.current.openReport(SAFE_A, CHAIN))
+
+    expect(safeScanContextMock).toHaveBeenLastCalledWith({ address: SAFE_A, chainId: CHAIN }, safes[0], undefined)
+  })
+
+  it('returns the resolved scanContext from useSafeScanContext', () => {
+    const ctx = { safeAddress: SAFE_A, chainId: CHAIN } as ScanContext
+    mockScanContext = ctx
+    const safes = [mkSafe(SAFE_A)]
+    const { result } = renderHook(() => useReportDrawer({ security: mkSecurity(), safes, overviewMap: {} }))
+
+    act(() => result.current.openReport(SAFE_A, CHAIN))
+
+    expect(result.current.scanContext).toBe(ctx)
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/hooks/__tests__/useScanResultsState.test.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/hooks/__tests__/useScanResultsState.test.ts
@@ -1,0 +1,137 @@
+import { act, renderHook } from '@testing-library/react'
+import useScanResultsState from '../useScanResultsState'
+import type { ScanResult } from '@/features/security/types'
+
+const useCurrentSpaceIdMock = jest.fn<string | null, []>()
+jest.mock('@/features/spaces/hooks/useCurrentSpaceId', () => ({
+  useCurrentSpaceId: () => useCurrentSpaceIdMock(),
+}))
+
+const SAFE_A = '0xA000000000000000000000000000000000000000'
+const SAFE_B = '0xB000000000000000000000000000000000000000'
+const CHAIN = '1'
+
+const mkResult = (overrides: Partial<ScanResult> = {}): ScanResult => ({
+  status: 'clear',
+  severity: 'Low',
+  score: 100,
+  evidence: [],
+  remediation: '',
+  lastChecked: new Date().toISOString(),
+  ...overrides,
+})
+
+const mkSecurity = (isReady = true) =>
+  ({
+    $isReady: isReady,
+    scanKey: (address: string, chainId: string) => `${address}:${chainId}`,
+  }) as unknown as Parameters<typeof useScanResultsState>[0]
+
+describe('useScanResultsState', () => {
+  beforeEach(() => {
+    useCurrentSpaceIdMock.mockReset()
+    useCurrentSpaceIdMock.mockReturnValue('space-1')
+  })
+
+  it('starts with empty results, empty timestamps, and null lastScannedAt', () => {
+    const { result } = renderHook(() => useScanResultsState(mkSecurity()))
+
+    expect(result.current.allScanResults).toEqual({})
+    expect(result.current.scanTimestamps).toEqual({})
+    expect(result.current.lastScannedAt).toBeNull()
+  })
+
+  it('records results and timestamps when handleScanComplete fires', () => {
+    const { result } = renderHook(() => useScanResultsState(mkSecurity()))
+    const results = { account_setup: mkResult() }
+
+    act(() => {
+      result.current.handleScanComplete(SAFE_A, CHAIN, 1000, results)
+    })
+
+    expect(result.current.allScanResults).toEqual({ [`${SAFE_A}:${CHAIN}`]: results })
+    expect(result.current.scanTimestamps).toEqual({ [`${SAFE_A}:${CHAIN}`]: 1000 })
+    expect(result.current.lastScannedAt).toBe(1000)
+  })
+
+  it('aggregates lastScannedAt as the max across timestamps', () => {
+    const { result } = renderHook(() => useScanResultsState(mkSecurity()))
+
+    act(() => {
+      result.current.handleScanComplete(SAFE_A, CHAIN, 1000, {})
+      result.current.handleScanComplete(SAFE_B, CHAIN, 2500, {})
+      result.current.handleScanComplete(SAFE_A, CHAIN, 1500, {}) // overwrites SAFE_A
+    })
+
+    expect(result.current.lastScannedAt).toBe(2500)
+    expect(result.current.scanTimestamps[`${SAFE_A}:${CHAIN}`]).toBe(1500)
+    expect(result.current.scanTimestamps[`${SAFE_B}:${CHAIN}`]).toBe(2500)
+  })
+
+  it('no-ops when the security feature is not ready', () => {
+    const { result } = renderHook(() => useScanResultsState(mkSecurity(false)))
+
+    act(() => {
+      result.current.handleScanComplete(SAFE_A, CHAIN, 1000, { account_setup: mkResult() })
+    })
+
+    expect(result.current.allScanResults).toEqual({})
+    expect(result.current.scanTimestamps).toEqual({})
+    expect(result.current.lastScannedAt).toBeNull()
+  })
+
+  it('keeps handleScanComplete identity stable while security props are stable', () => {
+    const security = mkSecurity()
+    const { result, rerender } = renderHook(() => useScanResultsState(security))
+    const first = result.current.handleScanComplete
+
+    rerender()
+
+    expect(result.current.handleScanComplete).toBe(first)
+  })
+
+  it('clears results and timestamps when the current space changes', () => {
+    const { result, rerender } = renderHook(() => useScanResultsState(mkSecurity()))
+
+    act(() => {
+      result.current.handleScanComplete(SAFE_A, CHAIN, 1000, { account_setup: mkResult() })
+    })
+    expect(result.current.allScanResults).not.toEqual({})
+    expect(result.current.lastScannedAt).toBe(1000)
+
+    useCurrentSpaceIdMock.mockReturnValue('space-2')
+    rerender()
+
+    expect(result.current.allScanResults).toEqual({})
+    expect(result.current.scanTimestamps).toEqual({})
+    expect(result.current.lastScannedAt).toBeNull()
+  })
+
+  it('does not clear state on unrelated re-renders within the same space', () => {
+    const { result, rerender } = renderHook(() => useScanResultsState(mkSecurity()))
+
+    act(() => {
+      result.current.handleScanComplete(SAFE_A, CHAIN, 1000, { account_setup: mkResult() })
+    })
+
+    rerender()
+    rerender()
+
+    expect(result.current.lastScannedAt).toBe(1000)
+  })
+
+  it('does not clear state when the current space ID is null', () => {
+    useCurrentSpaceIdMock.mockReturnValue('space-1')
+    const { result, rerender } = renderHook(() => useScanResultsState(mkSecurity()))
+
+    act(() => {
+      result.current.handleScanComplete(SAFE_A, CHAIN, 1000, { account_setup: mkResult() })
+    })
+
+    useCurrentSpaceIdMock.mockReturnValue(null)
+    rerender()
+
+    expect(result.current.lastScannedAt).toBe(1000)
+    expect(result.current.allScanResults[`${SAFE_A}:${CHAIN}`]).toBeDefined()
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/hooks/useAutoScanOrchestrator.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/hooks/useAutoScanOrchestrator.ts
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useRef } from 'react'
+import type { ScanResult } from '@/features/security/types'
+import type { useLoadFeature } from '@/features/__core__'
+import type { SecurityContract } from '@/features/security'
+import useAutoScan, { type AutoScanServices, type AutoScanState } from '@/features/spaces/hooks/useAutoScan'
+import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
+import type { OverviewMap, SelectedSafe, SpaceSafeEntry } from '../types'
+
+type SecurityHandle = ReturnType<typeof useLoadFeature<SecurityContract>>
+
+export type UseAutoScanOrchestratorParams = {
+  security: SecurityHandle
+  deployedEntries: SelectedSafe[]
+  safes: SpaceSafeEntry[]
+  overviewMap: OverviewMap
+  isLoadingSpacesSafes: boolean
+  onScanComplete: (address: string, chainId: string, timestamp: number, results: Record<string, ScanResult>) => void
+}
+
+/**
+ * Wraps `useAutoScan` with two responsibilities pulled out of the host component:
+ * - Builds the `AutoScanServices` bundle from the loaded feature handle.
+ * - Triggers `startScan()` whenever the queue identity changes (Safes added,
+ *   reconciled, or removed). Identity is compared via a sorted, joined key
+ *   string so reference churn from other re-renders doesn't re-trigger.
+ */
+const useAutoScanOrchestrator = ({
+  security,
+  deployedEntries,
+  safes,
+  overviewMap,
+  isLoadingSpacesSafes,
+  onScanComplete,
+}: UseAutoScanOrchestratorParams): AutoScanState => {
+  const services = useMemo<AutoScanServices | null>(
+    () =>
+      security.$isReady
+        ? {
+            scanners: security.scanners,
+            scanKey: security.scanKey,
+            setCachedScan: security.setCachedScan,
+            withScannerTimeout: security.withScannerTimeout,
+          }
+        : null,
+    [security.$isReady, security.scanners, security.scanKey, security.setCachedScan, security.withScannerTimeout],
+  )
+
+  const autoScan = useAutoScan(deployedEntries, safes, overviewMap, services, onScanComplete)
+  const { startScan } = autoScan
+
+  const currentSpaceId = useCurrentSpaceId()
+  const lastScannedSpaceIdRef = useRef(currentSpaceId)
+  const lastScannedKeysRef = useRef<string>('')
+
+  useEffect(() => {
+    if (isLoadingSpacesSafes || safes.length === 0 || !security.$isReady) return
+
+    // Page stays mounted across sidebar space switches. Force a fresh scan when the
+    // space changes so two spaces with overlapping Safes still trigger a rescan.
+    if (lastScannedSpaceIdRef.current !== currentSpaceId) {
+      lastScannedSpaceIdRef.current = currentSpaceId
+      lastScannedKeysRef.current = ''
+    }
+
+    const currentKeys = deployedEntries
+      .map((e) => security.scanKey(e.address, e.chainId))
+      .sort()
+      .join(',')
+    if (currentKeys !== lastScannedKeysRef.current) {
+      lastScannedKeysRef.current = currentKeys
+      startScan()
+    }
+  }, [
+    isLoadingSpacesSafes,
+    safes.length,
+    deployedEntries,
+    startScan,
+    security.$isReady,
+    security.scanKey,
+    currentSpaceId,
+  ])
+
+  return autoScan
+}
+
+export default useAutoScanOrchestrator

--- a/apps/web/src/features/spaces/components/SecurityHub/hooks/useReconciledSpaceSafes.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/hooks/useReconciledSpaceSafes.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react'
+import { useSpaceSafes } from '@/features/spaces'
+import { useAppSelector } from '@/store'
+import { selectUndeployedSafes, selectCurrency } from '@/store/slices'
+import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
+import type { useLoadFeature } from '@/features/__core__'
+import type { SecurityContract } from '@/features/security'
+import { flattenSafes, getDeployedEntries, reconcileDeployedSafes, toSafeItems } from '../utils'
+import type { BalanceMap, OverviewMap, SelectedSafe, SpaceSafeEntry } from '../types'
+
+type SecurityHandle = ReturnType<typeof useLoadFeature<SecurityContract>>
+
+export type ReconciledSpaceSafes = {
+  isLoadingSpacesSafes: boolean
+  safes: SpaceSafeEntry[]
+  deployedEntries: SelectedSafe[]
+  balanceMap: BalanceMap
+  overviewMap: OverviewMap
+}
+
+/**
+ * Fetches the Space's Safes, batches their overviews from CGW, and reconciles
+ * "ghost-deployed" chains — entries flagged deployed locally but absent from
+ * CGW's response (counterfactual for another Space member). The reconciled
+ * `safes` and derived `deployedEntries` feed both the table and the scan queue.
+ */
+const useReconciledSpaceSafes = (security: SecurityHandle): ReconciledSpaceSafes => {
+  const { allSafes, isLoading: isLoadingSpacesSafes } = useSpaceSafes()
+  const undeployedSafes = useAppSelector(selectUndeployedSafes)
+  const currency = useAppSelector(selectCurrency)
+
+  const rawSafes = useMemo(() => flattenSafes(allSafes, undeployedSafes), [allSafes, undeployedSafes])
+  const safeItems = useMemo(() => toSafeItems(rawSafes), [rawSafes])
+
+  const { data: overviews } = useGetMultipleSafeOverviewsQuery(
+    { safes: safeItems, currency },
+    { skip: safeItems.length === 0 },
+  )
+
+  const { confirmedDeployedKeys, balanceMap, overviewMap } = useMemo(() => {
+    if (!security.$isReady || !overviews) {
+      return { confirmedDeployedKeys: null, balanceMap: {} as BalanceMap, overviewMap: {} as OverviewMap }
+    }
+
+    const confirmed = new Set<string>()
+    const { bMap, oMap } = overviews.reduce(
+      (acc: { bMap: BalanceMap; oMap: OverviewMap }, ov) => {
+        if (!ov.address?.value || !ov.chainId) {
+          return acc
+        }
+
+        const key = security.scanKey(ov.address.value, ov.chainId)
+
+        confirmed.add(key)
+
+        acc.bMap[key] = ov.fiatTotal
+        acc.oMap[key] = { balanceUsd: Number(ov.fiatTotal) || 0, queuedTxCount: ov.queued ?? 0 }
+
+        return acc
+      },
+      { bMap: {}, oMap: {} },
+    )
+
+    return {
+      confirmedDeployedKeys: confirmed.size > 0 ? confirmed : null,
+      balanceMap: bMap,
+      overviewMap: oMap,
+    }
+  }, [overviews, security.$isReady, security.scanKey])
+
+  const safes = useMemo(
+    () => (security.$isReady ? reconcileDeployedSafes(rawSafes, confirmedDeployedKeys, security.scanKey) : rawSafes),
+    [rawSafes, confirmedDeployedKeys, security.$isReady, security.scanKey],
+  )
+
+  const deployedEntries = useMemo(() => getDeployedEntries(safes), [safes])
+
+  return { isLoadingSpacesSafes, safes, deployedEntries, balanceMap, overviewMap }
+}
+
+export default useReconciledSpaceSafes

--- a/apps/web/src/features/spaces/components/SecurityHub/hooks/useReportDrawer.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/hooks/useReportDrawer.ts
@@ -1,0 +1,63 @@
+import { useCallback, useMemo, useState } from 'react'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import type { ScanContext } from '@/features/security/types'
+import type { useLoadFeature } from '@/features/__core__'
+import type { SecurityContract } from '@/features/security'
+import useSafeScanContext from '@/features/spaces/hooks/useSafeScanContext'
+import type { OverviewMap, SelectedSafe, SpaceSafeEntry } from '../types'
+
+type SecurityHandle = ReturnType<typeof useLoadFeature<SecurityContract>>
+
+export type UseReportDrawerParams = {
+  security: SecurityHandle
+  safes: SpaceSafeEntry[]
+  overviewMap: OverviewMap
+}
+
+export type ReportDrawerState = {
+  selectedSafe: SelectedSafe | null
+  selectedEntry: SpaceSafeEntry | undefined
+  scanContext: ScanContext | null
+  openReport: (address: string, chainId: string) => void
+  closeReport: () => void
+}
+
+/**
+ * Owns the report drawer's selection state and its dependent derivations:
+ * the matching `SpaceSafeEntry`, the pre-fetched overview to skip a redundant
+ * per-Safe overview request, and the drawer's `ScanContext` for the
+ * security panel.
+ */
+const useReportDrawer = ({ security, safes, overviewMap }: UseReportDrawerParams): ReportDrawerState => {
+  const [selectedSafe, setSelectedSafe] = useState<SelectedSafe | null>(null)
+
+  const openReport = useCallback((address: string, chainId: string) => {
+    setSelectedSafe((prev) => {
+      if (prev && sameAddress(prev.address, address) && prev.chainId === chainId) return null
+      return { address, chainId }
+    })
+  }, [])
+
+  const closeReport = useCallback(() => setSelectedSafe(null), [])
+
+  const selectedEntry = useMemo(() => {
+    if (!selectedSafe) return undefined
+    // Multichain Safes share the same address across chains, so a plain address match
+    // can return a row whose chainEntries don't include the selected chain.
+    return safes.find(
+      (s) =>
+        sameAddress(s.address, selectedSafe.address) && s.chainEntries.some((c) => c.chainId === selectedSafe.chainId),
+    )
+  }, [safes, selectedSafe])
+
+  const drawerOverview =
+    selectedSafe && security.$isReady
+      ? overviewMap[security.scanKey(selectedSafe.address, selectedSafe.chainId)]
+      : undefined
+
+  const scanContext = useSafeScanContext(selectedSafe, selectedEntry, drawerOverview)
+
+  return { selectedSafe, selectedEntry, scanContext, openReport, closeReport }
+}
+
+export default useReportDrawer

--- a/apps/web/src/features/spaces/components/SecurityHub/hooks/useScanResultsState.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/hooks/useScanResultsState.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { ScanResult } from '@/features/security/types'
+import type { useLoadFeature } from '@/features/__core__'
+import type { SecurityContract } from '@/features/security'
+import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
+
+type SecurityHandle = ReturnType<typeof useLoadFeature<SecurityContract>>
+
+export type ScanResultsByKey = Record<string, Record<string, ScanResult>>
+export type ScanTimestampsByKey = Record<string, number>
+
+export type ScanResultsState = {
+  allScanResults: ScanResultsByKey
+  scanTimestamps: ScanTimestampsByKey
+  lastScannedAt: number | null
+  handleScanComplete: (address: string, chainId: string, timestamp: number, results: Record<string, ScanResult>) => void
+}
+
+/**
+ * Owns the per-Safe scan results map, the per-Safe timestamps map, and the
+ * `onComplete` callback that auto-scan and the drawer both write through.
+ *
+ * Resets state when the current space changes — the page stays mounted across
+ * sidebar space switches, so without this the workspace card would aggregate
+ * the previous space's results and `lastScannedAt` would show its old timestamp.
+ */
+const useScanResultsState = (security: SecurityHandle): ScanResultsState => {
+  const currentSpaceId = useCurrentSpaceId()
+  const [allScanResults, setAllScanResults] = useState<ScanResultsByKey>({})
+  const [scanTimestamps, setScanTimestamps] = useState<ScanTimestampsByKey>({})
+
+  useEffect(() => {
+    if (!currentSpaceId) return
+    setAllScanResults({})
+    setScanTimestamps({})
+  }, [currentSpaceId])
+
+  const handleScanComplete = useCallback(
+    (address: string, chainId: string, timestamp: number, results: Record<string, ScanResult>) => {
+      if (!security.$isReady) return
+      const key = security.scanKey(address, chainId)
+      setAllScanResults((prev) => ({ ...prev, [key]: results }))
+      setScanTimestamps((prev) => ({ ...prev, [key]: timestamp }))
+    },
+    [security.$isReady, security.scanKey],
+  )
+
+  const lastScannedAt = useMemo(() => {
+    const values = Object.values(scanTimestamps)
+    return values.length > 0 ? Math.max(...values) : null
+  }, [scanTimestamps])
+
+  return { allScanResults, scanTimestamps, lastScannedAt, handleScanComplete }
+}
+
+export default useScanResultsState

--- a/apps/web/src/features/spaces/components/SecurityHub/index.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/index.tsx
@@ -1,0 +1,89 @@
+import { type ReactElement, useState } from 'react'
+import { Box, Typography } from '@mui/material'
+import type { SafeGrade } from '@/features/security/types'
+import { SecurityFeature } from '@/features/security'
+import { useLoadFeature } from '@/features/__core__'
+import SecuritySafesTable from './components/SecuritySafesTable/SecuritySafesTable'
+import SecurityReportDrawer from './components/SecurityReportDrawer/SecurityReportDrawer'
+import WorkspaceHealthCard from './components/WorkspaceHealthCard/WorkspaceHealthCard'
+import useReconciledSpaceSafes from './hooks/useReconciledSpaceSafes'
+import useScanResultsState from './hooks/useScanResultsState'
+import useAutoScanOrchestrator from './hooks/useAutoScanOrchestrator'
+import useReportDrawer from './hooks/useReportDrawer'
+
+export type { BalanceMap, OverviewMap, SelectedSafe, SpaceSafeEntry, ChainEntry } from './types'
+
+const SecurityHub = (): ReactElement => {
+  const security = useLoadFeature(SecurityFeature)
+  const { isLoadingSpacesSafes, safes, deployedEntries, balanceMap, overviewMap } = useReconciledSpaceSafes(security)
+  const { allScanResults, scanTimestamps, lastScannedAt, handleScanComplete } = useScanResultsState(security)
+  const { scanningKeys, isRunning, startScan } = useAutoScanOrchestrator({
+    security,
+    deployedEntries,
+    safes,
+    overviewMap,
+    isLoadingSpacesSafes,
+    onScanComplete: handleScanComplete,
+  })
+  const { selectedSafe, selectedEntry, scanContext, openReport, closeReport } = useReportDrawer({
+    security,
+    safes,
+    overviewMap,
+  })
+  const [gradeFilter, setGradeFilter] = useState<SafeGrade | null>(null)
+
+  return (
+    <Box data-testid="security-hub">
+      <Box mb={3}>
+        <Typography variant="h1" mb={0.5}>
+          Security
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Overview of security checks across your accounts.
+        </Typography>
+      </Box>
+
+      {isLoadingSpacesSafes ? (
+        <Typography variant="body2" color="text.secondary">
+          Loading accounts...
+        </Typography>
+      ) : safes.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No Safe accounts in this space yet.
+        </Typography>
+      ) : (
+        <>
+          <WorkspaceHealthCard
+            safes={safes}
+            scanResults={allScanResults}
+            isScanning={isRunning}
+            activeFilter={gradeFilter}
+            onFilterChange={(grade) => setGradeFilter((prev) => (prev === grade ? null : grade))}
+            lastScannedAt={lastScannedAt}
+            onRescan={startScan}
+          />
+          <SecuritySafesTable
+            safes={safes}
+            onViewReport={openReport}
+            selectedSafe={selectedSafe}
+            scanResults={allScanResults}
+            scanTimestamps={scanTimestamps}
+            scanningKeys={scanningKeys}
+            gradeFilter={gradeFilter}
+            balanceMap={balanceMap}
+          />
+        </>
+      )}
+
+      <SecurityReportDrawer
+        selectedSafe={selectedSafe}
+        selectedEntry={selectedEntry}
+        scanContext={scanContext}
+        onClose={closeReport}
+        onScanComplete={handleScanComplete}
+      />
+    </Box>
+  )
+}
+
+export default SecurityHub

--- a/apps/web/src/features/spaces/components/SecurityHub/types.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/types.ts
@@ -1,0 +1,21 @@
+import { type OverviewData } from '../../hooks/useSafeScanContext'
+
+export type ChainEntry = {
+  chainId: string
+  isDeployed: boolean
+}
+
+export type BalanceMap = Record<string, string | undefined>
+export type OverviewMap = Record<string, OverviewData>
+export type SpaceSafeEntry = {
+  address: string
+  chainId: string
+  name?: string
+  isMultichain: boolean
+  chainEntries: ChainEntry[]
+}
+
+export type SelectedSafe = {
+  address: string
+  chainId: string
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/utils.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/utils.ts
@@ -1,0 +1,93 @@
+import { isMultiChainSafeItem, type SafeItem, type MultiChainSafeItem } from '@/hooks/safes'
+import type { UndeployedSafesState } from '@safe-global/utils/features/counterfactual/store/types'
+import type { SpaceSafeEntry, SelectedSafe } from './types'
+
+/** Build SpaceSafeEntry[] from the raw space items, applying the client's local undeployed flags. */
+export const flattenSafes = (
+  allSafes: Array<SafeItem | MultiChainSafeItem>,
+  undeployedSafes: UndeployedSafesState,
+): SpaceSafeEntry[] =>
+  allSafes.flatMap<SpaceSafeEntry>((item) => {
+    if (isMultiChainSafeItem(item)) {
+      // A multichain group with no chains is malformed (the grouping logic upstream
+      // never produces one in practice). Skip rather than synthesising a mainnet
+      // entry — a bogus chainId would queue scans for a Safe that doesn't exist there.
+      const firstChainId = item.safes[0]?.chainId
+      if (!firstChainId) return []
+      return [
+        {
+          address: item.address,
+          chainId: firstChainId,
+          name: item.name,
+          isMultichain: true,
+          chainEntries: item.safes.map((s) => ({
+            chainId: s.chainId,
+            isDeployed: !undeployedSafes[s.chainId]?.[s.address],
+          })),
+        },
+      ]
+    }
+    const isDeployed = !undeployedSafes[item.chainId]?.[item.address]
+    return [
+      {
+        address: item.address,
+        chainId: item.chainId,
+        name: item.name,
+        isMultichain: false,
+        chainEntries: [{ chainId: item.chainId, isDeployed }],
+      },
+    ]
+  })
+
+/** Collect all deployed chain entries across all safes. */
+export const getDeployedEntries = (safes: SpaceSafeEntry[]): SelectedSafe[] =>
+  safes.flatMap((safe) =>
+    safe.chainEntries.filter((c) => c.isDeployed).map((c) => ({ address: safe.address, chainId: c.chainId })),
+  )
+
+/**
+ * Project the deployed chain entries into the `SafeItem` shape required by
+ * `useGetMultipleSafeOverviewsQuery`. The per-Safe metadata fields are unused by
+ * the overview endpoint — we only need `(chainId, address)`.
+ */
+export const toSafeItems = (safes: SpaceSafeEntry[]): SafeItem[] =>
+  safes.flatMap((safe) =>
+    safe.chainEntries
+      .filter((c) => c.isDeployed)
+      .map((c) => ({
+        chainId: c.chainId,
+        address: safe.address,
+        isReadOnly: false,
+        isPinned: false,
+        lastVisited: 0,
+        name: undefined,
+      })),
+  )
+
+/**
+ * Reconcile local `isDeployed` flags against CGW's confirmed deployments.
+ *
+ * The local `undeployedSafes` slice only tracks counterfactual Safes this browser created.
+ * Multichain Safes coming from the space API can include chains that are counterfactual for
+ * another space member — `isDeployed` resolves to `true` locally, but CGW has no on-chain
+ * Safe to return. Without this reconciliation the table shows a chevron (scannable) for the
+ * ghost chain, the scan queue enqueues it, and its queries 404 — hanging the sequential queue.
+ *
+ * `confirmedDeployedKeys` is the set of `scanKey(address, chainId)` strings present in the
+ * batch overview response. Pass `null` while the query is still loading or returned nothing
+ * (treat as inconclusive) — the function then leaves flags untouched.
+ */
+export const reconcileDeployedSafes = (
+  safes: SpaceSafeEntry[],
+  confirmedDeployedKeys: Set<string> | null,
+  scanKey: (address: string, chainId: string) => string,
+): SpaceSafeEntry[] => {
+  if (!confirmedDeployedKeys) return safes
+  return safes.map((safe) => {
+    const reconciled = safe.chainEntries.map((c) =>
+      c.isDeployed && !confirmedDeployedKeys.has(scanKey(safe.address, c.chainId)) ? { ...c, isDeployed: false } : c,
+    )
+    const changed = reconciled.some((c, i) => c !== safe.chainEntries[i])
+    return changed ? { ...safe, chainEntries: reconciled } : safe
+  })
+}

--- a/apps/web/src/features/spaces/components/Sidebar/config/index.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/config/index.tsx
@@ -16,6 +16,7 @@ import {
   ChevronLeft,
   PanelRight,
   EllipsisVertical,
+  Shield,
 } from 'lucide-react'
 import { AppRoutes } from '@/config/routes'
 import type { SidebarItemConfig, SidebarGroupConfig } from '../types'
@@ -52,13 +53,12 @@ export const spacesSetupGroup: SidebarGroupConfig = {
       label: 'Team',
       href: AppRoutes.spaces.members,
     },
-    // TODO: Activate when Spaces Security page is ready
-    // {
-    //   icon: Shield,
-    //   label: 'Security',
-    //   href: AppRoutes.spaces.security,
-    //   activeMemberOnly: true,
-    // },
+    {
+      icon: Shield,
+      label: 'Security',
+      href: AppRoutes.spaces.security,
+      activeMemberOnly: true,
+    },
     {
       icon: Settings,
       label: 'Settings',

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/SpacesSidebarContent.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/SpacesSidebarContent.tsx
@@ -1,10 +1,13 @@
-import type { ReactElement } from 'react'
+import { type ReactElement, useMemo } from 'react'
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
 import { useIsActiveMember } from '@/features/spaces/hooks/useSpaceMembers'
 import { spacesMainNavigation, spacesSetupGroup } from '../../config'
 import { useResolvedSidebarNav } from '../../hooks/useResolvedSidebarNav'
 import type { SidebarItemConfig, SidebarVariantContentProps } from '../../types'
 import { SpacesSidebarVariant } from '../SpacesSidebarVariant'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { AppRoutes } from '@/config/routes'
 
 export const SpacesSidebarContent = ({
   selectedSpace,
@@ -14,6 +17,7 @@ export const SpacesSidebarContent = ({
 }: SidebarVariantContentProps): ReactElement => {
   const spaceId = useCurrentSpaceId()
   const isActiveMember = useIsActiveMember(selectedSpace?.id)
+  const isSecurityHubEnabled = useHasFeature(FEATURES.SECURITY_HUB)
 
   const getLink = (item: SidebarItemConfig) => ({
     pathname: item.href,
@@ -22,7 +26,17 @@ export const SpacesSidebarContent = ({
 
   const isItemDisabled = (item: SidebarItemConfig) => !!item.activeMemberOnly && !isActiveMember
 
-  const { mainNavItems, setupGroup } = useResolvedSidebarNav(spacesMainNavigation, spacesSetupGroup, {
+  // Drop the Security entry from the Setup group when the chain feature flag is explicitly
+  // off. `undefined` means the chain config is still loading — keep the item to avoid flicker.
+  const filteredSetupGroup = useMemo(
+    () =>
+      isSecurityHubEnabled === false
+        ? { ...spacesSetupGroup, items: spacesSetupGroup.items.filter((i) => i.href !== AppRoutes.spaces.security) }
+        : spacesSetupGroup,
+    [isSecurityHubEnabled],
+  )
+
+  const { mainNavItems, setupGroup } = useResolvedSidebarNav(spacesMainNavigation, filteredSetupGroup, {
     getLink,
     isItemDisabled,
   })

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/__tests__/SpacesSidebarContent.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/__tests__/SpacesSidebarContent.test.tsx
@@ -6,6 +6,7 @@ import type { SpaceItem, ResolvedSidebarItem, ResolvedSidebarGroup } from '../..
 const mockUseCurrentSpaceId = jest.fn()
 const mockUseIsActiveMember = jest.fn()
 const mockUseResolvedSidebarNav = jest.fn()
+const mockUseHasFeature = jest.fn()
 
 jest.mock('@/features/spaces/hooks/useCurrentSpaceId', () => ({
   useCurrentSpaceId: () => mockUseCurrentSpaceId(),
@@ -13,6 +14,10 @@ jest.mock('@/features/spaces/hooks/useCurrentSpaceId', () => ({
 
 jest.mock('@/features/spaces/hooks/useSpaceMembers', () => ({
   useIsActiveMember: jest.fn((spaceId) => mockUseIsActiveMember(spaceId)),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  useHasFeature: () => mockUseHasFeature(),
 }))
 
 jest.mock('../../../hooks/useResolvedSidebarNav', () => ({
@@ -110,6 +115,7 @@ describe('SpacesSidebarContent', () => {
     mockUseCurrentSpaceId.mockReturnValue('1')
     mockUseIsActiveMember.mockReturnValue(true)
     mockUseResolvedSidebarNav.mockReturnValue(mockResolvedNavItems)
+    mockUseHasFeature.mockReturnValue(true)
   })
 
   it('renders SpacesSidebarVariant with resolved navigation', () => {
@@ -157,6 +163,36 @@ describe('SpacesSidebarContent', () => {
     render(<SpacesSidebarContent spaceInitial="T" selectedSpace={undefined} spaces={mockSpaces} />)
 
     expect(screen.getByText(/Main items:/)).toBeInTheDocument()
+  })
+
+  describe('SECURITY_HUB feature flag', () => {
+    it('hides the Security entry when the flag is explicitly off', () => {
+      mockUseHasFeature.mockReturnValue(false)
+
+      render(<SpacesSidebarContent spaceInitial="T" selectedSpace={mockSpace} spaces={mockSpaces} />)
+
+      const [, setupGroup] = mockUseResolvedSidebarNav.mock.calls[0]
+      // The mocked config has Team + Security; only Team should remain.
+      expect(setupGroup.items.map((i: { href: string }) => i.href)).toEqual(['/spaces/members'])
+    })
+
+    it('keeps the Security entry while the flag is undefined (chain config still loading)', () => {
+      mockUseHasFeature.mockReturnValue(undefined)
+
+      render(<SpacesSidebarContent spaceInitial="T" selectedSpace={mockSpace} spaces={mockSpaces} />)
+
+      const [, setupGroup] = mockUseResolvedSidebarNav.mock.calls[0]
+      expect(setupGroup.items).toHaveLength(2)
+    })
+
+    it('keeps the Security entry when the flag is enabled', () => {
+      mockUseHasFeature.mockReturnValue(true)
+
+      render(<SpacesSidebarContent spaceInitial="T" selectedSpace={mockSpace} spaces={mockSpaces} />)
+
+      const [, setupGroup] = mockUseResolvedSidebarNav.mock.calls[0]
+      expect(setupGroup.items).toHaveLength(2)
+    })
   })
 
   it('is unaffected by geoblocking — nav items remain visible when user is blocked', () => {

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
@@ -7,6 +7,7 @@ import HomeIcon from '@/public/images/sidebar/home.svg'
 import SettingsIcon from '@/public/images/sidebar/settings.svg'
 import MembersIcon from '@/public/images/sidebar/members.svg'
 import AccountsIcon from '@/public/images/sidebar/wallet.svg'
+import SecurityIcon from '@mui/icons-material/ShieldOutlined'
 import { SvgIcon } from '@mui/material'
 
 export type DynamicNavItem = {
@@ -45,6 +46,12 @@ export const navItems: DynamicNavItem[] = [
     label: 'Address book',
     icon: <SvgIcon component={ABIcon} inheritViewBox />,
     href: AppRoutes.spaces.addressBook,
+  },
+  {
+    label: 'Security',
+    icon: <SecurityIcon />,
+    href: AppRoutes.spaces.security,
+    activeMemberOnly: true,
   },
   {
     label: 'Settings',

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/index.tsx
@@ -9,17 +9,24 @@ import {
   SidebarListItemText,
 } from '@/components/sidebar/SidebarList'
 import { useCurrentSpaceId, useIsActiveMember } from '@/features/spaces'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { AppRoutes } from '@/config/routes'
 import { navItems } from './config'
 
 const Navigation = (): ReactElement => {
   const router = useRouter()
   const spaceId = useCurrentSpaceId()
   const isActiveMember = useIsActiveMember()
+  const isSecurityHubEnabled = useHasFeature(FEATURES.SECURITY_HUB)
 
   return (
     <SidebarList>
       {navItems.map((item) => {
-        const hideItem = item.activeMemberOnly && !isActiveMember
+        // Hide the Security entry when the chain feature flag is explicitly off. While the
+        // chain config is still loading (`undefined`) we keep the item to avoid flicker.
+        const hideForFeatureFlag = item.href === AppRoutes.spaces.security && isSecurityHubEnabled === false
+        const hideItem = (item.activeMemberOnly && !isActiveMember) || hideForFeatureFlag
         const isSelected = router.pathname === item.href
 
         if (hideItem) return null

--- a/apps/web/src/features/spaces/contract.ts
+++ b/apps/web/src/features/spaces/contract.ts
@@ -32,6 +32,7 @@ import type CreateSpaceOnboarding from './components/CreateSpaceOnboarding'
 import type SelectSafesOnboarding from './components/SelectSafesOnboarding'
 import type InviteMembersOnboarding from './components/InviteMembersOnboarding'
 import type SelectSafeModal from './components/SelectSafeModal'
+import type SecurityHubPage from './components/SecurityHub/Page'
 
 // Utility services
 import type { isUnauthorized, filterSpacesByStatus, getNonDeclinedSpaces } from './utils'
@@ -63,6 +64,7 @@ export interface SpacesContract {
   SpaceSafeAccountsPage: typeof SpaceSafeAccountsPage
   SpaceAddressBookPage: typeof SpaceAddressBookPage
   SpaceSettingsPage: typeof SpaceSettingsPage
+  SecurityHubPage: typeof SecurityHubPage
 
   // Modal components (PascalCase) - stub renders null
   SelectSafeModal: typeof SelectSafeModal

--- a/apps/web/src/features/spaces/feature.ts
+++ b/apps/web/src/features/spaces/feature.ts
@@ -36,6 +36,7 @@ import CreateSpaceOnboarding from './components/CreateSpaceOnboarding'
 import SelectSafesOnboarding from './components/SelectSafesOnboarding'
 import InviteMembersOnboarding from './components/InviteMembersOnboarding'
 import SelectSafeModal from './components/SelectSafeModal'
+import SecurityHubPage from './components/SecurityHub/Page'
 
 // Service imports
 import { isUnauthorized, filterSpacesByStatus, getNonDeclinedSpaces } from './utils'
@@ -74,6 +75,7 @@ const feature: SpacesContract = {
   SpaceSafeAccountsPage,
   SpaceAddressBookPage,
   SpaceSettingsPage,
+  SecurityHubPage,
 
   // Services
   isUnauthorized,

--- a/apps/web/src/features/spaces/hooks/__tests__/useAutoScan.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useAutoScan.test.ts
@@ -1,0 +1,277 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import useAutoScan, { type AutoScanServices } from '../useAutoScan'
+import type { ScanContext, ScanResult, SecurityScanner } from '@/features/security/types'
+import type { SpaceSafeEntry, SelectedSafe } from '@/features/spaces/components/SecurityHub'
+
+// useSafeScanContext is mocked to return the value we inject via `mockScanContext`
+// so these tests stay focused on queue/scanner orchestration, not the context builder.
+let mockScanContext: ScanContext | null = null
+jest.mock('@/features/spaces/hooks/useSafeScanContext', () => ({
+  __esModule: true,
+  default: () => mockScanContext,
+}))
+
+// ── fixtures ─────────────────────────────────────────────────────────────
+
+const SAFE_A = '0xA000000000000000000000000000000000000000'
+const SAFE_B = '0xB000000000000000000000000000000000000000'
+const CHAIN = '1'
+
+const mkSafe = (address: string, chainId = CHAIN): SpaceSafeEntry => ({
+  address,
+  chainId,
+  name: `Safe ${address.slice(0, 6)}`,
+  isMultichain: false,
+  chainEntries: [{ chainId, isDeployed: true }],
+})
+
+const mkSelected = (address: string, chainId = CHAIN): SelectedSafe => ({ address, chainId })
+
+const mkResult = (overrides: Partial<ScanResult> = {}): ScanResult => ({
+  status: 'clear',
+  severity: 'Low',
+  score: 100,
+  evidence: [],
+  remediation: '',
+  lastChecked: new Date().toISOString(),
+  ...overrides,
+})
+
+const mkContext = (): ScanContext => ({
+  owners: [],
+  threshold: 1,
+  modules: null,
+  guard: null,
+  fallbackHandler: null,
+  implementationVersionState: 'UP_TO_DATE',
+  implementationAddress: '0x',
+  version: '1.4.1',
+  chainId: CHAIN,
+  safeAddress: SAFE_A,
+  latestVersion: '1.4.1',
+  isNonCriticalUpdate: false,
+  masterCopyDeployer: 'Gnosis',
+  nonce: 0,
+  queuedTxCount: 0,
+  balanceUsd: 0,
+  chainSupportsRecovery: false,
+  chainSupportsHypernative: false,
+  chainSupportsTransactionScanning: false,
+  isMultichain: false,
+  multichainSignersConsistent: true,
+  multichainDeviatingChains: [],
+  creationInfo: null,
+})
+
+/** A scanner that resolves on the next tick with a static result. */
+const mkScanner = (id: string, result: ScanResult = mkResult()): SecurityScanner => ({
+  id,
+  scan: jest.fn(() => Promise.resolve(result)),
+})
+
+/** A scanner that rejects — simulates a failure that should NOT block the queue. */
+const mkFailingScanner = (id: string, error: Error = new Error('boom')): SecurityScanner => ({
+  id,
+  scan: jest.fn(() => Promise.reject(error)),
+})
+
+/** Build the services bundle with sensible defaults + a real cache Map. */
+const mkServices = (scanners: SecurityScanner[]): AutoScanServices & { cache: Map<string, unknown> } => {
+  const cache = new Map<string, unknown>()
+  return {
+    scanners,
+    scanKey: (address: string, chainId: string) => `${address}:${chainId}`,
+    getScanResultsCache: () => cache as never,
+    evictScanCache: jest.fn(),
+    // Pass-through timeout wrapper for tests (real version races with a 15s timer)
+    withScannerTimeout: <T>(p: Promise<T>) => p,
+    cache,
+  }
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+describe('useAutoScan', () => {
+  beforeEach(() => {
+    mockScanContext = null
+    jest.useFakeTimers()
+    // Silence expected console.error for failing-scanner tests
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  it('returns initial idle state', () => {
+    const { result } = renderHook(() => useAutoScan([], [], {}, mkServices([mkScanner('a')]), jest.fn()))
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.justCompleted).toBe(false)
+    expect(result.current.scanningKeys.size).toBe(0)
+  })
+
+  it('startScan no-ops when services are null', () => {
+    const onComplete = jest.fn()
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, null, onComplete))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    // Services were null, so startScan should early-return without changing state
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.scanningKeys.size).toBe(0)
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('populates scanningKeys and starts running when startScan is called', () => {
+    const services = mkServices([mkScanner('a')])
+    const queue = [mkSelected(SAFE_A), mkSelected(SAFE_B)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A), mkSafe(SAFE_B)], {}, services, jest.fn()))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    expect(result.current.isRunning).toBe(true)
+    expect(result.current.scanningKeys.size).toBe(2)
+    expect(result.current.scanningKeys.has(`${SAFE_A}:${CHAIN}`)).toBe(true)
+    expect(result.current.scanningKeys.has(`${SAFE_B}:${CHAIN}`)).toBe(true)
+  })
+
+  it('runs scanners and invokes onComplete when context is ready', async () => {
+    const onComplete = jest.fn()
+    const scanner = mkScanner('account_setup', mkResult({ status: 'clear' }))
+    const services = mkServices([scanner])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, onComplete))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    expect(scanner.scan).toHaveBeenCalledWith(mockScanContext)
+    expect(onComplete).toHaveBeenCalledWith(
+      SAFE_A,
+      CHAIN,
+      expect.any(Number),
+      expect.objectContaining({ account_setup: expect.objectContaining({ status: 'clear' }) }),
+    )
+  })
+
+  it('writes completed results to the shared cache via getScanResultsCache', async () => {
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, jest.fn()))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    await waitFor(() => expect(services.cache.has(`${SAFE_A}:${CHAIN}`)).toBe(true))
+    expect(services.evictScanCache).toHaveBeenCalled()
+  })
+
+  it('advances past failing scanners — queue still drains', async () => {
+    const onComplete = jest.fn()
+    // One pass + one fail; the Safe should still complete and the queue should drain.
+    const passing = mkScanner('account_setup', mkResult({ status: 'clear' }))
+    const failing = mkFailingScanner('modules')
+    const services = mkServices([passing, failing])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, onComplete))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    // Passing result is recorded; failing one is omitted (not rethrown)
+    const [, , , results] = onComplete.mock.calls[0]
+    expect(results).toHaveProperty('account_setup')
+    expect(results).not.toHaveProperty('modules')
+  })
+
+  it('sets justCompleted briefly after the queue drains, then clears it', async () => {
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, jest.fn()))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    await waitFor(() => expect(result.current.isRunning).toBe(false))
+    expect(result.current.justCompleted).toBe(true)
+
+    // Advance past the 2.5s completion grace period
+    act(() => {
+      jest.advanceTimersByTime(2600)
+    })
+    expect(result.current.justCompleted).toBe(false)
+  })
+
+  it('bails past a target whose scanContext never resolves so the queue keeps draining', async () => {
+    // Regression: a multichain Safe can include chains marked isDeployed=true locally but
+    // counterfactual in reality; Safe/masterCopies queries 404, scanContext stays null,
+    // and the sequential queue used to hang indefinitely.
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const onComplete = jest.fn()
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+
+    // Leave scanContext null for SAFE_A (simulates the hung queries) but resolve for SAFE_B.
+    mockScanContext = null
+    const queue = [mkSelected(SAFE_A), mkSelected(SAFE_B)]
+    const safes = [mkSafe(SAFE_A), mkSafe(SAFE_B)]
+    const { result, rerender } = renderHook(() => useAutoScan(queue, safes, {}, services, onComplete))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    // While scanContext is null for SAFE_A, the scanner never fires.
+    expect(scanner.scan).not.toHaveBeenCalled()
+
+    // Advance past the bail timeout — queue should move off SAFE_A and onto SAFE_B.
+    mockScanContext = mkContext()
+    await act(async () => {
+      jest.advanceTimersByTime(15_000)
+    })
+    rerender()
+
+    // SAFE_A's scanning key should have been released so its table row stops showing loading.
+    await waitFor(() => expect(result.current.scanningKeys.has(`${SAFE_A}:${CHAIN}`)).toBe(false))
+    // SAFE_B runs normally and completes.
+    await waitFor(() => expect(onComplete).toHaveBeenCalledWith(SAFE_B, CHAIN, expect.any(Number), expect.any(Object)))
+  })
+
+  it('removes the scanned key from scanningKeys when its scanners complete', async () => {
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, jest.fn()))
+
+    act(() => {
+      result.current.startScan()
+    })
+    expect(result.current.scanningKeys.has(`${SAFE_A}:${CHAIN}`)).toBe(true)
+
+    await waitFor(() => expect(result.current.scanningKeys.has(`${SAFE_A}:${CHAIN}`)).toBe(false))
+  })
+})

--- a/apps/web/src/features/spaces/hooks/__tests__/useAutoScan.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useAutoScan.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import useAutoScan, { type AutoScanServices } from '../useAutoScan'
-import type { ScanContext, ScanResult, SecurityScanner } from '@/features/security/types'
+import type { ScanContext, ScanResult, ScannerId, SecurityScanner } from '@/features/security/types'
 import type { SpaceSafeEntry, SelectedSafe } from '@/features/spaces/components/SecurityHub'
 
 // useSafeScanContext is mocked to return the value we inject via `mockScanContext`
@@ -64,28 +64,31 @@ const mkContext = (): ScanContext => ({
 })
 
 /** A scanner that resolves on the next tick with a static result. */
-const mkScanner = (id: string, result: ScanResult = mkResult()): SecurityScanner => ({
+const mkScanner = (id: ScannerId, result: ScanResult = mkResult()): SecurityScanner => ({
   id,
   scan: jest.fn(() => Promise.resolve(result)),
 })
 
 /** A scanner that rejects — simulates a failure that should NOT block the queue. */
-const mkFailingScanner = (id: string, error: Error = new Error('boom')): SecurityScanner => ({
+const mkFailingScanner = (id: ScannerId, error: Error = new Error('boom')): SecurityScanner => ({
   id,
   scan: jest.fn(() => Promise.reject(error)),
 })
 
-/** Build the services bundle with sensible defaults + a real cache Map. */
-const mkServices = (scanners: SecurityScanner[]): AutoScanServices & { cache: Map<string, unknown> } => {
-  const cache = new Map<string, unknown>()
+/** Build the services bundle with sensible defaults + an in-test setCachedScan spy. */
+const mkServices = (
+  scanners: SecurityScanner[],
+): AutoScanServices & { writes: Map<string, { results: Record<string, ScanResult>; timestamp: number }> } => {
+  const writes = new Map<string, { results: Record<string, ScanResult>; timestamp: number }>()
   return {
     scanners,
     scanKey: (address: string, chainId: string) => `${address}:${chainId}`,
-    getScanResultsCache: () => cache as never,
-    evictScanCache: jest.fn(),
+    setCachedScan: jest.fn((key: string, results, timestamp) => {
+      writes.set(key, { results: results as Record<string, ScanResult>, timestamp })
+    }),
     // Pass-through timeout wrapper for tests (real version races with a 15s timer)
     withScannerTimeout: <T>(p: Promise<T>) => p,
-    cache,
+    writes,
   }
 }
 
@@ -105,7 +108,7 @@ describe('useAutoScan', () => {
   })
 
   it('returns initial idle state', () => {
-    const { result } = renderHook(() => useAutoScan([], [], {}, mkServices([mkScanner('a')]), jest.fn()))
+    const { result } = renderHook(() => useAutoScan([], [], {}, mkServices([mkScanner('account_setup')]), jest.fn()))
     expect(result.current.isRunning).toBe(false)
     expect(result.current.justCompleted).toBe(false)
     expect(result.current.scanningKeys.size).toBe(0)
@@ -127,7 +130,7 @@ describe('useAutoScan', () => {
   })
 
   it('populates scanningKeys and starts running when startScan is called', () => {
-    const services = mkServices([mkScanner('a')])
+    const services = mkServices([mkScanner('account_setup')])
     const queue = [mkSelected(SAFE_A), mkSelected(SAFE_B)]
     const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A), mkSafe(SAFE_B)], {}, services, jest.fn()))
 
@@ -164,7 +167,7 @@ describe('useAutoScan', () => {
     )
   })
 
-  it('writes completed results to the shared cache via getScanResultsCache', async () => {
+  it('writes completed results to the shared cache via setCachedScan', async () => {
     const scanner = mkScanner('account_setup')
     const services = mkServices([scanner])
     mockScanContext = mkContext()
@@ -176,8 +179,12 @@ describe('useAutoScan', () => {
       result.current.startScan()
     })
 
-    await waitFor(() => expect(services.cache.has(`${SAFE_A}:${CHAIN}`)).toBe(true))
-    expect(services.evictScanCache).toHaveBeenCalled()
+    await waitFor(() => expect(services.writes.has(`${SAFE_A}:${CHAIN}`)).toBe(true))
+    expect(services.setCachedScan).toHaveBeenCalledWith(
+      `${SAFE_A}:${CHAIN}`,
+      expect.objectContaining({ account_setup: expect.any(Object) }),
+      expect.any(Number),
+    )
   })
 
   it('advances past failing scanners — queue still drains', async () => {

--- a/apps/web/src/features/spaces/hooks/__tests__/useSafeScanContext.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSafeScanContext.test.ts
@@ -1,0 +1,217 @@
+import { renderHook } from '@testing-library/react'
+import useSafeScanContext from '../useSafeScanContext'
+import type { SelectedSafe, SpaceSafeEntry } from '@/features/spaces/components/SecurityHub'
+
+// ── mocks ──────────────────────────────────────────────────────────────
+
+const SAFE_ADDRESS = '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6'
+const CHAIN_ID = '1'
+
+const mockSafeInfo = {
+  owners: [{ value: '0x1111111111111111111111111111111111111111' }],
+  threshold: 1,
+  modules: null,
+  guard: null,
+  fallbackHandler: { value: '0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4' },
+  implementationVersionState: 'UP_TO_DATE' as const,
+  implementation: { value: '0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552' },
+  version: '1.4.1',
+  nonce: 5,
+}
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/safes', () => ({
+  useSafesGetSafeV1Query: jest.fn(),
+}))
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/chains', () => ({
+  useChainsGetMasterCopiesV1Query: jest.fn(),
+}))
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/transactions', () => ({
+  useTransactionsGetCreationTransactionV1Query: jest.fn(),
+}))
+jest.mock('@/store/api/gateway', () => ({
+  useGetSafeOverviewQuery: jest.fn(),
+  useGetMultipleSafeOverviewsQuery: jest.fn(),
+}))
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  useChain: jest.fn(),
+}))
+jest.mock('@/store', () => ({ useAppSelector: jest.fn() }))
+jest.mock('@/store/slices', () => ({ selectCurrency: jest.fn(), selectUndeployedSafes: jest.fn() }))
+jest.mock('@/features/multichain/utils', () => ({
+  getSafeSetups: jest.fn(),
+  getSharedSetup: jest.fn(),
+  getDeviatingSetups: jest.fn(),
+}))
+jest.mock('@safe-global/utils/utils/chains', () => ({
+  getLatestSafeVersion: jest.fn(() => '1.4.1'),
+  isNonCriticalUpdate: jest.fn(() => false),
+  hasFeature: jest.fn(() => false),
+  FEATURES: { RECOVERY: 'RECOVERY', HYPERNATIVE: 'HYPERNATIVE', RISK_MITIGATION: 'RISK_MITIGATION' },
+}))
+
+import { useSafesGetSafeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { useChainsGetMasterCopiesV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { useTransactionsGetCreationTransactionV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { useGetSafeOverviewQuery, useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
+import { useChain } from '@/hooks/useChains'
+import useChains from '@/hooks/useChains'
+import { useAppSelector } from '@/store'
+
+const defaultSelected: SelectedSafe = { address: SAFE_ADDRESS, chainId: CHAIN_ID }
+const defaultEntry: SpaceSafeEntry = {
+  address: SAFE_ADDRESS,
+  chainId: CHAIN_ID,
+  name: 'Test Safe',
+  isMultichain: false,
+  chainEntries: [{ chainId: CHAIN_ID, isDeployed: true }],
+}
+
+function setupDefaults() {
+  ;(useSafesGetSafeV1Query as jest.Mock).mockReturnValue({
+    currentData: mockSafeInfo,
+    isLoading: false,
+  })
+  ;(useChainsGetMasterCopiesV1Query as jest.Mock).mockReturnValue({ currentData: [], isLoading: false })
+  ;(useTransactionsGetCreationTransactionV1Query as jest.Mock).mockReturnValue({
+    currentData: undefined,
+    isLoading: false,
+  })
+  ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
+    currentData: { fiatTotal: '1000', queued: 2 },
+    isLoading: false,
+  })
+  ;(useGetMultipleSafeOverviewsQuery as jest.Mock).mockReturnValue({ currentData: undefined, isLoading: false })
+  ;(useChain as jest.Mock).mockReturnValue({ chainId: CHAIN_ID, features: [] })
+  ;(useChains as jest.Mock).mockReturnValue({ configs: [] })
+  ;(useAppSelector as jest.Mock).mockReturnValue({})
+}
+
+// ── tests ──────────────────────────────────────────────────────────────
+
+describe('useSafeScanContext', () => {
+  beforeEach(() => {
+    setupDefaults()
+  })
+
+  it('returns a valid ScanContext when all data is available', () => {
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
+    expect(result.current).not.toBeNull()
+    expect(result.current?.chainId).toBe(CHAIN_ID)
+    expect(result.current?.safeAddress).toBe(SAFE_ADDRESS)
+    expect(result.current?.threshold).toBe(1)
+    expect(result.current?.version).toBe('1.4.1')
+  })
+
+  it('returns null when selected is null', () => {
+    const { result } = renderHook(() => useSafeScanContext(null, defaultEntry))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when entry is undefined', () => {
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, undefined))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null when Safe data is still loading', () => {
+    ;(useSafesGetSafeV1Query as jest.Mock).mockReturnValue({
+      currentData: undefined,
+      isLoading: true,
+    })
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null for undeployed Safe', () => {
+    const undeployedEntry: SpaceSafeEntry = {
+      ...defaultEntry,
+      chainEntries: [{ chainId: CHAIN_ID, isDeployed: false }],
+    }
+    // useSafesGetSafeV1Query will skip and return no data
+    ;(useSafesGetSafeV1Query as jest.Mock).mockReturnValue({
+      currentData: undefined,
+      isLoading: false,
+    })
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, undeployedEntry))
+    expect(result.current).toBeNull()
+  })
+
+  it('includes correct balanceUsd from safeOverview.fiatTotal', () => {
+    ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
+      currentData: { fiatTotal: '50000.5', queued: 0 },
+      isLoading: false,
+    })
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
+    expect(result.current?.balanceUsd).toBe(50000.5)
+  })
+
+  it('includes correct queuedTxCount from safeOverview.queued', () => {
+    ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
+      currentData: { fiatTotal: '0', queued: 7 },
+      isLoading: false,
+    })
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
+    expect(result.current?.queuedTxCount).toBe(7)
+  })
+
+  it('sets isMultichain based on entry having multiple chain entries', () => {
+    const multichainEntry: SpaceSafeEntry = {
+      ...defaultEntry,
+      isMultichain: true,
+      chainEntries: [
+        { chainId: '1', isDeployed: true },
+        { chainId: '137', isDeployed: true },
+      ],
+    }
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, multichainEntry))
+    expect(result.current?.isMultichain).toBe(true)
+  })
+
+  it('handles creation info when available', () => {
+    ;(useTransactionsGetCreationTransactionV1Query as jest.Mock).mockReturnValue({
+      currentData: {
+        factoryAddress: '0xFactory',
+        creator: '0xCreator',
+        masterCopy: '0xMasterCopy',
+        transactionHash: '0xTxHash',
+      },
+    })
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
+    expect(result.current?.creationInfo).toEqual({
+      factoryAddress: '0xFactory',
+      creator: '0xCreator',
+      masterCopy: '0xMasterCopy',
+      transactionHash: '0xTxHash',
+    })
+  })
+
+  it('sets creationInfo to null when no creation data', () => {
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
+    expect(result.current?.creationInfo).toBeNull()
+  })
+
+  it('uses overviewData when provided instead of querying the API', () => {
+    // Override the query mock to return different values — these should be ignored
+    ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
+      currentData: { fiatTotal: '999999', queued: 99 },
+      isLoading: false,
+    })
+    const overviewData = { balanceUsd: 42000, queuedTxCount: 3 }
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry, overviewData))
+    expect(result.current?.balanceUsd).toBe(42000)
+    expect(result.current?.queuedTxCount).toBe(3)
+  })
+
+  it('skips overview loading guard when overviewData is provided', () => {
+    // Simulate the overview query still loading — should NOT block context creation
+    ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
+      currentData: undefined,
+      isLoading: true,
+    })
+    const overviewData = { balanceUsd: 500, queuedTxCount: 1 }
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry, overviewData))
+    expect(result.current).not.toBeNull()
+    expect(result.current?.balanceUsd).toBe(500)
+  })
+})

--- a/apps/web/src/features/spaces/hooks/useAutoScan.ts
+++ b/apps/web/src/features/spaces/hooks/useAutoScan.ts
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { ScanResult, SecurityScanner } from '@/features/security/types'
+import type { SecurityContract } from '@/features/security'
+import useSafeScanContext, { type OverviewData } from '@/features/spaces/hooks/useSafeScanContext'
+import type { SpaceSafeEntry, SelectedSafe } from '@/features/spaces/components/SecurityHub'
+
+// How long to wait for useSafeScanContext to resolve before bailing past a target.
+// Protects against "ghost-deployed" chains: a multichain Safe entry may be flagged
+// isDeployed=true locally (because this client's undeployedSafes slice doesn't track it),
+// but be counterfactual in reality — the Safe/masterCopies/creation queries then 404 and
+// scanContext stays null forever, hanging the sequential queue on that target.
+const SCAN_CONTEXT_BAIL_MS = 2_000
+
+/**
+ * Services this hook needs from the security feature. Callers obtain these via
+ * useLoadFeature and pass them in once the feature is $isReady.
+ */
+export type AutoScanServices = {
+  scanners: SecurityScanner[]
+  scanKey: SecurityContract['scanKey']
+  getScanResultsCache: SecurityContract['getScanResultsCache']
+  evictScanCache: SecurityContract['evictScanCache']
+  withScannerTimeout: SecurityContract['withScannerTimeout']
+}
+
+export type AutoScanState = {
+  /** Set of scanKey(address, chainId) currently being scanned. */
+  scanningKeys: Set<string>
+  /** True while the queue is actively advancing through Safes. */
+  isRunning: boolean
+  /** Briefly true for ~2.5s after the queue drains — useful for success toasts. */
+  justCompleted: boolean
+  /** Kicks off a fresh scan over the current queue. */
+  startScan: () => void
+}
+
+/**
+ * Runs security scanners sequentially over a queue of Safes.
+ *
+ * - Advances one Safe at a time so scanner load stays bounded.
+ * - Each Safe's scanners run in parallel, each with a timeout guard.
+ * - Completed results are written to the shared scanResultsCache so the
+ *   drawer reuses them instead of re-scanning when opened.
+ * - Returns {@link AutoScanState} for the host component.
+ *
+ * @param queue          - Safes to scan, in order.
+ * @param safes          - Full SpaceSafeEntry list (used to look up chain context per target).
+ * @param overviewMap    - Pre-fetched balances/queued counts, keyed by scanKey.
+ *                         Passed through to useSafeScanContext to avoid per-Safe overview requests.
+ * @param services       - Security-feature services; hook no-ops while null.
+ * @param onComplete     - Invoked with results each time a Safe finishes.
+ */
+const useAutoScan = (
+  queue: SelectedSafe[],
+  safes: SpaceSafeEntry[],
+  overviewMap: Record<string, OverviewData>,
+  services: AutoScanServices | null,
+  onComplete: (address: string, chainId: string, timestamp: number, results: Record<string, ScanResult>) => void,
+): AutoScanState => {
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [scanningKeys, setScanningKeys] = useState<Set<string>>(new Set())
+  const [isRunning, setIsRunning] = useState(false)
+  const [justCompleted, setJustCompleted] = useState(false)
+  const completedRef = useRef<Set<string>>(new Set())
+  const scanningRef = useRef<string | null>(null)
+  const completionTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  // Store onComplete in a ref to avoid stale closure — the effect captures
+  // this ref instead of the callback directly.
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
+
+  const currentTarget = isRunning && currentIndex < queue.length ? queue[currentIndex] : null
+  const currentEntry = currentTarget ? safes.find((s) => s.address === currentTarget.address) : undefined
+
+  // Pass pre-fetched overview data to avoid redundant per-Safe API requests.
+  // The batch query in SecurityHub already fetches all overviews — reuse that data.
+  const currentOverview =
+    currentTarget && services ? overviewMap[services.scanKey(currentTarget.address, currentTarget.chainId)] : undefined
+  const scanContext = useSafeScanContext(currentTarget, currentEntry, currentOverview)
+
+  // Run scanners when context is ready
+  useEffect(() => {
+    if (!scanContext || !currentTarget || !isRunning || !services) return
+
+    const { scanners, scanKey, getScanResultsCache, evictScanCache, withScannerTimeout } = services
+    const key = scanKey(currentTarget.address, currentTarget.chainId)
+    if (completedRef.current.has(key)) {
+      setCurrentIndex((i) => i + 1)
+      return
+    }
+
+    // Guard: don't re-launch scanners if already scanning this key
+    if (scanningRef.current === key) return
+    scanningRef.current = key
+
+    let completed = 0
+    const total = scanners.length
+    const results: Record<string, ScanResult> = {}
+
+    scanners.forEach((scanner) => {
+      withScannerTimeout(scanner.scan(scanContext))
+        .then((result) => {
+          results[scanner.id] = result
+        })
+        .catch((err) => {
+          // Includes "Scanner timed out" rejections from withScannerTimeout — a hung
+          // scanner now releases the slot so the queue can proceed to the next Safe.
+          console.error(`[SecurityHub] Scanner ${scanner.id} failed:`, err)
+        })
+        .finally(() => {
+          completed++
+          if (completed === total) {
+            completedRef.current.add(key)
+            scanningRef.current = null
+            const timestamp = Date.now()
+            // Share results with useSecurityScan's module-level cache so the drawer reuses
+            // them instead of re-scanning when the user opens this Safe's report.
+            getScanResultsCache().set(key, { results, timestamp })
+            evictScanCache()
+            onCompleteRef.current(currentTarget.address, currentTarget.chainId, timestamp, results)
+            setScanningKeys((prev) => {
+              const next = new Set(prev)
+              next.delete(key)
+              return next
+            })
+            setCurrentIndex((i) => i + 1)
+          }
+        })
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scanContext, currentTarget?.address, currentTarget?.chainId, isRunning, services])
+
+  // Bail past a target whose scanContext never resolves. Without this the entire queue
+  // stalls on a ghost-deployed chain (see SCAN_CONTEXT_BAIL_MS comment). The timer resets
+  // whenever currentTarget changes and is cleared as soon as scanContext becomes non-null.
+  useEffect(() => {
+    if (!currentTarget || !isRunning || !services || scanContext) return
+    const key = services.scanKey(currentTarget.address, currentTarget.chainId)
+    const timer = setTimeout(() => {
+      console.warn(
+        `[SecurityHub] scan context did not resolve for ${currentTarget.address}:${currentTarget.chainId} within ${SCAN_CONTEXT_BAIL_MS}ms — skipping`,
+      )
+      completedRef.current.add(key)
+      setScanningKeys((prev) => {
+        if (!prev.has(key)) return prev
+        const next = new Set(prev)
+        next.delete(key)
+        return next
+      })
+      setCurrentIndex((i) => i + 1)
+    }, SCAN_CONTEXT_BAIL_MS)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scanContext, currentTarget?.address, currentTarget?.chainId, isRunning, services])
+
+  // Stop when queue is exhausted, show brief completion state
+  useEffect(() => {
+    if (isRunning && currentIndex >= queue.length && queue.length > 0) {
+      setIsRunning(false)
+      setJustCompleted(true)
+      clearTimeout(completionTimerRef.current)
+      completionTimerRef.current = setTimeout(() => setJustCompleted(false), 2500)
+    }
+  }, [isRunning, currentIndex, queue.length])
+
+  // Cleanup on unmount only
+  useEffect(() => () => clearTimeout(completionTimerRef.current), [])
+
+  const startScan = useCallback(() => {
+    if (!services) return
+    completedRef.current = new Set()
+    scanningRef.current = null
+    // Pre-populate ALL keys as scanning so every row shows a loading state immediately.
+    // Each key is removed individually on completion. For multichain parents,
+    // `isAnyChainScanning` stays true until the last chain-child finishes.
+    setScanningKeys(new Set(queue.map((q) => services.scanKey(q.address, q.chainId))))
+    setCurrentIndex(0)
+    setJustCompleted(false)
+    setIsRunning(true)
+  }, [queue, services])
+
+  return { scanningKeys, isRunning, justCompleted, startScan }
+}
+
+export default useAutoScan

--- a/apps/web/src/features/spaces/hooks/useAutoScan.ts
+++ b/apps/web/src/features/spaces/hooks/useAutoScan.ts
@@ -18,8 +18,7 @@ const SCAN_CONTEXT_BAIL_MS = 2_000
 export type AutoScanServices = {
   scanners: SecurityScanner[]
   scanKey: SecurityContract['scanKey']
-  getScanResultsCache: SecurityContract['getScanResultsCache']
-  evictScanCache: SecurityContract['evictScanCache']
+  setCachedScan: SecurityContract['setCachedScan']
   withScannerTimeout: SecurityContract['withScannerTimeout']
 }
 
@@ -82,7 +81,7 @@ const useAutoScan = (
   useEffect(() => {
     if (!scanContext || !currentTarget || !isRunning || !services) return
 
-    const { scanners, scanKey, getScanResultsCache, evictScanCache, withScannerTimeout } = services
+    const { scanners, scanKey, setCachedScan, withScannerTimeout } = services
     const key = scanKey(currentTarget.address, currentTarget.chainId)
     if (completedRef.current.has(key)) {
       setCurrentIndex((i) => i + 1)
@@ -113,10 +112,9 @@ const useAutoScan = (
             completedRef.current.add(key)
             scanningRef.current = null
             const timestamp = Date.now()
-            // Share results with useSecurityScan's module-level cache so the drawer reuses
-            // them instead of re-scanning when the user opens this Safe's report.
-            getScanResultsCache().set(key, { results, timestamp })
-            evictScanCache()
+            // Share results with the module-level cache so the drawer reuses them
+            // instead of re-scanning when the user opens this Safe's report.
+            setCachedScan(key, results, timestamp)
             onCompleteRef.current(currentTarget.address, currentTarget.chainId, timestamp, results)
             setScanningKeys((prev) => {
               const next = new Set(prev)

--- a/apps/web/src/features/spaces/hooks/useSafeScanContext.ts
+++ b/apps/web/src/features/spaces/hooks/useSafeScanContext.ts
@@ -1,0 +1,178 @@
+import { useMemo } from 'react'
+import { type SafeItem } from '@/hooks/safes'
+import { useSafesGetSafeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { useChainsGetMasterCopiesV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+import { useTransactionsGetCreationTransactionV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
+import { useGetMultipleSafeOverviewsQuery, useGetSafeOverviewQuery } from '@/store/api/gateway'
+import useChains, { useChain } from '@/hooks/useChains'
+import { getLatestSafeVersion, isNonCriticalUpdate, hasFeature, FEATURES } from '@safe-global/utils/utils/chains'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { useAppSelector } from '@/store'
+import { selectCurrency, selectUndeployedSafes } from '@/store/slices'
+import { getSafeSetups, getSharedSetup, getDeviatingSetups } from '@/features/multichain/utils'
+import type { ScanContext } from '@/features/security/types'
+import type { SpaceSafeEntry, SelectedSafe } from '@/features/spaces/components/SecurityHub'
+
+export type OverviewData = {
+  balanceUsd: number
+  queuedTxCount: number
+}
+
+const useSafeScanContext = (
+  selected: SelectedSafe | null,
+  entry: SpaceSafeEntry | undefined,
+  overviewData?: OverviewData,
+): ScanContext | null => {
+  const chainId = selected?.chainId ?? ''
+  const address = selected?.address ?? ''
+  const isMultichain = (entry?.chainEntries.length ?? 0) > 1
+  const selectedChainEntry = entry?.chainEntries.find((c) => c.chainId === chainId)
+  const isDeployed = selectedChainEntry?.isDeployed ?? false
+
+  // Fetch SafeState for the selected chain — skip if not deployed
+  const { currentData: safeInfo, isLoading: isSafeLoading } = useSafesGetSafeV1Query(
+    { chainId, safeAddress: address },
+    { skip: !selected || !isDeployed },
+  )
+
+  // Fetch master copies for deployer resolution
+  const { currentData: masterCopies, isLoading: isMasterCopiesLoading } = useChainsGetMasterCopiesV1Query(
+    { chainId },
+    { skip: !selected || !isDeployed },
+  )
+
+  // Fetch creation transaction for factory/deployment validation
+  const { currentData: creationTx, isLoading: isCreationLoading } = useTransactionsGetCreationTransactionV1Query(
+    { chainId, safeAddress: address },
+    { skip: !selected || !isDeployed },
+  )
+
+  // For multichain: fetch overviews for all chains to compare signer setup
+  const currency = useAppSelector(selectCurrency)
+  const undeployedSafes = useAppSelector(selectUndeployedSafes)
+  const multichainSafeItems: SafeItem[] = useMemo(
+    () =>
+      isMultichain && entry
+        ? entry.chainEntries
+            .filter((c) => c.isDeployed)
+            .map((c) => ({
+              chainId: c.chainId,
+              address: entry.address,
+              isReadOnly: false,
+              isPinned: false,
+              lastVisited: 0,
+              name: undefined,
+            }))
+        : [],
+    [isMultichain, entry],
+  )
+  // Use `currentData` (not `data`) — `data` can briefly return the PREVIOUS Safe's overview
+  // when useAutoScan advances from one Safe to the next, before RTK Query resolves the new args.
+  const { currentData: safeOverviews, isLoading: isOverviewsLoading } = useGetMultipleSafeOverviewsQuery(
+    { safes: multichainSafeItems, currency },
+    { skip: !isMultichain || multichainSafeItems.length === 0 },
+  )
+
+  // Fetch overview for balance data (fiatTotal) on the selected chain.
+  // Skip when pre-fetched overviewData is provided (e.g. from the batch query in SecurityHub)
+  // to avoid redundant per-Safe API requests during auto-scan.
+  const { currentData: safeOverview, isLoading: isOverviewLoading } = useGetSafeOverviewQuery(
+    { chainId, safeAddress: address },
+    { skip: !selected || !isDeployed || !!overviewData },
+  )
+
+  const chain = useChain(chainId)
+  const latestVersion = getLatestSafeVersion(chain)
+  const { configs: allChains } = useChains()
+
+  return useMemo(() => {
+    // Wait for ALL dependent queries — not just safeInfo. Returning a context before
+    // overview/masterCopies/creationTx resolve causes scanners to run with defaults
+    // (balanceUsd=0, deployer=null, creationInfo=null) producing incorrect scores.
+    if (!selected || !entry || !safeInfo || isSafeLoading) return null
+    if ((!overviewData && isOverviewLoading) || isMasterCopiesLoading || isCreationLoading) return null
+    if (isMultichain && isOverviewsLoading) return null
+    // Chain config must be loaded — otherwise feature flags (recovery, hypernative,
+    // transaction scanning) all default to false, producing wrong scanner results.
+    if (!chain) return null
+
+    // Resolve deployer using the same logic as useMasterCopies + OutdatedMastercopyWarning
+    const matchingMc = masterCopies?.find((mc) => sameAddress(mc.address, safeInfo.implementation.value))
+    const isCircles = matchingMc?.version?.toLowerCase().includes('circles') ?? false
+    const deployer: 'Gnosis' | 'Circles' | null = matchingMc ? (isCircles ? 'Circles' : 'Gnosis') : null
+
+    // Compute multichain signer consistency using the same utils as InconsistentSignerSetupWarning
+    let multichainSignersConsistent = true
+    let multichainDeviatingChains: string[] = []
+    if (isMultichain && safeOverviews && safeOverviews.length > 0) {
+      const safeSetups = getSafeSetups(multichainSafeItems, safeOverviews, undeployedSafes)
+      const sharedSetup = getSharedSetup(safeSetups)
+      multichainSignersConsistent = sharedSetup !== undefined
+
+      if (!multichainSignersConsistent) {
+        const deviating = getDeviatingSetups(safeSetups, selected.chainId)
+        multichainDeviatingChains = deviating.map((setup) => {
+          const chainConfig = allChains.find((c) => c.chainId === setup.chainId)
+          return chainConfig?.chainName ?? `Chain ${setup.chainId}`
+        })
+      }
+    }
+
+    const ctx = {
+      owners: safeInfo.owners,
+      threshold: safeInfo.threshold,
+      modules: safeInfo.modules ?? null,
+      guard: safeInfo.guard ?? null,
+      fallbackHandler: safeInfo.fallbackHandler ?? null,
+      implementationVersionState: safeInfo.implementationVersionState,
+      implementationAddress: safeInfo.implementation.value,
+      version: safeInfo.version ?? null,
+      latestVersion,
+      isNonCriticalUpdate: !!isNonCriticalUpdate(safeInfo.version),
+      masterCopyDeployer: deployer,
+      chainId: selected.chainId,
+      safeAddress: selected.address,
+      nonce: safeInfo.nonce,
+      balanceUsd: overviewData?.balanceUsd ?? (Number(safeOverview?.fiatTotal) || 0),
+      queuedTxCount: overviewData?.queuedTxCount ?? safeOverview?.queued ?? 0,
+      chainSupportsRecovery: chain ? hasFeature(chain, FEATURES.RECOVERY) : false,
+      chainSupportsHypernative: chain ? hasFeature(chain, FEATURES.HYPERNATIVE) : false,
+      chainSupportsTransactionScanning: chain ? hasFeature(chain, FEATURES.RISK_MITIGATION) : false,
+      isMultichain,
+      multichainSignersConsistent,
+      multichainDeviatingChains,
+      creationInfo: creationTx
+        ? {
+            factoryAddress: creationTx.factoryAddress ?? null,
+            creator: creationTx.creator,
+            masterCopy: creationTx.masterCopy ?? null,
+            transactionHash: creationTx.transactionHash,
+          }
+        : null,
+    }
+
+    return ctx
+  }, [
+    selected,
+    entry,
+    safeInfo,
+    isSafeLoading,
+    overviewData,
+    isOverviewLoading,
+    isMasterCopiesLoading,
+    isCreationLoading,
+    isOverviewsLoading,
+    chain,
+    masterCopies,
+    latestVersion,
+    isMultichain,
+    safeOverview,
+    safeOverviews,
+    multichainSafeItems,
+    undeployedSafes,
+    allChains,
+    creationTx,
+  ])
+}
+
+export default useSafeScanContext

--- a/apps/web/src/pages/spaces/security.tsx
+++ b/apps/web/src/pages/spaces/security.tsx
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import { BRAND_NAME } from '@/config/constants'
+import { SpacesFeature, useFeatureFlagRedirect } from '@/features/spaces'
+import { useLoadFeature } from '@/features/__core__'
+import { useSecurityHubFeatureRedirect } from '@/features/security'
+
+export default function SpaceSecurityPage() {
+  const router = useRouter()
+  const { spaceId } = router.query
+  const spaces = useLoadFeature(SpacesFeature)
+  useFeatureFlagRedirect()
+  useSecurityHubFeatureRedirect()
+
+  if (!router.isReady || !spaceId) return null
+
+  return (
+    <>
+      <Head>
+        <title>{`${BRAND_NAME} – Security`}</title>
+      </Head>
+
+      <main>
+        <spaces.SecurityHubPage spaceId={spaceId as string} />
+      </main>
+    </>
+  )
+}


### PR DESCRIPTION
Adds the React hooks that consume the scoring engine from PR 4/8:

- features/security/hooks/useSecurityScan: runs SCANNERS against a Safe and exposes ScanResult[] with cache + loading metadata.
- features/security/hooks/useSecurityHubFeatureRedirect: gates the /spaces/security route behind the SECURITY_HUB flag.
- features/spaces/hooks/useAutoScan: queues per-Safe scans across a space with throttling + cancellation.
- features/spaces/hooks/useSafeScanContext: builds the per-Safe ScanContext required by the scanners (RTK Query data, chain, owners, threshold, etc).

Each hook ships with unit tests. SecurityHub container that orchestrates these lands in PR 6/8.

Part 5/8 of the security-hub split (originally PR #7820).


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
