### PR TITLE
fix(web): restore Manage trusted Safes entry on /spaces/safe-accounts

### DIFF
--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useLoadFeature } from '@/features/__core__'
+import { useSpaceSafes, useIsAdmin, useIsInvited } from '@/features/spaces'
+import { useSafeSelectionModal } from '@/features/myAccounts'
+import SpaceSafeAccounts from '../index'
+
+jest.mock('@/features/spaces', () => ({
+  useSpaceSafes: jest.fn(),
+  useIsAdmin: jest.fn(),
+  useIsInvited: jest.fn(),
+  SpacesFeature: { name: 'spaces' },
+}))
+
+jest.mock('@/features/myAccounts', () => ({
+  MyAccountsFeature: { name: 'myAccounts' },
+  useSafeSelectionModal: jest.fn(),
+}))
+
+jest.mock('@/features/__core__', () => ({
+  useLoadFeature: jest.fn(),
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: jest.fn(() => ({})),
+}))
+
+jest.mock('@/store/orderByPreferenceSlice', () => ({
+  selectOrderByPreference: jest.fn(),
+}))
+
+jest.mock('@/store/addedSafesSlice', () => ({
+  selectAllAddedSafes: jest.fn(),
+}))
+
+jest.mock('@/store/slices', () => ({
+  selectAllAddressBooks: jest.fn(),
+  selectAllVisitedSafes: jest.fn(),
+  selectUndeployedSafes: jest.fn(),
+}))
+
+jest.mock('@/hooks/safes', () => ({
+  _buildSafeItem: jest.fn(),
+  _getMultiChainAccounts: jest.fn(() => []),
+  _getSingleChainAccounts: jest.fn(() => []),
+  getComparator: jest.fn(() => () => 0),
+  useAllOwnedSafes: jest.fn(() => [{}]),
+}))
+
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}))
+
+jest.mock('@safe-global/utils/utils/addressSimilarity', () => ({
+  getFlaggedSimilarAddressSet: jest.fn(() => new Set()),
+}))
+
+jest.mock('../AccountsSafesList', () => {
+  const Mock = () => null
+  Mock.displayName = 'MockAccountsSafesList'
+  return Mock
+})
+jest.mock('../EmptySafeAccounts', () => {
+  const Mock = () => null
+  Mock.displayName = 'MockEmptySafeAccounts'
+  return Mock
+})
+jest.mock('../../AddAccounts', () => {
+  const Mock = () => <button data-testid="mock-add-accounts">Add Accounts</button>
+  Mock.displayName = 'MockAddAccounts'
+  return Mock
+})
+jest.mock('../../InviteBanner/PreviewInvite', () => {
+  const Mock = () => null
+  Mock.displayName = 'MockPreviewInvite'
+  return Mock
+})
+jest.mock('@/components/common/Track', () => {
+  const Track = ({ children }: { children: React.ReactNode }) => <>{children}</>
+  Track.displayName = 'Track'
+  return Track
+})
+
+const mockSafeSelectionModalOpen = jest.fn()
+const baseModalReturn = {
+  isOpen: false,
+  availableItems: [],
+  selectedAddresses: new Set<string>(),
+  pendingConfirmation: null,
+  pendingSelectAllConfirmation: false,
+  similarAddressesForSelectAll: [],
+  searchQuery: '',
+  isLoading: false,
+  hasChanges: false,
+  totalSafesCount: 0,
+  open: mockSafeSelectionModalOpen,
+  close: jest.fn(),
+  toggleSelection: jest.fn(),
+  selectAll: jest.fn(),
+  deselectAll: jest.fn(),
+  confirmSimilarAddress: jest.fn(),
+  cancelSimilarAddress: jest.fn(),
+  confirmSelectAll: jest.fn(),
+  cancelSelectAll: jest.fn(),
+  submitSelection: jest.fn(),
+  setSearchQuery: jest.fn(),
+}
+
+const MockSafeSelectionModal: jest.Mock = jest.fn((props: { modal: typeof baseModalReturn }) => {
+  void props
+  return null
+})
+
+describe('SpaceSafeAccounts – Manage trusted Safes entry point', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useSpaceSafes as jest.Mock).mockReturnValue({
+      allSafes: [],
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    })
+    ;(useIsInvited as jest.Mock).mockReturnValue(false)
+    ;(useSafeSelectionModal as jest.Mock).mockReturnValue(baseModalReturn)
+    ;(useLoadFeature as jest.Mock).mockReturnValue({ SafeSelectionModal: MockSafeSelectionModal })
+  })
+
+  it('renders the Manage trusted Safes button for non-admin members', () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(false)
+
+    render(<SpaceSafeAccounts />)
+
+    expect(screen.getByTestId('manage-trusted-safes-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('mock-add-accounts')).not.toBeInTheDocument()
+  })
+
+  it('renders both Manage trusted Safes and Add Accounts buttons for admins', () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(true)
+
+    render(<SpaceSafeAccounts />)
+
+    expect(screen.getByTestId('manage-trusted-safes-button')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-add-accounts')).toBeInTheDocument()
+  })
+
+  it('opens the trusted Safes modal when the button is clicked', () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(false)
+
+    render(<SpaceSafeAccounts />)
+    fireEvent.click(screen.getByTestId('manage-trusted-safes-button'))
+
+    expect(mockSafeSelectionModalOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the SafeSelectionModal with the modal handle from useSafeSelectionModal', () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(false)
+
+    render(<SpaceSafeAccounts />)
+
+    expect(MockSafeSelectionModal).toHaveBeenCalled()
+    expect(MockSafeSelectionModal.mock.calls[0][0]).toMatchObject({ modal: baseModalReturn })
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
@@ -122,7 +122,12 @@ describe('SpaceSafeAccounts – Manage trusted Safes entry point', () => {
     })
     ;(useIsInvited as jest.Mock).mockReturnValue(false)
     ;(useSafeSelectionModal as jest.Mock).mockReturnValue(baseModalReturn)
-    ;(useLoadFeature as jest.Mock).mockReturnValue({ SafeSelectionModal: MockSafeSelectionModal })
+    ;(useLoadFeature as jest.Mock).mockReturnValue({
+      SafeSelectionModal: MockSafeSelectionModal,
+      $isDisabled: false,
+      $isReady: true,
+      $error: undefined,
+    })
   })
 
   it('renders the Manage trusted Safes button for non-admin members', () => {
@@ -159,5 +164,20 @@ describe('SpaceSafeAccounts – Manage trusted Safes entry point', () => {
 
     expect(MockSafeSelectionModal).toHaveBeenCalled()
     expect(MockSafeSelectionModal.mock.calls[0][0]).toMatchObject({ modal: baseModalReturn })
+  })
+
+  it('hides the Manage trusted Safes button when MyAccountsFeature is disabled', () => {
+    ;(useIsAdmin as jest.Mock).mockReturnValue(true)
+    ;(useLoadFeature as jest.Mock).mockReturnValue({
+      SafeSelectionModal: MockSafeSelectionModal,
+      $isDisabled: true,
+      $isReady: false,
+      $error: undefined,
+    })
+
+    render(<SpaceSafeAccounts />)
+
+    expect(screen.queryByTestId('manage-trusted-safes-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('mock-add-accounts')).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -1,6 +1,7 @@
 import AddAccounts from '../AddAccounts'
 import EmptySafeAccounts from './EmptySafeAccounts'
 import { Stack } from '@mui/material'
+import { Button } from '@/components/ui/button'
 import { Typography } from '@/components/ui/typography'
 import { useMemo } from 'react'
 import { useAppSelector } from '@/store'
@@ -20,11 +21,13 @@ import useWallet from '@/hooks/wallets/useWallet'
 import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
 import { useSpaceSafes, useIsAdmin, useIsInvited } from '@/features/spaces'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
-import { TriangleAlert, RotateCw } from 'lucide-react'
+import { BookmarkPlus, TriangleAlert, RotateCw } from 'lucide-react'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import { SPACE_LABELS, SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 import AccountsSafesList from './AccountsSafesList'
+import { useLoadFeature } from '@/features/__core__'
+import { MyAccountsFeature, useSafeSelectionModal } from '@/features/myAccounts'
 
 const _groupAndSort = (
   items: SafeItem[],
@@ -39,6 +42,8 @@ const SpaceSafeAccounts = () => {
   const { allSafes, isError: isSpaceSafesError, error: spaceSafesError, refetch: refetchSpaceSafes } = useSpaceSafes()
   const isAdmin = useIsAdmin()
   const isInvited = useIsInvited()
+  const { SafeSelectionModal } = useLoadFeature(MyAccountsFeature)
+  const trustedSafesModal = useSafeSelectionModal()
 
   // Use same organization logic as onboarding
   const { orderBy } = useAppSelector(selectOrderByPreference)
@@ -80,13 +85,23 @@ const SpaceSafeAccounts = () => {
         <Typography variant="h2" className="font-bold leading-[1] tracking-tight">
           Safe Accounts
         </Typography>
-        {isAdmin && (
-          <Stack direction="row" justifyContent="flex-start">
+        <Stack direction="row" justifyContent="flex-start" gap={1.5} flexWrap="wrap">
+          {isAdmin && (
             <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>
               <AddAccounts buttonVariant="default" />
             </Track>
-          </Stack>
-        )}
+          )}
+          <Button
+            size="lg"
+            variant="outline"
+            className="font-normal px-4 py-0"
+            onClick={trustedSafesModal.open}
+            data-testid="manage-trusted-safes-button"
+          >
+            <BookmarkPlus className="size-4" />
+            Manage trusted Safes
+          </Button>
+        </Stack>
       </div>
 
       {isSpaceSafesError ? (
@@ -112,6 +127,8 @@ const SpaceSafeAccounts = () => {
       ) : (
         <AccountsSafesList safes={displaySafes} similarAddresses={similarAddresses} />
       )}
+
+      <SafeSelectionModal modal={trustedSafesModal} />
     </>
   )
 }

--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -42,7 +42,7 @@ const SpaceSafeAccounts = () => {
   const { allSafes, isError: isSpaceSafesError, error: spaceSafesError, refetch: refetchSpaceSafes } = useSpaceSafes()
   const isAdmin = useIsAdmin()
   const isInvited = useIsInvited()
-  const { SafeSelectionModal } = useLoadFeature(MyAccountsFeature)
+  const { SafeSelectionModal, $isDisabled: isMyAccountsDisabled } = useLoadFeature(MyAccountsFeature)
   const trustedSafesModal = useSafeSelectionModal()
 
   // Use same organization logic as onboarding
@@ -91,16 +91,18 @@ const SpaceSafeAccounts = () => {
               <AddAccounts buttonVariant="default" />
             </Track>
           )}
-          <Button
-            size="lg"
-            variant="outline"
-            className="font-normal px-4 py-0"
-            onClick={trustedSafesModal.open}
-            data-testid="manage-trusted-safes-button"
-          >
-            <BookmarkPlus className="size-4" />
-            Manage trusted Safes
-          </Button>
+          {!isMyAccountsDisabled && (
+            <Button
+              size="lg"
+              variant="outline"
+              className="font-normal px-4 py-0"
+              onClick={trustedSafesModal.open}
+              data-testid="manage-trusted-safes-button"
+            >
+              <BookmarkPlus className="size-4" />
+              Manage trusted Safes
+            </Button>
+          )}
         </Stack>
       </div>
 


### PR DESCRIPTION
> Trusted list returns,
> a button on safe-accounts
> opens the old door.

## What it solves

After #7884 turned on the "require login" gate, `AccountsNavigation` returns `null` and `/welcome/accounts` is no longer linked from anywhere a signed-in user with a Space can reach. That dropped the sole entry point to the "Manage trusted Safes" modal — the per-user, per-browser pinned list managed by `useSafeSelectionModal`. The underlying hook, modal, and Redux state are all intact; only the navigation was lost.

<img width="1920" height="1080" alt="manage-trusted-safes" src="https://github.com/user-attachments/assets/b9a25faf-cbf0-4693-aa22-94f6da8e9e54" />

## How this PR fixes it

- Adds a "Manage trusted Safes" outline button to the `/spaces/safe-accounts` page header, next to the existing admin-only "Add Accounts" button.
- Re-uses the lazy-loaded `SafeSelectionModal` and `useSafeSelectionModal` from `@/features/myAccounts` — no changes to that feature.
- Visible to all space members (admin and non-admin), since trusted-Safes management is a per-user local concept, not a per-space permission.

## How to test it

1. Sign in with a wallet that has at least one Space; navigate to `/spaces/safe-accounts`.
2. Confirm the "Manage trusted Safes" button is visible in the header. For admins, it sits alongside "Add Accounts". For non-admin members, it appears alone.
3. Click the button — the `SafeSelectionModal` (same dialog as `/welcome/accounts`) opens with the security banner and the selectable safe list.
4. Pin/unpin a safe, click Save — confirm the success notification and that the pinned list updates.
5. Repeat with the require-login gate explicitly OFF (`REQUIRE_LOGIN_DISABLED` set on chain 1) — the new button behaves the same. The legacy `/welcome/accounts` route remains untouched.

## Affected flows

- Trusted Safes management (per-user pinned list) — entry point restored.
- `/spaces/safe-accounts` header — now renders an action row for all members, not only admins.
- `/welcome/accounts` legacy view — unchanged; its `PinnedSafes` button is on an independent code path.

## Blast radius

- One source file changed: `apps/web/src/features/spaces/components/SafeAccounts/index.tsx`.
- Re-uses `SafeSelectionModal` and `useSafeSelectionModal` from `@/features/myAccounts` with no changes to those exports or to any state.
- New unit test covers admin / non-admin rendering and the modal-open click handler.

## Risks / not checked

- Two-button row layout on small/mobile widths was not visually verified.
- No design review on whether the per-user trusted list belongs on a space-scoped page in the long term — this PR is scoped to restoring the lost entry point.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1["Signed-in user, gate ON"] -. no link .-> C1["/welcome/accounts"]
    C1 --> M1["Manage trusted Safes"]
  end
  subgraph After
    A2["Signed-in user, gate ON"] --> B2["/spaces/safe-accounts"]
    B2 --> M2["Manage trusted Safes modal"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile (web-only change)
- [x] I've documented how it affects the analytics (no new events; reuses existing modal)
- [x] I've written a unit/e2e test for it
- [x] I've listed affected flows and blast radius, and named what I did not verify

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)