### PR TITLE
fix(spaces): rebalance members-list column widths

### DIFF
--- a/apps/web/src/features/spaces/components/MembersList/index.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.tsx
@@ -16,22 +16,22 @@ const headCells = [
   {
     id: 'name',
     label: 'Name',
-    width: '50%',
+    width: '40%',
   },
   {
     id: 'email',
     label: 'Email',
-    width: '21%',
+    width: '30%',
   },
   {
     id: 'role',
     label: 'Role',
-    width: '21%',
+    width: '15%',
   },
   {
     id: 'actions',
     label: '',
-    width: '8%',
+    width: '15%',
     sticky: true,
   },
 ]


### PR DESCRIPTION
## What it solves

Resolves: [WA-2377](https://linear.app/safe-global/issue/WA-2377/rebalance-members-list-column-widths)

After #7720 added the Email column with the default 50/21/21/8 split (name/email/role/actions), the email column is too narrow for typical addresses and the actions column is too tight for the edit + remove icon pair.

## How this PR fixes it

Rebalances the four columns to 40/30/15/15 (name/email/role/actions).

## How to test it

1. Open a Space with members, at least one with an email.
2. Email column is wider — typical addresses fit without immediate clipping.
3. Edit and remove icon buttons in the actions column sit with consistent spacing.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).