### PR TITLE
feat(web): show local Safes count on spaces sign-in screen

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eu
 
 # Validate commit message follows conventional commit format
 # Format: type(scope): description OR type: description

--- a/apps/web/src/features/spaces/components/SpacesList/LocalSafesAlert.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/LocalSafesAlert.tsx
@@ -1,0 +1,40 @@
+import { Box, Stack, Typography, alpha } from '@mui/material'
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet'
+import { useAppSelector } from '@/store'
+import { selectAllAddedSafes } from '@/store/addedSafesSlice'
+
+const LocalSafesAlert = () => {
+  const allAdded = useAppSelector(selectAllAddedSafes)
+  const count = Object.values(allAdded ?? {}).reduce((sum, safes) => sum + Object.keys(safes).length, 0)
+
+  if (count === 0) return null
+
+  return (
+    <Stack
+      direction="row"
+      alignItems="center"
+      gap={1.5}
+      data-testid="local-safes-alert"
+      sx={{
+        mb: 2,
+        p: 2,
+        borderRadius: 1,
+        border: '1px solid',
+        borderColor: 'success.main',
+        backgroundColor: (theme) => alpha(theme.palette.success.main, 0.08),
+      }}
+    >
+      <AccountBalanceWalletIcon sx={{ color: 'success.main' }} />
+      <Box>
+        <Typography fontWeight={700}>
+          {count} {count === 1 ? 'Safe' : 'Safes'} detected on this browser
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Sign in to resume where you left off.
+        </Typography>
+      </Box>
+    </Stack>
+  )
+}
+
+export default LocalSafesAlert

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/LocalSafesAlert.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/LocalSafesAlert.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import LocalSafesAlert from '../LocalSafesAlert'
+
+const mockUseAppSelector = jest.fn()
+
+jest.mock('@/store', () => ({
+  useAppSelector: (selector: unknown) => mockUseAppSelector(selector),
+}))
+
+jest.mock('@/store/addedSafesSlice', () => ({
+  selectAllAddedSafes: jest.fn(() => 'selectAllAddedSafes'),
+}))
+
+describe('LocalSafesAlert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders nothing when no local Safes are present', () => {
+    mockUseAppSelector.mockReturnValue({})
+    const { container } = render(<LocalSafesAlert />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the addedSafes slice is undefined (cold start)', () => {
+    mockUseAppSelector.mockReturnValue(undefined)
+    const { container } = render(<LocalSafesAlert />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders singular copy for exactly one Safe', () => {
+    mockUseAppSelector.mockReturnValue({
+      '1': { '0xAAA': { owners: [], threshold: 1 } },
+    })
+    render(<LocalSafesAlert />)
+    expect(screen.getByTestId('local-safes-alert')).toBeInTheDocument()
+    expect(screen.getByText('1 Safe detected on this browser')).toBeInTheDocument()
+    expect(screen.getByText('Sign in to resume where you left off.')).toBeInTheDocument()
+  })
+
+  it('aggregates Safes across multiple chains and uses plural copy', () => {
+    mockUseAppSelector.mockReturnValue({
+      '1': {
+        '0xAAA': { owners: [], threshold: 1 },
+        '0xBBB': { owners: [], threshold: 1 },
+      },
+      '137': {
+        '0xCCC': { owners: [], threshold: 1 },
+        '0xDDD': { owners: [], threshold: 1 },
+        '0xEEE': { owners: [], threshold: 1 },
+      },
+      '100': {
+        '0xFFF': { owners: [], threshold: 1 },
+        '0xGGG': { owners: [], threshold: 1 },
+      },
+    })
+    render(<LocalSafesAlert />)
+    expect(screen.getByText('7 Safes detected on this browser')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -2,6 +2,7 @@ import { useLoadFeature } from '@/features/__core__'
 import { MyAccountsFeature } from '@/features/myAccounts'
 import SpaceCard from 'src/features/spaces/components/SpaceCard'
 import SignInOptions from '../SignInOptions'
+import LocalSafesAlert from './LocalSafesAlert'
 import { useIsRequireLoginEnabled } from '@/hooks/useIsRequireLoginEnabled'
 import { useIsClassicViewFeatureEnabled } from '@/hooks/useClassicView'
 import ClassicViewLink from '../ClassicViewLink'
@@ -59,6 +60,8 @@ const SignedOutState = ({ afterSignIn, redirectLoading }: { afterSignIn: () => v
 
   return (
     <>
+      <LocalSafesAlert />
+
       <Card sx={{ p: 5, textAlign: 'center' }}>
         <Typography variant="h3" fontWeight={600} mb={3}>
           Sign in


### PR DESCRIPTION
> Local Safes spotted,
> green block above the sign-in,
> resume where you left.

## What it solves

Unauthenticated visitors on `/welcome/spaces` who already have Safes persisted in this browser get no nudge to sign back in — they may not realize their data is one sign-in away.

## How this PR fixes it

Adds a new `LocalSafesAlert` component, rendered inside `SignedOutState` above the existing sign-in card. It reads `selectAllAddedSafes`, sums Safes across all chains, and renders an outlined block (green border + transparent green background, wallet icon) with the count + pluralized noun and a "Sign in to resume where you left off." subtitle. Returns `null` when the count is zero so fresh installs see no change.

Also includes a tiny chore commit mirroring #7890: the `.husky/commit-msg` hook used `set -o pipefail`, which fails under `dash` on the Linux VM (same fix that was already applied to `.husky/pre-commit`). Validation logic is unchanged.

## How to test it

1. With a signed-out session, ensure at least one Safe is persisted in `addedSafes` (e.g. add a Safe in classic view, then sign out / clear auth).
2. Navigate to `/welcome/spaces`.
3. The outlined green block appears above the sign-in card with the correct count and pluralization ("1 Safe detected…" vs "N Safes detected…").
4. Clear the `addedSafes` slice (or use a fresh browser profile) → the block is hidden, the rest of the layout is unchanged.

## Visual summary

```mermaid
flowchart TB
  A[Visitor on /welcome/spaces] --> B{Signed in?}
  B -->|Yes| C[Spaces grid / no-spaces state]
  B -->|No| D[SignedOutState]
  D --> E{addedSafes count > 0?}
  E -->|Yes| F[LocalSafesAlert + Sign-in card]
  E -->|No| G[Sign-in card only]
```

## Checklist

- [x] Unit tests added for the new component (`LocalSafesAlert.test.tsx`, 4 cases incl. singular/plural + multi-chain aggregation)
- [x] Type-check, lint, and prettier pass on changed files
- [x] No regressions in `SpacesList` (pre-existing baseline failures on this branch are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)