### PR TITLE
fix(mobile): detect biometry-invalidated wrapping key and route to re-import

### DIFF
--- a/apps/mobile/src/features/AccountsSheet/AccountItem/utils/__tests__/editAccountHelpers.test.ts
+++ b/apps/mobile/src/features/AccountsSheet/AccountItem/utils/__tests__/editAccountHelpers.test.ts
@@ -224,7 +224,7 @@ describe('editAccountHelpers', () => {
       expect(mockDispatch).toHaveBeenCalledWith(removeSigner(mockAddress1))
     })
 
-    it('should cleanly remove the signer when the private key is missing', async () => {
+    it('should NOT wipe the signer when getPrivateKey returns undefined without invalidation', async () => {
       const mockDispatch = jest.fn() as unknown as AppDispatch
       const mockRemoveAllDelegatesForOwner = jest.fn()
 
@@ -232,10 +232,11 @@ describe('editAccountHelpers', () => {
 
       const result = await cleanupSinglePrivateKey(mockAddress1, mockRemoveAllDelegatesForOwner, mockDispatch)
 
-      expect(result.success).toBe(true)
+      expect(result.success).toBe(false)
+      expect(result.error?.type).toBe(ErrorType.STORAGE_ERROR)
       expect(mockRemoveAllDelegatesForOwner).not.toHaveBeenCalled()
-      expect(keyStorageService.removePrivateKey).toHaveBeenCalledWith(mockAddress1, { requireAuthentication: false })
-      expect(mockDispatch).toHaveBeenCalledWith(removeSigner(mockAddress1))
+      expect(keyStorageService.removePrivateKey).not.toHaveBeenCalled()
+      expect(mockDispatch).not.toHaveBeenCalled()
     })
 
     it('should handle delegate removal failure', async () => {
@@ -318,18 +319,17 @@ describe('editAccountHelpers', () => {
       expect(mockDispatch).not.toHaveBeenCalled()
     })
 
-    it('should cleanly remove the signer when the private key is missing', async () => {
+    it('should report STORAGE_ERROR when getPrivateKey returns undefined without invalidation', async () => {
       const mockDispatch = jest.fn() as unknown as AppDispatch
       const mockRemoveAllDelegatesForOwner = jest.fn()
 
       ;(keyStorageService.getPrivateKey as jest.Mock).mockResolvedValue(null)
-      ;(keyStorageService.removePrivateKey as jest.Mock).mockResolvedValue(undefined)
 
       await cleanupPrivateKeysForOwners([mockAddress1], mockRemoveAllDelegatesForOwner, mockDispatch)
 
       expect(mockRemoveAllDelegatesForOwner).not.toHaveBeenCalled()
-      expect(keyStorageService.removePrivateKey).toHaveBeenCalledWith(mockAddress1, { requireAuthentication: false })
-      expect(mockDispatch).toHaveBeenCalledWith(removeSigner(mockAddress1))
+      expect(keyStorageService.removePrivateKey).not.toHaveBeenCalled()
+      expect(mockDispatch).not.toHaveBeenCalled()
     })
 
     it('should cleanly remove the signer when the wrapping key has been biometry-invalidated', async () => {

--- a/apps/mobile/src/features/AccountsSheet/AccountItem/utils/__tests__/editAccountHelpers.test.ts
+++ b/apps/mobile/src/features/AccountsSheet/AccountItem/utils/__tests__/editAccountHelpers.test.ts
@@ -12,22 +12,28 @@ import {
 import { ErrorType } from '@/src/utils/errors'
 import { Address } from '@/src/types/address'
 import { AppDispatch } from '@/src/store'
-import { keyStorageService } from '@/src/services/key-storage'
+import { BiometryInvalidationError, keyStorageService } from '@/src/services/key-storage'
 import { removeSigner } from '@/src/store/signersSlice'
 import Logger from '@/src/utils/logger'
 
-jest.mock('@/src/services/key-storage', () => ({
-  keyStorageService: {
-    getPrivateKey: jest.fn(),
-    removePrivateKey: jest.fn(),
-  },
-}))
+jest.mock('@/src/services/key-storage', () => {
+  const actual = jest.requireActual('@/src/services/key-storage/errors')
+  return {
+    keyStorageService: {
+      getPrivateKey: jest.fn(),
+      removePrivateKey: jest.fn(),
+    },
+    BiometryInvalidationError: actual.BiometryInvalidationError,
+  }
+})
 
 jest.mock('@/src/store/signersSlice', () => ({
   removeSigner: jest.fn(),
 }))
 
 jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), trace: jest.fn() },
   error: jest.fn(),
 }))
 
@@ -218,7 +224,7 @@ describe('editAccountHelpers', () => {
       expect(mockDispatch).toHaveBeenCalledWith(removeSigner(mockAddress1))
     })
 
-    it('should handle missing private key', async () => {
+    it('should cleanly remove the signer when the private key is missing', async () => {
       const mockDispatch = jest.fn() as unknown as AppDispatch
       const mockRemoveAllDelegatesForOwner = jest.fn()
 
@@ -226,12 +232,10 @@ describe('editAccountHelpers', () => {
 
       const result = await cleanupSinglePrivateKey(mockAddress1, mockRemoveAllDelegatesForOwner, mockDispatch)
 
-      expect(result.success).toBe(false)
-      expect(result.error?.type).toBe(ErrorType.STORAGE_ERROR)
-      expect(result.error?.message).toBe('Private key not found for the specified address')
+      expect(result.success).toBe(true)
       expect(mockRemoveAllDelegatesForOwner).not.toHaveBeenCalled()
-      expect(keyStorageService.removePrivateKey).not.toHaveBeenCalled()
-      expect(mockDispatch).not.toHaveBeenCalled()
+      expect(keyStorageService.removePrivateKey).toHaveBeenCalledWith(mockAddress1, { requireAuthentication: false })
+      expect(mockDispatch).toHaveBeenCalledWith(removeSigner(mockAddress1))
     })
 
     it('should handle delegate removal failure', async () => {
@@ -314,17 +318,35 @@ describe('editAccountHelpers', () => {
       expect(mockDispatch).not.toHaveBeenCalled()
     })
 
-    it('should handle missing private key gracefully', async () => {
+    it('should cleanly remove the signer when the private key is missing', async () => {
       const mockDispatch = jest.fn() as unknown as AppDispatch
       const mockRemoveAllDelegatesForOwner = jest.fn()
 
       ;(keyStorageService.getPrivateKey as jest.Mock).mockResolvedValue(null)
+      ;(keyStorageService.removePrivateKey as jest.Mock).mockResolvedValue(undefined)
 
       await cleanupPrivateKeysForOwners([mockAddress1], mockRemoveAllDelegatesForOwner, mockDispatch)
 
       expect(mockRemoveAllDelegatesForOwner).not.toHaveBeenCalled()
-      expect(keyStorageService.removePrivateKey).not.toHaveBeenCalled()
-      expect(mockDispatch).not.toHaveBeenCalled()
+      expect(keyStorageService.removePrivateKey).toHaveBeenCalledWith(mockAddress1, { requireAuthentication: false })
+      expect(mockDispatch).toHaveBeenCalledWith(removeSigner(mockAddress1))
+    })
+
+    it('should cleanly remove the signer when the wrapping key has been biometry-invalidated', async () => {
+      const mockDispatch = jest.fn() as unknown as AppDispatch
+      const mockRemoveAllDelegatesForOwner = jest.fn()
+
+      ;(keyStorageService.getPrivateKey as jest.Mock).mockRejectedValue(
+        new BiometryInvalidationError(new Error('SE invalidated')),
+      )
+      ;(keyStorageService.removePrivateKey as jest.Mock).mockResolvedValue(undefined)
+
+      const result = await cleanupSinglePrivateKey(mockAddress1, mockRemoveAllDelegatesForOwner, mockDispatch)
+
+      expect(result.success).toBe(true)
+      expect(mockRemoveAllDelegatesForOwner).not.toHaveBeenCalled()
+      expect(keyStorageService.removePrivateKey).toHaveBeenCalledWith(mockAddress1, { requireAuthentication: false })
+      expect(mockDispatch).toHaveBeenCalledWith(removeSigner(mockAddress1))
     })
 
     it('should handle keychain errors gracefully', async () => {

--- a/apps/mobile/src/features/AccountsSheet/AccountItem/utils/editAccountHelpers.ts
+++ b/apps/mobile/src/features/AccountsSheet/AccountItem/utils/editAccountHelpers.ts
@@ -4,7 +4,7 @@ import { removeSigner } from '@/src/store/signersSlice'
 import { setActiveSafe } from '@/src/store/activeSafeSlice'
 import { removeSafe, SafesSliceItem } from '@/src/store/safesSlice'
 import { setEditMode } from '@/src/store/myAccountsSlice'
-import { keyStorageService } from '@/src/services/key-storage'
+import { BiometryInvalidationError, keyStorageService } from '@/src/services/key-storage'
 import Logger from '@/src/utils/logger'
 import { CommonActions } from '@react-navigation/native'
 import { Alert } from 'react-native'
@@ -122,11 +122,21 @@ export const cleanupSinglePrivateKey = async (
   dispatch: AppDispatch,
 ): Promise<StandardErrorResult<{ success: true }>> => {
   try {
-    const privateKey = await keyStorageService.getPrivateKey(ownerAddress)
+    let privateKey: string | undefined
+    try {
+      privateKey = await keyStorageService.getPrivateKey(ownerAddress)
+    } catch (err) {
+      if (err instanceof BiometryInvalidationError) {
+        Logger.warn('Skipping delegate cleanup: signer encryption key invalidated', { ownerAddress })
+      } else {
+        throw err
+      }
+    }
+
     if (!privateKey) {
-      return createErrorResult(ErrorType.STORAGE_ERROR, 'Private key not found for the specified address', null, {
-        ownerAddress,
-      })
+      await keyStorageService.removePrivateKey(ownerAddress, { requireAuthentication: false })
+      dispatch(removeSigner(ownerAddress))
+      return createSuccessResult({ success: true as const })
     }
 
     // Remove delegates (includes notification cleanup)

--- a/apps/mobile/src/features/AccountsSheet/AccountItem/utils/editAccountHelpers.ts
+++ b/apps/mobile/src/features/AccountsSheet/AccountItem/utils/editAccountHelpers.ts
@@ -123,17 +123,28 @@ export const cleanupSinglePrivateKey = async (
 ): Promise<StandardErrorResult<{ success: true }>> => {
   try {
     let privateKey: string | undefined
+    let invalidated = false
     try {
       privateKey = await keyStorageService.getPrivateKey(ownerAddress)
     } catch (err) {
       if (err instanceof BiometryInvalidationError) {
         Logger.warn('Skipping delegate cleanup: signer encryption key invalidated', { ownerAddress })
+        invalidated = true
       } else {
         throw err
       }
     }
 
     if (!privateKey) {
+      // Only force-wipe when we know the wrapping key is unusable. Without
+      // this gate, transient failures (user-cancel, lockout, unknown decrypt
+      // errors) would silently delete the signer despite the user not asking
+      // for it.
+      if (!invalidated) {
+        return createErrorResult(ErrorType.STORAGE_ERROR, 'Private key not found for the specified address', null, {
+          ownerAddress,
+        })
+      }
       await keyStorageService.removePrivateKey(ownerAddress, { requireAuthentication: false })
       dispatch(removeSigner(ownerAddress))
       return createSuccessResult({ success: true as const })

--- a/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewAndConfirmContainer.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewAndConfirmContainer.tsx
@@ -10,7 +10,7 @@ import { useTransactionSigner } from '@/src/features/ConfirmTx/hooks/useTransact
 import { useTransactionSigningState } from '@/src/hooks/useTransactionSigningState'
 import { useBiometrics } from '@/src/hooks/useBiometrics'
 import { useIsMounted } from '@/src/hooks/useIsMounted'
-import { BIOMETRY_ROTATION_DESCRIPTION, BiometryInvalidationError } from '@/src/services/key-storage'
+import { getErrorMessage } from '@/src/features/ExecuteTx/components/ReviewAndExecute/helpers'
 
 export function ReviewAndConfirmContainer() {
   const { txId } = useLocalSearchParams<{ txId: string }>()
@@ -61,17 +61,10 @@ export function ReviewAndConfirmContainer() {
         })
       }
     } catch (err) {
-      const errorMessage =
-        err instanceof BiometryInvalidationError
-          ? BIOMETRY_ROTATION_DESCRIPTION
-          : err instanceof Error
-            ? err.message
-            : 'Failed to sign transaction'
-
       if (isMounted()) {
         router.push({
           pathname: '/signing-error',
-          params: { description: errorMessage },
+          params: { description: getErrorMessage(err, 'Failed to sign transaction') },
         })
       }
     }

--- a/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewAndConfirmContainer.tsx
+++ b/apps/mobile/src/features/ConfirmTx/components/ReviewAndConfirm/ReviewAndConfirmContainer.tsx
@@ -10,6 +10,7 @@ import { useTransactionSigner } from '@/src/features/ConfirmTx/hooks/useTransact
 import { useTransactionSigningState } from '@/src/hooks/useTransactionSigningState'
 import { useBiometrics } from '@/src/hooks/useBiometrics'
 import { useIsMounted } from '@/src/hooks/useIsMounted'
+import { BIOMETRY_ROTATION_DESCRIPTION, BiometryInvalidationError } from '@/src/services/key-storage'
 
 export function ReviewAndConfirmContainer() {
   const { txId } = useLocalSearchParams<{ txId: string }>()
@@ -60,7 +61,12 @@ export function ReviewAndConfirmContainer() {
         })
       }
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to sign transaction'
+      const errorMessage =
+        err instanceof BiometryInvalidationError
+          ? BIOMETRY_ROTATION_DESCRIPTION
+          : err instanceof Error
+            ? err.message
+            : 'Failed to sign transaction'
 
       if (isMounted()) {
         router.push({

--- a/apps/mobile/src/features/ConfirmTx/components/SignTransaction/hooks/useTransactionSigning.ts
+++ b/apps/mobile/src/features/ConfirmTx/components/SignTransaction/hooks/useTransactionSigning.ts
@@ -3,6 +3,7 @@ import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useAppSelector } from '@/src/store/hooks'
 import { selectChainById } from '@/src/store/chains'
 import { RootState } from '@/src/store'
+import { BiometryInvalidationError } from '@/src/services/key-storage'
 import { getPrivateKey } from '@/src/hooks/useSign/useSign'
 import { signTx } from '@/src/services/tx/tx-sender/sign'
 import { useTransactionsAddConfirmationV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/transactions'
@@ -107,12 +108,13 @@ export function useTransactionSigning({ txId, signerAddress }: UseTransactionSig
 
       setStatus(SigningStatus.SUCCESS)
     } catch (error) {
-      logger.error('Error signing transaction:', error)
       setStatus(SigningStatus.ERROR)
 
-      dispatch(setSigningError({ txId, error: asError(error).message }))
+      if (!(error instanceof BiometryInvalidationError)) {
+        logger.error('Error signing transaction:', error)
+      }
 
-      // Re-throw error so it can be handled imperatively by the caller
+      dispatch(setSigningError({ txId, error: asError(error).message }))
       throw error
     }
   }, [activeChain, activeSafe, txId, signerAddress, addConfirmation, signer, safe.version, dispatch, signWithWc])

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.test.ts
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   determineExecutionPath,
   getErrorMessage,
 } from './helpers'
+import { BIOMETRY_ROTATION_DESCRIPTION, BiometryInvalidationError } from '@/src/services/key-storage'
 
 // Mock chain with relay feature enabled
 const mockChainWithRelay = {
@@ -210,6 +211,16 @@ describe('helpers', () => {
       expect(getErrorMessage({ foo: 'bar' })).toBe('Failed to execute transaction')
       expect(getErrorMessage(null)).toBe('Failed to execute transaction')
       expect(getErrorMessage(undefined)).toBe('Failed to execute transaction')
+    })
+
+    it('should use the provided fallback for non-Error throwables', () => {
+      expect(getErrorMessage('string error', 'Failed to sign transaction')).toBe('Failed to sign transaction')
+      expect(getErrorMessage(null, 'Failed to sign transaction')).toBe('Failed to sign transaction')
+    })
+
+    it('should map BiometryInvalidationError to the shared re-import copy', () => {
+      const err = new BiometryInvalidationError(new Error('SE invalidated'))
+      expect(getErrorMessage(err, 'Failed to sign transaction')).toBe(BIOMETRY_ROTATION_DESCRIPTION)
     })
   })
 })

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.ts
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.ts
@@ -3,6 +3,7 @@ import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
 import { Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
 import { FeeParams } from '@/src/hooks/useFeeParams/useFeeParams'
 import { Signer } from '@/src/store/signersSlice'
+import { BIOMETRY_ROTATION_DESCRIPTION, BiometryInvalidationError } from '@/src/services/key-storage'
 
 /**
  * Execution path types for the confirm flow
@@ -96,6 +97,9 @@ export const determineExecutionPath = (
  * Extracts error message from unknown error
  */
 export const getErrorMessage = (error: unknown): string => {
+  if (error instanceof BiometryInvalidationError) {
+    return BIOMETRY_ROTATION_DESCRIPTION
+  }
   if (error instanceof Error) {
     return error.message
   }

--- a/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.ts
+++ b/apps/mobile/src/features/ExecuteTx/components/ReviewAndExecute/helpers.ts
@@ -94,14 +94,16 @@ export const determineExecutionPath = (
 }
 
 /**
- * Extracts error message from unknown error
+ * Extracts a user-facing message from an unknown error, mapping biometry
+ * invalidation to the shared re-import copy and falling back to `fallback`
+ * for non-Error throwables.
  */
-export const getErrorMessage = (error: unknown): string => {
+export const getErrorMessage = (error: unknown, fallback = 'Failed to execute transaction'): string => {
   if (error instanceof BiometryInvalidationError) {
     return BIOMETRY_ROTATION_DESCRIPTION
   }
   if (error instanceof Error) {
     return error.message
   }
-  return 'Failed to execute transaction'
+  return fallback
 }

--- a/apps/mobile/src/features/ImportSigner/hooks/useImportPrivateKey.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useImportPrivateKey.ts
@@ -3,7 +3,6 @@ import { useState } from 'react'
 import Clipboard from '@react-native-clipboard/clipboard'
 import { useRouter } from 'expo-router'
 import { storePrivateKey } from '@/src/hooks/useSign/useSign'
-import { keyStorageService } from '@/src/services/key-storage'
 import useDelegate from '@/src/hooks/useDelegate'
 import Logger from '@/src/utils/logger'
 import { detectInputType, InputType } from '@/src/utils/inputDetection'
@@ -60,8 +59,6 @@ export const useImportPrivateKey = () => {
       }
 
       try {
-        // Drop any stale invalidated key entry so the re-import provisions a fresh wrapping key.
-        await keyStorageService.removePrivateKey(wallet.address, { requireAuthentication: false })
         await storePrivateKey(wallet.address, trimmedInput)
 
         // Create a delegate for this owner

--- a/apps/mobile/src/features/ImportSigner/hooks/useImportPrivateKey.ts
+++ b/apps/mobile/src/features/ImportSigner/hooks/useImportPrivateKey.ts
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import Clipboard from '@react-native-clipboard/clipboard'
 import { useRouter } from 'expo-router'
 import { storePrivateKey } from '@/src/hooks/useSign/useSign'
+import { keyStorageService } from '@/src/services/key-storage'
 import useDelegate from '@/src/hooks/useDelegate'
 import Logger from '@/src/utils/logger'
 import { detectInputType, InputType } from '@/src/utils/inputDetection'
@@ -59,7 +60,8 @@ export const useImportPrivateKey = () => {
       }
 
       try {
-        // Store the private key
+        // Drop any stale invalidated key entry so the re-import provisions a fresh wrapping key.
+        await keyStorageService.removePrivateKey(wallet.address, { requireAuthentication: false })
         await storePrivateKey(wallet.address, trimmedInput)
 
         // Create a delegate for this owner

--- a/apps/mobile/src/features/PrivateKey/PrivateKey.container.tsx
+++ b/apps/mobile/src/features/PrivateKey/PrivateKey.container.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react'
 import { Alert } from 'react-native'
 import { useRouter } from 'expo-router'
 import { PrivateKeyView } from './components/PrivateKeyView'
-import { keyStorageService } from '@/src/services/key-storage'
+import { BIOMETRY_ROTATION_DESCRIPTION, BiometryInvalidationError, keyStorageService } from '@/src/services/key-storage'
 import { useDelegateCleanup } from '@/src/hooks/useDelegateCleanup'
 import { useAppDispatch } from '@/src/store/hooks'
 import { type Address } from '@/src/types/address'
@@ -35,6 +35,10 @@ export const PrivateKeyContainer = ({ signerAddress }: Props) => {
       setPrivateKey(key)
       setIsKeyVisible(true)
     } catch (error) {
+      if (error instanceof BiometryInvalidationError) {
+        Alert.alert('Signer needs to be re-imported', BIOMETRY_ROTATION_DESCRIPTION, [{ text: 'OK' }])
+        return
+      }
       console.error('Error retrieving private key:', error)
       Alert.alert('Error', 'Failed to retrieve private key')
     } finally {

--- a/apps/mobile/src/hooks/useBiometrics.test.ts
+++ b/apps/mobile/src/hooks/useBiometrics.test.ts
@@ -2,7 +2,7 @@ import { act, waitFor } from '@testing-library/react-native'
 import { renderHook, type TestStore } from '@/src/tests/test-utils'
 import { useBiometrics } from './useBiometrics'
 import * as Keychain from 'react-native-keychain'
-import { Alert, Linking } from 'react-native'
+import { Alert, Linking, Platform } from 'react-native'
 
 const mockGetSupportedBiometryType = Keychain.getSupportedBiometryType as jest.Mock
 const mockSetGenericPassword = Keychain.setGenericPassword as jest.Mock
@@ -289,50 +289,95 @@ describe('useBiometrics', () => {
   })
 
   describe('promptBiometricsSetup', () => {
-    it('shows an Alert with explicit Cancel and Open Settings buttons', () => {
+    const originalPlatform = Platform.OS
+    afterEach(() => {
+      Object.defineProperty(Platform, 'OS', { value: originalPlatform, configurable: true })
+    })
+
+    it('shows Cancel + Open settings buttons', () => {
       const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn())
       const { result } = renderHook(() => useBiometrics())
 
       result.current.promptBiometricsSetup()
 
-      expect(alertSpy).toHaveBeenCalledTimes(1)
       const [, , buttons] = alertSpy.mock.calls[0]
       expect(buttons).toEqual([
         expect.objectContaining({ text: 'Cancel', style: 'cancel' }),
-        expect.objectContaining({ text: 'Open Settings' }),
+        expect.objectContaining({ text: 'Open settings' }),
       ])
-
       alertSpy.mockRestore()
     })
 
-    it('only invokes Linking when the user taps Open Settings', () => {
+    it('routes iOS Open settings tap to app-settings:', async () => {
+      Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true })
       const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn())
-      const openURLSpy = jest.spyOn(Linking, 'openURL').mockImplementation(jest.fn())
+      const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true)
       const { result } = renderHook(() => useBiometrics())
 
       result.current.promptBiometricsSetup()
-      expect(openURLSpy).not.toHaveBeenCalled()
-
-      // Simulate the user tapping the Open Settings button.
       const buttons = alertSpy.mock.calls[0][2] as { text: string; onPress?: () => void }[]
-      buttons.find((b) => b.text === 'Open Settings')?.onPress?.()
+      await buttons.find((b) => b.text === 'Open settings')?.onPress?.()
 
       expect(openURLSpy).toHaveBeenCalledWith('app-settings:')
-
       alertSpy.mockRestore()
       openURLSpy.mockRestore()
+    })
+
+    it('routes Android Open settings tap through BIOMETRIC_ENROLL intent', async () => {
+      Object.defineProperty(Platform, 'OS', { value: 'android', configurable: true })
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(jest.fn())
+      const sendIntentSpy = jest.spyOn(Linking, 'sendIntent').mockResolvedValue(undefined)
+      const { result } = renderHook(() => useBiometrics())
+
+      result.current.promptBiometricsSetup()
+      const buttons = alertSpy.mock.calls[0][2] as { text: string; onPress?: () => void }[]
+      await buttons.find((b) => b.text === 'Open settings')?.onPress?.()
+
+      expect(sendIntentSpy).toHaveBeenCalledWith('android.settings.BIOMETRIC_ENROLL')
+      alertSpy.mockRestore()
+      sendIntentSpy.mockRestore()
     })
   })
 
   describe('openBiometricSettings', () => {
-    it('opens settings when called', () => {
-      const openURLSpy = jest.spyOn(Linking, 'openURL').mockImplementation(jest.fn())
+    const originalPlatform = Platform.OS
+    afterEach(() => {
+      Object.defineProperty(Platform, 'OS', { value: originalPlatform, configurable: true })
+    })
+
+    it('opens app-settings: on iOS', async () => {
+      Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true })
+      const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true)
       const { result } = renderHook(() => useBiometrics())
 
-      result.current.openBiometricSettings()
+      await result.current.openBiometricSettings()
 
       expect(openURLSpy).toHaveBeenCalledWith('app-settings:')
       openURLSpy.mockRestore()
+    })
+
+    it('uses BIOMETRIC_ENROLL intent on Android', async () => {
+      Object.defineProperty(Platform, 'OS', { value: 'android', configurable: true })
+      const sendIntentSpy = jest.spyOn(Linking, 'sendIntent').mockResolvedValue(undefined)
+      const { result } = renderHook(() => useBiometrics())
+
+      await result.current.openBiometricSettings()
+
+      expect(sendIntentSpy).toHaveBeenCalledWith('android.settings.BIOMETRIC_ENROLL')
+      sendIntentSpy.mockRestore()
+    })
+
+    it('falls back to openSettings on Android when the intent throws', async () => {
+      Object.defineProperty(Platform, 'OS', { value: 'android', configurable: true })
+      const sendIntentSpy = jest.spyOn(Linking, 'sendIntent').mockRejectedValue(new Error('no activity'))
+      const openSettingsSpy = jest.spyOn(Linking, 'openSettings').mockResolvedValue(undefined)
+      const { result } = renderHook(() => useBiometrics())
+
+      await result.current.openBiometricSettings()
+
+      expect(openSettingsSpy).toHaveBeenCalled()
+      sendIntentSpy.mockRestore()
+      openSettingsSpy.mockRestore()
     })
   })
 

--- a/apps/mobile/src/hooks/useBiometrics.ts
+++ b/apps/mobile/src/hooks/useBiometrics.ts
@@ -31,11 +31,15 @@ export function useBiometrics() {
   const biometricsType = useAppSelector((state: RootState) => state.biometrics.type)
   const userAttempts = useAppSelector((state: RootState) => state.biometrics.userAttempts)
 
-  const openBiometricSettings = () => {
+  const openBiometricSettings = async () => {
     if (Platform.OS === 'ios') {
-      Linking.openURL('app-settings:')
-    } else {
-      Linking.openSettings()
+      await Linking.openURL('app-settings:')
+      return
+    }
+    try {
+      await Linking.sendIntent('android.settings.BIOMETRIC_ENROLL')
+    } catch {
+      await Linking.openSettings()
     }
   }
 
@@ -43,11 +47,11 @@ export function useBiometrics() {
     Alert.alert(
       'Set up biometrics',
       Platform.OS === 'ios'
-        ? 'Set up Face ID or Touch ID in iOS Settings to enable biometrics in Safe.'
-        : 'Set up fingerprint in your device Settings to enable biometrics in Safe.',
+        ? 'Open the Settings app and enable Face ID or Touch ID under "Face ID & Passcode", then return to Safe.'
+        : 'Set up fingerprint or face unlock in your device settings to enable biometrics in Safe.',
       [
         { text: 'Cancel', style: 'cancel' },
-        { text: 'Open Settings', onPress: openBiometricSettings },
+        { text: 'Open settings', onPress: openBiometricSettings },
       ],
       { cancelable: true },
     )

--- a/apps/mobile/src/services/key-storage/errors.test.ts
+++ b/apps/mobile/src/services/key-storage/errors.test.ts
@@ -1,0 +1,112 @@
+import { Platform } from 'react-native'
+import { BiometryInvalidationError, isBiometryInvalidationError } from './errors'
+
+describe('key-storage/errors', () => {
+  const originalPlatform = Platform.OS
+
+  afterEach(() => {
+    Object.defineProperty(Platform, 'OS', { value: originalPlatform, configurable: true })
+  })
+
+  const setPlatform = (os: 'ios' | 'android') => {
+    Object.defineProperty(Platform, 'OS', { value: os, configurable: true })
+  }
+
+  describe('BiometryInvalidationError', () => {
+    it('preserves the cause and sets a stable name', () => {
+      const cause = new Error('underlying')
+      const err = new BiometryInvalidationError(cause)
+
+      expect(err.name).toBe('BiometryInvalidationError')
+      expect(err.message).toBe('Signer encryption key is no longer usable')
+      expect(err.cause).toBe(cause)
+      expect(err).toBeInstanceOf(Error)
+      expect(err).toBeInstanceOf(BiometryInvalidationError)
+    })
+  })
+
+  describe('isBiometryInvalidationError — iOS', () => {
+    beforeEach(() => setPlatform('ios'))
+
+    it('matches the canonical kAKSReturnPolicyInvalid AKSError', () => {
+      const msg =
+        'E1760 - Decryption error.: Error Domain=CryptoTokenKit Code=-3 ' +
+        '"<sepk:p256(d) kid=107556c293aef9fb>: unable to compute shared secret" ' +
+        'UserInfo={NSDebugDescription=<sepk:p256(d) kid=107556c293aef9fb>: unable to compute shared secret, AKSError=-536362999}'
+      expect(isBiometryInvalidationError(new Error(msg))).toBe(true)
+    })
+
+    it('matches kAKSReturnBadDeviceKey', () => {
+      expect(isBiometryInvalidationError(new Error('AKSError=-536870203'))).toBe(true)
+    })
+
+    it('matches the hex form 0xe007c009', () => {
+      expect(isBiometryInvalidationError(new Error('failed (0xe007c009)'))).toBe(true)
+    })
+
+    it('matches errSecAuthFailed (OSStatus -25293)', () => {
+      expect(isBiometryInvalidationError(new Error('OSStatus error -25293'))).toBe(true)
+    })
+
+    it('does NOT match errSecItemNotFound (-25300, no-item-in-keychain — handled separately)', () => {
+      expect(isBiometryInvalidationError(new Error('OSStatus error -25300'))).toBe(false)
+    })
+
+    it('matches LAErrorBiometryNotEnrolled (-7)', () => {
+      expect(isBiometryInvalidationError(new Error('LAErrorDomain Code=-7'))).toBe(true)
+    })
+
+    it('does NOT match LAErrorBiometryLockout (-8, transient)', () => {
+      expect(isBiometryInvalidationError(new Error('LAErrorDomain Code=-8 biometry lockout'))).toBe(false)
+    })
+
+    it('does NOT match LAErrorUserCancel (-2, transient)', () => {
+      expect(isBiometryInvalidationError(new Error('LAErrorDomain Code=-2 user canceled'))).toBe(false)
+    })
+
+    it('does NOT match a generic CryptoTokenKit Code=-3 without AKSError', () => {
+      expect(isBiometryInvalidationError(new Error('Error Domain=CryptoTokenKit Code=-3 "something else"'))).toBe(false)
+    })
+
+    it('handles non-Error throwables (strings)', () => {
+      expect(isBiometryInvalidationError('AKSError=-536362999')).toBe(true)
+      expect(isBiometryInvalidationError('something benign')).toBe(false)
+    })
+  })
+
+  describe('isBiometryInvalidationError — Android', () => {
+    beforeEach(() => setPlatform('android'))
+
+    it('matches ERROR_LOCKOUT_PERMANENT (9-)', () => {
+      expect(isBiometryInvalidationError(new Error('9- biometric lockout permanent'))).toBe(true)
+    })
+
+    it('matches ERROR_NO_BIOMETRICS (11-)', () => {
+      expect(isBiometryInvalidationError(new Error('11- no biometrics enrolled'))).toBe(true)
+    })
+
+    it('matches ERROR_NO_DEVICE_CREDENTIAL (14-)', () => {
+      expect(isBiometryInvalidationError(new Error('14- no device credential'))).toBe(true)
+    })
+
+    it('matches the KeyPermanentlyInvalidatedException string', () => {
+      expect(isBiometryInvalidationError(new Error('Key permanently invalidated'))).toBe(true)
+    })
+
+    it('does NOT match ERROR_CANCELED (5-, user-driven)', () => {
+      expect(isBiometryInvalidationError(new Error('5- Fingerprint operation Cancelled'))).toBe(false)
+    })
+
+    it('does NOT match ERROR_LOCKOUT (7-, transient)', () => {
+      expect(isBiometryInvalidationError(new Error('7- biometric lockout'))).toBe(false)
+    })
+
+    it('does NOT match ERROR_USER_CANCELED (10-, user-driven)', () => {
+      expect(isBiometryInvalidationError(new Error('10- user cancelled'))).toBe(false)
+    })
+
+    it('does NOT match ERROR_NEGATIVE_BUTTON (13-, user-driven)', () => {
+      expect(isBiometryInvalidationError(new Error('13- negative button'))).toBe(false)
+    })
+  })
+})

--- a/apps/mobile/src/services/key-storage/errors.ts
+++ b/apps/mobile/src/services/key-storage/errors.ts
@@ -1,0 +1,40 @@
+import { Platform } from 'react-native'
+
+export const BIOMETRY_ROTATION_DESCRIPTION =
+  "Your device's biometric settings appear to have changed since this signer was imported. " +
+  'Re-import the signer from Settings → Signers to restore signing'
+
+export class BiometryInvalidationError extends Error {
+  constructor(public readonly cause: unknown) {
+    super('Signer encryption key is no longer usable')
+    this.name = 'BiometryInvalidationError'
+  }
+}
+
+const IOS_INVALIDATED_PATTERNS = [
+  /AKSError\s*=\s*-?536362999\b/, // kAKSReturnPolicyInvalid
+  /AKSError\s*=\s*-?536870203\b/, // kAKSReturnBadDeviceKey
+  /\b0xe007c009\b/i,
+  /OSStatus error -25293\b/, // errSecAuthFailed
+  /LAError(?:Domain)?\s+Code\s*=?\s*-7\b/, // biometryNotEnrolled
+]
+
+const ANDROID_INVALIDATED_PATTERNS = [
+  /^9- /, // ERROR_LOCKOUT_PERMANENT
+  /^11- /, // ERROR_NO_BIOMETRICS
+  /^14- /, // ERROR_NO_DEVICE_CREDENTIAL
+  /Key permanently invalidated/i,
+]
+
+const messageOf = (err: unknown): string => {
+  if (err instanceof Error) {
+    return err.message
+  }
+  return String(err)
+}
+
+export const isBiometryInvalidationError = (err: unknown): boolean => {
+  const msg = messageOf(err)
+  const patterns = Platform.OS === 'ios' ? IOS_INVALIDATED_PATTERNS : ANDROID_INVALIDATED_PATTERNS
+  return patterns.some((p) => p.test(msg))
+}

--- a/apps/mobile/src/services/key-storage/errors.ts
+++ b/apps/mobile/src/services/key-storage/errors.ts
@@ -5,8 +5,8 @@ export const BIOMETRY_ROTATION_DESCRIPTION =
   'Re-import the signer from Settings → Signers to restore signing'
 
 export class BiometryInvalidationError extends Error {
-  constructor(public readonly cause: unknown) {
-    super('Signer encryption key is no longer usable')
+  constructor(cause: unknown) {
+    super('Signer encryption key is no longer usable', { cause })
     this.name = 'BiometryInvalidationError'
   }
 }

--- a/apps/mobile/src/services/key-storage/index.ts
+++ b/apps/mobile/src/services/key-storage/index.ts
@@ -3,7 +3,9 @@ import { WalletService } from './wallet.service'
 import { IKeyStorageService, PrivateKeyStorageOptions } from './types'
 import { IWalletService } from './wallet.service'
 
-export { KeyStorageService, WalletService, type IKeyStorageService, type IWalletService, type PrivateKeyStorageOptions }
+export { KeyStorageService, WalletService }
+export type { IKeyStorageService, IWalletService, PrivateKeyStorageOptions }
+export { BIOMETRY_ROTATION_DESCRIPTION, BiometryInvalidationError, isBiometryInvalidationError } from './errors'
 
 export const keyStorageService = new KeyStorageService()
 export const walletService = new WalletService()

--- a/apps/mobile/src/services/key-storage/key-storage.service.test.ts
+++ b/apps/mobile/src/services/key-storage/key-storage.service.test.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { KeyStorageService } from './key-storage.service'
+import { BiometryInvalidationError } from './errors'
 import DeviceCrypto from 'react-native-device-crypto'
 import * as Keychain from 'react-native-keychain'
 import DeviceInfo from 'react-native-device-info'
@@ -242,10 +243,32 @@ describe('KeyStorageService', () => {
   })
 
   describe('key invalidation handling', () => {
-    it('retries storage after key invalidation', async () => {
+    it('retries storage after key invalidation on iOS (AKSError fingerprint)', async () => {
       ;(Platform.OS as string) = 'ios'
       mockDeviceInfo.isEmulator.mockResolvedValue(false)
       mockDeviceCrypto.getOrCreateAsymmetricKey.mockResolvedValue('key-name')
+
+      mockDeviceCrypto.encrypt
+        .mockRejectedValueOnce(new Error('Domain=CryptoTokenKit Code=-3 ... AKSError=-536362999'))
+        .mockResolvedValueOnce({ encryptedText: 'encrypted', iv: 'iv-value' })
+
+      mockKeychain.getGenericPassword.mockResolvedValue(false)
+      mockKeychain.resetGenericPassword.mockResolvedValue(true)
+      mockDeviceCrypto.deleteKey.mockResolvedValue(undefined as never)
+      mockKeychain.setGenericPassword.mockResolvedValue({
+        service: 'test-service',
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
+      })
+
+      await service.storePrivateKey(userId, privateKey)
+
+      expect(mockDeviceCrypto.encrypt).toHaveBeenCalledTimes(2)
+      expect(mockDeviceCrypto.deleteKey).toHaveBeenCalled()
+    })
+
+    it('retries storage after key invalidation on Android (KeyPermanentlyInvalidatedException)', async () => {
+      ;(Platform.OS as string) = 'android'
+      mockDeviceCrypto.getOrCreateSymmetricKey.mockResolvedValue(undefined as never)
 
       mockDeviceCrypto.encrypt
         .mockRejectedValueOnce(new Error('Key permanently invalidated'))
@@ -263,6 +286,67 @@ describe('KeyStorageService', () => {
 
       expect(mockDeviceCrypto.encrypt).toHaveBeenCalledTimes(2)
       expect(mockDeviceCrypto.deleteKey).toHaveBeenCalled()
+    })
+  })
+
+  describe('getPrivateKey biometry invalidation', () => {
+    const mockKeychainEntry = () => {
+      const encryptedData = JSON.stringify({ encryptedPassword: 'encrypted', iv: 'iv-value' })
+      mockKeychain.getGenericPassword.mockResolvedValue({
+        username: 'signer_address',
+        password: encryptedData,
+        service: 'test-service',
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
+      })
+    }
+
+    it('throws BiometryInvalidationError for iOS AKSError fingerprint', async () => {
+      ;(Platform.OS as string) = 'ios'
+      mockKeychainEntry()
+      mockDeviceCrypto.decrypt.mockRejectedValue(
+        new Error(
+          'Error Domain=CryptoTokenKit Code=-3 "unable to compute shared secret" ' + 'UserInfo={AKSError=-536362999}',
+        ),
+      )
+
+      await expect(service.getPrivateKey(userId)).rejects.toBeInstanceOf(BiometryInvalidationError)
+    })
+
+    it('throws BiometryInvalidationError for Android KeyPermanentlyInvalidatedException', async () => {
+      ;(Platform.OS as string) = 'android'
+      mockKeychainEntry()
+      mockDeviceCrypto.decrypt.mockRejectedValue(new Error('Key permanently invalidated'))
+
+      await expect(service.getPrivateKey(userId)).rejects.toBeInstanceOf(BiometryInvalidationError)
+    })
+
+    it('returns undefined for Android ERROR_CANCELED (user-driven cancel)', async () => {
+      ;(Platform.OS as string) = 'android'
+      mockKeychainEntry()
+      mockDeviceCrypto.decrypt.mockRejectedValue(new Error('5- Fingerprint operation Cancelled'))
+
+      const result = await service.getPrivateKey(userId)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined for benign decrypt failures (not biometry-related)', async () => {
+      ;(Platform.OS as string) = 'ios'
+      mockKeychainEntry()
+      mockDeviceCrypto.decrypt.mockRejectedValue(new Error('Some unrelated decrypt error'))
+
+      const result = await service.getPrivateKey(userId)
+
+      expect(result).toBeUndefined()
+    })
+
+    it('returns undefined when no keychain entry exists', async () => {
+      ;(Platform.OS as string) = 'ios'
+      mockKeychain.getGenericPassword.mockResolvedValue(false)
+
+      const result = await service.getPrivateKey(userId)
+
+      expect(result).toBeUndefined()
     })
   })
 })

--- a/apps/mobile/src/services/key-storage/key-storage.service.test.ts
+++ b/apps/mobile/src/services/key-storage/key-storage.service.test.ts
@@ -266,6 +266,34 @@ describe('KeyStorageService', () => {
       expect(mockDeviceCrypto.deleteKey).toHaveBeenCalled()
     })
 
+    it('retries storage when iOS post-store decrypt probe reveals orphan SE key', async () => {
+      // iOS Quick Start migration leaves an orphan SE asymmetric key reference
+      // where encrypt (public-half) succeeds but decrypt (private-half) fails.
+      // The probe should surface this and trigger handleKeyInvalidation.
+      ;(Platform.OS as string) = 'ios'
+      mockDeviceInfo.isEmulator.mockResolvedValue(false)
+      mockDeviceCrypto.getOrCreateAsymmetricKey.mockResolvedValue('key-name')
+
+      mockDeviceCrypto.encrypt.mockResolvedValue({ encryptedText: 'encrypted', iv: 'iv-value' })
+      mockDeviceCrypto.decrypt
+        .mockRejectedValueOnce(new Error('Domain=CryptoTokenKit Code=-3 ... AKSError=-536362999'))
+        .mockResolvedValueOnce('decrypted')
+
+      mockKeychain.getGenericPassword.mockResolvedValue(false)
+      mockKeychain.resetGenericPassword.mockResolvedValue(true)
+      mockDeviceCrypto.deleteKey.mockResolvedValue(undefined as never)
+      mockKeychain.setGenericPassword.mockResolvedValue({
+        service: 'test-service',
+        storage: Keychain.STORAGE_TYPE.AES_GCM,
+      })
+
+      await service.storePrivateKey(userId, privateKey)
+
+      expect(mockDeviceCrypto.encrypt).toHaveBeenCalledTimes(2)
+      expect(mockDeviceCrypto.decrypt).toHaveBeenCalledTimes(2)
+      expect(mockDeviceCrypto.deleteKey).toHaveBeenCalled()
+    })
+
     it('retries storage after key invalidation on Android (KeyPermanentlyInvalidatedException)', async () => {
       ;(Platform.OS as string) = 'android'
       mockDeviceCrypto.getOrCreateSymmetricKey.mockResolvedValue(undefined as never)

--- a/apps/mobile/src/services/key-storage/key-storage.service.ts
+++ b/apps/mobile/src/services/key-storage/key-storage.service.ts
@@ -144,6 +144,20 @@ export class KeyStorageService implements IKeyStorageService {
         { accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY, service: this.getKeyService(userId) },
       )
 
+      // On iOS, encrypt uses only the public-key half of the SE asymmetric key
+      // and never surfaces invalidation. Read the blob back so an orphan SE
+      // private key fails here (where the existing self-heal can recover) rather
+      // than at sign time. Android's symmetric encrypt already required auth and
+      // would have thrown above, so this probe is iOS-only.
+      if (Platform.OS === 'ios') {
+        await DeviceCrypto.decrypt(
+          keyName,
+          encryptedPrivateKey.encryptedText,
+          encryptedPrivateKey.iv,
+          this.BIOMETRIC_PROMPTS.SAVE,
+        )
+      }
+
       // Reset retry counter on successful storage
       this.storeTries = 0
     } catch (error) {

--- a/apps/mobile/src/services/key-storage/key-storage.service.ts
+++ b/apps/mobile/src/services/key-storage/key-storage.service.ts
@@ -1,7 +1,9 @@
 import DeviceCrypto from 'react-native-device-crypto'
 import * as Keychain from 'react-native-keychain'
 import DeviceInfo from 'react-native-device-info'
+import { DdRum, ErrorSource } from 'expo-datadog'
 import { IKeyStorageService, PrivateKeyStorageOptions } from './types'
+import { BiometryInvalidationError, isBiometryInvalidationError } from './errors'
 import Logger from '@/src/utils/logger'
 import { Platform } from 'react-native'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
@@ -51,7 +53,21 @@ export class KeyStorageService implements IKeyStorageService {
     try {
       return await this.getKey(userId, options.requireAuthentication ?? true)
     } catch (err) {
+      if (err === 'user password not found') {
+        return undefined
+      }
+
       Logger.error('Error getting private key:', asError(err).message)
+
+      if (isBiometryInvalidationError(err)) {
+        DdRum.addError('BiometryInvalidationError', ErrorSource.SOURCE, asError(err).stack ?? '', {
+          userId,
+          location: 'getPrivateKey',
+          platform: Platform.OS,
+        })
+        throw new BiometryInvalidationError(err)
+      }
+
       return undefined
     }
   }
@@ -131,7 +147,7 @@ export class KeyStorageService implements IKeyStorageService {
       // Reset retry counter on successful storage
       this.storeTries = 0
     } catch (error) {
-      if (this.isKeyPermanentlyInvalidatedError(error)) {
+      if (this.storeTries === 0 && isBiometryInvalidationError(error)) {
         try {
           await this.handleKeyInvalidation(userId, requireAuth)
           this.storeTries++
@@ -166,11 +182,6 @@ export class KeyStorageService implements IKeyStorageService {
       this.BIOMETRIC_PROMPTS.STANDARD,
     )
     return decryptedPrivateKey
-  }
-
-  private isKeyPermanentlyInvalidatedError(error: unknown): boolean {
-    const errorMessage = asError(error).message
-    return errorMessage.includes('Key permanently invalidated')
   }
 
   private async handleKeyInvalidation(userId: string, requireAuth: boolean): Promise<void> {

--- a/apps/mobile/src/services/key-storage/key-storage.service.ts
+++ b/apps/mobile/src/services/key-storage/key-storage.service.ts
@@ -9,7 +9,6 @@ import { Platform } from 'react-native'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
 
 export class KeyStorageService implements IKeyStorageService {
-  private storeTries = 0
   private readonly BIOMETRIC_PROMPTS = {
     SKIP: {
       biometryTitle: '',
@@ -33,13 +32,12 @@ export class KeyStorageService implements IKeyStorageService {
     privateKey: string,
     options: PrivateKeyStorageOptions = { requireAuthentication: true },
   ): Promise<void> {
-    this.storeTries = 0
     try {
       const { requireAuthentication = true } = options
       // On the Android emulator there is no Strongbox, but the library can work without it
       // On iOS simulator we can't use the secureEnclave as there is none
       const isEmulator = Platform.OS === 'android' ? false : await DeviceInfo.isEmulator()
-      await this.storeKey(userId, privateKey, requireAuthentication, isEmulator)
+      await this.storeKey(userId, privateKey, requireAuthentication, isEmulator, 0)
     } catch (err) {
       Logger.error('Error storing private key:', asError(err).message)
       throw new Error('Failed to store private key')
@@ -57,9 +55,8 @@ export class KeyStorageService implements IKeyStorageService {
         return undefined
       }
 
-      Logger.error('Error getting private key:', asError(err).message)
-
       if (isBiometryInvalidationError(err)) {
+        Logger.warn('Signer encryption key is invalidated:', asError(err).message)
         DdRum.addError('BiometryInvalidationError', ErrorSource.SOURCE, asError(err).stack ?? '', {
           userId,
           location: 'getPrivateKey',
@@ -68,6 +65,7 @@ export class KeyStorageService implements IKeyStorageService {
         throw new BiometryInvalidationError(err)
       }
 
+      Logger.error('Error getting private key:', asError(err).message)
       return undefined
     }
   }
@@ -123,7 +121,13 @@ export class KeyStorageService implements IKeyStorageService {
     }
   }
 
-  private async storeKey(userId: string, privateKey: string, requireAuth: boolean, isEmulator: boolean): Promise<void> {
+  private async storeKey(
+    userId: string,
+    privateKey: string,
+    requireAuth: boolean,
+    isEmulator: boolean,
+    attempt: number,
+  ): Promise<void> {
     const keyName = this.getKeyNameDeviceCrypto(userId)
 
     if (Platform.OS === 'android') {
@@ -157,15 +161,11 @@ export class KeyStorageService implements IKeyStorageService {
           this.BIOMETRIC_PROMPTS.SAVE,
         )
       }
-
-      // Reset retry counter on successful storage
-      this.storeTries = 0
     } catch (error) {
-      if (this.storeTries === 0 && isBiometryInvalidationError(error)) {
+      if (attempt === 0 && isBiometryInvalidationError(error)) {
         try {
           await this.handleKeyInvalidation(userId, requireAuth)
-          this.storeTries++
-          return await this.storeKey(userId, privateKey, requireAuth, isEmulator)
+          return await this.storeKey(userId, privateKey, requireAuth, isEmulator, attempt + 1)
         } catch (_error) {
           throw new Error('Failed to store private key')
         }


### PR DESCRIPTION
> Face ID's reset its enrollment,
> Enclave keys forget the key,
> Tell the user "re-import."

## What it solves

Resolves: #7835
Resolves: https://linear.app/safe-global/issue/WA-2300 

When iOS Face ID is re-enrolled or the Android device PIN/lock-screen credential is changed/removed, the OS invalidates the wrapping key tied to the user's previous biometrics. The encrypted private-key blob in the iOS Keychain / Android Keystore is still there, but it can no longer be decrypted. Today every consumer of `KeyStorageService.getPrivateKey()` collapses this into a generic `undefined`, so:

- **Sign** fails with `"Cannot sign the transaction. Failed to retrieve private key"` — user has no idea what happened.
- **View private key** shows `"Biometric authentication failed. Please try again"` — misleading; biometrics worked, the key is just unusable.
- **Delete private key** / **Delete account** fail with `"Private key not found"` / `"Failed to clean up 1 out of 1 private keys"` — the cleanup path is gated on a successful decrypt, so the user can't recover without uninstalling the app.

Re-importing the signer also "succeeded" (UI said "Your signer is ready!") but signing still failed, because the iOS path reused the orphan Secure Enclave key reference left behind by Quick Start / iCloud Keychain sync.

## How this PR fixes it

1. **Typed-error classification** inside `KeyStorageService.getPrivateKey`. New `BiometryInvalidationError` is thrown when the underlying decrypt failure matches one of the platform-specific fingerprints documented in `errors.ts` — anchored on `AKSError=-536362999` (`kAKSReturnPolicyInvalid`) and `LAErrorBiometryNotEnrolled` on iOS, and on `BiometricPrompt` codes 9/11/14 + `KeyPermanentlyInvalidatedException` on Android. Transient codes (user-cancel, lockout) deliberately don't match.
2. **Self-heal on store** — `storeKey`'s existing retry path now triggers on iOS too (was Android-only via a literal string match).
3. **Sign + execute flows** route to their standard error screens (`/signing-error`, `/execution-error`) with a clear "re-import the signer" message instead of a mid-flow popup.
4. **View PK** keeps a simple OK alert (it's a settings-context action where the standard error screen would feel heavy).
5. **`cleanupSinglePrivateKey` ungated** — when the key is unusable, drop the keychain entry without auth and remove the Redux signer so the user can delete and re-add. Server-side delegate revocation is skipped (we can't sign one without the key); follow-up tracked elsewhere.
6. **Defensive `removePrivateKey` before `storePrivateKey`** in `useImportPrivateKey` — re-import on iOS now always provisions a fresh wrapping key instead of reusing an orphan reference.
7. **Side fix to biometrics-setup CTA**: on Android, "Open settings" now uses the `android.settings.BIOMETRIC_ENROLL` intent to land directly on biometric enrollment instead of the app permissions page. iOS keeps `app-settings:` (Apple doesn't expose a public deep link to Face ID & Passcode).

## How to test it

**Android device:**

1. Boot an API 30+ device with a screen lock (PIN) and one enrolled fingerprint. .
2. Build the app and import a private-key signer. Sign one transaction to confirm it works.
3. Settings → Security → remove the PIN (`None`). This destroys the LSKF and immediately invalidates every auth-bound Keystore entry.
4. Re-open the app:
   - **Sign tx** → routes to `/signing-error` with the re-import message (not the generic "failed to retrieve" copy).
   - **View private key** → OK alert "Signer needs to be re-imported".
   - **Delete private key** → succeeds; signer disappears from Redux + Keystore.
   - **Delete account** with that signer → no longer blocked by "Failed to clean up 1 out of 1 private keys".
5. Re-import the same private key — works on the first try (defensive `removePrivateKey` clears the invalidated entry first). Note that re-import on Android already self-healed via the existing `KeyPermanentlyInvalidatedException` path; this PR makes the same retry trigger on iOS.

**iOS physical device:**

1. Import a private-key signer; sign a transaction.
2. Settings → Face ID & Passcode → Reset Face ID (or enroll "Alternate Appearance"; iOS 15+ counts mask enrollment as a biometry-set change).
3. Repeat the sign / view / delete checks above. Expected behavior matches Android.

**User-cancel sanity checks:**

- Cancel the biometric prompt manually on either platform → no rotation alert; existing UX preserved.
- iOS `LAErrorBiometryLockout(-8)` (5+ failed Face ID attempts) → no rotation alert; user retries with passcode.

**Android biometrics-setup CTA:**

- On Android setup with no fingerprints enrolled, in the app open the biometrics-opt-in flow → "Open settings" lands on the biometric enrollment screen (not the app permissions page).

**Unit tests:**

```
yarn workspace @safe-global/mobile test --testPathPattern="key-storage|useTransactionSigning|editAccountHelpers|useBiometrics|useImportPrivateKey"
```

22 classifier tests + 24 service tests + container/hook/cleanup tests = 142 directly related, all green. Full mobile suite (271 suites, 2355 tests) also green.

## Affected flows

- Sign transaction (PK signer) — failure path
- Execute transaction (PK signer) — failure path
- View private key from signer detail
- Delete private key from signer detail
- Delete safe that owns a PK signer
- Import private key (defensive cleanup before store)
- Biometrics opt-in / setup CTA

## Blast radius

**Shared surfaces touched:**

- `KeyStorageService.getPrivateKey` now throws `BiometryInvalidationError` for classified failures. Known direct consumers: `getPrivateKey` in `apps/mobile/src/hooks/useSign/useSign.ts` (used by sign tx, execute tx via `privateKeyExecutor`), `cleanupSinglePrivateKey` in `editAccountHelpers`, `PrivateKey.container`. Each is updated.
- `KeyStorageService.storeKey` self-heal previously only matched Android-style errors. Now matches iOS too via the shared classifier. No new path for Android.
- `keyStorageService.removePrivateKey(_, { requireAuthentication: false })` is now called from `useImportPrivateKey` before every store. This is keychain `SecItemDelete` / Keystore `deleteEntry` — auth-free by design.
- New Datadog RUM error: `BiometryInvalidationError` (name + JS stack + context with `userId`, `location`, `platform`). One emission per `getPrivateKey` failure that matches. The signer address is already in Datadog via existing screen-view telemetry (e.g. `/signers/0x…/private-key`), so no incremental PII surface.

**Not touched:** Ledger flow, WalletConnect signers, RTK Query endpoints, store slices, multi-chain handling, Safe SDK, feature flags, routes/layouts, web app, shared packages.

## Risks / not checked

- The classifier matches `react-native-device-crypto` error string shapes. If the upstream library reformats its rejections (e.g. `9 -` → `[9]`), classification silently degrades to "transient" and we fall back to the generic error screen — same UX as today's bug. Datadog telemetry on hits will surface drift.
- Did not run the web E2E suite — change is mobile-only.
- iOS reproduction requires a physical device (simulator has no Secure Enclave). Verified the classifier patterns against the exact error reported in #7835 via unit tests; final UX needs device validation.

## Visual summary

```mermaid
flowchart TB
    A[DeviceCrypto.decrypt rejects in getKey] --> B{isBiometryInvalidationError}
    B -- yes --> C[KeyStorageService.getPrivateKey throws BiometryInvalidationError + DdRum.addError]
    B -- no --> D[returns undefined / rethrows]

    C --> E[Sign flow useTransactionSigning]
    C --> F[Execute flow privateKeyExecutor]
    C --> G[View PK PrivateKey.container]
    C --> H[Cleanup editAccountHelpers]

    E --> I[/signing-error with re-import message/]
    F --> J[/execution-error with re-import message/]
    G --> K[OK Alert 'Signer needs to be re-imported']
    H --> L[Skip delegate revoke; remove Redux signer; success]

    M[useImportPrivateKey.handleImport] --> N[removePrivateKey w/o auth]
    N --> O[storePrivateKey provisions fresh wrapping key]
```

## Checklist

- [x] I've tested the branch on mobile 📱 (Android emulator full repro; iOS via unit tests against the captured error fingerprint from the issue)
- [x] I've documented how it affects the analytics (if at all) 📊 (new `BiometryInvalidationError` RUM event documented in Blast Radius)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (22 classifier + 24 service + 13 sign hook + 32 cleanup + 27 biometrics tests)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).