### PR TITLE
fix(web): stop pending CF delete queue from retrying 404s forever

### DIFF
--- a/apps/web/cypress/e2e/pages/main.page.js
+++ b/apps/web/cypress/e2e/pages/main.page.js
@@ -490,6 +490,22 @@ export const checkButtonByTextExists = (buttonText) => {
   cy.get('button').contains(buttonText).should('exist')
 }
 
+/**
+ * Read a key from the AUT's localStorage (after cy.visit) and assert its parsed
+ * value deep-equals `expectedValue`. Uses `.should()` so Cypress retries until
+ * the value matches or the default command timeout elapses — needed for keys
+ * the app writes asynchronously after sync completes.
+ */
+export function verifyAppLocalStorageItemEquals(key, expectedValue) {
+  cy.window()
+    .its('localStorage')
+    .invoke('getItem', key)
+    .should((stored) => {
+      const parsed = stored ? JSON.parse(stored) : null
+      expect(parsed).to.deep.equal(expectedValue)
+    })
+}
+
 export function getAddedSafeAddressFromLocalStorage(chainId, index) {
   return cy.window().then((win) => {
     const addedSafes = win.localStorage.getItem(constants.localStorageKeys.SAFE_v2__addedSafes)

--- a/apps/web/cypress/e2e/regression/counterfactual_pending_deletes.cy.js
+++ b/apps/web/cypress/e2e/regression/counterfactual_pending_deletes.cy.js
@@ -1,0 +1,38 @@
+import * as constants from '../../support/constants'
+import * as main from '../pages/main.page'
+import * as ls from '../../support/localstorage_data.js'
+import { getSafes, CATEGORIES } from '../../support/safes/safesHandler.js'
+
+let staticSafes = []
+
+describe('Counterfactual pending CF delete queue regression tests', () => {
+  before(async () => {
+    staticSafes = await getSafes(CATEGORIES.static)
+  })
+
+  beforeEach(() => {
+    // Seeded SIWE session so isAuthenticated() returns true on load — required
+    // for useCounterfactualSafeSync to flush the persisted queue.
+    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__auth, {
+      sessionExpiresAt: Date.now() + 24 * 60 * 60 * 1000,
+    })
+  })
+
+  it('Verify that ghost pending CF delete entries are drained on 404 instead of retried forever', () => {
+    main.addToLocalStorage(constants.localStorageKeys.SAFE_v2__pendingCfDeletes, ls.pendingCfDeletes.twoGhostEntries)
+
+    cy.intercept('DELETE', constants.counterfactualSafesEndpoint, {
+      statusCode: 404,
+      body: { message: 'not found' },
+    }).as('flushDelete')
+
+    cy.visit(constants.homeUrl + staticSafes.SEP_STATIC_SAFE_0)
+
+    // One DELETE per queued entry — both fire in parallel during the initial sync.
+    cy.wait(['@flushDelete', '@flushDelete'])
+
+    // Each 404 must drop its entry from the persisted queue. Before the fix the
+    // entries stayed forever and every page load fired N parallel DELETEs.
+    main.verifyAppLocalStorageItemEquals(constants.localStorageKeys.SAFE_v2__pendingCfDeletes, [])
+  })
+})

--- a/apps/web/cypress/support/constants.js
+++ b/apps/web/cypress/support/constants.js
@@ -321,7 +321,6 @@ export const localStorageKeys = {
   SAFE_v2__SafeApps__infoModal: 'SAFE_v2__SafeApps__infoModal',
   SAFE_v2__undeployedSafes: 'SAFE_v2__undeployedSafes',
   SAFE_v2__pendingCfDeletes: 'SAFE_v2__pendingCfDeletes',
-  SAFE_v2__batch: 'SAFE_v2__batch',
   SAFE_v2__visitedSafes: 'SAFE_v2__visitedSafes',
   SAFE_v2__auth: 'SAFE_v2__auth',
 }

--- a/apps/web/cypress/support/constants.js
+++ b/apps/web/cypress/support/constants.js
@@ -114,6 +114,7 @@ export const relayPath = '/relay/'
 export const stagingCGWAllTokensBalances = '/balances/USD?trusted=false&exclude_spam=false'
 
 export const usersEndpoint = '**/v1/users'
+export const counterfactualSafesEndpoint = '**/v1/users/counterfactual-safes'
 export const spacesEndpoint = '**/**/spaces*'
 export const spacesGetOneEndpoint = '**/v1/spaces/*'
 export const spacesMembersEndpoint = '**/v1/spaces/*/members'
@@ -319,6 +320,7 @@ export const localStorageKeys = {
   SAFE_v2__SafeApps__browserPermissions: 'SAFE_v2__SafeApps__browserPermissions',
   SAFE_v2__SafeApps__infoModal: 'SAFE_v2__SafeApps__infoModal',
   SAFE_v2__undeployedSafes: 'SAFE_v2__undeployedSafes',
+  SAFE_v2__pendingCfDeletes: 'SAFE_v2__pendingCfDeletes',
   SAFE_v2__batch: 'SAFE_v2__batch',
   SAFE_v2__visitedSafes: 'SAFE_v2__visitedSafes',
   SAFE_v2__auth: 'SAFE_v2__auth',

--- a/apps/web/cypress/support/localstorage_data.js
+++ b/apps/web/cypress/support/localstorage_data.js
@@ -975,6 +975,15 @@ export const safeLabsTerms = {
   acceptedTerms: 'true',
 }
 
+export const pendingCfDeletes = {
+  // Two ghost entries pointing at already-deleted CGW records. Used to reproduce
+  // the "[CF Sync] Failed to flush pending CF delete" 404 spam regression.
+  twoGhostEntries: [
+    { chainId: '11155111', address: '0x111111111111111111111111111111111111aaaa' },
+    { chainId: '11155111', address: '0x222222222222222222222222222222222222bbbb' },
+  ],
+}
+
 export const undeployedSafe = {
   safe1: {
     11155111: {

--- a/apps/web/src/features/counterfactual/hooks/__tests__/useCounterfactualSafeSync.test.ts
+++ b/apps/web/src/features/counterfactual/hooks/__tests__/useCounterfactualSafeSync.test.ts
@@ -7,6 +7,7 @@ const deleteInitiate = jest.fn()
 let userResponse: unknown = { safes: {} }
 let spaceResponse: unknown = { safes: {} }
 let deleteShouldFail = false
+let deleteRejection: unknown = null
 let pendingDeletesState: { chainId: string; address: string }[] = []
 let userFailureCount = 0
 
@@ -35,7 +36,11 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/counterfactual-safes', () =
         initiate: (arg: unknown) => {
           deleteInitiate(arg)
           return {
-            unwrap: () => (deleteShouldFail ? Promise.reject(new Error('boom')) : Promise.resolve({ ok: true })),
+            unwrap: () => {
+              if (deleteRejection !== null) return Promise.reject(deleteRejection)
+              if (deleteShouldFail) return Promise.reject(new Error('boom'))
+              return Promise.resolve({ ok: true })
+            },
           }
         },
       },
@@ -114,6 +119,7 @@ describe('useCounterfactualSafeSync', () => {
     userResponse = { safes: {} }
     spaceResponse = { safes: {} }
     deleteShouldFail = false
+    deleteRejection = null
     pendingDeletesState = []
     userFailureCount = 0
     ;(useAppSelector as jest.Mock).mockReset()
@@ -234,6 +240,33 @@ describe('useCounterfactualSafeSync', () => {
         typeof d === 'object' && d !== null && (d as { type?: string }).type === 'removePendingCfDelete',
     )
     expect(removeActions).toHaveLength(0)
+    consoleSpy.mockRestore()
+  })
+
+  it('drops queued entries on 404 so the queue does not retry forever against an already-deleted resource', async () => {
+    // Reproduces the bug: after activating a CF safe, ghost entries pile up in
+    // pendingCfDeletes and every page load fires N DELETEs that all 404. Each 404
+    // means the resource is already gone — drop the entry instead of retrying.
+    pendingDeletesState = [
+      { chainId: '1', address: '0xabc' },
+      { chainId: '1', address: '0xdef' },
+    ]
+    deleteRejection = { status: 404, data: { message: 'not found' } }
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    mockSelectors(true, true, null)
+
+    renderHook(() => useCounterfactualSafeSync())
+    await flush()
+
+    expect(deleteInitiate).toHaveBeenCalledTimes(2)
+    // Each 404 must remove the corresponding queue entry.
+    const removeActions = dispatched.filter(
+      (d): d is { type: string; payload: { chainId: string; address: string } } =>
+        typeof d === 'object' && d !== null && (d as { type?: string }).type === 'removePendingCfDelete',
+    )
+    expect(removeActions).toHaveLength(2)
+    // 404 is the intended end state — no error noise.
+    expect(consoleSpy).not.toHaveBeenCalled()
     consoleSpy.mockRestore()
   })
 

--- a/apps/web/src/features/counterfactual/hooks/__tests__/useCounterfactualSafeSync.test.ts
+++ b/apps/web/src/features/counterfactual/hooks/__tests__/useCounterfactualSafeSync.test.ts
@@ -48,6 +48,13 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/counterfactual-safes', () =
   },
 }))
 
+jest.mock('@/services/exceptions', () => ({
+  Errors: { _650: '650' },
+  logError: jest.fn(),
+}))
+
+const logErrorMock = jest.requireMock('@/services/exceptions').logError as jest.Mock
+
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
   cgwApi: {
     endpoints: {
@@ -122,6 +129,7 @@ describe('useCounterfactualSafeSync', () => {
     deleteRejection = null
     pendingDeletesState = []
     userFailureCount = 0
+    logErrorMock.mockClear()
     ;(useAppSelector as jest.Mock).mockReset()
   })
 
@@ -228,7 +236,6 @@ describe('useCounterfactualSafeSync', () => {
   it('keeps queued entries when the DELETE fails so they can retry on next sign-in', async () => {
     pendingDeletesState = [{ chainId: '1', address: '0xabc' }]
     deleteShouldFail = true
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
     mockSelectors(true, true, null)
 
     renderHook(() => useCounterfactualSafeSync())
@@ -240,7 +247,7 @@ describe('useCounterfactualSafeSync', () => {
         typeof d === 'object' && d !== null && (d as { type?: string }).type === 'removePendingCfDelete',
     )
     expect(removeActions).toHaveLength(0)
-    consoleSpy.mockRestore()
+    expect(logErrorMock).toHaveBeenCalledWith('650', expect.any(Error))
   })
 
   it('drops queued entries on 404 so the queue does not retry forever against an already-deleted resource', async () => {
@@ -252,7 +259,6 @@ describe('useCounterfactualSafeSync', () => {
       { chainId: '1', address: '0xdef' },
     ]
     deleteRejection = { status: 404, data: { message: 'not found' } }
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
     mockSelectors(true, true, null)
 
     renderHook(() => useCounterfactualSafeSync())
@@ -266,8 +272,7 @@ describe('useCounterfactualSafeSync', () => {
     )
     expect(removeActions).toHaveLength(2)
     // 404 is the intended end state — no error noise.
-    expect(consoleSpy).not.toHaveBeenCalled()
-    consoleSpy.mockRestore()
+    expect(logErrorMock).not.toHaveBeenCalled()
   })
 
   it('does not re-add a safe whose pending DELETE was just flushed', async () => {
@@ -397,7 +402,6 @@ describe('useCounterfactualSafeSync', () => {
     // Without the retry, a single network blip stuck users who land on a
     // space-mate's CF safe URL on "Safe couldn't be loaded".
     jest.useFakeTimers()
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     userFailureCount = 1
     userResponse = {
@@ -443,12 +447,10 @@ describe('useCounterfactualSafeSync', () => {
     expect(addActions.find((a) => a.payload.address === '0xRetry')).toBeDefined()
 
     jest.useRealTimers()
-    consoleSpy.mockRestore()
   })
 
   it('settles cfSafeSynced=true even when both attempts fail so consumers do not wait forever', async () => {
     jest.useFakeTimers()
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     userFailureCount = 2
     mockSelectors(true, true, null)
@@ -469,6 +471,5 @@ describe('useCounterfactualSafeSync', () => {
     expect(syncedActions.some((a) => a.payload === true)).toBe(true)
 
     jest.useRealTimers()
-    consoleSpy.mockRestore()
   })
 })

--- a/apps/web/src/features/counterfactual/hooks/useCounterfactualSafeSync.ts
+++ b/apps/web/src/features/counterfactual/hooks/useCounterfactualSafeSync.ts
@@ -4,6 +4,7 @@ import { getStoreInstance } from '@/store'
 import { isAuthenticated, selectIsStoreHydrated, lastUsedSpace, setCfSafeSynced } from '@/store/authSlice'
 import { addUndeployedSafe, selectUndeployedSafes } from '../store/undeployedSafesSlice'
 import { removePendingCfDelete, selectPendingCfDeletes } from '../store/pendingCfDeletesSlice'
+import { Errors, logError } from '@/services/exceptions'
 import { fromBackendDto } from '../services/counterfactualSafeMapper'
 import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
 import {
@@ -77,7 +78,7 @@ const useCounterfactualSafeSync = () => {
                 dispatch(removePendingCfDelete({ chainId, address }))
                 return
               }
-              console.error('[CF Sync] Failed to flush pending CF delete', e)
+              logError(Errors._650, e)
             }
           }),
         )
@@ -159,12 +160,12 @@ const useCounterfactualSafeSync = () => {
       try {
         await fetchAndMerge()
       } catch (firstError) {
-        console.error('[CF Sync] Initial sync failed, retrying once', firstError)
+        logError(Errors._650, firstError)
         await new Promise((resolve) => setTimeout(resolve, SYNC_RETRY_DELAY_MS))
         try {
           await fetchAndMerge()
         } catch (retryError) {
-          console.error('[CF Sync] Retry also failed, giving up until next auth/space change', retryError)
+          logError(Errors._650, retryError)
         }
       }
       // Settle regardless of outcome — leaving consumers waiting forever is worse

--- a/apps/web/src/features/counterfactual/hooks/useCounterfactualSafeSync.ts
+++ b/apps/web/src/features/counterfactual/hooks/useCounterfactualSafeSync.ts
@@ -16,6 +16,9 @@ import { parseSpaceId } from '@/utils/spaces'
 
 const SYNC_RETRY_DELAY_MS = 2000
 
+const is404 = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'status' in error && (error as { status?: unknown }).status === 404
+
 /**
  * Syncs counterfactual safes from the backend into Redux on app load.
  * Backend is the source of truth. Fetches from both the user endpoint
@@ -68,6 +71,12 @@ const useCounterfactualSafeSync = () => {
               ).unwrap()
               dispatch(removePendingCfDelete({ chainId, address }))
             } catch (e) {
+              // 404 means the record is already gone server-side — our intended end
+              // state. Drop the queue entry so we stop retrying it on every page load.
+              if (is404(e)) {
+                dispatch(removePendingCfDelete({ chainId, address }))
+                return
+              }
               console.error('[CF Sync] Failed to flush pending CF delete', e)
             }
           }),

--- a/apps/web/src/features/counterfactual/store/__tests__/counterfactualSyncListener.test.ts
+++ b/apps/web/src/features/counterfactual/store/__tests__/counterfactualSyncListener.test.ts
@@ -24,7 +24,13 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/counterfactual-safes', () =
   },
 }))
 
+jest.mock('@/services/exceptions', () => ({
+  Errors: { _650: '650' },
+  logError: jest.fn(),
+}))
+
 const initiateMock = counterfactualSafesApi.endpoints.counterfactualSafesDeleteV1.initiate as jest.Mock
+const logErrorMock = jest.requireMock('@/services/exceptions').logError as jest.Mock
 
 describe('counterfactualSyncListener', () => {
   const listenerMiddlewareInstance = createListenerMiddleware<RootState>()
@@ -108,25 +114,22 @@ describe('counterfactualSyncListener', () => {
 
     const error = new Error('boom')
     initiateMock.mockImplementationOnce(makeInitiateMock(() => Promise.reject(error)))
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     const { listenerApi } = runListener(state, removeUndeployedSafe({ chainId: '1', address: '0x123' }))
     await Promise.resolve()
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(consoleSpy).toHaveBeenCalled()
+    expect(logErrorMock).toHaveBeenCalledWith('650', error)
     // Failure must enqueue a pending delete so the next sync retries — otherwise
     // the next GET would resurrect the activated safe as "Not activated".
     expect(listenerApi.dispatch).toHaveBeenCalledWith(enqueuePendingCfDelete({ chainId: '1', address: '0x123' }))
-    consoleSpy.mockRestore()
   })
 
   it('does NOT enqueue a retry when the DELETE returns 404 (already gone)', async () => {
     const state = authedState({ '1': { '0x123': { isCreator: true } } })
 
     initiateMock.mockImplementationOnce(makeInitiateMock(() => Promise.reject({ status: 404, data: {} })))
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
     const { listenerApi } = runListener(state, removeUndeployedSafe({ chainId: '1', address: '0x123' }))
     await Promise.resolve()
@@ -134,9 +137,8 @@ describe('counterfactualSyncListener', () => {
     await Promise.resolve()
 
     // 404 = already deleted, our intended end state. No error noise, no retry queued.
-    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(logErrorMock).not.toHaveBeenCalled()
     expect(listenerApi.dispatch).not.toHaveBeenCalledWith(enqueuePendingCfDelete({ chainId: '1', address: '0x123' }))
-    consoleSpy.mockRestore()
   })
 
   it('does NOT call the DELETE API when the pre-action state has no entry for the safe', async () => {

--- a/apps/web/src/features/counterfactual/store/__tests__/counterfactualSyncListener.test.ts
+++ b/apps/web/src/features/counterfactual/store/__tests__/counterfactualSyncListener.test.ts
@@ -122,6 +122,37 @@ describe('counterfactualSyncListener', () => {
     consoleSpy.mockRestore()
   })
 
+  it('does NOT enqueue a retry when the DELETE returns 404 (already gone)', async () => {
+    const state = authedState({ '1': { '0x123': { isCreator: true } } })
+
+    initiateMock.mockImplementationOnce(makeInitiateMock(() => Promise.reject({ status: 404, data: {} })))
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { listenerApi } = runListener(state, removeUndeployedSafe({ chainId: '1', address: '0x123' }))
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // 404 = already deleted, our intended end state. No error noise, no retry queued.
+    expect(consoleSpy).not.toHaveBeenCalled()
+    expect(listenerApi.dispatch).not.toHaveBeenCalledWith(enqueuePendingCfDelete({ chainId: '1', address: '0x123' }))
+    consoleSpy.mockRestore()
+  })
+
+  it('does NOT call the DELETE API when the pre-action state has no entry for the safe', async () => {
+    // Reproduces the dup-dispatch case: useLoadSafeInfo + INDEXED event both fire
+    // removeUndeployedSafe in the same tick; the second one finds nothing in
+    // originalState and must short-circuit, otherwise it 404s and pollutes the queue.
+    const state = authedState({})
+
+    const { listenerApi } = runListener(state, removeUndeployedSafe({ chainId: '1', address: '0x123' }))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(initiateMock).not.toHaveBeenCalled()
+    expect(listenerApi.dispatch).not.toHaveBeenCalled()
+  })
+
   it('queues a pending delete (instead of calling the API) when user is not authenticated', () => {
     const state = {
       auth: { sessionExpiresAt: null },

--- a/apps/web/src/features/counterfactual/store/counterfactualSyncListener.ts
+++ b/apps/web/src/features/counterfactual/store/counterfactualSyncListener.ts
@@ -1,5 +1,6 @@
 import type { listenerMiddlewareInstance, RootState } from '@/store/index'
 import { isAuthenticated } from '@/store/authSlice'
+import { Errors, logError } from '@/services/exceptions'
 import { removeUndeployedSafe } from './undeployedSafesSlice'
 import { enqueuePendingCfDelete } from './pendingCfDeletesSlice'
 import { cgwApi as counterfactualSafesApi } from '@safe-global/store/gateway/AUTO_GENERATED/counterfactual-safes'
@@ -54,7 +55,7 @@ export const counterfactualSyncListener = (listenerMiddleware: typeof listenerMi
         // 404 means the record is already gone server-side — that's our intended
         // end state, no retry needed.
         if (is404(e)) return
-        console.error('[CF Sync] Failed to delete CF safe from backend', e)
+        logError(Errors._650, e)
         // Network/5xx during the live DELETE leaves backend stuck on the now-deployed
         // safe. Queue it so the next sync flushes the retry — otherwise the next GET
         // would return it and the merge would re-add a "Not activated" chip.

--- a/apps/web/src/features/counterfactual/store/counterfactualSyncListener.ts
+++ b/apps/web/src/features/counterfactual/store/counterfactualSyncListener.ts
@@ -4,6 +4,9 @@ import { removeUndeployedSafe } from './undeployedSafesSlice'
 import { enqueuePendingCfDelete } from './pendingCfDeletesSlice'
 import { cgwApi as counterfactualSafesApi } from '@safe-global/store/gateway/AUTO_GENERATED/counterfactual-safes'
 
+const is404 = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && 'status' in error && (error as { status?: unknown }).status === 404
+
 export const counterfactualSyncListener = (listenerMiddleware: typeof listenerMiddlewareInstance) => {
   // Sync removeUndeployedSafe to backend
   listenerMiddleware.startListening({
@@ -13,16 +16,21 @@ export const counterfactualSyncListener = (listenerMiddleware: typeof listenerMi
       const { chainId, address } = action.payload
 
       // Look up the entry in the *pre-action* state — by the time this effect
-      // runs, the reducer has already removed it from current state. Backend
-      // DELETE rejects non-creators with 40x, so skip the call for safes the
-      // current user didn't create (e.g. ones synced from a space endpoint).
-      // Read the raw slice directly (no memoized selector) to keep the check
-      // dependency-free and easy to test.
+      // runs, the reducer has already removed it from current state.
       const originalState = listenerApi.getOriginalState() as RootState
       const removed = originalState.undeployedSafes?.[chainId]?.[address]
+      // Nothing was actually removed by this dispatch — a prior `removeUndeployedSafe`
+      // already cleared the entry. Skip the DELETE call to avoid spamming the backend
+      // with calls that 404 (and pollute the pending-delete queue) when multiple
+      // dispatchers fire in the same tick after activation (self-heal in
+      // useLoadSafeInfo + INDEXED event in usePendingSafeStatuses).
+      if (!removed) return
+
+      // Backend DELETE rejects non-creators with 40x, so skip the call for safes the
+      // current user didn't create (e.g. ones synced from a space endpoint).
       // Treat undefined as `true` for backwards compatibility with entries
       // persisted before the isCreator flag existed.
-      const wasCreator = removed?.isCreator !== false
+      const wasCreator = removed.isCreator !== false
       if (!wasCreator) return
 
       // The user can deploy a safe before signing in with SIWE (just a wallet
@@ -43,6 +51,9 @@ export const counterfactualSyncListener = (listenerMiddleware: typeof listenerMi
           )
           .unwrap()
       } catch (e) {
+        // 404 means the record is already gone server-side — that's our intended
+        // end state, no retry needed.
+        if (is404(e)) return
         console.error('[CF Sync] Failed to delete CF safe from backend', e)
         // Network/5xx during the live DELETE leaves backend stuck on the now-deployed
         // safe. Queue it so the next sync flushes the retry — otherwise the next GET

--- a/packages/utils/src/services/exceptions/ErrorCodes.ts
+++ b/packages/utils/src/services/exceptions/ErrorCodes.ts
@@ -43,6 +43,7 @@ enum ErrorCodes {
   _632 = '632: Error fetching relay task status',
   _633 = '633: Notification (un-)registration failed',
   _640 = '640: Error signing in with Ethereum',
+  _650 = '650: Error syncing counterfactual safes with backend',
 
   _700 = '700: Failed to read from local/session storage',
   _701 = '701: Failed to write to local/session storage',


### PR DESCRIPTION
> Ghost entries piled in the queue,
> each reload spawned DELETEs anew —
> 404 now means we're done,
> the spam stops, the state stays clean.

## What it solves

After creating and activating a counterfactual Safe, the next page load fires dozens of DELETE requests against `https://safe-client.staging.5afe.dev/v1/users/counterfactual-safes`, each returning 404, with `[CF Sync] Failed to flush pending CF delete {status: 404, data: {...}}` repeated in the console.

Linear: https://linear.app/safe-global/issue/WA-2438/repeated-counterfactual-safe-delete-404-errors-in-console

## How this PR fixes it

Two interacting bugs in the CF-delete sync path:

1. **Duplicate dispatches generated ghost entries.** Multiple call sites dispatch `removeUndeployedSafe` for the same safe during activation:
   - self-heal effect in `useLoadSafeInfo` (cgwData arrived → undeployedSafe still present)
   - deployment-detection effect in `usePendingSafeStatuses` (`isSmartContract` returned true)
   - INDEXED event handler in `usePendingSafeStatuses`

   The listener processed every dispatch. The first DELETE cleared the CGW record; subsequent DELETEs hit a non-existent resource, 404'd, and the catch block enqueued a "ghost" entry into `pendingCfDeletes`. The listener's previous guard (`removed?.isCreator !== false`) evaluated `true` even when `removed` was `undefined`, so the duplicate dispatches weren't filtered.

2. **The queue never drained.** Both the live DELETE in the listener and the flush in `useCounterfactualSafeSync` treated 404 the same as a transient failure. Since `pendingCfDeletesSlice` is persisted (`store/index.ts`), entries accumulated across sessions and all fired in parallel via `Promise.all` on each sync.

Fixes:
- Listener bails when pre-action state has no entry to remove → duplicate dispatches become no-ops.
- Listener treats DELETE 404 as success → no enqueue, no error log.
- Flush in `useCounterfactualSafeSync` treats DELETE 404 as success → drops the entry from `pendingCfDeletes`.

Result: already-accumulated ghost entries drain on the next sync; new activations stop generating them.

## How to test it

1. Sign in with SIWE on staging.
2. Create and activate a counterfactual Safe end-to-end.
3. Reload the page.
4. Network tab: confirm there are **no** repeated DELETE requests to `/v1/users/counterfactual-safes`. Users with already-accumulated ghost entries should see at most a single drain pass that ends with the queue empty.
5. Console: confirm no `[CF Sync] Failed to flush pending CF delete` lines.
6. Regression: activate while not SIWE-authenticated, then sign in. The queued DELETE must still be flushed on sign-in; a 5xx/network failure (simulate by blocking the request) must still keep the entry for retry.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[Activate CF Safe] --> B1[removeUndeployedSafe dispatched x3]
    B1 --> C1[Listener fires for every dispatch]
    C1 --> D1[1st DELETE -> 200<br/>2nd+ DELETE -> 404]
    D1 --> E1[catch enqueues ghost entry]
    E1 --> F1[Next page load: flush retries -> 404]
    F1 --> G1[Entry retained -> queue grows forever]
  end
  subgraph After
    A2[Activate CF Safe] --> B2[removeUndeployedSafe dispatched x3]
    B2 --> C2[Listener no-ops when originalState empty]
    C2 --> D2[Single DELETE -> 200]
    D2 --> E2[No ghost entry queued]
    E2 --> F2[Any pre-existing 404 drops its queue entry]
    F2 --> G2[Queue drains, no spam]
  end
```

## Regression checklist

**Surfaces touched:**
- `apps/web/src/features/counterfactual/store/counterfactualSyncListener.ts`
- `apps/web/src/features/counterfactual/hooks/useCounterfactualSafeSync.ts`

**Neighbouring flows verified by tests:**
- CF activation under auth, single dispatch — DELETE 200, queue empty.
- CF activation with concurrent dispatches — only the first hits the backend.
- 404 on live DELETE — no enqueue, no error log.
- 404 on flush — entry removed, no error log.
- 5xx / generic failure — still enqueues / retains for retry.
- Unauthenticated path — still enqueues for later flush.
- Block-list path in `fetchAndMerge` — unchanged; still skips re-adding deleted safes.

**E2E coverage:** new `apps/web/cypress/e2e/regression/counterfactual_pending_deletes.cy.js` seeds two ghost queue entries plus a SIWE session, intercepts the CGW DELETE with a 404 stub, and asserts the persisted `pendingCfDeletes` slice drains to `[]` after the initial sync.

**Not verified (risks):**
- No live staging reproduction — diagnosis is by code reading.
- 403 (non-creator) responses are not special-cased; legacy queued entries for safes the user can't delete will continue to retry. Out of scope.

## Checklist

- [x] I've added unit tests for the new behaviour
- [x] I've added a regression e2e for the queue-drain path
- [x] `type-check`, `lint`, `prettier --check`, and the counterfactual test suite are green
- [x] PR title follows conventional commits
- [x] No changes to generated files or shared theme tokens
