### PR TITLE
fix(web): hide safe selector on 404 and 403 pages; add home icon where it was missing

### DIFF
--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -114,7 +114,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
 
       {isStaticPage && (
         <div className="px-6 py-4">
-          <SafeLogo />
+          <SafeLogo href={AppRoutes.welcome.spaces} />
         </div>
       )}
 

--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -114,7 +114,7 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
 
       {isStaticPage && (
         <div className="px-6 py-4">
-          <SafeLogo href={AppRoutes.welcome.spaces} />
+          <SafeLogo />
         </div>
       )}
 

--- a/apps/web/src/components/common/SafeLogo/__tests__/SafeLogo.test.tsx
+++ b/apps/web/src/components/common/SafeLogo/__tests__/SafeLogo.test.tsx
@@ -9,9 +9,9 @@ jest.mock('next/link', () => {
 })
 
 describe('SafeLogo', () => {
-  it('renders a link to /welcome/accounts by default', () => {
+  it('renders a link to /welcome/spaces by default', () => {
     render(<SafeLogo />)
-    expect(screen.getByRole('link')).toHaveAttribute('href', AppRoutes.welcome.accounts)
+    expect(screen.getByRole('link')).toHaveAttribute('href', AppRoutes.welcome.spaces)
   })
 
   it('renders a link to the provided href', () => {

--- a/apps/web/src/components/common/SafeLogo/index.tsx
+++ b/apps/web/src/components/common/SafeLogo/index.tsx
@@ -4,7 +4,7 @@ import { AppRoutes } from '@/config/routes'
 import css from './SafeLogo.module.css'
 
 const SafeLogo = ({
-  href = AppRoutes.welcome.accounts,
+  href = AppRoutes.welcome.spaces,
   className,
   'data-testid': testId,
 }: {

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -29,6 +29,7 @@ const HIDDEN_ROUTES = [
   AppRoutes.welcome.accounts,
   AppRoutes.welcome.spaces,
   AppRoutes.newSafe.create,
+  AppRoutes.newSafe.advancedCreate,
   AppRoutes.newSafe.load,
   AppRoutes.terms,
   AppRoutes.privacy,

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -35,6 +35,9 @@ const HIDDEN_ROUTES = [
   AppRoutes.licenses,
   AppRoutes.imprint,
   AppRoutes.cookie,
+  AppRoutes['403'],
+  AppRoutes['404'],
+  AppRoutes['_offline'],
 ]
 
 function DropdownHeader({ isPinned, onPin }: { isPinned: boolean; onPin: () => void }) {

--- a/apps/web/src/pages/403.tsx
+++ b/apps/web/src/pages/403.tsx
@@ -2,10 +2,14 @@ import { AppRoutes } from '@/config/routes'
 import type { NextPage } from 'next'
 import Link from 'next/link'
 import MUILink from '@mui/material/Link'
+import SafeLogo from '@/components/common/SafeLogo'
 
 const Custom403: NextPage = () => {
   return (
     <main>
+      <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
+        <SafeLogo href={AppRoutes.welcome.spaces} />
+      </div>
       <h1 style={{ fontSize: '2rem', fontWeight: 700, marginBottom: '1rem' }}>403 – Access Restricted</h1>
       <p>
         We regret to inform you that access to this service is currently unavailable in your region. For further

--- a/apps/web/src/pages/403.tsx
+++ b/apps/web/src/pages/403.tsx
@@ -8,7 +8,7 @@ const Custom403: NextPage = () => {
   return (
     <main>
       <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
-        <SafeLogo href={AppRoutes.welcome.spaces} />
+        <SafeLogo />
       </div>
       <h1 style={{ fontSize: '2rem', fontWeight: 700, marginBottom: '1rem' }}>403 – Access Restricted</h1>
       <p>

--- a/apps/web/src/pages/404.tsx
+++ b/apps/web/src/pages/404.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
+import SafeLogo from '@/components/common/SafeLogo'
 
 // Rewrite the URL to put the Safe address into the query.
 export const _getRedirectUrl = (location: Location): string | undefined => {
@@ -45,7 +46,14 @@ const Custom404: NextPage = () => {
     }
   }, [router])
 
-  return <main>{!isRedirecting && <h1 style={{ fontSize: '2rem', fontWeight: 700 }}>404 – Page not found</h1>}</main>
+  return (
+    <main>
+      <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
+        <SafeLogo href={AppRoutes.welcome.spaces} />
+      </div>
+      {!isRedirecting && <h1 style={{ fontSize: '2rem', fontWeight: 700 }}>404 – Page not found</h1>}
+    </main>
+  )
 }
 
 export default Custom404

--- a/apps/web/src/pages/404.tsx
+++ b/apps/web/src/pages/404.tsx
@@ -49,7 +49,7 @@ const Custom404: NextPage = () => {
   return (
     <main>
       <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
-        <SafeLogo href={AppRoutes.welcome.spaces} />
+        <SafeLogo />
       </div>
       {!isRedirecting && <h1 style={{ fontSize: '2rem', fontWeight: 700 }}>404 – Page not found</h1>}
     </main>

--- a/apps/web/src/pages/_offline.tsx
+++ b/apps/web/src/pages/_offline.tsx
@@ -3,6 +3,7 @@ import WifiOffIcon from '@mui/icons-material/WifiOff'
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { BRAND_NAME } from '@/config/constants'
+import SafeLogo from '@/components/common/SafeLogo'
 
 const Offline: NextPage = () => {
   return (
@@ -12,6 +13,9 @@ const Offline: NextPage = () => {
       </Head>
 
       <main>
+        <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
+          <SafeLogo />
+        </div>
         <Box display="flex" justifyContent="center">
           <Paper sx={{ p: 4, mb: 2, maxWidth: 900 }}>
             <Box display="flex" justifyContent="center" mb={2} fontSize={100}>

--- a/apps/web/src/pages/new-safe/advanced-create.tsx
+++ b/apps/web/src/pages/new-safe/advanced-create.tsx
@@ -3,10 +3,14 @@ import type { NextPage } from 'next'
 
 import AdvancedCreateSafe from '@/components/new-safe/create/AdvancedCreateSafe'
 import { BRAND_NAME } from '@/config/constants'
+import SafeLogo from '@/components/common/SafeLogo'
 
 const Open: NextPage = () => {
   return (
     <main>
+      <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
+        <SafeLogo />
+      </div>
       <Head>
         <title>{`${BRAND_NAME} – Advanced Safe creation`}</title>
       </Head>

--- a/apps/web/src/pages/new-safe/create.tsx
+++ b/apps/web/src/pages/new-safe/create.tsx
@@ -3,10 +3,14 @@ import type { NextPage } from 'next'
 
 import CreateSafe from '@/components/new-safe/create'
 import { BRAND_NAME } from '@/config/constants'
+import SafeLogo from '@/components/common/SafeLogo'
 
 const Open: NextPage = () => {
   return (
     <main>
+      <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
+        <SafeLogo />
+      </div>
       <Head>
         <title>{`${BRAND_NAME} – Create Safe Account`}</title>
       </Head>

--- a/apps/web/src/pages/new-safe/load.tsx
+++ b/apps/web/src/pages/new-safe/load.tsx
@@ -3,6 +3,8 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 import LoadSafe, { loadSafeDefaultData } from '@/components/new-safe/load'
 import { BRAND_NAME } from '@/config/constants'
+import SafeLogo from '@/components/common/SafeLogo'
+import { AppRoutes } from '@/config/routes'
 
 const Load: NextPage = () => {
   const router = useRouter()
@@ -11,6 +13,9 @@ const Load: NextPage = () => {
 
   return (
     <main>
+      <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
+        <SafeLogo href={AppRoutes.welcome.spaces} />
+      </div>
       <Head>
         <title>{`${BRAND_NAME} – Add Safe Account`}</title>
       </Head>

--- a/apps/web/src/pages/new-safe/load.tsx
+++ b/apps/web/src/pages/new-safe/load.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router'
 import LoadSafe, { loadSafeDefaultData } from '@/components/new-safe/load'
 import { BRAND_NAME } from '@/config/constants'
 import SafeLogo from '@/components/common/SafeLogo'
-import { AppRoutes } from '@/config/routes'
 
 const Load: NextPage = () => {
   const router = useRouter()
@@ -14,7 +13,7 @@ const Load: NextPage = () => {
   return (
     <main>
       <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
-        <SafeLogo href={AppRoutes.welcome.spaces} />
+        <SafeLogo />
       </div>
       <Head>
         <title>{`${BRAND_NAME} – Add Safe Account`}</title>


### PR DESCRIPTION
## What it solves

Safe Selector was visible on static pages where it should not be visible.
Some pages did not have a Safe logo that enables navigation back to the home page (and had Safe Selector instead).

Resolves: [WA-2376](https://linear.app/safe-global/issue/WA-2376/add-logo-navigation-to-create-and-add-safe-flow)
Resolves: [WA-2385](https://linear.app/safe-global/issue/WA-2385/bug-remove-safe-selector-from-pages-404-and-403)

## How this PR fixes it

Hide the SafeSelector (Safe account switcher in the top bar) on error and static pages where no Safe context is needed:
- `/403`, `/404`, `/_offline` — error pages
- `/cookie`, `/privacy`, `/terms`, `/imprint`, `/licenses` — static legal pages (already hidden via existing `HIDDEN_ROUTES`, now consistent)

Also adds a Safe logo linking to `/welcome/spaces` in the top-left corner of `/403`, `/404`, and `/new-safe/load` pages, and fixes the logo link on static legal pages to point to `/welcome/spaces` instead of `/welcome/accounts`.

## How to test it

1. Visit `/403` — no Safe selector in top bar, Safe logo visible top-left, logo links to `/welcome/spaces`
2. Visit `/404` — same as above
3. Visit `/_offline` (disconnect network) — no Safe selector
4. Visit `/terms`, `/privacy`, `/cookie`, `/imprint`, `/licenses` — logo links to `/welcome/spaces`
5. Visit `/new-safe/load` — Safe logo visible top-left, links to `/welcome/spaces`

Before:
<img width="800" height="428" alt="image" src="https://github.com/user-attachments/assets/48005a77-f53c-4034-bfbd-b420ce350928" />

After:
<img width="1489" height="702" alt="image" src="https://github.com/user-attachments/assets/6977a0cf-24bb-45b4-a8c9-61467453f680" />

## Affected flows

- Accessing restricted/missing pages while a Safe is loaded in state
- Navigating from legal pages back to the app

## Blast radius

- `SpaceSafeBar` — `HIDDEN_ROUTES` extended; no logic change, only route list
- `PageLayout` — `SafeLogo` href changed for static pages only
- `/403`, `/404`, `/new-safe/load` — layout additions only, no logic change

## Risks / not checked

- Did not verify dark mode rendering of the logo on error pages
- Did not test mobile layout for the fixed-position logo

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).