### PR TITLE
chore: drop --max-turns 10 from claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -85,6 +85,5 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-7
-            --max-turns 10
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           trigger_phrase: '@claude review'


### PR DESCRIPTION
> Workflow trims a turn cap,
> reviewer thinks until it's done,
> one line, one less wall.

##  What it solves

  Resolves: Claude PR review runs occasionally hit the 10-turn ceiling and cut off mid-review, producing partial feedback instead of a complete pass.

##  How this PR fixes it

  Removes --max-turns 10 from claude_args in .github/workflows/claude-code-review.yml. With the flag dropped, the review job uses the action's default turn budget instead of a hard cap.

##  How to test it

  1. Open this PR and trigger the workflow with @claude review (the configured trigger_phrase).
  2. Confirm the review runs to completion and the action logs no longer print a --max-turns 10 argument.
  3. Confirm a normal-sized PR still gets a single, complete review comment (no premature cutoff, no duplicate runs).

##  Affected flows

  - Automated PR review on @claude review mentions — the only flow this workflow drives.

##  Blast radius

  - File touched: .github/workflows/claude-code-review.yml only.
  - No app/runtime code, no shared packages, no RTK Query endpoints, no feature flags, no persisted state.
  - Mobile impact: none.
  - Cost/runtime impact: review jobs may now run longer per invocation since the turn cap is gone; bounded by the action's own defaults and the GitHub Actions job timeout.

##  Risks / not checked

  - Did not measure the new average/95p runtime of the review job — only removed the cap.
  - Did not verify behavior against a deliberately oversized diff (where the previous 10-turn limit would have bitten).
  - Did not check whether any downstream automation or dashboard parses --max-turns from the workflow file.

##  Checklist

  - I've tested the branch on mobile 📱 — N/A (CI workflow only)
  - I've documented how it affects the analytics (if at all) 📊 — N/A
  - I've written a unit/e2e test for it (if applicable) 🧑‍💻 — N/A (workflow file)
  - I've listed affected flows and blast radius, and named what I did not verify 🎯

  ---