### PR TITLE
feat: add a warning on RPC provider change to the Safe Selector Dropdown

### DIFF
--- a/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/__tests__/EnvHintButton.test.tsx
+++ b/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/__tests__/EnvHintButton.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { render } from '@/tests/test-utils'
+import { initialState as settingsInitialState } from '@/store/settingsSlice'
+import { AppRoutes } from '@/config/routes'
+import EnvHintButton from '..'
+
+jest.mock('@/hooks/useChainId', () => ({
+  __esModule: true,
+  default: jest.fn(() => '1'),
+}))
+
+const renderButton = (
+  options: {
+    chainId?: string
+    rpc?: Record<string, string>
+    tenderly?: { url: string; accessToken: string }
+    routerPush?: jest.Mock
+    routerQuery?: Record<string, string>
+  } = {},
+) => {
+  const push = options.routerPush ?? jest.fn()
+  const result = render(<EnvHintButton chainId={options.chainId} />, {
+    routerProps: {
+      push,
+      query: options.routerQuery ?? {},
+    },
+    initialReduxState: {
+      settings: {
+        ...settingsInitialState,
+        env: {
+          rpc: options.rpc ?? {},
+          tenderly: options.tenderly ?? settingsInitialState.env.tenderly,
+        },
+      },
+    },
+  })
+  return { ...result, push }
+}
+
+describe('EnvHintButton', () => {
+  it('renders nothing when env is in its initial state', () => {
+    renderButton()
+    expect(screen.queryByRole('button', { name: 'Default environment has been changed' })).not.toBeInTheDocument()
+  })
+
+  it('renders the warning trigger when an RPC override exists for the current chain', () => {
+    renderButton({ rpc: { '1': 'https://my-rpc.example.com' } })
+    expect(screen.getByRole('button', { name: 'Default environment has been changed' })).toBeInTheDocument()
+  })
+
+  it('renders the warning trigger when Tenderly settings are overridden', () => {
+    renderButton({
+      tenderly: { url: 'https://tenderly.example.com', accessToken: 'abc' },
+    })
+    expect(screen.getByRole('button', { name: 'Default environment has been changed' })).toBeInTheDocument()
+  })
+
+  it('renders nothing when the override is for a different chain than the one passed via prop', () => {
+    renderButton({ chainId: '5', rpc: { '1': 'https://my-rpc.example.com' } })
+    expect(screen.queryByRole('button', { name: 'Default environment has been changed' })).not.toBeInTheDocument()
+  })
+
+  it('renders the warning when the override matches the chainId prop', () => {
+    renderButton({ chainId: '5', rpc: { '5': 'https://my-rpc.example.com' } })
+    expect(screen.getByRole('button', { name: 'Default environment has been changed' })).toBeInTheDocument()
+  })
+
+  it('navigates to the environment variables settings page on click', () => {
+    const push = jest.fn()
+    renderButton({ rpc: { '1': 'https://my-rpc.example.com' }, routerPush: push })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Default environment has been changed' }))
+
+    expect(push).toHaveBeenCalledWith({
+      pathname: AppRoutes.settings.environmentVariables,
+      query: {},
+    })
+  })
+
+  it('preserves the current router query (e.g. safe) when navigating', () => {
+    const push = jest.fn()
+    const query = { safe: 'eth:0x1234567890123456789012345678901234567890' }
+    renderButton({ rpc: { '1': 'https://my-rpc.example.com' }, routerPush: push, routerQuery: query })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Default environment has been changed' }))
+
+    expect(push).toHaveBeenCalledWith({
+      pathname: AppRoutes.settings.environmentVariables,
+      query,
+    })
+  })
+
+  it('navigates on Enter key', () => {
+    const push = jest.fn()
+    renderButton({ rpc: { '1': 'https://my-rpc.example.com' }, routerPush: push })
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Default environment has been changed' }), { key: 'Enter' })
+
+    expect(push).toHaveBeenCalledTimes(1)
+  })
+
+  it('navigates on Space key', () => {
+    const push = jest.fn()
+    renderButton({ rpc: { '1': 'https://my-rpc.example.com' }, routerPush: push })
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Default environment has been changed' }), { key: ' ' })
+
+    expect(push).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not navigate on other keys', () => {
+    const push = jest.fn()
+    renderButton({ rpc: { '1': 'https://my-rpc.example.com' }, routerPush: push })
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Default environment has been changed' }), { key: 'a' })
+
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('stops click propagation so the surrounding dropdown trigger does not open', () => {
+    const push = jest.fn()
+    const parentClick = jest.fn()
+    render(
+      <div onClick={parentClick} data-testid="parent">
+        <EnvHintButton chainId="1" />
+      </div>,
+      {
+        routerProps: { push, query: {} },
+        initialReduxState: {
+          settings: {
+            ...settingsInitialState,
+            env: { rpc: { '1': 'https://my-rpc.example.com' }, tenderly: settingsInitialState.env.tenderly },
+          },
+        },
+      },
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Default environment has been changed' }))
+
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(parentClick).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/index.tsx
+++ b/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/index.tsx
@@ -1,36 +1,68 @@
-import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { SvgIcon, IconButton, Tooltip } from '@mui/material'
+import { type KeyboardEvent, type MouseEvent, type PointerEvent } from 'react'
+import { TriangleAlert } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { AppRoutes } from '@/config/routes'
 import { useAppSelector } from '@/store'
 import { isEnvInitialState } from '@/store/settingsSlice'
-import css from './styles.module.css'
-import AlertIcon from '@/public/images/common/alert.svg'
 import useChainId from '@/hooks/useChainId'
+import { cn } from '@/utils/cn'
 
-const EnvHintButton = () => {
+type EnvHintButtonProps = {
+  chainId?: string
+  className?: string
+}
+
+const EnvHintButton = ({ chainId: chainIdProp, className }: EnvHintButtonProps = {}) => {
   const router = useRouter()
-  const chainId = useChainId()
+  const fallbackChainId = useChainId()
+  const chainId = chainIdProp ?? fallbackChainId
   const isInitialState = useAppSelector((state) => isEnvInitialState(state, chainId))
 
   if (isInitialState) {
     return null
   }
 
+  const navigate = () => {
+    router.push({ pathname: AppRoutes.settings.environmentVariables, query: router.query })
+  }
+
+  const handlePointer = (e: MouseEvent | PointerEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    navigate()
+  }
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return
+    e.stopPropagation()
+    e.preventDefault()
+    navigate()
+  }
+
   return (
-    <Link href={{ pathname: AppRoutes.settings.environmentVariables, query: router.query }} passHref legacyBehavior>
-      <Tooltip title="Default environment has been changed" placement="top" arrow>
-        <IconButton
-          className={css.button}
-          size="small"
-          color="warning"
-          sx={{ justifySelf: 'flex-end', marginLeft: { sm: '0', md: 'auto' } }}
-          disableRipple
-        >
-          <SvgIcon component={AlertIcon} inheritViewBox fontSize="small" />
-        </IconButton>
-      </Tooltip>
-    </Link>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <div
+            role="button"
+            tabIndex={0}
+            aria-label="Default environment has been changed"
+            onClick={handlePointer}
+            onPointerDown={handlePointer}
+            onKeyDown={handleKeyDown}
+            className={cn(
+              'inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded outline-none transition-colors hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring/50',
+              className,
+            )}
+            style={{ backgroundColor: 'var(--color-warning-background)', color: 'var(--color-warning-main)' }}
+          />
+        }
+      >
+        <TriangleAlert className="size-3.5" />
+      </TooltipTrigger>
+      <TooltipContent>Default environment has been changed</TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/styles.module.css
+++ b/apps/web/src/components/settings/EnvironmentVariables/EnvHintButton/styles.module.css
@@ -1,7 +1,0 @@
-.button {
-  border-radius: 4px;
-  padding: 6px;
-  width: 32px;
-  height: 32px;
-  background: var(--color-warning-background);
-}

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
@@ -9,6 +9,7 @@ import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
 import SafeBalanceBlock from './SafeBalanceBlock'
 import type { SafeItemData } from '../types'
 import { OVERVIEW_EVENTS, trackEvent, MixpanelEventParams } from '@/services/analytics'
+import EnvHintButton from '@/components/settings/EnvironmentVariables/EnvHintButton'
 
 export interface SafeSelectorTriggerContentProps {
   selectedItem: SafeItemData
@@ -81,6 +82,7 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
             {displayName}
           </Typography>
           {!showAddressLine && copyButton}
+          {!showAddressLine && <EnvHintButton chainId={selectedChainId} />}
         </div>
         {showAddressLine && (
           <div className="flex items-center gap-1">
@@ -88,6 +90,7 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
               {addressWithPrefix}
             </Typography>
             {copyButton}
+            <EnvHintButton chainId={selectedChainId} />
           </div>
         )}
       </div>

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
@@ -14,6 +14,12 @@ jest.mock('../SafeBalanceBlock', () => {
   return { __esModule: true, default: Mock }
 })
 
+jest.mock('@/components/settings/EnvironmentVariables/EnvHintButton', () => {
+  const Mock = () => null
+  Mock.displayName = 'EnvHintButton'
+  return { __esModule: true, default: Mock }
+})
+
 const createItem = (overrides: Partial<SafeItemData> = {}): SafeItemData => ({
   id: '1:0xabc',
   name: 'Space AB Name',


### PR DESCRIPTION
## What it solves
Resolves: [WA-2201](https://linear.app/safe-global/issue/WA-2201/rpc-provider-warning-icon-not-shown-anywhere)

The RPC-override warning indicator that was in the old sidebar was lost. This PR restores it to the Safe Selector Dropdown.

When a user changes the RPC provider in Settings → Environment Variables, a warning icon now appears next to the Copy Address button in the Safe selector. Clicking it navigates to `/settings/environment-variables?safe=…`.

## How this PR fixes it
- Migrated `EnvHintButton` from MUI (`IconButton` + `Tooltip` + `alert.svg`) to shadcn (`Tooltip` + `lucide-react`'s `TriangleAlert`) and removed the dead `styles.module.css`.
- Rendered via `<div role="button">` to avoid nested-button HTML inside `SelectTrigger`. Click / pointerdown stop propagation so the surrounding Safe selector dropdown doesn't open.
- Added an optional `chainId` prop so callers in multi-chain contexts (Spaces) can override the URL-derived chain id.
- Mounted the button in `SafeSelectorTriggerContent` next to the existing Copy Address control, passing `selectedChainId`.

## How to test it
1. Go to `/settings/environment-variables?safe=…`
2. Change the RPC provider URL
3. The icon appears on the Safe Selector Dropdown
4. Remove custom RPC URL --> the icon disappears

## Visual summary

<img width="989" height="391" alt="image" src="https://github.com/user-attachments/assets/642ec0b6-faa1-46a2-8eb8-a107e31490e8" />

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).