### PR TITLE
fix: enable modules removal

### DIFF
--- a/apps/web/src/components/settings/SafeModules/__tests__/SafeModules.test.tsx
+++ b/apps/web/src/components/settings/SafeModules/__tests__/SafeModules.test.tsx
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
 import { fireEvent, render, waitFor } from '@/tests/test-utils'
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
@@ -6,6 +7,18 @@ import { TxModalContext, type TxModalContextType } from '@/components/tx-flow'
 import SafeModules from '..'
 import { zeroPadValue } from 'ethers'
 import type { ReactElement } from 'react'
+import type { RecoveryStateItem } from '@/features/recovery/services/recovery-state'
+
+const buildDelayModifier = (overrides: Partial<RecoveryStateItem> = {}): RecoveryStateItem => ({
+  address: faker.finance.ethereumAddress(),
+  recoverers: [],
+  expiry: 0n,
+  delay: 0n,
+  txNonce: 0n,
+  queueNonce: 0n,
+  queue: [],
+  ...overrides,
+})
 
 const MOCK_MODULE_1 = zeroPadValue('0x01', 20)
 const MOCK_MODULE_2 = zeroPadValue('0x02', 20)
@@ -115,10 +128,10 @@ describe('SafeModules', () => {
 
   it('should open the remove recovery flow for a recovery module', async () => {
     const setTxFlow = jest.fn()
-    const delayModifier = { address: MOCK_MODULE_1 }
+    const delayModifier = buildDelayModifier({ address: MOCK_MODULE_1 })
 
     jest.spyOn(recoveryHooks, 'useDelayModifierByAddress').mockReturnValue({
-      delayModifier: delayModifier as never,
+      delayModifier,
       loading: false,
     })
     jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({

--- a/apps/web/src/components/settings/SafeModules/__tests__/SafeModules.test.tsx
+++ b/apps/web/src/components/settings/SafeModules/__tests__/SafeModules.test.tsx
@@ -1,14 +1,53 @@
 import { extendedSafeInfoBuilder } from '@/tests/builders/safe'
-import { render, waitFor } from '@/tests/test-utils'
+import { fireEvent, render, waitFor } from '@/tests/test-utils'
 import * as useSafeInfoHook from '@/hooks/useSafeInfo'
+import * as recoveryHooks from '@/features/recovery'
+import { TxModalContext, type TxModalContextType } from '@/components/tx-flow'
 import SafeModules from '..'
 import { zeroPadValue } from 'ethers'
+import type { ReactElement } from 'react'
 
 const MOCK_MODULE_1 = zeroPadValue('0x01', 20)
 const MOCK_MODULE_2 = zeroPadValue('0x02', 20)
 
+type RemoveModuleFlowElement = ReactElement<{ address: string }>
+type RemoveRecoveryFlowElement = ReactElement<{ delayModifier: { address: string } }>
+
+jest.mock('@/components/common/CheckWallet', () => ({
+  __esModule: true,
+  default({ children }: { children: (ok: boolean) => ReactElement }) {
+    return children(true)
+  },
+}))
+
+jest.mock('@/components/tx-flow/flows', () => ({
+  __esModule: true,
+  RemoveModuleFlow: ({ address }: { address: string }) => <div data-testid="remove-module-flow">{address}</div>,
+  RemoveRecoveryFlow: ({ delayModifier }: { delayModifier: { address: string } }) => (
+    <div data-testid="remove-recovery-flow">{delayModifier.address}</div>
+  ),
+}))
+
+const renderWithTxContext = (ui: ReactElement, value?: Partial<TxModalContextType>) => {
+  const txModalValue: TxModalContextType = {
+    txFlow: undefined,
+    setTxFlow: jest.fn(),
+    setFullWidth: jest.fn(),
+    ...value,
+  }
+
+  return {
+    ...render(<TxModalContext.Provider value={txModalValue}>{ui}</TxModalContext.Provider>),
+    txModalValue,
+  }
+}
+
 describe('SafeModules', () => {
   const extendedSafeInfo = extendedSafeInfoBuilder().build()
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
 
   it('should render placeholder label without any modules', async () => {
     jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
@@ -57,5 +96,54 @@ describe('SafeModules', () => {
     const utils = render(<SafeModules />)
     await waitFor(() => expect(utils.getByText(MOCK_MODULE_1)).toBeDefined())
     await waitFor(() => expect(utils.getByText(MOCK_MODULE_2)).toBeDefined())
+  })
+
+  it('should open the remove module flow for a regular module', async () => {
+    const setTxFlow = jest.fn()
+
+    jest.spyOn(recoveryHooks, 'useDelayModifierByAddress').mockReturnValue(undefined)
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
+      safe: {
+        ...extendedSafeInfo,
+        modules: [{ value: MOCK_MODULE_1 }],
+      },
+      safeAddress: '0x123',
+      safeError: undefined,
+      safeLoading: false,
+      safeLoaded: true,
+    }))
+
+    const { getByTestId } = renderWithTxContext(<SafeModules />, { setTxFlow })
+
+    fireEvent.click(getByTestId('module-remove-btn'))
+
+    expect(setTxFlow).toHaveBeenCalledTimes(1)
+    const txFlow = setTxFlow.mock.calls[0]?.[0] as RemoveModuleFlowElement
+    expect(txFlow.props.address).toBe(MOCK_MODULE_1)
+  })
+
+  it('should open the remove recovery flow for a recovery module', async () => {
+    const setTxFlow = jest.fn()
+    const delayModifier = { address: MOCK_MODULE_1 }
+
+    jest.spyOn(recoveryHooks, 'useDelayModifierByAddress').mockReturnValue(delayModifier as never)
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
+      safe: {
+        ...extendedSafeInfo,
+        modules: [{ value: MOCK_MODULE_1 }],
+      },
+      safeAddress: '0x123',
+      safeError: undefined,
+      safeLoading: false,
+      safeLoaded: true,
+    }))
+
+    const { getByTestId } = renderWithTxContext(<SafeModules />, { setTxFlow })
+
+    fireEvent.click(getByTestId('module-remove-btn'))
+
+    expect(setTxFlow).toHaveBeenCalledTimes(1)
+    const txFlow = setTxFlow.mock.calls[0]?.[0] as RemoveRecoveryFlowElement
+    expect(txFlow.props.delayModifier).toBe(delayModifier)
   })
 })

--- a/apps/web/src/components/settings/SafeModules/__tests__/SafeModules.test.tsx
+++ b/apps/web/src/components/settings/SafeModules/__tests__/SafeModules.test.tsx
@@ -101,7 +101,10 @@ describe('SafeModules', () => {
   it('should open the remove module flow for a regular module', async () => {
     const setTxFlow = jest.fn()
 
-    jest.spyOn(recoveryHooks, 'useDelayModifierByAddress').mockReturnValue(undefined)
+    jest.spyOn(recoveryHooks, 'useDelayModifierByAddress').mockReturnValue({
+      delayModifier: undefined,
+      loading: false,
+    })
     jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
       safe: {
         ...extendedSafeInfo,
@@ -126,7 +129,10 @@ describe('SafeModules', () => {
     const setTxFlow = jest.fn()
     const delayModifier = { address: MOCK_MODULE_1 }
 
-    jest.spyOn(recoveryHooks, 'useDelayModifierByAddress').mockReturnValue(delayModifier as never)
+    jest.spyOn(recoveryHooks, 'useDelayModifierByAddress').mockReturnValue({
+      delayModifier: delayModifier as never,
+      loading: false,
+    })
     jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
       safe: {
         ...extendedSafeInfo,
@@ -145,5 +151,56 @@ describe('SafeModules', () => {
     expect(setTxFlow).toHaveBeenCalledTimes(1)
     const txFlow = setTxFlow.mock.calls[0]?.[0] as RemoveRecoveryFlowElement
     expect(txFlow.props.delayModifier).toBe(delayModifier)
+  })
+
+  it('should disable the remove button while recovery state is loading', async () => {
+    const setTxFlow = jest.fn()
+
+    jest.spyOn(recoveryHooks, 'useDelayModifierByAddress').mockReturnValue({
+      delayModifier: undefined,
+      loading: true,
+    })
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
+      safe: {
+        ...extendedSafeInfo,
+        modules: [{ value: MOCK_MODULE_1 }],
+      },
+      safeAddress: '0x123',
+      safeError: undefined,
+      safeLoading: false,
+      safeLoaded: true,
+    }))
+
+    const { getByTestId } = renderWithTxContext(<SafeModules />, { setTxFlow })
+
+    const button = getByTestId('module-remove-btn') as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+
+    fireEvent.click(button)
+    expect(setTxFlow).not.toHaveBeenCalled()
+  })
+
+  it('should enable the remove button once recovery state has loaded', async () => {
+    const setTxFlow = jest.fn()
+
+    jest.spyOn(recoveryHooks, 'useDelayModifierByAddress').mockReturnValue({
+      delayModifier: undefined,
+      loading: false,
+    })
+    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
+      safe: {
+        ...extendedSafeInfo,
+        modules: [{ value: MOCK_MODULE_1 }],
+      },
+      safeAddress: '0x123',
+      safeError: undefined,
+      safeLoading: false,
+      safeLoaded: true,
+    }))
+
+    const { getByTestId } = renderWithTxContext(<SafeModules />, { setTxFlow })
+
+    const button = getByTestId('module-remove-btn') as HTMLButtonElement
+    expect(button.disabled).toBe(false)
   })
 })

--- a/apps/web/src/components/settings/SafeModules/__tests__/SafeModules.test.tsx
+++ b/apps/web/src/components/settings/SafeModules/__tests__/SafeModules.test.tsx
@@ -62,18 +62,6 @@ describe('SafeModules', () => {
     await waitFor(() => expect(utils.getByText('No modules enabled')).toBeDefined())
   })
 
-  it('should render placeholder label if safe is loading', async () => {
-    jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
-      safe: extendedSafeInfo,
-      safeAddress: '',
-      safeError: undefined,
-      safeLoading: true,
-      safeLoaded: false,
-    }))
-
-    const utils = render(<SafeModules />)
-    await waitFor(() => expect(utils.getByText('No modules enabled')).toBeDefined())
-  })
   it('should render module addresses for defined modules', async () => {
     jest.spyOn(useSafeInfoHook, 'default').mockImplementation(() => ({
       safe: {

--- a/apps/web/src/components/settings/SafeModules/index.tsx
+++ b/apps/web/src/components/settings/SafeModules/index.tsx
@@ -9,8 +9,7 @@ import CheckWallet from '@/components/common/CheckWallet'
 import { useContext } from 'react'
 import { TxModalContext } from '@/components/tx-flow'
 import { RemoveRecoveryFlow } from '@/components/tx-flow/flows'
-import { RecoveryFeature, useRecovery } from '@/features/recovery'
-import { useLoadFeature } from '@/features/__core__'
+import { useDelayModifierByAddress } from '@/features/recovery'
 
 import css from '../TransactionGuards/styles.module.css'
 
@@ -24,9 +23,7 @@ const NoModules = () => {
 
 const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string; chainId: string; name?: string }) => {
   const { setTxFlow } = useContext(TxModalContext)
-  const [recovery] = useRecovery()
-  const { selectDelayModifierByAddress, $isReady } = useLoadFeature(RecoveryFeature)
-  const delayModifier = recovery && selectDelayModifierByAddress?.(recovery, moduleAddress)
+  const delayModifier = useDelayModifierByAddress(moduleAddress)
 
   const onRemove = () => {
     if (delayModifier) {
@@ -53,7 +50,7 @@ const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string
             onClick={onRemove}
             color="error"
             size="small"
-            disabled={!isOk || !$isReady}
+            disabled={!isOk}
             title="Remove module"
           >
             <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />

--- a/apps/web/src/components/settings/SafeModules/index.tsx
+++ b/apps/web/src/components/settings/SafeModules/index.tsx
@@ -23,7 +23,7 @@ const NoModules = () => {
 
 const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string; chainId: string; name?: string }) => {
   const { setTxFlow } = useContext(TxModalContext)
-  const delayModifier = useDelayModifierByAddress(moduleAddress)
+  const { delayModifier, loading: recoveryLoading } = useDelayModifierByAddress(moduleAddress)
 
   const onRemove = () => {
     if (delayModifier) {
@@ -50,7 +50,7 @@ const ModuleDisplay = ({ moduleAddress, chainId, name }: { moduleAddress: string
             onClick={onRemove}
             color="error"
             size="small"
-            disabled={!isOk}
+            disabled={!isOk || recoveryLoading}
             title="Remove module"
           >
             <SvgIcon component={DeleteIcon} inheritViewBox color="error" fontSize="small" />

--- a/apps/web/src/features/recovery/hooks/__tests__/useDelayModifierByAddress.test.ts
+++ b/apps/web/src/features/recovery/hooks/__tests__/useDelayModifierByAddress.test.ts
@@ -4,19 +4,25 @@ import * as useRecoveryHook from '../useRecovery'
 import { useDelayModifierByAddress } from '../useDelayModifierByAddress'
 import type { RecoveryStateItem } from '../../services/recovery-state'
 
+const buildDelayModifier = (overrides: Partial<RecoveryStateItem> = {}): RecoveryStateItem => ({
+  address: faker.finance.ethereumAddress(),
+  recoverers: [],
+  expiry: 0n,
+  delay: 0n,
+  txNonce: 0n,
+  queueNonce: 0n,
+  queue: [],
+  ...overrides,
+})
+
 describe('useDelayModifierByAddress', () => {
   afterEach(() => {
     jest.restoreAllMocks()
   })
 
   it('should return the matching delay modifier', () => {
-    const delayModifier1 = {
-      address: faker.finance.ethereumAddress(),
-    } as unknown as RecoveryStateItem
-
-    const delayModifier2 = {
-      address: faker.finance.ethereumAddress(),
-    } as unknown as RecoveryStateItem
+    const delayModifier1 = buildDelayModifier()
+    const delayModifier2 = buildDelayModifier()
 
     jest.spyOn(useRecoveryHook, 'default').mockReturnValue([[delayModifier1, delayModifier2], undefined, false])
 

--- a/apps/web/src/features/recovery/hooks/__tests__/useDelayModifierByAddress.test.ts
+++ b/apps/web/src/features/recovery/hooks/__tests__/useDelayModifierByAddress.test.ts
@@ -1,0 +1,35 @@
+import { faker } from '@faker-js/faker'
+import { renderHook } from '@/tests/test-utils'
+import * as useRecoveryHook from '../useRecovery'
+import { useDelayModifierByAddress } from '../useDelayModifierByAddress'
+import type { RecoveryStateItem } from '../../services/recovery-state'
+
+describe('useDelayModifierByAddress', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should return the matching delay modifier', () => {
+    const delayModifier1 = {
+      address: faker.finance.ethereumAddress(),
+    } as unknown as RecoveryStateItem
+
+    const delayModifier2 = {
+      address: faker.finance.ethereumAddress(),
+    } as unknown as RecoveryStateItem
+
+    jest.spyOn(useRecoveryHook, 'default').mockReturnValue([[delayModifier1, delayModifier2], undefined, false])
+
+    const { result } = renderHook(() => useDelayModifierByAddress(delayModifier2.address))
+
+    expect(result.current).toStrictEqual(delayModifier2)
+  })
+
+  it('should return undefined when recovery state is not available', () => {
+    jest.spyOn(useRecoveryHook, 'default').mockReturnValue([undefined, undefined, false])
+
+    const { result } = renderHook(() => useDelayModifierByAddress(faker.finance.ethereumAddress()))
+
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/apps/web/src/features/recovery/hooks/__tests__/useDelayModifierByAddress.test.ts
+++ b/apps/web/src/features/recovery/hooks/__tests__/useDelayModifierByAddress.test.ts
@@ -22,7 +22,7 @@ describe('useDelayModifierByAddress', () => {
 
     const { result } = renderHook(() => useDelayModifierByAddress(delayModifier2.address))
 
-    expect(result.current).toStrictEqual(delayModifier2)
+    expect(result.current).toStrictEqual({ delayModifier: delayModifier2, loading: false })
   })
 
   it('should return undefined when recovery state is not available', () => {
@@ -30,6 +30,14 @@ describe('useDelayModifierByAddress', () => {
 
     const { result } = renderHook(() => useDelayModifierByAddress(faker.finance.ethereumAddress()))
 
-    expect(result.current).toBeUndefined()
+    expect(result.current).toStrictEqual({ delayModifier: undefined, loading: false })
+  })
+
+  it('should pass through the loading flag from useRecovery', () => {
+    jest.spyOn(useRecoveryHook, 'default').mockReturnValue([undefined, undefined, true])
+
+    const { result } = renderHook(() => useDelayModifierByAddress(faker.finance.ethereumAddress()))
+
+    expect(result.current).toStrictEqual({ delayModifier: undefined, loading: true })
   })
 })

--- a/apps/web/src/features/recovery/hooks/useDelayModifierByAddress.ts
+++ b/apps/web/src/features/recovery/hooks/useDelayModifierByAddress.ts
@@ -1,7 +1,11 @@
 import useRecovery from './useRecovery'
 import { selectDelayModifierByAddress } from '../services/selectors'
+import type { RecoveryStateItem } from '../services/recovery-state'
 
-export function useDelayModifierByAddress(moduleAddress: string) {
+export function useDelayModifierByAddress(moduleAddress: string): {
+  delayModifier: RecoveryStateItem | undefined
+  loading: boolean
+} {
   const [recovery, , loading] = useRecovery()
 
   return {

--- a/apps/web/src/features/recovery/hooks/useDelayModifierByAddress.ts
+++ b/apps/web/src/features/recovery/hooks/useDelayModifierByAddress.ts
@@ -2,7 +2,10 @@ import useRecovery from './useRecovery'
 import { selectDelayModifierByAddress } from '../services/selectors'
 
 export function useDelayModifierByAddress(moduleAddress: string) {
-  const [recovery] = useRecovery()
+  const [recovery, , loading] = useRecovery()
 
-  return recovery ? selectDelayModifierByAddress(recovery, moduleAddress) : undefined
+  return {
+    delayModifier: recovery ? selectDelayModifierByAddress(recovery, moduleAddress) : undefined,
+    loading,
+  }
 }

--- a/apps/web/src/features/recovery/hooks/useDelayModifierByAddress.ts
+++ b/apps/web/src/features/recovery/hooks/useDelayModifierByAddress.ts
@@ -1,0 +1,8 @@
+import useRecovery from './useRecovery'
+import { selectDelayModifierByAddress } from '../services/selectors'
+
+export function useDelayModifierByAddress(moduleAddress: string) {
+  const [recovery] = useRecovery()
+
+  return recovery ? selectDelayModifierByAddress(recovery, moduleAddress) : undefined
+}

--- a/apps/web/src/features/recovery/index.ts
+++ b/apps/web/src/features/recovery/index.ts
@@ -52,6 +52,7 @@ export type { RecoveryContract } from './contract'
 export { useIsRecoverer } from './hooks/useIsRecoverer'
 export { useIsRecoverySupported } from './hooks/useIsRecoverySupported'
 export { default as useRecovery } from './hooks/useRecovery'
+export { useDelayModifierByAddress } from './hooks/useDelayModifierByAddress'
 export { useRecoveryQueue } from './hooks/useRecoveryQueue'
 // NOTE: useIsValidRecoveryExecTransactionFromModule is NOT exported here because it
 // imports @gnosis.pm/zodiac which is heavy. Import directly from hooks file if needed.


### PR DESCRIPTION
> Remove module actions breathe,
> recovery checks moved into a hook,
> delete works again.

## What it solves

Resolves: [WA-2349](https://linear.app/safe-global/issue/WA-2349/modules-cannot-be-deleted-from-settings-tab)
- Safe modules in Settings could become non-clickable for removal because the delete action was gated by recovery feature readiness.

## How this PR fixes it

- Replaces the direct recovery service usage in `SafeModules` with a lightweight `useDelayModifierByAddress` hook exported from `@/features/recovery`.
- Removes the extra `$isReady` gate from the delete button so normal module removal is not blocked by lazy recovery feature loading.
- Preserves recovery-specific behavior by still routing recovery modules to `RemoveRecoveryFlow`.
- Adds regression tests for the new hook and both remove-flow branches in `SafeModules`.

## How to test it

1. Open Settings > Safe modules on a Safe with a normal module enabled.
2. Confirm the delete button is clickable and opens the remove module flow.
3. Open the same screen for a recovery module.
4. Confirm the delete button opens the recovery removal flow.
5. Run the relevant unit tests.

## Affected flows

- User removes a normal module from Settings > Safe modules.
- User removes a recovery module from Settings > Safe modules.

## Blast radius

- `SafeModules` removal flow selection logic.
- Recovery feature public API via the new `useDelayModifierByAddress` hook.
- Recovery selector consumption pattern for this screen only.

## Risks / not checked

- Did not verify manually on mobile.
- Did not manually test feature-disabled recovery behavior.
- If CI has stricter type/test expectations, those still need to be run locally/in CI.

## Visual summary

```mermaid
flowchart LR
  A[Safe modules delete button] --> B{useDelayModifierByAddress}
  B -->|match| C[RemoveRecoveryFlow]
  B -->|no match| D[RemoveModuleFlow]
  ```

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
