### PR TITLE
fix(web/Spaces): show +X chains for address book contacts

### DIFF
--- a/apps/web/src/features/multichain/components/NetworkLogosList/NetworkLogosList.test.tsx
+++ b/apps/web/src/features/multichain/components/NetworkLogosList/NetworkLogosList.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import NetworkLogosList from './index'
+
+jest.mock('@/components/common/ChainIndicator', () => {
+  const ChainIndicator = ({ chainId }: { chainId: string }) => <span data-testid={`chain-${chainId}`} />
+  return ChainIndicator
+})
+
+const networks = (ids: string[]) => ids.map((chainId) => ({ chainId }))
+
+describe('NetworkLogosList', () => {
+  describe('showHasMore=false (default)', () => {
+    it('renders all logos without overflow indicator', () => {
+      render(<NetworkLogosList networks={networks(['1', '137', '10', '42161', '8453'])} />)
+
+      expect(screen.getByTestId('chain-1')).toBeInTheDocument()
+      expect(screen.getByTestId('chain-8453')).toBeInTheDocument()
+      expect(screen.queryByText(/^\+/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('showHasMore=true with default maxVisible=4', () => {
+    it('renders 4 logos and overflow indicator when there are more than 4 networks', () => {
+      render(<NetworkLogosList networks={networks(['1', '137', '10', '42161', '8453', '100'])} showHasMore />)
+
+      expect(screen.getByTestId('chain-1')).toBeInTheDocument()
+      expect(screen.getByTestId('chain-42161')).toBeInTheDocument()
+      expect(screen.queryByTestId('chain-8453')).not.toBeInTheDocument()
+      expect(screen.getByText('+2')).toBeInTheDocument()
+    })
+
+    it('does not render overflow indicator when networks count equals maxVisible', () => {
+      render(<NetworkLogosList networks={networks(['1', '137', '10', '42161'])} showHasMore />)
+
+      expect(screen.queryByText(/^\+/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('showHasMore=true with maxVisible=3', () => {
+    it('renders 3 logos and overflow indicator when there are more than 3 networks', () => {
+      render(<NetworkLogosList networks={networks(['1', '137', '10', '42161', '8453'])} showHasMore maxVisible={3} />)
+
+      expect(screen.getByTestId('chain-1')).toBeInTheDocument()
+      expect(screen.getByTestId('chain-10')).toBeInTheDocument()
+      expect(screen.queryByTestId('chain-42161')).not.toBeInTheDocument()
+      expect(screen.getByText('+2')).toBeInTheDocument()
+    })
+
+    it('shows correct overflow count', () => {
+      render(
+        <NetworkLogosList
+          networks={networks(['1', '137', '10', '42161', '8453', '100', '56'])}
+          showHasMore
+          maxVisible={3}
+        />,
+      )
+
+      expect(screen.getByText('+4')).toBeInTheDocument()
+    })
+
+    it('does not render overflow indicator when networks count equals maxVisible', () => {
+      render(<NetworkLogosList networks={networks(['1', '137', '10'])} showHasMore maxVisible={3} />)
+
+      expect(screen.queryByText(/^\+/)).not.toBeInTheDocument()
+    })
+
+    it('does not render overflow indicator when networks count is less than maxVisible', () => {
+      render(<NetworkLogosList networks={networks(['1', '137'])} showHasMore maxVisible={3} />)
+
+      expect(screen.queryByText(/^\+/)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/features/multichain/components/NetworkLogosList/index.tsx
+++ b/apps/web/src/features/multichain/components/NetworkLogosList/index.tsx
@@ -6,20 +6,21 @@ import css from './styles.module.css'
 const NetworkLogosList = ({
   networks,
   showHasMore = false,
+  maxVisible = 4,
 }: {
   networks: Pick<Chain, 'chainId'>[]
   showHasMore?: boolean
+  maxVisible?: number
 }) => {
-  const MAX_NUM_VISIBLE_CHAINS = 4
-  const visibleChains = showHasMore ? networks.slice(0, MAX_NUM_VISIBLE_CHAINS) : networks
+  const visibleChains = showHasMore ? networks.slice(0, maxVisible) : networks
 
   return (
     <Box className={css.networks}>
       {visibleChains.map((chain) => (
         <ChainIndicator key={chain.chainId} chainId={chain.chainId} onlyLogo inline />
       ))}
-      {showHasMore && networks.length > MAX_NUM_VISIBLE_CHAINS && (
-        <Box className={css.moreChainsIndicator}>+{networks.length - MAX_NUM_VISIBLE_CHAINS}</Box>
+      {showHasMore && networks.length > maxVisible && (
+        <Box className={css.moreChainsIndicator}>+{networks.length - maxVisible}</Box>
       )}
     </Box>
   )

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import EthHashInfo from '@/components/common/EthHashInfo'
 import { NetworkLogosList } from '@/features/multichain'
@@ -9,7 +8,6 @@ import ChainIndicator from '@/components/common/ChainIndicator'
 import { BookUser, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import SpaceAddressBookActions from './SpaceAddressBookActions'
-import useChains from '@/hooks/useChains'
 import { cn } from '@/utils/cn'
 import { formatDate } from './ActivityLog'
 
@@ -34,7 +32,6 @@ function SpaceAddressBookTable({
   showLastUpdated = false,
   renderExtraAction,
 }: SpaceAddressBookTableProps) {
-  const chains = useChains()
   const [page, setPage] = useState(0)
 
   useEffect(() => {
@@ -99,11 +96,11 @@ function SpaceAddressBookTable({
                 <Tooltip>
                   <TooltipTrigger>
                     <span className="inline-flex origin-left scale-85">
-                      {chains.configs.length === entry.chainIds.length ? (
-                        <Badge variant="secondary">All</Badge>
-                      ) : (
-                        <NetworkLogosList networks={entry.chainIds.map((chainId) => ({ chainId }))} />
-                      )}
+                      <NetworkLogosList
+                        networks={entry.chainIds.map((chainId) => ({ chainId }))}
+                        showHasMore
+                        maxVisible={3}
+                      />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/SpaceAddressBookTable.test.tsx
@@ -14,7 +14,22 @@ jest.mock('@/components/common/Identicon', () => {
   return Identicon
 })
 jest.mock('@/features/multichain', () => ({
-  NetworkLogosList: () => <span data-testid="network-logos" />,
+  NetworkLogosList: ({
+    networks,
+    showHasMore,
+    maxVisible,
+  }: {
+    networks: { chainId: string }[]
+    showHasMore?: boolean
+    maxVisible?: number
+  }) => (
+    <span
+      data-testid="network-logos"
+      data-show-has-more={showHasMore}
+      data-max-visible={maxVisible}
+      data-count={networks.length}
+    />
+  ),
 }))
 jest.mock('@/components/common/ChainIndicator', () => {
   const ChainIndicator = () => <span data-testid="chain-indicator" />
@@ -46,5 +61,30 @@ describe('SpaceAddressBookTable', () => {
     render(<SpaceAddressBookTable entries={[entryBuilder().with({ isLocal: true }).build()]} />)
 
     expect(screen.queryByTestId('actions')).not.toBeInTheDocument()
+  })
+
+  it('renders NetworkLogosList with showHasMore and maxVisible=3 for chain logos', () => {
+    const chainIds = ['1', '137', '10', '42161', '8453']
+    render(<SpaceAddressBookTable entries={[entryBuilder().with({ chainIds }).build()]} />)
+
+    const logosList = screen.getByTestId('network-logos')
+    expect(logosList).toHaveAttribute('data-show-has-more', 'true')
+    expect(logosList).toHaveAttribute('data-max-visible', '3')
+    expect(logosList).toHaveAttribute('data-count', '5')
+  })
+
+  it('renders NetworkLogosList even when entry covers all chains', () => {
+    render(
+      <SpaceAddressBookTable
+        entries={[
+          entryBuilder()
+            .with({ chainIds: ['1', '137', '10'] })
+            .build(),
+        ]}
+      />,
+    )
+
+    expect(screen.getByTestId('network-logos')).toBeInTheDocument()
+    expect(screen.queryByText('All')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/index.tsx
@@ -150,7 +150,7 @@ const SpaceAddressBook = () => {
               setActiveTab(val)
             }}
           >
-            <TabsList variant="line">
+            <TabsList variant="line" className="flex-wrap h-auto mb-4 sm:mb-0">
               <TabsTrigger value="workspace" className="cursor-pointer">
                 Workspace contacts ({addressBookItems.length})
               </TabsTrigger>


### PR DESCRIPTION
## What it solves

Resolves: [WA-2001](https://linear.app/safe-global/issue/WA-2001/address-book-multiple-networks-display-show-x)
In the Spaces Address Book, safes with many networks showed all chain logos. They should show 3 logos max, with a "+X" circle for remaining networks.

## How this PR fixes it

- Added a `maxVisible` prop to `NetworkLogosList`, replacing the hardcoded constant. Existing usages are unaffected.
- Updated `SpaceAddressBookTable` to pass `showHasMore maxVisible={3}`, so the Chains column shows 3 logos + "+X" overflow.
- Removed the "All" badge — entries covering all chains now show logos like any other entry.
- Adjusts mobile view for the Address Book - the layout for small screens was broken

## How to test it

1. Open a Space with address book entries that have 4+ chains assigned.
2. Verify the Chains column shows 3 chain logos and a "+X" circle for the remainder.
3. Hover the Chains cell — tooltip should list all chains.
4. Verify entries with 1–3 chains show all logos with no overflow circle.

## Affected flows

- Spaces Address Book — Chains column display

## Blast radius

- `NetworkLogosList` (shared component): new optional `maxVisible` prop — no change to existing callers (`AccountItemChainBadge`, etc.)
- `SpaceAddressBookTable`: removed `useChains` hook call and `Badge` import

## Risks / not checked

- Did not verify with a large number of chains (20+) beyond manual inspection

## Visual summary

Before: all logos rendered: 
<img width="1084" height="282" alt="image" src="https://github.com/user-attachments/assets/a4783fd9-ce33-4ca7-874e-fcb4d8f96a63" />

After: max 3 logos shown, "+X" circle for the rest:
<img width="165" height="109" alt="image" src="https://github.com/user-attachments/assets/501089b2-5369-4f79-b68e-5a7ac6d988f1" />


## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
