### PR TITLE
fix(web): sidebar styles for mid-width screens

### DIFF
--- a/apps/web/src/components/common/PageLayout/SideDrawer.tsx
+++ b/apps/web/src/components/common/PageLayout/SideDrawer.tsx
@@ -10,6 +10,8 @@ import classnames from 'classnames'
 import css from './styles.module.css'
 import useDebounce from '@safe-global/utils/hooks/useDebounce'
 import { useIsSidebarRoute } from '@/hooks/useIsSidebarRoute'
+import { ShadcnProvider } from '@/components/ui/ShadcnProvider'
+import { useDarkMode } from '@/hooks/useDarkMode'
 
 type SideDrawerProps = {
   isOpen: boolean
@@ -20,7 +22,9 @@ type SideDrawerProps = {
 const SideDrawer = ({ isOpen, onToggle, onSidebarOpenChange }: SideDrawerProps): ReactElement => {
   const { breakpoints } = useTheme()
   const isSmallScreen = useMediaQuery(breakpoints.down('md'))
+  const isTabletDrawer = useMediaQuery('(min-width:768px) and (max-width:899.95px)')
   const [, isSafeAppRoute] = useIsSidebarRoute()
+  const isDarkMode = useDarkMode()
 
   const showSidebarToggle = isSafeAppRoute && !isSmallScreen
   // Keep the sidebar hidden on small screens via CSS until we collapse it via JS.
@@ -54,16 +58,39 @@ const SideDrawer = ({ isOpen, onToggle, onSidebarOpenChange }: SideDrawerProps):
           // fixes a bug on small screens where the drawer is not visible,
           // but it steals all the events from the rest of the page
           position: 'relative',
-          '& .MuiPaper-root': { zIndex: 1250 },
+          '& .MuiPaper-root': {
+            zIndex: 1250,
+            ...(isTabletDrawer && {
+              height: '100dvh',
+              maxHeight: '100dvh',
+              backgroundColor: 'transparent',
+              backgroundImage: 'none',
+              boxShadow: 'none',
+              borderRight: 0,
+              overflow: 'visible',
+              display: 'flex',
+            }),
+          },
         }}
         className={smDrawerHidden ? css.smDrawerHidden : undefined}
       >
-        <aside>
-          <SpacesEnhancedSidebar
-            isDrawerOpen={isOpen}
-            onDrawerClose={() => onToggle(false)}
-            onOpenChange={onSidebarOpenChange}
-          />
+        <aside className={isTabletDrawer ? 'flex h-dvh' : undefined}>
+          {isTabletDrawer ? (
+            <ShadcnProvider dark={isDarkMode} className="h-full">
+              <SpacesEnhancedSidebar
+                isDrawerOpen={isOpen}
+                onDrawerClose={() => onToggle(false)}
+                onOpenChange={onSidebarOpenChange}
+                isContainedInDrawer
+              />
+            </ShadcnProvider>
+          ) : (
+            <SpacesEnhancedSidebar
+              isDrawerOpen={isOpen}
+              onDrawerClose={() => onToggle(false)}
+              onOpenChange={onSidebarOpenChange}
+            />
+          )}
         </aside>
       </Drawer>
 

--- a/apps/web/src/components/ui/ShadcnProvider.tsx
+++ b/apps/web/src/components/ui/ShadcnProvider.tsx
@@ -60,7 +60,15 @@ export function usePortalContainerElement(): HTMLDivElement | null {
   return ctx?.element ?? null
 }
 
-export function ShadcnProvider({ children, dark }: { children: ReactNode; dark?: boolean }) {
+export function ShadcnProvider({
+  children,
+  dark,
+  className,
+}: {
+  children: ReactNode
+  dark?: boolean
+  className?: string
+}) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [element, setElement] = useState<HTMLDivElement | null>(null)
 
@@ -75,7 +83,7 @@ export function ShadcnProvider({ children, dark }: { children: ReactNode; dark?:
 
   return (
     <PortalContainerContext.Provider value={value}>
-      <div className={cn('shadcn-scope', dark && 'dark')} ref={callbackRef}>
+      <div className={cn('shadcn-scope', dark && 'dark', className)} ref={callbackRef}>
         {children}
       </div>
     </PortalContainerContext.Provider>

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -292,12 +292,18 @@ function Sidebar({
   variant = 'sidebar',
   collapsible = 'offcanvas',
   className,
+  containerClassName,
+  innerClassName,
+  contained = false,
   children,
   ...props
 }: ComponentProps<'div'> & {
   side?: 'left' | 'right'
   variant?: 'sidebar' | 'floating' | 'inset'
   collapsible?: 'offcanvas' | 'icon' | 'none'
+  containerClassName?: string
+  innerClassName?: string
+  contained?: boolean
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
 
@@ -318,7 +324,7 @@ function Sidebar({
     )
   }
 
-  if (isMobile) {
+  if (isMobile && !contained) {
     return (
       <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
         <SheetContent
@@ -343,47 +349,53 @@ function Sidebar({
     )
   }
 
+  const containerBaseClassName = contained
+    ? cn(
+        'relative z-[var(--z-sidebar)] flex h-full min-h-full w-(--sidebar-width) max-w-full',
+        variant === 'floating' || variant === 'inset' ? 'p-2' : '',
+        containerClassName,
+        className,
+      )
+    : cn(
+        'inset-y-0 z-[var(--z-sidebar)] h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear fixed hidden md:flex',
+        side === 'left'
+          ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
+          : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+        variant === 'floating' || variant === 'inset'
+          ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
+          : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
+        containerClassName,
+        className,
+      )
+
   return (
     <div
-      className="group peer text-sidebar-foreground hidden md:block"
-      data-state={state}
-      data-collapsible={state === 'collapsed' ? collapsible : ''}
+      className={cn('group peer text-sidebar-foreground', contained ? 'block h-full' : 'hidden md:block')}
+      data-state={contained ? 'expanded' : state}
+      data-collapsible={contained ? '' : state === 'collapsed' ? collapsible : ''}
       data-variant={variant}
       data-side={side}
       data-slot="sidebar"
     >
       {/* This is what handles the sidebar gap on desktop */}
-      <div
-        data-slot="sidebar-gap"
-        className={cn(
-          'transition-[width] duration-200 ease-linear relative w-(--sidebar-width) bg-transparent',
-          'group-data-[collapsible=offcanvas]:w-0',
-          'group-data-[side=right]:rotate-180',
-          variant === 'floating' || variant === 'inset'
-            ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
-            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
-        )}
-      />
-      <div
-        data-slot="sidebar-container"
-        data-testid="sidebar-container"
-        className={cn(
-          'fixed inset-y-0 z-[var(--z-sidebar)] hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex',
-          side === 'left'
-            ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-            : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
-          // Adjust the padding for floating and inset variants.
-          variant === 'floating' || variant === 'inset'
-            ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
-          className,
-        )}
-        {...props}
-      >
+      {!contained && (
+        <div
+          data-slot="sidebar-gap"
+          className={cn(
+            'transition-[width] duration-200 ease-linear relative w-(--sidebar-width) bg-transparent',
+            'group-data-[collapsible=offcanvas]:w-0',
+            'group-data-[side=right]:rotate-180',
+            variant === 'floating' || variant === 'inset'
+              ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
+              : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
+          )}
+        />
+      )}
+      <div data-slot="sidebar-container" data-testid="sidebar-container" className={containerBaseClassName} {...props}>
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="bg-sidebar group-data-[variant=floating]:rounded-lg flex size-full flex-col"
+          className={cn('bg-sidebar group-data-[variant=floating]:rounded-lg flex size-full flex-col', innerClassName)}
         >
           {children}
         </div>

--- a/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/ApiCtaSidebar/ApiCtaSidebar.tsx
@@ -30,7 +30,7 @@ export const ApiCtaSidebar = (): ReactElement => {
           render={isIconCollapsed ? <a href={API_DOCS_URL} target="_blank" rel="noopener noreferrer" /> : undefined}
         >
           <Tooltip>
-            <TooltipTrigger render={<span />} className="flex min-w-0 cursor-pointer items-center gap-3">
+            <TooltipTrigger render={<div />} className="flex min-w-0 cursor-pointer items-center gap-3">
               <Image
                 src="/images/spaces/api-sidebar.svg"
                 alt="API"

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
@@ -81,7 +81,7 @@ export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?:
             onClick={handleHelpClick}
           >
             <Tooltip>
-              <TooltipTrigger render={<span />} className="flex min-w-0 cursor-pointer items-center gap-3">
+              <TooltipTrigger render={<div />} className="flex min-w-0 cursor-pointer items-center gap-3">
                 <icons.CircleHelp />
                 <span className="truncate group-data-[collapsible=icon]:hidden">Help</span>
               </TooltipTrigger>

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarSkeleton/SidebarSkeleton.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarSkeleton/SidebarSkeleton.tsx
@@ -12,6 +12,9 @@ import {
 import { SidebarTopBar } from '../SidebarTopBar'
 import css from '../styles.module.css'
 
+const SIDEBAR_CONTAINER_CLASSNAME = '!p-0 border-r-0 group-data-[side=left]:border-r-0'
+const SIDEBAR_INNER_CLASSNAME = 'rounded-none rounded-tr-[8px] rounded-br-[8px] shadow-none'
+
 const Pulse = ({ className }: { className: string }): ReactElement => (
   <div className={`bg-sidebar-border animate-pulse ${className}`} />
 )
@@ -28,12 +31,14 @@ const NavRow = (): ReactElement => (
   </SidebarMenuItem>
 )
 
-export const SidebarSkeleton = (): ReactElement => {
+export const SidebarSkeleton = ({ contained = false }: { contained?: boolean }): ReactElement => {
   return (
     <Sidebar
       collapsible="icon"
       variant="floating"
-      className="!p-0 border-r-0 group-data-[side=left]:border-r-0 [&_[data-slot=sidebar-inner]]:rounded-none [&_[data-slot=sidebar-inner]]:rounded-tr-[8px] [&_[data-slot=sidebar-inner]]:rounded-br-[8px] [&_[data-slot=sidebar-inner]]:shadow-none"
+      contained={contained}
+      containerClassName={SIDEBAR_CONTAINER_CLASSNAME}
+      innerClassName={SIDEBAR_INNER_CLASSNAME}
       data-testid="sidebar-skeleton"
     >
       <SidebarHeader>

--- a/apps/web/src/features/spaces/components/Sidebar/SpacesEnhancedSidebar/SpacesEnhancedSidebar.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SpacesEnhancedSidebar/SpacesEnhancedSidebar.tsx
@@ -22,6 +22,8 @@ interface SpacesEnhancedSidebarProps {
   onDrawerClose?: () => void
   /** Called when the sidebar expands or collapses (icon mode). */
   onOpenChange?: (open: boolean) => void
+  /** When true, render the desktop sidebar contained inside a parent drawer instead of fixed to the viewport. */
+  isContainedInDrawer?: boolean
 }
 
 /** Reports sidebar open/collapsed state to parent without interfering with internal state. */
@@ -37,23 +39,30 @@ export const SpacesEnhancedSidebar = ({
   isDrawerOpen,
   onDrawerClose,
   onOpenChange,
+  isContainedInDrawer = false,
 }: SpacesEnhancedSidebarProps = {}): ReactElement => {
   const isHydrated = useSidebarHydrated()
   const spacesSidebarWidth = 'min(230px, 100%)'
 
   return (
     <SidebarProvider
+      open={isContainedInDrawer ? true : undefined}
       openMobile={isDrawerOpen}
       onOpenMobileChange={(open) => !open && onDrawerClose?.()}
       style={{ '--sidebar-width': spacesSidebarWidth } as CSSProperties}
+      className={isContainedInDrawer ? 'h-dvh' : undefined}
     >
       <SidebarStateReporter onOpenChange={onOpenChange} />
-      {isHydrated ? <HydratedSidebar /> : <SidebarSkeleton />}
+      {isHydrated ? (
+        <HydratedSidebar contained={isContainedInDrawer} />
+      ) : (
+        <SidebarSkeleton contained={isContainedInDrawer} />
+      )}
     </SidebarProvider>
   )
 }
 
-const HydratedSidebar = (): ReactElement => {
+const HydratedSidebar = ({ contained = false }: { contained?: boolean }): ReactElement => {
   const router = useRouter()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const resolvedSpaceId = useCurrentSpaceId()
@@ -89,6 +98,7 @@ const HydratedSidebar = (): ReactElement => {
 
   return (
     <EnhancedSidebar
+      contained={contained}
       type={sidebarType}
       selectedSpace={effectiveSelectedSpace}
       spaces={nonDeclinedSpaces}

--- a/apps/web/src/features/spaces/components/Sidebar/index.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/index.tsx
@@ -10,7 +10,11 @@ import type { SidebarVariantType } from './variants'
 interface SidebarProps extends SpaceSelectorProps {
   type: SidebarVariantType
   isLoading?: boolean
+  contained?: boolean
 }
+
+const SIDEBAR_CONTAINER_CLASSNAME = '!p-0 border-r-0 group-data-[side=left]:border-r-0'
+const SIDEBAR_INNER_CLASSNAME = 'rounded-none rounded-tr-[8px] rounded-br-[8px] shadow-none'
 
 export const EnhancedSidebar = ({
   type,
@@ -19,13 +23,16 @@ export const EnhancedSidebar = ({
   spaces,
   onSpaceAdded,
   isLoading = false,
+  contained = false,
 }: SidebarProps): ReactElement => {
   const Variant = getSidebarVariant(type)
   return (
     <Sidebar
       collapsible="icon"
       variant="floating"
-      className="!p-0 border-r-0 group-data-[side=left]:border-r-0 [&_[data-slot=sidebar-inner]]:rounded-none [&_[data-slot=sidebar-inner]]:rounded-tr-[8px] [&_[data-slot=sidebar-inner]]:rounded-br-[8px] [&_[data-slot=sidebar-inner]]:shadow-none"
+      contained={contained}
+      containerClassName={SIDEBAR_CONTAINER_CLASSNAME}
+      innerClassName={SIDEBAR_INNER_CLASSNAME}
       data-testid="sidebar-container"
     >
       <SidebarHeader>

--- a/apps/web/src/features/spaces/components/Sidebar/styles.module.css
+++ b/apps/web/src/features/spaces/components/Sidebar/styles.module.css
@@ -291,7 +291,6 @@
 .footerHelpRow {
   display: flex;
   align-items: center;
-  gap: 8px;
   overflow: visible;
 }
 

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
@@ -85,7 +85,7 @@ export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: Na
       onClick={handleClick}
     >
       <Tooltip>
-        <TooltipTrigger className="flex min-w-0 cursor-pointer items-center gap-3">
+        <TooltipTrigger render={<div />} className="flex min-w-0 cursor-pointer items-center gap-3">
           <div className={item.isActive ? css.activeIcon : undefined}>
             <item.icon />
           </div>


### PR DESCRIPTION
## What it solves

The Spaces sidebar was not rendering correctly in the tablet viewport range (768px–899px), where the side drawer is used but the sidebar still needs desktop-style layout.

Resolves: [WA-2358](https://linear.app/safe-global/issue/WA-2358/restore-ipad-view-behavior-with-new-sidebar)

## How this PR fixes it

Adds a `contained` mode to the shadcn `Sidebar` that renders it inline (full height, no fixed positioning) instead of fixed-to-viewport or mobile sheet. `SideDrawer` detects the tablet range and wraps `SpacesEnhancedSidebar` in `ShadcnProvider` with the new contained flag, plus strips MUI Drawer paper styling so the sidebar fills the drawer cleanly.

## How to test it

1. Open the app and resize the viewport to tablet width (768px–899px).
2. Open the side drawer (sidebar toggle).
3. Verify the Spaces sidebar renders inside the drawer at full viewport height with a transparent drawer background (no MUI paper styling).
4. Confirm dark mode is respected inside the drawer-contained sidebar.
5. Resize below 768px and above 900px — sidebar should fall back to the original mobile sheet / desktop fixed behavior respectively.
6. Toggle sidebar open/collapse states; verify no layout shift or scroll issues.

## Affected flows

- Opening/closing the Spaces sidebar via the side drawer on tablet viewports (768px–899px).

## Blast radius

- `Sidebar` (shadcn) — new `contained`, `containerClassName`, `innerClassName` props; consumers `EnhancedSidebar` and `SidebarSkeleton` updated.
- `ShadcnProvider` — new optional `className` prop.
- `SpacesEnhancedSidebar` — new `isContainedInDrawer` prop; forces `open` and adjusts height when set.
- `SideDrawer` (PageLayout) — tablet-range branch changes Drawer paper styling.
- No API, feature flag, persistence, or mobile-package changes.

## Risks / not checked

- Did not verify on real mobile devices (only via responsive resize).
- Did not test RTL layouts.

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
