### PR TITLE
feat(security-hub): wire SecurityHub into sidebar + routing

### DIFF
--- a/apps/web/src/features/security/data/scanners/constants.ts
+++ b/apps/web/src/features/security/data/scanners/constants.ts
@@ -1,6 +1,7 @@
 import { IS_PRODUCTION } from '@/config/constants'
 import type { SafeVersion } from '@safe-global/types-kit'
 import type { SecurityGrade } from '../securityTypes'
+import type { SafeGrade } from './types'
 
 /** Maximum time a single scanner is allowed to run before being rejected. */
 export const SCANNER_TIMEOUT_MS = 15_000
@@ -17,6 +18,18 @@ export const SEVERITY_RANK: Record<SecurityGrade, number> = {
   High: 1,
   Medium: 2,
   Low: 3,
+}
+
+/**
+ * Sort order for SafeGrade — overall per-Safe assessment. Distinct from `SEVERITY_RANK`,
+ * which ranks per-check `SecurityGrade`. Lower number = worse, so a "worst-grade-first"
+ * scan picks the smallest rank across a multichain Safe's chain entries.
+ */
+export const SAFE_GRADE_RANK: Record<SafeGrade, number> = {
+  critical: 0,
+  at_risk: 1,
+  needs_attention: 2,
+  passing: 3,
 }
 
 /** Score thresholds that bucket a numeric score into a SecurityGrade. */

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SafeGradeChip/SafeGradeChip.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SafeGradeChip/SafeGradeChip.tsx
@@ -1,0 +1,66 @@
+import { Chip, type ChipProps } from '@mui/material'
+import type { SafeGrade } from '@/features/security/types'
+
+/** Human-readable label per SafeGrade. Shared by every chip in the SecurityHub UI. */
+export const SAFE_GRADE_LABEL: Record<SafeGrade, string> = {
+  critical: 'Critical',
+  at_risk: 'At risk',
+  needs_attention: 'Needs review',
+  passing: 'Healthy',
+}
+
+/**
+ * Color tokens per SafeGrade.
+ * - `accent` is the strong color (foreground text when soft, background when active).
+ * - `bg`     is the paired soft background (chip fill in the default soft variant).
+ *
+ * Both static "status" chips (StatusCell) and the interactive filter chips
+ * (WorkspaceHealthCard) compose their styling from this pair.
+ */
+export const SAFE_GRADE_PALETTE: Record<SafeGrade, { accent: string; bg: string }> = {
+  critical: { accent: 'error.dark', bg: 'error.background' },
+  at_risk: { accent: 'error.main', bg: 'error.background' },
+  needs_attention: { accent: 'warning.main', bg: 'warning.background' },
+  passing: { accent: 'success.main', bg: 'success.background' },
+}
+
+export type SafeGradeChipProps = Omit<ChipProps, 'color'> & {
+  grade: SafeGrade
+  /** When true, render filled (accent background, paper text). Default is soft (bg + accent text). */
+  active?: boolean
+  /** Override the default grade label (e.g. prefix a count like "3 Critical"). */
+  label?: string
+}
+
+/**
+ * Single visual primitive for SafeGrade chips. Encapsulates label/palette lookup,
+ * size/weight, and the soft-vs-active variant; consumers add their own `sx` overrides
+ * (height, transition, hover) for context-specific tweaks.
+ */
+const SafeGradeChip = ({ grade, active = false, label, onClick, sx, ...chipProps }: SafeGradeChipProps) => {
+  const { accent, bg } = SAFE_GRADE_PALETTE[grade]
+  const backgroundColor = active ? accent : bg
+  const color = active ? 'background.paper' : accent
+  return (
+    <Chip
+      label={label ?? SAFE_GRADE_LABEL[grade]}
+      size="small"
+      onClick={onClick}
+      sx={{
+        backgroundColor,
+        color,
+        fontWeight: 700,
+        '& .MuiChip-label': { px: 1 },
+        ...(onClick && {
+          cursor: 'pointer',
+          transition: 'background-color 0.15s, color 0.15s',
+          '&:hover': { backgroundColor, color, opacity: 0.8 },
+        }),
+        ...sx,
+      }}
+      {...chipProps}
+    />
+  )
+}
+
+export default SafeGradeChip

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.tsx
@@ -20,6 +20,7 @@ import type { ScanResult, GradeSummary, SafeGrade } from '@/features/security/ty
 import { SecurityFeature } from '@/features/security'
 import { useLoadFeature } from '@/features/__core__'
 import type { SecurityContract } from '@/features/security'
+import { SAFE_GRADE_RANK } from '@/features/security/data/scanners/constants'
 import Identicon from '@/components/common/Identicon'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import { NetworkLogosList } from '@/features/multichain'
@@ -50,14 +51,6 @@ type ScoreCellProps = {
   isScanning?: boolean
   getStrengthLevel: SecurityContract['getStrengthLevel']
   getStrengthColor: SecurityContract['getStrengthColor']
-}
-
-/** Worst-grade ranking matches the SafeGrade ordering used by the top filter chips. */
-const SAFE_GRADE_RANK: Record<SafeGrade, number> = {
-  critical: 0,
-  at_risk: 1,
-  needs_attention: 2,
-  passing: 3,
 }
 
 const ScoreCell = ({ summary, isScanning, getStrengthLevel, getStrengthColor }: ScoreCellProps) => {

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecuritySafesTable/SecuritySafesTable.tsx
@@ -28,6 +28,7 @@ import { useGetChainsConfigV2Query } from '@safe-global/store/gateway'
 import { CONFIG_SERVICE_KEY } from '@/config/constants'
 import { AppRoutes } from '@/config/routes'
 import type { SelectedSafe, SpaceSafeEntry } from '../../types'
+import StatusCell from '../StatusCell/StatusCell'
 
 const DASH = '—'
 
@@ -49,6 +50,14 @@ type ScoreCellProps = {
   isScanning?: boolean
   getStrengthLevel: SecurityContract['getStrengthLevel']
   getStrengthColor: SecurityContract['getStrengthColor']
+}
+
+/** Worst-grade ranking matches the SafeGrade ordering used by the top filter chips. */
+const SAFE_GRADE_RANK: Record<SafeGrade, number> = {
+  critical: 0,
+  at_risk: 1,
+  needs_attention: 2,
+  passing: 3,
 }
 
 const ScoreCell = ({ summary, isScanning, getStrengthLevel, getStrengthColor }: ScoreCellProps) => {
@@ -174,6 +183,33 @@ const getAggregateSummary = (
   }
 }
 
+/**
+ * Worst SafeGrade across a multichain Safe's chain entries. Used for the collapsed
+ * parent row's Status cell so it reflects the most severe chain (matching the badge
+ * counting semantics in WorkspaceHealthCard).
+ */
+const getAggregateSafeGrade = (
+  safe: SpaceSafeEntry,
+  scanResults: Record<string, Record<string, ScanResult>>,
+  scanKey: SecurityContract['scanKey'],
+  getSafeGrade: SecurityContract['getSafeGrade'],
+): SafeGrade | null => {
+  let worstRank = SAFE_GRADE_RANK.passing + 1
+  let worstGrade: SafeGrade | null = null
+  for (const chain of safe.chainEntries) {
+    const key = scanKey(safe.address, chain.chainId)
+    const results = scanResults[key]
+    if (!results) continue
+    const grade = getSafeGrade(results)
+    const rank = SAFE_GRADE_RANK[grade]
+    if (rank < worstRank) {
+      worstRank = rank
+      worstGrade = grade
+    }
+  }
+  return worstGrade
+}
+
 const hasMultichainWarning = (
   safe: SpaceSafeEntry,
   scanResults: Record<string, Record<string, ScanResult>>,
@@ -282,7 +318,7 @@ const SecuritySafesTable = ({
   if (!security.$isReady) return <></>
 
   // After the $isReady check, services are guaranteed to be defined.
-  const { scanKey, computeSummary, formatTimestamp, getStrengthLevel, getStrengthColor } = security
+  const { scanKey, computeSummary, formatTimestamp, getStrengthLevel, getStrengthColor, getSafeGrade } = security
 
   return (
     <Table
@@ -323,14 +359,15 @@ const SecuritySafesTable = ({
     >
       <TableHead>
         <TableRow>
-          <TableCell sx={{ width: '26%' }}>Account</TableCell>
-          <TableCell sx={{ width: '12%' }}>Network</TableCell>
-          <TableCell sx={{ width: '10%' }}>Balance</TableCell>
-          <TableCell sx={{ width: '10%' }}>Threshold</TableCell>
-          <TableCell sx={{ width: '9%' }}>Version</TableCell>
-          <TableCell sx={{ width: '11%' }}>Score</TableCell>
-          <TableCell sx={{ width: '13%' }}>Last scanned</TableCell>
-          <TableCell sx={{ width: '9%' }} />
+          <TableCell sx={{ width: '22%' }}>Account</TableCell>
+          <TableCell sx={{ width: '11%' }}>Network</TableCell>
+          <TableCell sx={{ width: '9%' }}>Balance</TableCell>
+          <TableCell sx={{ width: '9%' }}>Threshold</TableCell>
+          <TableCell sx={{ width: '8%' }}>Version</TableCell>
+          <TableCell sx={{ width: '11%' }}>Status</TableCell>
+          <TableCell sx={{ width: '10%' }}>Score</TableCell>
+          <TableCell sx={{ width: '12%' }}>Last scanned</TableCell>
+          <TableCell sx={{ width: '8%' }} />
         </TableRow>
       </TableHead>
       <AnimatePresence mode="wait">
@@ -348,6 +385,7 @@ const SecuritySafesTable = ({
             if (!isMultichain) {
               const key = scanKey(safe.address, safe.chainId)
               const summary = scanResults[key] ? computeSummary(scanResults[key]) : null
+              const grade = scanResults[key] ? getSafeGrade(scanResults[key]) : null
               const isSelected = selectedSafe?.address === safe.address && selectedSafe?.chainId === safe.chainId
               const isScanning = scanningKeys?.has(key)
 
@@ -407,6 +445,9 @@ const SecuritySafesTable = ({
                     <VersionCell results={scanResults[key]} isScanning={isScanning} />
                   </TableCell>
                   <TableCell>
+                    <StatusCell grade={grade} isScanning={isScanning} />
+                  </TableCell>
+                  <TableCell>
                     <ScoreCell
                       summary={summary}
                       isScanning={isScanning}
@@ -440,6 +481,7 @@ const SecuritySafesTable = ({
             }
 
             const aggregateSummary = getAggregateSummary(safe, scanResults, security)
+            const aggregateGrade = getAggregateSafeGrade(safe, scanResults, scanKey, getSafeGrade)
             const aggregateScanning = isAnyChainScanning(safe, scanningKeys, scanKey)
             const showMultichainWarning = hasMultichainWarning(safe, scanResults, scanKey)
             const totalBalance = safe.chainEntries.reduce(
@@ -532,6 +574,9 @@ const SecuritySafesTable = ({
                     </Typography>
                   </TableCell>
                   <TableCell>
+                    <StatusCell grade={aggregateGrade} isScanning={aggregateScanning} />
+                  </TableCell>
+                  <TableCell>
                     <ScoreCell
                       summary={aggregateSummary}
                       isScanning={aggregateScanning}
@@ -551,6 +596,7 @@ const SecuritySafesTable = ({
                   safe.chainEntries.map((chain, childIdx) => {
                     const key = scanKey(safe.address, chain.chainId)
                     const summary = scanResults[key] ? computeSummary(scanResults[key]) : null
+                    const childGrade = scanResults[key] ? getSafeGrade(scanResults[key]) : null
                     const isSelected = selectedSafe?.address === safe.address && selectedSafe?.chainId === chain.chainId
                     const isScanning = scanningKeys?.has(key)
                     const childHref = getSafeSecurityHref(safe.address, chain.chainId)
@@ -597,6 +643,9 @@ const SecuritySafesTable = ({
                         </TableCell>
                         <TableCell>
                           <VersionCell results={scanResults[key]} isScanning={isScanning} />
+                        </TableCell>
+                        <TableCell>
+                          <StatusCell grade={childGrade} isScanning={isScanning} />
                         </TableCell>
                         <TableCell>
                           <ScoreCell

--- a/apps/web/src/features/spaces/components/SecurityHub/components/StatusCell/StatusCell.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/StatusCell/StatusCell.tsx
@@ -1,21 +1,8 @@
-import { Chip, Skeleton, Typography } from '@mui/material'
+import { Skeleton, Typography } from '@mui/material'
 import type { SafeGrade } from '@/features/security/types'
+import SafeGradeChip from '../SafeGradeChip/SafeGradeChip'
 
 const DASH = '—'
-
-const STATUS_LABELS: Record<SafeGrade, string> = {
-  critical: 'Critical',
-  at_risk: 'At risk',
-  needs_attention: 'Needs review',
-  passing: 'Healthy',
-}
-
-const STATUS_PALETTE: Record<SafeGrade, { bg: string; text: string }> = {
-  critical: { bg: 'error.background', text: 'error.dark' },
-  at_risk: { bg: 'error.background', text: 'error.main' },
-  needs_attention: { bg: 'warning.background', text: 'warning.main' },
-  passing: { bg: 'success.background', text: 'success.main' },
-}
 
 export type StatusCellProps = {
   grade: SafeGrade | null
@@ -31,20 +18,7 @@ const StatusCell = ({ grade, isScanning }: StatusCellProps) => {
       </Typography>
     )
   }
-  const { bg, text } = STATUS_PALETTE[grade]
-  return (
-    <Chip
-      label={STATUS_LABELS[grade]}
-      size="small"
-      sx={{
-        backgroundColor: bg,
-        color: text,
-        fontWeight: 700,
-        height: 22,
-        '& .MuiChip-label': { px: 1 },
-      }}
-    />
-  )
+  return <SafeGradeChip grade={grade} sx={{ height: 22 }} />
 }
 
 export default StatusCell

--- a/apps/web/src/features/spaces/components/SecurityHub/components/StatusCell/StatusCell.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/StatusCell/StatusCell.tsx
@@ -1,0 +1,50 @@
+import { Chip, Skeleton, Typography } from '@mui/material'
+import type { SafeGrade } from '@/features/security/types'
+
+const DASH = '—'
+
+const STATUS_LABELS: Record<SafeGrade, string> = {
+  critical: 'Critical',
+  at_risk: 'At risk',
+  needs_attention: 'Needs review',
+  passing: 'Healthy',
+}
+
+const STATUS_PALETTE: Record<SafeGrade, { bg: string; text: string }> = {
+  critical: { bg: 'error.background', text: 'error.dark' },
+  at_risk: { bg: 'error.background', text: 'error.main' },
+  needs_attention: { bg: 'warning.background', text: 'warning.main' },
+  passing: { bg: 'success.background', text: 'success.main' },
+}
+
+export type StatusCellProps = {
+  grade: SafeGrade | null
+  isScanning?: boolean
+}
+
+const StatusCell = ({ grade, isScanning }: StatusCellProps) => {
+  if (!grade) {
+    if (isScanning) return <Skeleton variant="rounded" width={70} height={20} />
+    return (
+      <Typography variant="body2" color="text.secondary">
+        {DASH}
+      </Typography>
+    )
+  }
+  const { bg, text } = STATUS_PALETTE[grade]
+  return (
+    <Chip
+      label={STATUS_LABELS[grade]}
+      size="small"
+      sx={{
+        backgroundColor: bg,
+        color: text,
+        fontWeight: 700,
+        height: 22,
+        '& .MuiChip-label': { px: 1 },
+      }}
+    />
+  )
+}
+
+export default StatusCell

--- a/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.tsx
@@ -4,7 +4,10 @@ import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded'
 import type { ScanResult, SafeGrade, StrengthLevel } from '@/features/security/types'
 import { SecurityFeature } from '@/features/security'
 import { useLoadFeature } from '@/features/__core__'
+import SafeGradeChip, { SAFE_GRADE_LABEL } from '../SafeGradeChip/SafeGradeChip'
 import type { SpaceSafeEntry } from '../../types'
+
+const FILTER_GRADES: SafeGrade[] = ['critical', 'at_risk', 'needs_attention', 'passing']
 
 type WorkspaceHealthCardProps = {
   safes: SpaceSafeEntry[]
@@ -188,67 +191,16 @@ const WorkspaceHealthCard = ({
             Combined score from all security checks across your accounts.
           </Typography>
           <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-            {(
-              [
-                {
-                  grade: 'critical' as const,
-                  label: 'Critical',
-                  activeBg: 'error.dark',
-                  inactiveBg: 'error.background',
-                  text: 'error.dark',
-                  count: gradeCounts.critical,
-                },
-                {
-                  grade: 'at_risk' as const,
-                  label: 'At risk',
-                  activeBg: 'error.main',
-                  inactiveBg: 'error.background',
-                  text: 'error.main',
-                  count: gradeCounts.at_risk,
-                },
-                {
-                  grade: 'needs_attention' as const,
-                  label: 'Needs review',
-                  activeBg: 'warning.main',
-                  inactiveBg: 'warning.background',
-                  text: 'warning.main',
-                  count: gradeCounts.needs_attention,
-                },
-                {
-                  grade: 'passing' as const,
-                  label: 'Healthy',
-                  activeBg: 'success.main',
-                  inactiveBg: 'success.background',
-                  text: 'success.main',
-                  count: gradeCounts.passing,
-                },
-              ] as const
-            )
-              .filter((c) => c.count > 0)
-              .map((c) => {
-                const isActive = activeFilter === c.grade
-                return (
-                  <Chip
-                    key={c.grade}
-                    label={`${c.count} ${c.label}`}
-                    size="small"
-                    onClick={() => onFilterChange(c.grade)}
-                    sx={{
-                      cursor: 'pointer',
-                      fontWeight: 700,
-                      transition: 'background-color 0.15s, color 0.15s',
-                      '& .MuiChip-root:active, & .MuiTouchRipple-root': { display: 'none' },
-                      backgroundColor: isActive ? c.activeBg : c.inactiveBg,
-                      color: isActive ? 'background.paper' : c.text,
-                      '&:hover': {
-                        backgroundColor: isActive ? c.activeBg : c.inactiveBg,
-                        color: isActive ? 'background.paper' : c.text,
-                        opacity: 0.8,
-                      },
-                    }}
-                  />
-                )
-              })}
+            {FILTER_GRADES.filter((grade) => gradeCounts[grade] > 0).map((grade) => (
+              <SafeGradeChip
+                key={grade}
+                grade={grade}
+                active={activeFilter === grade}
+                label={`${gradeCounts[grade]} ${SAFE_GRADE_LABEL[grade]}`}
+                onClick={() => onFilterChange(grade)}
+                sx={{ '& .MuiChip-root:active, & .MuiTouchRipple-root': { display: 'none' } }}
+              />
+            ))}
           </Stack>
 
           {lastScannedAt && (

--- a/apps/web/src/features/spaces/components/Sidebar/config/index.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/config/index.tsx
@@ -16,6 +16,7 @@ import {
   ChevronLeft,
   PanelRight,
   EllipsisVertical,
+  Shield,
 } from 'lucide-react'
 import { AppRoutes } from '@/config/routes'
 import type { SidebarItemConfig, SidebarGroupConfig } from '../types'
@@ -52,13 +53,12 @@ export const spacesSetupGroup: SidebarGroupConfig = {
       label: 'Team',
       href: AppRoutes.spaces.members,
     },
-    // TODO: Activate when Spaces Security page is ready
-    // {
-    //   icon: Shield,
-    //   label: 'Security',
-    //   href: AppRoutes.spaces.security,
-    //   activeMemberOnly: true,
-    // },
+    {
+      icon: Shield,
+      label: 'Security',
+      href: AppRoutes.spaces.security,
+      activeMemberOnly: true,
+    },
     {
       icon: Settings,
       label: 'Settings',

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/SpacesSidebarContent.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/SpacesSidebarContent.tsx
@@ -1,10 +1,13 @@
-import type { ReactElement } from 'react'
+import { type ReactElement, useMemo } from 'react'
 import { useCurrentSpaceId } from '@/features/spaces/hooks/useCurrentSpaceId'
 import { useIsActiveMember } from '@/features/spaces/hooks/useSpaceMembers'
 import { spacesMainNavigation, spacesSetupGroup } from '../../config'
 import { useResolvedSidebarNav } from '../../hooks/useResolvedSidebarNav'
 import type { SidebarItemConfig, SidebarVariantContentProps } from '../../types'
 import { SpacesSidebarVariant } from '../SpacesSidebarVariant'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { AppRoutes } from '@/config/routes'
 
 export const SpacesSidebarContent = ({
   selectedSpace,
@@ -14,6 +17,7 @@ export const SpacesSidebarContent = ({
 }: SidebarVariantContentProps): ReactElement => {
   const spaceId = useCurrentSpaceId()
   const isActiveMember = useIsActiveMember(selectedSpace?.id)
+  const isSecurityHubEnabled = useHasFeature(FEATURES.SECURITY_HUB)
 
   const getLink = (item: SidebarItemConfig) => ({
     pathname: item.href,
@@ -22,7 +26,17 @@ export const SpacesSidebarContent = ({
 
   const isItemDisabled = (item: SidebarItemConfig) => !!item.activeMemberOnly && !isActiveMember
 
-  const { mainNavItems, setupGroup } = useResolvedSidebarNav(spacesMainNavigation, spacesSetupGroup, {
+  // Drop the Security entry from the Setup group when the chain feature flag is explicitly
+  // off. `undefined` means the chain config is still loading — keep the item to avoid flicker.
+  const filteredSetupGroup = useMemo(
+    () =>
+      isSecurityHubEnabled === false
+        ? { ...spacesSetupGroup, items: spacesSetupGroup.items.filter((i) => i.href !== AppRoutes.spaces.security) }
+        : spacesSetupGroup,
+    [isSecurityHubEnabled],
+  )
+
+  const { mainNavItems, setupGroup } = useResolvedSidebarNav(spacesMainNavigation, filteredSetupGroup, {
     getLink,
     isItemDisabled,
   })

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/__tests__/SpacesSidebarContent.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/__tests__/SpacesSidebarContent.test.tsx
@@ -6,6 +6,7 @@ import type { SpaceItem, ResolvedSidebarItem, ResolvedSidebarGroup } from '../..
 const mockUseCurrentSpaceId = jest.fn()
 const mockUseIsActiveMember = jest.fn()
 const mockUseResolvedSidebarNav = jest.fn()
+const mockUseHasFeature = jest.fn()
 
 jest.mock('@/features/spaces/hooks/useCurrentSpaceId', () => ({
   useCurrentSpaceId: () => mockUseCurrentSpaceId(),
@@ -13,6 +14,10 @@ jest.mock('@/features/spaces/hooks/useCurrentSpaceId', () => ({
 
 jest.mock('@/features/spaces/hooks/useSpaceMembers', () => ({
   useIsActiveMember: jest.fn((spaceId) => mockUseIsActiveMember(spaceId)),
+}))
+
+jest.mock('@/hooks/useChains', () => ({
+  useHasFeature: () => mockUseHasFeature(),
 }))
 
 jest.mock('../../../hooks/useResolvedSidebarNav', () => ({
@@ -110,6 +115,7 @@ describe('SpacesSidebarContent', () => {
     mockUseCurrentSpaceId.mockReturnValue('1')
     mockUseIsActiveMember.mockReturnValue(true)
     mockUseResolvedSidebarNav.mockReturnValue(mockResolvedNavItems)
+    mockUseHasFeature.mockReturnValue(true)
   })
 
   it('renders SpacesSidebarVariant with resolved navigation', () => {
@@ -157,6 +163,36 @@ describe('SpacesSidebarContent', () => {
     render(<SpacesSidebarContent spaceInitial="T" selectedSpace={undefined} spaces={mockSpaces} />)
 
     expect(screen.getByText(/Main items:/)).toBeInTheDocument()
+  })
+
+  describe('SECURITY_HUB feature flag', () => {
+    it('hides the Security entry when the flag is explicitly off', () => {
+      mockUseHasFeature.mockReturnValue(false)
+
+      render(<SpacesSidebarContent spaceInitial="T" selectedSpace={mockSpace} spaces={mockSpaces} />)
+
+      const [, setupGroup] = mockUseResolvedSidebarNav.mock.calls[0]
+      // The mocked config has Team + Security; only Team should remain.
+      expect(setupGroup.items.map((i: { href: string }) => i.href)).toEqual(['/spaces/members'])
+    })
+
+    it('keeps the Security entry while the flag is undefined (chain config still loading)', () => {
+      mockUseHasFeature.mockReturnValue(undefined)
+
+      render(<SpacesSidebarContent spaceInitial="T" selectedSpace={mockSpace} spaces={mockSpaces} />)
+
+      const [, setupGroup] = mockUseResolvedSidebarNav.mock.calls[0]
+      expect(setupGroup.items).toHaveLength(2)
+    })
+
+    it('keeps the Security entry when the flag is enabled', () => {
+      mockUseHasFeature.mockReturnValue(true)
+
+      render(<SpacesSidebarContent spaceInitial="T" selectedSpace={mockSpace} spaces={mockSpaces} />)
+
+      const [, setupGroup] = mockUseResolvedSidebarNav.mock.calls[0]
+      expect(setupGroup.items).toHaveLength(2)
+    })
   })
 
   it('is unaffected by geoblocking — nav items remain visible when user is blocked', () => {

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/config.tsx
@@ -7,6 +7,7 @@ import HomeIcon from '@/public/images/sidebar/home.svg'
 import SettingsIcon from '@/public/images/sidebar/settings.svg'
 import MembersIcon from '@/public/images/sidebar/members.svg'
 import AccountsIcon from '@/public/images/sidebar/wallet.svg'
+import SecurityIcon from '@mui/icons-material/ShieldOutlined'
 import { SvgIcon } from '@mui/material'
 
 export type DynamicNavItem = {
@@ -45,6 +46,12 @@ export const navItems: DynamicNavItem[] = [
     label: 'Address book',
     icon: <SvgIcon component={ABIcon} inheritViewBox />,
     href: AppRoutes.spaces.addressBook,
+  },
+  {
+    label: 'Security',
+    icon: <SecurityIcon />,
+    href: AppRoutes.spaces.security,
+    activeMemberOnly: true,
   },
   {
     label: 'Settings',

--- a/apps/web/src/features/spaces/components/SpaceSidebarNavigation/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSidebarNavigation/index.tsx
@@ -9,17 +9,24 @@ import {
   SidebarListItemText,
 } from '@/components/sidebar/SidebarList'
 import { useCurrentSpaceId, useIsActiveMember } from '@/features/spaces'
+import { useHasFeature } from '@/hooks/useChains'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { AppRoutes } from '@/config/routes'
 import { navItems } from './config'
 
 const Navigation = (): ReactElement => {
   const router = useRouter()
   const spaceId = useCurrentSpaceId()
   const isActiveMember = useIsActiveMember()
+  const isSecurityHubEnabled = useHasFeature(FEATURES.SECURITY_HUB)
 
   return (
     <SidebarList>
       {navItems.map((item) => {
-        const hideItem = item.activeMemberOnly && !isActiveMember
+        // Hide the Security entry when the chain feature flag is explicitly off. While the
+        // chain config is still loading (`undefined`) we keep the item to avoid flicker.
+        const hideForFeatureFlag = item.href === AppRoutes.spaces.security && isSecurityHubEnabled === false
+        const hideItem = (item.activeMemberOnly && !isActiveMember) || hideForFeatureFlag
         const isSelected = router.pathname === item.href
 
         if (hideItem) return null

--- a/apps/web/src/features/spaces/contract.ts
+++ b/apps/web/src/features/spaces/contract.ts
@@ -32,6 +32,7 @@ import type CreateSpaceOnboarding from './components/CreateSpaceOnboarding'
 import type SelectSafesOnboarding from './components/SelectSafesOnboarding'
 import type InviteMembersOnboarding from './components/InviteMembersOnboarding'
 import type SelectSafeModal from './components/SelectSafeModal'
+import type SecurityHubPage from './components/SecurityHub/Page'
 
 // Utility services
 import type { isUnauthorized, filterSpacesByStatus, getNonDeclinedSpaces } from './utils'
@@ -63,6 +64,7 @@ export interface SpacesContract {
   SpaceSafeAccountsPage: typeof SpaceSafeAccountsPage
   SpaceAddressBookPage: typeof SpaceAddressBookPage
   SpaceSettingsPage: typeof SpaceSettingsPage
+  SecurityHubPage: typeof SecurityHubPage
 
   // Modal components (PascalCase) - stub renders null
   SelectSafeModal: typeof SelectSafeModal

--- a/apps/web/src/features/spaces/feature.ts
+++ b/apps/web/src/features/spaces/feature.ts
@@ -36,6 +36,7 @@ import CreateSpaceOnboarding from './components/CreateSpaceOnboarding'
 import SelectSafesOnboarding from './components/SelectSafesOnboarding'
 import InviteMembersOnboarding from './components/InviteMembersOnboarding'
 import SelectSafeModal from './components/SelectSafeModal'
+import SecurityHubPage from './components/SecurityHub/Page'
 
 // Service imports
 import { isUnauthorized, filterSpacesByStatus, getNonDeclinedSpaces } from './utils'
@@ -74,6 +75,7 @@ const feature: SpacesContract = {
   SpaceSafeAccountsPage,
   SpaceAddressBookPage,
   SpaceSettingsPage,
+  SecurityHubPage,
 
   // Services
   isUnauthorized,

--- a/apps/web/src/pages/spaces/security.tsx
+++ b/apps/web/src/pages/spaces/security.tsx
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import { BRAND_NAME } from '@/config/constants'
+import { SpacesFeature, useFeatureFlagRedirect } from '@/features/spaces'
+import { useLoadFeature } from '@/features/__core__'
+import { useSecurityHubFeatureRedirect } from '@/features/security'
+
+export default function SpaceSecurityPage() {
+  const router = useRouter()
+  const { spaceId } = router.query
+  const spaces = useLoadFeature(SpacesFeature)
+  useFeatureFlagRedirect()
+  useSecurityHubFeatureRedirect()
+
+  if (!router.isReady || !spaceId) return null
+
+  return (
+    <>
+      <Head>
+        <title>{`${BRAND_NAME} – Security`}</title>
+      </Head>
+
+      <main>
+        <spaces.SecurityHubPage spaceId={spaceId as string} />
+      </main>
+    </>
+  )
+}


### PR DESCRIPTION
Final integration PR — connects the SecurityHub container from PR 6/8 and its panel components from PR 7/8 to the rest of the app:

- pages/spaces/security.tsx: Next.js page entry
- features/spaces/components/Sidebar/config: registers Security item
- features/spaces/components/SpaceSidebarNavigation: nav item + active state handling
- features/spaces/contract.ts / feature.ts: feature-flag plumbing

After this PR is merged on top of 1-7, the resulting state is byte-for-byte identical to PR #7820.

Part 8/8 of the security-hub split (originally PR #7820).


## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
