### PR TITLE
feat: new workspace settings UI

### DIFF
--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -56,6 +56,9 @@ export const AppRoutes = {
   },
   spaces: {
     settings: '/spaces/settings',
+    settingsGeneral: '/spaces/settings/general',
+    settingsAccount: '/spaces/settings/account',
+    settingsAbout: '/spaces/settings/about',
     safeAccounts: '/spaces/safe-accounts',
     members: '/spaces/members',
     index: '/spaces',

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarCommonFooter/SidebarCommonFooter.tsx
@@ -111,7 +111,7 @@ export const SidebarCommonFooter = ({ isSafeSidebar = false }: { isSafeSidebar?:
             <TooltipContent side="top">What&apos;s new</TooltipContent>
           </Tooltip>
           <div className={css.footerHelpStatus}>
-            <SidebarIndexingStatus />
+            <SidebarIndexingStatus isSafeSidebar={isSafeSidebar} />
           </div>
         </SidebarMenuItem>
       </SidebarMenu>

--- a/apps/web/src/features/spaces/components/Sidebar/SidebarIndexingStatus/SidebarIndexingStatus.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/SidebarIndexingStatus/SidebarIndexingStatus.tsx
@@ -24,7 +24,7 @@ const getStatus = (synced: boolean, lastSync: number): Status => {
   return 'outOfSync'
 }
 
-export const SidebarIndexingStatus = (): ReactElement | null => {
+export const SidebarIndexingStatus = ({ isSafeSidebar = true }: { isSafeSidebar?: boolean }): ReactElement | null => {
   const chainId = useChainId()
   const { data, isLoading, isError } = useChainsGetIndexingStatusV1Query(
     { chainId },
@@ -37,6 +37,9 @@ export const SidebarIndexingStatus = (): ReactElement | null => {
 
   const status = getStatus(data.synced, data.lastSync)
   const time = formatDistanceToNow(data.lastSync, { addSuffix: true })
+  const tooltipText = isSafeSidebar
+    ? `Last synced with the blockchain ${time}`
+    : 'Blockchain sync status across networks'
 
   return (
     <Tooltip>
@@ -55,7 +58,7 @@ export const SidebarIndexingStatus = (): ReactElement | null => {
       >
         <StatusIcon className={css.indexingStatusIcon} />
       </TooltipTrigger>
-      <TooltipContent side="top">{`Last synced with the blockchain ${time}`}</TooltipContent>
+      <TooltipContent side="top">{tooltipText}</TooltipContent>
     </Tooltip>
   )
 }

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/SpacesSidebarContent.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarContent/SpacesSidebarContent.tsx
@@ -26,6 +26,15 @@ export const SpacesSidebarContent = ({
 
   const isItemDisabled = (item: SidebarItemConfig) => !!item.activeMemberOnly && !isActiveMember
 
+  // Match the item when the URL is the item's href or one of its sub-routes
+  // (e.g. /spaces/settings/general should highlight the Settings nav item).
+  // The spaces index (/spaces) is exact-match only — otherwise every space
+  // sub-route would also highlight Home.
+  const isItemActive = (item: SidebarItemConfig, pathname: string) => {
+    if (item.href === AppRoutes.spaces.index) return pathname === item.href
+    return pathname === item.href || pathname.startsWith(`${item.href}/`)
+  }
+
   // Drop the Security entry from the Setup group when the chain feature flag is explicitly
   // off. `undefined` means the chain config is still loading — keep the item to avoid flicker.
   const filteredSetupGroup = useMemo(
@@ -39,6 +48,7 @@ export const SpacesSidebarContent = ({
   const { mainNavItems, setupGroup } = useResolvedSidebarNav(spacesMainNavigation, filteredSetupGroup, {
     getLink,
     isItemDisabled,
+    isItemActive,
   })
 
   return (

--- a/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
@@ -1,57 +1,71 @@
-import {
-  Alert,
-  Button,
-  DialogActions,
-  DialogContent,
-  List,
-  ListItem,
-  ListItemIcon,
-  SvgIcon,
-  Typography,
-} from '@mui/material'
-import ModalDialog from '@/components/common/ModalDialog'
-import { type GetSpaceResponse, useSpacesDeleteV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import CheckIcon from '@/public/images/common/check.svg'
-import CloseIcon from '@/public/images/common/close.svg'
-import css from './styles.module.css'
-import { AppRoutes } from '@/config/routes'
-import { useRouter } from 'next/router'
 import { useState } from 'react'
-import { showNotification } from '@/store/notificationsSlice'
+import { useRouter } from 'next/router'
+import { AlertTriangle, Check, X } from 'lucide-react'
+import { type GetSpaceResponse, useSpacesDeleteV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Typography } from '@/components/ui/typography'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { AppRoutes } from '@/config/routes'
 import { useAppDispatch } from '@/store'
+import { showNotification } from '@/store/notificationsSlice'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { trackEvent } from '@/services/analytics'
 
-const ListIcon = ({ variant }: { variant: 'success' | 'danger' }) => {
-  const Icon = variant === 'success' ? CheckIcon : CloseIcon
+type Consequence = { variant: 'danger' | 'success'; text: string }
 
-  return (
-    <ListItemIcon className={variant === 'success' ? css.success : css.danger}>
-      <SvgIcon component={Icon} inheritViewBox />
-    </ListItemIcon>
-  )
-}
+const CONSEQUENCES: Consequence[] = [
+  { variant: 'danger', text: 'Members lose access to this workspace immediately.' },
+  { variant: 'danger', text: 'Member list and Safe Account names are deleted.' },
+  { variant: 'success', text: 'Linked Safe Accounts keep working — only the workspace is removed.' },
+]
+
+const ConsequenceRow = ({ variant, text }: Consequence) => (
+  <li className="flex items-start gap-3">
+    <span
+      className={
+        variant === 'danger'
+          ? 'flex items-center justify-center size-5 rounded-full bg-destructive/10 text-destructive shrink-0 mt-0.5'
+          : 'flex items-center justify-center size-5 rounded-full bg-sidebar-accent text-sidebar-accent-foreground shrink-0 mt-0.5'
+      }
+    >
+      {variant === 'danger' ? <X className="size-3" /> : <Check className="size-3" />}
+    </span>
+    <Typography variant="paragraph-small">{text}</Typography>
+  </li>
+)
 
 const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefined; onClose: () => void }) => {
   const [error, setError] = useState<string>()
+  const [confirmName, setConfirmName] = useState('')
   const router = useRouter()
   const dispatch = useAppDispatch()
-  const [deleteSpace] = useSpacesDeleteV1Mutation()
+  const [deleteSpace, { isLoading }] = useSpacesDeleteV1Mutation()
+
+  const canConfirm = !!space && confirmName.trim() === space.name && !isLoading
 
   const onDelete = async () => {
-    if (!space) return
+    if (!space || !canConfirm) return
 
     setError(undefined)
 
     try {
-      await deleteSpace({ id: space.id })
-
+      await deleteSpace({ id: space.id }).unwrap()
       onClose()
 
       trackEvent({ ...SPACE_EVENTS.DELETE_SPACE })
       dispatch(
         showNotification({
-          message: `Deleted space ${space.name}.`,
+          message: `Deleted workspace ${space.name}.`,
           variant: 'success',
           groupKey: 'delete-space-success',
         }),
@@ -65,41 +79,57 @@ const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undef
   }
 
   return (
-    <ModalDialog dialogTitle="Delete workspace" hideChainIndicator open onClose={onClose}>
-      <DialogContent sx={{ mt: 2 }}>
-        <Typography mb={2}>
-          Are you sure you want to delete <b>{space?.name}</b>? Deleting this workspace:
-        </Typography>
+    <AlertDialog open onOpenChange={(open) => !open && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="flex items-center justify-center size-10 rounded-full bg-destructive/10 text-destructive shrink-0">
+            <AlertTriangle className="size-5" />
+          </div>
+          <AlertDialogTitle>Delete workspace</AlertDialogTitle>
+          <AlertDialogDescription>This action is permanent and cannot be undone.</AlertDialogDescription>
+        </AlertDialogHeader>
 
-        <List sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <ListItem disablePadding>
-            <ListIcon variant="danger" />
-            Will permanently revoke access to workspace data for you and its members
-          </ListItem>
-          <ListItem disablePadding>
-            <ListIcon variant="danger" />
-            Will remove members and Safe Accounts names from our database
-          </ListItem>
-          <ListItem disablePadding>
-            <ListIcon variant="success" />
-            Will keep access to the Safe Accounts added to this workspace. They will not be deleted.
-          </ListItem>
-        </List>
+        <ul className="flex flex-col gap-3">
+          {CONSEQUENCES.map((item) => (
+            <ConsequenceRow key={item.text} {...item} />
+          ))}
+        </ul>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="delete-confirm-input">
+            Type <span className="font-mono font-semibold text-foreground">{space?.name}</span> to confirm
+          </Label>
+          <Input
+            id="delete-confirm-input"
+            data-testid="space-confirm-name-input"
+            value={confirmName}
+            onChange={(e) => setConfirmName(e.target.value)}
+            placeholder={space?.name}
+            autoComplete="off"
+          />
+        </div>
 
         {error && (
-          <Alert severity="error" sx={{ mt: 2 }}>
-            {error}
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
           </Alert>
         )}
-      </DialogContent>
 
-      <DialogActions>
-        <Button onClick={onClose}>No, keep it</Button>
-        <Button data-testid="space-confirm-delete-button" variant="danger" onClick={onDelete}>
-          Permanently delete it
-        </Button>
-      </DialogActions>
-    </ModalDialog>
+        <AlertDialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onDelete}
+            disabled={!canConfirm}
+            data-testid="space-confirm-delete-button"
+          >
+            {isLoading ? 'Deleting…' : 'Delete workspace'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 

--- a/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
@@ -79,7 +79,7 @@ const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undef
   }
 
   return (
-    <AlertDialog open onOpenChange={(open) => !open && onClose()}>
+    <AlertDialog open onOpenChange={(open) => !open && !isLoading && onClose()}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <div className="flex items-center justify-center size-10 rounded-full bg-destructive/10 text-destructive shrink-0">

--- a/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/DeleteSpaceDialog.tsx
@@ -51,7 +51,7 @@ const DeleteSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undef
   const dispatch = useAppDispatch()
   const [deleteSpace, { isLoading }] = useSpacesDeleteV1Mutation()
 
-  const canConfirm = !!space && confirmName.trim() === space.name && !isLoading
+  const canConfirm = !!space && confirmName.trim() === space.name.trim() && !isLoading
 
   const onDelete = async () => {
     if (!space || !canConfirm) return

--- a/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
@@ -51,7 +51,7 @@ const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefi
   }
 
   return (
-    <AlertDialog open onOpenChange={(open) => !open && onClose()}>
+    <AlertDialog open onOpenChange={(open) => !open && !isLoading && onClose()}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <div className="flex items-center justify-center size-10 rounded-full bg-destructive/10 text-destructive shrink-0">

--- a/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
@@ -1,11 +1,21 @@
-import { Alert, Button, DialogActions, DialogContent, Typography } from '@mui/material'
-import ModalDialog from '@/components/common/ModalDialog'
-import { type GetSpaceResponse, useMembersSelfRemoveV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import { AppRoutes } from '@/config/routes'
-import { useRouter } from 'next/router'
 import { useState } from 'react'
-import { showNotification } from '@/store/notificationsSlice'
+import { useRouter } from 'next/router'
+import { LogOut } from 'lucide-react'
+import { type GetSpaceResponse, useMembersSelfRemoveV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Typography } from '@/components/ui/typography'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { AppRoutes } from '@/config/routes'
 import { useAppDispatch } from '@/store'
+import { showNotification } from '@/store/notificationsSlice'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { trackEvent } from '@/services/analytics'
 
@@ -13,7 +23,7 @@ const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefi
   const [error, setError] = useState<string>()
   const router = useRouter()
   const dispatch = useAppDispatch()
-  const [leaveSpace] = useMembersSelfRemoveV1Mutation()
+  const [leaveSpace, { isLoading }] = useMembersSelfRemoveV1Mutation()
 
   const onLeave = async () => {
     if (!space) return
@@ -46,26 +56,44 @@ const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefi
   }
 
   return (
-    <ModalDialog dialogTitle="Leave workspace" hideChainIndicator open onClose={onClose}>
-      <DialogContent sx={{ mt: 2 }}>
-        <Typography mb={2}>
-          Are you sure you want to leave this workspace? You won’t be able to access its data anymore.
+    <AlertDialog open onOpenChange={(open) => !open && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="flex items-center justify-center size-10 rounded-full bg-destructive/10 text-destructive shrink-0">
+            <LogOut className="size-5" />
+          </div>
+          <AlertDialogTitle>Leave workspace</AlertDialogTitle>
+          <AlertDialogDescription>
+            You&apos;ll lose access to <span className="font-semibold text-foreground">{space?.name}</span> immediately.
+            An admin can re-invite you later.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <Typography variant="paragraph-small" color="muted">
+          Your wallet and any linked Safe Accounts are not affected.
         </Typography>
 
         {error && (
-          <Alert severity="error" sx={{ mt: 2 }}>
-            {error}
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
           </Alert>
         )}
-      </DialogContent>
 
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button data-testid="space-confirm-leave-button" variant="danger" onClick={onLeave}>
-          Leave workspace
-        </Button>
-      </DialogActions>
-    </ModalDialog>
+        <AlertDialogFooter>
+          <Button variant="ghost" onClick={onClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onLeave}
+            disabled={isLoading || !space}
+            data-testid="space-confirm-leave-button"
+          >
+            {isLoading ? 'Leaving…' : 'Leave workspace'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 

--- a/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/LeaveSpaceDialog.tsx
@@ -31,12 +31,7 @@ const LeaveSpaceDialog = ({ space, onClose }: { space: GetSpaceResponse | undefi
     setError(undefined)
 
     try {
-      const res = await leaveSpace({ spaceId: space.id })
-
-      if (res.error) {
-        throw new Error(JSON.stringify(res.error))
-      }
-
+      await leaveSpace({ spaceId: space.id }).unwrap()
       onClose()
 
       trackEvent({ ...SPACE_EVENTS.LEAVE_SPACE })

--- a/apps/web/src/features/spaces/components/SpaceSettings/Page.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/Page.tsx
@@ -1,12 +1,19 @@
 import { AddressBookSourceProvider } from '@/components/common/AddressBookSourceProvider'
 import AuthState from '../AuthState'
 import SpaceSettings from './index'
+import { type SettingsPageKey } from './SettingsRail'
 
-export default function SpaceSettingsPage({ spaceId }: { spaceId: string }) {
+export default function SpaceSettingsPage({
+  spaceId,
+  activePage = 'general',
+}: {
+  spaceId: string
+  activePage?: SettingsPageKey
+}) {
   return (
     <AuthState spaceId={spaceId}>
       <AddressBookSourceProvider source="spaceOnly">
-        <SpaceSettings />
+        <SpaceSettings activePage={activePage} />
       </AddressBookSourceProvider>
     </AuthState>
   )

--- a/apps/web/src/features/spaces/components/SpaceSettings/SettingsRail.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/SettingsRail.tsx
@@ -39,7 +39,7 @@ const SettingsRail = ({ activePage }: { activePage: SettingsPageKey }) => {
   const router = useRouter()
 
   return (
-    <aside className="w-[220px] shrink-0 sticky top-6 flex flex-col gap-2">
+    <aside className="sm:w-[220px] sm:shrink-0 sm:sticky sm:top-6 flex flex-row sm:flex-col gap-1 mb-4 sm:mb-0 overflow-x-auto">
       {RAIL_ITEMS.map((item) => {
         const isActive = activePage === item.key
         return (
@@ -48,7 +48,7 @@ const SettingsRail = ({ activePage }: { activePage: SettingsPageKey }) => {
             href={{ pathname: item.href, query: router.query }}
             data-testid={`settings-rail-${item.key}`}
             className={cn(
-              'flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors no-underline',
+              'flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors no-underline whitespace-nowrap',
               isActive
                 ? 'bg-sidebar-accent text-sidebar-accent-foreground font-semibold dark:bg-accent dark:text-primary'
                 : 'text-sidebar-foreground hover:bg-muted',

--- a/apps/web/src/features/spaces/components/SpaceSettings/SettingsRail.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/SettingsRail.tsx
@@ -37,6 +37,7 @@ const RAIL_ITEMS: RailItem[] = [
 
 const SettingsRail = ({ activePage }: { activePage: SettingsPageKey }) => {
   const router = useRouter()
+  const spaceId = typeof router.query.spaceId === 'string' ? router.query.spaceId : undefined
 
   return (
     <aside className="sm:w-[220px] sm:shrink-0 sm:sticky sm:top-6 flex flex-row sm:flex-col gap-1 mb-4 sm:mb-0 overflow-x-auto">
@@ -45,7 +46,7 @@ const SettingsRail = ({ activePage }: { activePage: SettingsPageKey }) => {
         return (
           <Link
             key={item.key}
-            href={{ pathname: item.href, query: router.query }}
+            href={{ pathname: item.href, query: spaceId ? { spaceId } : undefined }}
             data-testid={`settings-rail-${item.key}`}
             className={cn(
               'flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors no-underline whitespace-nowrap',

--- a/apps/web/src/features/spaces/components/SpaceSettings/SettingsRail.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/SettingsRail.tsx
@@ -23,7 +23,7 @@ const RAIL_ITEMS: RailItem[] = [
   },
   {
     key: 'account',
-    label: 'Account settings',
+    label: 'User settings',
     icon: <User className="h-4 w-4" />,
     href: AppRoutes.spaces.settingsAccount,
   },

--- a/apps/web/src/features/spaces/components/SpaceSettings/SettingsRail.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/SettingsRail.tsx
@@ -1,0 +1,69 @@
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+import { Info, SlidersHorizontal, User } from 'lucide-react'
+import { type ReactElement } from 'react'
+import { cn } from '@/utils/cn'
+import { AppRoutes } from '@/config/routes'
+
+export type SettingsPageKey = 'general' | 'account' | 'about'
+
+type RailItem = {
+  key: SettingsPageKey
+  label: string
+  icon: ReactElement
+  href: string
+}
+
+const RAIL_ITEMS: RailItem[] = [
+  {
+    key: 'general',
+    label: 'Workspace settings',
+    icon: <SlidersHorizontal className="h-4 w-4" />,
+    href: AppRoutes.spaces.settingsGeneral,
+  },
+  {
+    key: 'account',
+    label: 'Account settings',
+    icon: <User className="h-4 w-4" />,
+    href: AppRoutes.spaces.settingsAccount,
+  },
+  {
+    key: 'about',
+    label: 'About',
+    icon: <Info className="h-4 w-4" />,
+    href: AppRoutes.spaces.settingsAbout,
+  },
+]
+
+const SettingsRail = ({ activePage }: { activePage: SettingsPageKey }) => {
+  const router = useRouter()
+
+  return (
+    <aside className="w-[220px] shrink-0 sticky top-6 flex flex-col gap-2">
+      {RAIL_ITEMS.map((item) => {
+        const isActive = activePage === item.key
+        return (
+          <Link
+            key={item.key}
+            href={{ pathname: item.href, query: router.query }}
+            data-testid={`settings-rail-${item.key}`}
+            className={cn(
+              'flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors no-underline',
+              isActive
+                ? 'bg-sidebar-accent text-sidebar-accent-foreground font-semibold dark:bg-accent dark:text-primary'
+                : 'text-sidebar-foreground hover:bg-muted',
+            )}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            <span className={cn('shrink-0', isActive ? 'dark:text-primary' : 'text-muted-foreground')}>
+              {item.icon}
+            </span>
+            {item.label}
+          </Link>
+        )
+      })}
+    </aside>
+  )
+}
+
+export default SettingsRail

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
@@ -111,9 +111,9 @@ describe('AboutPage', () => {
       expect(link).toHaveAttribute('href', HELP_CENTER_URL)
     })
 
-    it('renders Service Status link', () => {
+    it('renders Sync Status link', () => {
       renderWithStore()
-      const link = screen.getByRole('link', { name: /Service Status/i })
+      const link = screen.getByRole('link', { name: /Sync Status/i })
       expect(link).toHaveAttribute('href', 'https://status.safe.global')
     })
   })

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/store'
+import AboutPage from '../pages/AboutPage'
+import { AppRoutes } from '@/config/routes'
+import { HELP_CENTER_URL } from '@safe-global/utils/config/constants'
+import { APP_VERSION, APP_HOMEPAGE } from '@/config/version'
+import { selectCookieBanner } from '@/store/popupSlice'
+import { CookieAndTermType } from '@/store/cookiesAndTermsSlice'
+
+const renderWithStore = () => {
+  const store = makeStore(undefined, { skipBroadcast: true })
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <AboutPage />
+      </Provider>,
+    ),
+  }
+}
+
+describe('AboutPage', () => {
+  describe('legal links', () => {
+    it('renders Terms & Conditions with correct href', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /Terms & Conditions/i })
+      expect(link).toHaveAttribute('href', AppRoutes.terms)
+    })
+
+    it('renders Privacy Policy with correct href', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /Privacy Policy/i })
+      expect(link).toHaveAttribute('href', AppRoutes.privacy)
+    })
+
+    it('renders Licenses with correct href', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /Licenses/i })
+      expect(link).toHaveAttribute('href', AppRoutes.licenses)
+    })
+
+    it('renders Imprint with correct href', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /Imprint/i })
+      expect(link).toHaveAttribute('href', AppRoutes.imprint)
+    })
+
+    it('renders Cookie Policy with correct href', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /Cookie Policy/i })
+      expect(link).toHaveAttribute('href', AppRoutes.cookie)
+    })
+
+    it('opens all legal links in a new tab with noopener', () => {
+      renderWithStore()
+      const legalLinks = [
+        screen.getByRole('link', { name: /Terms & Conditions/i }),
+        screen.getByRole('link', { name: /Privacy Policy/i }),
+        screen.getByRole('link', { name: /Licenses/i }),
+        screen.getByRole('link', { name: /Imprint/i }),
+        screen.getByRole('link', { name: /Cookie Policy/i }),
+      ]
+      legalLinks.forEach((link) => {
+        expect(link).toHaveAttribute('target', '_blank')
+        expect(link).toHaveAttribute('rel', 'noreferrer noopener')
+      })
+    })
+  })
+
+  describe('help links', () => {
+    it('renders Help Center link pointing to HELP_CENTER_URL', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /Help Center/i })
+      expect(link).toHaveAttribute('href', HELP_CENTER_URL)
+    })
+
+    it('renders Service Status link', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /Service Status/i })
+      expect(link).toHaveAttribute('href', 'https://status.safe.global')
+    })
+
+    it('renders Contact Support link pointing to HELP_CENTER_URL', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /Contact Support/i })
+      expect(link).toHaveAttribute('href', HELP_CENTER_URL)
+    })
+  })
+
+  describe('version section', () => {
+    it('renders the current version badge', () => {
+      renderWithStore()
+      expect(screen.getByText(`v${APP_VERSION}`)).toBeInTheDocument()
+    })
+
+    it('release notes link points to the correct GitHub release URL', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /View release notes/i })
+      expect(link).toHaveAttribute('href', `${APP_HOMEPAGE}/releases/tag/web-v${APP_VERSION}`)
+    })
+
+    it('GitHub button links to APP_HOMEPAGE', () => {
+      renderWithStore()
+      const link = screen.getByRole('link', { name: /GitHub/i })
+      expect(link).toHaveAttribute('href', APP_HOMEPAGE)
+    })
+  })
+
+  describe('cookie preferences', () => {
+    it('renders the cookie preferences button', () => {
+      renderWithStore()
+      expect(screen.getByTestId('cookie-preferences-button')).toBeInTheDocument()
+    })
+
+    it('dispatches openCookieBanner with NECESSARY key when clicked', () => {
+      const { store } = renderWithStore()
+
+      fireEvent.click(screen.getByTestId('cookie-preferences-button'))
+
+      const cookieBanner = selectCookieBanner(store.getState())
+      expect(cookieBanner.open).toBe(true)
+      expect(cookieBanner.warningKey).toBe(CookieAndTermType.NECESSARY)
+    })
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AboutPage.test.tsx
@@ -7,6 +7,37 @@ import { HELP_CENTER_URL } from '@safe-global/utils/config/constants'
 import { APP_VERSION, APP_HOMEPAGE } from '@/config/version'
 import { selectCookieBanner } from '@/store/popupSlice'
 import { CookieAndTermType } from '@/store/cookiesAndTermsSlice'
+import { useLoadFeature } from '@/features/__core__'
+import { useIsOfficialHost } from '@/hooks/useIsOfficialHost'
+
+const mockSupportChatDrawer = jest.fn()
+
+jest.mock('@/features/__core__', () => ({
+  useLoadFeature: jest.fn(),
+}))
+
+jest.mock('@/features/support-chat', () => ({
+  SupportChatFeature: 'support-chat-feature',
+  useSupportChat: () => ({
+    config: { appId: 'test-app', chatUrl: 'https://chat.test', aliasDomain: 'test.local', allowedParents: [] },
+    user: { email: 'guest@test.local', name: 'Safe{Wallet}' },
+  }),
+}))
+
+jest.mock('@/hooks/useIsOfficialHost', () => ({
+  useIsOfficialHost: jest.fn(),
+}))
+
+const setSupportFeature = ({ disabled, isOfficialHost }: { disabled: boolean; isOfficialHost: boolean }) => {
+  mockSupportChatDrawer.mockImplementation(({ open }: { open: boolean }) =>
+    open ? <div data-testid="support-chat-drawer" /> : null,
+  )
+  ;(useLoadFeature as jest.Mock).mockReturnValue({
+    SupportChatDrawer: mockSupportChatDrawer,
+    $isDisabled: disabled,
+  })
+  ;(useIsOfficialHost as jest.Mock).mockReturnValue(isOfficialHost)
+}
 
 const renderWithStore = () => {
   const store = makeStore(undefined, { skipBroadcast: true })
@@ -21,6 +52,11 @@ const renderWithStore = () => {
 }
 
 describe('AboutPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setSupportFeature({ disabled: false, isOfficialHost: true })
+  })
+
   describe('legal links', () => {
     it('renders Terms & Conditions with correct href', () => {
       renderWithStore()
@@ -80,11 +116,34 @@ describe('AboutPage', () => {
       const link = screen.getByRole('link', { name: /Service Status/i })
       expect(link).toHaveAttribute('href', 'https://status.safe.global')
     })
+  })
 
-    it('renders Contact Support link pointing to HELP_CENTER_URL', () => {
+  describe('Contact Support', () => {
+    it('renders Contact Support as a button when the support chat feature is available', () => {
       renderWithStore()
-      const link = screen.getByRole('link', { name: /Contact Support/i })
-      expect(link).toHaveAttribute('href', HELP_CENTER_URL)
+      expect(screen.getByRole('button', { name: /Contact Support/i })).toBeInTheDocument()
+      expect(screen.queryByRole('link', { name: /Contact Support/i })).not.toBeInTheDocument()
+    })
+
+    it('does not render Contact Support when the feature is disabled', () => {
+      setSupportFeature({ disabled: true, isOfficialHost: true })
+      renderWithStore()
+      expect(screen.queryByRole('button', { name: /Contact Support/i })).not.toBeInTheDocument()
+    })
+
+    it('does not render Contact Support on unofficial hosts', () => {
+      setSupportFeature({ disabled: false, isOfficialHost: false })
+      renderWithStore()
+      expect(screen.queryByRole('button', { name: /Contact Support/i })).not.toBeInTheDocument()
+    })
+
+    it('opens the support chat drawer when clicked', () => {
+      renderWithStore()
+      expect(screen.queryByTestId('support-chat-drawer')).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: /Contact Support/i }))
+
+      expect(screen.getByTestId('support-chat-drawer')).toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AppearanceSection.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AppearanceSection.test.tsx
@@ -28,9 +28,9 @@ const renderWithStore = () => {
 describe('AppearanceSection', () => {
   it('selects "system" by default when no theme preference is set', () => {
     renderWithStore()
-    expect(screen.getByTestId('theme-card-system')).toHaveAttribute('aria-checked', 'true')
-    expect(screen.getByTestId('theme-card-dark')).toHaveAttribute('aria-checked', 'false')
-    expect(screen.getByTestId('theme-card-light')).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByTestId('theme-card-system')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('theme-card-dark')).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByTestId('theme-card-light')).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('persists the theme choice to settingsSlice when a card is clicked', () => {

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AppearanceSection.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/AppearanceSection.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/store'
+import AppearanceSection from '../sections/AppearanceSection'
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+  SETTINGS_EVENTS: {
+    APPEARANCE: {
+      DARK_MODE: { action: 'Dark mode', category: 'settings' },
+      COPY_PREFIXES: { action: 'Copy prefixes', category: 'settings' },
+    },
+  },
+}))
+
+const renderWithStore = () => {
+  const store = makeStore(undefined, { skipBroadcast: true })
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <AppearanceSection />
+      </Provider>,
+    ),
+  }
+}
+
+describe('AppearanceSection', () => {
+  it('selects "system" by default when no theme preference is set', () => {
+    renderWithStore()
+    expect(screen.getByTestId('theme-card-system')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('theme-card-dark')).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByTestId('theme-card-light')).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('persists the theme choice to settingsSlice when a card is clicked', () => {
+    const { store } = renderWithStore()
+
+    fireEvent.click(screen.getByTestId('theme-card-dark'))
+    expect(store.getState().settings.theme.darkMode).toBe(true)
+
+    fireEvent.click(screen.getByTestId('theme-card-light'))
+    expect(store.getState().settings.theme.darkMode).toBe(false)
+
+    fireEvent.click(screen.getByTestId('theme-card-system'))
+    expect(store.getState().settings.theme.darkMode).toBeUndefined()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DangerZoneSection.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DangerZoneSection.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/store'
+import DangerZoneSection from '../sections/DangerZoneSection'
+import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useIsAdmin, useIsActiveMember, useIsLastActiveAdmin } from '@/features/spaces'
+
+jest.mock('@/features/spaces', () => ({
+  useIsAdmin: jest.fn(() => false),
+  useIsActiveMember: jest.fn(() => false),
+  useIsLastActiveAdmin: jest.fn(() => false),
+}))
+
+jest.mock('../DeleteSpaceDialog', () => () => null)
+jest.mock('../LeaveSpaceDialog', () => () => null)
+
+const renderSection = (space: GetSpaceResponse | undefined) =>
+  render(
+    <Provider store={makeStore(undefined, { skipBroadcast: true })}>
+      <DangerZoneSection space={space} />
+    </Provider>,
+  )
+
+describe('DangerZoneSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('passes the viewed space id to useIsAdmin and useIsActiveMember', () => {
+    const space: GetSpaceResponse = { id: 42, name: 'Other Workspace', members: [], safeCount: 0 }
+
+    renderSection(space)
+
+    expect(useIsAdmin).toHaveBeenCalledWith(42)
+    expect(useIsActiveMember).toHaveBeenCalledWith(42)
+  })
+
+  it('passes undefined when the space is not loaded yet', () => {
+    renderSection(undefined)
+
+    expect(useIsAdmin).toHaveBeenCalledWith(undefined)
+    expect(useIsActiveMember).toHaveBeenCalledWith(undefined)
+  })
+
+  it('does not fall back to the last-used space when a different space is viewed', () => {
+    const viewedSpace: GetSpaceResponse = { id: 99, name: 'Viewed', members: [], safeCount: 0 }
+
+    renderSection(viewedSpace)
+
+    expect(useIsAdmin).not.toHaveBeenCalledWith(undefined)
+    expect(useIsActiveMember).not.toHaveBeenCalledWith(undefined)
+    expect(useIsLastActiveAdmin).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DeleteSpaceDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DeleteSpaceDialog.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/store'
+import DeleteSpaceDialog from '../DeleteSpaceDialog'
+import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { AppRoutes } from '@/config/routes'
+
+const mockDeleteSpace = jest.fn()
+const mockRouterPush = jest.fn()
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useSpacesDeleteV1Mutation: jest.fn(() => [mockDeleteSpace, { isLoading: false }]),
+}))
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+const mockSpace: GetSpaceResponse = { id: 7, name: 'My Workspace', members: [], safeCount: 0 }
+
+const renderDialog = (space = mockSpace, onClose = jest.fn()) => {
+  const store = makeStore(undefined, { skipBroadcast: true })
+  return {
+    store,
+    onClose,
+    ...render(
+      <Provider store={store}>
+        <DeleteSpaceDialog space={space} onClose={onClose} />
+      </Provider>,
+    ),
+  }
+}
+
+describe('DeleteSpaceDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDeleteSpace.mockReset()
+  })
+
+  it('renders the dialog with space name in the confirmation label', () => {
+    renderDialog()
+    expect(screen.getByText(/My Workspace/)).toBeInTheDocument()
+  })
+
+  it('confirm button is disabled when the input is empty', () => {
+    renderDialog()
+    expect(screen.getByTestId('space-confirm-delete-button')).toBeDisabled()
+  })
+
+  it('confirm button is disabled when the name is typed incorrectly', () => {
+    renderDialog()
+    fireEvent.change(screen.getByTestId('space-confirm-name-input'), {
+      target: { value: 'wrong name' },
+    })
+    expect(screen.getByTestId('space-confirm-delete-button')).toBeDisabled()
+  })
+
+  it('confirm button is disabled when name matches but has extra whitespace', () => {
+    renderDialog()
+    fireEvent.change(screen.getByTestId('space-confirm-name-input'), {
+      target: { value: '  My Workspace  ' },
+    })
+    // trim() is applied, so leading/trailing spaces do not matter — button should be enabled
+    expect(screen.getByTestId('space-confirm-delete-button')).not.toBeDisabled()
+  })
+
+  it('confirm button is enabled only when the name matches exactly', () => {
+    renderDialog()
+    fireEvent.change(screen.getByTestId('space-confirm-name-input'), {
+      target: { value: 'My Workspace' },
+    })
+    expect(screen.getByTestId('space-confirm-delete-button')).not.toBeDisabled()
+  })
+
+  it('calls deleteSpace with the space id on confirm', async () => {
+    mockDeleteSpace.mockReturnValue({ unwrap: () => Promise.resolve() })
+    renderDialog()
+
+    fireEvent.change(screen.getByTestId('space-confirm-name-input'), {
+      target: { value: 'My Workspace' },
+    })
+    fireEvent.click(screen.getByTestId('space-confirm-delete-button'))
+
+    await waitFor(() => {
+      expect(mockDeleteSpace).toHaveBeenCalledWith({ id: 7 })
+    })
+  })
+
+  it('redirects to the spaces welcome page after successful deletion', async () => {
+    mockDeleteSpace.mockReturnValue({ unwrap: () => Promise.resolve() })
+    renderDialog()
+
+    fireEvent.change(screen.getByTestId('space-confirm-name-input'), {
+      target: { value: 'My Workspace' },
+    })
+    fireEvent.click(screen.getByTestId('space-confirm-delete-button'))
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith({ pathname: AppRoutes.welcome.spaces })
+    })
+  })
+
+  it('dispatches a success notification after deletion', async () => {
+    mockDeleteSpace.mockReturnValue({ unwrap: () => Promise.resolve() })
+    const { store } = renderDialog()
+
+    fireEvent.change(screen.getByTestId('space-confirm-name-input'), {
+      target: { value: 'My Workspace' },
+    })
+    fireEvent.click(screen.getByTestId('space-confirm-delete-button'))
+
+    await waitFor(() => {
+      const notifications = store.getState().notifications
+      expect(notifications.length).toBeGreaterThan(0)
+      const last = notifications[notifications.length - 1]
+      expect(last.message).toBe('Deleted workspace My Workspace.')
+      expect(last.variant).toBe('success')
+    })
+  })
+
+  it('shows an error message when deletion fails', async () => {
+    mockDeleteSpace.mockReturnValue({ unwrap: () => Promise.reject(new Error('server error')) })
+    renderDialog()
+
+    fireEvent.change(screen.getByTestId('space-confirm-name-input'), {
+      target: { value: 'My Workspace' },
+    })
+    fireEvent.click(screen.getByTestId('space-confirm-delete-button'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Error deleting the workspace. Please try again.')).toBeInTheDocument()
+    })
+  })
+
+  it('does not redirect when deletion fails', async () => {
+    mockDeleteSpace.mockReturnValue({ unwrap: () => Promise.reject(new Error('fail')) })
+    renderDialog()
+
+    fireEvent.change(screen.getByTestId('space-confirm-name-input'), {
+      target: { value: 'My Workspace' },
+    })
+    fireEvent.click(screen.getByTestId('space-confirm-delete-button'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Error deleting the workspace. Please try again.')).toBeInTheDocument()
+    })
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = jest.fn()
+    renderDialog(mockSpace, onClose)
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('confirm button is disabled when space is undefined', () => {
+    renderDialog(undefined)
+    expect(screen.getByTestId('space-confirm-delete-button')).toBeDisabled()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DeleteSpaceDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/DeleteSpaceDialog.test.tsx
@@ -59,12 +59,11 @@ describe('DeleteSpaceDialog', () => {
     expect(screen.getByTestId('space-confirm-delete-button')).toBeDisabled()
   })
 
-  it('confirm button is disabled when name matches but has extra whitespace', () => {
+  it('confirm button is enabled when name matches with leading/trailing whitespace', () => {
     renderDialog()
     fireEvent.change(screen.getByTestId('space-confirm-name-input'), {
       target: { value: '  My Workspace  ' },
     })
-    // trim() is applied, so leading/trailing spaces do not matter — button should be enabled
     expect(screen.getByTestId('space-confirm-delete-button')).not.toBeDisabled()
   })
 

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/LeaveSpaceDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/LeaveSpaceDialog.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/store'
+import LeaveSpaceDialog from '../LeaveSpaceDialog'
+import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { AppRoutes } from '@/config/routes'
+
+const mockLeaveSpace = jest.fn()
+const mockRouterPush = jest.fn()
+let mockIsLoading = false
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useMembersSelfRemoveV1Mutation: jest.fn(() => [mockLeaveSpace, { isLoading: mockIsLoading }]),
+}))
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}))
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+const mockSpace: GetSpaceResponse = { id: 7, name: 'My Workspace', members: [], safeCount: 0 }
+
+const renderDialog = (opts: { space?: GetSpaceResponse | undefined; onClose?: () => void } = {}) => {
+  const space = 'space' in opts ? opts.space : mockSpace
+  const onClose = opts.onClose ?? jest.fn()
+  const store = makeStore(undefined, { skipBroadcast: true })
+  return {
+    store,
+    onClose,
+    ...render(
+      <Provider store={store}>
+        <LeaveSpaceDialog space={space} onClose={onClose} />
+      </Provider>,
+    ),
+  }
+}
+
+describe('LeaveSpaceDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLeaveSpace.mockReset()
+    mockIsLoading = false
+  })
+
+  it('renders the dialog with the space name', () => {
+    renderDialog()
+    expect(screen.getByText('My Workspace')).toBeInTheDocument()
+  })
+
+  it('confirm button is disabled when space is undefined', () => {
+    renderDialog({ space: undefined })
+    expect(screen.getByTestId('space-confirm-leave-button')).toBeDisabled()
+  })
+
+  it('calls leaveSpace with the space id on confirm', async () => {
+    mockLeaveSpace.mockReturnValue({ unwrap: () => Promise.resolve() })
+    renderDialog()
+
+    fireEvent.click(screen.getByTestId('space-confirm-leave-button'))
+
+    await waitFor(() => {
+      expect(mockLeaveSpace).toHaveBeenCalledWith({ spaceId: 7 })
+    })
+  })
+
+  it('redirects to the spaces welcome page after successfully leaving', async () => {
+    mockLeaveSpace.mockReturnValue({ unwrap: () => Promise.resolve() })
+    renderDialog()
+
+    fireEvent.click(screen.getByTestId('space-confirm-leave-button'))
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith({ pathname: AppRoutes.welcome.spaces })
+    })
+  })
+
+  it('dispatches a success notification after leaving', async () => {
+    mockLeaveSpace.mockReturnValue({ unwrap: () => Promise.resolve() })
+    const { store } = renderDialog()
+
+    fireEvent.click(screen.getByTestId('space-confirm-leave-button'))
+
+    await waitFor(() => {
+      const notifications = store.getState().notifications
+      expect(notifications.length).toBeGreaterThan(0)
+      const last = notifications[notifications.length - 1]
+      expect(last.message).toBe('Left workspace My Workspace.')
+      expect(last.variant).toBe('success')
+    })
+  })
+
+  it('shows an error message when leaving fails', async () => {
+    mockLeaveSpace.mockReturnValue({ unwrap: () => Promise.reject(new Error('server error')) })
+    renderDialog()
+
+    fireEvent.click(screen.getByTestId('space-confirm-leave-button'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Error leaving the workspace. Please try again.')).toBeInTheDocument()
+    })
+  })
+
+  it('does not redirect when leaving fails', async () => {
+    mockLeaveSpace.mockReturnValue({ unwrap: () => Promise.reject(new Error('fail')) })
+    renderDialog()
+
+    fireEvent.click(screen.getByTestId('space-confirm-leave-button'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Error leaving the workspace. Please try again.')).toBeInTheDocument()
+    })
+    expect(mockRouterPush).not.toHaveBeenCalled()
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = jest.fn()
+    renderDialog({ onClose })
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('disables both buttons and shows loading label while the mutation is in flight', () => {
+    mockIsLoading = true
+    renderDialog()
+
+    expect(screen.getByTestId('space-confirm-leave-button')).toBeDisabled()
+    expect(screen.getByTestId('space-confirm-leave-button')).toHaveTextContent('Leaving…')
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/SettingsRail.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/SettingsRail.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react'
+import SettingsRail from '../SettingsRail'
+import { AppRoutes } from '@/config/routes'
+
+const mockRouterQuery: { spaceId?: string } = {}
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: mockRouterQuery }),
+}))
+
+const setSpaceId = (id: string | undefined) => {
+  if (id === undefined) delete mockRouterQuery.spaceId
+  else mockRouterQuery.spaceId = id
+}
+
+const parseHref = (anchor: HTMLAnchorElement) => {
+  const url = new URL(anchor.href, 'http://localhost')
+  return {
+    pathname: url.pathname,
+    spaceId: url.searchParams.get('spaceId'),
+  }
+}
+
+describe('SettingsRail', () => {
+  beforeEach(() => {
+    setSpaceId(undefined)
+  })
+
+  it('marks the active page with aria-current="page"', () => {
+    setSpaceId('42')
+    render(<SettingsRail activePage="general" />)
+
+    expect(screen.getByTestId('settings-rail-general')).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByTestId('settings-rail-account')).not.toHaveAttribute('aria-current')
+    expect(screen.getByTestId('settings-rail-about')).not.toHaveAttribute('aria-current')
+  })
+
+  it('updates the active page when activePage prop changes', () => {
+    setSpaceId('42')
+    const { rerender } = render(<SettingsRail activePage="general" />)
+    rerender(<SettingsRail activePage="about" />)
+
+    expect(screen.getByTestId('settings-rail-general')).not.toHaveAttribute('aria-current')
+    expect(screen.getByTestId('settings-rail-about')).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('propagates spaceId from router query into every link', () => {
+    setSpaceId('42')
+    render(<SettingsRail activePage="general" />)
+
+    const general = parseHref(screen.getByTestId('settings-rail-general') as HTMLAnchorElement)
+    const account = parseHref(screen.getByTestId('settings-rail-account') as HTMLAnchorElement)
+    const about = parseHref(screen.getByTestId('settings-rail-about') as HTMLAnchorElement)
+
+    expect(general).toEqual({ pathname: AppRoutes.spaces.settingsGeneral, spaceId: '42' })
+    expect(account).toEqual({ pathname: AppRoutes.spaces.settingsAccount, spaceId: '42' })
+    expect(about).toEqual({ pathname: AppRoutes.spaces.settingsAbout, spaceId: '42' })
+  })
+
+  it('omits the spaceId query when none is present in the router', () => {
+    render(<SettingsRail activePage="general" />)
+
+    const general = parseHref(screen.getByTestId('settings-rail-general') as HTMLAnchorElement)
+    expect(general.pathname).toBe(AppRoutes.spaces.settingsGeneral)
+    expect(general.spaceId).toBeNull()
+  })
+
+  it('ignores a non-string spaceId query value', () => {
+    // next/router can return string[] for repeated query params
+    ;(mockRouterQuery as unknown as { spaceId: string[] }).spaceId = ['42', '43']
+    render(<SettingsRail activePage="general" />)
+
+    const general = parseHref(screen.getByTestId('settings-rail-general') as HTMLAnchorElement)
+    expect(general.spaceId).toBeNull()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/UpdateSpaceForm.test.tsx
@@ -6,8 +6,8 @@ import UpdateSpaceForm from '../UpdateSpaceForm'
 // Import the real type
 import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 
-// Mock the hooks
-const mockUpdateSpace = jest.fn()
+const mockUnwrap = jest.fn()
+const mockUpdateSpace = jest.fn(() => ({ unwrap: mockUnwrap }))
 const mockUseIsAdmin = jest.fn()
 
 jest.mock('@/features/spaces/hooks/useSpaceMembers', () => ({
@@ -53,7 +53,7 @@ describe('UpdateSpaceForm', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUpdateSpace.mockReset()
+    mockUnwrap.mockReset()
     mockUseIsAdmin.mockReset()
   })
 
@@ -110,7 +110,7 @@ describe('UpdateSpaceForm', () => {
   })
 
   it('should call updateSpace mutation on submit', async () => {
-    mockUpdateSpace.mockResolvedValue({})
+    mockUnwrap.mockResolvedValue({})
     setupForm(mockSpace, true)
 
     changeSpaceName('New Space Name')
@@ -127,7 +127,7 @@ describe('UpdateSpaceForm', () => {
   })
 
   it('should show success notification on successful update', async () => {
-    mockUpdateSpace.mockResolvedValue({})
+    mockUnwrap.mockResolvedValue({})
     const { store } = setupForm(mockSpace, true)
 
     changeSpaceName('New Space Name')
@@ -147,7 +147,7 @@ describe('UpdateSpaceForm', () => {
   })
 
   it('should display error message when update fails', async () => {
-    mockUpdateSpace.mockRejectedValue(new Error('Network error'))
+    mockUnwrap.mockRejectedValue(new Error('Network error'))
     setupForm(mockSpace, true)
 
     changeSpaceName('New Space Name')
@@ -174,7 +174,7 @@ describe('UpdateSpaceForm', () => {
   })
 
   it('should clear error message when user retries after error', async () => {
-    mockUpdateSpace.mockRejectedValueOnce(new Error('Network error')).mockResolvedValueOnce({})
+    mockUnwrap.mockRejectedValueOnce(new Error('Network error')).mockResolvedValueOnce({})
     setupForm(mockSpace, true)
 
     // First attempt fails

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/useUpdateSpace.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/useUpdateSpace.test.tsx
@@ -1,0 +1,97 @@
+import { act, renderHook } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { makeStore } from '@/store'
+import { useUpdateSpace } from '../useUpdateSpace'
+import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+const mockUpdateSpace = jest.fn()
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useSpacesUpdateV1Mutation: jest.fn(() => [mockUpdateSpace]),
+}))
+
+const mockSpace: GetSpaceResponse = { id: 42, name: 'My Workspace', members: [], safeCount: 0 }
+
+const renderWithStore = () => {
+  const store = makeStore(undefined, { skipBroadcast: true })
+  const wrapper = ({ children }: { children: React.ReactNode }) => <Provider store={store}>{children}</Provider>
+  return { store, ...renderHook(() => useUpdateSpace(mockSpace), { wrapper }) }
+}
+
+describe('useUpdateSpace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUpdateSpace.mockReset()
+  })
+
+  it('returns handleUpdate and no initial error', () => {
+    const { result } = renderWithStore()
+    expect(typeof result.current.handleUpdate).toBe('function')
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('calls the mutation with the space id and new name', async () => {
+    mockUpdateSpace.mockResolvedValue({})
+    const { result } = renderWithStore()
+
+    await act(async () => {
+      await result.current.handleUpdate({ name: 'Renamed' })
+    })
+
+    expect(mockUpdateSpace).toHaveBeenCalledWith({ id: 42, updateSpaceDto: { name: 'Renamed' } })
+  })
+
+  it('dispatches a success notification after a successful update', async () => {
+    mockUpdateSpace.mockResolvedValue({})
+    const { result, store } = renderWithStore()
+
+    await act(async () => {
+      await result.current.handleUpdate({ name: 'Renamed' })
+    })
+
+    const notifications = store.getState().notifications
+    expect(notifications.length).toBeGreaterThan(0)
+    const last = notifications[notifications.length - 1]
+    expect(last.message).toBe('Updated workspace name')
+    expect(last.variant).toBe('success')
+    expect(last.groupKey).toBe('space-update-name')
+  })
+
+  it('sets an error message when the mutation rejects', async () => {
+    mockUpdateSpace.mockRejectedValue(new Error('network'))
+    const { result } = renderWithStore()
+
+    await act(async () => {
+      await result.current.handleUpdate({ name: 'Renamed' })
+    })
+
+    expect(result.current.error).toBe('Error updating the workspace. Please try again.')
+  })
+
+  it('clears a previous error before a new attempt', async () => {
+    mockUpdateSpace.mockRejectedValueOnce(new Error('first')).mockResolvedValueOnce({})
+    const { result } = renderWithStore()
+
+    await act(async () => {
+      await result.current.handleUpdate({ name: 'A' })
+    })
+    expect(result.current.error).toBeDefined()
+
+    await act(async () => {
+      await result.current.handleUpdate({ name: 'B' })
+    })
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('does nothing when space is undefined', async () => {
+    const store = makeStore(undefined, { skipBroadcast: true })
+    const wrapper = ({ children }: { children: React.ReactNode }) => <Provider store={store}>{children}</Provider>
+    const { result } = renderHook(() => useUpdateSpace(undefined), { wrapper })
+
+    await act(async () => {
+      await result.current.handleUpdate({ name: 'X' })
+    })
+
+    expect(mockUpdateSpace).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/spaces/components/SpaceSettings/__tests__/useUpdateSpace.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/__tests__/useUpdateSpace.test.tsx
@@ -4,7 +4,8 @@ import { makeStore } from '@/store'
 import { useUpdateSpace } from '../useUpdateSpace'
 import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 
-const mockUpdateSpace = jest.fn()
+const mockUnwrap = jest.fn()
+const mockUpdateSpace = jest.fn(() => ({ unwrap: mockUnwrap }))
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
   useSpacesUpdateV1Mutation: jest.fn(() => [mockUpdateSpace]),
@@ -21,7 +22,7 @@ const renderWithStore = () => {
 describe('useUpdateSpace', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUpdateSpace.mockReset()
+    mockUnwrap.mockReset()
   })
 
   it('returns handleUpdate and no initial error', () => {
@@ -31,7 +32,7 @@ describe('useUpdateSpace', () => {
   })
 
   it('calls the mutation with the space id and new name', async () => {
-    mockUpdateSpace.mockResolvedValue({})
+    mockUnwrap.mockResolvedValue({})
     const { result } = renderWithStore()
 
     await act(async () => {
@@ -42,7 +43,7 @@ describe('useUpdateSpace', () => {
   })
 
   it('dispatches a success notification after a successful update', async () => {
-    mockUpdateSpace.mockResolvedValue({})
+    mockUnwrap.mockResolvedValue({})
     const { result, store } = renderWithStore()
 
     await act(async () => {
@@ -58,7 +59,7 @@ describe('useUpdateSpace', () => {
   })
 
   it('sets an error message when the mutation rejects', async () => {
-    mockUpdateSpace.mockRejectedValue(new Error('network'))
+    mockUnwrap.mockRejectedValue(new Error('network'))
     const { result } = renderWithStore()
 
     await act(async () => {
@@ -69,7 +70,7 @@ describe('useUpdateSpace', () => {
   })
 
   it('clears a previous error before a new attempt', async () => {
-    mockUpdateSpace.mockRejectedValueOnce(new Error('first')).mockResolvedValueOnce({})
+    mockUnwrap.mockRejectedValueOnce(new Error('first')).mockResolvedValueOnce({})
     const { result } = renderWithStore()
 
     await act(async () => {

--- a/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
@@ -19,9 +19,9 @@ const SpaceSettings = ({ activePage = 'general' }: { activePage?: SettingsPageKe
   return (
     <div>
       {isInvited && <PreviewInvite />}
-      <div className="flex items-start gap-8 max-w-[1180px]">
+      <div className="flex items-start gap-12 max-w-[1100px]">
         <SettingsRail activePage={activePage} />
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0 max-w-[720px]">
           <ActiveContent />
         </div>
       </div>

--- a/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
@@ -19,9 +19,9 @@ const SpaceSettings = ({ activePage = 'general' }: { activePage?: SettingsPageKe
   return (
     <div>
       {isInvited && <PreviewInvite />}
-      <div className="flex items-start gap-12 max-w-[1100px]">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:gap-12 sm:max-w-[1100px]">
         <SettingsRail activePage={activePage} />
-        <div className="flex-1 min-w-0 max-w-[720px]">
+        <div className="flex-1 min-w-0 sm:max-w-[720px]">
           <ActiveContent />
         </div>
       </div>

--- a/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
@@ -1,4 +1,3 @@
-import type { ComponentType } from 'react'
 import { useIsInvited } from '@/features/spaces'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import SettingsRail, { type SettingsPageKey } from './SettingsRail'
@@ -6,15 +5,8 @@ import GeneralPage from './pages/GeneralPage'
 import AccountPage from './pages/AccountPage'
 import AboutPage from './pages/AboutPage'
 
-const PAGES: Record<SettingsPageKey, ComponentType> = {
-  general: GeneralPage,
-  account: AccountPage,
-  about: AboutPage,
-}
-
 const SpaceSettings = ({ activePage = 'general' }: { activePage?: SettingsPageKey }) => {
   const isInvited = useIsInvited()
-  const ActiveContent = PAGES[activePage]
 
   return (
     <div>
@@ -22,7 +14,9 @@ const SpaceSettings = ({ activePage = 'general' }: { activePage?: SettingsPageKe
       <div className="flex flex-col sm:flex-row sm:items-start sm:gap-12 sm:max-w-[1100px]">
         <SettingsRail activePage={activePage} />
         <div className="flex-1 min-w-0 sm:max-w-[720px]">
-          <ActiveContent />
+          {activePage === 'general' && <GeneralPage />}
+          {activePage === 'account' && <AccountPage />}
+          {activePage === 'about' && <AboutPage />}
         </div>
       </div>
     </div>

--- a/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/index.tsx
@@ -1,96 +1,30 @@
-import { useAppSelector } from '@/store'
-import { Button, Card, Grid2, Stack, Tooltip } from '@mui/material'
-import { Typography } from '@/components/ui/typography'
-import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import { useState } from 'react'
-import { useCurrentSpaceId, useIsAdmin, useIsInvited, useIsActiveMember } from '@/features/spaces'
-import { isAuthenticated } from '@/store/authSlice'
+import type { ComponentType } from 'react'
+import { useIsInvited } from '@/features/spaces'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
-import DeleteSpaceDialog from './DeleteSpaceDialog'
-import UpdateSpaceForm from './UpdateSpaceForm'
-import { trackEvent } from '@/services/analytics'
-import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
-import ExternalLink from '@/components/common/ExternalLink'
-import { AppRoutes } from '@/config/routes'
-import LeaveSpaceDialog from './LeaveSpaceDialog'
-import { useIsLastActiveAdmin } from '../../hooks/useIsLastActiveAdmin'
+import SettingsRail, { type SettingsPageKey } from './SettingsRail'
+import GeneralPage from './pages/GeneralPage'
+import AccountPage from './pages/AccountPage'
+import AboutPage from './pages/AboutPage'
 
-const SpaceSettings = () => {
-  const [deleteSpaceOpen, setDeleteSpaceOpen] = useState(false)
-  const [leaveSpaceOpen, setLeaveSpaceOpen] = useState(false)
-  const isAdmin = useIsAdmin()
-  const spaceId = useCurrentSpaceId()
-  const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { currentData: space } = useSpacesGetOneV1Query({ id: Number(spaceId) }, { skip: !isUserSignedIn || !spaceId })
+const PAGES: Record<SettingsPageKey, ComponentType> = {
+  general: GeneralPage,
+  account: AccountPage,
+  about: AboutPage,
+}
+
+const SpaceSettings = ({ activePage = 'general' }: { activePage?: SettingsPageKey }) => {
   const isInvited = useIsInvited()
-  const isLastActiveAdmin = useIsLastActiveAdmin()
-  const isActiveMember = useIsActiveMember()
+  const ActiveContent = PAGES[activePage]
 
   return (
     <div>
       {isInvited && <PreviewInvite />}
-      <Typography variant="h2" className="font-bold leading-[1] tracking-tight mb-6">
-        Settings
-      </Typography>
-      <Card>
-        <Grid2 container p={4} spacing={2}>
-          <Grid2 size={{ xs: 12, md: 4 }}>
-            <Typography variant="paragraph-bold">General</Typography>
-          </Grid2>
-          <Grid2 size={{ xs: 12, md: 8 }}>
-            <Typography className="mb-4">
-              The workspace name is visible in the sidebar menu, headings to all its members. Usually it&apos;s a name
-              of the company or a business.{' '}
-              <ExternalLink href={AppRoutes.privacy}>How is this data stored?</ExternalLink>
-            </Typography>
-
-            <UpdateSpaceForm space={space} />
-          </Grid2>
-        </Grid2>
-
-        <Grid2 container p={4} spacing={2}>
-          <Grid2 size={{ xs: 12, md: 4 }}>
-            <Typography variant="paragraph-bold">Danger Zone</Typography>
-          </Grid2>
-          <Grid2 size={{ xs: 12, md: 8 }}>
-            <Typography className="mb-4">This action cannot be undone.</Typography>
-
-            <Stack direction="row" spacing={2}>
-              <Tooltip title={isLastActiveAdmin ? 'You are the last active admin and cannot leave the workspace.' : ''}>
-                <span>
-                  <Button
-                    data-testid="space-leave-button"
-                    onClick={() => {
-                      setLeaveSpaceOpen(true)
-                      trackEvent({ ...SPACE_EVENTS.LEAVE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
-                    }}
-                    variant={isAdmin ? 'outlined' : 'danger'}
-                    color="error"
-                    disabled={isLastActiveAdmin || !isActiveMember}
-                  >
-                    Leave workspace
-                  </Button>
-                </span>
-              </Tooltip>
-
-              {isAdmin && (
-                <Button
-                  data-testid="space-delete-button"
-                  variant="danger"
-                  onClick={() => {
-                    setDeleteSpaceOpen(true)
-                    trackEvent({ ...SPACE_EVENTS.DELETE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
-                  }}
-                >
-                  Delete workspace
-                </Button>
-              )}
-            </Stack>
-          </Grid2>
-        </Grid2>
-      </Card>
-      {deleteSpaceOpen && <DeleteSpaceDialog space={space} onClose={() => setDeleteSpaceOpen(false)} />}
-      {leaveSpaceOpen && <LeaveSpaceDialog space={space} onClose={() => setLeaveSpaceOpen(false)} />}
+      <div className="flex items-start gap-8 max-w-[1180px]">
+        <SettingsRail activePage={activePage} />
+        <div className="flex-1 min-w-0">
+          <ActiveContent />
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
@@ -92,18 +92,20 @@ const LinkRow = ({
     href={href}
     target={external ? '_blank' : undefined}
     rel={external ? 'noreferrer noopener' : undefined}
-    className="flex items-center gap-3 px-3 py-3 rounded-md text-foreground no-underline transition-colors hover:bg-muted/60"
+    className="group flex items-center gap-3 px-3 py-3 rounded-md text-foreground no-underline transition-colors hover:bg-muted/60"
   >
-    <span className="shrink-0">{icon}</span>
+    <span className="shrink-0 transition-colors [&_svg]:transition-colors [&_svg]:group-hover:text-green-600">
+      {icon}
+    </span>
     <span className="flex-1 min-w-0">
-      <Typography variant="paragraph-small-bold" className="block">
+      <Typography variant="paragraph-small-bold" className="block transition-colors group-hover:text-green-600">
         {title}
       </Typography>
       <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
         {description}
       </Typography>
     </span>
-    <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+    <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 transition-colors group-hover:text-green-600" />
   </a>
 )
 
@@ -158,20 +160,23 @@ const AboutPage = () => {
             <button
               type="button"
               onClick={handleContactSupportClick}
-              className="flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer w-full"
+              className="group flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer w-full"
             >
               <span className="shrink-0">
-                <LifeBuoy className="h-4 w-4 text-muted-foreground" />
+                <LifeBuoy className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-green-600" />
               </span>
               <span className="flex-1 min-w-0">
-                <Typography variant="paragraph-small-bold" className="block">
+                <Typography
+                  variant="paragraph-small-bold"
+                  className="block transition-colors group-hover:text-green-600"
+                >
                   Contact Support
                 </Typography>
                 <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
                   Get help from our team
                 </Typography>
               </span>
-              <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 transition-colors group-hover:text-green-600" />
             </button>
           )}
         </div>
@@ -190,18 +195,18 @@ const AboutPage = () => {
             type="button"
             onClick={handleCookiePrefs}
             data-testid="cookie-preferences-button"
-            className="flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer"
+            className="group flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer"
           >
-            <Settings2 className="h-4 w-4 text-muted-foreground shrink-0" />
+            <Settings2 className="h-4 w-4 text-muted-foreground shrink-0 transition-colors group-hover:text-green-600" />
             <span className="flex-1 min-w-0">
-              <Typography variant="paragraph-small-bold" className="block">
+              <Typography variant="paragraph-small-bold" className="block transition-colors group-hover:text-green-600">
                 Cookie Preferences
               </Typography>
               <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
                 Manage what&apos;s enabled
               </Typography>
             </span>
-            <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 transition-colors group-hover:text-green-600" />
           </button>
         </div>
       </section>

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
@@ -94,18 +94,18 @@ const LinkRow = ({
     rel={external ? 'noreferrer noopener' : undefined}
     className="group flex items-center gap-3 px-3 py-3 rounded-md text-foreground no-underline transition-colors hover:bg-muted/60"
   >
-    <span className="shrink-0 transition-colors [&_svg]:transition-colors [&_svg]:group-hover:text-green-600">
+    <span className="shrink-0 transition-colors [&_svg]:transition-colors [&_svg]:group-hover:text-accent-success">
       {icon}
     </span>
     <span className="flex-1 min-w-0">
-      <Typography variant="paragraph-small-bold" className="block transition-colors group-hover:text-green-600">
+      <Typography variant="paragraph-small-bold" className="block transition-colors group-hover:text-accent-success">
         {title}
       </Typography>
       <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
         {description}
       </Typography>
     </span>
-    <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 transition-colors group-hover:text-green-600" />
+    <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 transition-colors group-hover:text-accent-success" />
   </a>
 )
 
@@ -148,11 +148,11 @@ const AboutPage = () => {
           <LinkRow
             href={STATUS_PAGE_URL}
             external
-            icon={<ActivityIcon className="h-4 w-4 text-green-600" />}
+            icon={<ActivityIcon className="h-4 w-4 text-accent-success" />}
             title="Service Status"
             description={
               <span>
-                <span className="text-green-600 font-semibold">●</span> All systems operational
+                <span className="text-accent-success font-semibold">●</span> All systems operational
               </span>
             }
           />
@@ -163,12 +163,12 @@ const AboutPage = () => {
               className="group flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer w-full"
             >
               <span className="shrink-0">
-                <LifeBuoy className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-green-600" />
+                <LifeBuoy className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-accent-success" />
               </span>
               <span className="flex-1 min-w-0">
                 <Typography
                   variant="paragraph-small-bold"
-                  className="block transition-colors group-hover:text-green-600"
+                  className="block transition-colors group-hover:text-accent-success"
                 >
                   Contact Support
                 </Typography>
@@ -176,7 +176,7 @@ const AboutPage = () => {
                   Get help from our team
                 </Typography>
               </span>
-              <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 transition-colors group-hover:text-green-600" />
+              <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 transition-colors group-hover:text-accent-success" />
             </button>
           )}
         </div>
@@ -197,16 +197,19 @@ const AboutPage = () => {
             data-testid="cookie-preferences-button"
             className="group flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer"
           >
-            <Settings2 className="h-4 w-4 text-muted-foreground shrink-0 transition-colors group-hover:text-green-600" />
+            <Settings2 className="h-4 w-4 text-muted-foreground shrink-0 transition-colors group-hover:text-accent-success" />
             <span className="flex-1 min-w-0">
-              <Typography variant="paragraph-small-bold" className="block transition-colors group-hover:text-green-600">
+              <Typography
+                variant="paragraph-small-bold"
+                className="block transition-colors group-hover:text-accent-success"
+              >
                 Cookie Preferences
               </Typography>
               <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
                 Manage what&apos;s enabled
               </Typography>
             </span>
-            <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 transition-colors group-hover:text-green-600" />
+            <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0 transition-colors group-hover:text-accent-success" />
           </button>
         </div>
       </section>

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
@@ -148,13 +148,9 @@ const AboutPage = () => {
           <LinkRow
             href={STATUS_PAGE_URL}
             external
-            icon={<ActivityIcon className="h-4 w-4 text-accent-success" />}
-            title="Service Status"
-            description={
-              <span>
-                <span className="text-accent-success font-semibold">●</span> All systems operational
-              </span>
-            }
+            icon={<ActivityIcon className="h-4 w-4 text-muted-foreground" />}
+            title="Sync Status"
+            description="Blockchain sync status across networks"
           />
           {showSupport && (
             <button

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
@@ -112,9 +112,74 @@ const AboutPage = () => {
 
   return (
     <div data-testid="settings-about-page">
+      {/* Help */}
+      <section className="bg-card rounded-2xl p-6 mb-3">
+        <Typography variant="paragraph-bold" className="mb-5 block tracking-tight">
+          Help
+        </Typography>
+
+        <div className="flex flex-col -mx-2">
+          <LinkRow
+            href={HELP_CENTER_URL}
+            external
+            icon={<BookOpen className="h-4 w-4 text-muted-foreground" />}
+            title="Help center"
+            description="Guides, FAQs, and troubleshooting."
+          />
+          <LinkRow
+            href={STATUS_PAGE_URL}
+            external
+            icon={<ActivityIcon className="h-4 w-4 text-green-600" />}
+            title="Service status"
+            description={
+              <span>
+                <span className="text-green-600 font-semibold">●</span> All systems operational
+              </span>
+            }
+          />
+          <LinkRow
+            href={HELP_CENTER_URL}
+            external
+            icon={<LifeBuoy className="h-4 w-4 text-muted-foreground" />}
+            title="Contact support"
+            description="Get help from our team."
+          />
+        </div>
+      </section>
+
+      {/* Legal & policies */}
+      <section className="bg-card rounded-2xl p-6 mb-3">
+        <Typography variant="paragraph-bold" className="mb-5 block tracking-tight">
+          Legal &amp; policies
+        </Typography>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 -mx-2">
+          {LEGAL_LINKS.map((link) => (
+            <LinkRow key={link.title} {...link} />
+          ))}
+          <button
+            type="button"
+            onClick={handleCookiePrefs}
+            data-testid="cookie-preferences-button"
+            className="flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer"
+          >
+            <Settings2 className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="flex-1 min-w-0">
+              <Typography variant="paragraph-small-bold" className="block">
+                Cookie preferences
+              </Typography>
+              <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
+                Manage what&apos;s enabled
+              </Typography>
+            </span>
+            <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          </button>
+        </div>
+      </section>
+
       {/* Version */}
-      <section className="bg-card rounded-2xl p-6 mb-4">
-        <Typography variant="paragraph-bold" className="mb-4 block">
+      <section className="bg-card rounded-2xl p-6 mb-3">
+        <Typography variant="paragraph-bold" className="mb-5 block tracking-tight">
           Version
         </Typography>
 
@@ -154,71 +219,6 @@ const AboutPage = () => {
             <ArrowUpRight className="h-3.5 w-3.5" />
             GitHub
           </Button>
-        </div>
-      </section>
-
-      {/* Legal & policies */}
-      <section className="bg-card rounded-2xl p-6 mb-4">
-        <Typography variant="paragraph-bold" className="mb-4 block">
-          Legal &amp; policies
-        </Typography>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 -mx-2">
-          {LEGAL_LINKS.map((link) => (
-            <LinkRow key={link.title} {...link} />
-          ))}
-          <button
-            type="button"
-            onClick={handleCookiePrefs}
-            data-testid="cookie-preferences-button"
-            className="flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer"
-          >
-            <Settings2 className="h-4 w-4 text-muted-foreground shrink-0" />
-            <span className="flex-1 min-w-0">
-              <Typography variant="paragraph-small-bold" className="block">
-                Cookie preferences
-              </Typography>
-              <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
-                Manage what&apos;s enabled
-              </Typography>
-            </span>
-            <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-          </button>
-        </div>
-      </section>
-
-      {/* Help & community */}
-      <section className="bg-card rounded-2xl p-6 mb-4">
-        <Typography variant="paragraph-bold" className="mb-4 block">
-          Help &amp; community
-        </Typography>
-
-        <div className="flex flex-col -mx-2">
-          <LinkRow
-            href={HELP_CENTER_URL}
-            external
-            icon={<BookOpen className="h-4 w-4 text-muted-foreground" />}
-            title="Help center"
-            description="Guides, FAQs, and troubleshooting."
-          />
-          <LinkRow
-            href={STATUS_PAGE_URL}
-            external
-            icon={<ActivityIcon className="h-4 w-4 text-green-600" />}
-            title="Service status"
-            description={
-              <span>
-                <span className="text-green-600 font-semibold">●</span> All systems operational
-              </span>
-            }
-          />
-          <LinkRow
-            href={HELP_CENTER_URL}
-            external
-            icon={<LifeBuoy className="h-4 w-4 text-muted-foreground" />}
-            title="Contact support"
-            description="Get help from our team."
-          />
         </div>
       </section>
     </div>

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
@@ -1,0 +1,228 @@
+import {
+  ActivityIcon,
+  ArrowUpRight,
+  BookOpen,
+  Building2,
+  Cookie,
+  FileText,
+  Github,
+  LifeBuoy,
+  Scale,
+  Settings2,
+  Shield,
+} from 'lucide-react'
+import { useAppDispatch } from '@/store'
+import { openCookieBanner } from '@/store/popupSlice'
+import { CookieAndTermType } from '@/store/cookiesAndTermsSlice'
+import { APP_HOMEPAGE, APP_VERSION } from '@/config/version'
+import { BRAND_NAME } from '@/config/constants'
+import { AppRoutes } from '@/config/routes'
+import { HELP_CENTER_URL } from '@safe-global/utils/config/constants'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Typography } from '@/components/ui/typography'
+
+const STATUS_PAGE_URL = 'https://status.safe.global'
+const RELEASE_URL = `${APP_HOMEPAGE}/releases/tag/web-v${APP_VERSION}`
+
+type LegalLink = {
+  title: string
+  description: string
+  href: string
+  icon: React.ReactNode
+  external?: boolean
+}
+
+const LEGAL_LINKS: LegalLink[] = [
+  {
+    title: 'Terms of use',
+    description: 'Conditions for using Safe{Wallet}',
+    href: AppRoutes.terms,
+    icon: <FileText className="h-4 w-4 text-muted-foreground" />,
+    external: true,
+  },
+  {
+    title: 'Privacy policy',
+    description: 'What we collect and why',
+    href: AppRoutes.privacy,
+    icon: <Shield className="h-4 w-4 text-muted-foreground" />,
+    external: true,
+  },
+  {
+    title: 'Licenses',
+    description: 'Open source attribution',
+    href: AppRoutes.licenses,
+    icon: <Scale className="h-4 w-4 text-muted-foreground" />,
+    external: true,
+  },
+  {
+    title: 'Imprint',
+    description: 'Safe Ecosystem Foundation',
+    href: AppRoutes.imprint,
+    icon: <Building2 className="h-4 w-4 text-muted-foreground" />,
+    external: true,
+  },
+  {
+    title: 'Cookie policy',
+    description: 'How cookies are used',
+    href: AppRoutes.cookie,
+    icon: <Cookie className="h-4 w-4 text-muted-foreground" />,
+    external: true,
+  },
+]
+
+const LinkRow = ({
+  href,
+  icon,
+  title,
+  description,
+  external = false,
+}: {
+  href: string
+  icon: React.ReactNode
+  title: string
+  description: React.ReactNode
+  external?: boolean
+}) => (
+  <a
+    href={href}
+    target={external ? '_blank' : undefined}
+    rel={external ? 'noreferrer noopener' : undefined}
+    className="flex items-center gap-3 px-3 py-3 rounded-md text-foreground no-underline transition-colors hover:bg-muted/60"
+  >
+    <span className="shrink-0">{icon}</span>
+    <span className="flex-1 min-w-0">
+      <Typography variant="paragraph-small-bold" className="block">
+        {title}
+      </Typography>
+      <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
+        {description}
+      </Typography>
+    </span>
+    <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+  </a>
+)
+
+const AboutPage = () => {
+  const dispatch = useAppDispatch()
+
+  const handleCookiePrefs = () => {
+    dispatch(openCookieBanner({ warningKey: CookieAndTermType.NECESSARY }))
+  }
+
+  return (
+    <div data-testid="settings-about-page">
+      {/* Version */}
+      <section className="bg-card rounded-2xl p-6 mb-4">
+        <Typography variant="paragraph-bold" className="mb-4 block">
+          Version
+        </Typography>
+
+        <a
+          href={RELEASE_URL}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center gap-2 no-underline"
+          aria-label={`View release notes for v${APP_VERSION}`}
+        >
+          <Badge variant="secondary" className="h-6 px-2.5 text-sm font-mono">
+            v{APP_VERSION}
+          </Badge>
+          <span className="inline-flex items-center gap-1 text-muted-foreground text-xs font-semibold">
+            Release notes
+            <ArrowUpRight className="h-3 w-3" />
+          </span>
+        </a>
+
+        <div className="flex items-center justify-between gap-4 mt-4 pt-4 border-t border-border">
+          <span className="flex items-center gap-3 min-w-0">
+            <Github className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="min-w-0">
+              <Typography variant="paragraph-small-bold" className="block">
+                Open source
+              </Typography>
+              <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
+                {BRAND_NAME} is fully open source.
+              </Typography>
+            </span>
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            render={<a href={APP_HOMEPAGE} target="_blank" rel="noreferrer noopener" />}
+          >
+            <ArrowUpRight className="h-3.5 w-3.5" />
+            GitHub
+          </Button>
+        </div>
+      </section>
+
+      {/* Legal & policies */}
+      <section className="bg-card rounded-2xl p-6 mb-4">
+        <Typography variant="paragraph-bold" className="mb-4 block">
+          Legal &amp; policies
+        </Typography>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 -mx-2">
+          {LEGAL_LINKS.map((link) => (
+            <LinkRow key={link.title} {...link} />
+          ))}
+          <button
+            type="button"
+            onClick={handleCookiePrefs}
+            data-testid="cookie-preferences-button"
+            className="flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer"
+          >
+            <Settings2 className="h-4 w-4 text-muted-foreground shrink-0" />
+            <span className="flex-1 min-w-0">
+              <Typography variant="paragraph-small-bold" className="block">
+                Cookie preferences
+              </Typography>
+              <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
+                Manage what&apos;s enabled
+              </Typography>
+            </span>
+            <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          </button>
+        </div>
+      </section>
+
+      {/* Help & community */}
+      <section className="bg-card rounded-2xl p-6 mb-4">
+        <Typography variant="paragraph-bold" className="mb-4 block">
+          Help &amp; community
+        </Typography>
+
+        <div className="flex flex-col -mx-2">
+          <LinkRow
+            href={HELP_CENTER_URL}
+            external
+            icon={<BookOpen className="h-4 w-4 text-muted-foreground" />}
+            title="Help center"
+            description="Guides, FAQs, and troubleshooting."
+          />
+          <LinkRow
+            href={STATUS_PAGE_URL}
+            external
+            icon={<ActivityIcon className="h-4 w-4 text-green-600" />}
+            title="Service status"
+            description={
+              <span>
+                <span className="text-green-600 font-semibold">●</span> All systems operational
+              </span>
+            }
+          />
+          <LinkRow
+            href={HELP_CENTER_URL}
+            external
+            icon={<LifeBuoy className="h-4 w-4 text-muted-foreground" />}
+            title="Contact support"
+            description="Get help from our team."
+          />
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default AboutPage

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
@@ -35,14 +35,14 @@ type LegalLink = {
 
 const LEGAL_LINKS: LegalLink[] = [
   {
-    title: 'Terms of use',
-    description: 'Conditions for using Safe{Wallet}',
+    title: 'Terms & Conditions',
+    description: 'For using Safe{Wallet}',
     href: AppRoutes.terms,
     icon: <FileText className="h-4 w-4 text-muted-foreground" />,
     external: true,
   },
   {
-    title: 'Privacy policy',
+    title: 'Privacy Policy',
     description: 'What we collect and why',
     href: AppRoutes.privacy,
     icon: <Shield className="h-4 w-4 text-muted-foreground" />,
@@ -57,13 +57,13 @@ const LEGAL_LINKS: LegalLink[] = [
   },
   {
     title: 'Imprint',
-    description: 'Safe Ecosystem Foundation',
+    description: 'Safe Labs GmbH',
     href: AppRoutes.imprint,
     icon: <Building2 className="h-4 w-4 text-muted-foreground" />,
     external: true,
   },
   {
-    title: 'Cookie policy',
+    title: 'Cookie Policy',
     description: 'How cookies are used',
     href: AppRoutes.cookie,
     icon: <Cookie className="h-4 w-4 text-muted-foreground" />,
@@ -123,14 +123,14 @@ const AboutPage = () => {
             href={HELP_CENTER_URL}
             external
             icon={<BookOpen className="h-4 w-4 text-muted-foreground" />}
-            title="Help center"
-            description="Guides, FAQs, and troubleshooting."
+            title="Help Center"
+            description="Guides, FAQs, and troubleshooting"
           />
           <LinkRow
             href={STATUS_PAGE_URL}
             external
             icon={<ActivityIcon className="h-4 w-4 text-green-600" />}
-            title="Service status"
+            title="Service Status"
             description={
               <span>
                 <span className="text-green-600 font-semibold">●</span> All systems operational
@@ -141,16 +141,15 @@ const AboutPage = () => {
             href={HELP_CENTER_URL}
             external
             icon={<LifeBuoy className="h-4 w-4 text-muted-foreground" />}
-            title="Contact support"
-            description="Get help from our team."
+            title="Contact Support"
+            description="Get help from our team"
           />
         </div>
       </section>
 
-      {/* Legal & policies */}
       <section className="bg-card rounded-2xl p-6 mb-3">
         <Typography variant="paragraph-bold" className="mb-5 block tracking-tight">
-          Legal &amp; policies
+          Legal &amp; Policies
         </Typography>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 -mx-2">
@@ -166,7 +165,7 @@ const AboutPage = () => {
             <Settings2 className="h-4 w-4 text-muted-foreground shrink-0" />
             <span className="flex-1 min-w-0">
               <Typography variant="paragraph-small-bold" className="block">
-                Cookie preferences
+                Cookie Preferences
               </Typography>
               <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
                 Manage what&apos;s enabled
@@ -207,7 +206,7 @@ const AboutPage = () => {
                 Open source
               </Typography>
               <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
-                {BRAND_NAME} is fully open source.
+                {BRAND_NAME} is fully open source
               </Typography>
             </span>
           </span>

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AboutPage.tsx
@@ -11,6 +11,7 @@ import {
   Settings2,
   Shield,
 } from 'lucide-react'
+import { useState, useCallback } from 'react'
 import { useAppDispatch } from '@/store'
 import { openCookieBanner } from '@/store/popupSlice'
 import { CookieAndTermType } from '@/store/cookiesAndTermsSlice'
@@ -21,6 +22,9 @@ import { HELP_CENTER_URL } from '@safe-global/utils/config/constants'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Typography } from '@/components/ui/typography'
+import { useLoadFeature } from '@/features/__core__'
+import { SupportChatFeature, useSupportChat } from '@/features/support-chat'
+import { useIsOfficialHost } from '@/hooks/useIsOfficialHost'
 
 const STATUS_PAGE_URL = 'https://status.safe.global'
 const RELEASE_URL = `${APP_HOMEPAGE}/releases/tag/web-v${APP_VERSION}`
@@ -105,6 +109,19 @@ const LinkRow = ({
 
 const AboutPage = () => {
   const dispatch = useAppDispatch()
+  const [isSupportOpen, setSupportOpen] = useState(false)
+  const { SupportChatDrawer, $isDisabled } = useLoadFeature(SupportChatFeature)
+  const { config, user } = useSupportChat()
+  const isOfficialHost = useIsOfficialHost()
+  const showSupport = !$isDisabled && isOfficialHost
+
+  const handleContactSupportClick = useCallback(() => {
+    setSupportOpen(true)
+  }, [])
+
+  const handleSupportClose = useCallback(() => {
+    setSupportOpen(false)
+  }, [])
 
   const handleCookiePrefs = () => {
     dispatch(openCookieBanner({ warningKey: CookieAndTermType.NECESSARY }))
@@ -137,13 +154,26 @@ const AboutPage = () => {
               </span>
             }
           />
-          <LinkRow
-            href={HELP_CENTER_URL}
-            external
-            icon={<LifeBuoy className="h-4 w-4 text-muted-foreground" />}
-            title="Contact Support"
-            description="Get help from our team"
-          />
+          {showSupport && (
+            <button
+              type="button"
+              onClick={handleContactSupportClick}
+              className="flex items-center gap-3 px-3 py-3 rounded-md text-foreground text-left transition-colors hover:bg-muted/60 cursor-pointer w-full"
+            >
+              <span className="shrink-0">
+                <LifeBuoy className="h-4 w-4 text-muted-foreground" />
+              </span>
+              <span className="flex-1 min-w-0">
+                <Typography variant="paragraph-small-bold" className="block">
+                  Contact Support
+                </Typography>
+                <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
+                  Get help from our team
+                </Typography>
+              </span>
+              <ArrowUpRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            </button>
+          )}
         </div>
       </section>
 
@@ -220,6 +250,10 @@ const AboutPage = () => {
           </Button>
         </div>
       </section>
+
+      {showSupport && (
+        <SupportChatDrawer open={isSupportOpen} onClose={handleSupportClose} config={config} user={user} />
+      )}
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
@@ -50,7 +50,6 @@ const AccountPage = () => {
   }
 
   const memberName = membership.name || 'User'
-  const displayName = signerAddress ? shortenAddress(signerAddress) : memberName
   const role = membership.role.toLowerCase()
 
   return (
@@ -81,17 +80,13 @@ const AccountPage = () => {
                     />
                   }
                 >
-                  {displayName}
+                  {shortenAddress(signerAddress)}
                 </TooltipTrigger>
                 <TooltipContent side="top" className="font-mono">
                   {signerAddress}
                 </TooltipContent>
               </Tooltip>
-            ) : (
-              <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 font-mono">
-                {displayName}
-              </Typography>
-            )}
+            ) : null}
             <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 capitalize">
               {role}
             </Typography>

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
@@ -15,7 +15,7 @@ const AccountPage = () => {
   const { logout } = useLogout()
 
   const handleSignOut = () => {
-    trackEvent(SPACE_EVENTS.AUTH_LOGGED_OUT, { timestamp: new Date().toISOString() })
+    trackEvent(SPACE_EVENTS.AUTH_LOGGED_OUT)
     logout()
   }
 

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
@@ -1,0 +1,92 @@
+import { LogOut } from 'lucide-react'
+import { useCurrentMemberProfile, MemberStatus } from '@/features/spaces'
+import useLogout from '@/hooks/useLogout'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import InitialsAvatar from '../../InitialsAvatar'
+import { Button } from '@/components/ui/button'
+import { Typography } from '@/components/ui/typography'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const AccountPage = () => {
+  const { membership, signerAddress, isLoading } = useCurrentMemberProfile()
+  const { logout } = useLogout()
+
+  const handleSignOut = () => {
+    trackEvent(SPACE_EVENTS.AUTH_LOGGED_OUT, { timestamp: new Date().toISOString() })
+    logout()
+  }
+
+  if (isLoading && !membership) {
+    return (
+      <section className="bg-card rounded-2xl p-6 mb-4">
+        <Typography variant="paragraph-bold" className="mb-4 block">
+          Signed in
+        </Typography>
+        <div className="flex items-center gap-4">
+          <Skeleton className="size-12 rounded-md" />
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  if (!membership || membership.status !== MemberStatus.ACTIVE) {
+    return (
+      <section className="bg-card rounded-2xl p-6 mb-4" data-testid="settings-account-page">
+        <Typography variant="paragraph-bold" className="mb-2 block">
+          Account
+        </Typography>
+        <Typography variant="paragraph-small" color="muted">
+          You&apos;re not signed in to this workspace.
+        </Typography>
+      </section>
+    )
+  }
+
+  const memberName = membership.name || 'User'
+  const displayName = signerAddress ? shortenAddress(signerAddress) : memberName
+  const role = membership.role.toLowerCase()
+
+  return (
+    <section className="bg-card rounded-2xl p-6 mb-4" data-testid="settings-account-page">
+      <Typography variant="paragraph-bold" className="mb-4 block">
+        Signed in
+      </Typography>
+
+      <div className="flex items-center gap-4 mb-6">
+        <InitialsAvatar name={memberName} size="large" />
+        <div className="flex-1 min-w-0">
+          <Typography variant="paragraph-small-bold" className="block">
+            {memberName}
+          </Typography>
+          <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 font-mono">
+            {displayName}
+          </Typography>
+          <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 capitalize">
+            {role}
+          </Typography>
+        </div>
+      </div>
+
+      <div className="pt-4 border-t border-border">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleSignOut}
+          data-testid="settings-account-sign-out"
+          className="text-destructive"
+        >
+          <LogOut className="h-3.5 w-3.5" />
+          Sign out
+        </Button>
+      </div>
+    </section>
+  )
+}
+
+export default AccountPage

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
@@ -20,8 +20,8 @@ const AccountPage = () => {
 
   if (isLoading && !membership) {
     return (
-      <section className="bg-card rounded-2xl p-6 mb-4">
-        <Typography variant="paragraph-bold" className="mb-4 block">
+      <section className="bg-card rounded-2xl p-6 mb-3">
+        <Typography variant="paragraph-bold" className="mb-5 block tracking-tight">
           Signed in
         </Typography>
         <div className="flex items-center gap-4">
@@ -37,9 +37,9 @@ const AccountPage = () => {
 
   if (!membership || membership.status !== MemberStatus.ACTIVE) {
     return (
-      <section className="bg-card rounded-2xl p-6 mb-4" data-testid="settings-account-page">
-        <Typography variant="paragraph-bold" className="mb-2 block">
-          Account
+      <section className="bg-card rounded-2xl p-6 mb-3" data-testid="settings-account-page">
+        <Typography variant="paragraph-bold" className="mb-2 block tracking-tight">
+          Signed in
         </Typography>
         <Typography variant="paragraph-small" color="muted">
           You&apos;re not signed in to this workspace.
@@ -53,34 +53,27 @@ const AccountPage = () => {
   const role = membership.role.toLowerCase()
 
   return (
-    <section className="bg-card rounded-2xl p-6 mb-4" data-testid="settings-account-page">
-      <Typography variant="paragraph-bold" className="mb-4 block">
+    <section className="bg-card rounded-2xl p-6 mb-3" data-testid="settings-account-page">
+      <Typography variant="paragraph-bold" className="mb-5 block tracking-tight">
         Signed in
       </Typography>
 
-      <div className="flex items-center gap-4 mb-6">
-        <InitialsAvatar name={memberName} size="large" />
-        <div className="flex-1 min-w-0">
-          <Typography variant="paragraph-small-bold" className="block">
-            {memberName}
-          </Typography>
-          <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 font-mono">
-            {displayName}
-          </Typography>
-          <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 capitalize">
-            {role}
-          </Typography>
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-4 min-w-0">
+          <InitialsAvatar name={memberName} size="large" />
+          <div className="flex flex-col min-w-0">
+            <Typography variant="paragraph-small-bold" className="block">
+              {memberName}
+            </Typography>
+            <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 font-mono">
+              {displayName}
+            </Typography>
+            <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 capitalize">
+              {role}
+            </Typography>
+          </div>
         </div>
-      </div>
-
-      <div className="pt-4 border-t border-border">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleSignOut}
-          data-testid="settings-account-sign-out"
-          className="text-destructive"
-        >
+        <Button variant="outline" size="sm" onClick={handleSignOut} data-testid="settings-account-sign-out">
           <LogOut className="h-3.5 w-3.5" />
           Sign out
         </Button>

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
@@ -10,7 +10,7 @@ import { Typography } from '@/components/ui/typography'
 import { Skeleton } from '@/components/ui/skeleton'
 
 const AccountPage = () => {
-  const { membership, signerAddress, isLoading } = useCurrentMemberProfile()
+  const { membership, signerAddress, email, isLoading } = useCurrentMemberProfile()
   const { logout } = useLogout()
 
   const handleSignOut = () => {
@@ -65,9 +65,15 @@ const AccountPage = () => {
             <Typography variant="paragraph-small-bold" className="block">
               {memberName}
             </Typography>
-            <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 font-mono">
-              {displayName}
-            </Typography>
+            {email ? (
+              <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
+                {email}
+              </Typography>
+            ) : (
+              <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 font-mono">
+                {displayName}
+              </Typography>
+            )}
             <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 capitalize">
               {role}
             </Typography>

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
@@ -8,6 +8,7 @@ import InitialsAvatar from '../../InitialsAvatar'
 import { Button } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
 const AccountPage = () => {
   const { membership, signerAddress, email, isLoading } = useCurrentMemberProfile()
@@ -69,6 +70,23 @@ const AccountPage = () => {
               <Typography variant="paragraph-mini" color="muted" className="block mt-0.5">
                 {email}
               </Typography>
+            ) : signerAddress ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Typography
+                      variant="paragraph-mini"
+                      color="muted"
+                      className="block mt-0.5 font-mono w-fit cursor-default"
+                    />
+                  }
+                >
+                  {displayName}
+                </TooltipTrigger>
+                <TooltipContent side="top" className="font-mono">
+                  {signerAddress}
+                </TooltipContent>
+              </Tooltip>
             ) : (
               <Typography variant="paragraph-mini" color="muted" className="block mt-0.5 font-mono">
                 {displayName}

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/AccountPage.tsx
@@ -60,7 +60,7 @@ const AccountPage = () => {
 
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-4 min-w-0">
-          <InitialsAvatar name={memberName} size="large" />
+          <InitialsAvatar name={memberName} size="large" rounded />
           <div className="flex flex-col min-w-0">
             <Typography variant="paragraph-small-bold" className="block">
               {memberName}

--- a/apps/web/src/features/spaces/components/SpaceSettings/pages/GeneralPage.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/pages/GeneralPage.tsx
@@ -1,0 +1,23 @@
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
+import { useCurrentSpaceId } from '@/features/spaces'
+import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import IdentitySection from '../sections/IdentitySection'
+import AppearanceSection from '../sections/AppearanceSection'
+import DangerZoneSection from '../sections/DangerZoneSection'
+
+const GeneralPage = () => {
+  const spaceId = useCurrentSpaceId()
+  const isSignedIn = useAppSelector(isAuthenticated)
+  const { currentData: space } = useSpacesGetOneV1Query({ id: Number(spaceId) }, { skip: !isSignedIn || !spaceId })
+
+  return (
+    <div data-testid="settings-general-page">
+      <IdentitySection space={space} />
+      <AppearanceSection />
+      <DangerZoneSection space={space} />
+    </div>
+  )
+}
+
+export default GeneralPage

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/AppearanceSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/AppearanceSection.tsx
@@ -1,0 +1,84 @@
+import { useAppDispatch, useAppSelector } from '@/store'
+import { selectSettings, setDarkMode } from '@/store/settingsSlice'
+import { trackEvent, SETTINGS_EVENTS } from '@/services/analytics'
+import { Label } from '@/components/ui/label'
+import { Typography } from '@/components/ui/typography'
+import { cn } from '@/utils/cn'
+
+type ThemeOption = {
+  value: 'light' | 'dark' | 'system'
+  label: string
+}
+
+const THEME_OPTIONS: ThemeOption[] = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+]
+
+const getCurrentTheme = (darkMode: boolean | undefined): ThemeOption['value'] => {
+  if (darkMode === true) return 'dark'
+  if (darkMode === false) return 'light'
+  return 'system'
+}
+
+const AppearanceSection = () => {
+  const dispatch = useAppDispatch()
+  const settings = useAppSelector(selectSettings)
+  const current = getCurrentTheme(settings.theme.darkMode)
+
+  const handleChange = (value: ThemeOption['value']) => {
+    if (value === current) return
+    const nextDarkMode = value === 'dark' ? true : value === 'light' ? false : undefined
+    dispatch(setDarkMode(nextDarkMode))
+    if (value !== 'system') {
+      trackEvent({ ...SETTINGS_EVENTS.APPEARANCE.DARK_MODE, label: value === 'dark' })
+    }
+  }
+
+  return (
+    <section className="bg-card rounded-2xl p-6 mb-4">
+      <Typography variant="paragraph-bold" className="mb-4 block">
+        Appearance
+      </Typography>
+
+      <div className="flex flex-col gap-1.5">
+        <Label>Theme</Label>
+        <div role="radiogroup" aria-label="Theme" className="flex flex-col sm:flex-row gap-2">
+          {THEME_OPTIONS.map((opt) => {
+            const isSelected = current === opt.value
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                role="radio"
+                aria-checked={isSelected}
+                onClick={() => handleChange(opt.value)}
+                data-testid={`theme-card-${opt.value}`}
+                className={cn(
+                  'flex-1 flex items-center gap-3 px-4 py-3 rounded-lg text-left transition-colors',
+                  isSelected
+                    ? 'bg-sidebar-accent text-sidebar-accent-foreground dark:bg-accent dark:text-primary'
+                    : 'bg-muted hover:bg-muted/70',
+                )}
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    'h-4 w-4 rounded-full border-[1.5px] flex items-center justify-center shrink-0',
+                    isSelected ? 'border-sidebar-accent-foreground dark:border-primary' : 'border-muted-foreground',
+                  )}
+                >
+                  {isSelected && <span className="h-2 w-2 rounded-full bg-sidebar-accent-foreground dark:bg-primary" />}
+                </span>
+                <Typography variant="paragraph-small-bold">{opt.label}</Typography>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default AppearanceSection

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/AppearanceSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/AppearanceSection.tsx
@@ -37,13 +37,13 @@ const AppearanceSection = () => {
   }
 
   return (
-    <section className="bg-card rounded-2xl p-6 mb-4">
-      <Typography variant="paragraph-bold" className="mb-4 block">
+    <section className="bg-card rounded-2xl p-6 mb-3">
+      <Typography variant="paragraph-bold" className="mb-5 block tracking-tight">
         Appearance
       </Typography>
 
-      <div className="flex flex-col gap-1.5">
-        <Label>Theme</Label>
+      <div className="flex flex-col gap-2">
+        <Label className="text-muted-foreground">Theme</Label>
         <div role="radiogroup" aria-label="Theme" className="flex flex-col sm:flex-row gap-2">
           {THEME_OPTIONS.map((opt) => {
             const isSelected = current === opt.value

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/AppearanceSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/AppearanceSection.tsx
@@ -31,9 +31,7 @@ const AppearanceSection = () => {
     if (value === current) return
     const nextDarkMode = value === 'dark' ? true : value === 'light' ? false : undefined
     dispatch(setDarkMode(nextDarkMode))
-    if (value !== 'system') {
-      trackEvent({ ...SETTINGS_EVENTS.APPEARANCE.DARK_MODE, label: value === 'dark' })
-    }
+    trackEvent({ ...SETTINGS_EVENTS.APPEARANCE.DARK_MODE, label: value })
   }
 
   return (
@@ -44,15 +42,14 @@ const AppearanceSection = () => {
 
       <div className="flex flex-col gap-2">
         <Label className="text-muted-foreground">Theme</Label>
-        <div role="radiogroup" aria-label="Theme" className="flex flex-col sm:flex-row gap-2">
+        <div aria-label="Theme" className="flex flex-col sm:flex-row gap-2">
           {THEME_OPTIONS.map((opt) => {
             const isSelected = current === opt.value
             return (
               <button
                 key={opt.value}
                 type="button"
-                role="radio"
-                aria-checked={isSelected}
+                aria-pressed={isSelected}
                 onClick={() => handleChange(opt.value)}
                 data-testid={`theme-card-${opt.value}`}
                 className={cn(

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
@@ -6,6 +6,7 @@ import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import { Button } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
 import { Tooltip } from '@mui/material'
+import { cn } from '@/utils/cn'
 import DeleteSpaceDialog from '../DeleteSpaceDialog'
 import LeaveSpaceDialog from '../LeaveSpaceDialog'
 
@@ -22,7 +23,12 @@ const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) =
         Manage workspace
       </Typography>
 
-      <div className="flex items-center justify-between gap-6 py-4 border-b border-border/60 first:pt-0">
+      <div
+        className={cn(
+          'flex items-center justify-between gap-6 py-4 first:pt-0',
+          isAdmin && 'border-b border-border/60',
+        )}
+      >
         <Typography variant="paragraph-small-bold" className="flex-1 min-w-0">
           Leave this workspace
         </Typography>

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
@@ -5,7 +5,7 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import { Button } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
-import { Tooltip } from '@mui/material'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/utils/cn'
 import DeleteSpaceDialog from '../DeleteSpaceDialog'
 import LeaveSpaceDialog from '../LeaveSpaceDialog'
@@ -32,23 +32,40 @@ const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) =
         <Typography variant="paragraph-small-bold" className="flex-1 min-w-0">
           Leave this workspace
         </Typography>
-        <Tooltip title={isLastActiveAdmin ? 'You are the last active admin and cannot leave the workspace.' : ''}>
-          <span>
-            <Button
-              variant="outline"
-              size="sm"
-              data-testid="space-leave-button"
-              disabled={isLastActiveAdmin || !isActiveMember}
-              onClick={() => {
-                setLeaveOpen(true)
-                trackEvent({ ...SPACE_EVENTS.LEAVE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
-              }}
-              className="text-destructive"
-            >
-              Leave workspace
-            </Button>
-          </span>
-        </Tooltip>
+        {isLastActiveAdmin ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    data-testid="space-leave-button"
+                    disabled
+                    className="text-destructive"
+                  >
+                    Leave workspace
+                  </Button>
+                </span>
+              }
+            />
+            <TooltipContent side="top">You are the last active admin and cannot leave the workspace.</TooltipContent>
+          </Tooltip>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="space-leave-button"
+            disabled={!isActiveMember}
+            onClick={() => {
+              setLeaveOpen(true)
+              trackEvent({ ...SPACE_EVENTS.LEAVE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
+            }}
+            className="text-destructive"
+          >
+            Leave workspace
+          </Button>
+        )}
       </div>
 
       {isAdmin && (

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
@@ -13,8 +13,8 @@ import LeaveSpaceDialog from '../LeaveSpaceDialog'
 const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) => {
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [leaveOpen, setLeaveOpen] = useState(false)
-  const isAdmin = useIsAdmin()
-  const isActiveMember = useIsActiveMember()
+  const isAdmin = useIsAdmin(space?.id)
+  const isActiveMember = useIsActiveMember(space?.id)
   const isLastActiveAdmin = useIsLastActiveAdmin()
 
   return (

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
@@ -36,7 +36,7 @@ const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) =
           <Tooltip>
             <TooltipTrigger
               render={
-                <span>
+                <span tabIndex={0}>
                   <Button
                     variant="outline"
                     size="sm"

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
@@ -17,16 +17,16 @@ const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) =
   const isLastActiveAdmin = useIsLastActiveAdmin()
 
   return (
-    <section className="bg-card rounded-2xl p-6 mb-4">
-      <Typography variant="paragraph-bold" className="mb-4 block">
+    <section className="bg-card rounded-2xl p-6 mb-3">
+      <Typography variant="paragraph-bold" className="mb-5 block tracking-tight">
         Manage workspace
       </Typography>
 
-      <div className="flex items-center justify-between gap-6 py-3 border-b border-border">
+      <div className="flex items-center justify-between gap-6 py-4 border-b border-border/60 first:pt-0">
         <Typography variant="paragraph-small-bold" className="flex-1 min-w-0">
           Leave this workspace
         </Typography>
-        <Tooltip title={isLastActiveAdmin ? 'You are the last active admin and cannot leave the space.' : ''}>
+        <Tooltip title={isLastActiveAdmin ? 'You are the last active admin and cannot leave the workspace.' : ''}>
           <span>
             <Button
               variant="outline"
@@ -39,14 +39,14 @@ const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) =
               }}
               className="text-destructive"
             >
-              Leave space
+              Leave workspace
             </Button>
           </span>
         </Tooltip>
       </div>
 
       {isAdmin && (
-        <div className="flex items-center justify-between gap-6 pt-3">
+        <div className="flex items-center justify-between gap-6 py-4 last:pb-0">
           <Typography variant="paragraph-small-bold" className="flex-1 min-w-0">
             Delete workspace
           </Typography>

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/DangerZoneSection.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react'
+import { type GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useIsAdmin, useIsActiveMember, useIsLastActiveAdmin } from '@/features/spaces'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
+import { Button } from '@/components/ui/button'
+import { Typography } from '@/components/ui/typography'
+import { Tooltip } from '@mui/material'
+import DeleteSpaceDialog from '../DeleteSpaceDialog'
+import LeaveSpaceDialog from '../LeaveSpaceDialog'
+
+const DangerZoneSection = ({ space }: { space: GetSpaceResponse | undefined }) => {
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [leaveOpen, setLeaveOpen] = useState(false)
+  const isAdmin = useIsAdmin()
+  const isActiveMember = useIsActiveMember()
+  const isLastActiveAdmin = useIsLastActiveAdmin()
+
+  return (
+    <section className="bg-card rounded-2xl p-6 mb-4">
+      <Typography variant="paragraph-bold" className="mb-4 block">
+        Manage workspace
+      </Typography>
+
+      <div className="flex items-center justify-between gap-6 py-3 border-b border-border">
+        <Typography variant="paragraph-small-bold" className="flex-1 min-w-0">
+          Leave this workspace
+        </Typography>
+        <Tooltip title={isLastActiveAdmin ? 'You are the last active admin and cannot leave the space.' : ''}>
+          <span>
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="space-leave-button"
+              disabled={isLastActiveAdmin || !isActiveMember}
+              onClick={() => {
+                setLeaveOpen(true)
+                trackEvent({ ...SPACE_EVENTS.LEAVE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
+              }}
+              className="text-destructive"
+            >
+              Leave space
+            </Button>
+          </span>
+        </Tooltip>
+      </div>
+
+      {isAdmin && (
+        <div className="flex items-center justify-between gap-6 pt-3">
+          <Typography variant="paragraph-small-bold" className="flex-1 min-w-0">
+            Delete workspace
+          </Typography>
+          <Button
+            variant="destructive"
+            size="sm"
+            data-testid="space-delete-button"
+            onClick={() => {
+              setDeleteOpen(true)
+              trackEvent({ ...SPACE_EVENTS.DELETE_SPACE_MODAL, label: SPACE_LABELS.space_settings })
+            }}
+          >
+            Delete workspace
+          </Button>
+        </div>
+      )}
+
+      {deleteOpen && <DeleteSpaceDialog space={space} onClose={() => setDeleteOpen(false)} />}
+      {leaveOpen && <LeaveSpaceDialog space={space} onClose={() => setLeaveOpen(false)} />}
+    </section>
+  )
+}
+
+export default DangerZoneSection

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { type GetSpaceResponse, useSpacesUpdateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import InitialsAvatar from '../../InitialsAvatar'
 import { useIsAdmin } from '@/features/spaces'
@@ -18,20 +18,30 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
 
   const [name, setName] = useState(space?.name ?? '')
   const [error, setError] = useState<string>()
+  const isAwaitingCacheSync = useRef(false)
 
   useEffect(() => {
     setName(space?.name ?? '')
+    isAwaitingCacheSync.current = false
   }, [space?.name])
 
   const trimmedName = name.trim()
   const isDirty = !!space && trimmedName !== space.name && trimmedName.length > 0
   const canSave = isDirty && isAdmin && !isSaving
+  const canCancel = !!space && name !== space.name && isAdmin && !isSaving && !isAwaitingCacheSync.current
+
+  const handleCancel = () => {
+    setName(space?.name ?? '')
+    setError(undefined)
+  }
 
   const handleSave = async () => {
     if (!space || !canSave) return
     setError(undefined)
     try {
+      isAwaitingCacheSync.current = true
       await updateSpace({ id: space.id, updateSpaceDto: { name: trimmedName } }).unwrap()
+      setName(trimmedName)
       dispatch(
         showNotification({
           variant: 'success',
@@ -41,6 +51,7 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
       )
     } catch (e) {
       console.error(e)
+      isAwaitingCacheSync.current = false
       setError("Couldn't update workspace. Please try again.")
     }
   }
@@ -63,10 +74,21 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
             value={name}
             maxLength={MAX_NAME_LENGTH}
             onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && canSave) {
+                e.preventDefault()
+                handleSave()
+              }
+            }}
             disabled={!isAdmin}
             error={error}
             className="max-w-md"
           />
+          {canCancel && (
+            <Button size="sm" variant="outline" onClick={handleCancel} data-testid="space-cancel-button">
+              Cancel
+            </Button>
+          )}
           <Button size="sm" onClick={handleSave} disabled={!canSave} data-testid="space-save-button">
             {isSaving ? 'Saving…' : 'Save'}
           </Button>

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -30,7 +30,7 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
 
   const trimmedName = name.trim()
   const isDirty = !!space && trimmedName !== space.name && trimmedName.length > 0
-  const canSave = isDirty && isAdmin && !isSaving
+  const canSave = isDirty && isAdmin && !isSaving && !isAwaitingCacheSync.current
   const canCancel = !!space && name !== space.name && isAdmin && !isSaving && !isAwaitingCacheSync.current
 
   const handleCancel = () => {

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react'
+import { Upload } from 'lucide-react'
+import { type GetSpaceResponse, useSpacesUpdateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import InitialsAvatar from '../../InitialsAvatar'
+import { useIsAdmin } from '@/features/spaces'
+import { useAppDispatch } from '@/store'
+import { showNotification } from '@/store/notificationsSlice'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Typography } from '@/components/ui/typography'
+
+const MAX_NAME_LENGTH = 60
+
+const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => {
+  const dispatch = useAppDispatch()
+  const isAdmin = useIsAdmin(space?.id)
+  const [updateSpace, { isLoading: isSaving }] = useSpacesUpdateV1Mutation()
+
+  const [name, setName] = useState(space?.name ?? '')
+  const [error, setError] = useState<string>()
+
+  useEffect(() => {
+    setName(space?.name ?? '')
+  }, [space?.name])
+
+  const isDirty = !!space && name !== space.name && name.trim().length > 0
+  const canSave = isDirty && isAdmin && !isSaving
+
+  const handleSave = async () => {
+    if (!space || !canSave) return
+    setError(undefined)
+    try {
+      await updateSpace({ id: space.id, updateSpaceDto: { name: name.trim() } }).unwrap()
+      dispatch(
+        showNotification({
+          variant: 'success',
+          message: 'Updated space name',
+          groupKey: 'space-update-name',
+        }),
+      )
+    } catch (e) {
+      console.error(e)
+      setError('Error updating the space. Please try again.')
+    }
+  }
+
+  return (
+    <section className="bg-card rounded-2xl p-6 mb-4">
+      <Typography variant="paragraph-bold" className="mb-4 block">
+        Identity
+      </Typography>
+
+      <div className="flex items-center gap-4 p-4 bg-muted rounded-lg mb-4">
+        <InitialsAvatar name={space?.name ?? '?'} size="large" />
+        <Typography variant="paragraph-small-bold" className="flex-1 min-w-0">
+          Workspace avatar
+        </Typography>
+        <Button variant="outline" size="sm" disabled aria-label="Upload avatar (coming soon)">
+          <Upload className="h-3.5 w-3.5" />
+          Upload
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="space-name">Workspace name</Label>
+        <Input
+          id="space-name"
+          data-testid="space-name-input"
+          value={name}
+          maxLength={MAX_NAME_LENGTH}
+          onChange={(e) => setName(e.target.value)}
+          disabled={!isAdmin}
+          error={error}
+        />
+        <div className="flex justify-end mt-2">
+          <Button size="sm" onClick={handleSave} disabled={!canSave} data-testid="space-save-button">
+            {isSaving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default IdentitySection

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -23,14 +23,15 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
     setName(space?.name ?? '')
   }, [space?.name])
 
-  const isDirty = !!space && name !== space.name && name.trim().length > 0
+  const trimmedName = name.trim()
+  const isDirty = !!space && trimmedName !== space.name && trimmedName.length > 0
   const canSave = isDirty && isAdmin && !isSaving
 
   const handleSave = async () => {
     if (!space || !canSave) return
     setError(undefined)
     try {
-      await updateSpace({ id: space.id, updateSpaceDto: { name: name.trim() } }).unwrap()
+      await updateSpace({ id: space.id, updateSpaceDto: { name: trimmedName } }).unwrap()
       dispatch(
         showNotification({
           variant: 'success',

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { Upload } from 'lucide-react'
 import { type GetSpaceResponse, useSpacesUpdateV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import InitialsAvatar from '../../InitialsAvatar'
 import { useIsAdmin } from '@/features/spaces'
@@ -35,45 +34,38 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
       dispatch(
         showNotification({
           variant: 'success',
-          message: 'Updated space name',
+          message: 'Workspace name updated',
           groupKey: 'space-update-name',
         }),
       )
     } catch (e) {
       console.error(e)
-      setError('Error updating the space. Please try again.')
+      setError("Couldn't update workspace. Please try again.")
     }
   }
 
   return (
-    <section className="bg-card rounded-2xl p-6 mb-4">
-      <Typography variant="paragraph-bold" className="mb-4 block">
+    <section className="bg-card rounded-2xl p-6 mb-3">
+      <Typography variant="paragraph-bold" className="mb-5 block tracking-tight">
         Identity
       </Typography>
 
-      <div className="flex items-center gap-4 p-4 bg-muted rounded-lg mb-4">
-        <InitialsAvatar name={space?.name ?? '?'} size="large" />
-        <Typography variant="paragraph-small-bold" className="flex-1 min-w-0">
-          Workspace avatar
-        </Typography>
-        <Button variant="outline" size="sm" disabled aria-label="Upload avatar (coming soon)">
-          <Upload className="h-3.5 w-3.5" />
-          Upload
-        </Button>
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="space-name">Workspace name</Label>
-        <Input
-          id="space-name"
-          data-testid="space-name-input"
-          value={name}
-          maxLength={MAX_NAME_LENGTH}
-          onChange={(e) => setName(e.target.value)}
-          disabled={!isAdmin}
-          error={error}
-        />
-        <div className="flex justify-end mt-2">
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="space-name" className="text-muted-foreground">
+          Workspace name
+        </Label>
+        <div className="flex items-center gap-3">
+          <InitialsAvatar name={space?.name ?? '?'} size="large" />
+          <Input
+            id="space-name"
+            data-testid="space-name-input"
+            value={name}
+            maxLength={MAX_NAME_LENGTH}
+            onChange={(e) => setName(e.target.value)}
+            disabled={!isAdmin}
+            error={error}
+            className="max-w-md"
+          />
           <Button size="sm" onClick={handleSave} disabled={!canSave} data-testid="space-save-button">
             {isSaving ? 'Saving…' : 'Save'}
           </Button>

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -45,6 +45,7 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
       isAwaitingCacheSync.current = true
       await updateSpace({ id: space.id, updateSpaceDto: { name: trimmedName } }).unwrap()
       setName(trimmedName)
+      isAwaitingCacheSync.current = false
       dispatch(
         showNotification({
           variant: 'success',

--- a/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
+++ b/apps/web/src/features/spaces/components/SpaceSettings/sections/IdentitySection.tsx
@@ -21,8 +21,11 @@ const IdentitySection = ({ space }: { space: GetSpaceResponse | undefined }) => 
   const isAwaitingCacheSync = useRef(false)
 
   useEffect(() => {
+    if (isAwaitingCacheSync.current) {
+      isAwaitingCacheSync.current = false
+      return
+    }
     setName(space?.name ?? '')
-    isAwaitingCacheSync.current = false
   }, [space?.name])
 
   const trimmedName = name.trim()

--- a/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
+++ b/apps/web/src/features/spaces/components/SpaceSettings/useUpdateSpace.ts
@@ -20,7 +20,7 @@ export const useUpdateSpace = (space: GetSpaceResponse | undefined) => {
     }
 
     try {
-      await updateSpace({ id: space.id, updateSpaceDto: { name: data.name } })
+      await updateSpace({ id: space.id, updateSpaceDto: { name: data.name } }).unwrap()
 
       dispatch(
         showNotification({

--- a/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
@@ -68,6 +68,7 @@ export const useCurrentMemberProfile = () => {
   return {
     membership,
     signerAddress: session?.authMethod === 'siwe' ? session.signerAddress : undefined,
+    email: session?.authMethod === 'oidc' ? (session.email ?? membership?.user.email ?? undefined) : undefined,
     isLoading: isSessionLoading || isMembershipLoading,
   }
 }

--- a/apps/web/src/hooks/__tests__/useIsSpaceRoute.test.ts
+++ b/apps/web/src/hooks/__tests__/useIsSpaceRoute.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react'
+import { usePathname } from 'next/navigation'
+import { useIsSpaceRoute } from '../useIsSpaceRoute'
+import * as store from '@/store'
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}))
+
+const mockUsePathname = usePathname as jest.Mock
+
+describe('useIsSpaceRoute', () => {
+  const mockSpaceId = '42'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(store, 'useAppSelector').mockReturnValue(mockSpaceId)
+  })
+
+  it('returns true on /spaces', () => {
+    mockUsePathname.mockReturnValue('/spaces')
+    const { result } = renderHook(() => useIsSpaceRoute())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns true on a prefix route like /spaces/settings', () => {
+    mockUsePathname.mockReturnValue('/spaces/settings')
+    const { result } = renderHook(() => useIsSpaceRoute())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns true on a nested prefix route like /spaces/settings/general', () => {
+    mockUsePathname.mockReturnValue('/spaces/settings/general')
+    const { result } = renderHook(() => useIsSpaceRoute())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false on /spaces/create-space', () => {
+    mockUsePathname.mockReturnValue('/spaces/create-space')
+    const { result } = renderHook(() => useIsSpaceRoute())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false on /spaces/transactions', () => {
+    mockUsePathname.mockReturnValue('/spaces/transactions')
+    const { result } = renderHook(() => useIsSpaceRoute())
+    expect(result.current).toBe(false)
+  })
+
+  it('does not match a prefix-overlap like /spaces/settings-foo', () => {
+    mockUsePathname.mockReturnValue('/spaces/settings-foo')
+    const { result } = renderHook(() => useIsSpaceRoute())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false on a non-spaces route', () => {
+    mockUsePathname.mockReturnValue('/welcome')
+    const { result } = renderHook(() => useIsSpaceRoute())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when there is no last-used space, even on a matching route', () => {
+    jest.spyOn(store, 'useAppSelector').mockReturnValue(undefined)
+    mockUsePathname.mockReturnValue('/spaces')
+    const { result } = renderHook(() => useIsSpaceRoute())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when pathname is null', () => {
+    mockUsePathname.mockReturnValue(null)
+    const { result } = renderHook(() => useIsSpaceRoute())
+    expect(result.current).toBe(false)
+  })
+})

--- a/apps/web/src/hooks/useIsSpaceRoute.ts
+++ b/apps/web/src/hooks/useIsSpaceRoute.ts
@@ -3,8 +3,9 @@ import { AppRoutes } from '@/config/routes'
 import { useAppSelector } from '@/store'
 import { lastUsedSpace } from '@/store/authSlice'
 
-const SPACES_ROUTES = [
-  AppRoutes.spaces.index,
+const SPACES_EXACT_ROUTES = [AppRoutes.spaces.index]
+
+const SPACES_PREFIX_ROUTES = [
   AppRoutes.spaces.settings,
   AppRoutes.spaces.members,
   AppRoutes.spaces.safeAccounts,
@@ -17,7 +18,8 @@ export const useIsSpaceRoute = (): boolean => {
   const route = clientPathname || ''
   const spaceId = useAppSelector(lastUsedSpace)
 
-  const isMatch = SPACES_ROUTES.some((r) => route === r || route.startsWith(r + '/'))
+  const isMatch =
+    SPACES_EXACT_ROUTES.includes(route) || SPACES_PREFIX_ROUTES.some((r) => route === r || route.startsWith(r + '/'))
 
   return isMatch && !!spaceId
 }

--- a/apps/web/src/hooks/useIsSpaceRoute.ts
+++ b/apps/web/src/hooks/useIsSpaceRoute.ts
@@ -17,5 +17,7 @@ export const useIsSpaceRoute = (): boolean => {
   const route = clientPathname || ''
   const spaceId = useAppSelector(lastUsedSpace)
 
-  return SPACES_ROUTES.includes(route) && !!spaceId
+  const isMatch = SPACES_ROUTES.some((r) => route === r || route.startsWith(r + '/'))
+
+  return isMatch && !!spaceId
 }

--- a/apps/web/src/pages/spaces/settings/about.tsx
+++ b/apps/web/src/pages/spaces/settings/about.tsx
@@ -1,0 +1,26 @@
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { BRAND_NAME } from '@/config/constants'
+import { SpacesFeature, useCurrentSpaceId, useFeatureFlagRedirect } from '@/features/spaces'
+import { useLoadFeature } from '@/features/__core__'
+
+export default function SpaceSettingsAboutPage() {
+  const router = useRouter()
+  const spaceId = useCurrentSpaceId()
+  const spaces = useLoadFeature(SpacesFeature)
+  useFeatureFlagRedirect()
+
+  if (!router.isReady || !spaceId) return null
+
+  return (
+    <>
+      <Head>
+        <title>{`${BRAND_NAME} – Settings – About`}</title>
+      </Head>
+
+      <main>
+        <spaces.SpaceSettingsPage spaceId={spaceId} activePage="about" />
+      </main>
+    </>
+  )
+}

--- a/apps/web/src/pages/spaces/settings/account.tsx
+++ b/apps/web/src/pages/spaces/settings/account.tsx
@@ -1,0 +1,26 @@
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { BRAND_NAME } from '@/config/constants'
+import { SpacesFeature, useCurrentSpaceId, useFeatureFlagRedirect } from '@/features/spaces'
+import { useLoadFeature } from '@/features/__core__'
+
+export default function SpaceSettingsAccountPage() {
+  const router = useRouter()
+  const spaceId = useCurrentSpaceId()
+  const spaces = useLoadFeature(SpacesFeature)
+  useFeatureFlagRedirect()
+
+  if (!router.isReady || !spaceId) return null
+
+  return (
+    <>
+      <Head>
+        <title>{`${BRAND_NAME} – Settings – Account`}</title>
+      </Head>
+
+      <main>
+        <spaces.SpaceSettingsPage spaceId={spaceId} activePage="account" />
+      </main>
+    </>
+  )
+}

--- a/apps/web/src/pages/spaces/settings/general.tsx
+++ b/apps/web/src/pages/spaces/settings/general.tsx
@@ -1,12 +1,12 @@
-import { useRouter } from 'next/router'
 import Head from 'next/head'
+import { useRouter } from 'next/router'
 import { BRAND_NAME } from '@/config/constants'
-import { SpacesFeature, useFeatureFlagRedirect } from '@/features/spaces'
+import { SpacesFeature, useCurrentSpaceId, useFeatureFlagRedirect } from '@/features/spaces'
 import { useLoadFeature } from '@/features/__core__'
 
-export default function SpaceSettingsPage() {
+export default function SpaceSettingsGeneralPage() {
   const router = useRouter()
-  const { spaceId } = router.query
+  const spaceId = useCurrentSpaceId()
   const spaces = useLoadFeature(SpacesFeature)
   useFeatureFlagRedirect()
 
@@ -15,11 +15,11 @@ export default function SpaceSettingsPage() {
   return (
     <>
       <Head>
-        <title>{`${BRAND_NAME} – Workspace settings`}</title>
+        <title>{`${BRAND_NAME} – Settings – General`}</title>
       </Head>
 
       <main>
-        <spaces.SpaceSettingsPage spaceId={spaceId as string} />
+        <spaces.SpaceSettingsPage spaceId={spaceId} activePage="general" />
       </main>
     </>
   )

--- a/apps/web/src/pages/spaces/settings/index.tsx
+++ b/apps/web/src/pages/spaces/settings/index.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import { BRAND_NAME } from '@/config/constants'
+import { AppRoutes } from '@/config/routes'
+
+export default function SpaceSettingsIndexPage() {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!router.isReady) return
+    router.replace({ pathname: AppRoutes.spaces.settingsGeneral, query: router.query })
+  }, [router])
+
+  return (
+    <Head>
+      <title>{`${BRAND_NAME} – Space settings`}</title>
+    </Head>
+  )
+}

--- a/apps/web/src/pages/spaces/settings/index.tsx
+++ b/apps/web/src/pages/spaces/settings/index.tsx
@@ -14,7 +14,7 @@ export default function SpaceSettingsIndexPage() {
 
   return (
     <Head>
-      <title>{`${BRAND_NAME} – Space settings`}</title>
+      <title>{`${BRAND_NAME} – Workspace Settings`}</title>
     </Head>
   )
 }

--- a/apps/web/src/styles/shadcn.css
+++ b/apps/web/src/styles/shadcn.css
@@ -43,6 +43,7 @@
   --sidebar-ring: #d4d4d4;
   --accent-secondary: #c4fddd;
   --accent-secondary-foreground: #121312;
+  --accent-success: #16a34a;
   --z-sidebar: 1300;
   --z-overlay: 1400;
 }
@@ -83,6 +84,7 @@
   --sidebar-ring: #404040;
   --accent-secondary: #c4fddd;
   --accent-secondary-foreground: #121312;
+  --accent-success: #16a34a;
 }
 
 @theme inline {
@@ -121,6 +123,7 @@
   --color-sidebar-ring: var(--sidebar-ring);
   --color-accent-secondary: var(--accent-secondary);
   --color-accent-secondary-foreground: var(--accent-secondary-foreground);
+  --color-accent-success: var(--accent-success);
   --radius-2xs: 0.25rem;
   --radius-xs: 0.5rem;
   --radius-sm: 0.5rem;


### PR DESCRIPTION
> Workspace settings reborn,
> three tabs replace the lone form,
> tokens speak as one.

## What it solves

Resolves: [WA-2384](https://linear.app/safe-global/issue/WA-2384/update-workspaces-settings-ui)

The existing space settings page was two fields and a leave button on a `<Card>` — no IA, no design-system alignment, and the destructive confirm dialogs were stylistically off-brand. This PR rebuilds the surface as an enterprise-grade settings shell with a left rail and dedicated sub-pages, all built on the shadcn/ui primitives the rest of the app uses.

## How this PR fixes it

**Route structure** — converted `/spaces/settings.tsx` (single file) into a directory of sub-routes:
- `/spaces/settings` → redirects to `/spaces/settings/general`
- `/spaces/settings/general` — Identity (avatar + name with inline Save) → Appearance (Light / Dark / System radio) → Manage workspace (Leave / Delete)
- `/spaces/settings/account` — current member identity, role, sign-out
- `/spaces/settings/about` — Version (release-notes link) → Legal & policies (Terms, Privacy, Licenses, Imprint, Cookie policy + Cookie preferences) → Help & community (Help center, Service status, Contact support)

**Settings rail** — new sub-app rail (`Workspace settings` / `Account settings` / `About`) with selected state matching the main space sidebar.

**Design system alignment** — every selected-state visual uses `bg-sidebar-accent` (light) paired with `dark:bg-accent dark:text-primary` so the Safe-green tint survives dark mode. Cards are flat `bg-card` on the grey canvas (no borders). List rows use hover-only affordance rather than nested grey boxes.

**Dialog rework** — `DeleteSpaceDialog` and `LeaveSpaceDialog` migrated from MUI `ModalDialog` to shadcn `AlertDialog`. Delete adds type-to-confirm (must type the workspace name). Both pull destructive colors from the `destructive` button variant and `text-destructive` / `bg-destructive/10` tokens — no more hard-coded `#fecaca` / `#b91c1c`.

**Sidebar-aware routing** — added prefix matching in `useIsSpaceRoute` so `/spaces/settings/*` sub-routes are recognised as space routes (was strict equality, causing the main sidebar to disappear and the `SpaceSafeBar` to show a Safe-not-available error on the new pages).

## How to test it

1. `yarn workspace @safe-global/web dev` and sign in to a workspace.
2. Visit `/spaces/settings` → should redirect to `/spaces/settings/general`.
3. Confirm the main space sidebar (Home / Accounts / etc.) is still visible. The Topbar should show the global search input — not the Safe selector.
4. Toggle Dark mode (sidebar toggle). The rail's active item and the Theme radio's selected card should both render with a Safe-green tint — not collapse to invisible.
5. As an admin, edit the workspace name → inline Save button enables. Save → success notification.
6. Open Delete workspace → type-to-confirm blocks the destructive button until the name matches.
7. Open About → Version badge links to the release tag; legal links open in new tabs; Cookie preferences opens the existing consent modal.

## Affected flows

- Workspace settings (rename, theme, leave, delete) — moved off MUI Grid2/Card to shadcn primitives
- Sub-app routing for `/spaces/settings/*` — added to `useIsSpaceRoute` so the existing Topbar and SideDrawer dispatch correctly
- Cookie consent modal trigger — reused via `openCookieBanner({ warningKey: NECESSARY })`
- Theme + address-prefix preferences — wired to existing `settingsSlice.theme.darkMode` and `setCopyShortName`, instant-save (no save bar)

## Blast radius

- **`useIsSpaceRoute`** (`apps/web/src/hooks/useIsSpaceRoute.ts`) — changed from exact-path match to prefix match. Consumers: PageLayout (sidebar visibility), Topbar (SpaceSafeBar vs GlobalSearchInput), SpacesEnhancedSidebar (variant selection). Verified that no other `/spaces/*` route currently has sub-routes that would unintentionally flip into space-route mode.
- **`SpaceSettings/index.tsx`** — replaced the old single-component layout; the feature contract still exposes `SpaceSettings` and `SpaceSettingsPage` with the same public surface (`SpaceSettingsPage` now accepts an optional `activePage` prop, defaulting to `'general'`).
- **`DeleteSpaceDialog` / `LeaveSpaceDialog`** — internals rewritten; same `space` + `onClose` props, same `useSpacesDeleteV1Mutation` / `useMembersSelfRemoveV1Mutation` flow, same analytics events.
- **Routes config** — added `settingsGeneral`, `settingsAccount`, `settingsAbout` under `AppRoutes.spaces`.
- **Mobile impact** — none; web-only routes and components.

## Risks / not checked

- Did not test on small viewport widths (< 768px) — settings rail/content uses `sm:` breakpoint and should stack but visual not verified.
- Did not exercise the type-to-confirm input with edge whitespace (e.g. trailing spaces in space name).
- Did not test the legal links flow end-to-end (the existing `/terms`, `/privacy`, `/licenses`, `/imprint`, `/cookie` pages render content elsewhere; this PR only links to them).
- Service status link is a static "All systems operational" string — no live fetch from status.safe.global API in this cycle.
- Did not verify e2e Cypress coverage; existing `UpdateSpaceForm` Cypress paths may need selector updates (the old `space-save-button` data-testid is preserved on the inline Save button to minimise breakage).


## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — reuses existing `SPACE_EVENTS.LEAVE_SPACE_MODAL` / `DELETE_SPACE_MODAL` and `SETTINGS_EVENTS.APPEARANCE.*`
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — `AppearanceSection.test.tsx`; existing `UpdateSpaceForm` tests still green
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

