### PR TITLE
fix(ci): Sign release and back-merge commits with GPG key

### DIFF
--- a/.github/workflows/web-release-start.yml
+++ b/.github/workflows/web-release-start.yml
@@ -44,8 +44,8 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           git_config_global: true
-          git_committer_name: 'github-actions[bot]'
-          git_committer_email: 'github-actions[bot]@users.noreply.github.com'
+          git_committer_name: 'GH Signer Bot'
+          git_committer_email: 'gh-signer-bot@safe.global'
 
       - name: Determine base branch
         id: base
@@ -162,6 +162,8 @@ jobs:
 
       - name: Commit version bump
         run: |
+          git config user.name "GH Signer Bot"
+          git config user.email "gh-signer-bot@safe.global"
           git add apps/web/package.json
           git commit -S -m "${{ steps.version.outputs.version }}"
           git push origin release

--- a/.github/workflows/web-tag-release.yml
+++ b/.github/workflows/web-tag-release.yml
@@ -44,8 +44,8 @@ jobs:
           git_user_signingkey: true
           git_tag_gpgsign: true
           git_config_global: true
-          git_committer_name: 'github-actions[bot]'
-          git_committer_email: 'github-actions[bot]@users.noreply.github.com'
+          git_committer_name: 'GH Signer Bot'
+          git_committer_email: 'gh-signer-bot@safe.global'
 
       - name: Verify PR commits are in main
         if: github.event.pull_request.merged != true
@@ -110,6 +110,18 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: 'GH Signer Bot'
+          git_committer_email: 'gh-signer-bot@safe.global'
 
       - name: Create GitHub release (draft)
         if: needs.tag.outputs.version
@@ -196,8 +208,8 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "GH Signer Bot"
+          git config user.email "gh-signer-bot@safe.global"
 
           # Fetch latest changes
           git fetch origin main dev
@@ -207,7 +219,7 @@ jobs:
           git checkout -B "$BRANCH_NAME" origin/dev
 
           # Attempt to merge main into the branch
-          if git merge origin/main -m "chore: back-merge main to dev after release ${VERSION}"; then
+          if git merge -S origin/main -m "chore: back-merge main to dev after release ${VERSION}"; then
             git push origin "$BRANCH_NAME"
 
             # Create PR body file to avoid shell interpolation issues


### PR DESCRIPTION
 ## What it solves

  Resolves: Automated release commits (version bumps and back-merge merge commits)
  always showing as "Unverified" in GitHub due to a misconfigured GPG identity.

  ## How this PR fixes it

  The root cause was that the GPG key registered on the `Safe-infra` account used
  `github-actions[bot]@users.noreply.github.com` as its UID email — an email that
  doesn't belong to that account, so GitHub could never verify the signature.

  Two things are required (workflow changes here + secret update separately):

  1. **Workflow changes (this PR):**
     - `web-release-start.yml`: update committer identity to `GH Signer Bot
  <gh-signer-bot@safe.global>`
     - `web-tag-release.yml` (`tag` job): same identity update
     - `web-tag-release.yml` (`release-deploy` job): add missing GPG import step (this
  job had no signing setup at all), add `RELEASE_BOT_TOKEN` to checkout, and use `-S`
  flag on `git merge` for the back-merge commit

  2. **Secret update (manual, done separately):** Regenerate the GPG key with email
  `gh-signer-bot@safe.global`, register the public key on the `Safe-infra` GitHub
  account, and update `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` secrets.

  ## How to test it

  Validated with a POC in `safe-global/workflow-tests`:
  - Created a test workflow with the same GPG setup
  - Confirmed commits show as ✅ **Verified** on GitHub with `GH Signer Bot` as
  committer

  Full validation will be confirmed on the next release cycle when
  `web-release-start.yml` and `web-tag-release.yml` run with the updated secrets.

  ## Affected flows

  - Automated version bump commit pushed to `release` branch on each release start
  - Automated back-merge merge commit pushed to `backmerge/main-to-dev-*` on each
  release

  ## Blast radius

  - `.github/workflows/web-release-start.yml` — only affects committer identity and
  signing of the version bump commit
  - `.github/workflows/web-tag-release.yml` — only affects committer identity, tag
  signing, and back-merge commit signing
  - No application code, shared packages, hooks, or components touched
  - No mobile impact

  ## Risks / not checked

  - Not tested end-to-end in production — will be confirmed on next release run
  - If `gh-signer-bot@safe.global` is not added as a verified email on the `Safe-infra`
  GitHub account before the next release, commits will still be unverified (manual step
  required outside this PR)
  - Enterprise committer email rule (`/^([^@]+@safe\.global|...)`) —
  `gh-signer-bot@safe.global` matches ✅


  Checklist

  - [ ] I've tested the branch on mobile 📱
  - [ ] I've documented how it affects the analytics (if at all) 📊
  - [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
  - [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
