### PR TITLE
fix(web): don't bounce existing users into create-space on re-login (round 2)

### DIFF
--- a/apps/web/cypress/e2e/pages/spaces.page.js
+++ b/apps/web/cypress/e2e/pages/spaces.page.js
@@ -93,6 +93,12 @@ const acceptInviteBtn = '[data-testid="accept-invite-button"]'
 const inviteNameInput = '[data-testid="invite-name-input"]'
 const confirmAcceptInviteBtn = '[data-testid="confirm-accept-invite-button"]'
 
+// -- Sidebar profile (sign-out) --
+const sidebarProfileTrigger = '[data-testid="sidebar-profile-trigger"]'
+const sidebarProfilePopover = '[data-testid="sidebar-profile-popover"]'
+const sidebarProfileSignOutBtn = '[data-testid="sidebar-profile-sign-out"]'
+const continueWithWalletBtn = '[data-testid="continue-with-wallet-btn"]'
+
 // -- Onboarding --
 const orgSpaceInput = '[data-testid="space-name-input"]'
 const createSpaceOnboardingContinueBtn = '[data-testid="create-space-onboarding-continue-button"]'
@@ -166,7 +172,26 @@ const spaceDashboardWidgetSelectorByTitle = {
 // ===========================================
 
 export function clickOnSignInBtn() {
-  cy.get('[data-testid="continue-with-wallet-btn"]').click()
+  cy.get(continueWithWalletBtn).click()
+}
+
+export function signOutViaSidebarProfile() {
+  cy.get(sidebarProfileTrigger, { timeout: 30000 }).should('be.visible').click()
+  cy.get(sidebarProfilePopover).should('be.visible')
+  cy.get(sidebarProfileSignOutBtn).should('be.visible').click()
+  // useLogout submits a form to the gateway which 303-redirects back to
+  // /welcome/spaces — wait for the round-trip to land and the signed-out
+  // sign-in button to render before letting the next step run.
+  cy.url({ timeout: 60000 }).should('include', constants.spacesUrl)
+  cy.get(continueWithWalletBtn, { timeout: 30000 }).should('be.visible')
+}
+
+export function verifyOnSpacesWelcomePage() {
+  cy.url({ timeout: 30000 }).should('include', '/welcome/spaces').and('not.include', onboardingCreateSpacePath)
+}
+
+export function verifySpaceCardVisible(name) {
+  cy.get(spaceCard, { timeout: 30000 }).contains(name).should('be.visible')
 }
 
 export function waitForSpacesWelcomeReady() {

--- a/apps/web/cypress/e2e/pages/spaces.page.js
+++ b/apps/web/cypress/e2e/pages/spaces.page.js
@@ -186,12 +186,16 @@ export function signOutViaSidebarProfile() {
   cy.get(continueWithWalletBtn, { timeout: 30000 }).should('be.visible')
 }
 
-export function verifyOnSpacesWelcomePage() {
-  cy.url({ timeout: 30000 }).should('include', '/welcome/spaces').and('not.include', onboardingCreateSpacePath)
-}
-
-export function verifySpaceCardVisible(name) {
-  cy.get(spaceCard, { timeout: 30000 }).contains(name).should('be.visible')
+export function verifyOnSingleSpaceDashboard(spaceName) {
+  // After re-login the single-space short-circuit pushes us straight to the
+  // space dashboard. Assert the URL is the space dashboard (not the
+  // workspace list, not the create-space onboarding) AND that the space's
+  // own selector now shows the expected name.
+  cy.url({ timeout: 60000 })
+    .should('include', constants.spaceDashboardUrl)
+    .and('include', 'spaceId=')
+    .and('not.include', onboardingCreateSpacePath)
+  cy.get(spaceSelectorBtn, { timeout: 30000 }).should('be.visible').and('contain.text', spaceName)
 }
 
 export function waitForSpacesWelcomeReady() {

--- a/apps/web/cypress/e2e/regression/spaces_basicflow.cy.js
+++ b/apps/web/cypress/e2e/regression/spaces_basicflow.cy.js
@@ -52,6 +52,30 @@ describe('Spaces basic flow tests', () => {
     space.addAccountManually(staticSafes.SEP_STATIC_SAFE_35.substring(4), constants.networks.sepolia)
   })
 
+  it('Verify that re-signing in after sign-out lands on the spaces list, not on /welcome/create-space', () => {
+    const spaceName = 'Space ' + Math.random().toString(36).substring(2, 12)
+
+    wallet.connectSigner(admin)
+    space.clickOnSignInBtn()
+    space.ensureReadyToCreateSpace()
+    cy.wait(3000)
+    space.createSpaceViaOnboardingWithSkip(spaceName)
+
+    space.signOutViaSidebarProfile()
+    wallet.connectSigner(admin)
+    space.clickOnSignInBtn()
+
+    // Wait for the spaces list to stabilize before asserting URL — if the
+    // re-login redirect bug fires we end up on /welcome/create-space and the
+    // space card never appears.
+    space.verifySpaceCardVisible(spaceName)
+    space.verifyOnSpacesWelcomePage()
+
+    space.clickOnSpaceSelector(spaceName)
+    space.goToSpaceSettings()
+    space.deleteSpace(spaceName)
+  })
+
   it('Verify a new member can be invited and accept the invite', () => {
     const spaceName = 'Space ' + Math.random().toString(36).substring(2, 12)
     const memberName = 'Member ' + Math.random().toString(36).substring(2, 12)

--- a/apps/web/cypress/e2e/regression/spaces_basicflow.cy.js
+++ b/apps/web/cypress/e2e/regression/spaces_basicflow.cy.js
@@ -52,7 +52,7 @@ describe('Spaces basic flow tests', () => {
     space.addAccountManually(staticSafes.SEP_STATIC_SAFE_35.substring(4), constants.networks.sepolia)
   })
 
-  it('Verify that re-signing in after sign-out lands on the spaces list, not on /welcome/create-space', () => {
+  it('Verify that re-signing in lands on the single space, not on /welcome/create-space', () => {
     const spaceName = 'Space ' + Math.random().toString(36).substring(2, 12)
 
     wallet.connectSigner(admin)
@@ -65,13 +65,11 @@ describe('Spaces basic flow tests', () => {
     wallet.connectSigner(admin)
     space.clickOnSignInBtn()
 
-    // Wait for the spaces list to stabilize before asserting URL — if the
-    // re-login redirect bug fires we end up on /welcome/create-space and the
-    // space card never appears.
-    space.verifySpaceCardVisible(spaceName)
-    space.verifyOnSpacesWelcomePage()
+    // With exactly one space, sign-in should short-circuit straight to the
+    // space dashboard. Crucially we must NOT be bounced into /welcome/create-space
+    // (the regressed re-login behavior).
+    space.verifyOnSingleSpaceDashboard(spaceName)
 
-    space.clickOnSpaceSelector(spaceName)
     space.goToSpaceSettings()
     space.deleteSpace(spaceName)
   })

--- a/apps/web/src/components/welcome/WelcomeLogin/hooks/__tests__/useSignInRedirect.test.ts
+++ b/apps/web/src/components/welcome/WelcomeLogin/hooks/__tests__/useSignInRedirect.test.ts
@@ -365,5 +365,79 @@ describe('useSignInRedirect', () => {
 
       expect(mockPush).toHaveBeenCalledWith({ pathname: '/balances', query: {} })
     })
+
+    it('?next= wins over the single-space short-circuit when the gate is on', async () => {
+      setupMocks({ routerQuery: { next: '/balances' } })
+
+      const { result } = renderHook(() =>
+        useSignInRedirect({ ...defaultProps, spacesAmount: 1, singleSpaceId: 'space-42' }),
+      )
+
+      await act(async () => {
+        result.current.setHasSignedIn(true)
+      })
+
+      expect(mockPush).toHaveBeenCalledWith({ pathname: '/balances', query: {} })
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // Single-space short-circuit
+  // -----------------------------------------------------------------------
+
+  describe('when the user has exactly one space', () => {
+    it('redirects to that space after sign-in instead of the workspace list', async () => {
+      setupMocks()
+
+      const { result } = renderHook(() =>
+        useSignInRedirect({ ...defaultProps, spacesAmount: 1, singleSpaceId: 'space-42' }),
+      )
+
+      await act(async () => {
+        result.current.setHasSignedIn(true)
+      })
+
+      expect(mockPush).toHaveBeenCalledWith({ pathname: '/spaces', query: { spaceId: 'space-42' } })
+      expect(result.current.redirectLoading).toBe(true)
+    })
+
+    it('does not redirect when there are multiple spaces (no singleSpaceId)', async () => {
+      setupMocks()
+
+      const { result } = renderHook(() => useSignInRedirect({ ...defaultProps, spacesAmount: 3, singleSpaceId: null }))
+
+      await act(async () => {
+        result.current.setHasSignedIn(true)
+      })
+
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('does not short-circuit before the user has signed in', async () => {
+      setupMocks()
+
+      renderHook(() => useSignInRedirect({ ...defaultProps, spacesAmount: 1, singleSpaceId: 'space-42' }))
+
+      expect(mockPush).not.toHaveBeenCalled()
+    })
+
+    it('does not short-circuit while spaces are still loading', async () => {
+      setupMocks()
+
+      const { result } = renderHook(() =>
+        useSignInRedirect({
+          ...defaultProps,
+          spacesAmount: 1,
+          isSpacesLoading: true,
+          singleSpaceId: 'space-42',
+        }),
+      )
+
+      await act(async () => {
+        result.current.setHasSignedIn(true)
+      })
+
+      expect(mockPush).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/web/src/components/welcome/WelcomeLogin/hooks/useSignInRedirect.ts
+++ b/apps/web/src/components/welcome/WelcomeLogin/hooks/useSignInRedirect.ts
@@ -15,13 +15,23 @@ interface UseSignInRedirectProps {
   inviteAmount: number
   isSpacesLoading: boolean
   error: RtkError | undefined
+  // When the signed-in user has exactly one active space, jump straight to it
+  // after sign-in instead of leaving them on the workspace list. Pass null when
+  // there are zero or multiple active spaces.
+  singleSpaceId?: string | null
 }
 
 const hasNotFoundSpaces = (error?: RtkError) => {
   return error && 'status' in error && error.status === 404
 }
 
-export const useSignInRedirect = ({ spacesAmount, inviteAmount, isSpacesLoading, error }: UseSignInRedirectProps) => {
+export const useSignInRedirect = ({
+  spacesAmount,
+  inviteAmount,
+  isSpacesLoading,
+  error,
+  singleSpaceId,
+}: UseSignInRedirectProps) => {
   const [hasSignedIn, setHasSignedIn] = useState(false)
   const router = useRouter()
   const [redirectLoading, setRedirectLoading] = useState(false)
@@ -51,19 +61,39 @@ export const useSignInRedirect = ({ spacesAmount, inviteAmount, isSpacesLoading,
       return
     }
 
-    // When the "must log in" gate is on, an existing user who just signed in
-    // should land on the URL they originally tried to open. Without ?next= we
-    // let them stay on /welcome/spaces, which now renders their Spaces list.
-    // Wait for the gate flag to resolve so a fast sign-in + slow chains config
-    // doesn't permanently strand the user on /welcome/spaces.
-    if (isRequireLoginEnabled === true && hasSignedIn && isUserSignedIn && !isSpacesLoading && spacesAmount > 0) {
-      const next = parseNextUrlForRouter(router.query.next)
-      if (next) {
+    if (hasSignedIn && isUserSignedIn && !isSpacesLoading && spacesAmount > 0) {
+      // Priority 1: an explicit ?next= round-trip target wins (the user
+      // originally tried to open that URL and was bounced to login). Only the
+      // require-login gate populates this — wait for the flag to resolve so a
+      // fast sign-in + slow chains config doesn't permanently strand the user.
+      if (isRequireLoginEnabled === true) {
+        const next = parseNextUrlForRouter(router.query.next)
+        if (next) {
+          setRedirectLoading(true)
+          router.push(next)
+          return
+        }
+      }
+
+      // Priority 2: if the user has exactly one space, jump straight to it.
+      // Falling back to the workspace list (i.e. leaving the user on
+      // /welcome/spaces) is intentional only when there are multiple to choose
+      // between.
+      if (singleSpaceId) {
         setRedirectLoading(true)
-        router.push(next)
+        router.push({ pathname: AppRoutes.spaces.index, query: { spaceId: singleSpaceId } })
       }
     }
-  }, [hasSignedIn, isSpacesLoading, spacesAmount, inviteAmount, isUserSignedIn, error, isRequireLoginEnabled])
+  }, [
+    hasSignedIn,
+    isSpacesLoading,
+    spacesAmount,
+    inviteAmount,
+    isUserSignedIn,
+    error,
+    isRequireLoginEnabled,
+    singleSpaceId,
+  ])
 
   return { setHasSignedIn, redirectLoading }
 }

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -121,6 +121,29 @@ describe('SpacesList — auth/expiry state rendering', () => {
     expect(screen.queryByTestId('sign-in-options')).not.toBeInTheDocument()
   })
 
+  // Regression: on re-login after logout the spaces RTK Query cache entry
+  // already exists (the post-logout page load fired a request with stale
+  // persisted auth that errored, then invalidateTags marked it stale). When
+  // skip flips to false on re-login, both isFetching and isUninitialized are
+  // briefly false while currentData is still undefined — the previous fix
+  // relied solely on `isFetching || isUninitialized`, which missed this case
+  // and bounced existing users into /welcome/create-space. SpacesList must
+  // pass isSpacesLoading=true whenever currentData and error are both absent.
+  it('passes isSpacesLoading=true to useSignInRedirect when spaces data and error are both undefined', () => {
+    mockUseAppSelector.mockReturnValue(true)
+    mockUseSpacesGetV1Query.mockReturnValue({
+      currentData: undefined,
+      isFetching: false,
+      isUninitialized: false,
+      error: undefined,
+    })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    expect(mockUseSignInRedirect).toHaveBeenCalledWith(expect.objectContaining({ isSpacesLoading: true }))
+  })
+
   it('disables the Create space button and shows a tooltip when the user has reached the 10-space limit', async () => {
     mockUseAppSelector.mockReturnValue(true)
     const tenSpaces = Array.from({ length: 10 }, (_, i) => ({ id: i + 1, name: `Space ${i + 1}` }))

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -128,6 +128,8 @@ const SpacesList = () => {
   const inviteAmount = pendingInvites?.length
   const isAtSpacesLimit = activeSpaces.length >= SPACES_LIMIT
 
+  const singleSpaceId = activeSpaces.length === 1 ? String(activeSpaces[0].id) : null
+
   const { setHasSignedIn, redirectLoading } = useSignInRedirect({
     spacesAmount: spaces?.length || 0,
     inviteAmount: inviteAmount || 0,
@@ -141,6 +143,7 @@ const SpacesList = () => {
     // resolves, this clause becomes false and the normal redirect logic runs.
     isSpacesLoading: isFetching || isUninitialized || (spaces === undefined && !error),
     error: error || undefined,
+    singleSpaceId,
   })
 
   const afterSignIn = useCallback(() => {

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -131,12 +131,15 @@ const SpacesList = () => {
   const { setHasSignedIn, redirectLoading } = useSignInRedirect({
     spacesAmount: spaces?.length || 0,
     inviteAmount: inviteAmount || 0,
-    // Treat the "skip→unskip" transition as still loading. On the render where
-    // skip flips to false RTK Query returns isFetching=false but hasn't yet
-    // dispatched the fetch (that happens in a useEffect), so isFetching alone
-    // would lead useSignInRedirect to read spacesAmount=0 and bounce existing
-    // users into the create-space flow on re-login.
-    isSpacesLoading: isFetching || isUninitialized,
+    // Treat any state without a definitive answer as still loading. The
+    // skip→unskip transition (re-login after logout) returns isFetching=false
+    // and isUninitialized=false on the render where skip flips — RTK Query
+    // dispatches the refetch in a useEffect, so the loading flags lag one
+    // render behind. Without the `spaces === undefined && !error` clause an
+    // existing user gets bounced into /welcome/create-space because the hook
+    // reads spacesAmount=0 with isSpacesLoading=false. Once spaces or error
+    // resolves, this clause becomes false and the normal redirect logic runs.
+    isSpacesLoading: isFetching || isUninitialized || (spaces === undefined && !error),
     error: error || undefined,
   })
 

--- a/apps/web/src/hooks/useRouterGuard/activationGuards/__tests__/useFlowActivationGuard.test.ts
+++ b/apps/web/src/hooks/useRouterGuard/activationGuards/__tests__/useFlowActivationGuard.test.ts
@@ -400,6 +400,23 @@ describe('useFlowActivationGuard', () => {
         redirectTo: AppRoutes.welcome.createSpace,
       })
     })
+
+    // Regression: after a logout the persisted authSlice still says
+    // "signed in" until reconcileAuth resolves, so the guard runs with
+    // isSiweAuthenticated=true while the cookies have already been cleared.
+    // fetchSpaces then resolves with a 401/403 error and data=undefined —
+    // the old code treated that as "no spaces" and bounced the user into
+    // /welcome/create-space. The guard must instead treat transient/auth
+    // errors as "uncertain" and let the page render.
+    it('should NOT redirect to create-space when the spaces fetch errors with 403 (cookies cleared post-logout)', async () => {
+      setupMocks({ pathname: AppRoutes.spaces.index, isSpaceRoute: true })
+      mockFetchSpaces.mockResolvedValueOnce({ data: undefined, error: { status: 403, data: 'Forbidden' } })
+
+      const { result } = renderHook(() => useFlowActivationGuard())
+      const guardResult = await result.current.activationGuard()
+
+      expect(guardResult.success).not.toBe(false)
+    })
   })
 
   // -----------------------------------------------------------------------

--- a/apps/web/src/hooks/useRouterGuard/activationGuards/useFlowActivationGuard.ts
+++ b/apps/web/src/hooks/useRouterGuard/activationGuards/useFlowActivationGuard.ts
@@ -212,8 +212,20 @@ export const useFlowActivationGuard: UseGuard = () => {
     let isPartOfSpaceUrl = true
 
     if (isSiweAuthenticated) {
-      const { data: spaces } = await fetchSpaces(undefined)
-      hasSpaces = !!spaces && spaces.length > 0
+      const { data: spaces, error } = await fetchSpaces(undefined)
+      // Trust the response only when it's definitive: a successful fetch
+      // (possibly empty) or a 404 confirming the user has no spaces. On any
+      // other error (401/403 from cleared cookies, network failure, 5xx),
+      // assume the user has spaces so we don't bounce them into create-space.
+      // The auth listener / reconcileAuth flow will clean up the stale auth
+      // state and re-trigger the guard with a correct isSiweAuthenticated.
+      const isNotFound = !!error && (error as { status?: unknown }).status === 404
+      const transientError = !!error && !isNotFound
+      if (transientError) {
+        hasSpaces = true
+      } else {
+        hasSpaces = !!spaces && spaces.length > 0
+      }
 
       if (query.spaceId) {
         isPartOfSpaceUrl = hasSpaces && !!spaces && spaces.some((s) => String(s.id) === query.spaceId)


### PR DESCRIPTION
> Stale cache after logout,
> single space — straight to it,
> never to create-space.

## What it solves

Two related issues in the spaces sign-in flow:

1. **(Bug)** Existing users who log out and log back in are redirected to `/welcome/create-space` instead of seeing their workspaces. Despite a previous fix in [9166bb41b](https://github.com/safe-global/safe-wallet-monorepo/commit/9166bb41b), the bounce was still reproducible — the actual root cause was in the route guard, not `useSignInRedirect`.
2. **(Feature)** When the signed-in user has exactly one space, the workspace list page is just an extra click. Sign-in now short-circuits straight into that space's dashboard.

## How this PR fixes it

### Root cause of the re-login bounce

`useFlowActivationGuard` reads the spaces list to decide whether to redirect to `/welcome/create-space`:

```typescript
if (isSiweAuthenticated) {
  const { data: spaces } = await fetchSpaces(undefined)
  hasSpaces = !!spaces && spaces.length > 0  // ← ANY error → false → redirect
}
```

After the gateway logout, the persisted `authSlice.sessionExpiresAt` still says "signed in" until `reconcileAuth` resolves. During that window the guard runs with `isSiweAuthenticated=true`, `fetchSpaces` returns a 401/403 error (cookies cleared) with `data: undefined`, and the old code treated that as "no spaces" → `router.replace('/welcome/create-space')`.

Fix: distinguish transient/auth errors from a confirmed empty/404 response. Only redirect to create-space when the fetch resolved with no error or with a 404. On any other error keep `hasSpaces=true` so the page renders, let the auth listener clean up the stale auth state, and let the guard re-run with the correct `isSiweAuthenticated`.

### Defensive fix in SpacesList

The earlier `useSignInRedirect` gate (`isFetching || isUninitialized`) only catches the *first-ever* skip→unskip transition. After invalidation the cache entry exists, so both flags are false on the render where skip flips. Added a `(spaces === undefined && !error)` clause so any state without a definitive answer is treated as still loading.

### Single-space short-circuit

`useSignInRedirect` now accepts a `singleSpaceId`. When sign-in completes and the user has exactly one active space, push straight to `/spaces?spaceId=<id>`. The existing `?next=` round-trip (require-login gate) still takes precedence — that's the URL the user originally tried to open.

## How to test it

1. Sign in with a wallet that has exactly one workspace. **Expected:** lands on `/spaces?spaceId=<id>` directly (not on the workspace list).
2. Sidebar profile → Sign out. The gateway logout redirect lands back on `/welcome/spaces`, signed out.
3. Sign in again with the same wallet. **Expected:** lands on `/spaces?spaceId=<id>` again. **Before this fix:** bounced into `/welcome/create-space`.

Neighbouring flows:
- New user (no workspaces) signs in → still redirects to `/welcome/create-space`.
- User with 2+ workspaces signs in → lands on `/welcome/spaces` (the picker).
- Spaces 404 → still redirects to `/welcome/create-space`.
- Spaces 5xx → stays on `/welcome/spaces` (error early-return).
- Require-login gate ON + `?next=/balances` → lands on `/balances`, even with one space.

## Affected flows

- Re-login after explicit logout (SIWE wallet path) — bug fix
- Single-space sign-in — behavior change
- First-time wallet login (with/without spaces) — unchanged
- OIDC re-login — same loading semantics + single-space short-circuit benefit it
- `?next=` round-trip via require-login gate — unchanged
- Spaces 404 / 5xx error handling — unchanged

## Blast radius

- `useFlowActivationGuard` is the route guard for every protected page — but the change only affects the branch where `isSiweAuthenticated=true && fetchSpaces returns an error`. All other branches keep their existing behavior. New unit test pins the regression.
- `useSignInRedirect` consumers: `SpacesList` is the only one. The hook gained one optional `singleSpaceId` prop with a `null`/`undefined` default — existing callers see no behavior change.
- The auth listener (`spacesApi.util.invalidateTags(['spaces'])` on `setUnauthenticated`) stays untouched.
- No changes to RTK Query endpoints, persisted state, feature flags, or routes.
- Mobile not impacted (Spaces sign-in lives in `apps/web` only).

## Risks / not checked

- The fix is informed by reading the route guard + hook code. The Cypress E2E in this PR (`spaces_basicflow.cy.js`) exercises the full sign-in → create space → sidebar sign-out → re-sign-in flow with the private-key wallet module — but it needs a real CI run against staging to confirm.
- Did not manually exercise the OIDC re-login path.
- Did not verify the multi-tab broadcast scenario (logout in tab A, re-login in tab B).
- Did not test on mobile.

## Visual summary

```mermaid
sequenceDiagram
    participant U as User
    participant App as Web app (Redux + RTK Query + RouterGuard)
    participant CGW as CGW (/v1/spaces, /v1/auth/*)

    Note over U,CGW: Logout → page reload via gateway
    U->>App: Click "Sign out"
    App->>CGW: POST /v1/auth/logout/redirect
    CGW-->>App: 303 → /welcome/spaces (cookies cleared)

    Note over App: Persisted sessionExpiresAt still valid<br/>isSiweAuthenticated=true on initial render

    rect rgb(255, 230, 230)
        Note over App: useFlowActivationGuard runs
        App->>CGW: GET /v1/spaces (via fetchSpaces in guard)
        CGW-->>App: 401/403 (cookies cleared)
        Note over App: Before: data=undefined → hasSpaces=false<br/>→ router.replace(/welcome/create-space) ❌
        Note over App: After: transient error → hasSpaces=true (be lenient)<br/>→ allow page to render ✓
    end

    App->>CGW: GET /v1/auth/me (reconcileAuth)
    CGW-->>App: 403
    App->>App: setUnauthenticated → invalidateTags(['spaces'])

    Note over U,CGW: User re-signs-in
    U->>App: Click "Sign in" → SIWE
    App->>App: setAuthenticated → isSiweAuthenticated=true

    App->>CGW: GET /v1/spaces (with new cookies)
    CGW-->>App: [space1]

    rect rgb(230, 255, 230)
        Note over App: activeSpaces.length === 1<br/>→ singleSpaceId = "space1"
        Note over App: useSignInRedirect short-circuit:<br/>router.push(/spaces?spaceId=space1)
    end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web only)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics changes)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)