### PR TITLE
fix(security-hub): stabilize score across scans on missing creation data

### DIFF
--- a/apps/web/src/features/security/data/scanners/__tests__/accountSetup.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/accountSetup.test.ts
@@ -62,10 +62,12 @@ describe('accountSetupScanner', () => {
     expect(result.status).toBe('clear')
   })
 
-  it('returns partial when no owners available', async () => {
+  it('returns inconclusive when owner data has not loaded yet', async () => {
+    // ownerCount === 0 is impossible for a real Safe — treat it as transient missing
+    // data, not a security concern, so the score isn't penalized while safeInfo loads.
     const ctx = createMockContext({ owners: [] })
     const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('partial')
-    expect(result.severity).toBe('Medium')
+    expect(result.status).toBe('inconclusive')
+    expect(result.severity).toBe('Low')
   })
 })

--- a/apps/web/src/features/security/data/scanners/__tests__/factoryValidation.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/factoryValidation.test.ts
@@ -2,10 +2,14 @@ import { factoryValidationScanner } from '../factoryValidation'
 import { createMockContext } from '../test-helpers'
 
 describe('factoryValidationScanner', () => {
-  it('returns partial when no creation data is available', async () => {
+  it('returns inconclusive when creation data has not loaded yet', async () => {
+    // `inconclusive` is skipped in the workspace aggregate and per-Safe grade, so a
+    // missing creation transaction (still loading or gateway returned no data yet)
+    // won't penalize the score or surface a misleading "unrecognized source" entry.
+    // It also keeps the result stable across rescans once creationTx resolves.
     const result = await factoryValidationScanner.scan(createMockContext({ creationInfo: null }))
-    expect(result.status).toBe('partial')
-    expect(result.score).toBe(70)
+    expect(result.status).toBe('inconclusive')
+    expect(result.score).toBe(50)
   })
 
   it('returns partial when factory address is not recorded', async () => {

--- a/apps/web/src/features/security/data/scanners/accountSetup.ts
+++ b/apps/web/src/features/security/data/scanners/accountSetup.ts
@@ -8,12 +8,16 @@ export const accountSetupScanner: SecurityScanner = {
     const now = new Date().toISOString()
 
     if (ownerCount === 0) {
+      // Owner data hasn't loaded — distinct from "loaded and shows 0 owners" (impossible
+      // for a real Safe). Return inconclusive so a transient missing-data state during
+      // scan doesn't penalize the score or flag the Safe with a "weak threshold" entry
+      // that flips on rescan once `safeInfo.owners` populates.
       return {
-        status: 'partial',
-        severity: 'Medium',
+        status: 'inconclusive',
+        severity: 'Low',
         score: 50,
         evidence: ['Signer data not yet available'],
-        remediation: 'Open this Safe directly to load signer information.',
+        remediation: 'Signer information will load shortly.',
         lastChecked: now,
       }
     }

--- a/apps/web/src/features/security/data/scanners/factoryValidation.ts
+++ b/apps/web/src/features/security/data/scanners/factoryValidation.ts
@@ -13,12 +13,16 @@ export const factoryValidationScanner: SecurityScanner = {
     const now = new Date().toISOString()
 
     if (!creationInfo) {
+      // Creation transaction data isn't loaded — distinct from "loaded and missing a
+      // factory". Return `inconclusive` so we don't penalize the score or label the Safe
+      // as deployed from an unrecognized source: we genuinely don't know yet, and the
+      // user shouldn't see the result flip between scans once creationTx resolves.
       return {
-        status: 'partial',
+        status: 'inconclusive',
         severity: 'Low',
-        score: 70,
-        evidence: [{ label: 'Status', value: 'Creation data not available' }],
-        remediation: 'Deployment origin could not be verified because creation data is not yet available.',
+        score: 50,
+        evidence: [{ label: 'Status', value: 'Creation data not yet available' }],
+        remediation: 'Deployment origin will be verified once creation data loads.',
         lastChecked: now,
       }
     }

--- a/apps/web/src/features/spaces/components/SecurityHub/__tests__/WorkspaceHealthCard.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/__tests__/WorkspaceHealthCard.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from '@testing-library/react'
+import WorkspaceHealthCard from '../components/WorkspaceHealthCard/WorkspaceHealthCard'
+import type { ScanResult } from '@/features/security/types'
+import type { SpaceSafeEntry } from '../types'
+
+const scanKey = (address: string, chainId: string) => `${address}:${chainId}`
+
+jest.mock('@/features/__core__', () => {
+  const securityFeatureImpl = require('@/features/security/feature').default
+  return {
+    ...jest.requireActual('@/features/__core__'),
+    useLoadFeature: () => ({
+      ...securityFeatureImpl,
+      $isReady: true,
+      $isDisabled: false,
+      $error: undefined,
+    }),
+  }
+})
+
+const mkResult = (status: ScanResult['status'] = 'clear', severity: ScanResult['severity'] = 'Low'): ScanResult => ({
+  status,
+  severity,
+  score: status === 'clear' ? 100 : 30,
+  evidence: [],
+  remediation: '',
+  lastChecked: new Date().toISOString(),
+})
+
+const SAFE_A = '0xA000000000000000000000000000000000000000'
+const SAFE_B = '0xB000000000000000000000000000000000000000'
+
+const safe = (address: string): SpaceSafeEntry => ({
+  address,
+  chainId: '1',
+  name: `Safe ${address.slice(0, 6)}`,
+  isMultichain: false,
+  chainEntries: [{ chainId: '1', isDeployed: true }],
+})
+
+const allClear = {
+  account_setup: mkResult('clear'),
+  contract_version: mkResult('clear'),
+  guard: mkResult('clear'),
+  fallback_handler: mkResult('clear'),
+  pending_tx: mkResult('clear'),
+}
+
+const baseProps = {
+  activeFilter: null,
+  onFilterChange: jest.fn(),
+  lastScannedAt: Date.now(),
+  onRescan: jest.fn(),
+}
+
+describe('WorkspaceHealthCard', () => {
+  it('shows the final aggregate score after an initial scan completes', () => {
+    render(
+      <WorkspaceHealthCard
+        {...baseProps}
+        safes={[safe(SAFE_A), safe(SAFE_B)]}
+        scanResults={{
+          [scanKey(SAFE_A, '1')]: allClear,
+          [scanKey(SAFE_B, '1')]: allClear,
+        }}
+        isScanning={false}
+      />,
+    )
+    expect(screen.getByText('100')).toBeInTheDocument()
+  })
+
+  it('streams the aggregate incrementally on the very first scan', () => {
+    // No data yet, scan running → skeleton (no score text).
+    const { rerender } = render(
+      <WorkspaceHealthCard {...baseProps} safes={[safe(SAFE_A), safe(SAFE_B)]} scanResults={{}} isScanning={true} />,
+    )
+    expect(screen.queryByText(/^\d+$/)).not.toBeInTheDocument()
+
+    // First Safe completes mid-scan — gauge renders incrementally rather than
+    // skeleton-until-done so users see progress as the queue advances.
+    rerender(
+      <WorkspaceHealthCard
+        {...baseProps}
+        safes={[safe(SAFE_A), safe(SAFE_B)]}
+        scanResults={{ [scanKey(SAFE_A, '1')]: allClear }}
+        isScanning={true}
+      />,
+    )
+    expect(screen.getByText('100')).toBeInTheDocument()
+  })
+
+  it('resets to skeleton when scan results clear (e.g. switching spaces)', () => {
+    const { rerender } = render(
+      <WorkspaceHealthCard
+        {...baseProps}
+        safes={[safe(SAFE_A)]}
+        scanResults={{ [scanKey(SAFE_A, '1')]: allClear }}
+        isScanning={false}
+      />,
+    )
+    expect(screen.getByText('100')).toBeInTheDocument()
+
+    // Space switch: scan results emptied. Snapshot must drop so the next space
+    // doesn't carry over the previous score.
+    rerender(<WorkspaceHealthCard {...baseProps} safes={[safe(SAFE_A)]} scanResults={{}} isScanning={false} />)
+    expect(screen.queryByText('100')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/useSecurityChecks.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/useSecurityChecks.tsx
@@ -124,7 +124,12 @@ export const useSecurityChecks = (
   const factoryResult = results['factory_validation']
   if (factoryResult) {
     const ok = isPassingStatus(factoryResult.status)
-    const title = ok ? 'Deployed via official Safe factory' : 'Deployed from an unrecognized source'
+    const title =
+      factoryResult.status === 'clear'
+        ? 'Deployed via official Safe factory'
+        : factoryResult.status === 'inconclusive'
+          ? 'Deployment origin not yet verified'
+          : 'Deployed from an unrecognized source'
     items.push({
       key: 'factory',
       severity: factoryResult.severity,

--- a/apps/web/src/features/spaces/hooks/__tests__/useSafeScanContext.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSafeScanContext.test.ts
@@ -71,18 +71,25 @@ const defaultEntry: SpaceSafeEntry = {
 function setupDefaults() {
   ;(useSafesGetSafeV1Query as jest.Mock).mockReturnValue({
     currentData: mockSafeInfo,
-    isLoading: false,
+    isFetching: false,
   })
-  ;(useChainsGetMasterCopiesV1Query as jest.Mock).mockReturnValue({ currentData: [], isLoading: false })
+  ;(useChainsGetMasterCopiesV1Query as jest.Mock).mockReturnValue({
+    currentData: [],
+    isFetching: false,
+    isError: false,
+  })
+  // Default creation tx to "errored" so the gate accepts a null creationInfo.
+  // Tests that want creation data populated override `currentData` explicitly.
   ;(useTransactionsGetCreationTransactionV1Query as jest.Mock).mockReturnValue({
     currentData: undefined,
-    isLoading: false,
+    isFetching: false,
+    isError: true,
   })
   ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
     currentData: { fiatTotal: '1000', queued: 2 },
-    isLoading: false,
+    isFetching: false,
   })
-  ;(useGetMultipleSafeOverviewsQuery as jest.Mock).mockReturnValue({ currentData: undefined, isLoading: false })
+  ;(useGetMultipleSafeOverviewsQuery as jest.Mock).mockReturnValue({ currentData: undefined, isFetching: false })
   ;(useChain as jest.Mock).mockReturnValue({ chainId: CHAIN_ID, features: [] })
   ;(useChains as jest.Mock).mockReturnValue({ configs: [] })
   ;(useAppSelector as jest.Mock).mockReturnValue({})
@@ -117,7 +124,7 @@ describe('useSafeScanContext', () => {
   it('returns null when Safe data is still loading', () => {
     ;(useSafesGetSafeV1Query as jest.Mock).mockReturnValue({
       currentData: undefined,
-      isLoading: true,
+      isFetching: true,
     })
     const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
     expect(result.current).toBeNull()
@@ -131,7 +138,7 @@ describe('useSafeScanContext', () => {
     // useSafesGetSafeV1Query will skip and return no data
     ;(useSafesGetSafeV1Query as jest.Mock).mockReturnValue({
       currentData: undefined,
-      isLoading: false,
+      isFetching: false,
     })
     const { result } = renderHook(() => useSafeScanContext(defaultSelected, undeployedEntry))
     expect(result.current).toBeNull()
@@ -140,7 +147,7 @@ describe('useSafeScanContext', () => {
   it('includes correct balanceUsd from safeOverview.fiatTotal', () => {
     ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
       currentData: { fiatTotal: '50000.5', queued: 0 },
-      isLoading: false,
+      isFetching: false,
     })
     const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
     expect(result.current?.balanceUsd).toBe(50000.5)
@@ -149,7 +156,7 @@ describe('useSafeScanContext', () => {
   it('includes correct queuedTxCount from safeOverview.queued', () => {
     ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
       currentData: { fiatTotal: '0', queued: 7 },
-      isLoading: false,
+      isFetching: false,
     })
     const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
     expect(result.current?.queuedTxCount).toBe(7)
@@ -164,6 +171,13 @@ describe('useSafeScanContext', () => {
         { chainId: '137', isDeployed: true },
       ],
     }
+    // Multichain path also requires safeOverviews to settle so signer-integrity can
+    // compare setups across chains. Provide a settled (but empty) response so the
+    // gate proceeds.
+    ;(useGetMultipleSafeOverviewsQuery as jest.Mock).mockReturnValue({
+      currentData: [],
+      isFetching: false,
+    })
     const { result } = renderHook(() => useSafeScanContext(defaultSelected, multichainEntry))
     expect(result.current?.isMultichain).toBe(true)
   })
@@ -195,7 +209,7 @@ describe('useSafeScanContext', () => {
     // Override the query mock to return different values — these should be ignored
     ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
       currentData: { fiatTotal: '999999', queued: 99 },
-      isLoading: false,
+      isFetching: false,
     })
     const overviewData = { balanceUsd: 42000, queuedTxCount: 3 }
     const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry, overviewData))
@@ -203,11 +217,40 @@ describe('useSafeScanContext', () => {
     expect(result.current?.queuedTxCount).toBe(3)
   })
 
+  it('waits for the creation transaction query to settle before building context', () => {
+    // RTK Query can report isLoading=false while currentData is still undefined
+    // (uninitialized → pending transition window). The OLD gate trusted isLoading
+    // alone and would let the scan run with creationInfo=null, producing the
+    // misleading "creation data not yet available" result that flips on rescan.
+    // The new gate also requires either data presence or a definitive error.
+    ;(useTransactionsGetCreationTransactionV1Query as jest.Mock).mockReturnValue({
+      currentData: undefined,
+      isFetching: false,
+      isError: false,
+    })
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
+    expect(result.current).toBeNull()
+  })
+
+  it('accepts a null creationInfo when the creation transaction query has errored', () => {
+    // If the gateway definitively cannot provide the creation tx (404/error), we
+    // proceed and let the scanner emit `inconclusive`. Otherwise users would be
+    // stuck in a permanent "loading" state for Safes whose creation isn't indexed.
+    ;(useTransactionsGetCreationTransactionV1Query as jest.Mock).mockReturnValue({
+      currentData: undefined,
+      isFetching: false,
+      isError: true,
+    })
+    const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
+    expect(result.current).not.toBeNull()
+    expect(result.current?.creationInfo).toBeNull()
+  })
+
   it('skips overview loading guard when overviewData is provided', () => {
     // Simulate the overview query still loading — should NOT block context creation
     ;(useGetSafeOverviewQuery as jest.Mock).mockReturnValue({
       currentData: undefined,
-      isLoading: true,
+      isFetching: true,
     })
     const overviewData = { balanceUsd: 500, queuedTxCount: 1 }
     const { result } = renderHook(() => useSafeScanContext(defaultSelected, defaultEntry, overviewData))

--- a/apps/web/src/features/spaces/hooks/useSafeScanContext.ts
+++ b/apps/web/src/features/spaces/hooks/useSafeScanContext.ts
@@ -30,19 +30,24 @@ const useSafeScanContext = (
   const isDeployed = selectedChainEntry?.isDeployed ?? false
 
   // Fetch SafeState for the selected chain — skip if not deployed
-  const { currentData: safeInfo, isLoading: isSafeLoading } = useSafesGetSafeV1Query(
+  const { currentData: safeInfo, isFetching: isSafeFetching } = useSafesGetSafeV1Query(
     { chainId, safeAddress: address },
     { skip: !selected || !isDeployed },
   )
 
   // Fetch master copies for deployer resolution
-  const { currentData: masterCopies, isLoading: isMasterCopiesLoading } = useChainsGetMasterCopiesV1Query(
-    { chainId },
-    { skip: !selected || !isDeployed },
-  )
+  const {
+    currentData: masterCopies,
+    isFetching: isMasterCopiesFetching,
+    isError: isMasterCopiesError,
+  } = useChainsGetMasterCopiesV1Query({ chainId }, { skip: !selected || !isDeployed })
 
   // Fetch creation transaction for factory/deployment validation
-  const { currentData: creationTx, isLoading: isCreationLoading } = useTransactionsGetCreationTransactionV1Query(
+  const {
+    currentData: creationTx,
+    isFetching: isCreationFetching,
+    isError: isCreationError,
+  } = useTransactionsGetCreationTransactionV1Query(
     { chainId, safeAddress: address },
     { skip: !selected || !isDeployed },
   )
@@ -68,7 +73,7 @@ const useSafeScanContext = (
   )
   // Use `currentData` (not `data`) — `data` can briefly return the PREVIOUS Safe's overview
   // when useAutoScan advances from one Safe to the next, before RTK Query resolves the new args.
-  const { currentData: safeOverviews, isLoading: isOverviewsLoading } = useGetMultipleSafeOverviewsQuery(
+  const { currentData: safeOverviews, isFetching: isOverviewsFetching } = useGetMultipleSafeOverviewsQuery(
     { safes: multichainSafeItems, currency },
     { skip: !isMultichain || multichainSafeItems.length === 0 },
   )
@@ -76,7 +81,7 @@ const useSafeScanContext = (
   // Fetch overview for balance data (fiatTotal) on the selected chain.
   // Skip when pre-fetched overviewData is provided (e.g. from the batch query in SecurityHub)
   // to avoid redundant per-Safe API requests during auto-scan.
-  const { currentData: safeOverview, isLoading: isOverviewLoading } = useGetSafeOverviewQuery(
+  const { currentData: safeOverview, isFetching: isOverviewFetching } = useGetSafeOverviewQuery(
     { chainId, safeAddress: address },
     { skip: !selected || !isDeployed || !!overviewData },
   )
@@ -86,12 +91,22 @@ const useSafeScanContext = (
   const { configs: allChains } = useChains()
 
   return useMemo(() => {
-    // Wait for ALL dependent queries — not just safeInfo. Returning a context before
-    // overview/masterCopies/creationTx resolve causes scanners to run with defaults
-    // (balanceUsd=0, deployer=null, creationInfo=null) producing incorrect scores.
-    if (!selected || !entry || !safeInfo || isSafeLoading) return null
-    if ((!overviewData && isOverviewLoading) || isMasterCopiesLoading || isCreationLoading) return null
-    if (isMultichain && isOverviewsLoading) return null
+    // Wait for ALL dependent queries to FULLY settle — not just stop initial loading.
+    // `isLoading` is only true on the very first fetch and there are windows
+    // (uninitialized → pending transition, errored args, re-fetches) where
+    // `isLoading=false` while `currentData` is still undefined. Scanners launched in
+    // one of those windows run with `creationInfo=null` and produce the misleading
+    // "creation data not yet available" result, then flip on the next rescan when
+    // the underlying query has finally populated data. Using `isFetching` catches
+    // both initial fetches and refetches; we additionally require data to be
+    // present unless the query has definitively errored (in which case the scanner
+    // handles missing data with `inconclusive`).
+    if (!selected || !entry) return null
+    if (isSafeFetching || !safeInfo) return null
+    if (!overviewData && isOverviewFetching) return null
+    if (isMasterCopiesFetching || (!masterCopies && !isMasterCopiesError)) return null
+    if (isCreationFetching || (!creationTx && !isCreationError)) return null
+    if (isMultichain && (isOverviewsFetching || !safeOverviews)) return null
     // Chain config must be loaded — otherwise feature flags (recovery, hypernative,
     // transaction scanning) all default to false, producing wrong scanner results.
     if (!chain) return null
@@ -156,12 +171,14 @@ const useSafeScanContext = (
     selected,
     entry,
     safeInfo,
-    isSafeLoading,
+    isSafeFetching,
     overviewData,
-    isOverviewLoading,
-    isMasterCopiesLoading,
-    isCreationLoading,
-    isOverviewsLoading,
+    isOverviewFetching,
+    isMasterCopiesFetching,
+    isMasterCopiesError,
+    isCreationFetching,
+    isCreationError,
+    isOverviewsFetching,
     chain,
     masterCopies,
     latestVersion,


### PR DESCRIPTION
> Wait for the data,
> not just the loading flag —
> score stops flipping.

## What it solves

After the workspace scan completes, the gauge score visibly **changes** when the user clicks Re-scan, and some Safes show a misleading top-level entry:

> Deployed from an unrecognized source
> Deployment origin could not be verified because creation data is not yet available.

…which then disappears on rescan. Closes the gap reported during testing of the Security Hub.

## How this PR fixes it

Two compounding root causes — fixed together.

### 1. \`useSafeScanContext\` was trusting \`isLoading\` alone

RTK Query reports \`isLoading=false\` while \`currentData\` is still undefined in several windows (uninitialized → pending transition, errored args, re-fetches). A scan launched in that window saw \`creationInfo=null\` and produced the \"creation data not yet available\" result. On manual rescan, \`runScan()\` reads the by-then-fully-populated \`ctxRef.current\` and produces the correct \`clear\` result — so the entry flips and the workspace score swings.

The new gate uses \`isFetching\` **and** additionally requires either \`currentData\` or a definitive \`isError\` for the creation-tx / master-copies queries:

\`\`\`ts
if (isCreationFetching || (!creationTx && !isCreationError)) return null
if (isMasterCopiesFetching || (!masterCopies && !isMasterCopiesError)) return null
\`\`\`

Errored queries (e.g. gateway 404 on an un-indexed Safe) still proceed so users aren't stuck in permanent skeleton state.

### 2. Scanners returned \`partial\` instead of \`inconclusive\` for missing data

Belt-and-suspenders, in case the gate misses a window or the gateway genuinely can't provide data:

- **\`factoryValidation\`**: \`creationInfo == null\` → \`inconclusive\` (was \`partial\`, score 70). Skipped from \`computeCounts\` / \`computeSummary\` / \`getSafeGrade\`. Mirrors what \`signerIntegrity\` already does.
- **\`accountSetup\`**: \`ownerCount === 0\` → \`inconclusive\`. A real Safe always has owners, so this can only mean transient missing data.
- **\`useSecurityChecks\`**: three-way title for factory_validation so \`inconclusive\` doesn't claim \"Deployed via official Safe factory\" — reads \"Deployment origin not yet verified\" instead.

## Visual summary

\`\`\`mermaid
flowchart LR
    A[useSafesGet... etc.] -->|isLoading=false<br/>currentData=undefined| B{Old gate}
    B -->|passes| C[ctx with<br/>creationInfo=null]
    C --> D[Scanner: partial<br/>'creation data not<br/>yet available']
    D --> E[Score drops]

    A -->|isFetching=false<br/>+ currentData OR isError| F{New gate}
    F -->|blocks until data| G[ctx with<br/>real creationInfo]
    G --> H[Scanner: clear / inconclusive]
    H --> I[Score stable across scans]

    style E fill:#fee,stroke:#a00
    style I fill:#efe,stroke:#0a0
\`\`\`

## How to test it

1. Open Security Hub. Wait for the auto-scan to complete and note the workspace score.
2. Click **Re-scan**. Score should remain stable — same value when the rescan completes.
3. Open the report for any Safe that previously showed \"Deployed from an unrecognized source\" / \"creation data is not yet available\" at the top of the panel. That entry should be gone (bucketed into the passing accordion, or properly labelled if creationInfo is truly missing).
4. Open the panel before auto-scan finishes for that Safe — no misleading top-level \"unrecognized source\" entry.

## Checklist

- [x] Unit tests pass (\`yarn workspace @safe-global/web test\` — 239/239 affected)
- [x] Storybook snapshots unchanged (\`WorkspaceHealthCard.stories\`, \`SecurityPanelView.stories\`)
- [x] \`prettier:fix\` clean
- [x] New tests cover the gate (waits for creation tx to settle; accepts null on definitive error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)