### PR TITLE
tests: handle nullable composed types in fixture schema validation

### DIFF
--- a/apps/web/src/tests/__tests__/fixtures-match-schema.test.ts
+++ b/apps/web/src/tests/__tests__/fixtures-match-schema.test.ts
@@ -21,14 +21,16 @@ function convertNullable(obj: Record<string, unknown>): void {
 
   if (obj.nullable === true) {
     delete obj.nullable
-    if (typeof obj.type === 'string') {
-      obj.type = [obj.type, 'null']
-    } else if (!obj.type && (obj.$ref || obj.oneOf || obj.anyOf || obj.allOf)) {
-      // nullable ref or composed type — wrap in anyOf with null
-      const { nullable: _, ...existing } = obj
+    if (obj.$ref || obj.oneOf || obj.anyOf || obj.allOf) {
+      // nullable ref or composed type — wrap in anyOf with null. A bare
+      // `type: [..., "null"]` is not enough here: the composition keyword
+      // (e.g. allOf -> $ref) would still be applied to `null` and reject it.
+      const { ...existing } = obj
       Object.keys(obj).forEach((k) => delete obj[k])
       obj.anyOf = [existing, { type: 'null' }]
       return
+    } else if (typeof obj.type === 'string') {
+      obj.type = [obj.type, 'null']
     }
   }
 
@@ -216,14 +218,14 @@ describe('Fixture-schema validation', () => {
         const valid = validate!(item)
         if (!valid) {
           const fields = validate!.errors?.map((e) => `  ${e.instancePath || '/'}: ${e.message}`).join('\n')
-          fail(`Item [${index}] in ${fixture} failed ${schemaRef} validation:\n${fields}`)
+          throw new Error(`Item [${index}] in ${fixture} failed ${schemaRef} validation:\n${fields}`)
         }
       })
     } else {
       const valid = validate!(data)
       if (!valid) {
         const fields = validate!.errors?.map((e) => `  ${e.instancePath || '/'}: ${e.message}`).join('\n')
-        fail(`${fixture} failed ${schemaRef} validation:\n${fields}`)
+        throw new Error(`${fixture} failed ${schemaRef} validation:\n${fields}`)
       }
     }
   })


### PR DESCRIPTION
> Swagger now stamps `type: object`
> on nullable refs; the shim ignored it
> and rejected valid nulls. Now wraps in anyOf.

## What it solves

The web unit test `fixtures-match-schema.test.ts` breaks the moment the CGW `schema.json` is regenerated against current staging. It surfaces as a confusing `ReferenceError: fail is not defined`, masking the real failures: `SafeState.guard`, `SafeState.fallbackHandler`, and `SafeApp.provider` are reported as `must be object` even though they are legitimately nullable.

Root cause is **not** a CGW bug and **not** stale fixtures. CGW bumped `@nestjs/swagger` (11.2.6 → 11.4.2, [CGW #3088](https://github.com/safe-global/safe-client-gateway/pull/3088)); since [nestjs/swagger#3784](https://github.com/nestjs/swagger/pull/3784) (11.3.0), a `nullable` property using `allOf` now **also** emits `type: "object"`:

```diff
- "guard": { "nullable": true, "allOf": [{ "$ref": ".../AddressInfo" }] }
+ "guard": { "nullable": true, "type": "object", "allOf": [{ "$ref": ".../AddressInfo" }] }
```

The test's `convertNullable` shim only wrapped composed types in `anyOf: [..., {type:"null"}]` when **no** `type` was present. With `type: "object"` now present, it instead appended `"null"` to the type but left the `allOf` constraint applied to `null` → `null` can't satisfy `AddressInfo` → `must be object`.

This lands **before** the back-merge PR (#7947), which carries the regenerated schema. The fix is backward-compatible (no-op on `dev`'s current schema), so the back-merge inherits it and goes green.

## How this PR fixes it

- `convertNullable` now wraps **any** nullable composed type (`$ref`/`allOf`/`oneOf`/`anyOf`) in `anyOf: [existing, {type:"null"}]`, regardless of whether an explicit `type` is also present.
- Replaced the non-existent `fail()` global with `throw new Error()` so future schema/fixture drift surfaces the real validation message instead of a `ReferenceError`.

## How to test it

```bash
yarn workspace @safe-global/web test src/tests/__tests__/fixtures-match-schema.test.ts
```

Passes against the current (old) `dev` schema **and** against the regenerated schema in #7947 (22/22).

## Affected flows

- None at runtime. Test-infrastructure only — touches a single `*.test.ts` helper. No app/store/fixture code changed.

## Blast radius

- `convertNullable` is a local function inside `fixtures-match-schema.test.ts`; not exported, no external consumers.
- No change to `schema.json`, fixtures, store types, or any shipped code.

## Risks / not checked

- Did not run the full web suite locally (watchman is unavailable in my sandbox); this was the only failing suite in #7947's CI and CI here will run the rest.
- Did not change the daily `Store Codegen Drift` workflow — it still only files an issue and does not run this test. A follow-up could wire the fixtures test into that job to catch this class of drift automatically.

## Visual summary

```mermaid
flowchart TD
  A["nullable: true + allOf/$ref"] --> B{explicit type present?}
  B -->|"old schema: no type"| C["wrap in anyOf [existing, null]"]
  B -->|"new schema: type: object"| D["BEFORE: type becomes [object, null]<br/>but allOf still rejects null"]
  D --> E["AFTER: always wrap in anyOf [existing, null]"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (n/a — web test infra)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (this *is* the test fix; 22/22 pass)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
