### PR TITLE
fix(spaces): refresh aggregated balance after a tx executes

### DIFF
--- a/apps/web/src/hooks/__tests__/useInvalidateOverviewsOnTx.test.ts
+++ b/apps/web/src/hooks/__tests__/useInvalidateOverviewsOnTx.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook, waitFor } from '@/tests/test-utils'
+import { faker } from '@faker-js/faker'
+import useInvalidateOverviewsOnTx from '../useInvalidateOverviewsOnTx'
+import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
+import * as txEvents from '@/services/tx/txEvents'
+import { TxEvent, txDispatch } from '@/services/tx/txEvents'
+import { additionalSafesRtkApi } from '@safe-global/store/gateway/safes'
+import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+
+const mockedInitiate = jest.spyOn(additionalSafesRtkApi.endpoints.safesGetOverviewForMany, 'initiate')
+
+type InitiateThunk = ReturnType<typeof additionalSafesRtkApi.endpoints.safesGetOverviewForMany.initiate>
+type QueryActionResult = ReturnType<InitiateThunk>
+
+const mockQueryAction = (data: SafeOverview[]) => {
+  const queryResult = {
+    unwrap: jest.fn().mockResolvedValue(data),
+    unsubscribe: jest.fn(),
+  } as unknown as QueryActionResult
+
+  mockedInitiate.mockImplementationOnce(() => (() => queryResult) as InitiateThunk)
+}
+
+const makeOverview = (address: string, fiatTotal: string): SafeOverview =>
+  ({
+    address: { value: address },
+    chainId: '1',
+    awaitingConfirmation: null,
+    fiatTotal,
+    owners: [{ value: faker.finance.ethereumAddress() }],
+    threshold: 1,
+    queued: 0,
+  }) as unknown as SafeOverview
+
+const txDetail = { txId: '0x1', nonce: 1, chainId: '1', safeAddress: faker.finance.ethereumAddress() }
+
+describe('useInvalidateOverviewsOnTx', () => {
+  beforeEach(() => {
+    mockedInitiate.mockReset()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('refetches Safe overviews when a tx is executed', async () => {
+    const safe = {
+      address: faker.finance.ethereumAddress(),
+      chainId: '1',
+      isReadOnly: false,
+      isPinned: false,
+      lastVisited: 0,
+      name: undefined,
+    }
+    const request = { currency: 'usd', safes: [safe] }
+    const stale = makeOverview(safe.address, '100')
+    const fresh = makeOverview(safe.address, '200')
+
+    mockQueryAction([stale])
+
+    const { result } = renderHook(() => {
+      useInvalidateOverviewsOnTx()
+      return useGetMultipleSafeOverviewsQuery(request)
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([stale])
+    })
+    expect(mockedInitiate).toHaveBeenCalledTimes(1)
+
+    // A tx is executed -> overviews must be refetched and the fresh balance shown
+    mockQueryAction([fresh])
+    act(() => {
+      txDispatch(TxEvent.SUCCESS, txDetail)
+    })
+
+    await waitFor(() => {
+      expect(mockedInitiate).toHaveBeenCalledTimes(2)
+      expect(result.current.data).toEqual([fresh])
+    })
+  })
+
+  it('subscribes to tx success and unsubscribes on unmount', () => {
+    const unsubscribe = jest.fn()
+    const subscribeSpy = jest.spyOn(txEvents, 'txSubscribe').mockReturnValue(unsubscribe)
+
+    const { unmount } = renderHook(() => useInvalidateOverviewsOnTx())
+
+    expect(subscribeSpy).toHaveBeenCalledWith(TxEvent.SUCCESS, expect.any(Function))
+    expect(unsubscribe).not.toHaveBeenCalled()
+
+    unmount()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/hooks/__tests__/useInvalidateOverviewsOnTx.test.ts
+++ b/apps/web/src/hooks/__tests__/useInvalidateOverviewsOnTx.test.ts
@@ -32,29 +32,25 @@ const makeOverview = (address: string, fiatTotal: string): SafeOverview =>
     queued: 0,
   }) as unknown as SafeOverview
 
-const txDetail = { txId: '0x1', nonce: 1, chainId: '1', safeAddress: faker.finance.ethereumAddress() }
+const makeSafeItem = (address: string) => ({
+  address,
+  chainId: '1',
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+})
 
 describe('useInvalidateOverviewsOnTx', () => {
   beforeEach(() => {
     mockedInitiate.mockReset()
   })
 
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
-  it('refetches Safe overviews when a tx is executed', async () => {
-    const safe = {
-      address: faker.finance.ethereumAddress(),
-      chainId: '1',
-      isReadOnly: false,
-      isPinned: false,
-      lastVisited: 0,
-      name: undefined,
-    }
-    const request = { currency: 'usd', safes: [safe] }
-    const stale = makeOverview(safe.address, '100')
-    const fresh = makeOverview(safe.address, '200')
+  it('refetches the overviews of the Safe that executed the tx', async () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    const request = { currency: 'usd', safes: [makeSafeItem(safeAddress)] }
+    const stale = makeOverview(safeAddress, '100')
+    const fresh = makeOverview(safeAddress, '200')
 
     mockQueryAction([stale])
 
@@ -68,16 +64,47 @@ describe('useInvalidateOverviewsOnTx', () => {
     })
     expect(mockedInitiate).toHaveBeenCalledTimes(1)
 
-    // A tx is executed -> overviews must be refetched and the fresh balance shown
+    // tx executed on this Safe -> its overviews must be refetched and the fresh balance shown
     mockQueryAction([fresh])
     act(() => {
-      txDispatch(TxEvent.SUCCESS, txDetail)
+      txDispatch(TxEvent.SUCCESS, { txId: '0x1', nonce: 1, chainId: '1', safeAddress })
     })
 
     await waitFor(() => {
       expect(mockedInitiate).toHaveBeenCalledTimes(2)
       expect(result.current.data).toEqual([fresh])
     })
+  })
+
+  it('does not refetch overviews of an unrelated Safe', async () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    const request = { currency: 'usd', safes: [makeSafeItem(safeAddress)] }
+
+    mockQueryAction([makeOverview(safeAddress, '100')])
+
+    const { result } = renderHook(() => {
+      useInvalidateOverviewsOnTx()
+      return useGetMultipleSafeOverviewsQuery(request)
+    })
+
+    await waitFor(() => {
+      expect(result.current.data?.[0]?.fiatTotal).toBe('100')
+    })
+    expect(mockedInitiate).toHaveBeenCalledTimes(1)
+
+    // tx executed on a different Safe -> this query must not refetch
+    act(() => {
+      txDispatch(TxEvent.SUCCESS, {
+        txId: '0x2',
+        nonce: 1,
+        chainId: '1',
+        safeAddress: faker.finance.ethereumAddress(),
+      })
+    })
+
+    // wait past the 300ms batching window to be sure no fetch was scheduled
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(mockedInitiate).toHaveBeenCalledTimes(1)
   })
 
   it('subscribes to tx success and unsubscribes on unmount', () => {
@@ -91,5 +118,7 @@ describe('useInvalidateOverviewsOnTx', () => {
 
     unmount()
     expect(unsubscribe).toHaveBeenCalledTimes(1)
+
+    subscribeSpy.mockRestore()
   })
 })

--- a/apps/web/src/hooks/useInvalidateOverviewsOnTx.ts
+++ b/apps/web/src/hooks/useInvalidateOverviewsOnTx.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useAppDispatch } from '@/store'
-import { gatewayApi } from '@/store/api/gateway'
+import { gatewayApi, makeSafeOverviewTag } from '@/store/api/gateway'
 import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
 
 /**
@@ -10,13 +10,18 @@ import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
  * The single-Safe balance refreshes via the portfolio/balances endpoints, but the
  * overview endpoints have no polling or tag invalidation of their own, so without this
  * the aggregated balance would stay stale until a full page reload.
+ *
+ * Invalidation is scoped to the executing Safe (chainId:address) so a tx only refetches
+ * the overview queries that actually contain that Safe, not every mounted overview query.
  */
 const useInvalidateOverviewsOnTx = (): void => {
   const dispatch = useAppDispatch()
 
   useEffect(() => {
-    return txSubscribe(TxEvent.SUCCESS, () => {
-      dispatch(gatewayApi.util.invalidateTags(['SafeOverviews']))
+    return txSubscribe(TxEvent.SUCCESS, ({ chainId, safeAddress }) => {
+      dispatch(
+        gatewayApi.util.invalidateTags([{ type: 'SafeOverviews', id: makeSafeOverviewTag(chainId, safeAddress) }]),
+      )
     })
   }, [dispatch])
 }

--- a/apps/web/src/hooks/useInvalidateOverviewsOnTx.ts
+++ b/apps/web/src/hooks/useInvalidateOverviewsOnTx.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+import { useAppDispatch } from '@/store'
+import { gatewayApi } from '@/store/api/gateway'
+import { TxEvent, txSubscribe } from '@/services/tx/txEvents'
+
+/**
+ * Refreshes the Safe overview cache (aggregated balances shown on the Space dashboard,
+ * My accounts list, Safe selectors, …) once an executed transaction has been indexed.
+ *
+ * The single-Safe balance refreshes via the portfolio/balances endpoints, but the
+ * overview endpoints have no polling or tag invalidation of their own, so without this
+ * the aggregated balance would stay stale until a full page reload.
+ */
+const useInvalidateOverviewsOnTx = (): void => {
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    return txSubscribe(TxEvent.SUCCESS, () => {
+      dispatch(gatewayApi.util.invalidateTags(['SafeOverviews']))
+    })
+  }, [dispatch])
+}
+
+export default useInvalidateOverviewsOnTx

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -85,6 +85,7 @@ import PkModulePopup from '@/services/private-key-module/PkModulePopup'
 import GeoblockingProvider from '@/components/common/GeoblockingProvider'
 import { useVisitedSafes } from '@/features/myAccounts'
 import { usePortfolioRefetchOnTxHistory } from '@/features/portfolio'
+import useInvalidateOverviewsOnTx from '@/hooks/useInvalidateOverviewsOnTx'
 import { GATEWAY_URL } from '@/config/gateway'
 import { captureException, initObservability } from '@/services/observability'
 import useMixpanel from '@/services/analytics/useMixpanel'
@@ -121,6 +122,7 @@ const SafeScopedSubscriptions = (): null => {
   useTxTracking()
   useSafeMsgTracking()
   usePortfolioRefetchOnTxHistory()
+  useInvalidateOverviewsOnTx()
   useCounterfactualSafeSync()
   return null
 }

--- a/apps/web/src/store/__tests__/safeOverviews.invalidation.test.ts
+++ b/apps/web/src/store/__tests__/safeOverviews.invalidation.test.ts
@@ -1,0 +1,70 @@
+import { http, HttpResponse } from 'msw'
+import { faker } from '@faker-js/faker'
+import { act, renderHook, waitFor } from '@/tests/test-utils'
+import { server } from '@/tests/server'
+import { GATEWAY_URL } from '@/config/gateway'
+import { gatewayApi, useGetMultipleSafeOverviewsQuery } from '../api/gateway'
+import { useAppDispatch } from '@/store'
+
+/**
+ * Integration test (no mocking of the inner safesGetOverviewForMany query) that guards the
+ * forceRefetch behaviour: invalidating the overview cache must issue a real, fresh /v2/safes
+ * request rather than returning the still-warm inner cache. Dropping forceRefetch would make
+ * the inner initiate dedupe against that cache and silently reintroduce WA-2348.
+ */
+describe('safeOverviews cache invalidation (integration)', () => {
+  it('fetches fresh overviews from the network when the SafeOverviews tag is invalidated', async () => {
+    const safeAddress = faker.finance.ethereumAddress()
+    let requestCount = 0
+
+    server.use(
+      http.get(`${GATEWAY_URL}/v2/safes`, () => {
+        requestCount += 1
+        return HttpResponse.json([
+          {
+            address: { value: safeAddress },
+            chainId: '1',
+            awaitingConfirmation: null,
+            fiatTotal: requestCount === 1 ? '100' : '200',
+            owners: [{ value: faker.finance.ethereumAddress() }],
+            threshold: 1,
+            queued: 0,
+          },
+        ])
+      }),
+    )
+
+    const request = {
+      currency: 'usd',
+      safes: [
+        { address: safeAddress, chainId: '1', isReadOnly: false, isPinned: false, lastVisited: 0, name: undefined },
+      ],
+    }
+
+    const { result } = renderHook(() => ({
+      dispatch: useAppDispatch(),
+      query: useGetMultipleSafeOverviewsQuery(request),
+    }))
+
+    await waitFor(
+      () => {
+        expect(result.current.query.data?.[0]?.fiatTotal).toBe('100')
+      },
+      { timeout: 2000 },
+    )
+    expect(requestCount).toBe(1)
+
+    // A transaction invalidates the overview cache -> a fresh network request must follow
+    act(() => {
+      result.current.dispatch(gatewayApi.util.invalidateTags(['SafeOverviews']))
+    })
+
+    await waitFor(
+      () => {
+        expect(requestCount).toBe(2)
+        expect(result.current.query.data?.[0]?.fiatTotal).toBe('200')
+      },
+      { timeout: 2000 },
+    )
+  })
+})

--- a/apps/web/src/store/__tests__/safeOverviews.invalidation.test.ts
+++ b/apps/web/src/store/__tests__/safeOverviews.invalidation.test.ts
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { act, renderHook, waitFor } from '@/tests/test-utils'
 import { server } from '@/tests/server'
 import { GATEWAY_URL } from '@/config/gateway'
-import { gatewayApi, useGetMultipleSafeOverviewsQuery } from '../api/gateway'
+import { gatewayApi, makeSafeOverviewTag, useGetMultipleSafeOverviewsQuery } from '../api/gateway'
 import { useAppDispatch } from '@/store'
 
 /**
@@ -54,9 +54,11 @@ describe('safeOverviews cache invalidation (integration)', () => {
     )
     expect(requestCount).toBe(1)
 
-    // A transaction invalidates the overview cache -> a fresh network request must follow
+    // A transaction invalidates this Safe's overview tag -> a fresh network request must follow
     act(() => {
-      result.current.dispatch(gatewayApi.util.invalidateTags(['SafeOverviews']))
+      result.current.dispatch(
+        gatewayApi.util.invalidateTags([{ type: 'SafeOverviews', id: makeSafeOverviewTag('1', safeAddress) }]),
+      )
     })
 
     await waitFor(

--- a/apps/web/src/store/__tests__/safeOverviews.test.ts
+++ b/apps/web/src/store/__tests__/safeOverviews.test.ts
@@ -1,5 +1,6 @@
-import { renderHook, waitFor } from '@/tests/test-utils'
-import { useGetMultipleSafeOverviewsQuery, useGetSafeOverviewQuery } from '../api/gateway'
+import { act, renderHook, waitFor } from '@/tests/test-utils'
+import { gatewayApi, useGetMultipleSafeOverviewsQuery, useGetSafeOverviewQuery } from '../api/gateway'
+import { useAppDispatch } from '@/store'
 import { faker } from '@faker-js/faker'
 import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
 import { additionalSafesRtkApi } from '@safe-global/store/gateway/safes'
@@ -134,13 +135,16 @@ describe('safeOverviews', () => {
         expect(result.current.data).toEqual(mockOverview)
       })
 
-      // Should call the store endpoint with the safe ID
-      expect(mockedInitiate).toHaveBeenCalledWith({
-        safes: [`1:${fakeSafeAddress}`],
-        currency: 'usd',
-        trusted: false,
-        walletAddress: undefined,
-      })
+      // Should call the store endpoint with the safe ID, forcing a fresh fetch
+      expect(mockedInitiate).toHaveBeenCalledWith(
+        {
+          safes: [`1:${fakeSafeAddress}`],
+          currency: 'usd',
+          trusted: false,
+          walletAddress: undefined,
+        },
+        { forceRefetch: true },
+      )
     })
   })
 
@@ -302,13 +306,16 @@ describe('safeOverviews', () => {
         expect(result.current.data).toEqual(allOverviews)
       })
 
-      // Should call the store endpoint once with all safes
-      expect(mockedInitiate).toHaveBeenCalledWith({
-        safes: request.safes.map((safe) => `1:${safe.address}`),
-        currency: 'usd',
-        trusted: false,
-        walletAddress: undefined,
-      })
+      // Should call the store endpoint once with all safes, forcing a fresh fetch
+      expect(mockedInitiate).toHaveBeenCalledWith(
+        {
+          safes: request.safes.map((safe) => `1:${safe.address}`),
+          currency: 'usd',
+          trusted: false,
+          walletAddress: undefined,
+        },
+        { forceRefetch: true },
+      )
     })
 
     it('should return only the safes that exist in the response (partial results)', async () => {
@@ -481,6 +488,7 @@ describe('safeOverviews', () => {
         expect.objectContaining({
           safes: expect.arrayContaining([`1:${request1.safeAddress}`, `1:${request2.safeAddress}`]),
         }),
+        { forceRefetch: true },
       )
     })
 
@@ -513,6 +521,58 @@ describe('safeOverviews', () => {
 
       await waitFor(() => {
         expect(mockedInitiate).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('cache invalidation', () => {
+    it('refetches overviews when the SafeOverviews tag is invalidated', async () => {
+      const request = {
+        currency: 'usd',
+        safes: [
+          {
+            address: faker.finance.ethereumAddress(),
+            chainId: '1',
+            isReadOnly: false,
+            isPinned: false,
+            lastVisited: 0,
+            name: undefined,
+          },
+        ],
+      }
+
+      const staleOverview = {
+        address: { value: request.safes[0].address },
+        chainId: '1',
+        awaitingConfirmation: null,
+        fiatTotal: '100',
+        owners: [{ value: faker.finance.ethereumAddress() }],
+        threshold: 1,
+        queued: 0,
+      }
+      const freshOverview = { ...staleOverview, fiatTotal: '200' }
+
+      mockQueryAction({ data: [staleOverview] })
+
+      const { result } = renderHook(() => ({
+        dispatch: useAppDispatch(),
+        query: useGetMultipleSafeOverviewsQuery(request),
+      }))
+
+      await waitFor(() => {
+        expect(result.current.query.data).toEqual([staleOverview])
+      })
+      expect(mockedInitiate).toHaveBeenCalledTimes(1)
+
+      // A transaction invalidates the overview cache -> the query must re-run and fetch fresh data
+      mockQueryAction({ data: [freshOverview] })
+      act(() => {
+        result.current.dispatch(gatewayApi.util.invalidateTags(['SafeOverviews']))
+      })
+
+      await waitFor(() => {
+        expect(mockedInitiate).toHaveBeenCalledTimes(2)
+        expect(result.current.query.data).toEqual([freshOverview])
       })
     })
   })

--- a/apps/web/src/store/api/gateway/index.ts
+++ b/apps/web/src/store/api/gateway/index.ts
@@ -18,7 +18,7 @@ export function makeSafeTag(chainId: string, address: string): `${number}:0x${st
 export const gatewayApi = createApi({
   reducerPath: 'gatewayApi',
   baseQuery: fakeBaseQuery<Error>(),
-  tagTypes: ['Submissions'],
+  tagTypes: ['Submissions', 'SafeOverviews'],
   endpoints: (builder) => ({
     ...safeOverviewEndpoints(builder),
   }),

--- a/apps/web/src/store/api/gateway/index.ts
+++ b/apps/web/src/store/api/gateway/index.ts
@@ -15,6 +15,10 @@ export function makeSafeTag(chainId: string, address: string): `${number}:0x${st
   return `${chainId}:${address}` as `${number}:0x${string}`
 }
 
+// Cache-tag id for the SafeOverviews tag. Lowercased so the id built from a CGW
+// response (checksummed) matches the one built from a TxEvent payload.
+export const makeSafeOverviewTag = (chainId: string, address: string): string => `${chainId}:${address.toLowerCase()}`
+
 export const gatewayApi = createApi({
   reducerPath: 'gatewayApi',
   baseQuery: fakeBaseQuery<Error>(),

--- a/apps/web/src/store/api/gateway/safeOverviews.ts
+++ b/apps/web/src/store/api/gateway/safeOverviews.ts
@@ -39,12 +39,18 @@ class SafeOverviewFetcher {
     currency: string
     dispatch: DispatchFn
   }) {
-    const queryThunk = additionalSafesRtkApi.endpoints.safesGetOverviewForMany.initiate({
-      safes: safeIds,
-      currency,
-      walletAddress,
-      trusted: false,
-    })
+    // forceRefetch so a cache invalidation (e.g. after a tx) re-runs the wrapping
+    // query AND bypasses the inner cache, otherwise the inner entry — unsubscribed
+    // here — would return stale data and the displayed balance would not update.
+    const queryThunk = additionalSafesRtkApi.endpoints.safesGetOverviewForMany.initiate(
+      {
+        safes: safeIds,
+        currency,
+        walletAddress,
+        trusted: false,
+      },
+      { forceRefetch: true },
+    )
     const queryAction = dispatch(queryThunk)
 
     try {
@@ -123,9 +129,12 @@ type MultiOverviewQueryParams = {
   safes: SafeItem[]
 }
 
-export const safeOverviewEndpoints = (builder: EndpointBuilder<any, 'Submissions', 'gatewayApi'>) => ({
+export const safeOverviewEndpoints = (
+  builder: EndpointBuilder<any, 'Submissions' | 'SafeOverviews', 'gatewayApi'>,
+) => ({
   getSafeOverview: builder.query<SafeOverview | null, { safeAddress: string; walletAddress?: string; chainId: string }>(
     {
+      providesTags: ['SafeOverviews'],
       async queryFn({ safeAddress, walletAddress, chainId }, { getState, dispatch }) {
         const currency = selectCurrency(getState() as never)
         const dispatchFn: DispatchFn = (action) => dispatch(action)
@@ -150,6 +159,7 @@ export const safeOverviewEndpoints = (builder: EndpointBuilder<any, 'Submissions
     },
   ),
   getMultipleSafeOverviews: builder.query<SafeOverview[], MultiOverviewQueryParams>({
+    providesTags: ['SafeOverviews'],
     async queryFn(params, { dispatch }) {
       const { safes, walletAddress, currency } = params
       const dispatchFn: DispatchFn = (action) => dispatch(action)

--- a/apps/web/src/store/api/gateway/safeOverviews.ts
+++ b/apps/web/src/store/api/gateway/safeOverviews.ts
@@ -5,7 +5,7 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { selectCurrency } from '../../settingsSlice'
 import { type SafeItem } from '@/hooks/safes'
 import { asError } from '@safe-global/utils/services/exceptions/utils'
-import { makeSafeTag } from '.'
+import { makeSafeTag, makeSafeOverviewTag } from '.'
 import { additionalSafesRtkApi } from '@safe-global/store/gateway/safes'
 
 type InitiateThunk = ReturnType<typeof additionalSafesRtkApi.endpoints.safesGetOverviewForMany.initiate>
@@ -134,7 +134,10 @@ export const safeOverviewEndpoints = (
 ) => ({
   getSafeOverview: builder.query<SafeOverview | null, { safeAddress: string; walletAddress?: string; chainId: string }>(
     {
-      providesTags: ['SafeOverviews'],
+      providesTags: (result) =>
+        result
+          ? [{ type: 'SafeOverviews' as const, id: makeSafeOverviewTag(result.chainId, result.address.value) }]
+          : [{ type: 'SafeOverviews' as const }],
       async queryFn({ safeAddress, walletAddress, chainId }, { getState, dispatch }) {
         const currency = selectCurrency(getState() as never)
         const dispatchFn: DispatchFn = (action) => dispatch(action)
@@ -159,7 +162,13 @@ export const safeOverviewEndpoints = (
     },
   ),
   getMultipleSafeOverviews: builder.query<SafeOverview[], MultiOverviewQueryParams>({
-    providesTags: ['SafeOverviews'],
+    providesTags: (result) =>
+      result && result.length > 0
+        ? result.map((overview) => ({
+            type: 'SafeOverviews' as const,
+            id: makeSafeOverviewTag(overview.chainId, overview.address.value),
+          }))
+        : [{ type: 'SafeOverviews' as const }],
     async queryFn(params, { dispatch }) {
       const { safes, walletAddress, currency } = params
       const dispatchFn: DispatchFn = (action) => dispatch(action)


### PR DESCRIPTION
> Send from a Space, balance stayed asleep —
> overview cache had no key to keep.
> Tag it, invalidate on success, force the fetch through;
> now the number wakes up the moment the tx goes through.

## What it solves

Resolves: [WA-2348](https://linear.app/safe-global/issue/WA-2348/bug-balance-does-not-update-at-space-level-after-transaction-execution)

After executing a Send transaction from the Space level, the aggregated balance on the Space dashboard did not update — it kept showing the pre-transfer amount until a full (and unreliable) page reload.

The root cause is that the Space aggregated balance is sourced from a different data channel than the single-Safe dashboard balance:

- **Single Safe dashboard** → portfolio/balances endpoints, refreshed after a tx by `usePortfolioRefetchOnTxHistory` (watches `txHistoryTag`) + 15s polling.
- **Space aggregated balance** → the `getMultipleSafeOverviews` RTK Query endpoint, which had **no `providesTags`, no `pollingInterval`, and no post-tx refetch**. Nothing ever invalidated or re-ran it, so the displayed number stayed at whatever was cached when the Space first loaded.

## How this PR fixes it

Wires up the missing "refresh overviews after a tx" link, in three parts (all required):

1. **Tag the overview endpoints** — `getSafeOverview` / `getMultipleSafeOverviews` now `providesTags: ['SafeOverviews']` (new tag type on `gatewayApi`), making them targetable by cache invalidation.
2. **Invalidate at the right moment** — a new global hook `useInvalidateOverviewsOnTx` subscribes to `TxEvent.SUCCESS` (fired when the tx is indexed by the gateway = the backend balance is fresh) and dispatches `invalidateTags(['SafeOverviews'])`, which re-runs the outer query. `SUCCESS` is used rather than the earlier `PROCESSED` because at `PROCESSED` time the gateway has not indexed the new balance yet.
3. **Bypass the inner cache** — the outer query internally re-dispatches the inner `safesGetOverviewForMany` query. Without help, a still-warm inner cache would return the same stale aggregate on re-run, so the inner `initiate` now passes `{ forceRefetch: true }`. (`forceRefetch` is deterministic and avoids relying on RTK's subtle "invalidate an unsubscribed cache entry" semantics.)

## How to test it

1. `yarn workspace @safe-global/web dev`, open a Space that contains a Safe with some balance, connect a wallet (Sepolia).
2. Open DevTools → Network, filter `v2/safes`. **Do not reload the page.**
3. Click **Send** on the Space dashboard, perform a small transfer and execute it.
4. After the tx is indexed (~15–30s) a fresh `GET /v2/safes?...` request fires automatically and the aggregated balance updates to the post-transfer amount — no manual refresh.
5. Compare against `dev`: there, no `v2/safes` request fires after the tx and the number stays stale.

Unit/integration tests:

```bash
yarn workspace @safe-global/web test src/store/__tests__/safeOverviews.test.ts src/hooks/__tests__/useInvalidateOverviewsOnTx.test.ts
```

## Affected flows

- Space dashboard: send a transaction → aggregated balance refreshes automatically (primary fix).
- My accounts list, sidebar Safe selectors, and any other view backed by Safe overviews now also refresh after a tx (they shared the same latent staleness bug).

## Blast radius

- **RTK Query**: adds tag type `'SafeOverviews'` to `gatewayApi`; `getSafeOverview` / `getMultipleSafeOverviews` now provide it. Inner `safesGetOverviewForMany` (cgw `/v2/safes`) is now called with `forceRefetch: true` from these endpoints.
- **Consumers of the overview endpoints** (all refetch on `TxEvent.SUCCESS`): `useSpaceAccountsData`, `useMultiAccountItemData`, `useSafeItemData`, `SafeCardReadOnly`, `useReconciledSpaceSafes`, `useSafeScanContext`, `InconsistentSignerSetupWarning`, `NestedSafesList`, `useSpaceSafeSelectorItems`, `AggregatedBalances`.
- **New global subscription**: `useInvalidateOverviewsOnTx` mounted in `_app.tsx` → `SafeScopedSubscriptions` (active only when logged in, alongside the other tx-event subscribers). Cleans up its subscription on unmount.
- **Not touched**: single-Safe portfolio/balances channel; mobile (change is web-only).

## Risks / not checked

- **Trigger scope is "outgoing tracked txs"**: the refresh fires on `TxEvent.SUCCESS`, which `txHistorySlice` only dispatches for a nonce-tracked pending tx that appears in history — i.e. the Space-level Send this ticket is about. It intentionally does **not** cover module / spending-limit executions (dispatched with only a `groupKey`, no nonce) or **incoming** transfers. Those paths can still leave the aggregated overview stale until a reload. A broader fix (parity with the single-Safe portfolio channel, which watches `txHistoryTag`) is not cleanly possible here: `txHistoryTag` is scoped to the single active Safe via `useSafeInfo`, so it cannot cover incoming changes to the *other* Safes in a multi-Safe Space aggregate — that would need per-Safe tracking and is out of scope for this bug.
- **Indexer lag**: `TxEvent.SUCCESS` is the app's standard "tx indexed" signal; if the gateway's aggregate lags a few seconds behind, a single refetch could momentarily still show the old value. Same signal the rest of the app already trusts.
- **Request burst**: every successful tx now refetches all currently-mounted overview queries (one batched `/v2/safes` per subscription group). Acceptable.
- **Marginal extra traffic**: when the outer `gatewayApi` cache has expired but the inner `cgwClient` cache (default `keepUnusedDataFor` 60s) is still warm, the `forceRefetch` makes the outer re-run always hit the network instead of deduping. Small, and arguably desirable freshness.
- Did not test on mobile (web-only change).

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before — Space aggregated balance never refreshes"]
    TX1[Send tx executes] -.no trigger.-> OV1["getMultipleSafeOverviews<br/>(no tag, no polling, no refetch)"]
    OV1 --> STALE["Shows pre-transfer balance<br/>until full page reload"]
  end

  subgraph After["After — refresh link wired up"]
    TX2[Send tx executes] --> IDX[Gateway indexes tx]
    IDX --> SUCCESS[TxEvent.SUCCESS]
    SUCCESS --> HOOK["useInvalidateOverviewsOnTx<br/>invalidateTags(['SafeOverviews'])"]
    HOOK --> OUTER["Outer getMultipleSafeOverviews<br/>re-runs (tag invalidated)"]
    OUTER --> INNER["Inner safesGetOverviewForMany<br/>initiate(forceRefetch: true) → /v2/safes"]
    INNER --> FRESH[Aggregated balance updates, no reload]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only change)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics change)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).