### PR TITLE
feat(web): Integrate spaces pending txs endpoint

### DIFF
--- a/apps/web/src/features/spaces/hooks/__tests__/useSpacePendingTransactions.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSpacePendingTransactions.test.ts
@@ -1,30 +1,48 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook } from '@testing-library/react'
 import { faker } from '@faker-js/faker'
+import type { TransactionQueuedItem } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useSpacePendingTransactions } from '../useSpacePendingTransactions'
-import type { TransactionQueuedItem } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
-import * as transactionsService from '@/services/transactions'
-import * as txList from '@/utils/tx-list'
 
-jest.mock('../useSpaceSafesWithQueue', () => ({
-  useSpaceSafesWithQueue: jest.fn(),
-}))
-jest.mock('@/services/transactions', () => ({
-  getTransactionQueue: jest.fn(),
-}))
-jest.mock('@/utils/tx-list', () => ({
-  getLatestTransactions: jest.fn(),
+const mockUseCurrentSpaceId = jest.fn()
+const mockUseSpaceSafesGetV1Query = jest.fn()
+const mockUseSpaceTransactionsGetTransactionQueueV1Query = jest.fn()
+const mockUseAppSelector = jest.fn()
+
+jest.mock('../useCurrentSpaceId', () => ({
+  useCurrentSpaceId: () => mockUseCurrentSpaceId(),
 }))
 
-import { useSpaceSafesWithQueue } from '../useSpaceSafesWithQueue'
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useSpaceSafesGetV1Query: (...args: unknown[]) => mockUseSpaceSafesGetV1Query(...args),
+  useSpaceTransactionsGetTransactionQueueV1Query: (...args: unknown[]) =>
+    mockUseSpaceTransactionsGetTransactionQueueV1Query(...args),
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: (...args: unknown[]) => mockUseAppSelector(...args),
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: 'isAuthenticated',
+}))
+
+const SAFE_1 = '0xa77de01e157f9f57c7c4a326eee9c4874d0598b6'
+const SAFE_2 = '0xb4ad06d5514d68e55655b3e30a8cc4c5ab5e798a'
+const SAFE_UNKNOWN = '0x0000000000000000000000000000000000000000'
+
+const refetch = jest.fn()
+
+const txHash = (): string => `0x${faker.string.hexadecimal({ length: 64, casing: 'lower', prefix: '' })}`
 
 const createQueuedItem = (
+  safeAddress: string,
   timestamp: number,
-  overrides: Partial<TransactionQueuedItem> = {},
+  overrides: Partial<TransactionQueuedItem['transaction']> = {},
 ): TransactionQueuedItem => ({
   type: 'TRANSACTION',
   transaction: {
-    id: faker.string.uuid(),
-    txHash: faker.string.hexadecimal({ length: 64 }),
+    id: `multisig_${safeAddress}_${txHash()}`,
+    txHash: txHash(),
     timestamp,
     txStatus: 'AWAITING_CONFIRMATIONS',
     txInfo: {
@@ -42,159 +60,144 @@ const createQueuedItem = (
       confirmationsSubmitted: 1,
       missingSigners: [],
     },
-    ...overrides.transaction,
-  },
+    ...overrides,
+  } as TransactionQueuedItem['transaction'],
   conflictType: 'None',
-  ...overrides,
 })
 
-const SAFE_ADDRESS_1 = faker.finance.ethereumAddress()
-const SAFE_ADDRESS_2 = faker.finance.ethereumAddress()
+const mockSpaceSafes = (safes: Record<string, string[]>): void => {
+  mockUseSpaceSafesGetV1Query.mockReturnValue({ currentData: { safes }, isFetching: false })
+}
+
+const mockQueue = (
+  results: TransactionQueuedItem[] | undefined,
+  opts: { isFetching?: boolean; error?: unknown } = {},
+): void => {
+  mockUseSpaceTransactionsGetTransactionQueueV1Query.mockReturnValue({
+    currentData: results ? { count: results.length, next: null, previous: null, results } : undefined,
+    isFetching: opts.isFetching ?? false,
+    error: opts.error,
+    refetch,
+  })
+}
 
 describe('useSpacePendingTransactions', () => {
   beforeEach(() => {
     jest.resetAllMocks()
-    ;(useSpaceSafesWithQueue as jest.Mock).mockReturnValue({
-      safesWithQueue: [
-        { chainId: '1', address: SAFE_ADDRESS_1 },
-        { chainId: '137', address: SAFE_ADDRESS_2 },
-      ],
-      isLoading: false,
-    })
+    mockUseAppSelector.mockReturnValue(true)
+    mockUseCurrentSpaceId.mockReturnValue('42')
+    mockSpaceSafes({ '1': [SAFE_1], '137': [SAFE_2] })
+    mockQueue([])
   })
 
-  it('should return empty transactions when no safes have queued txs', async () => {
-    ;(useSpaceSafesWithQueue as jest.Mock).mockReturnValue({
-      safesWithQueue: [],
-      isLoading: false,
-    })
-
+  it('returns empty list when the queue response is empty', () => {
     const { result } = renderHook(() => useSpacePendingTransactions())
-
-    await waitFor(() => {
-      expect(result.current.transactions).toEqual([])
-      expect(result.current.count).toBe(0)
-      expect(result.current.isLoading).toBe(false)
-    })
+    expect(result.current.transactions).toEqual([])
+    expect(result.current.count).toBe(0)
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeUndefined()
   })
 
-  it('should reflect loading state from useSpaceSafesWithQueue', () => {
-    ;(useSpaceSafesWithQueue as jest.Mock).mockReturnValue({
-      safesWithQueue: [],
-      isLoading: true,
-    })
-
+  it('reflects loading state from the queue query', () => {
+    mockQueue(undefined, { isFetching: true })
     const { result } = renderHook(() => useSpacePendingTransactions())
-
     expect(result.current.isLoading).toBe(true)
   })
 
-  it('should fetch and merge transactions from multiple safes', async () => {
-    const tx1 = createQueuedItem(1000)
-    const tx2 = createQueuedItem(2000)
-
-    ;(transactionsService.getTransactionQueue as jest.Mock)
-      .mockResolvedValueOnce({ results: [tx1] })
-      .mockResolvedValueOnce({ results: [tx2] })
-    ;(txList.getLatestTransactions as jest.Mock).mockImplementation((results) =>
-      results.filter((r: TransactionQueuedItem) => r.type === 'TRANSACTION'),
-    )
-
+  it('attaches safeAddress and chainId by parsing tx id and looking up the space safes map', () => {
+    mockQueue([createQueuedItem(SAFE_1, 1000), createQueuedItem(SAFE_2, 2000)])
     const { result } = renderHook(() => useSpacePendingTransactions())
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false)
-      expect(result.current.transactions).toHaveLength(2)
-      expect(result.current.count).toBe(2)
-    })
+    expect(result.current.transactions).toHaveLength(2)
+    expect(result.current.transactions[0]).toMatchObject({ safeAddress: SAFE_1, chainId: '1' })
+    expect(result.current.transactions[1]).toMatchObject({ safeAddress: SAFE_2, chainId: '137' })
   })
 
-  it('should sort transactions by timestamp ascending (oldest first)', async () => {
-    const oldTx = createQueuedItem(1000)
-    const recentTx = createQueuedItem(3000)
-    const middleTx = createQueuedItem(2000)
-
-    ;(transactionsService.getTransactionQueue as jest.Mock)
-      .mockResolvedValueOnce({ results: [recentTx, oldTx] })
-      .mockResolvedValueOnce({ results: [middleTx] })
-    ;(txList.getLatestTransactions as jest.Mock).mockImplementation((results) =>
-      results.filter((r: TransactionQueuedItem) => r.type === 'TRANSACTION'),
-    )
-
+  it('matches safeAddress lookup case-insensitively', () => {
+    mockSpaceSafes({ '1': [SAFE_1.toUpperCase()] })
+    mockQueue([createQueuedItem(SAFE_1, 1000)])
     const { result } = renderHook(() => useSpacePendingTransactions())
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false)
-      const timestamps = result.current.transactions.map((tx) => tx.transaction.timestamp)
-      expect(timestamps).toEqual([1000, 2000, 3000])
-    })
+    expect(result.current.transactions[0].chainId).toBe('1')
   })
 
-  it('should respect the limit parameter', async () => {
-    const tx1 = createQueuedItem(1000)
-    const tx2 = createQueuedItem(2000)
-    const tx3 = createQueuedItem(3000)
+  it('falls back to an empty chainId when the safe is not in the space lookup', () => {
+    mockQueue([createQueuedItem(SAFE_UNKNOWN, 1000)])
+    const { result } = renderHook(() => useSpacePendingTransactions())
+    expect(result.current.transactions).toHaveLength(1)
+    expect(result.current.transactions[0].chainId).toBe('')
+    expect(result.current.transactions[0].safeAddress).toBe(SAFE_UNKNOWN)
+  })
 
-    ;(transactionsService.getTransactionQueue as jest.Mock)
-      .mockResolvedValueOnce({ results: [tx1, tx2] })
-      .mockResolvedValueOnce({ results: [tx3] })
-    ;(txList.getLatestTransactions as jest.Mock).mockImplementation((results) =>
-      results.filter((r: TransactionQueuedItem) => r.type === 'TRANSACTION'),
-    )
+  it('sorts transactions by timestamp ascending', () => {
+    mockQueue([createQueuedItem(SAFE_1, 3000), createQueuedItem(SAFE_2, 1000), createQueuedItem(SAFE_1, 2000)])
+    const { result } = renderHook(() => useSpacePendingTransactions())
+    expect(result.current.transactions.map((tx) => tx.transaction.timestamp)).toEqual([1000, 2000, 3000])
+  })
 
+  it('respects the limit parameter when slicing results', () => {
+    mockQueue([createQueuedItem(SAFE_1, 1000), createQueuedItem(SAFE_2, 2000), createQueuedItem(SAFE_1, 3000)])
     const { result } = renderHook(() => useSpacePendingTransactions(2))
-
-    await waitFor(() => {
-      expect(result.current.transactions).toHaveLength(2)
-      expect(result.current.transactions[0].transaction.timestamp).toBe(1000)
-      expect(result.current.transactions[1].transaction.timestamp).toBe(2000)
-    })
+    expect(result.current.transactions).toHaveLength(2)
+    expect(result.current.transactions.map((tx) => tx.transaction.timestamp)).toEqual([1000, 2000])
   })
 
-  it('should attach safeAddress and chainId to each transaction', async () => {
-    const tx1 = createQueuedItem(1000)
-    const tx2 = createQueuedItem(2000)
-
-    ;(transactionsService.getTransactionQueue as jest.Mock)
-      .mockResolvedValueOnce({ results: [tx1] })
-      .mockResolvedValueOnce({ results: [tx2] })
-    ;(txList.getLatestTransactions as jest.Mock).mockImplementation((results) =>
-      results.filter((r: TransactionQueuedItem) => r.type === 'TRANSACTION'),
-    )
-
+  it('skips non-TRANSACTION queued items', () => {
+    const tx = createQueuedItem(SAFE_1, 1000)
+    const label = { type: 'LABEL', label: 'Next' } as unknown as TransactionQueuedItem
+    const conflict = { type: 'CONFLICT_HEADER', nonce: 1 } as unknown as TransactionQueuedItem
+    mockQueue([label, tx, conflict])
     const { result } = renderHook(() => useSpacePendingTransactions())
-
-    await waitFor(() => {
-      expect(result.current.transactions[0]).toHaveProperty('safeAddress', SAFE_ADDRESS_1)
-      expect(result.current.transactions[0]).toHaveProperty('chainId', '1')
-      expect(result.current.transactions[1]).toHaveProperty('safeAddress', SAFE_ADDRESS_2)
-      expect(result.current.transactions[1]).toHaveProperty('chainId', '137')
-    })
+    expect(result.current.transactions).toHaveLength(1)
+    expect(result.current.transactions[0].transaction.timestamp).toBe(1000)
   })
 
-  it('should set error when fetching fails', async () => {
-    ;(transactionsService.getTransactionQueue as jest.Mock).mockRejectedValue(new Error('Network error'))
-
+  it('skips items whose id does not match the multisig_<addr>_<hash> shape', () => {
+    const tx = createQueuedItem(SAFE_1, 1000)
+    const malformed = {
+      ...createQueuedItem(SAFE_2, 2000),
+      transaction: { ...createQueuedItem(SAFE_2, 2000).transaction, id: 'not-a-multisig-id' },
+    }
+    mockQueue([tx, malformed])
     const { result } = renderHook(() => useSpacePendingTransactions())
-
-    await waitFor(() => {
-      expect(result.current.error).toBe('Failed to load pending transactions')
-      expect(result.current.isLoading).toBe(false)
-      expect(result.current.transactions).toEqual([])
-    })
+    expect(result.current.transactions).toHaveLength(1)
+    expect(result.current.transactions[0].safeAddress).toBe(SAFE_1)
   })
 
-  it('should pass correct cursor with limit to getTransactionQueue', async () => {
-    ;(transactionsService.getTransactionQueue as jest.Mock).mockResolvedValue({ results: [] })
-    ;(txList.getLatestTransactions as jest.Mock).mockReturnValue([])
+  it('surfaces an error message when the queue query fails', () => {
+    mockQueue(undefined, { error: { status: 500, data: 'boom' } })
+    const { result } = renderHook(() => useSpacePendingTransactions())
+    expect(result.current.error).toBe('Failed to load pending transactions')
+    expect(result.current.transactions).toEqual([])
+  })
 
+  it('passes the cursor with the right limit to the queue query', () => {
     renderHook(() => useSpacePendingTransactions(5))
+    expect(mockUseSpaceTransactionsGetTransactionQueueV1Query).toHaveBeenCalledWith(
+      { spaceId: 42, cursor: 'limit=5&offset=0' },
+      { skip: false },
+    )
+  })
 
-    await waitFor(() => {
-      expect(transactionsService.getTransactionQueue).toHaveBeenCalledWith('1', SAFE_ADDRESS_1, {
-        trusted: true,
-        cursor: 'limit=5&offset=0',
-      })
-    })
+  it('skips both queries when the user is not signed in', () => {
+    mockUseAppSelector.mockReturnValue(false)
+    renderHook(() => useSpacePendingTransactions())
+    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith({ spaceId: 42 }, { skip: true })
+    expect(mockUseSpaceTransactionsGetTransactionQueueV1Query).toHaveBeenCalledWith(
+      { spaceId: 42, cursor: 'limit=3&offset=0' },
+      { skip: true },
+    )
+  })
+
+  it('skips both queries when there is no current spaceId', () => {
+    mockUseCurrentSpaceId.mockReturnValue(undefined)
+    renderHook(() => useSpacePendingTransactions())
+    const safesCall = mockUseSpaceSafesGetV1Query.mock.calls[0][1]
+    const queueCall = mockUseSpaceTransactionsGetTransactionQueueV1Query.mock.calls[0][1]
+    expect(safesCall).toEqual({ skip: true })
+    expect(queueCall).toEqual({ skip: true })
+  })
+
+  it('exposes refetch from the queue query', () => {
+    const { result } = renderHook(() => useSpacePendingTransactions())
+    expect(result.current.refetch).toBe(refetch)
   })
 })

--- a/apps/web/src/features/spaces/hooks/useSpacePendingTransactions.ts
+++ b/apps/web/src/features/spaces/hooks/useSpacePendingTransactions.ts
@@ -1,75 +1,74 @@
-import { useState, useEffect, useCallback } from 'react'
-import type { TransactionQueuedItem } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
-import { getTransactionQueue } from '@/services/transactions'
-import { getLatestTransactions } from '@/utils/tx-list'
-import { useSpaceSafesWithQueue } from './useSpaceSafesWithQueue'
+import { useMemo } from 'react'
+import {
+  useSpaceTransactionsGetTransactionQueueV1Query,
+  useSpaceSafesGetV1Query,
+  type TransactionQueuedItem,
+} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useCurrentSpaceId } from './useCurrentSpaceId'
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
 
 type SpacePendingTxItem = TransactionQueuedItem & { safeAddress: string; chainId: string }
-type SafeQueueResult = { chainId: string; address: string; transactions: TransactionQueuedItem[] }
 
-const BATCH_SIZE = 3
-const BATCH_DELAY_MS = 300
+const TX_ID_PREFIX = 'multisig_'
+const TX_ID_SEPARATOR = '_'
+
+const parseSafeAddress = (txId: string): string | null => {
+  if (!txId.startsWith(TX_ID_PREFIX)) return null
+  const rest = txId.slice(TX_ID_PREFIX.length)
+  const sepIdx = rest.indexOf(TX_ID_SEPARATOR)
+  if (sepIdx === -1) return null
+  return rest.slice(0, sepIdx)
+}
 
 export const useSpacePendingTransactions = (limit = 3) => {
-  const { safesWithQueue, isLoading: isLoadingQueue } = useSpaceSafesWithQueue()
-  const [allTransactions, setAllTransactions] = useState<SpacePendingTxItem[]>([])
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string>()
+  const spaceId = useCurrentSpaceId()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
 
-  const fetchAll = useCallback(async () => {
-    if (safesWithQueue.length === 0) {
-      setAllTransactions([])
-      return
-    }
+  const { currentData: spaceSafes } = useSpaceSafesGetV1Query(
+    { spaceId: Number(spaceId) },
+    { skip: !isUserSignedIn || !spaceId },
+  )
 
-    setIsLoading(true)
-    setError(undefined)
-
-    try {
-      const results: SafeQueueResult[] = []
-
-      for (let i = 0; i < safesWithQueue.length; i += BATCH_SIZE) {
-        if (i > 0) {
-          await new Promise((resolve) => setTimeout(resolve, BATCH_DELAY_MS))
-        }
-
-        const batch = safesWithQueue.slice(i, i + BATCH_SIZE)
-        const batchResults = await Promise.all(
-          batch.map(async ({ chainId, address }) => {
-            const page = await getTransactionQueue(chainId, address, {
-              trusted: true,
-              cursor: `limit=${limit}&offset=0`,
-            })
-            return { chainId, address, transactions: getLatestTransactions(page.results) }
-          }),
-        )
-        results.push(...batchResults)
+  const addressToChainId = useMemo(() => {
+    const map = new Map<string, string>()
+    if (!spaceSafes?.safes) return map
+    for (const [chainId, addresses] of Object.entries(spaceSafes.safes)) {
+      for (const address of addresses as string[]) {
+        map.set(address.toLowerCase(), chainId)
       }
-
-      const merged = results
-        .flatMap(({ chainId, address, transactions }) =>
-          transactions.map((tx) => ({ ...tx, safeAddress: address, chainId })),
-        )
-        .sort((a, b) => a.transaction.timestamp - b.transaction.timestamp)
-        .slice(0, limit)
-
-      setAllTransactions(merged)
-    } catch {
-      setError('Failed to load pending transactions')
-    } finally {
-      setIsLoading(false)
     }
-  }, [safesWithQueue, limit])
+    return map
+  }, [spaceSafes?.safes])
 
-  useEffect(() => {
-    fetchAll()
-  }, [fetchAll])
+  const {
+    currentData: queuePage,
+    isFetching,
+    error,
+    refetch,
+  } = useSpaceTransactionsGetTransactionQueueV1Query(
+    { spaceId: Number(spaceId), cursor: `limit=${limit}&offset=0` },
+    { skip: !isUserSignedIn || !spaceId },
+  )
+
+  const transactions = useMemo<SpacePendingTxItem[]>(() => {
+    if (!queuePage?.results) return []
+    const items: SpacePendingTxItem[] = []
+    for (const item of queuePage.results) {
+      if (item.type !== 'TRANSACTION') continue
+      const safeAddress = parseSafeAddress(item.transaction.id)
+      if (!safeAddress) continue
+      const chainId = addressToChainId.get(safeAddress.toLowerCase()) ?? ''
+      items.push({ ...item, safeAddress, chainId })
+    }
+    return items.sort((a, b) => a.transaction.timestamp - b.transaction.timestamp).slice(0, limit)
+  }, [queuePage?.results, addressToChainId, limit])
 
   return {
-    transactions: allTransactions,
-    count: allTransactions.length,
-    isLoading: isLoadingQueue || isLoading,
-    error,
-    refetch: fetchAll,
+    transactions,
+    count: transactions.length,
+    isLoading: isFetching,
+    error: error ? 'Failed to load pending transactions' : undefined,
+    refetch,
   }
 }

--- a/packages/store/scripts/api-schema/schema.json
+++ b/packages/store/scripts/api-schema/schema.json
@@ -151,99 +151,6 @@
         ]
       }
     },
-    "/v1/auth/oidc/authorize": {
-      "get": {
-        "description": "Redirects the browser to OIDC provider login page with a generated state value stored in an HTTP-only cookie.",
-        "operationId": "oidcAuthAuthorizeV1",
-        "parameters": [
-          {
-            "name": "redirect_url",
-            "required": false,
-            "in": "query",
-            "description": "URL to redirect to after successful login. Must be same-origin as the configured post-login redirect URI.",
-            "schema": {
-              "example": "/settings",
-              "type": "string"
-            }
-          },
-          {
-            "name": "connection",
-            "required": false,
-            "in": "query",
-            "description": "OIDC connection name to route to a specific identity provider.",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "302": {
-            "description": "Redirect to OIDC authorize endpoint"
-          }
-        },
-        "summary": "Start OIDC authorization code flow",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
-    "/v1/auth/oidc/callback": {
-      "get": {
-        "description": "Exchanges the OIDC authorization code for user information, mints the internal JWT cookie, and redirects to the provided post-login URL or a configured default one.",
-        "operationId": "oidcAuthCallbackV1",
-        "parameters": [
-          {
-            "name": "code",
-            "required": false,
-            "in": "query",
-            "description": "Authorization code returned by the OIDC provider",
-            "schema": {
-              "example": "SplxlOBeZQQYbYS6WxSbIA",
-              "type": "string"
-            }
-          },
-          {
-            "name": "state",
-            "required": false,
-            "in": "query",
-            "description": "State parameter returned by the OIDC provider",
-            "schema": {
-              "example": "af0ifjsldkj",
-              "type": "string"
-            }
-          },
-          {
-            "name": "error",
-            "required": false,
-            "in": "query",
-            "description": "Error parameter returned by the OIDC provider",
-            "schema": {
-              "example": "access_denied",
-              "type": "string"
-            }
-          },
-          {
-            "name": "error_description",
-            "required": false,
-            "in": "query",
-            "description": "Description of the error returned by the OIDC provider (if failed)",
-            "schema": {
-              "example": "The user has denied the request",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "302": {
-            "description": "Redirect to the post-login URL. On error, includes error query parameter."
-          }
-        },
-        "summary": "Handle OIDC authorization callback",
-        "tags": [
-          "auth"
-        ]
-      }
-    },
     "/v1/chains/{chainId}/safes/{safeAddress}/balances/{fiatCode}": {
       "get": {
         "description": "Retrieves token balances for a Safe on a specific chain, converted to the specified fiat currency. Includes native tokens, ERC-20 tokens, and their current market values.",
@@ -1295,86 +1202,6 @@
         "summary": "Decode transaction data",
         "tags": [
           "data-decoded"
-        ]
-      }
-    },
-    "/v1/chains/{chainId}/safes/{safeAddress}/recovery": {
-      "post": {
-        "operationId": "recoveryAddRecoveryModuleV1",
-        "parameters": [
-          {
-            "name": "chainId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "safeAddress",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AddRecoveryModuleDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "recovery"
-        ]
-      }
-    },
-    "/v1/chains/{chainId}/safes/{safeAddress}/recovery/{moduleAddress}": {
-      "delete": {
-        "operationId": "recoveryDeleteRecoveryModuleV1",
-        "parameters": [
-          {
-            "name": "chainId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "moduleAddress",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "safeAddress",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "recovery"
         ]
       }
     },
@@ -2668,6 +2495,52 @@
           }
         },
         "summary": "Remove Safes from space",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/v1/spaces/{spaceId}/transactions/queued": {
+      "get": {
+        "description": "Retrieves a paginated list of queued (pending) transactions across all Safes in a space, ordered by nonce ascending (oldest first).",
+        "operationId": "spaceTransactionsGetTransactionQueueV1",
+        "parameters": [
+          {
+            "name": "cursor",
+            "required": false,
+            "in": "query",
+            "description": "Pagination cursor for retrieving the next set of results",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "spaceId",
+            "required": true,
+            "in": "path",
+            "description": "Space ID to fetch queued transactions for",
+            "schema": {
+              "example": 1,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of queued transactions for the space",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueuedItemPage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Space not found"
+          }
+        },
+        "summary": "Get space transaction queue",
         "tags": [
           "spaces"
         ]
@@ -6077,7 +5950,7 @@
   "info": {
     "title": "Safe Client Gateway",
     "description": "",
-    "version": "main",
+    "version": "",
     "contact": {}
   },
   "tags": [],
@@ -7956,17 +7829,6 @@
           "method"
         ]
       },
-      "AddRecoveryModuleDto": {
-        "type": "object",
-        "properties": {
-          "moduleAddress": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "moduleAddress"
-        ]
-      },
       "GetEstimationDto": {
         "type": "object",
         "properties": {
@@ -9028,6 +8890,1957 @@
         },
         "required": [
           "safes"
+        ]
+      },
+      "ConflictHeaderQueuedItem": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "CONFLICT_HEADER"
+            ]
+          },
+          "nonce": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "type",
+          "nonce"
+        ]
+      },
+      "LabelQueuedItem": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "LABEL"
+            ]
+          },
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "label"
+        ]
+      },
+      "TransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Bridge",
+              "Creation",
+              "Custom",
+              "NativeStakingDeposit",
+              "NativeStakingValidatorsExit",
+              "NativeStakingWithdraw",
+              "SettingsChange",
+              "Swap",
+              "SwapAndBridge",
+              "SwapOrder",
+              "SwapTransfer",
+              "Transfer",
+              "TwapOrder",
+              "VaultDeposit",
+              "VaultRedeem"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "CreationTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Creation"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "creator": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "transactionHash": {
+            "type": "string"
+          },
+          "implementation": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AddressInfo"
+              }
+            ]
+          },
+          "factory": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "saltNonce": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "creator",
+          "transactionHash"
+        ]
+      },
+      "CustomTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Custom"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "to": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "dataSize": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "isCancellation": {
+            "type": "boolean"
+          },
+          "methodName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "to",
+          "dataSize",
+          "isCancellation"
+        ]
+      },
+      "MultiSendTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Custom"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "to": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "dataSize": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "isCancellation": {
+            "type": "boolean"
+          },
+          "methodName": {
+            "type": "string",
+            "enum": [
+              "multiSend"
+            ]
+          },
+          "actionCount": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "type",
+          "to",
+          "dataSize",
+          "isCancellation",
+          "methodName",
+          "actionCount"
+        ]
+      },
+      "AddOwner": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "ADD_OWNER"
+            ]
+          },
+          "owner": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "threshold": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "type",
+          "owner",
+          "threshold"
+        ]
+      },
+      "ChangeMasterCopy": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "CHANGE_MASTER_COPY"
+            ]
+          },
+          "implementation": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "implementation"
+        ]
+      },
+      "ChangeThreshold": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "CHANGE_THRESHOLD"
+            ]
+          },
+          "threshold": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "type",
+          "threshold"
+        ]
+      },
+      "DeleteGuard": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "DELETE_GUARD"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "DisableModule": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "DISABLE_MODULE"
+            ]
+          },
+          "module": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "module"
+        ]
+      },
+      "EnableModule": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "ENABLE_MODULE"
+            ]
+          },
+          "module": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "module"
+        ]
+      },
+      "RemoveOwner": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "REMOVE_OWNER"
+            ]
+          },
+          "owner": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "threshold": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "type",
+          "owner",
+          "threshold"
+        ]
+      },
+      "SetFallbackHandler": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SET_FALLBACK_HANDLER"
+            ]
+          },
+          "handler": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "handler"
+        ]
+      },
+      "SetGuard": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SET_GUARD"
+            ]
+          },
+          "guard": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "guard"
+        ]
+      },
+      "SettingsChange": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "ADD_OWNER",
+              "CHANGE_MASTER_COPY",
+              "CHANGE_THRESHOLD",
+              "DELETE_GUARD",
+              "DISABLE_MODULE",
+              "ENABLE_MODULE",
+              "REMOVE_OWNER",
+              "SET_FALLBACK_HANDLER",
+              "SET_GUARD",
+              "SWAP_OWNER"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "SwapOwner": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SWAP_OWNER"
+            ]
+          },
+          "oldOwner": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "newOwner": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "oldOwner",
+          "newOwner"
+        ]
+      },
+      "SettingsChangeTransaction": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SettingsChange"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "dataDecoded": {
+            "$ref": "#/components/schemas/DataDecoded"
+          },
+          "settingsInfo": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/AddOwner"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeMasterCopy"
+              },
+              {
+                "$ref": "#/components/schemas/ChangeThreshold"
+              },
+              {
+                "$ref": "#/components/schemas/DeleteGuard"
+              },
+              {
+                "$ref": "#/components/schemas/DisableModule"
+              },
+              {
+                "$ref": "#/components/schemas/EnableModule"
+              },
+              {
+                "$ref": "#/components/schemas/RemoveOwner"
+              },
+              {
+                "$ref": "#/components/schemas/SetFallbackHandler"
+              },
+              {
+                "$ref": "#/components/schemas/SetGuard"
+              },
+              {
+                "$ref": "#/components/schemas/SwapOwner"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "dataDecoded",
+          "settingsInfo"
+        ]
+      },
+      "Erc20Transfer": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "ERC20"
+            ]
+          },
+          "tokenAddress": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "tokenName": {
+            "type": "string",
+            "nullable": true
+          },
+          "tokenSymbol": {
+            "type": "string",
+            "nullable": true
+          },
+          "logoUri": {
+            "type": "string",
+            "nullable": true
+          },
+          "decimals": {
+            "type": "number",
+            "nullable": true
+          },
+          "trusted": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "imitation": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "type",
+          "tokenAddress",
+          "value",
+          "imitation"
+        ]
+      },
+      "Erc721Transfer": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "ERC721"
+            ]
+          },
+          "tokenAddress": {
+            "type": "string"
+          },
+          "tokenId": {
+            "type": "string"
+          },
+          "tokenName": {
+            "type": "string",
+            "nullable": true
+          },
+          "tokenSymbol": {
+            "type": "string",
+            "nullable": true
+          },
+          "logoUri": {
+            "type": "string",
+            "nullable": true
+          },
+          "trusted": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "tokenAddress",
+          "tokenId"
+        ]
+      },
+      "NativeCoinTransfer": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "NATIVE_COIN"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "Transfer": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "NATIVE_COIN",
+              "ERC20",
+              "ERC721"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "TransferTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Transfer"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "sender": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "recipient": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "INCOMING",
+              "OUTGOING",
+              "UNKNOWN"
+            ]
+          },
+          "transferInfo": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Erc20Transfer"
+              },
+              {
+                "$ref": "#/components/schemas/Erc721Transfer"
+              },
+              {
+                "$ref": "#/components/schemas/NativeCoinTransfer"
+              }
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Transfer"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "sender",
+          "recipient",
+          "direction",
+          "transferInfo"
+        ]
+      },
+      "BridgeFee": {
+        "type": "object",
+        "properties": {
+          "tokenAddress": {
+            "type": "string"
+          },
+          "integratorFee": {
+            "type": "string"
+          },
+          "lifiFee": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tokenAddress",
+          "integratorFee",
+          "lifiFee"
+        ]
+      },
+      "TokenInfo": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "The token address"
+          },
+          "decimals": {
+            "type": "number",
+            "description": "The token decimals"
+          },
+          "logoUri": {
+            "type": "string",
+            "nullable": true,
+            "description": "The logo URI for the token"
+          },
+          "name": {
+            "type": "string",
+            "description": "The token name"
+          },
+          "symbol": {
+            "type": "string",
+            "description": "The token symbol"
+          },
+          "trusted": {
+            "type": "boolean",
+            "description": "The token trusted status"
+          }
+        },
+        "required": [
+          "address",
+          "decimals",
+          "name",
+          "symbol",
+          "trusted"
+        ]
+      },
+      "BridgeAndSwapTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SwapAndBridge"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "fromToken": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "recipient": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "explorerUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "NOT_FOUND",
+              "INVALID",
+              "PENDING",
+              "DONE",
+              "FAILED",
+              "UNKNOWN",
+              "AWAITING_EXECUTION"
+            ]
+          },
+          "substatus": {
+            "type": "string",
+            "enum": [
+              "WAIT_SOURCE_CONFIRMATIONS",
+              "WAIT_DESTINATION_TRANSACTION",
+              "BRIDGE_NOT_AVAILABLE",
+              "CHAIN_NOT_AVAILABLE",
+              "REFUND_IN_PROGRESS",
+              "UNKNOWN_ERROR",
+              "COMPLETED",
+              "PARTIAL",
+              "REFUNDED",
+              "INSUFFICIENT_ALLOWANCE",
+              "INSUFFICIENT_BALANCE",
+              "OUT_OF_GAS",
+              "EXPIRED",
+              "SLIPPAGE_EXCEEDED",
+              "UNKNOWN_FAILED_ERROR",
+              "UNKNOWN",
+              "AWAITING_EXECUTION"
+            ]
+          },
+          "fees": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BridgeFee"
+              }
+            ]
+          },
+          "fromAmount": {
+            "type": "string"
+          },
+          "toChain": {
+            "type": "string"
+          },
+          "toToken": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "toAmount": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "fromToken",
+          "recipient",
+          "explorerUrl",
+          "status",
+          "substatus",
+          "fees",
+          "fromAmount",
+          "toChain",
+          "toToken",
+          "toAmount"
+        ]
+      },
+      "SwapOrderTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SwapOrder"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "uid": {
+            "type": "string",
+            "description": "The order UID"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "presignaturePending",
+              "open",
+              "fulfilled",
+              "cancelled",
+              "expired",
+              "unknown"
+            ]
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell",
+              "unknown"
+            ]
+          },
+          "orderClass": {
+            "type": "string",
+            "enum": [
+              "market",
+              "limit",
+              "liquidity",
+              "unknown"
+            ]
+          },
+          "validUntil": {
+            "type": "number",
+            "description": "The timestamp when the order expires"
+          },
+          "sellAmount": {
+            "type": "string",
+            "description": "The sell token raw amount (no decimals)"
+          },
+          "buyAmount": {
+            "type": "string",
+            "description": "The buy token raw amount (no decimals)"
+          },
+          "executedSellAmount": {
+            "type": "string",
+            "description": "The executed sell token raw amount (no decimals)"
+          },
+          "executedBuyAmount": {
+            "type": "string",
+            "description": "The executed buy token raw amount (no decimals)"
+          },
+          "sellToken": {
+            "description": "The sell token of the order",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "buyToken": {
+            "description": "The buy token of the order",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "explorerUrl": {
+            "type": "string",
+            "description": "The URL to the explorer page of the order"
+          },
+          "executedFee": {
+            "type": "string",
+            "description": "The amount of fees paid for this order."
+          },
+          "executedFeeToken": {
+            "description": "The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "receiver": {
+            "type": "string",
+            "nullable": true,
+            "description": "The (optional) address to receive the proceeds of the trade"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "fullAppData": {
+            "type": "object",
+            "nullable": true,
+            "description": "The App Data for this order"
+          }
+        },
+        "required": [
+          "type",
+          "uid",
+          "status",
+          "kind",
+          "orderClass",
+          "validUntil",
+          "sellAmount",
+          "buyAmount",
+          "executedSellAmount",
+          "executedBuyAmount",
+          "sellToken",
+          "buyToken",
+          "explorerUrl",
+          "executedFee",
+          "executedFeeToken",
+          "owner"
+        ]
+      },
+      "SwapTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Swap"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "recipient": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "fees": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BridgeFee"
+              }
+            ]
+          },
+          "fromToken": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "fromAmount": {
+            "type": "string"
+          },
+          "toToken": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "toAmount": {
+            "type": "string"
+          },
+          "lifiExplorerUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "recipient",
+          "fees",
+          "fromToken",
+          "fromAmount",
+          "toToken",
+          "toAmount",
+          "lifiExplorerUrl"
+        ]
+      },
+      "SwapTransferTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "SwapTransfer"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "sender": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "recipient": {
+            "$ref": "#/components/schemas/AddressInfo"
+          },
+          "direction": {
+            "type": "string"
+          },
+          "transferInfo": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Erc20Transfer"
+              },
+              {
+                "$ref": "#/components/schemas/Erc721Transfer"
+              },
+              {
+                "$ref": "#/components/schemas/NativeCoinTransfer"
+              }
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Transfer"
+              }
+            ]
+          },
+          "uid": {
+            "type": "string",
+            "description": "The order UID"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "presignaturePending",
+              "open",
+              "fulfilled",
+              "cancelled",
+              "expired",
+              "unknown"
+            ]
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell",
+              "unknown"
+            ]
+          },
+          "orderClass": {
+            "type": "string",
+            "enum": [
+              "market",
+              "limit",
+              "liquidity",
+              "unknown"
+            ]
+          },
+          "validUntil": {
+            "type": "number",
+            "description": "The timestamp when the order expires"
+          },
+          "sellAmount": {
+            "type": "string",
+            "description": "The sell token raw amount (no decimals)"
+          },
+          "buyAmount": {
+            "type": "string",
+            "description": "The buy token raw amount (no decimals)"
+          },
+          "executedSellAmount": {
+            "type": "string",
+            "description": "The executed sell token raw amount (no decimals)"
+          },
+          "executedBuyAmount": {
+            "type": "string",
+            "description": "The executed buy token raw amount (no decimals)"
+          },
+          "sellToken": {
+            "description": "The sell token of the order",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "buyToken": {
+            "description": "The buy token of the order",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "explorerUrl": {
+            "type": "string",
+            "description": "The URL to the explorer page of the order"
+          },
+          "executedFee": {
+            "type": "string",
+            "description": "The amount of fees paid for this order."
+          },
+          "executedFeeToken": {
+            "description": "The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "receiver": {
+            "type": "string",
+            "nullable": true,
+            "description": "The (optional) address to receive the proceeds of the trade"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "fullAppData": {
+            "type": "object",
+            "nullable": true,
+            "description": "The App Data for this order"
+          }
+        },
+        "required": [
+          "type",
+          "sender",
+          "recipient",
+          "direction",
+          "transferInfo",
+          "uid",
+          "status",
+          "kind",
+          "orderClass",
+          "validUntil",
+          "sellAmount",
+          "buyAmount",
+          "executedSellAmount",
+          "executedBuyAmount",
+          "sellToken",
+          "buyToken",
+          "explorerUrl",
+          "executedFee",
+          "executedFeeToken",
+          "owner"
+        ]
+      },
+      "DurationAuto": {
+        "type": "object",
+        "properties": {
+          "durationType": {
+            "type": "string",
+            "enum": [
+              "AUTO"
+            ]
+          }
+        },
+        "required": [
+          "durationType"
+        ]
+      },
+      "DurationLimit": {
+        "type": "object",
+        "properties": {
+          "durationType": {
+            "type": "string",
+            "enum": [
+              "LIMIT_DURATION"
+            ]
+          },
+          "duration": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "durationType",
+          "duration"
+        ]
+      },
+      "StartTimeAtMining": {
+        "type": "object",
+        "properties": {
+          "startType": {
+            "type": "string",
+            "enum": [
+              "AT_MINING_TIME"
+            ]
+          }
+        },
+        "required": [
+          "startType"
+        ]
+      },
+      "StartTimeAtEpoch": {
+        "type": "object",
+        "properties": {
+          "startType": {
+            "type": "string",
+            "enum": [
+              "AT_EPOCH"
+            ]
+          },
+          "epoch": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "startType",
+          "epoch"
+        ]
+      },
+      "TwapOrderTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "TwapOrder"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "description": "The TWAP status",
+            "enum": [
+              "presignaturePending",
+              "open",
+              "fulfilled",
+              "cancelled",
+              "expired",
+              "unknown"
+            ]
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell",
+              "unknown"
+            ]
+          },
+          "class": {
+            "type": "string",
+            "enum": [
+              "market",
+              "limit",
+              "liquidity",
+              "unknown"
+            ]
+          },
+          "activeOrderUid": {
+            "type": "string",
+            "nullable": true,
+            "description": "The order UID of the active order, or null if none is active"
+          },
+          "validUntil": {
+            "type": "number",
+            "description": "The timestamp when the TWAP expires"
+          },
+          "sellAmount": {
+            "type": "string",
+            "description": "The sell token raw amount (no decimals)"
+          },
+          "buyAmount": {
+            "type": "string",
+            "description": "The buy token raw amount (no decimals)"
+          },
+          "executedSellAmount": {
+            "type": "string",
+            "nullable": true,
+            "description": "The executed sell token raw amount (no decimals), or null if there are too many parts"
+          },
+          "executedBuyAmount": {
+            "type": "string",
+            "nullable": true,
+            "description": "The executed buy token raw amount (no decimals), or null if there are too many parts"
+          },
+          "executedFee": {
+            "type": "string",
+            "nullable": true,
+            "description": "The executed surplus fee raw amount (no decimals), or null if there are too many parts"
+          },
+          "executedFeeToken": {
+            "description": "The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "sellToken": {
+            "description": "The sell token of the TWAP",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "buyToken": {
+            "description": "The buy token of the TWAP",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenInfo"
+              }
+            ]
+          },
+          "receiver": {
+            "type": "string",
+            "description": "The address to receive the proceeds of the trade"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "fullAppData": {
+            "type": "object",
+            "nullable": true,
+            "description": "The App Data for this TWAP"
+          },
+          "numberOfParts": {
+            "type": "string",
+            "description": "The number of parts in the TWAP"
+          },
+          "partSellAmount": {
+            "type": "string",
+            "description": "The amount of sellToken to sell in each part"
+          },
+          "minPartLimit": {
+            "type": "string",
+            "description": "The amount of buyToken that must be bought in each part"
+          },
+          "timeBetweenParts": {
+            "type": "number",
+            "description": "The duration of the TWAP interval"
+          },
+          "durationOfPart": {
+            "description": "Whether the TWAP is valid for the entire interval or not",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DurationAuto"
+              },
+              {
+                "$ref": "#/components/schemas/DurationLimit"
+              }
+            ]
+          },
+          "startTime": {
+            "description": "The start time of the TWAP",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/StartTimeAtMining"
+              },
+              {
+                "$ref": "#/components/schemas/StartTimeAtEpoch"
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "status",
+          "kind",
+          "validUntil",
+          "sellAmount",
+          "buyAmount",
+          "executedFeeToken",
+          "sellToken",
+          "buyToken",
+          "receiver",
+          "owner",
+          "numberOfParts",
+          "partSellAmount",
+          "minPartLimit",
+          "timeBetweenParts",
+          "durationOfPart",
+          "startTime"
+        ]
+      },
+      "NativeStakingDepositTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "NativeStakingDeposit"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "NOT_STAKED",
+              "ACTIVATING",
+              "DEPOSIT_IN_PROGRESS",
+              "ACTIVE",
+              "EXIT_REQUESTED",
+              "EXITING",
+              "EXITED",
+              "SLASHED"
+            ]
+          },
+          "estimatedEntryTime": {
+            "type": "number"
+          },
+          "estimatedExitTime": {
+            "type": "number"
+          },
+          "estimatedWithdrawalTime": {
+            "type": "number"
+          },
+          "fee": {
+            "type": "number"
+          },
+          "monthlyNrr": {
+            "type": "number"
+          },
+          "annualNrr": {
+            "type": "number"
+          },
+          "value": {
+            "type": "string"
+          },
+          "numValidators": {
+            "type": "number"
+          },
+          "expectedAnnualReward": {
+            "type": "string"
+          },
+          "expectedMonthlyReward": {
+            "type": "string"
+          },
+          "expectedFiatAnnualReward": {
+            "type": "number"
+          },
+          "expectedFiatMonthlyReward": {
+            "type": "number"
+          },
+          "tokenInfo": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "validators": {
+            "nullable": true,
+            "description": "Populated after transaction has been executed",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "status",
+          "estimatedEntryTime",
+          "estimatedExitTime",
+          "estimatedWithdrawalTime",
+          "fee",
+          "monthlyNrr",
+          "annualNrr",
+          "value",
+          "numValidators",
+          "expectedAnnualReward",
+          "expectedMonthlyReward",
+          "expectedFiatAnnualReward",
+          "expectedFiatMonthlyReward",
+          "tokenInfo"
+        ]
+      },
+      "NativeStakingValidatorsExitTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "NativeStakingValidatorsExit"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "NOT_STAKED",
+              "ACTIVATING",
+              "DEPOSIT_IN_PROGRESS",
+              "ACTIVE",
+              "EXIT_REQUESTED",
+              "EXITING",
+              "EXITED",
+              "SLASHED"
+            ]
+          },
+          "estimatedExitTime": {
+            "type": "number"
+          },
+          "estimatedWithdrawalTime": {
+            "type": "number"
+          },
+          "value": {
+            "type": "string"
+          },
+          "numValidators": {
+            "type": "number"
+          },
+          "tokenInfo": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "validators": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "status",
+          "estimatedExitTime",
+          "estimatedWithdrawalTime",
+          "value",
+          "numValidators",
+          "tokenInfo",
+          "validators"
+        ]
+      },
+      "NativeStakingWithdrawTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "NativeStakingWithdraw"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "type": "string"
+          },
+          "tokenInfo": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "validators": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "tokenInfo",
+          "validators"
+        ]
+      },
+      "VaultInfo": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "dashboardUri": {
+            "type": "string",
+            "nullable": true
+          },
+          "logoUri": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "address",
+          "name",
+          "description",
+          "logoUri"
+        ]
+      },
+      "VaultExtraReward": {
+        "type": "object",
+        "properties": {
+          "tokenInfo": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "nrr": {
+            "type": "number"
+          },
+          "claimable": {
+            "type": "string"
+          },
+          "claimableNext": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "tokenInfo",
+          "nrr",
+          "claimable",
+          "claimableNext"
+        ]
+      },
+      "VaultDepositTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "VaultDeposit"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "type": "string"
+          },
+          "baseNrr": {
+            "type": "number"
+          },
+          "fee": {
+            "type": "number"
+          },
+          "tokenInfo": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "vaultInfo": {
+            "$ref": "#/components/schemas/VaultInfo"
+          },
+          "currentReward": {
+            "type": "string"
+          },
+          "additionalRewardsNrr": {
+            "type": "number"
+          },
+          "additionalRewards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VaultExtraReward"
+            }
+          },
+          "expectedMonthlyReward": {
+            "type": "string"
+          },
+          "expectedAnnualReward": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "baseNrr",
+          "fee",
+          "tokenInfo",
+          "vaultInfo",
+          "currentReward",
+          "additionalRewardsNrr",
+          "additionalRewards",
+          "expectedMonthlyReward",
+          "expectedAnnualReward"
+        ]
+      },
+      "VaultRedeemTransactionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "VaultRedeem"
+            ]
+          },
+          "humanDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "type": "string"
+          },
+          "baseNrr": {
+            "type": "number"
+          },
+          "fee": {
+            "type": "number"
+          },
+          "tokenInfo": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "vaultInfo": {
+            "$ref": "#/components/schemas/VaultInfo"
+          },
+          "currentReward": {
+            "type": "string"
+          },
+          "additionalRewardsNrr": {
+            "type": "number"
+          },
+          "additionalRewards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VaultExtraReward"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "value",
+          "baseNrr",
+          "fee",
+          "tokenInfo",
+          "vaultInfo",
+          "currentReward",
+          "additionalRewardsNrr",
+          "additionalRewards"
+        ]
+      },
+      "ModuleExecutionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MODULE"
+            ]
+          },
+          "address": {
+            "$ref": "#/components/schemas/AddressInfo"
+          }
+        },
+        "required": [
+          "type",
+          "address"
+        ]
+      },
+      "MultisigExecutionInfo": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MULTISIG"
+            ]
+          },
+          "nonce": {
+            "type": "number"
+          },
+          "confirmationsRequired": {
+            "type": "number"
+          },
+          "confirmationsSubmitted": {
+            "type": "number"
+          },
+          "missingSigners": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddressInfo"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "nonce",
+          "confirmationsRequired",
+          "confirmationsSubmitted"
+        ]
+      },
+      "SafeAppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "logoUri": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "name",
+          "url"
+        ]
+      },
+      "Transaction": {
+        "type": "object",
+        "properties": {
+          "txInfo": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CreationTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/CustomTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/MultiSendTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/SettingsChangeTransaction"
+              },
+              {
+                "$ref": "#/components/schemas/TransferTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/SwapOrderTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/BridgeAndSwapTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/SwapTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/SwapTransferTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/TwapOrderTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/NativeStakingDepositTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/NativeStakingValidatorsExitTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/NativeStakingWithdrawTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/VaultDepositTransactionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/VaultRedeemTransactionInfo"
+              }
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionInfo"
+              }
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "txHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "txStatus": {
+            "type": "string",
+            "enum": [
+              "SUCCESS",
+              "FAILED",
+              "CANCELLED",
+              "AWAITING_CONFIRMATIONS",
+              "AWAITING_EXECUTION"
+            ]
+          },
+          "executionInfo": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/MultisigExecutionInfo"
+              },
+              {
+                "$ref": "#/components/schemas/ModuleExecutionInfo"
+              }
+            ],
+            "nullable": true
+          },
+          "safeAppInfo": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SafeAppInfo"
+              }
+            ]
+          },
+          "note": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "txInfo",
+          "id",
+          "timestamp",
+          "txStatus"
+        ]
+      },
+      "TransactionQueuedItem": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "TRANSACTION"
+            ]
+          },
+          "transaction": {
+            "$ref": "#/components/schemas/Transaction"
+          },
+          "conflictType": {
+            "type": "string",
+            "enum": [
+              "None",
+              "HasNext",
+              "End"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "transaction",
+          "conflictType"
+        ]
+      },
+      "QueuedItemPage": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number",
+            "nullable": true
+          },
+          "next": {
+            "type": "string",
+            "nullable": true
+          },
+          "previous": {
+            "type": "string",
+            "nullable": true
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ConflictHeaderQueuedItem"
+                },
+                {
+                  "$ref": "#/components/schemas/LabelQueuedItem"
+                },
+                {
+                  "$ref": "#/components/schemas/TransactionQueuedItem"
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "results"
         ]
       },
       "InviteUserDto": {
@@ -10922,1680 +12735,6 @@
           "completed"
         ]
       },
-      "TransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "Bridge",
-              "Creation",
-              "Custom",
-              "NativeStakingDeposit",
-              "NativeStakingValidatorsExit",
-              "NativeStakingWithdraw",
-              "SettingsChange",
-              "Swap",
-              "SwapAndBridge",
-              "SwapOrder",
-              "SwapTransfer",
-              "Transfer",
-              "TwapOrder",
-              "VaultDeposit",
-              "VaultRedeem"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "CreationTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "Creation"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "creator": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "transactionHash": {
-            "type": "string"
-          },
-          "implementation": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AddressInfo"
-              }
-            ]
-          },
-          "factory": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "saltNonce": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "type",
-          "creator",
-          "transactionHash"
-        ]
-      },
-      "CustomTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "Custom"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "to": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "dataSize": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string",
-            "nullable": true
-          },
-          "isCancellation": {
-            "type": "boolean"
-          },
-          "methodName": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "type",
-          "to",
-          "dataSize",
-          "isCancellation"
-        ]
-      },
-      "MultiSendTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "Custom"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "to": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "dataSize": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string",
-            "nullable": true
-          },
-          "isCancellation": {
-            "type": "boolean"
-          },
-          "methodName": {
-            "type": "string",
-            "enum": [
-              "multiSend"
-            ]
-          },
-          "actionCount": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "type",
-          "to",
-          "dataSize",
-          "isCancellation",
-          "methodName",
-          "actionCount"
-        ]
-      },
-      "AddOwner": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "ADD_OWNER"
-            ]
-          },
-          "owner": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "threshold": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "type",
-          "owner",
-          "threshold"
-        ]
-      },
-      "ChangeMasterCopy": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "CHANGE_MASTER_COPY"
-            ]
-          },
-          "implementation": {
-            "$ref": "#/components/schemas/AddressInfo"
-          }
-        },
-        "required": [
-          "type",
-          "implementation"
-        ]
-      },
-      "ChangeThreshold": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "CHANGE_THRESHOLD"
-            ]
-          },
-          "threshold": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "type",
-          "threshold"
-        ]
-      },
-      "DeleteGuard": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "DELETE_GUARD"
-            ]
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "DisableModule": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "DISABLE_MODULE"
-            ]
-          },
-          "module": {
-            "$ref": "#/components/schemas/AddressInfo"
-          }
-        },
-        "required": [
-          "type",
-          "module"
-        ]
-      },
-      "EnableModule": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "ENABLE_MODULE"
-            ]
-          },
-          "module": {
-            "$ref": "#/components/schemas/AddressInfo"
-          }
-        },
-        "required": [
-          "type",
-          "module"
-        ]
-      },
-      "RemoveOwner": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "REMOVE_OWNER"
-            ]
-          },
-          "owner": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "threshold": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "type",
-          "owner",
-          "threshold"
-        ]
-      },
-      "SetFallbackHandler": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "SET_FALLBACK_HANDLER"
-            ]
-          },
-          "handler": {
-            "$ref": "#/components/schemas/AddressInfo"
-          }
-        },
-        "required": [
-          "type",
-          "handler"
-        ]
-      },
-      "SetGuard": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "SET_GUARD"
-            ]
-          },
-          "guard": {
-            "$ref": "#/components/schemas/AddressInfo"
-          }
-        },
-        "required": [
-          "type",
-          "guard"
-        ]
-      },
-      "SettingsChange": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "ADD_OWNER",
-              "CHANGE_MASTER_COPY",
-              "CHANGE_THRESHOLD",
-              "DELETE_GUARD",
-              "DISABLE_MODULE",
-              "ENABLE_MODULE",
-              "REMOVE_OWNER",
-              "SET_FALLBACK_HANDLER",
-              "SET_GUARD",
-              "SWAP_OWNER"
-            ]
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "SwapOwner": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "SWAP_OWNER"
-            ]
-          },
-          "oldOwner": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "newOwner": {
-            "$ref": "#/components/schemas/AddressInfo"
-          }
-        },
-        "required": [
-          "type",
-          "oldOwner",
-          "newOwner"
-        ]
-      },
-      "SettingsChangeTransaction": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "SettingsChange"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "dataDecoded": {
-            "$ref": "#/components/schemas/DataDecoded"
-          },
-          "settingsInfo": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/AddOwner"
-              },
-              {
-                "$ref": "#/components/schemas/ChangeMasterCopy"
-              },
-              {
-                "$ref": "#/components/schemas/ChangeThreshold"
-              },
-              {
-                "$ref": "#/components/schemas/DeleteGuard"
-              },
-              {
-                "$ref": "#/components/schemas/DisableModule"
-              },
-              {
-                "$ref": "#/components/schemas/EnableModule"
-              },
-              {
-                "$ref": "#/components/schemas/RemoveOwner"
-              },
-              {
-                "$ref": "#/components/schemas/SetFallbackHandler"
-              },
-              {
-                "$ref": "#/components/schemas/SetGuard"
-              },
-              {
-                "$ref": "#/components/schemas/SwapOwner"
-              }
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "dataDecoded",
-          "settingsInfo"
-        ]
-      },
-      "Erc20Transfer": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "ERC20"
-            ]
-          },
-          "tokenAddress": {
-            "type": "string"
-          },
-          "value": {
-            "type": "string"
-          },
-          "tokenName": {
-            "type": "string",
-            "nullable": true
-          },
-          "tokenSymbol": {
-            "type": "string",
-            "nullable": true
-          },
-          "logoUri": {
-            "type": "string",
-            "nullable": true
-          },
-          "decimals": {
-            "type": "number",
-            "nullable": true
-          },
-          "trusted": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "imitation": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "type",
-          "tokenAddress",
-          "value",
-          "imitation"
-        ]
-      },
-      "Erc721Transfer": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "ERC721"
-            ]
-          },
-          "tokenAddress": {
-            "type": "string"
-          },
-          "tokenId": {
-            "type": "string"
-          },
-          "tokenName": {
-            "type": "string",
-            "nullable": true
-          },
-          "tokenSymbol": {
-            "type": "string",
-            "nullable": true
-          },
-          "logoUri": {
-            "type": "string",
-            "nullable": true
-          },
-          "trusted": {
-            "type": "boolean",
-            "nullable": true
-          }
-        },
-        "required": [
-          "type",
-          "tokenAddress",
-          "tokenId"
-        ]
-      },
-      "NativeCoinTransfer": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "NATIVE_COIN"
-            ]
-          },
-          "value": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "Transfer": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "NATIVE_COIN",
-              "ERC20",
-              "ERC721"
-            ]
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "TransferTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "Transfer"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "sender": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "recipient": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "direction": {
-            "type": "string",
-            "enum": [
-              "INCOMING",
-              "OUTGOING",
-              "UNKNOWN"
-            ]
-          },
-          "transferInfo": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/Erc20Transfer"
-              },
-              {
-                "$ref": "#/components/schemas/Erc721Transfer"
-              },
-              {
-                "$ref": "#/components/schemas/NativeCoinTransfer"
-              }
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Transfer"
-              }
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "sender",
-          "recipient",
-          "direction",
-          "transferInfo"
-        ]
-      },
-      "BridgeFee": {
-        "type": "object",
-        "properties": {
-          "tokenAddress": {
-            "type": "string"
-          },
-          "integratorFee": {
-            "type": "string"
-          },
-          "lifiFee": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "tokenAddress",
-          "integratorFee",
-          "lifiFee"
-        ]
-      },
-      "TokenInfo": {
-        "type": "object",
-        "properties": {
-          "address": {
-            "type": "string",
-            "description": "The token address"
-          },
-          "decimals": {
-            "type": "number",
-            "description": "The token decimals"
-          },
-          "logoUri": {
-            "type": "string",
-            "nullable": true,
-            "description": "The logo URI for the token"
-          },
-          "name": {
-            "type": "string",
-            "description": "The token name"
-          },
-          "symbol": {
-            "type": "string",
-            "description": "The token symbol"
-          },
-          "trusted": {
-            "type": "boolean",
-            "description": "The token trusted status"
-          }
-        },
-        "required": [
-          "address",
-          "decimals",
-          "name",
-          "symbol",
-          "trusted"
-        ]
-      },
-      "BridgeAndSwapTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "SwapAndBridge"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "fromToken": {
-            "$ref": "#/components/schemas/TokenInfo"
-          },
-          "recipient": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "explorerUrl": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "NOT_FOUND",
-              "INVALID",
-              "PENDING",
-              "DONE",
-              "FAILED",
-              "UNKNOWN",
-              "AWAITING_EXECUTION"
-            ]
-          },
-          "substatus": {
-            "type": "string",
-            "enum": [
-              "WAIT_SOURCE_CONFIRMATIONS",
-              "WAIT_DESTINATION_TRANSACTION",
-              "BRIDGE_NOT_AVAILABLE",
-              "CHAIN_NOT_AVAILABLE",
-              "REFUND_IN_PROGRESS",
-              "UNKNOWN_ERROR",
-              "COMPLETED",
-              "PARTIAL",
-              "REFUNDED",
-              "INSUFFICIENT_ALLOWANCE",
-              "INSUFFICIENT_BALANCE",
-              "OUT_OF_GAS",
-              "EXPIRED",
-              "SLIPPAGE_EXCEEDED",
-              "UNKNOWN_FAILED_ERROR",
-              "UNKNOWN",
-              "AWAITING_EXECUTION"
-            ]
-          },
-          "fees": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BridgeFee"
-              }
-            ]
-          },
-          "fromAmount": {
-            "type": "string"
-          },
-          "toChain": {
-            "type": "string"
-          },
-          "toToken": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "toAmount": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "type",
-          "fromToken",
-          "recipient",
-          "explorerUrl",
-          "status",
-          "substatus",
-          "fees",
-          "fromAmount",
-          "toChain",
-          "toToken",
-          "toAmount"
-        ]
-      },
-      "SwapOrderTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "SwapOrder"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "uid": {
-            "type": "string",
-            "description": "The order UID"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "presignaturePending",
-              "open",
-              "fulfilled",
-              "cancelled",
-              "expired",
-              "unknown"
-            ]
-          },
-          "kind": {
-            "type": "string",
-            "enum": [
-              "buy",
-              "sell",
-              "unknown"
-            ]
-          },
-          "orderClass": {
-            "type": "string",
-            "enum": [
-              "market",
-              "limit",
-              "liquidity",
-              "unknown"
-            ]
-          },
-          "validUntil": {
-            "type": "number",
-            "description": "The timestamp when the order expires"
-          },
-          "sellAmount": {
-            "type": "string",
-            "description": "The sell token raw amount (no decimals)"
-          },
-          "buyAmount": {
-            "type": "string",
-            "description": "The buy token raw amount (no decimals)"
-          },
-          "executedSellAmount": {
-            "type": "string",
-            "description": "The executed sell token raw amount (no decimals)"
-          },
-          "executedBuyAmount": {
-            "type": "string",
-            "description": "The executed buy token raw amount (no decimals)"
-          },
-          "sellToken": {
-            "description": "The sell token of the order",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "buyToken": {
-            "description": "The buy token of the order",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "explorerUrl": {
-            "type": "string",
-            "description": "The URL to the explorer page of the order"
-          },
-          "executedFee": {
-            "type": "string",
-            "description": "The amount of fees paid for this order."
-          },
-          "executedFeeToken": {
-            "description": "The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders).",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "receiver": {
-            "type": "string",
-            "nullable": true,
-            "description": "The (optional) address to receive the proceeds of the trade"
-          },
-          "owner": {
-            "type": "string"
-          },
-          "fullAppData": {
-            "type": "object",
-            "nullable": true,
-            "description": "The App Data for this order"
-          }
-        },
-        "required": [
-          "type",
-          "uid",
-          "status",
-          "kind",
-          "orderClass",
-          "validUntil",
-          "sellAmount",
-          "buyAmount",
-          "executedSellAmount",
-          "executedBuyAmount",
-          "sellToken",
-          "buyToken",
-          "explorerUrl",
-          "executedFee",
-          "executedFeeToken",
-          "owner"
-        ]
-      },
-      "SwapTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "Swap"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "recipient": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "fees": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BridgeFee"
-              }
-            ]
-          },
-          "fromToken": {
-            "$ref": "#/components/schemas/TokenInfo"
-          },
-          "fromAmount": {
-            "type": "string"
-          },
-          "toToken": {
-            "$ref": "#/components/schemas/TokenInfo"
-          },
-          "toAmount": {
-            "type": "string"
-          },
-          "lifiExplorerUrl": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "type",
-          "recipient",
-          "fees",
-          "fromToken",
-          "fromAmount",
-          "toToken",
-          "toAmount",
-          "lifiExplorerUrl"
-        ]
-      },
-      "SwapTransferTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "SwapTransfer"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "sender": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "recipient": {
-            "$ref": "#/components/schemas/AddressInfo"
-          },
-          "direction": {
-            "type": "string"
-          },
-          "transferInfo": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/Erc20Transfer"
-              },
-              {
-                "$ref": "#/components/schemas/Erc721Transfer"
-              },
-              {
-                "$ref": "#/components/schemas/NativeCoinTransfer"
-              }
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Transfer"
-              }
-            ]
-          },
-          "uid": {
-            "type": "string",
-            "description": "The order UID"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "presignaturePending",
-              "open",
-              "fulfilled",
-              "cancelled",
-              "expired",
-              "unknown"
-            ]
-          },
-          "kind": {
-            "type": "string",
-            "enum": [
-              "buy",
-              "sell",
-              "unknown"
-            ]
-          },
-          "orderClass": {
-            "type": "string",
-            "enum": [
-              "market",
-              "limit",
-              "liquidity",
-              "unknown"
-            ]
-          },
-          "validUntil": {
-            "type": "number",
-            "description": "The timestamp when the order expires"
-          },
-          "sellAmount": {
-            "type": "string",
-            "description": "The sell token raw amount (no decimals)"
-          },
-          "buyAmount": {
-            "type": "string",
-            "description": "The buy token raw amount (no decimals)"
-          },
-          "executedSellAmount": {
-            "type": "string",
-            "description": "The executed sell token raw amount (no decimals)"
-          },
-          "executedBuyAmount": {
-            "type": "string",
-            "description": "The executed buy token raw amount (no decimals)"
-          },
-          "sellToken": {
-            "description": "The sell token of the order",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "buyToken": {
-            "description": "The buy token of the order",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "explorerUrl": {
-            "type": "string",
-            "description": "The URL to the explorer page of the order"
-          },
-          "executedFee": {
-            "type": "string",
-            "description": "The amount of fees paid for this order."
-          },
-          "executedFeeToken": {
-            "description": "The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders).",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "receiver": {
-            "type": "string",
-            "nullable": true,
-            "description": "The (optional) address to receive the proceeds of the trade"
-          },
-          "owner": {
-            "type": "string"
-          },
-          "fullAppData": {
-            "type": "object",
-            "nullable": true,
-            "description": "The App Data for this order"
-          }
-        },
-        "required": [
-          "type",
-          "sender",
-          "recipient",
-          "direction",
-          "transferInfo",
-          "uid",
-          "status",
-          "kind",
-          "orderClass",
-          "validUntil",
-          "sellAmount",
-          "buyAmount",
-          "executedSellAmount",
-          "executedBuyAmount",
-          "sellToken",
-          "buyToken",
-          "explorerUrl",
-          "executedFee",
-          "executedFeeToken",
-          "owner"
-        ]
-      },
-      "DurationAuto": {
-        "type": "object",
-        "properties": {
-          "durationType": {
-            "type": "string",
-            "enum": [
-              "AUTO"
-            ]
-          }
-        },
-        "required": [
-          "durationType"
-        ]
-      },
-      "DurationLimit": {
-        "type": "object",
-        "properties": {
-          "durationType": {
-            "type": "string",
-            "enum": [
-              "LIMIT_DURATION"
-            ]
-          },
-          "duration": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "durationType",
-          "duration"
-        ]
-      },
-      "StartTimeAtMining": {
-        "type": "object",
-        "properties": {
-          "startType": {
-            "type": "string",
-            "enum": [
-              "AT_MINING_TIME"
-            ]
-          }
-        },
-        "required": [
-          "startType"
-        ]
-      },
-      "StartTimeAtEpoch": {
-        "type": "object",
-        "properties": {
-          "startType": {
-            "type": "string",
-            "enum": [
-              "AT_EPOCH"
-            ]
-          },
-          "epoch": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "startType",
-          "epoch"
-        ]
-      },
-      "TwapOrderTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "TwapOrder"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "description": "The TWAP status",
-            "enum": [
-              "presignaturePending",
-              "open",
-              "fulfilled",
-              "cancelled",
-              "expired",
-              "unknown"
-            ]
-          },
-          "kind": {
-            "type": "string",
-            "enum": [
-              "buy",
-              "sell",
-              "unknown"
-            ]
-          },
-          "class": {
-            "type": "string",
-            "enum": [
-              "market",
-              "limit",
-              "liquidity",
-              "unknown"
-            ]
-          },
-          "activeOrderUid": {
-            "type": "string",
-            "nullable": true,
-            "description": "The order UID of the active order, or null if none is active"
-          },
-          "validUntil": {
-            "type": "number",
-            "description": "The timestamp when the TWAP expires"
-          },
-          "sellAmount": {
-            "type": "string",
-            "description": "The sell token raw amount (no decimals)"
-          },
-          "buyAmount": {
-            "type": "string",
-            "description": "The buy token raw amount (no decimals)"
-          },
-          "executedSellAmount": {
-            "type": "string",
-            "nullable": true,
-            "description": "The executed sell token raw amount (no decimals), or null if there are too many parts"
-          },
-          "executedBuyAmount": {
-            "type": "string",
-            "nullable": true,
-            "description": "The executed buy token raw amount (no decimals), or null if there are too many parts"
-          },
-          "executedFee": {
-            "type": "string",
-            "nullable": true,
-            "description": "The executed surplus fee raw amount (no decimals), or null if there are too many parts"
-          },
-          "executedFeeToken": {
-            "description": "The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders).",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "sellToken": {
-            "description": "The sell token of the TWAP",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "buyToken": {
-            "description": "The buy token of the TWAP",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TokenInfo"
-              }
-            ]
-          },
-          "receiver": {
-            "type": "string",
-            "description": "The address to receive the proceeds of the trade"
-          },
-          "owner": {
-            "type": "string"
-          },
-          "fullAppData": {
-            "type": "object",
-            "nullable": true,
-            "description": "The App Data for this TWAP"
-          },
-          "numberOfParts": {
-            "type": "string",
-            "description": "The number of parts in the TWAP"
-          },
-          "partSellAmount": {
-            "type": "string",
-            "description": "The amount of sellToken to sell in each part"
-          },
-          "minPartLimit": {
-            "type": "string",
-            "description": "The amount of buyToken that must be bought in each part"
-          },
-          "timeBetweenParts": {
-            "type": "number",
-            "description": "The duration of the TWAP interval"
-          },
-          "durationOfPart": {
-            "description": "Whether the TWAP is valid for the entire interval or not",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/DurationAuto"
-              },
-              {
-                "$ref": "#/components/schemas/DurationLimit"
-              }
-            ]
-          },
-          "startTime": {
-            "description": "The start time of the TWAP",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/StartTimeAtMining"
-              },
-              {
-                "$ref": "#/components/schemas/StartTimeAtEpoch"
-              }
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "status",
-          "kind",
-          "validUntil",
-          "sellAmount",
-          "buyAmount",
-          "executedFeeToken",
-          "sellToken",
-          "buyToken",
-          "receiver",
-          "owner",
-          "numberOfParts",
-          "partSellAmount",
-          "minPartLimit",
-          "timeBetweenParts",
-          "durationOfPart",
-          "startTime"
-        ]
-      },
-      "NativeStakingDepositTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "NativeStakingDeposit"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "NOT_STAKED",
-              "ACTIVATING",
-              "DEPOSIT_IN_PROGRESS",
-              "ACTIVE",
-              "EXIT_REQUESTED",
-              "EXITING",
-              "EXITED",
-              "SLASHED"
-            ]
-          },
-          "estimatedEntryTime": {
-            "type": "number"
-          },
-          "estimatedExitTime": {
-            "type": "number"
-          },
-          "estimatedWithdrawalTime": {
-            "type": "number"
-          },
-          "fee": {
-            "type": "number"
-          },
-          "monthlyNrr": {
-            "type": "number"
-          },
-          "annualNrr": {
-            "type": "number"
-          },
-          "value": {
-            "type": "string"
-          },
-          "numValidators": {
-            "type": "number"
-          },
-          "expectedAnnualReward": {
-            "type": "string"
-          },
-          "expectedMonthlyReward": {
-            "type": "string"
-          },
-          "expectedFiatAnnualReward": {
-            "type": "number"
-          },
-          "expectedFiatMonthlyReward": {
-            "type": "number"
-          },
-          "tokenInfo": {
-            "$ref": "#/components/schemas/TokenInfo"
-          },
-          "validators": {
-            "nullable": true,
-            "description": "Populated after transaction has been executed",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "type",
-          "status",
-          "estimatedEntryTime",
-          "estimatedExitTime",
-          "estimatedWithdrawalTime",
-          "fee",
-          "monthlyNrr",
-          "annualNrr",
-          "value",
-          "numValidators",
-          "expectedAnnualReward",
-          "expectedMonthlyReward",
-          "expectedFiatAnnualReward",
-          "expectedFiatMonthlyReward",
-          "tokenInfo"
-        ]
-      },
-      "NativeStakingValidatorsExitTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "NativeStakingValidatorsExit"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "NOT_STAKED",
-              "ACTIVATING",
-              "DEPOSIT_IN_PROGRESS",
-              "ACTIVE",
-              "EXIT_REQUESTED",
-              "EXITING",
-              "EXITED",
-              "SLASHED"
-            ]
-          },
-          "estimatedExitTime": {
-            "type": "number"
-          },
-          "estimatedWithdrawalTime": {
-            "type": "number"
-          },
-          "value": {
-            "type": "string"
-          },
-          "numValidators": {
-            "type": "number"
-          },
-          "tokenInfo": {
-            "$ref": "#/components/schemas/TokenInfo"
-          },
-          "validators": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "type",
-          "status",
-          "estimatedExitTime",
-          "estimatedWithdrawalTime",
-          "value",
-          "numValidators",
-          "tokenInfo",
-          "validators"
-        ]
-      },
-      "NativeStakingWithdrawTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "NativeStakingWithdraw"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "value": {
-            "type": "string"
-          },
-          "tokenInfo": {
-            "$ref": "#/components/schemas/TokenInfo"
-          },
-          "validators": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "type",
-          "value",
-          "tokenInfo",
-          "validators"
-        ]
-      },
-      "VaultInfo": {
-        "type": "object",
-        "properties": {
-          "address": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "dashboardUri": {
-            "type": "string",
-            "nullable": true
-          },
-          "logoUri": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "address",
-          "name",
-          "description",
-          "logoUri"
-        ]
-      },
-      "VaultExtraReward": {
-        "type": "object",
-        "properties": {
-          "tokenInfo": {
-            "$ref": "#/components/schemas/TokenInfo"
-          },
-          "nrr": {
-            "type": "number"
-          },
-          "claimable": {
-            "type": "string"
-          },
-          "claimableNext": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "tokenInfo",
-          "nrr",
-          "claimable",
-          "claimableNext"
-        ]
-      },
-      "VaultDepositTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "VaultDeposit"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "value": {
-            "type": "string"
-          },
-          "baseNrr": {
-            "type": "number"
-          },
-          "fee": {
-            "type": "number"
-          },
-          "tokenInfo": {
-            "$ref": "#/components/schemas/TokenInfo"
-          },
-          "vaultInfo": {
-            "$ref": "#/components/schemas/VaultInfo"
-          },
-          "currentReward": {
-            "type": "string"
-          },
-          "additionalRewardsNrr": {
-            "type": "number"
-          },
-          "additionalRewards": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/VaultExtraReward"
-            }
-          },
-          "expectedMonthlyReward": {
-            "type": "string"
-          },
-          "expectedAnnualReward": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "value",
-          "baseNrr",
-          "fee",
-          "tokenInfo",
-          "vaultInfo",
-          "currentReward",
-          "additionalRewardsNrr",
-          "additionalRewards",
-          "expectedMonthlyReward",
-          "expectedAnnualReward"
-        ]
-      },
-      "VaultRedeemTransactionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "VaultRedeem"
-            ]
-          },
-          "humanDescription": {
-            "type": "string",
-            "nullable": true
-          },
-          "value": {
-            "type": "string"
-          },
-          "baseNrr": {
-            "type": "number"
-          },
-          "fee": {
-            "type": "number"
-          },
-          "tokenInfo": {
-            "$ref": "#/components/schemas/TokenInfo"
-          },
-          "vaultInfo": {
-            "$ref": "#/components/schemas/VaultInfo"
-          },
-          "currentReward": {
-            "type": "string"
-          },
-          "additionalRewardsNrr": {
-            "type": "number"
-          },
-          "additionalRewards": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/VaultExtraReward"
-            }
-          }
-        },
-        "required": [
-          "type",
-          "value",
-          "baseNrr",
-          "fee",
-          "tokenInfo",
-          "vaultInfo",
-          "currentReward",
-          "additionalRewardsNrr",
-          "additionalRewards"
-        ]
-      },
       "TransactionData": {
         "type": "object",
         "properties": {
@@ -12816,25 +12955,6 @@
         "required": [
           "type",
           "address"
-        ]
-      },
-      "SafeAppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "url": {
-            "type": "string"
-          },
-          "logoUri": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "name",
-          "url"
         ]
       },
       "TransactionDetails": {
@@ -13120,165 +13240,6 @@
           "results"
         ]
       },
-      "ModuleExecutionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "MODULE"
-            ]
-          },
-          "address": {
-            "$ref": "#/components/schemas/AddressInfo"
-          }
-        },
-        "required": [
-          "type",
-          "address"
-        ]
-      },
-      "MultisigExecutionInfo": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "MULTISIG"
-            ]
-          },
-          "nonce": {
-            "type": "number"
-          },
-          "confirmationsRequired": {
-            "type": "number"
-          },
-          "confirmationsSubmitted": {
-            "type": "number"
-          },
-          "missingSigners": {
-            "nullable": true,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AddressInfo"
-            }
-          }
-        },
-        "required": [
-          "type",
-          "nonce",
-          "confirmationsRequired",
-          "confirmationsSubmitted"
-        ]
-      },
-      "Transaction": {
-        "type": "object",
-        "properties": {
-          "txInfo": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/CreationTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/CustomTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/MultiSendTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/SettingsChangeTransaction"
-              },
-              {
-                "$ref": "#/components/schemas/TransferTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/SwapOrderTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/BridgeAndSwapTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/SwapTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/SwapTransferTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/TwapOrderTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/NativeStakingDepositTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/NativeStakingValidatorsExitTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/NativeStakingWithdrawTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/VaultDepositTransactionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/VaultRedeemTransactionInfo"
-              }
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TransactionInfo"
-              }
-            ]
-          },
-          "id": {
-            "type": "string"
-          },
-          "txHash": {
-            "type": "string",
-            "nullable": true
-          },
-          "timestamp": {
-            "type": "number"
-          },
-          "txStatus": {
-            "type": "string",
-            "enum": [
-              "SUCCESS",
-              "FAILED",
-              "CANCELLED",
-              "AWAITING_CONFIRMATIONS",
-              "AWAITING_EXECUTION"
-            ]
-          },
-          "executionInfo": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/MultisigExecutionInfo"
-              },
-              {
-                "$ref": "#/components/schemas/ModuleExecutionInfo"
-              }
-            ],
-            "nullable": true
-          },
-          "safeAppInfo": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SafeAppInfo"
-              }
-            ]
-          },
-          "note": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "required": [
-          "txInfo",
-          "id",
-          "timestamp",
-          "txStatus"
-        ]
-      },
       "MultisigTransaction": {
         "type": "object",
         "properties": {
@@ -13548,105 +13509,6 @@
         "required": [
           "txInfo",
           "txData"
-        ]
-      },
-      "ConflictHeaderQueuedItem": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "CONFLICT_HEADER"
-            ]
-          },
-          "nonce": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "type",
-          "nonce"
-        ]
-      },
-      "LabelQueuedItem": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "LABEL"
-            ]
-          },
-          "label": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type",
-          "label"
-        ]
-      },
-      "TransactionQueuedItem": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "TRANSACTION"
-            ]
-          },
-          "transaction": {
-            "$ref": "#/components/schemas/Transaction"
-          },
-          "conflictType": {
-            "type": "string",
-            "enum": [
-              "None",
-              "HasNext",
-              "End"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "transaction",
-          "conflictType"
-        ]
-      },
-      "QueuedItemPage": {
-        "type": "object",
-        "properties": {
-          "count": {
-            "type": "number",
-            "nullable": true
-          },
-          "next": {
-            "type": "string",
-            "nullable": true
-          },
-          "previous": {
-            "type": "string",
-            "nullable": true
-          },
-          "results": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/ConflictHeaderQueuedItem"
-                },
-                {
-                  "$ref": "#/components/schemas/LabelQueuedItem"
-                },
-                {
-                  "$ref": "#/components/schemas/TransactionQueuedItem"
-                }
-              ]
-            }
-          }
-        },
-        "required": [
-          "results"
         ]
       },
       "TransactionItem": {

--- a/packages/store/scripts/openapi-config.ts
+++ b/packages/store/scripts/openapi-config.ts
@@ -71,7 +71,7 @@ const config: ConfigFile = {
       filterEndpoints: [/^users/],
     },
     '../src/gateway/AUTO_GENERATED/spaces.ts': {
-      filterEndpoints: [/^(spaces|members|spaceSafes|addressBook|userAddressBook)/],
+      filterEndpoints: [/^(spaces|members|spaceSafes|spaceTransactions|addressBook|userAddressBook)/],
     },
     '../src/gateway/AUTO_GENERATED/positions.ts': {
       filterEndpoints: [/^positions/],

--- a/packages/store/src/gateway/AUTO_GENERATED/auth.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/auth.ts
@@ -26,28 +26,6 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/v1/auth/logout/redirect`, method: 'POST', body: queryArg.logoutDto }),
         invalidatesTags: ['auth'],
       }),
-      oidcAuthAuthorizeV1: build.query<OidcAuthAuthorizeV1ApiResponse, OidcAuthAuthorizeV1ApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/auth/oidc/authorize`,
-          params: {
-            redirect_url: queryArg.redirectUrl,
-            connection: queryArg.connection,
-          },
-        }),
-        providesTags: ['auth'],
-      }),
-      oidcAuthCallbackV1: build.query<OidcAuthCallbackV1ApiResponse, OidcAuthCallbackV1ApiArg>({
-        query: (queryArg) => ({
-          url: `/v1/auth/oidc/callback`,
-          params: {
-            code: queryArg.code,
-            state: queryArg.state,
-            error: queryArg.error,
-            error_description: queryArg.errorDescription,
-          },
-        }),
-        providesTags: ['auth'],
-      }),
     }),
     overrideExisting: false,
   })
@@ -66,24 +44,6 @@ export type AuthLogoutV1ApiArg = void
 export type AuthLogoutWithRedirectV1ApiResponse = unknown
 export type AuthLogoutWithRedirectV1ApiArg = {
   logoutDto: LogoutDto
-}
-export type OidcAuthAuthorizeV1ApiResponse = unknown
-export type OidcAuthAuthorizeV1ApiArg = {
-  /** URL to redirect to after successful login. Must be same-origin as the configured post-login redirect URI. */
-  redirectUrl?: string
-  /** OIDC connection name to route to a specific identity provider. */
-  connection?: string
-}
-export type OidcAuthCallbackV1ApiResponse = unknown
-export type OidcAuthCallbackV1ApiArg = {
-  /** Authorization code returned by the OIDC provider */
-  code?: string
-  /** State parameter returned by the OIDC provider */
-  state?: string
-  /** Error parameter returned by the OIDC provider */
-  error?: string
-  /** Description of the error returned by the OIDC provider (if failed) */
-  errorDescription?: string
 }
 export type UserSession = {
   id: string
@@ -112,8 +72,4 @@ export const {
   useAuthVerifyV1Mutation,
   useAuthLogoutV1Mutation,
   useAuthLogoutWithRedirectV1Mutation,
-  useOidcAuthAuthorizeV1Query,
-  useLazyOidcAuthAuthorizeV1Query,
-  useOidcAuthCallbackV1Query,
-  useLazyOidcAuthCallbackV1Query,
 } = injectedRtkApi

--- a/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
@@ -144,6 +144,18 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['spaces'],
       }),
+      spaceTransactionsGetTransactionQueueV1: build.query<
+        SpaceTransactionsGetTransactionQueueV1ApiResponse,
+        SpaceTransactionsGetTransactionQueueV1ApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/v1/spaces/${queryArg.spaceId}/transactions/queued`,
+          params: {
+            cursor: queryArg.cursor,
+          },
+        }),
+        providesTags: ['spaces'],
+      }),
       membersInviteUserV1: build.mutation<MembersInviteUserV1ApiResponse, MembersInviteUserV1ApiArg>({
         query: (queryArg) => ({
           url: `/v1/spaces/${queryArg.spaceId}/members/invite`,
@@ -318,6 +330,14 @@ export type SpaceSafesDeleteV1ApiArg = {
   /** List of Safe addresses and their chain information to remove from the space */
   deleteSpaceSafesDto: DeleteSpaceSafesDto
 }
+export type SpaceTransactionsGetTransactionQueueV1ApiResponse =
+  /** status 200 Paginated list of queued transactions for the space */ QueuedItemPage
+export type SpaceTransactionsGetTransactionQueueV1ApiArg = {
+  /** Pagination cursor for retrieving the next set of results */
+  cursor?: string
+  /** Space ID to fetch queued transactions for */
+  spaceId: number
+}
 export type MembersInviteUserV1ApiResponse = /** status 200 Users invited successfully */ Invitation[]
 export type MembersInviteUserV1ApiArg = {
   /** Space ID to invite users to */
@@ -475,6 +495,500 @@ export type GetSpaceSafeResponse = {
 export type DeleteSpaceSafesDto = {
   safes: SpaceSafeDto[]
 }
+export type ConflictHeaderQueuedItem = {
+  type: 'CONFLICT_HEADER'
+  nonce: number
+}
+export type LabelQueuedItem = {
+  type: 'LABEL'
+  label: string
+}
+export type AddressInfo = {
+  value: string
+  name?: string | null
+  logoUri?: string | null
+}
+export type CreationTransactionInfo = {
+  type: 'Creation'
+  humanDescription?: string | null
+  creator: AddressInfo
+  transactionHash: string
+  implementation?: AddressInfo | null
+  factory?: AddressInfo
+  saltNonce?: string | null
+}
+export type CustomTransactionInfo = {
+  type: 'Custom'
+  humanDescription?: string | null
+  to: AddressInfo
+  dataSize: string
+  value?: string | null
+  isCancellation: boolean
+  methodName?: string | null
+}
+export type MultiSendTransactionInfo = {
+  type: 'Custom'
+  humanDescription?: string | null
+  to: AddressInfo
+  dataSize: string
+  value?: string | null
+  isCancellation: boolean
+  methodName: 'multiSend'
+  actionCount: number
+}
+export type BaseDataDecoded = {
+  method: string
+  parameters?: DataDecodedParameter[]
+}
+export type Operation = 0 | 1
+export type MultiSend = {
+  /** Operation type: 0 for CALL, 1 for DELEGATE */
+  operation: Operation
+  value: string
+  dataDecoded?: BaseDataDecoded
+  to: string
+  /** Hexadecimal encoded data */
+  data: string | null
+}
+export type DataDecodedParameter = {
+  name: string
+  type: string
+  /** Parameter value - typically a string, but may be an array of strings for array types (e.g., address[], uint256[]) */
+  value: string | string[]
+  valueDecoded?: BaseDataDecoded | MultiSend[] | null
+}
+export type DataDecoded = {
+  method: string
+  parameters?: DataDecodedParameter[] | null
+  accuracy?: 'FULL_MATCH' | 'PARTIAL_MATCH' | 'ONLY_FUNCTION_MATCH' | 'NO_MATCH' | 'UNKNOWN'
+}
+export type AddOwner = {
+  type: 'ADD_OWNER'
+  owner: AddressInfo
+  threshold: number
+}
+export type ChangeMasterCopy = {
+  type: 'CHANGE_MASTER_COPY'
+  implementation: AddressInfo
+}
+export type ChangeThreshold = {
+  type: 'CHANGE_THRESHOLD'
+  threshold: number
+}
+export type DeleteGuard = {
+  type: 'DELETE_GUARD'
+}
+export type DisableModule = {
+  type: 'DISABLE_MODULE'
+  module: AddressInfo
+}
+export type EnableModule = {
+  type: 'ENABLE_MODULE'
+  module: AddressInfo
+}
+export type RemoveOwner = {
+  type: 'REMOVE_OWNER'
+  owner: AddressInfo
+  threshold: number
+}
+export type SetFallbackHandler = {
+  type: 'SET_FALLBACK_HANDLER'
+  handler: AddressInfo
+}
+export type SetGuard = {
+  type: 'SET_GUARD'
+  guard: AddressInfo
+}
+export type SwapOwner = {
+  type: 'SWAP_OWNER'
+  oldOwner: AddressInfo
+  newOwner: AddressInfo
+}
+export type SettingsChangeTransaction = {
+  type: 'SettingsChange'
+  humanDescription?: string | null
+  dataDecoded: DataDecoded
+  settingsInfo:
+    | AddOwner
+    | ChangeMasterCopy
+    | ChangeThreshold
+    | DeleteGuard
+    | DisableModule
+    | EnableModule
+    | RemoveOwner
+    | SetFallbackHandler
+    | SetGuard
+    | SwapOwner
+}
+export type Erc20Transfer = {
+  type: 'ERC20'
+  tokenAddress: string
+  value: string
+  tokenName?: string | null
+  tokenSymbol?: string | null
+  logoUri?: string | null
+  decimals?: number | null
+  trusted?: boolean | null
+  imitation: boolean
+}
+export type Erc721Transfer = {
+  type: 'ERC721'
+  tokenAddress: string
+  tokenId: string
+  tokenName?: string | null
+  tokenSymbol?: string | null
+  logoUri?: string | null
+  trusted?: boolean | null
+}
+export type NativeCoinTransfer = {
+  type: 'NATIVE_COIN'
+  value?: string | null
+}
+export type TransferTransactionInfo = {
+  type: 'Transfer'
+  humanDescription?: string | null
+  sender: AddressInfo
+  recipient: AddressInfo
+  direction: 'INCOMING' | 'OUTGOING' | 'UNKNOWN'
+  transferInfo: Erc20Transfer | Erc721Transfer | NativeCoinTransfer
+}
+export type TokenInfo = {
+  /** The token address */
+  address: string
+  /** The token decimals */
+  decimals: number
+  /** The logo URI for the token */
+  logoUri?: string | null
+  /** The token name */
+  name: string
+  /** The token symbol */
+  symbol: string
+  /** The token trusted status */
+  trusted: boolean
+}
+export type SwapOrderTransactionInfo = {
+  type: 'SwapOrder'
+  humanDescription?: string | null
+  /** The order UID */
+  uid: string
+  status: 'presignaturePending' | 'open' | 'fulfilled' | 'cancelled' | 'expired' | 'unknown'
+  kind: 'buy' | 'sell' | 'unknown'
+  orderClass: 'market' | 'limit' | 'liquidity' | 'unknown'
+  /** The timestamp when the order expires */
+  validUntil: number
+  /** The sell token raw amount (no decimals) */
+  sellAmount: string
+  /** The buy token raw amount (no decimals) */
+  buyAmount: string
+  /** The executed sell token raw amount (no decimals) */
+  executedSellAmount: string
+  /** The executed buy token raw amount (no decimals) */
+  executedBuyAmount: string
+  /** The sell token of the order */
+  sellToken: TokenInfo
+  /** The buy token of the order */
+  buyToken: TokenInfo
+  /** The URL to the explorer page of the order */
+  explorerUrl: string
+  /** The amount of fees paid for this order. */
+  executedFee: string
+  /** The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders). */
+  executedFeeToken: TokenInfo
+  /** The (optional) address to receive the proceeds of the trade */
+  receiver?: string | null
+  owner: string
+  /** The App Data for this order */
+  fullAppData?: object | null
+}
+export type BridgeFee = {
+  tokenAddress: string
+  integratorFee: string
+  lifiFee: string
+}
+export type BridgeAndSwapTransactionInfo = {
+  type: 'SwapAndBridge'
+  humanDescription?: string | null
+  fromToken: TokenInfo
+  recipient: AddressInfo
+  explorerUrl: string | null
+  status: 'NOT_FOUND' | 'INVALID' | 'PENDING' | 'DONE' | 'FAILED' | 'UNKNOWN' | 'AWAITING_EXECUTION'
+  substatus:
+    | 'WAIT_SOURCE_CONFIRMATIONS'
+    | 'WAIT_DESTINATION_TRANSACTION'
+    | 'BRIDGE_NOT_AVAILABLE'
+    | 'CHAIN_NOT_AVAILABLE'
+    | 'REFUND_IN_PROGRESS'
+    | 'UNKNOWN_ERROR'
+    | 'COMPLETED'
+    | 'PARTIAL'
+    | 'REFUNDED'
+    | 'INSUFFICIENT_ALLOWANCE'
+    | 'INSUFFICIENT_BALANCE'
+    | 'OUT_OF_GAS'
+    | 'EXPIRED'
+    | 'SLIPPAGE_EXCEEDED'
+    | 'UNKNOWN_FAILED_ERROR'
+    | 'UNKNOWN'
+    | 'AWAITING_EXECUTION'
+  fees: BridgeFee | null
+  fromAmount: string
+  toChain: string
+  toToken: TokenInfo | null
+  toAmount: string | null
+}
+export type SwapTransactionInfo = {
+  type: 'Swap'
+  humanDescription?: string | null
+  recipient: AddressInfo
+  fees: BridgeFee | null
+  fromToken: TokenInfo
+  fromAmount: string
+  toToken: TokenInfo
+  toAmount: string
+  lifiExplorerUrl: string | null
+}
+export type SwapTransferTransactionInfo = {
+  type: 'SwapTransfer'
+  humanDescription?: string | null
+  sender: AddressInfo
+  recipient: AddressInfo
+  direction: string
+  transferInfo: Erc20Transfer | Erc721Transfer | NativeCoinTransfer
+  /** The order UID */
+  uid: string
+  status: 'presignaturePending' | 'open' | 'fulfilled' | 'cancelled' | 'expired' | 'unknown'
+  kind: 'buy' | 'sell' | 'unknown'
+  orderClass: 'market' | 'limit' | 'liquidity' | 'unknown'
+  /** The timestamp when the order expires */
+  validUntil: number
+  /** The sell token raw amount (no decimals) */
+  sellAmount: string
+  /** The buy token raw amount (no decimals) */
+  buyAmount: string
+  /** The executed sell token raw amount (no decimals) */
+  executedSellAmount: string
+  /** The executed buy token raw amount (no decimals) */
+  executedBuyAmount: string
+  /** The sell token of the order */
+  sellToken: TokenInfo
+  /** The buy token of the order */
+  buyToken: TokenInfo
+  /** The URL to the explorer page of the order */
+  explorerUrl: string
+  /** The amount of fees paid for this order. */
+  executedFee: string
+  /** The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders). */
+  executedFeeToken: TokenInfo
+  /** The (optional) address to receive the proceeds of the trade */
+  receiver?: string | null
+  owner: string
+  /** The App Data for this order */
+  fullAppData?: object | null
+}
+export type DurationAuto = {
+  durationType: 'AUTO'
+}
+export type DurationLimit = {
+  durationType: 'LIMIT_DURATION'
+  duration: string
+}
+export type StartTimeAtMining = {
+  startType: 'AT_MINING_TIME'
+}
+export type StartTimeAtEpoch = {
+  startType: 'AT_EPOCH'
+  epoch: number
+}
+export type TwapOrderTransactionInfo = {
+  type: 'TwapOrder'
+  humanDescription?: string | null
+  /** The TWAP status */
+  status: 'presignaturePending' | 'open' | 'fulfilled' | 'cancelled' | 'expired' | 'unknown'
+  kind: 'buy' | 'sell' | 'unknown'
+  class?: 'market' | 'limit' | 'liquidity' | 'unknown'
+  /** The order UID of the active order, or null if none is active */
+  activeOrderUid?: string | null
+  /** The timestamp when the TWAP expires */
+  validUntil: number
+  /** The sell token raw amount (no decimals) */
+  sellAmount: string
+  /** The buy token raw amount (no decimals) */
+  buyAmount: string
+  /** The executed sell token raw amount (no decimals), or null if there are too many parts */
+  executedSellAmount?: string | null
+  /** The executed buy token raw amount (no decimals), or null if there are too many parts */
+  executedBuyAmount?: string | null
+  /** The executed surplus fee raw amount (no decimals), or null if there are too many parts */
+  executedFee?: string | null
+  /** The token in which the fee was paid, expressed by SURPLUS tokens (BUY tokens for SELL orders and SELL tokens for BUY orders). */
+  executedFeeToken: TokenInfo
+  /** The sell token of the TWAP */
+  sellToken: TokenInfo
+  /** The buy token of the TWAP */
+  buyToken: TokenInfo
+  /** The address to receive the proceeds of the trade */
+  receiver: string
+  owner: string
+  /** The App Data for this TWAP */
+  fullAppData?: object | null
+  /** The number of parts in the TWAP */
+  numberOfParts: string
+  /** The amount of sellToken to sell in each part */
+  partSellAmount: string
+  /** The amount of buyToken that must be bought in each part */
+  minPartLimit: string
+  /** The duration of the TWAP interval */
+  timeBetweenParts: number
+  /** Whether the TWAP is valid for the entire interval or not */
+  durationOfPart: DurationAuto | DurationLimit
+  /** The start time of the TWAP */
+  startTime: StartTimeAtMining | StartTimeAtEpoch
+}
+export type NativeStakingDepositTransactionInfo = {
+  type: 'NativeStakingDeposit'
+  humanDescription?: string | null
+  status:
+    | 'NOT_STAKED'
+    | 'ACTIVATING'
+    | 'DEPOSIT_IN_PROGRESS'
+    | 'ACTIVE'
+    | 'EXIT_REQUESTED'
+    | 'EXITING'
+    | 'EXITED'
+    | 'SLASHED'
+  estimatedEntryTime: number
+  estimatedExitTime: number
+  estimatedWithdrawalTime: number
+  fee: number
+  monthlyNrr: number
+  annualNrr: number
+  value: string
+  numValidators: number
+  expectedAnnualReward: string
+  expectedMonthlyReward: string
+  expectedFiatAnnualReward: number
+  expectedFiatMonthlyReward: number
+  tokenInfo: TokenInfo
+  /** Populated after transaction has been executed */
+  validators?: string[] | null
+}
+export type NativeStakingValidatorsExitTransactionInfo = {
+  type: 'NativeStakingValidatorsExit'
+  humanDescription?: string | null
+  status:
+    | 'NOT_STAKED'
+    | 'ACTIVATING'
+    | 'DEPOSIT_IN_PROGRESS'
+    | 'ACTIVE'
+    | 'EXIT_REQUESTED'
+    | 'EXITING'
+    | 'EXITED'
+    | 'SLASHED'
+  estimatedExitTime: number
+  estimatedWithdrawalTime: number
+  value: string
+  numValidators: number
+  tokenInfo: TokenInfo
+  validators: string[]
+}
+export type NativeStakingWithdrawTransactionInfo = {
+  type: 'NativeStakingWithdraw'
+  humanDescription?: string | null
+  value: string
+  tokenInfo: TokenInfo
+  validators: string[]
+}
+export type VaultInfo = {
+  address: string
+  name: string
+  description: string
+  dashboardUri?: string | null
+  logoUri: string
+}
+export type VaultExtraReward = {
+  tokenInfo: TokenInfo
+  nrr: number
+  claimable: string
+  claimableNext: string
+}
+export type VaultDepositTransactionInfo = {
+  type: 'VaultDeposit'
+  humanDescription?: string | null
+  value: string
+  baseNrr: number
+  fee: number
+  tokenInfo: TokenInfo
+  vaultInfo: VaultInfo
+  currentReward: string
+  additionalRewardsNrr: number
+  additionalRewards: VaultExtraReward[]
+  expectedMonthlyReward: string
+  expectedAnnualReward: string
+}
+export type VaultRedeemTransactionInfo = {
+  type: 'VaultRedeem'
+  humanDescription?: string | null
+  value: string
+  baseNrr: number
+  fee: number
+  tokenInfo: TokenInfo
+  vaultInfo: VaultInfo
+  currentReward: string
+  additionalRewardsNrr: number
+  additionalRewards: VaultExtraReward[]
+}
+export type MultisigExecutionInfo = {
+  type: 'MULTISIG'
+  nonce: number
+  confirmationsRequired: number
+  confirmationsSubmitted: number
+  missingSigners?: AddressInfo[] | null
+}
+export type ModuleExecutionInfo = {
+  type: 'MODULE'
+  address: AddressInfo
+}
+export type SafeAppInfo = {
+  name: string
+  url: string
+  logoUri?: string | null
+}
+export type Transaction = {
+  txInfo:
+    | CreationTransactionInfo
+    | CustomTransactionInfo
+    | MultiSendTransactionInfo
+    | SettingsChangeTransaction
+    | TransferTransactionInfo
+    | SwapOrderTransactionInfo
+    | BridgeAndSwapTransactionInfo
+    | SwapTransactionInfo
+    | SwapTransferTransactionInfo
+    | TwapOrderTransactionInfo
+    | NativeStakingDepositTransactionInfo
+    | NativeStakingValidatorsExitTransactionInfo
+    | NativeStakingWithdrawTransactionInfo
+    | VaultDepositTransactionInfo
+    | VaultRedeemTransactionInfo
+  id: string
+  txHash?: string | null
+  timestamp: number
+  txStatus: 'SUCCESS' | 'FAILED' | 'CANCELLED' | 'AWAITING_CONFIRMATIONS' | 'AWAITING_EXECUTION'
+  executionInfo?: (MultisigExecutionInfo | ModuleExecutionInfo) | null
+  safeAppInfo?: SafeAppInfo | null
+  note?: string | null
+}
+export type TransactionQueuedItem = {
+  type: 'TRANSACTION'
+  transaction: Transaction
+  conflictType: 'None' | 'HasNext' | 'End'
+}
+export type QueuedItemPage = {
+  count?: number | null
+  next?: string | null
+  previous?: string | null
+  results: (ConflictHeaderQueuedItem | LabelQueuedItem | TransactionQueuedItem)[]
+}
 export type Invitation = {
   userId: number
   name: string
@@ -546,6 +1060,8 @@ export const {
   useSpaceSafesGetV1Query,
   useLazySpaceSafesGetV1Query,
   useSpaceSafesDeleteV1Mutation,
+  useSpaceTransactionsGetTransactionQueueV1Query,
+  useLazySpaceTransactionsGetTransactionQueueV1Query,
   useMembersInviteUserV1Mutation,
   useMembersAcceptInviteV1Mutation,
   useMembersDeclineInviteV1Mutation,


### PR DESCRIPTION
## What it solves

Resolves: https://linear.app/safe-global/issue/WA-1432/add-endpoint-to-get-list-of-pending-transactions-across-all-safes-in-a#comment-b2035768

## How this PR fixes it
It integrates the new CGW spaces queue endpoint.

**⚠️ PS: it depends on https://github.com/safe-global/safe-client-gateway/pull/3098 to be ready to review**

## How to test it
- Login on a space with a safe with pending txs.
- The pending tx view should work as is.

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
