### PR TITLE
fix(mobile): stop Datadog RUM view on app background to kill false frozen-frame alerts

### DIFF
--- a/apps/mobile/src/hooks/__tests__/useScreenTracking.test.ts
+++ b/apps/mobile/src/hooks/__tests__/useScreenTracking.test.ts
@@ -1,0 +1,81 @@
+import { AppState, AppStateStatus, NativeEventSubscription } from 'react-native'
+import { act, renderHook } from '@/src/tests/test-utils'
+import { useScreenTracking } from '../useScreenTracking'
+import { trackScreenView, trackDatadogView } from '@/src/services/analytics'
+import { stopActiveDatadogView, resumeActiveDatadogView } from '@/src/services/analytics/datadogAnalytics'
+
+jest.mock('expo-router', () => ({
+  usePathname: jest.fn(() => '/home'),
+  useGlobalSearchParams: jest.fn(() => ({})),
+}))
+
+jest.mock('@/src/services/analytics', () => ({
+  trackScreenView: jest.fn(),
+  trackDatadogView: jest.fn(),
+}))
+
+jest.mock('@/src/services/analytics/datadogAnalytics', () => ({
+  stopActiveDatadogView: jest.fn(),
+  resumeActiveDatadogView: jest.fn(),
+}))
+
+describe('useScreenTracking', () => {
+  let changeHandler: (state: AppStateStatus) => void
+  const remove = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, handler) => {
+      changeHandler = handler as (state: AppStateStatus) => void
+      return { remove } as unknown as NativeEventSubscription
+    })
+  })
+
+  it('tracks the current screen on mount (Datadog + Firebase)', () => {
+    renderHook(() => useScreenTracking())
+
+    expect(trackDatadogView).toHaveBeenCalledWith('/home', '/home')
+    expect(trackScreenView).toHaveBeenCalledWith('/home', '/home')
+  })
+
+  it('stops the Datadog view on background, without touching Firebase', () => {
+    renderHook(() => useScreenTracking())
+    expect(trackScreenView).toHaveBeenCalledTimes(1)
+
+    act(() => changeHandler('background'))
+
+    expect(stopActiveDatadogView).toHaveBeenCalledTimes(1)
+    expect(resumeActiveDatadogView).not.toHaveBeenCalled()
+    // Firebase screen tracking stays navigation-only.
+    expect(trackScreenView).toHaveBeenCalledTimes(1)
+  })
+
+  it('resumes the Datadog view on active', () => {
+    renderHook(() => useScreenTracking())
+
+    act(() => changeHandler('active'))
+
+    expect(resumeActiveDatadogView).toHaveBeenCalledTimes(1)
+    expect(stopActiveDatadogView).not.toHaveBeenCalled()
+  })
+
+  it('ignores inactive transitions (no stop, no resume)', () => {
+    renderHook(() => useScreenTracking())
+
+    act(() => changeHandler('active'))
+    act(() => changeHandler('inactive'))
+    act(() => changeHandler('active'))
+
+    // Only the two 'active' transitions resume; 'inactive' does nothing.
+    expect(stopActiveDatadogView).not.toHaveBeenCalled()
+    expect(resumeActiveDatadogView).toHaveBeenCalledTimes(2)
+  })
+
+  it('removes the AppState subscription on unmount', () => {
+    const { unmount } = renderHook(() => useScreenTracking())
+
+    unmount()
+
+    expect(remove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mobile/src/hooks/useScreenTracking.ts
+++ b/apps/mobile/src/hooks/useScreenTracking.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react'
+import { AppState, AppStateStatus } from 'react-native'
 import { usePathname, useGlobalSearchParams } from 'expo-router'
 import { trackScreenView, trackDatadogView } from '@/src/services/analytics'
+import { stopActiveDatadogView, resumeActiveDatadogView } from '@/src/services/analytics/datadogAnalytics'
 
 export const useScreenTracking = () => {
   const pathname = usePathname()
@@ -10,4 +12,24 @@ export const useScreenTracking = () => {
     trackDatadogView(pathname, pathname)
     trackScreenView(pathname, pathname)
   }, [pathname, params])
+
+  // App-lifecycle tracking for Datadog RUM only. Without this, a view left open
+  // while the app is in the background stays active, and the JS-thread
+  // suspension is recorded as a false `is_frozen_frame` long task on resume.
+  // Empty deps is correct: the handler closes over no React state, so it never
+  // goes stale and must not re-subscribe.
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
+      if (nextAppState === 'background') {
+        stopActiveDatadogView()
+      } else if (nextAppState === 'active') {
+        resumeActiveDatadogView()
+      }
+      // 'inactive' (iOS-only transition state) is intentionally ignored — the JS
+      // thread is not suspended there. This matches Datadog's own navigation
+      // trackers, which only stop on 'background' and start on 'active'.
+    })
+
+    return () => subscription.remove()
+  }, [])
 }

--- a/apps/mobile/src/services/analytics/datadogAnalytics.test.ts
+++ b/apps/mobile/src/services/analytics/datadogAnalytics.test.ts
@@ -1,0 +1,102 @@
+import { DdRum } from 'expo-datadog'
+import {
+  trackDatadogView,
+  stopActiveDatadogView,
+  resumeActiveDatadogView,
+  __resetDatadogViewStateForTests,
+} from './datadogAnalytics'
+
+const startView = DdRum.startView as jest.Mock
+const stopView = DdRum.stopView as jest.Mock
+
+describe('datadogAnalytics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    __resetDatadogViewStateForTests()
+  })
+
+  describe('trackDatadogView', () => {
+    it('starts a view and does not stop a previous one on first navigation', () => {
+      trackDatadogView('/home', '/home')
+
+      expect(startView).toHaveBeenCalledWith('/home', '/home')
+      expect(stopView).not.toHaveBeenCalled()
+    })
+
+    it('stops the previous view before starting a new one on navigation', () => {
+      trackDatadogView('/home', '/home')
+      trackDatadogView('/settings', '/settings')
+
+      expect(stopView).toHaveBeenCalledTimes(1)
+      expect(stopView).toHaveBeenCalledWith('/home')
+      expect(startView).toHaveBeenLastCalledWith('/settings', '/settings')
+    })
+  })
+
+  describe('stopActiveDatadogView', () => {
+    it('stops the active view once', () => {
+      trackDatadogView('/home', '/home')
+      stopView.mockClear()
+
+      stopActiveDatadogView()
+
+      expect(stopView).toHaveBeenCalledTimes(1)
+      expect(stopView).toHaveBeenCalledWith('/home')
+    })
+
+    it('is a no-op when there is no view', () => {
+      stopActiveDatadogView()
+      expect(stopView).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when the view is already stopped', () => {
+      trackDatadogView('/home', '/home')
+      stopActiveDatadogView()
+      stopView.mockClear()
+
+      stopActiveDatadogView()
+
+      expect(stopView).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('resumeActiveDatadogView', () => {
+    it('restarts the last view with the reused key', () => {
+      trackDatadogView('/home', '/home')
+      stopActiveDatadogView()
+      startView.mockClear()
+
+      resumeActiveDatadogView()
+
+      expect(startView).toHaveBeenCalledTimes(1)
+      expect(startView).toHaveBeenCalledWith('/home', '/home')
+    })
+
+    it('is a no-op when the view is already active', () => {
+      trackDatadogView('/home', '/home')
+      startView.mockClear()
+
+      resumeActiveDatadogView()
+
+      expect(startView).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when no view has been tracked', () => {
+      resumeActiveDatadogView()
+      expect(startView).not.toHaveBeenCalled()
+    })
+  })
+
+  it('track -> background -> resume issues exactly one stop and one fresh start', () => {
+    trackDatadogView('/transactions', '/transactions')
+    jest.clearAllMocks()
+
+    stopActiveDatadogView()
+    resumeActiveDatadogView()
+
+    expect(stopView).toHaveBeenCalledTimes(1)
+    expect(stopView).toHaveBeenCalledWith('/transactions')
+    expect(startView).toHaveBeenCalledTimes(1)
+    expect(startView).toHaveBeenCalledWith('/transactions', '/transactions')
+  })
+})

--- a/apps/mobile/src/services/analytics/datadogAnalytics.ts
+++ b/apps/mobile/src/services/analytics/datadogAnalytics.ts
@@ -1,6 +1,7 @@
 import { DdRum } from 'expo-datadog'
 
 let previousViewKey: string | null = null
+let isViewActive = false
 
 /**
  * Track screen views in Datadog RUM.
@@ -13,4 +14,41 @@ export const trackDatadogView = (viewKey: string, viewName: string): void => {
 
   DdRum.startView(viewKey, viewName)
   previousViewKey = viewKey
+  isViewActive = true
+}
+
+/**
+ * Stop the active RUM view when the app goes to the background.
+ *
+ * React Native's RUM SDK derives JS long tasks from frame-time deltas. On iOS
+ * the detector is never paused while suspended, so the first frame after resume
+ * is measured against the pre-suspension timestamp and reported as a single
+ * `is_frozen_frame` long task spanning the whole background interval. Dropping
+ * the active view here means that stale-frame long task has no view to attach
+ * to and is discarded by the SDK.
+ */
+export const stopActiveDatadogView = (): void => {
+  if (previousViewKey && isViewActive) {
+    DdRum.stopView(previousViewKey)
+    isViewActive = false
+  }
+}
+
+/**
+ * Restart the last view when the app returns to the foreground. The navigation
+ * effect does not re-fire on resume (the pathname is unchanged), so the view
+ * must be restarted explicitly. Reusing the key is safe — the SDK starts a
+ * fresh view instance per `startView`.
+ */
+export const resumeActiveDatadogView = (): void => {
+  if (previousViewKey && !isViewActive) {
+    DdRum.startView(previousViewKey, previousViewKey)
+    isViewActive = true
+  }
+}
+
+/** Test-only: reset module state between cases. */
+export const __resetDatadogViewStateForTests = (): void => {
+  previousViewKey = null
+  isViewActive = false
 }


### PR DESCRIPTION
> Backgrounded, the screen sits still,
> its frozen frame a phantom alarm.
> We stop the view at the door on suspend —
> and the false pages fall silent.

## What it solves

The mobile **Frozen Frame Rate** RUM monitors page `@slack-datadog-wallet-alerts-prod` constantly. The dominant cause is **our instrumentation, not real UI jank**: RUM view tracking is navigation-only, so a view left open while the app is backgrounded stays `active`. On iOS the SDK's JS long-task detector is never paused while suspended (`JSRefreshRateListener` never resets `lastFrameTimestamp`; the `appWillResignActive`/`appDidBecomeActive` hooks have **zero callers** — verified by repo-wide code search), so the first frame after resume is measured against the pre-suspension timestamp and recorded as one `is_frozen_frame` long task spanning the whole background interval.

Evidence (7d, prod): 219 frozen-frame views; **62 (26%)** have a `long_task > 20s` (impossible as foreground compute — iOS watchdog kills at ~20s); largest single long task **892s**; worked example session `6ef0e475` = a 701.85s `is_frozen_frame` long task on `/transactions` ending exactly at resume.

Resolves: WA-2411

## How this PR fixes it

Add an `AppState` listener inside `useScreenTracking` (no new hook, no new mount point):
- `background` → `stopActiveDatadogView()` (`DdRum.stopView`)
- `active` → `resumeActiveDatadogView()` (`DdRum.startView`, reusing the `pathname` key — safe; the SDK starts a fresh view scope per call)

With no active view at resume, the stale-frame long task is **dropped** — verified in dd-sdk-ios: `RUMAddLongTaskCommand.canStartBackgroundView = false` and the view scope records long tasks only `where isActiveView`. **Android is already protected** by the SDK (`onHostPause`/`onHostResume` reset `lastFrameTime = -1`). `trackBackgroundEvents` stays `false`. The lifecycle branch touches **Datadog only** — Firebase `trackScreenView` stays navigation-only.

## How to test it

- `yarn workspace @safe-global/mobile test src/services/analytics/datadogAnalytics.test.ts src/hooks/__tests__/useScreenTracking.test.ts` — 14 tests pass.
- **On-device gate (the real confirmation):** background a build on `/transactions` for > 2 min, foreground, and confirm in Datadog RUM (a) no `is_frozen_frame` long task spanning the gap on the resumed view, and (b) a fresh view *is* recorded on resume.

## Affected flows

- Datadog RUM screen/view tracking on **every** mobile screen (the `useScreenTracking` hook).
- App background → foreground transitions.

## Blast radius

- `apps/mobile/src/hooks/useScreenTracking.ts` — mounted once in `RootLayout`; sole owner of RUM view lifecycle.
- `apps/mobile/src/services/analytics/datadogAnalytics.ts` — added module-level `isViewActive` flag + two helpers; the navigation stop/start path is byte-for-byte unchanged.
- **Mobile only.** No web, no shared `packages/*`. No RTK Query endpoints, feature flags, routes, or persisted state. Firebase analytics untouched.

## Risks / not checked

- **iOS resume-timing race — not verified on device.** Shipped a **synchronous** resume. The plan's default was a deferred resume via `InteractionManager.runAfterInteractions`, but that API is **deprecated in react-native@0.83.4** (zero-warnings policy), so I shipped synchronous and rely on the structural drop (`stopView` on background + `trackBackgroundEvents:false`). If the on-device gate shows the gap still attaches to the resumed view, add a frame-deferred restart (double `requestAnimationFrame`).
- Android SDK frame-protection was confirmed from research, not re-read line-by-line in this PR.
- **Out of scope:** the ~45% of frozen frames under 5s (genuine jank — e.g. synchronous signing/encoding, list rendering). Separate performance workstream.
- Not run on web (N/A — mobile-only change).

## Visual summary

```mermaid
sequenceDiagram
  participant U as User
  participant OS as iOS
  participant RN as JS thread
  participant DD as Datadog RUM

  Note over U,DD: Before
  U->>OS: background app (view still "active")
  OS->>RN: suspend JS thread
  U->>OS: foreground (minutes later)
  RN->>DD: long_task is_frozen_frame, duration = whole gap ❌

  Note over U,DD: After
  U->>OS: background app
  OS-->>RN: AppState 'background'
  RN->>DD: stopView() — no active view
  OS->>RN: suspend
  U->>OS: foreground
  OS-->>RN: AppState 'active'
  RN->>DD: stale-frame long task dropped (no active view) ✅
  RN->>DD: startView() — fresh view resumes
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (unit tests pass; on-device RUM gate pending — see "How to test it")
- [x] I've documented how it affects the analytics (if at all) 📊 (Datadog RUM view lifecycle; Firebase unchanged)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯