### PR TITLE
fix(web): stabilize security hub score and harden re-scan

### DIFF
--- a/apps/web/src/features/spaces/components/SecurityHub/__tests__/WorkspaceHealthCard.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/__tests__/WorkspaceHealthCard.test.tsx
@@ -104,4 +104,30 @@ describe('WorkspaceHealthCard', () => {
     rerender(<WorkspaceHealthCard {...baseProps} safes={[safe(SAFE_A)]} scanResults={{}} isScanning={false} />)
     expect(screen.queryByText('100')).not.toBeInTheDocument()
   })
+
+  it('shows an incomplete-scan note when the last scan was partial and not running', () => {
+    render(
+      <WorkspaceHealthCard
+        {...baseProps}
+        safes={[safe(SAFE_A)]}
+        scanResults={{ [scanKey(SAFE_A, '1')]: allClear }}
+        isScanning={false}
+        scanIncomplete
+      />,
+    )
+    expect(screen.getByText(/last scan didn't finish/i)).toBeInTheDocument()
+  })
+
+  it('hides the incomplete-scan note while a scan is running', () => {
+    render(
+      <WorkspaceHealthCard
+        {...baseProps}
+        safes={[safe(SAFE_A)]}
+        scanResults={{ [scanKey(SAFE_A, '1')]: allClear }}
+        isScanning={true}
+        scanIncomplete
+      />,
+    )
+    expect(screen.queryByText(/last scan didn't finish/i)).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/WorkspaceHealthCard/WorkspaceHealthCard.tsx
@@ -17,6 +17,7 @@ type WorkspaceHealthCardProps = {
   onFilterChange: (grade: SafeGrade) => void
   lastScannedAt: number | null
   onRescan: () => void
+  scanIncomplete?: boolean
 }
 
 type AggregateCounts = {
@@ -108,6 +109,7 @@ const WorkspaceHealthCard = ({
   onFilterChange,
   lastScannedAt,
   onRescan,
+  scanIncomplete = false,
 }: WorkspaceHealthCardProps): ReactElement => {
   const security = useLoadFeature(SecurityFeature)
 
@@ -228,6 +230,12 @@ const WorkspaceHealthCard = ({
                 </Typography>
               </Stack>
             </Stack>
+          )}
+
+          {scanIncomplete && !isScanning && (
+            <Typography variant="caption" color="warning.main" sx={{ display: 'block', mt: 0.5 }}>
+              The last scan didn&apos;t finish. Showing your most recent complete score — re-scan to update it.
+            </Typography>
           )}
         </Box>
       </Stack>

--- a/apps/web/src/features/spaces/components/SecurityHub/index.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/index.tsx
@@ -18,7 +18,7 @@ const SecurityHub = (): ReactElement => {
   const security = useLoadFeature(SecurityFeature)
   const { isLoadingSpacesSafes, safes, deployedEntries, balanceMap, overviewMap } = useReconciledSpaceSafes(security)
   const { allScanResults, scanTimestamps, lastScannedAt, handleScanComplete } = useScanResultsState(security)
-  const { scanningKeys, isRunning, startScan } = useAutoScanOrchestrator({
+  const { scanningKeys, isRunning, scanIncomplete, startScan } = useAutoScanOrchestrator({
     security,
     deployedEntries,
     safes,
@@ -59,7 +59,8 @@ const SecurityHub = (): ReactElement => {
             activeFilter={gradeFilter}
             onFilterChange={(grade) => setGradeFilter((prev) => (prev === grade ? null : grade))}
             lastScannedAt={lastScannedAt}
-            onRescan={startScan}
+            onRescan={() => startScan({ isManual: true })}
+            scanIncomplete={scanIncomplete}
           />
           <SecuritySafesTable
             safes={safes}

--- a/apps/web/src/features/spaces/hooks/__tests__/useAutoScan.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useAutoScan.test.ts
@@ -187,9 +187,11 @@ describe('useAutoScan', () => {
     )
   })
 
-  it('advances past failing scanners — queue still drains', async () => {
+  it('does not commit a partial scan (a scanner failed) but still drains the queue', async () => {
     const onComplete = jest.fn()
-    // One pass + one fail; the Safe should still complete and the queue should drain.
+    // One pass + one fail: the Safe's result set is incomplete, so it must NOT be
+    // committed (committing a partial set would shift the gauge score between scans).
+    // The queue must still advance so it doesn't hang.
     const passing = mkScanner('account_setup', mkResult({ status: 'clear' }))
     const failing = mkFailingScanner('modules')
     const services = mkServices([passing, failing])
@@ -202,11 +204,78 @@ describe('useAutoScan', () => {
       result.current.startScan()
     })
 
+    // Queue drains: scanning key released and the run stops.
+    await waitFor(() => expect(result.current.isRunning).toBe(false))
+    expect(result.current.scanningKeys.has(`${SAFE_A}:${CHAIN}`)).toBe(false)
+    // Partial scan is NOT committed anywhere…
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(services.setCachedScan).not.toHaveBeenCalled()
+    // …and the incomplete state is surfaced so the gauge can keep the prior score.
+    expect(result.current.scanIncomplete).toBe(true)
+  })
+
+  it('commits a complete scan and reports scanIncomplete=false', async () => {
+    const onComplete = jest.fn()
+    const a = mkScanner('account_setup', mkResult({ status: 'clear' }))
+    const b = mkScanner('modules', mkResult({ status: 'clear' }))
+    const services = mkServices([a, b])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, onComplete))
+
+    act(() => {
+      result.current.startScan()
+    })
+
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
-    // Passing result is recorded; failing one is omitted (not rethrown)
-    const [, , , results] = onComplete.mock.calls[0]
-    expect(results).toHaveProperty('account_setup')
-    expect(results).not.toHaveProperty('modules')
+    expect(services.setCachedScan).toHaveBeenCalledTimes(1)
+    expect(result.current.scanIncomplete).toBe(false)
+  })
+
+  it('resets scanIncomplete when a fresh scan starts', async () => {
+    const onComplete = jest.fn()
+    const passing = mkScanner('account_setup', mkResult({ status: 'clear' }))
+    const failing = mkFailingScanner('modules')
+    const services = mkServices([passing, failing])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, onComplete))
+
+    act(() => {
+      result.current.startScan()
+    })
+    await waitFor(() => expect(result.current.scanIncomplete).toBe(true))
+
+    // Starting a new scan clears the stale incomplete flag immediately.
+    act(() => {
+      result.current.startScan()
+    })
+    expect(result.current.scanIncomplete).toBe(false)
+  })
+
+  it('marks scanIncomplete when a target is bailed past', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const onComplete = jest.fn()
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+
+    // scanContext never resolves for SAFE_A → bail path fires.
+    mockScanContext = null
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, onComplete))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    await act(async () => {
+      jest.advanceTimersByTime(10_000)
+    })
+
+    await waitFor(() => expect(result.current.scanIncomplete).toBe(true))
+    expect(onComplete).not.toHaveBeenCalled()
   })
 
   it('sets justCompleted briefly after the queue drains, then clears it', async () => {
@@ -264,6 +333,128 @@ describe('useAutoScan', () => {
     await waitFor(() => expect(result.current.scanningKeys.has(`${SAFE_A}:${CHAIN}`)).toBe(false))
     // SAFE_B runs normally and completes.
     await waitFor(() => expect(onComplete).toHaveBeenCalledWith(SAFE_B, CHAIN, expect.any(Number), expect.any(Object)))
+  })
+
+  it('flags isRescanning while a manual re-scan runs and clears it when done', async () => {
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, jest.fn()))
+
+    act(() => {
+      result.current.startScan({ isManual: true })
+    })
+    expect(result.current.isRescanning).toBe(true)
+
+    // Let the scan finish, then advance past the minimum-visible window.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    act(() => {
+      jest.advanceTimersByTime(1_000)
+    })
+    expect(result.current.isRunning).toBe(false)
+    expect(result.current.isRescanning).toBe(false)
+  })
+
+  it('keeps a manual re-scan visible for a minimum duration even if it finishes instantly', async () => {
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, jest.fn()))
+
+    act(() => {
+      result.current.startScan({ isManual: true })
+    })
+
+    // Let the fast scanner resolve + effects flush WITHOUT advancing the min-visible timer.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    // Scan already completed, but the "Scanning..." state must still be showing.
+    expect(result.current.isRunning).toBe(true)
+
+    // Once the minimum window (1s) elapses, it finishes.
+    act(() => {
+      jest.advanceTimersByTime(1_000)
+    })
+    expect(result.current.isRunning).toBe(false)
+  })
+
+  it('does not hold an automatic scan open for the minimum duration', async () => {
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, jest.fn()))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    // Automatic scan finishes as soon as the scanner resolves — no minimum-visible hold.
+    await waitFor(() => expect(result.current.isRunning).toBe(false))
+  })
+
+  it('does not flag isRescanning for an automatic scan', () => {
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+    mockScanContext = mkContext()
+
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, jest.fn()))
+
+    act(() => {
+      result.current.startScan()
+    })
+    expect(result.current.isRunning).toBe(true)
+    expect(result.current.isRescanning).toBe(false)
+  })
+
+  it('does not bail while the tab is hidden, then resumes the countdown on return', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const setVisibility = (state: 'visible' | 'hidden') => {
+      Object.defineProperty(document, 'visibilityState', { value: state, configurable: true })
+      document.dispatchEvent(new Event('visibilitychange'))
+    }
+
+    const scanner = mkScanner('account_setup')
+    const services = mkServices([scanner])
+    // Context never resolves so only the bail timer can advance the queue.
+    mockScanContext = null
+    const queue = [mkSelected(SAFE_A)]
+    const { result } = renderHook(() => useAutoScan(queue, [mkSafe(SAFE_A)], {}, services, jest.fn()))
+
+    act(() => {
+      result.current.startScan()
+    })
+
+    // Tab hidden: even well past the bail window, the scan must NOT be marked incomplete.
+    act(() => {
+      setVisibility('hidden')
+    })
+    act(() => {
+      jest.advanceTimersByTime(10_000)
+    })
+    expect(result.current.scanIncomplete).toBe(false)
+    expect(result.current.scanningKeys.has(`${SAFE_A}:${CHAIN}`)).toBe(true)
+
+    // Back to the tab: the countdown restarts and bails after the window elapses.
+    // Advance well past any reasonable bail window so the test is robust to its value.
+    act(() => {
+      setVisibility('visible')
+    })
+    await act(async () => {
+      jest.advanceTimersByTime(10_000)
+    })
+    await waitFor(() => expect(result.current.scanIncomplete).toBe(true))
   })
 
   it('removes the scanned key from scanningKeys when its scanners complete', async () => {

--- a/apps/web/src/features/spaces/hooks/__tests__/useSafeScanContext.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSafeScanContext.test.ts
@@ -257,4 +257,32 @@ describe('useSafeScanContext', () => {
     expect(result.current).not.toBeNull()
     expect(result.current?.balanceUsd).toBe(500)
   })
+
+  it('does not force a refetch by default (uses cached data)', () => {
+    renderHook(() => useSafeScanContext(defaultSelected, defaultEntry))
+    for (const query of [
+      useSafesGetSafeV1Query,
+      useChainsGetMasterCopiesV1Query,
+      useTransactionsGetCreationTransactionV1Query,
+    ]) {
+      expect(query).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({ refetchOnMountOrArgChange: false }),
+      )
+    }
+  })
+
+  it('forces the scan data queries to refetch when forceRefetch is true', () => {
+    renderHook(() => useSafeScanContext(defaultSelected, defaultEntry, undefined, true))
+    for (const query of [
+      useSafesGetSafeV1Query,
+      useChainsGetMasterCopiesV1Query,
+      useTransactionsGetCreationTransactionV1Query,
+    ]) {
+      expect(query).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({ refetchOnMountOrArgChange: true }),
+      )
+    }
+  })
 })

--- a/apps/web/src/features/spaces/hooks/useAutoScan.ts
+++ b/apps/web/src/features/spaces/hooks/useAutoScan.ts
@@ -9,7 +9,12 @@ import type { SpaceSafeEntry, SelectedSafe } from '@/features/spaces/components/
 // isDeployed=true locally (because this client's undeployedSafes slice doesn't track it),
 // but be counterfactual in reality — the Safe/masterCopies/creation queries then 404 and
 // scanContext stays null forever, hanging the sequential queue on that target.
-const SCAN_CONTEXT_BAIL_MS = 2_000
+const SCAN_CONTEXT_BAIL_MS = 5_000
+
+// Minimum time a user-triggered re-scan keeps its "Scanning..." state on screen. Without
+// this, a fast scan (warm cache / quick backend) flips back to "Re-scan" almost instantly
+// and the click feels like nothing happened.
+const MIN_RESCAN_VISIBLE_MS = 1_000
 
 /**
  * Services this hook needs from the security feature. Callers obtain these via
@@ -29,8 +34,24 @@ export type AutoScanState = {
   isRunning: boolean
   /** Briefly true for ~2.5s after the queue drains — useful for success toasts. */
   justCompleted: boolean
-  /** Kicks off a fresh scan over the current queue. */
-  startScan: () => void
+  /**
+   * True when the most recent run couldn't fully scan every Safe — a scanner
+   * threw/timed out, or a target was bailed past. Such partial results are NOT
+   * committed (the gauge keeps the prior complete score), so this flag lets the
+   * UI explain why the score didn't refresh. Reset at the start of each scan.
+   */
+  scanIncomplete: boolean
+  /**
+   * True only while a user-triggered re-scan is running (the "Re-scan" button),
+   * not for automatic scans on load/queue changes. Lets the UI reset the gauge to
+   * a scanning state and rebuild, instead of leaving the prior score on screen.
+   */
+  isRescanning: boolean
+  /**
+   * Kicks off a fresh scan over the current queue. Pass `{ isManual: true }` for
+   * an explicit user re-scan so the UI can show a full restart.
+   */
+  startScan: (options?: { isManual?: boolean }) => void
 }
 
 /**
@@ -60,9 +81,13 @@ const useAutoScan = (
   const [scanningKeys, setScanningKeys] = useState<Set<string>>(new Set())
   const [isRunning, setIsRunning] = useState(false)
   const [justCompleted, setJustCompleted] = useState(false)
+  const [scanIncomplete, setScanIncomplete] = useState(false)
+  const [isRescanning, setIsRescanning] = useState(false)
   const completedRef = useRef<Set<string>>(new Set())
   const scanningRef = useRef<string | null>(null)
   const completionTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  // When the current run started — used to keep a manual re-scan visible for a minimum time.
+  const scanStartedAtRef = useRef(0)
   // Store onComplete in a ref to avoid stale closure — the effect captures
   // this ref instead of the callback directly.
   const onCompleteRef = useRef(onComplete)
@@ -75,7 +100,9 @@ const useAutoScan = (
   // The batch query in SecurityHub already fetches all overviews — reuse that data.
   const currentOverview =
     currentTarget && services ? overviewMap[services.scanKey(currentTarget.address, currentTarget.chainId)] : undefined
-  const scanContext = useSafeScanContext(currentTarget, currentEntry, currentOverview)
+  // During a user-triggered re-scan, force the scan's data queries to refetch from the
+  // backend so the new scan reflects current on-chain/config state rather than cache.
+  const scanContext = useSafeScanContext(currentTarget, currentEntry, currentOverview, isRescanning)
 
   // Run scanners when context is ready
   useEffect(() => {
@@ -111,17 +138,27 @@ const useAutoScan = (
           if (completed === total) {
             completedRef.current.add(key)
             scanningRef.current = null
-            const timestamp = Date.now()
-            // Share results with the module-level cache so the drawer reuses them
-            // instead of re-scanning when the user opens this Safe's report.
-            setCachedScan(key, results, timestamp)
-            onCompleteRef.current(currentTarget.address, currentTarget.chainId, timestamp, results)
             setScanningKeys((prev) => {
               const next = new Set(prev)
               next.delete(key)
               return next
             })
             setCurrentIndex((i) => i + 1)
+
+            // Only commit when every scanner produced a result. A thrown/timed-out
+            // scanner leaves its id absent from `results`, which would shrink the
+            // gauge's denominator and shift the score between scans of an unchanged
+            // account. Skip the commit instead — the prior complete score stays put.
+            if (Object.keys(results).length < total) {
+              setScanIncomplete(true)
+              return
+            }
+
+            const timestamp = Date.now()
+            // Share results with the module-level cache so the drawer reuses them
+            // instead of re-scanning when the user opens this Safe's report.
+            setCachedScan(key, results, timestamp)
+            onCompleteRef.current(currentTarget.address, currentTarget.chainId, timestamp, results)
           }
         })
     })
@@ -134,50 +171,91 @@ const useAutoScan = (
   useEffect(() => {
     if (!currentTarget || !isRunning || !services || scanContext) return
     const key = services.scanKey(currentTarget.address, currentTarget.chainId)
-    const timer = setTimeout(() => {
-      console.warn(
-        `[SecurityHub] scan context did not resolve for ${currentTarget.address}:${currentTarget.chainId} within ${SCAN_CONTEXT_BAIL_MS}ms — skipping`,
-      )
-      completedRef.current.add(key)
-      setScanningKeys((prev) => {
-        if (!prev.has(key)) return prev
-        const next = new Set(prev)
-        next.delete(key)
-        return next
-      })
-      setCurrentIndex((i) => i + 1)
-    }, SCAN_CONTEXT_BAIL_MS)
-    return () => clearTimeout(timer)
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    // Only count down while the tab is visible. A backgrounded tab throttles timers and
+    // defers React renders, so the bail can fire before the still-in-flight queries'
+    // resolution re-render clears it — falsely marking the scan incomplete on tab return.
+    // Re-arm from scratch each time the tab becomes visible again.
+    const arm = () => {
+      clearTimeout(timer)
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
+      timer = setTimeout(() => {
+        console.warn(
+          `[SecurityHub] scan context did not resolve for ${currentTarget.address}:${currentTarget.chainId} within ${SCAN_CONTEXT_BAIL_MS}ms — skipping`,
+        )
+        completedRef.current.add(key)
+        // A bailed target contributes no results, so the run is partial — surface it
+        // and leave the committed score untouched (same rationale as the commit gate).
+        setScanIncomplete(true)
+        setScanningKeys((prev) => {
+          if (!prev.has(key)) return prev
+          const next = new Set(prev)
+          next.delete(key)
+          return next
+        })
+        setCurrentIndex((i) => i + 1)
+      }, SCAN_CONTEXT_BAIL_MS)
+    }
+
+    arm()
+    document.addEventListener('visibilitychange', arm)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('visibilitychange', arm)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scanContext, currentTarget?.address, currentTarget?.chainId, isRunning, services])
 
   // Stop when queue is exhausted, show brief completion state
   useEffect(() => {
-    if (isRunning && currentIndex >= queue.length && queue.length > 0) {
+    if (!(isRunning && currentIndex >= queue.length && queue.length > 0)) return
+
+    const finish = () => {
       setIsRunning(false)
+      setIsRescanning(false)
       setJustCompleted(true)
       clearTimeout(completionTimerRef.current)
       completionTimerRef.current = setTimeout(() => setJustCompleted(false), 2500)
     }
-  }, [isRunning, currentIndex, queue.length])
+
+    // Hold a manual re-scan's "Scanning..." state for a minimum period so it doesn't
+    // flash by when results come back fast. Automatic scans finish immediately.
+    const remaining = isRescanning ? MIN_RESCAN_VISIBLE_MS - (Date.now() - scanStartedAtRef.current) : 0
+    if (remaining <= 0) {
+      finish()
+      return
+    }
+    const timer = setTimeout(finish, remaining)
+    return () => clearTimeout(timer)
+  }, [isRunning, currentIndex, queue.length, isRescanning])
 
   // Cleanup on unmount only
   useEffect(() => () => clearTimeout(completionTimerRef.current), [])
 
-  const startScan = useCallback(() => {
-    if (!services) return
-    completedRef.current = new Set()
-    scanningRef.current = null
-    // Pre-populate ALL keys as scanning so every row shows a loading state immediately.
-    // Each key is removed individually on completion. For multichain parents,
-    // `isAnyChainScanning` stays true until the last chain-child finishes.
-    setScanningKeys(new Set(queue.map((q) => services.scanKey(q.address, q.chainId))))
-    setCurrentIndex(0)
-    setJustCompleted(false)
-    setIsRunning(true)
-  }, [queue, services])
+  const startScan = useCallback(
+    (options?: { isManual?: boolean }) => {
+      if (!services) return
+      completedRef.current = new Set()
+      scanningRef.current = null
+      setScanIncomplete(false)
+      scanStartedAtRef.current = Date.now()
+      // Manual re-scans force a fresh backend refetch and keep the "Scanning..." state
+      // visible for a minimum period; automatic scans on load/queue changes do neither.
+      setIsRescanning(Boolean(options?.isManual))
+      // Pre-populate ALL keys as scanning so every row shows a loading state immediately.
+      // Each key is removed individually on completion. For multichain parents,
+      // `isAnyChainScanning` stays true until the last chain-child finishes.
+      setScanningKeys(new Set(queue.map((q) => services.scanKey(q.address, q.chainId))))
+      setCurrentIndex(0)
+      setJustCompleted(false)
+      setIsRunning(true)
+    },
+    [queue, services],
+  )
 
-  return { scanningKeys, isRunning, justCompleted, startScan }
+  return { scanningKeys, isRunning, justCompleted, scanIncomplete, isRescanning, startScan }
 }
 
 export default useAutoScan

--- a/apps/web/src/features/spaces/hooks/useAutoScan.ts
+++ b/apps/web/src/features/spaces/hooks/useAutoScan.ts
@@ -3,6 +3,7 @@ import type { ScanResult, SecurityScanner } from '@/features/security/types'
 import type { SecurityContract } from '@/features/security'
 import useSafeScanContext, { type OverviewData } from '@/features/spaces/hooks/useSafeScanContext'
 import type { SpaceSafeEntry, SelectedSafe } from '@/features/spaces/components/SecurityHub'
+import { scheduleWhileVisible } from '@/utils/visibility'
 
 // How long to wait for useSafeScanContext to resolve before bailing past a target.
 // Protects against "ghost-deployed" chains: a multichain Safe entry may be flagged
@@ -172,39 +173,25 @@ const useAutoScan = (
     if (!currentTarget || !isRunning || !services || scanContext) return
     const key = services.scanKey(currentTarget.address, currentTarget.chainId)
 
-    let timer: ReturnType<typeof setTimeout> | undefined
-
-    // Only count down while the tab is visible. A backgrounded tab throttles timers and
-    // defers React renders, so the bail can fire before the still-in-flight queries'
-    // resolution re-render clears it — falsely marking the scan incomplete on tab return.
-    // Re-arm from scratch each time the tab becomes visible again.
-    const arm = () => {
-      clearTimeout(timer)
-      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
-      timer = setTimeout(() => {
-        console.warn(
-          `[SecurityHub] scan context did not resolve for ${currentTarget.address}:${currentTarget.chainId} within ${SCAN_CONTEXT_BAIL_MS}ms — skipping`,
-        )
-        completedRef.current.add(key)
-        // A bailed target contributes no results, so the run is partial — surface it
-        // and leave the committed score untouched (same rationale as the commit gate).
-        setScanIncomplete(true)
-        setScanningKeys((prev) => {
-          if (!prev.has(key)) return prev
-          const next = new Set(prev)
-          next.delete(key)
-          return next
-        })
-        setCurrentIndex((i) => i + 1)
-      }, SCAN_CONTEXT_BAIL_MS)
+    const bailPastTarget = () => {
+      console.warn(
+        `[SecurityHub] scan context did not resolve for ${currentTarget.address}:${currentTarget.chainId} within ${SCAN_CONTEXT_BAIL_MS}ms — skipping`,
+      )
+      completedRef.current.add(key)
+      // A bailed target contributes no results, so the run is partial — surface it
+      // and leave the committed score untouched (same rationale as the commit gate).
+      setScanIncomplete(true)
+      setScanningKeys((prev) => {
+        if (!prev.has(key)) return prev
+        const next = new Set(prev)
+        next.delete(key)
+        return next
+      })
+      setCurrentIndex((i) => i + 1)
     }
 
-    arm()
-    document.addEventListener('visibilitychange', arm)
-    return () => {
-      clearTimeout(timer)
-      document.removeEventListener('visibilitychange', arm)
-    }
+    // Only count down while the tab is visible — see scheduleWhileVisible.
+    return scheduleWhileVisible(SCAN_CONTEXT_BAIL_MS, bailPastTarget)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scanContext, currentTarget?.address, currentTarget?.chainId, isRunning, services])
 

--- a/apps/web/src/features/spaces/hooks/useSafeScanContext.ts
+++ b/apps/web/src/features/spaces/hooks/useSafeScanContext.ts
@@ -22,6 +22,9 @@ const useSafeScanContext = (
   selected: SelectedSafe | null,
   entry: SpaceSafeEntry | undefined,
   overviewData?: OverviewData,
+  // When true (a user-triggered re-scan), bypass the cache and refetch the scan's
+  // data queries from the backend so the new scan reflects current state.
+  forceRefetch = false,
 ): ScanContext | null => {
   const chainId = selected?.chainId ?? ''
   const address = selected?.address ?? ''
@@ -32,7 +35,7 @@ const useSafeScanContext = (
   // Fetch SafeState for the selected chain — skip if not deployed
   const { currentData: safeInfo, isFetching: isSafeFetching } = useSafesGetSafeV1Query(
     { chainId, safeAddress: address },
-    { skip: !selected || !isDeployed },
+    { skip: !selected || !isDeployed, refetchOnMountOrArgChange: forceRefetch },
   )
 
   // Fetch master copies for deployer resolution
@@ -40,7 +43,10 @@ const useSafeScanContext = (
     currentData: masterCopies,
     isFetching: isMasterCopiesFetching,
     isError: isMasterCopiesError,
-  } = useChainsGetMasterCopiesV1Query({ chainId }, { skip: !selected || !isDeployed })
+  } = useChainsGetMasterCopiesV1Query(
+    { chainId },
+    { skip: !selected || !isDeployed, refetchOnMountOrArgChange: forceRefetch },
+  )
 
   // Fetch creation transaction for factory/deployment validation
   const {
@@ -49,7 +55,7 @@ const useSafeScanContext = (
     isError: isCreationError,
   } = useTransactionsGetCreationTransactionV1Query(
     { chainId, safeAddress: address },
-    { skip: !selected || !isDeployed },
+    { skip: !selected || !isDeployed, refetchOnMountOrArgChange: forceRefetch },
   )
 
   // For multichain: fetch overviews for all chains to compare signer setup
@@ -75,7 +81,7 @@ const useSafeScanContext = (
   // when useAutoScan advances from one Safe to the next, before RTK Query resolves the new args.
   const { currentData: safeOverviews, isFetching: isOverviewsFetching } = useGetMultipleSafeOverviewsQuery(
     { safes: multichainSafeItems, currency },
-    { skip: !isMultichain || multichainSafeItems.length === 0 },
+    { skip: !isMultichain || multichainSafeItems.length === 0, refetchOnMountOrArgChange: forceRefetch },
   )
 
   // Fetch overview for balance data (fiatTotal) on the selected chain.
@@ -83,7 +89,7 @@ const useSafeScanContext = (
   // to avoid redundant per-Safe API requests during auto-scan.
   const { currentData: safeOverview, isFetching: isOverviewFetching } = useGetSafeOverviewQuery(
     { chainId, safeAddress: address },
-    { skip: !selected || !isDeployed || !!overviewData },
+    { skip: !selected || !isDeployed || !!overviewData, refetchOnMountOrArgChange: forceRefetch },
   )
 
   const chain = useChain(chainId)

--- a/apps/web/src/utils/__tests__/visibility.test.ts
+++ b/apps/web/src/utils/__tests__/visibility.test.ts
@@ -1,0 +1,74 @@
+import { scheduleWhileVisible } from '../visibility'
+
+const setVisibility = (state: 'visible' | 'hidden') => {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true })
+  document.dispatchEvent(new Event('visibilitychange'))
+}
+
+describe('scheduleWhileVisible', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    setVisibility('visible')
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    setVisibility('visible')
+  })
+
+  it('runs the callback after the delay while visible', () => {
+    const onTimeout = jest.fn()
+    scheduleWhileVisible(1_000, onTimeout)
+
+    jest.advanceTimersByTime(999)
+    expect(onTimeout).not.toHaveBeenCalled()
+
+    jest.advanceTimersByTime(1)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not run while the tab is hidden, then runs once it is visible again', () => {
+    const onTimeout = jest.fn()
+    scheduleWhileVisible(1_000, onTimeout)
+
+    setVisibility('hidden')
+    jest.advanceTimersByTime(10_000)
+    expect(onTimeout).not.toHaveBeenCalled()
+
+    setVisibility('visible')
+    jest.advanceTimersByTime(1_000)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('restarts the countdown from scratch each time the tab becomes visible', () => {
+    const onTimeout = jest.fn()
+    scheduleWhileVisible(1_000, onTimeout)
+
+    // Almost there, then hide before it fires.
+    jest.advanceTimersByTime(900)
+    setVisibility('hidden')
+    jest.advanceTimersByTime(10_000)
+    expect(onTimeout).not.toHaveBeenCalled()
+
+    // Returning resets the full delay — 900ms of prior progress is discarded.
+    setVisibility('visible')
+    jest.advanceTimersByTime(999)
+    expect(onTimeout).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(1)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleanup cancels the timer and stops listening', () => {
+    const onTimeout = jest.fn()
+    const cleanup = scheduleWhileVisible(1_000, onTimeout)
+
+    cleanup()
+    jest.advanceTimersByTime(10_000)
+    // A visibility change after cleanup must not re-arm.
+    setVisibility('hidden')
+    setVisibility('visible')
+    jest.advanceTimersByTime(10_000)
+
+    expect(onTimeout).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/utils/visibility.ts
+++ b/apps/web/src/utils/visibility.ts
@@ -1,0 +1,36 @@
+/**
+ * Runs `onTimeout` after `delay` ms, but only counts down while the tab is visible.
+ *
+ * A backgrounded tab throttles timers and defers React renders, so a plain `setTimeout`
+ * can fire before the work it guards has had a chance to complete — making time-based
+ * bail/timeout logic misbehave on tab return. This pauses the countdown while the tab is
+ * hidden and re-arms it from scratch each time the tab becomes visible again.
+ *
+ * @returns a cleanup function that cancels the timer and removes the listener.
+ */
+export const scheduleWhileVisible = (delay: number, onTimeout: () => void): (() => void) => {
+  // SSR / non-DOM environments: fall back to a plain timeout.
+  if (typeof document === 'undefined') {
+    const timer = setTimeout(onTimeout, delay)
+    return () => clearTimeout(timer)
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  // Cancels any pending countdown, then starts a fresh one only if the tab is visible.
+  // Used both to kick things off and as the visibilitychange handler: becoming visible
+  // (re)starts the full delay, becoming hidden just cancels it.
+  const restartCountdown = () => {
+    clearTimeout(timer)
+    if (document.visibilityState !== 'visible') return
+    timer = setTimeout(onTimeout, delay)
+  }
+
+  restartCountdown()
+  document.addEventListener('visibilitychange', restartCountdown)
+
+  return () => {
+    clearTimeout(timer)
+    document.removeEventListener('visibilitychange', restartCountdown)
+  }
+}


### PR DESCRIPTION
> Partial scans no longer commit,
> re-scan pulls fresh and waits a beat,
> hidden tabs hold their countdown —
> the gauge stops flip-flopping.

## What it solves

Resolves three Security Hub issues around the workspace score gauge:

1. **Score changed on re-scan of an unchanged account.** The overall score is `round(passing / applicableCount * 100)`, computed over whatever checks produced a *definitive* result that scan. A scanner that threw, timed out, or whose Safe was bailed past was silently dropped, shrinking the denominator — so transient RPC/CGW jitter between scans moved the score even though nothing about the account changed.
2. **"Re-scan" re-ran scanners over cached data**, so it couldn't reflect fresh backend state.
3. **Switching browser tabs falsely reported `The last scan didn't finish`**, with a `[SecurityHub] scan context did not resolve … within Nms — skipping` warning in the console.

## How this PR fixes it

- **Don't commit partial scans** (`useAutoScan.ts`): a Safe's results are written to the gauge/cache only when *every* scanner produced a result (`Object.keys(results).length === total`). A partial run no longer overwrites the prior complete score; the queue still drains so nothing hangs. A `scanIncomplete` flag surfaces a note: *"The last scan didn't finish. Showing your most recent complete score — re-scan to update it."*
- **Forced backend refetch on manual re-scan** (`useSafeScanContext.ts`): a new `forceRefetch` param sets `refetchOnMountOrArgChange` on the scan's CGW queries (safes, master-copies, creation tx, safe overviews). Driven by an `isRescanning` signal that is true **only** for the user-triggered "Re-scan" button — automatic scans (load / queue change / space switch) stay on cache.
- **Minimum visible re-scan duration**: a manual re-scan holds the "Scanning…" state for at least 1s so a fast scan doesn't flash by.
- **Visibility-aware bail countdown**: the scan-context bail timer only counts down while `document.visibilityState === 'visible'`, re-arming on `visibilitychange`. A backgrounded tab (which throttles timers and defers renders) can no longer fire the bail before the still-in-flight query resolves. Genuine "ghost-deployed" stalls still bail after a real foreground window.

## How to test it

1. Open the Security tab for a workspace with at least one Safe; let the scan complete and note the score.
2. Click **Re-scan** repeatedly — the score stays stable for an unchanged account, and "Scanning…" is visible for ~1s each time.
3. With the network throttled, click **Re-scan** and confirm fresh requests for the scan's CGW endpoints go out.
4. Start a scan, switch to another browser tab for a few seconds, come back — no `scan context did not resolve … — skipping` warning and no false "scan didn't finish" note.

## Affected flows

- Security Hub workspace score gauge (`WorkspaceHealthCard`) — aggregate score + "scan incomplete" note.
- Security Hub auto-scan + manual re-scan queue (`useAutoScan` / `useAutoScanOrchestrator`).
- Per-Safe scan data fetch (`useSafeScanContext`) — manual re-scan now refetches from backend.

## Blast radius

- **`useSafeScanContext`** (shared by `useAutoScan` and the report drawer): added optional `forceRefetch` param (defaults `false`), so the drawer's behavior is unchanged. Sets `refetchOnMountOrArgChange` on `useSafesGetSafeV1Query`, `useChainsGetMasterCopiesV1Query`, `useTransactionsGetCreationTransactionV1Query`, `useGetSafeOverviewQuery`, `useGetMultipleSafeOverviewsQuery`.
- **`useAutoScan` / `AutoScanState`**: added `scanIncomplete` and `isRescanning`; `startScan` now takes `{ isManual?: boolean }`. Consumed only by `useAutoScanOrchestrator` → `SecurityHub`.
- **`setCachedScan` / `scanResultsCache`**: partial scans are no longer cached, so the drawer re-scans on open instead of reusing a partial result (acceptable).
- No API contract, feature flag, route, or shared-package (mobile) changes.

## Risks / not checked

- **Balances batch query not force-refreshed**: the `overviewMap` (balance / queued-count) from `useReconciledSpaceSafes` is passed in as `overviewData` and isn't part of `forceRefetch`, so those cosmetic fields stay cached on a manual re-scan. All *score-relevant* data does refresh.
- **Per-scanner 15s `withScannerTimeout` is not visibility-aware**: a tab left in the background long enough for a scanner to time out (after its context resolves) could still mark a Safe incomplete. Much longer window than the bail; not the reported symptom. Left as a follow-up.
- **Issue carried over from prior work**: a scanner that *resolves* to `inconclusive` because its underlying query errored is indistinguishable from a legitimate `inconclusive`, so it remains a narrower residual source of score drift. Not addressed here.
- Not tested on mobile (web-only feature). No manual E2E run; relying on unit coverage.

## Visual summary

```mermaid
flowchart TD
  Click["Re-scan click"] --> SS["startScan({ isManual: true })"]
  SS --> RS["isRescanning = true"]
  RS --> FR["useSafeScanContext forceRefetch\n→ refetchOnMountOrArgChange on CGW queries"]
  RS --> MIN["hold 'Scanning…' ≥ 1s"]

  subgraph PerSafe["Per-Safe completion"]
    AllDone{"every scanner\nproduced a result?"}
    AllDone -->|yes| Commit["commit results\n→ gauge + cache"]
    AllDone -->|no| Skip["skip commit\nscanIncomplete = true\n(keep prior score)"]
  end
  FR --> PerSafe

  subgraph Bail["Context bail countdown"]
    Vis{"document visible?"}
    Vis -->|yes| Count["count down → bail after window"]
    Vis -->|no| Pause["paused; re-arm on visibilitychange"]
  end

  Skip --> Note["WorkspaceHealthCard:\n'last scan didn't finish' note"]
  Count --> Skip
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (web-only feature; N/A)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics change)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
