### PR TITLE
fix(mobile): show explainer immediately when OS notifications are DENIED

### DIFF
--- a/apps/mobile/src/hooks/useNotificationManager.test.ts
+++ b/apps/mobile/src/hooks/useNotificationManager.test.ts
@@ -5,6 +5,7 @@ const mockRegisterForNotifications = jest.fn()
 const mockUnregisterForNotifications = jest.fn()
 jest.mock('@/src/services/notifications/NotificationService', () => ({
   isDeviceNotificationEnabled: jest.fn(),
+  isAuthorizationDenied: jest.fn().mockResolvedValue(false),
   getAllPermissions: jest.fn(),
   requestPushNotificationsPermission: jest.fn(),
 }))
@@ -120,6 +121,27 @@ describe('useNotificationManager', () => {
         notifications: { ...mockState.notifications, promptAttempts: 5 },
       } as unknown as RootState
       const { result } = renderHook(() => useNotificationManager(), stateAtThreshold)
+
+      await act(async () => {
+        await result.current.enableNotification()
+      })
+
+      expect(NotificationsService.requestPushNotificationsPermission).toHaveBeenCalled()
+      expect(NotificationsService.getAllPermissions).not.toHaveBeenCalled()
+    })
+
+    // WA-2238 follow-up: when the user disabled push in iOS Settings and returns to the app,
+    // promptAttempts is reset to 0. Without this branch, the hook would call notifee.requestPermission()
+    // (a silent no-op once OS auth is DENIED) and the user would have to tap multiple times before
+    // the explainer Alert appeared.
+    it('enableNotification shows the explainer immediately when OS auth is DENIED, regardless of promptAttempts', async () => {
+      jest.mocked(NotificationsService.isDeviceNotificationEnabled).mockResolvedValue(false)
+      jest.mocked(NotificationsService.isAuthorizationDenied).mockResolvedValueOnce(true)
+      const stateBelowThreshold = {
+        ...mockState,
+        notifications: { ...mockState.notifications, promptAttempts: 0 },
+      } as unknown as RootState
+      const { result } = renderHook(() => useNotificationManager(), stateBelowThreshold)
 
       await act(async () => {
         await result.current.enableNotification()

--- a/apps/mobile/src/hooks/useNotificationManager.ts
+++ b/apps/mobile/src/hooks/useNotificationManager.ts
@@ -52,7 +52,6 @@ export const useNotificationManager = () => {
   const enableNotification = useCallback(async () => {
     try {
       Logger.info('enableNotification :: STARTED', { promptAttempts })
-      // Check if device notifications are enabled
       const deviceNotificationStatus = await NotificationsService.isDeviceNotificationEnabled()
 
       if (deviceNotificationStatus) {
@@ -63,16 +62,28 @@ export const useNotificationManager = () => {
           return true
         }
         return false
-      } else if (promptAttempts < promptThreshold) {
+      }
+
+      // Once iOS auth status is DENIED (user said "no" to the native prompt or disabled in Settings),
+      // notifee.requestPermission() is a silent no-op — looping through the threshold just burns
+      // taps invisibly. Go straight to the in-app explainer Alert so the user can EXPLICITLY tap
+      // "Turn on" to open Settings. Apple 5.1.1(iv): never auto-redirect on denial.
+      if (await NotificationsService.isAuthorizationDenied()) {
+        pendingPermissionRequestRef.current = true
+        await NotificationsService.requestPushNotificationsPermission()
+        return false
+      }
+
+      // NOT_DETERMINED: the native OS prompt can still be shown. Use the threshold to limit how
+      // many times we attempt it before falling back to the explainer.
+      if (promptAttempts < promptThreshold) {
         dispatch(updatePromptAttempts(promptAttempts + 1))
         const { success } = await requestAndRegister()
         return success
-      } else {
-        // Threshold reached — surface the in-app explainer Alert so the user can EXPLICITLY tap
-        // "Turn on" to open Settings. Never auto-redirect on denial (Apple 5.1.1(iv)).
-        pendingPermissionRequestRef.current = true
-        await NotificationsService.requestPushNotificationsPermission()
       }
+
+      pendingPermissionRequestRef.current = true
+      await NotificationsService.requestPushNotificationsPermission()
     } catch (error) {
       pendingPermissionRequestRef.current = false
       Logger.error('Error enabling push notifications', error)


### PR DESCRIPTION
> Tap to enable, but nothing —
> iOS already said no,
> show the alert at once.

## What it solves

After the user disables push in iOS Settings and returns to the app, the first tap on the "Allow notifications" toggle did nothing visible. Only the second (or third) tap surfaced the in-app explainer Alert.

Resolves: [WA-2238](https://linear.app/safe-global/issue/WA-2238/notifications-permission-flow-remove-auto-redirect-to-settings-on) [WA-2282](https://linear.app/safe-global/issue/WA-2282/notification-prompt-not-appearing-under-specific-conditions)

## How this PR fixes it

The AppState 'active' handler resets `promptAttempts` to 0 when it auto-disables in-app notifications to mirror the OS state. The next tap on the toggle then hit the `promptAttempts < threshold` branch in `enableNotification` and called `notifee.requestPermission()` — a silent no-op once iOS auth status is `DENIED`. The user had to tap until `promptAttempts` reached the threshold before the explainer Alert appeared.

`enableNotification` now branches on three OS states instead of two:

- `AUTHORIZED` / `PROVISIONAL`: register directly (unchanged)
- `DENIED`: skip the silent retry, show the in-app explainer Alert immediately
- `NOT_DETERMINED`: existing threshold + `requestAndRegister` flow

First-run behavior is unchanged — a fresh install starts in `NOT_DETERMINED`, so the native iOS prompt still surfaces on first tap. Apple 5.1.1(iv) compliance is unchanged: Settings is still only opened from an explicit "Turn on" tap inside the Alert.

### Regression checklist

**Primary flow changed:** `enableNotification` in `useNotificationManager` — the path triggered from the Settings "Allow notifications" toggle and the notifications opt-in screen.

**Surfaces touched:**
- `useNotificationManager.enableNotification` (Settings toggle, opt-in screen)
- `NotificationsService.isAuthorizationDenied` (now consumed by the hook)

**Neighbouring flows to verify:**
- First-run opt-in (`NOT_DETERMINED`) — native iOS prompt must still appear on first tap
- Threshold reached (`NOT_DETERMINED`, attempts >= threshold) — explainer Alert still shown
- Toggle off → on while OS still grants — direct registration path still works
- `toggleNotificationState` (NotificationsSettings screen) — unchanged, separate code path

**Tests added:**
- `enableNotification shows the explainer immediately when OS auth is DENIED, regardless of promptAttempts`

**Not verified (risks):**
- Android behavior unchanged (Android's `notifee.requestPermission()` semantics differ; the new DENIED branch only triggers when `isAuthorizationDenied()` returns true, which on Android requires API 33+ with an explicit denial).

## How to test it

1. Enable push notifications in Settings → Allow notifications, accept the iOS prompt.
2. Open iOS Settings → Safe → Notifications → toggle Allow Notifications off.
3. Return to the app — the in-app toggle should auto-flip to off.
4. Tap "Allow notifications" once — the explainer Alert ("Enable Push Notifications") should appear immediately. Before this fix, the first tap (and sometimes the second) did nothing.

## Screenshots

N/A — no UI changes, behavior fix only.

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).