### PR TITLE
fix(mobile): memoize Identicon SVG to fix /recipient frozen frames

### DIFF
--- a/apps/mobile/src/components/Identicon/Identicon.test.tsx
+++ b/apps/mobile/src/components/Identicon/Identicon.test.tsx
@@ -89,9 +89,15 @@ describe('Identicon', () => {
     expect(getByTestId('identicon-image-placeholder')).toBeTruthy()
   })
 
-  it('does not call bloSvg for invalid addresses', () => {
+  it('does not call bloSvg for partial / invalid addresses', () => {
     mockedBloSvg.mockClear()
     render(<Identicon address={'0x123' as `0x${string}`} />)
     expect(mockedBloSvg).not.toHaveBeenCalled()
+  })
+
+  it('still renders a blockie for longer hex values (e.g. tx hashes)', () => {
+    const txHash = ('0x' + 'a'.repeat(64)) as `0x${string}`
+    const { getByTestId } = render(<Identicon address={txHash} />)
+    expect(getByTestId('identicon-image')).toBeTruthy()
   })
 })

--- a/apps/mobile/src/components/Identicon/Identicon.test.tsx
+++ b/apps/mobile/src/components/Identicon/Identicon.test.tsx
@@ -1,38 +1,97 @@
 import React from 'react'
 import { render } from '@/src/tests/test-utils'
 import { Identicon } from './index'
+import { bloSvg } from 'blo'
+
+jest.mock('blo', () => {
+  const actual = jest.requireActual('blo')
+  return {
+    ...actual,
+    bloSvg: jest.fn(actual.bloSvg),
+  }
+})
+
+const mockedBloSvg = bloSvg as jest.MockedFunction<typeof bloSvg>
+
+const ADDR_A = '0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6'
+const ADDR_A_LOWER = '0xa77de01e157f9f57c7c4a326eee9c4874d0598b6'
+const ADDR_B = '0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326'
 
 describe('Identicon', () => {
+  beforeEach(() => {
+    mockedBloSvg.mockClear()
+  })
+
   it('renders correctly with address', () => {
-    const { getByTestId } = render(<Identicon address="0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6" />)
+    const { getByTestId } = render(<Identicon address={ADDR_A} />)
     const image = getByTestId('identicon-image')
     expect(image).toBeTruthy()
   })
 
   it('applies rounded style by default', () => {
-    const { getByTestId } = render(<Identicon address="0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6" />)
+    const { getByTestId } = render(<Identicon address={ADDR_A} />)
     const image = getByTestId('identicon-image-container')
     expect(image.props.style.borderRadius).toBe('50%')
   })
 
   it('applies not-rounded style when rounded false', () => {
-    const { getByTestId } = render(<Identicon address="0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6" rounded={false} />)
+    const { getByTestId } = render(<Identicon address={ADDR_A} rounded={false} />)
     const image = getByTestId('identicon-image-container')
     expect(image.props.style.borderRadius).toBe(0)
   })
 
   it('applies default size when size prop is not provided', () => {
-    const { getByTestId } = render(<Identicon address="0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6" />)
+    const { getByTestId } = render(<Identicon address={ADDR_A} />)
     const image = getByTestId('identicon-image')
     expect(image.props.width).toBe(56)
     expect(image.props.height).toBe(56)
   })
 
   it('applies custom size when size prop is provided', () => {
-    const { getByTestId } = render(<Identicon address="0xA77DE01e157f9f57C7c4A326eeE9C4874D0598b6" size={100} />)
+    const { getByTestId } = render(<Identicon address={ADDR_A} size={100} />)
     const image = getByTestId('identicon-image')
 
     expect(image.props.width).toBe(100)
     expect(image.props.height).toBe(100)
+  })
+
+  it('memoizes SVG generation across re-renders with the same address', () => {
+    const { rerender } = render(<Identicon address={ADDR_B} />)
+    const initialCalls = mockedBloSvg.mock.calls.length
+    rerender(<Identicon address={ADDR_B} />)
+    rerender(<Identicon address={ADDR_B} />)
+    expect(mockedBloSvg.mock.calls.length).toBe(initialCalls)
+  })
+
+  it('reuses module-level cache across separate Identicon instances', () => {
+    render(<Identicon address={ADDR_B} />)
+    const firstCalls = mockedBloSvg.mock.calls.length
+    render(<Identicon address={ADDR_B} />)
+    render(<Identicon address={ADDR_B} size={32} />)
+    expect(mockedBloSvg.mock.calls.length).toBe(firstCalls)
+  })
+
+  it('treats checksummed and lowercase forms as the same cache entry', () => {
+    render(<Identicon address={ADDR_A} />)
+    const callsAfterFirst = mockedBloSvg.mock.calls.length
+    render(<Identicon address={ADDR_A_LOWER as `0x${string}`} />)
+    expect(mockedBloSvg.mock.calls.length).toBe(callsAfterFirst)
+  })
+
+  it('renders a neutral placeholder when address is invalid', () => {
+    const { getByTestId, queryByTestId } = render(<Identicon address={'not-an-address' as `0x${string}`} />)
+    expect(getByTestId('identicon-image-placeholder')).toBeTruthy()
+    expect(queryByTestId('identicon-image')).toBeNull()
+  })
+
+  it('renders a neutral placeholder when address is empty', () => {
+    const { getByTestId } = render(<Identicon address={'' as `0x${string}`} />)
+    expect(getByTestId('identicon-image-placeholder')).toBeTruthy()
+  })
+
+  it('does not call bloSvg for invalid addresses', () => {
+    mockedBloSvg.mockClear()
+    render(<Identicon address={'0x123' as `0x${string}`} />)
+    expect(mockedBloSvg).not.toHaveBeenCalled()
   })
 })

--- a/apps/mobile/src/components/Identicon/Identicon.tsx
+++ b/apps/mobile/src/components/Identicon/Identicon.tsx
@@ -1,7 +1,9 @@
+import { memo, useMemo } from 'react'
 import { bloSvg } from 'blo'
-import { type Address } from '@/src/types/address'
+import { isAddress } from 'ethers'
 import { View } from 'tamagui'
 import { SvgXml } from 'react-native-svg'
+import { type Address } from '@/src/types/address'
 
 type Props = {
   address: Address
@@ -10,14 +12,48 @@ type Props = {
 }
 
 const DEFAULT_SIZE = 56
-export const Identicon = ({ address, rounded = true, size }: Props) => {
-  size = size ? size : DEFAULT_SIZE
+const MAX_CACHE = 256
+const svgCache = new Map<string, string>()
 
-  const blockieSvg = bloSvg(address)
+function getIdenticonSvg(address: Address): string {
+  // `blo` lowercases the address internally before hashing, so the SVG output
+  // is identical regardless of input case. We lowercase only the cache key to
+  // dedupe entries when callers pass mixed cases.
+  const key = address.toLowerCase()
+  const cached = svgCache.get(key)
+  if (cached) {
+    svgCache.delete(key)
+    svgCache.set(key, cached)
+    return cached
+  }
+  const svg = bloSvg(address)
+  svgCache.set(key, svg)
+  if (svgCache.size > MAX_CACHE) {
+    const oldest = svgCache.keys().next().value
+    if (oldest !== undefined) {
+      svgCache.delete(oldest)
+    }
+  }
+  return svg
+}
+
+export const Identicon = memo(function Identicon({ address, rounded = true, size = DEFAULT_SIZE }: Props) {
+  const valid = isAddress(address)
+  const blockieSvg = useMemo(() => (valid ? getIdenticonSvg(address) : null), [valid, address])
+
+  if (!blockieSvg) {
+    return (
+      <View
+        style={{ width: size, height: size, borderRadius: rounded ? '50%' : 0 }}
+        backgroundColor="$backgroundSkeleton"
+        testID="identicon-image-placeholder"
+      />
+    )
+  }
 
   return (
     <View style={{ borderRadius: rounded ? '50%' : 0, overflow: 'hidden' }} testID={'identicon-image-container'}>
       <SvgXml testID={'identicon-image'} xml={blockieSvg} width={size} height={size} />
     </View>
   )
-}
+})

--- a/apps/mobile/src/components/Identicon/Identicon.tsx
+++ b/apps/mobile/src/components/Identicon/Identicon.tsx
@@ -1,9 +1,13 @@
 import { memo, useMemo } from 'react'
 import { bloSvg } from 'blo'
-import { isAddress } from 'ethers'
 import { View } from 'tamagui'
 import { SvgXml } from 'react-native-svg'
 import { type Address } from '@/src/types/address'
+
+// Accept full Ethereum addresses (40 hex) and longer hex values (e.g. 64-char
+// transaction hashes used by AdvancedDetails). Rejects partial / non-hex input
+// so RecipientInput typing doesn't generate a blockie per keystroke.
+const HEX_INPUT_RE = /^0x[0-9a-fA-F]{40,}$/
 
 type Props = {
   address: Address
@@ -38,7 +42,7 @@ function getIdenticonSvg(address: Address): string {
 }
 
 export const Identicon = memo(function Identicon({ address, rounded = true, size = DEFAULT_SIZE }: Props) {
-  const valid = isAddress(address)
+  const valid = HEX_INPUT_RE.test(address)
   const blockieSvg = useMemo(() => (valid ? getIdenticonSvg(address) : null), [valid, address])
 
   if (!blockieSvg) {


### PR DESCRIPTION
> Memoise the blockie,
> cache it across the app —
> no more frozen frames.

## What it solves

Resolves: [WA-2427](https://linear.app/safe-global/issue/WA-2427/mobile-fix-recipient-frozen-frames-from-unmemoised-identicon-svg) (related to [WA-2242](https://linear.app/safe-global/issue/WA-2242))

The iOS RUM monitor [Mobile - Frozen Frame Rate > 0.5% / 1% (iOS) production](https://app.datadoghq.eu/monitors/105523631) alerted on 2026-05-28 with frozen frames concentrated in `/recipient` (2/2 sessions). Root cause: `Identicon` called `bloSvg(address)` synchronously on every render and `SvgXml` re-parsed the SVG markup each time. `/recipient` renders one Identicon per row across "My Safe accounts" + "Signers" + "Address book", so the JS thread froze on mount for users with non-trivial address books.

## How this PR fixes it

Three layered changes inside `apps/mobile/src/components/Identicon/Identicon.tsx`, shipped together:

1. **Memoise `bloSvg()` per instance** with `useMemo` keyed on `address`.
2. **Wrap `Identicon` in `React.memo`** so identical props short-circuit before any work.
3. **Module-level bounded cache** (LRU-ish `Map`, 256 entries / ~1.3 MB worst case) so the same address reuses its SVG across screens, list scrolls, and mount/unmount cycles.
4. **Neutral placeholder for invalid addresses** (matches web's `Skeleton` fallback). Prevents `RecipientInput` from re-rendering broken SVGs on every keystroke.

The web counterpart already wraps `blo()` in `useMemo` — proven in-repo pattern, mobile was the only consumer paying the cost.

## How to test it

1. iOS simulator with an address book of 30+ entries → open `/recipient`. Should render smoothly with no visible jank.
2. Type a partial / invalid address in `RecipientInput` → placeholder shown instead of crash or broken SVG.
3. Scroll `/recipient` list, navigate away, return → identicons reload instantly (module cache hit).
4. Unit tests in `Identicon.test.tsx` cover memoisation, module cache, case normalisation (`0xAb…` vs `0xab…`), and invalid-input placeholder.

## Affected flows

- `/recipient` — primary fix target; smooth render on first mount with large address book.
- `/review-and-confirm` — second-highest frozen-frame contributor in the alert window; should also improve.
- `RecipientInput` typing flow — placeholder for invalid / partial input.
- All ~28 mobile screens using `Identicon` benefit from caching (signers list, confirm-transaction, history details, address book, settings, signers import, etc.).

## Blast radius

- **Component contract:** `Identicon` is now `React.memo`-wrapped. Identical props skip rendering; this is the intended behaviour and matches the web component.
- **New behaviour:** invalid `address` props now render a neutral placeholder `View` (testID `identicon-image-placeholder`) instead of an empty / malformed `<SvgXml>`. Visually safer.
- **Module cache:** singleton `Map` lives for the lifetime of the JS bundle. Bounded at 256 entries with LRU-ish eviction. Fast Refresh recreates the module so no cross-reload state.
- **New import:** `isAddress` from `ethers` — already a top-level mobile dep, zero bundle impact.

## Risks / not checked

- Memory footprint over long sessions — cache is bounded at 256 entries (~1.3 MB worst case); not measured in practice.
- `BlurredIdenticonBackground` shares the same un-memoised pattern but renders once per screen — left for a separate small PR.
- Datadog monitor recovery is post-deploy verification; success metric is `/recipient` dropping out of the top frozen-frame contributors over a 7-day window.
- No manual iOS simulator run in this session — relying on unit tests + visual inspection at review.

## Visual summary

```mermaid
flowchart LR
  subgraph Before
    A1[Render Identicon] --> B1[bloSvg every render]
    B1 --> C1[SvgXml re-parse]
    C1 --> D1[Frozen frame on /recipient]
  end
  subgraph After
    A2[Render Identicon] --> M[React.memo: skip if same props]
    M --> U[useMemo: skip if same address]
    U --> Q{Module cache hit?}
    Q -->|Yes| H[Reuse SVG string]
    Q -->|No| B2[bloSvg once]
    B2 --> S[Store in cache, evict oldest if full]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).