### PR TITLE
feat(web/Spaces): Accounts management popup

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -23,3 +23,5 @@ storybook-static
 # Generated build-time data
 src/config/__generated__/
 public/version.json
+
+docs/superpowers/

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) 
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/50 fixed inset-0 z-[var(--z-overlay)]',
+        'data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-starting-style:opacity-0 data-ending-style:opacity-0 bg-black/50 fixed inset-0 z-[var(--z-overlay)]',
         className,
       )}
       {...props}
@@ -73,7 +73,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 fixed top-[50%] left-[50%] z-[var(--z-overlay)] w-full max-w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-xl shadow-lg duration-200',
+          'bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-starting-style:opacity-0 data-ending-style:opacity-0 fixed top-[50%] left-[50%] z-[var(--z-overlay)] w-full max-w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-xl shadow-lg duration-200',
           className,
         )}
         {...props}

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
@@ -130,4 +130,34 @@ describe('AddAccountsChooser', () => {
 
     expect(mockPush).toHaveBeenCalledWith('/new-safe/create')
   })
+
+  it('lets non-admin members open OwnedSafesModal from "See owned Safe accounts"', () => {
+    mockIsAdmin = false
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByText('See owned Safe accounts'))
+
+    expect(screen.getByTestId('owned-safes-modal')).toBeInTheDocument()
+  })
+
+  it('lets non-admin members navigate to /new-safe/create from "Create new Safe"', () => {
+    mockIsAdmin = false
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByText('Create new Safe'))
+
+    expect(mockPush).toHaveBeenCalledWith('/new-safe/create')
+  })
+
+  it('does not fire WORKSPACE_SAFE_LINK_STARTED when a non-admin clicks the disabled row', () => {
+    mockIsAdmin = false
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByRole('button', { name: /Add Safe accounts to the Workspace/i }))
+
+    expect(mockTrackEvent).not.toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
@@ -42,19 +42,19 @@ describe('AddAccountsChooser', () => {
   })
 
   it('respects a custom buttonLabel', () => {
-    render(<AddAccountsChooser buttonLabel="Add account" />)
+    render(<AddAccountsChooser buttonLabel="Manage accounts" />)
 
-    expect(screen.getByTestId('add-space-account-button')).toHaveTextContent('Add account')
+    expect(screen.getByTestId('add-space-account-button')).toHaveTextContent('Manage accounts')
   })
 
   it('opens the chooser dialog when the trigger button is clicked', () => {
     render(<AddAccountsChooser />)
 
-    expect(screen.queryByText('Add a Safe Account')).not.toBeInTheDocument()
+    expect(screen.queryByText('Manage Safe accounts')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
 
-    expect(screen.getByText('Add a Safe Account')).toBeInTheDocument()
+    expect(screen.getByText('Manage Safe accounts')).toBeInTheDocument()
   })
 
   it('shows three chooser rows', () => {
@@ -63,7 +63,7 @@ describe('AddAccountsChooser', () => {
     fireEvent.click(screen.getByTestId('add-space-account-button'))
 
     expect(screen.getByText('See owned Safe accounts')).toBeInTheDocument()
-    expect(screen.getByText('Add Safe accounts to the Workspace')).toBeInTheDocument()
+    expect(screen.getByText('Add Safe accounts to this workspace')).toBeInTheDocument()
     expect(screen.getByText('Create new Safe')).toBeInTheDocument()
   })
 
@@ -76,11 +76,11 @@ describe('AddAccountsChooser', () => {
     expect(screen.getByTestId('owned-safes-modal')).toBeInTheDocument()
   })
 
-  it('opens AddAccounts picker when admin clicks "Add Safe accounts to the Workspace"', () => {
+  it('opens AddAccounts picker when admin clicks "Add Safe accounts to this workspace"', () => {
     render(<AddAccountsChooser />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
-    fireEvent.click(screen.getByText('Add Safe accounts to the Workspace'))
+    fireEvent.click(screen.getByText('Add Safe accounts to this workspace'))
 
     expect(screen.getByTestId('add-accounts-picker')).toBeInTheDocument()
   })
@@ -89,7 +89,7 @@ describe('AddAccountsChooser', () => {
     render(<AddAccountsChooser />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
-    fireEvent.click(screen.getByText('Add Safe accounts to the Workspace'))
+    fireEvent.click(screen.getByText('Add Safe accounts to this workspace'))
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({ action: expect.any(String) }),
@@ -103,7 +103,7 @@ describe('AddAccountsChooser', () => {
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
 
-    const row = screen.getByRole('button', { name: /Add Safe accounts to the Workspace/i })
+    const row = screen.getByRole('button', { name: /Add Safe accounts to this workspace/i })
     expect(row).toHaveAttribute('aria-disabled', 'true')
 
     fireEvent.click(row)
@@ -116,7 +116,7 @@ describe('AddAccountsChooser', () => {
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
 
-    expect(screen.getByRole('button', { name: /Add Safe accounts to the Workspace/i })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: /Add Safe accounts to this workspace/i })).toHaveAttribute(
       'title',
       'You need to be an Admin to add accounts',
     )
@@ -156,7 +156,7 @@ describe('AddAccountsChooser', () => {
     render(<AddAccountsChooser />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
-    fireEvent.click(screen.getByRole('button', { name: /Add Safe accounts to the Workspace/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Add Safe accounts to this workspace/i }))
 
     expect(mockTrackEvent).not.toHaveBeenCalled()
   })

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
@@ -17,15 +17,22 @@ jest.mock('next/router', () => ({
   useRouter: () => ({ push: mockPush }),
 }))
 
+const mockAddAccountsMount = jest.fn()
 jest.mock('@/features/spaces/components/AddAccounts', () => ({
   __esModule: true,
-  default: ({ externalOpen }: { externalOpen?: boolean }) =>
-    externalOpen ? <div data-testid="add-accounts-picker" /> : null,
+  default: ({ externalOpen }: { externalOpen?: boolean }) => {
+    mockAddAccountsMount()
+    return externalOpen ? <div data-testid="add-accounts-picker" /> : null
+  },
 }))
 
+const mockOwnedSafesModalMount = jest.fn()
 jest.mock('@/features/spaces/components/OwnedSafesModal', () => ({
   __esModule: true,
-  default: ({ open }: { open: boolean }) => (open ? <div data-testid="owned-safes-modal" /> : null),
+  default: ({ open }: { open: boolean }) => {
+    mockOwnedSafesModalMount()
+    return open ? <div data-testid="owned-safes-modal" /> : null
+  },
 }))
 
 describe('AddAccountsChooser', () => {
@@ -33,6 +40,8 @@ describe('AddAccountsChooser', () => {
     mockIsAdmin = true
     mockTrackEvent.mockClear()
     mockPush.mockClear()
+    mockAddAccountsMount.mockClear()
+    mockOwnedSafesModalMount.mockClear()
   })
 
   it('renders the trigger button with the default label', () => {
@@ -159,5 +168,47 @@ describe('AddAccountsChooser', () => {
     fireEvent.click(screen.getByRole('button', { name: /Add Safe accounts to this workspace/i }))
 
     expect(mockTrackEvent).not.toHaveBeenCalled()
+  })
+
+  it('does not mount OwnedSafesModal or AddAccounts before the chooser is opened', () => {
+    render(<AddAccountsChooser />)
+
+    expect(mockOwnedSafesModalMount).not.toHaveBeenCalled()
+    expect(mockAddAccountsMount).not.toHaveBeenCalled()
+  })
+
+  it('does not mount OwnedSafesModal or AddAccounts when only the chooser is opened', () => {
+    render(<AddAccountsChooser />)
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+
+    expect(mockOwnedSafesModalMount).not.toHaveBeenCalled()
+    expect(mockAddAccountsMount).not.toHaveBeenCalled()
+  })
+
+  it('mounts only OwnedSafesModal when "See owned Safe accounts" is clicked', () => {
+    render(<AddAccountsChooser />)
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByText('See owned Safe accounts'))
+
+    expect(mockOwnedSafesModalMount).toHaveBeenCalled()
+    expect(mockAddAccountsMount).not.toHaveBeenCalled()
+  })
+
+  it('mounts only AddAccounts when an admin picks "Add Safe accounts to this workspace"', () => {
+    render(<AddAccountsChooser />)
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByText('Add Safe accounts to this workspace'))
+
+    expect(mockAddAccountsMount).toHaveBeenCalled()
+    expect(mockOwnedSafesModalMount).not.toHaveBeenCalled()
+  })
+
+  it('does not mount AddAccounts when a non-admin clicks the disabled row', () => {
+    mockIsAdmin = false
+    render(<AddAccountsChooser />)
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByRole('button', { name: /Add Safe accounts to this workspace/i }))
+
+    expect(mockAddAccountsMount).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
@@ -131,16 +131,13 @@ describe('AddAccountsChooser', () => {
     expect(screen.queryByTestId('add-accounts-picker')).not.toBeInTheDocument()
   })
 
-  it('renders the admin-only tooltip text in the DOM for non-admins', () => {
+  it('does not set a native title attribute on the disabled row (Tooltip handles it)', () => {
     mockIsAdmin = false
     render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
 
-    expect(screen.getByRole('button', { name: /Add Safe accounts to this workspace/i })).toHaveAttribute(
-      'title',
-      'You need to be an Admin to add accounts',
-    )
+    expect(screen.getByRole('button', { name: /Add Safe accounts to this workspace/i })).not.toHaveAttribute('title')
   })
 
   it('navigates to /new-safe/create when "Create new Safe" is clicked', () => {

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent } from '@/tests/test-utils'
+import AddAccountsChooser from '../index'
+
+let mockIsAdmin = true
+jest.mock('@/features/spaces', () => ({
+  useCurrentSpaceId: () => '1',
+  useIsAdmin: () => mockIsAdmin,
+}))
+
+const mockTrackEvent = jest.fn()
+jest.mock('@/services/analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}))
+
+const mockPush = jest.fn()
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+jest.mock('@/features/spaces/components/AddAccounts', () => ({
+  __esModule: true,
+  default: ({ externalOpen }: { externalOpen?: boolean }) =>
+    externalOpen ? <div data-testid="add-accounts-picker" /> : null,
+}))
+
+jest.mock('@/features/spaces/components/OwnedSafesModal', () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="owned-safes-modal" /> : null),
+}))
+
+describe('AddAccountsChooser', () => {
+  beforeEach(() => {
+    mockIsAdmin = true
+    mockTrackEvent.mockClear()
+    mockPush.mockClear()
+  })
+
+  it('renders the trigger button with the default label', () => {
+    render(<AddAccountsChooser />)
+
+    expect(screen.getByTestId('add-space-account-button')).toHaveTextContent('Add Accounts')
+  })
+
+  it('respects a custom buttonLabel', () => {
+    render(<AddAccountsChooser buttonLabel="Add account" />)
+
+    expect(screen.getByTestId('add-space-account-button')).toHaveTextContent('Add account')
+  })
+
+  it('opens the chooser dialog when the trigger button is clicked', () => {
+    render(<AddAccountsChooser />)
+
+    expect(screen.queryByText('Add a Safe Account')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+
+    expect(screen.getByText('Add a Safe Account')).toBeInTheDocument()
+  })
+
+  it('shows three chooser rows', () => {
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+
+    expect(screen.getByText('See owned Safe accounts')).toBeInTheDocument()
+    expect(screen.getByText('Add Safe accounts to the Workspace')).toBeInTheDocument()
+    expect(screen.getByText('Create new Safe')).toBeInTheDocument()
+  })
+
+  it('opens OwnedSafesModal when "See owned Safe accounts" is clicked', () => {
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByText('See owned Safe accounts'))
+
+    expect(screen.getByTestId('owned-safes-modal')).toBeInTheDocument()
+  })
+
+  it('opens AddAccounts picker when admin clicks "Add Safe accounts to the Workspace"', () => {
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByText('Add Safe accounts to the Workspace'))
+
+    expect(screen.getByTestId('add-accounts-picker')).toBeInTheDocument()
+  })
+
+  it('fires WORKSPACE_SAFE_LINK_STARTED when admin opens the picker', () => {
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByText('Add Safe accounts to the Workspace'))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: expect.any(String) }),
+      expect.objectContaining({ workspace_id: '1' }),
+    )
+  })
+
+  it('disables the "Add to Workspace" row for non-admin and shows the tooltip text', () => {
+    mockIsAdmin = false
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+
+    const row = screen.getByRole('button', { name: /Add Safe accounts to the Workspace/i })
+    expect(row).toHaveAttribute('aria-disabled', 'true')
+
+    fireEvent.click(row)
+    expect(screen.queryByTestId('add-accounts-picker')).not.toBeInTheDocument()
+  })
+
+  it('renders the admin-only tooltip text in the DOM for non-admins', () => {
+    mockIsAdmin = false
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+
+    expect(screen.getByRole('button', { name: /Add Safe accounts to the Workspace/i })).toHaveAttribute(
+      'title',
+      'You need to be an Admin to add accounts',
+    )
+  })
+
+  it('navigates to /new-safe/create when "Create new Safe" is clicked', () => {
+    render(<AddAccountsChooser />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByText('Create new Safe'))
+
+    expect(mockPush).toHaveBeenCalledWith('/new-safe/create')
+  })
+})

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
@@ -47,7 +47,7 @@ describe('AddAccountsChooser', () => {
   it('renders the trigger button with the default label', () => {
     render(<AddAccountsChooser entryPoint="dashboard" />)
 
-    expect(screen.getByTestId('add-space-account-button')).toHaveTextContent('Add Accounts')
+    expect(screen.getByTestId('add-space-account-button')).toHaveTextContent('Add accounts')
   })
 
   it('respects a custom buttonLabel', () => {

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
@@ -45,19 +45,19 @@ describe('AddAccountsChooser', () => {
   })
 
   it('renders the trigger button with the default label', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     expect(screen.getByTestId('add-space-account-button')).toHaveTextContent('Add Accounts')
   })
 
   it('respects a custom buttonLabel', () => {
-    render(<AddAccountsChooser buttonLabel="Manage accounts" />)
+    render(<AddAccountsChooser buttonLabel="Manage accounts" entryPoint="dashboard" />)
 
     expect(screen.getByTestId('add-space-account-button')).toHaveTextContent('Manage accounts')
   })
 
   it('opens the chooser dialog when the trigger button is clicked', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     expect(screen.queryByText('Manage Safe accounts')).not.toBeInTheDocument()
 
@@ -67,7 +67,7 @@ describe('AddAccountsChooser', () => {
   })
 
   it('shows three chooser rows', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
 
@@ -77,7 +77,7 @@ describe('AddAccountsChooser', () => {
   })
 
   it('opens OwnedSafesModal when "See owned Safe accounts" is clicked', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByText('See owned Safe accounts'))
@@ -86,7 +86,7 @@ describe('AddAccountsChooser', () => {
   })
 
   it('opens AddAccounts picker when admin clicks "Add Safe accounts to this workspace"', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByText('Add Safe accounts to this workspace'))
@@ -94,21 +94,33 @@ describe('AddAccountsChooser', () => {
     expect(screen.getByTestId('add-accounts-picker')).toBeInTheDocument()
   })
 
-  it('fires WORKSPACE_SAFE_LINK_STARTED when admin opens the picker', () => {
-    render(<AddAccountsChooser />)
+  it('fires WORKSPACE_SAFE_LINK_STARTED with the dashboard entry point when rendered from the dashboard', () => {
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByText('Add Safe accounts to this workspace'))
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({ action: expect.any(String) }),
-      expect.objectContaining({ workspace_id: '1' }),
+      expect.objectContaining({ workspace_id: '1', entry_point: 'dashboard' }),
+    )
+  })
+
+  it('fires WORKSPACE_SAFE_LINK_STARTED with the safe_accounts entry point when rendered from the SafeAccounts page', () => {
+    render(<AddAccountsChooser entryPoint="safe_accounts" />)
+
+    fireEvent.click(screen.getByTestId('add-space-account-button'))
+    fireEvent.click(screen.getByText('Add Safe accounts to this workspace'))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: expect.any(String) }),
+      expect.objectContaining({ workspace_id: '1', entry_point: 'safe_accounts' }),
     )
   })
 
   it('disables the "Add to Workspace" row for non-admin and shows the tooltip text', () => {
     mockIsAdmin = false
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
 
@@ -121,7 +133,7 @@ describe('AddAccountsChooser', () => {
 
   it('renders the admin-only tooltip text in the DOM for non-admins', () => {
     mockIsAdmin = false
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
 
@@ -132,7 +144,7 @@ describe('AddAccountsChooser', () => {
   })
 
   it('navigates to /new-safe/create when "Create new Safe" is clicked', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByText('Create new Safe'))
@@ -142,7 +154,7 @@ describe('AddAccountsChooser', () => {
 
   it('lets non-admin members open OwnedSafesModal from "See owned Safe accounts"', () => {
     mockIsAdmin = false
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByText('See owned Safe accounts'))
@@ -152,7 +164,7 @@ describe('AddAccountsChooser', () => {
 
   it('lets non-admin members navigate to /new-safe/create from "Create new Safe"', () => {
     mockIsAdmin = false
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByText('Create new Safe'))
@@ -162,7 +174,7 @@ describe('AddAccountsChooser', () => {
 
   it('does not fire WORKSPACE_SAFE_LINK_STARTED when a non-admin clicks the disabled row', () => {
     mockIsAdmin = false
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByRole('button', { name: /Add Safe accounts to this workspace/i }))
@@ -171,14 +183,14 @@ describe('AddAccountsChooser', () => {
   })
 
   it('does not mount OwnedSafesModal or AddAccounts before the chooser is opened', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
 
     expect(mockOwnedSafesModalMount).not.toHaveBeenCalled()
     expect(mockAddAccountsMount).not.toHaveBeenCalled()
   })
 
   it('does not mount OwnedSafesModal or AddAccounts when only the chooser is opened', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
     fireEvent.click(screen.getByTestId('add-space-account-button'))
 
     expect(mockOwnedSafesModalMount).not.toHaveBeenCalled()
@@ -186,7 +198,7 @@ describe('AddAccountsChooser', () => {
   })
 
   it('mounts only OwnedSafesModal when "See owned Safe accounts" is clicked', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByText('See owned Safe accounts'))
 
@@ -195,7 +207,7 @@ describe('AddAccountsChooser', () => {
   })
 
   it('mounts only AddAccounts when an admin picks "Add Safe accounts to this workspace"', () => {
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByText('Add Safe accounts to this workspace'))
 
@@ -205,7 +217,7 @@ describe('AddAccountsChooser', () => {
 
   it('does not mount AddAccounts when a non-admin clicks the disabled row', () => {
     mockIsAdmin = false
-    render(<AddAccountsChooser />)
+    render(<AddAccountsChooser entryPoint="dashboard" />)
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByRole('button', { name: /Add Safe accounts to this workspace/i }))
 

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
@@ -37,7 +37,6 @@ const ChooserRow = ({ icon, title, subtitle, onClick, disabled, disabledTooltip 
       type="button"
       onClick={disabled ? undefined : onClick}
       aria-disabled={disabled || undefined}
-      title={disabled ? disabledTooltip : undefined}
       className={cn(
         'group flex w-full items-center gap-2 rounded-md p-2 text-left text-sm text-sidebar-foreground transition-colors',
         '[&_svg]:[stroke-width:2] [&_svg]:transition-colors',

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
@@ -1,0 +1,145 @@
+import { useState, type ReactNode } from 'react'
+import { useRouter } from 'next/router'
+import { AppRoutes } from '@/config/routes'
+import { ChevronRight, CirclePlus, Plus, Search } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/utils/cn'
+import OwnedSafesModal from '@/features/spaces/components/OwnedSafesModal'
+import AddAccounts from '@/features/spaces/components/AddAccounts'
+import { useCurrentSpaceId, useIsAdmin } from '@/features/spaces'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+interface AddAccountsChooserProps {
+  buttonVariant?: 'outline' | 'default'
+  buttonLabel?: string
+}
+
+type SubModal = 'find' | 'add' | null
+
+interface ChooserRowProps {
+  icon: ReactNode
+  title: string
+  subtitle: string
+  onClick: () => void
+  disabled?: boolean
+  disabledTooltip?: string
+}
+
+const ChooserRow = ({ icon, title, subtitle, onClick, disabled, disabledTooltip }: ChooserRowProps) => {
+  const row = (
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      aria-disabled={disabled || undefined}
+      title={disabled ? disabledTooltip : undefined}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-lg p-3 text-left transition-colors',
+        disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-muted/60',
+      )}
+    >
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted">{icon}</span>
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm font-semibold text-foreground">{title}</span>
+        <span className="block text-xs text-muted-foreground">{subtitle}</span>
+      </span>
+      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+    </button>
+  )
+
+  if (disabled && disabledTooltip) {
+    return (
+      <Tooltip>
+        <TooltipTrigger render={row} />
+        <TooltipContent>{disabledTooltip}</TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return row
+}
+
+const AddAccountsChooser = ({
+  buttonVariant = 'outline',
+  buttonLabel = 'Add Accounts',
+}: AddAccountsChooserProps = {}) => {
+  const [chooserOpen, setChooserOpen] = useState(false)
+  const [subModal, setSubModal] = useState<SubModal>(null)
+  const isAdmin = useIsAdmin()
+  const spaceId = useCurrentSpaceId()
+
+  const router = useRouter()
+
+  const handleCreate = () => {
+    setChooserOpen(false)
+    router.push(AppRoutes.newSafe.create)
+  }
+
+  const handleAdd = () => {
+    if (!isAdmin) return
+    trackEvent(
+      { ...SPACE_EVENTS.WORKSPACE_SAFE_LINK_STARTED, label: spaceId },
+      { workspace_id: spaceId, entry_point: 'dashboard' },
+    )
+    setChooserOpen(false)
+    setSubModal('add')
+  }
+
+  return (
+    <>
+      <Button
+        size="lg"
+        variant={buttonVariant}
+        className="font-normal px-4 py-0"
+        onClick={() => setChooserOpen(true)}
+        data-testid="add-space-account-button"
+      >
+        <Plus
+          className={cn('size-4', {
+            'text-green-500': buttonVariant === 'default',
+          })}
+        />
+        {buttonLabel}
+      </Button>
+
+      <Dialog open={chooserOpen} onOpenChange={setChooserOpen}>
+        <DialogContent showCloseButton className="max-w-[440px] p-4">
+          <DialogHeader className="p-0 pb-2">
+            <DialogTitle>Add a Safe Account</DialogTitle>
+          </DialogHeader>
+          <div className="flex flex-col gap-1">
+            <ChooserRow
+              icon={<Search className="size-4" />}
+              title="See owned Safe accounts"
+              subtitle="View all Safes linked to your wallet"
+              onClick={() => {
+                setChooserOpen(false)
+                setSubModal('find')
+              }}
+            />
+            <ChooserRow
+              icon={<Plus className="size-4" />}
+              title="Add Safe accounts to the Workspace"
+              subtitle="Add Safe accounts that are linked to your wallet to this workspace"
+              onClick={handleAdd}
+              disabled={!isAdmin}
+              disabledTooltip="You need to be an Admin to add accounts"
+            />
+            <ChooserRow
+              icon={<CirclePlus className="size-4" />}
+              title="Create new Safe"
+              subtitle="Deploy a new Safe Account"
+              onClick={handleCreate}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+      <OwnedSafesModal open={subModal === 'find'} onClose={() => setSubModal(null)} />
+      <AddAccounts externalOpen={subModal === 'add'} onExternalClose={() => setSubModal(null)} />
+    </>
+  )
+}
+
+export default AddAccountsChooser

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
@@ -12,9 +12,12 @@ import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
+type EntryPoint = 'dashboard' | 'safe_accounts'
+
 interface AddAccountsChooserProps {
   buttonVariant?: 'outline' | 'default'
   buttonLabel?: string
+  entryPoint: EntryPoint
 }
 
 type SubModal = 'find' | 'add' | null
@@ -69,7 +72,8 @@ const ChooserRow = ({ icon, title, subtitle, onClick, disabled, disabledTooltip 
 const AddAccountsChooser = ({
   buttonVariant = 'outline',
   buttonLabel = 'Add Accounts',
-}: AddAccountsChooserProps = {}) => {
+  entryPoint,
+}: AddAccountsChooserProps) => {
   const [chooserOpen, setChooserOpen] = useState(false)
   const [subModal, setSubModal] = useState<SubModal>(null)
   const isAdmin = useIsAdmin()
@@ -86,7 +90,7 @@ const AddAccountsChooser = ({
     if (!isAdmin) return
     trackEvent(
       { ...SPACE_EVENTS.WORKSPACE_SAFE_LINK_STARTED, label: spaceId },
-      { workspace_id: spaceId, entry_point: 'dashboard' },
+      { workspace_id: spaceId, entry_point: entryPoint },
     )
     setChooserOpen(false)
     setSubModal('add')

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
@@ -36,18 +36,21 @@ const ChooserRow = ({ icon, title, subtitle, onClick, disabled, disabledTooltip 
       aria-disabled={disabled || undefined}
       title={disabled ? disabledTooltip : undefined}
       className={cn(
-        'group flex w-full items-center gap-3 rounded-md px-3 py-3 text-left text-foreground transition-colors',
-        disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-muted/60 cursor-pointer',
+        'group flex w-full items-center gap-2 rounded-md p-2 text-left text-sm text-sidebar-foreground transition-colors',
+        '[&_svg]:[stroke-width:2] [&_svg]:transition-colors',
+        disabled
+          ? 'cursor-not-allowed opacity-50'
+          : 'cursor-pointer hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:[&_svg]:text-green-500',
       )}
     >
-      <span className="shrink-0 text-muted-foreground transition-colors [&_svg]:transition-colors [&_svg]:group-hover:text-accent-success">
-        {icon}
-      </span>
+      <span className="shrink-0">{icon}</span>
       <span className="flex-1 min-w-0">
-        <span className="block text-sm font-semibold transition-colors group-hover:text-accent-success">{title}</span>
-        <span className="block text-xs text-muted-foreground mt-0.5">{subtitle}</span>
+        <span className="block font-semibold">{title}</span>
+        <span className="block text-xs text-muted-foreground mt-0.5 group-hover:text-sidebar-accent-foreground/70">
+          {subtitle}
+        </span>
       </span>
-      <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-accent-success" />
+      <ChevronRight className="size-3.5 shrink-0" />
     </button>
   )
 
@@ -109,9 +112,17 @@ const AddAccountsChooser = ({
       <Dialog open={chooserOpen} onOpenChange={setChooserOpen}>
         <DialogContent showCloseButton className="max-w-[440px] p-4 dark:border dark:border-border">
           <DialogHeader className="p-0 pb-2">
-            <DialogTitle className="font-bold">Add a Safe Account</DialogTitle>
+            <DialogTitle className="font-bold">Manage Safe accounts</DialogTitle>
           </DialogHeader>
           <div className="flex flex-col gap-1">
+            <ChooserRow
+              icon={<Plus className="size-4" />}
+              title="Add Safe accounts to this workspace"
+              subtitle="Add Safe accounts that are linked to your wallet to this workspace"
+              onClick={handleAdd}
+              disabled={!isAdmin}
+              disabledTooltip="You need to be an Admin to add accounts"
+            />
             <ChooserRow
               icon={<Search className="size-4" />}
               title="See owned Safe accounts"
@@ -122,17 +133,9 @@ const AddAccountsChooser = ({
               }}
             />
             <ChooserRow
-              icon={<Plus className="size-4" />}
-              title="Add Safe accounts to the Workspace"
-              subtitle="Add Safe accounts that are linked to your wallet to this workspace"
-              onClick={handleAdd}
-              disabled={!isAdmin}
-              disabledTooltip="You need to be an Admin to add accounts"
-            />
-            <ChooserRow
               icon={<CirclePlus className="size-4" />}
               title="Create new Safe"
-              subtitle="Deploy a new Safe Account"
+              subtitle="Create a new Safe account"
               onClick={handleCreate}
             />
           </div>

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
@@ -36,16 +36,18 @@ const ChooserRow = ({ icon, title, subtitle, onClick, disabled, disabledTooltip 
       aria-disabled={disabled || undefined}
       title={disabled ? disabledTooltip : undefined}
       className={cn(
-        'flex w-full items-center gap-3 rounded-lg p-3 text-left transition-colors',
-        disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-muted/60',
+        'group flex w-full items-center gap-3 rounded-md px-3 py-3 text-left text-foreground transition-colors',
+        disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-muted/60 cursor-pointer',
       )}
     >
-      <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted">{icon}</span>
-      <span className="flex-1 min-w-0">
-        <span className="block text-sm font-semibold text-foreground">{title}</span>
-        <span className="block text-xs text-muted-foreground">{subtitle}</span>
+      <span className="shrink-0 text-muted-foreground transition-colors [&_svg]:transition-colors [&_svg]:group-hover:text-accent-success">
+        {icon}
       </span>
-      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm font-semibold transition-colors group-hover:text-accent-success">{title}</span>
+        <span className="block text-xs text-muted-foreground mt-0.5">{subtitle}</span>
+      </span>
+      <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-accent-success" />
     </button>
   )
 
@@ -105,9 +107,9 @@ const AddAccountsChooser = ({
       </Button>
 
       <Dialog open={chooserOpen} onOpenChange={setChooserOpen}>
-        <DialogContent showCloseButton className="max-w-[440px] p-4">
+        <DialogContent showCloseButton className="max-w-[440px] p-4 dark:border dark:border-border">
           <DialogHeader className="p-0 pb-2">
-            <DialogTitle>Add a Safe Account</DialogTitle>
+            <DialogTitle className="font-bold">Add a Safe Account</DialogTitle>
           </DialogHeader>
           <div className="flex flex-col gap-1">
             <ChooserRow

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
@@ -71,7 +71,7 @@ const ChooserRow = ({ icon, title, subtitle, onClick, disabled, disabledTooltip 
 
 const AddAccountsChooser = ({
   buttonVariant = 'outline',
-  buttonLabel = 'Add Accounts',
+  buttonLabel = 'Add accounts',
   entryPoint,
 }: AddAccountsChooserProps) => {
   const [chooserOpen, setChooserOpen] = useState(false)

--- a/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/index.tsx
@@ -141,8 +141,8 @@ const AddAccountsChooser = ({
           </div>
         </DialogContent>
       </Dialog>
-      <OwnedSafesModal open={subModal === 'find'} onClose={() => setSubModal(null)} />
-      <AddAccounts externalOpen={subModal === 'add'} onExternalClose={() => setSubModal(null)} />
+      {subModal === 'find' && <OwnedSafesModal open onClose={() => setSubModal(null)} />}
+      {subModal === 'add' && <AddAccounts externalOpen onExternalClose={() => setSubModal(null)} />}
     </>
   )
 }

--- a/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
@@ -26,7 +26,7 @@ const AddAccountsCard = () => {
           </Typography>
 
           <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-            <AddAccountsChooser buttonLabel="Manage accounts" />
+            <AddAccountsChooser buttonLabel="Manage accounts" entryPoint="dashboard" />
           </Track>
         </Box>
 

--- a/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
@@ -1,4 +1,4 @@
-import AddAccounts from '../AddAccounts'
+import AddAccountsChooser from '../AddAccountsChooser'
 import Image from 'next/image'
 import { Typography, Paper, Box, Stack } from '@mui/material'
 import EmptyDashboard from '@/public/images/spaces/empty_dashboard.png'
@@ -26,7 +26,7 @@ const AddAccountsCard = () => {
           </Typography>
 
           <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-            <AddAccounts />
+            <AddAccountsChooser />
           </Track>
         </Box>
 

--- a/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/AddAccountsCard.tsx
@@ -26,7 +26,7 @@ const AddAccountsCard = () => {
           </Typography>
 
           <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-            <AddAccountsChooser />
+            <AddAccountsChooser buttonLabel="Manage accounts" />
           </Track>
         </Box>
 

--- a/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsButtons.test.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsButtons.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react'
+import SpaceDashboard from '../index'
+import { useLoadFeature } from '@/features/__core__'
+import {
+  useCurrentSpaceId,
+  useSpaceSafes,
+  useSpaceMembersByStatus,
+  useIsInvited,
+  useSpacePendingTransactions,
+} from '@/features/spaces'
+import { useSpaceAccountsData } from '@/features/myAccounts'
+import type { ReactNode } from 'react'
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('@/services/analytics/events/spaces', () => ({
+  SPACE_EVENTS: {
+    ADD_ACCOUNTS_MODAL: { action: 'add_accounts_modal', category: 'spaces' },
+    ACCOUNTS_WIDGET_CLICKED: { action: 'accounts_widget_clicked', category: 'spaces' },
+    PENDING_TX_WIDGET_CLICKED: { action: 'pending_tx_widget_clicked', category: 'spaces' },
+    WORKSPACE_DASHBOARD_VIEWED: { action: 'workspace_dashboard_viewed', category: 'spaces' },
+  },
+  SPACE_LABELS: { space_dashboard_card: 'space_dashboard_card' },
+}))
+
+jest.mock('@/services/analytics/mixpanel-events', () => ({
+  MixpanelEventParams: { SAFE_ADDRESS: 'Safe Address', TX_ID: 'TX ID' },
+}))
+
+jest.mock('@/features/spaces', () => ({
+  useSpaceSafes: jest.fn(),
+  useCurrentSpaceId: jest.fn(),
+  useSpaceMembersByStatus: jest.fn(),
+  useIsInvited: jest.fn(),
+  useTrackSpace: jest.fn(),
+  useSpacePendingTransactions: jest.fn(),
+  useGetSpaceAddressBook: jest.fn(() => []),
+  SpacesFeature: { name: 'spaces' },
+}))
+
+jest.mock('@/features/myAccounts', () => ({
+  MyAccountsFeature: { name: 'myAccounts' },
+  useSpaceAccountsData: jest.fn(() => ({ accounts: [], isLoading: false, error: null, refetch: jest.fn() })),
+}))
+
+jest.mock('@/features/__core__', () => ({
+  useLoadFeature: jest.fn(),
+}))
+
+jest.mock('@/services/local-storage/useLocalStorage', () => jest.fn(() => [{}, jest.fn()]))
+
+jest.mock('@/hooks/safes', () => ({
+  flattenSafeItems: jest.fn((items: unknown[]) => items),
+}))
+
+jest.mock('../MembersCard', () => () => null)
+jest.mock('../SpacesCTACard', () => () => null)
+jest.mock('../ImportAddressBookCard', () => () => null)
+jest.mock('../AddAccountsCard', () => () => null)
+jest.mock('../AggregatedBalances', () => () => null)
+jest.mock('../../InviteBanner/PreviewInvite', () => () => null)
+jest.mock('../../SetupWidget', () => () => null)
+jest.mock('@/components/common/Track', () => {
+  const Track = ({ children }: { children: ReactNode }) => <>{children}</>
+  Track.displayName = 'Track'
+  return Track
+})
+
+jest.mock('@/features/spaces/components/AddAccountsChooser', () => ({
+  __esModule: true,
+  default: ({ buttonLabel }: { buttonLabel?: string }) => (
+    <button data-testid="add-accounts-chooser">{buttonLabel ?? 'Add Accounts'}</button>
+  ),
+}))
+
+const MOCK_SPACE_ID = '42'
+
+const AccountsWidgetStub = (props: { action?: ReactNode; emptyStateAction?: ReactNode }) => (
+  <div data-testid="accounts-widget">
+    {props.action && <div data-testid="action-slot">{props.action}</div>}
+    {props.emptyStateAction && <div data-testid="empty-state-action-slot">{props.emptyStateAction}</div>}
+  </div>
+)
+
+const restoreDefaultMocks = (safes: Array<{ address: string; chainId: string }>) => {
+  ;(useCurrentSpaceId as jest.Mock).mockReturnValue(MOCK_SPACE_ID)
+  ;(useSpaceSafes as jest.Mock).mockReturnValue({ allSafes: safes, isLoading: false })
+  ;(useSpaceMembersByStatus as jest.Mock).mockReturnValue({ activeMembers: [] })
+  ;(useIsInvited as jest.Mock).mockReturnValue(false)
+  ;(useSpacePendingTransactions as jest.Mock).mockReturnValue({
+    transactions: [],
+    count: 0,
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  })
+  ;(useSpaceAccountsData as jest.Mock).mockReturnValue({
+    accounts: safes,
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  })
+}
+
+const stubAccountsWidget = () => {
+  ;(useLoadFeature as jest.Mock).mockImplementation((feature: { name: string }) => {
+    if (feature.name === 'myAccounts') {
+      return { AccountsWidget: AccountsWidgetStub, $isReady: true }
+    }
+    return { PendingTxWidget: () => null, $isReady: true }
+  })
+}
+
+describe('SpaceDashboard – AddAccountsChooser button labels', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    stubAccountsWidget()
+  })
+
+  it('passes "Manage accounts" as the buttonLabel for the populated action slot', () => {
+    restoreDefaultMocks([{ address: '0xaaaa', chainId: '1' }])
+
+    render(<SpaceDashboard />)
+
+    const actionSlot = screen.getByTestId('action-slot')
+    expect(actionSlot).toHaveTextContent('Manage accounts')
+  })
+
+  it('passes "Manage accounts" as the buttonLabel for the empty state action slot', () => {
+    restoreDefaultMocks([])
+
+    render(<SpaceDashboard />)
+
+    const emptyStateSlot = screen.getByTestId('empty-state-action-slot')
+    expect(emptyStateSlot).toHaveTextContent('Manage accounts')
+  })
+})

--- a/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsButtons.test.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsButtons.test.tsx
@@ -74,8 +74,10 @@ jest.mock('@/components/common/Track', () => {
 
 jest.mock('@/features/spaces/components/AddAccountsChooser', () => ({
   __esModule: true,
-  default: ({ buttonLabel }: { buttonLabel?: string }) => (
-    <button data-testid="add-accounts-chooser">{buttonLabel ?? 'Add Accounts'}</button>
+  default: ({ buttonLabel, entryPoint }: { buttonLabel?: string; entryPoint?: string }) => (
+    <button data-testid="add-accounts-chooser" data-entry-point={entryPoint}>
+      {buttonLabel ?? 'Add Accounts'}
+    </button>
   ),
 }))
 
@@ -139,5 +141,21 @@ describe('SpaceDashboard – AddAccountsChooser button labels', () => {
 
     const emptyStateSlot = screen.getByTestId('empty-state-action-slot')
     expect(emptyStateSlot).toHaveTextContent('Manage accounts')
+  })
+
+  it('passes entryPoint="dashboard" to the populated action slot', () => {
+    restoreDefaultMocks([{ address: '0xaaaa', chainId: '1' }])
+
+    render(<SpaceDashboard />)
+
+    expect(screen.getByTestId('action-slot').querySelector('[data-entry-point="dashboard"]')).not.toBeNull()
+  })
+
+  it('passes entryPoint="dashboard" to the empty state action slot', () => {
+    restoreDefaultMocks([])
+
+    render(<SpaceDashboard />)
+
+    expect(screen.getByTestId('empty-state-action-slot').querySelector('[data-entry-point="dashboard"]')).not.toBeNull()
   })
 })

--- a/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsButtons.test.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsButtons.test.tsx
@@ -76,7 +76,7 @@ jest.mock('@/features/spaces/components/AddAccountsChooser', () => ({
   __esModule: true,
   default: ({ buttonLabel, entryPoint }: { buttonLabel?: string; entryPoint?: string }) => (
     <button data-testid="add-accounts-chooser" data-entry-point={entryPoint}>
-      {buttonLabel ?? 'Add Accounts'}
+      {buttonLabel ?? 'Add accounts'}
     </button>
   ),
 }))

--- a/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsCard.test.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsCard.test.tsx
@@ -13,8 +13,10 @@ jest.mock('@/components/common/Track', () => {
 
 jest.mock('../../AddAccountsChooser', () => ({
   __esModule: true,
-  default: ({ buttonLabel }: { buttonLabel?: string }) => (
-    <button data-testid="add-accounts-chooser">{buttonLabel}</button>
+  default: ({ buttonLabel, entryPoint }: { buttonLabel?: string; entryPoint?: string }) => (
+    <button data-testid="add-accounts-chooser" data-entry-point={entryPoint}>
+      {buttonLabel}
+    </button>
   ),
 }))
 
@@ -23,5 +25,11 @@ describe('AddAccountsCard', () => {
     render(<AddAccountsCard />)
 
     expect(screen.getByTestId('add-accounts-chooser')).toHaveTextContent('Manage accounts')
+  })
+
+  it('passes "dashboard" as the entryPoint to AddAccountsChooser', () => {
+    render(<AddAccountsCard />)
+
+    expect(screen.getByTestId('add-accounts-chooser')).toHaveAttribute('data-entry-point', 'dashboard')
   })
 })

--- a/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsCard.test.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/__tests__/AddAccountsCard.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import AddAccountsCard from '../AddAccountsCard'
+
+jest.mock('@/hooks/useDarkMode', () => ({
+  useDarkMode: () => false,
+}))
+
+jest.mock('@/components/common/Track', () => {
+  const Track = ({ children }: { children: React.ReactNode }) => <>{children}</>
+  Track.displayName = 'Track'
+  return Track
+})
+
+jest.mock('../../AddAccountsChooser', () => ({
+  __esModule: true,
+  default: ({ buttonLabel }: { buttonLabel?: string }) => (
+    <button data-testid="add-accounts-chooser">{buttonLabel}</button>
+  ),
+}))
+
+describe('AddAccountsCard', () => {
+  it('renders the AddAccountsChooser with the "Manage accounts" label', () => {
+    render(<AddAccountsCard />)
+
+    expect(screen.getByTestId('add-accounts-chooser')).toHaveTextContent('Manage accounts')
+  })
+})

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -28,7 +28,7 @@ import useLocalStorage from '@/services/local-storage/useLocalStorage'
 const AddActionsAction = () => {
   return (
     <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-      <AddAccountsChooser />
+      <AddAccountsChooser buttonLabel="Manage accounts" />
     </Track>
   )
 }

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -28,7 +28,7 @@ import useLocalStorage from '@/services/local-storage/useLocalStorage'
 const AddActionsAction = () => {
   return (
     <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-      <AddAccountsChooser buttonLabel="Manage accounts" />
+      <AddAccountsChooser buttonLabel="Manage accounts" entryPoint="dashboard" />
     </Track>
   )
 }
@@ -36,7 +36,7 @@ const AddActionsAction = () => {
 const EmptyStateAddAction = () => {
   return (
     <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-      <AddAccountsChooser buttonVariant="default" buttonLabel="Manage accounts" />
+      <AddAccountsChooser buttonVariant="default" buttonLabel="Manage accounts" entryPoint="dashboard" />
     </Track>
   )
 }

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -36,7 +36,7 @@ const AddActionsAction = () => {
 const EmptyStateAddAction = () => {
   return (
     <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-      <AddAccountsChooser buttonVariant="default" buttonLabel="Add account" />
+      <AddAccountsChooser buttonVariant="default" buttonLabel="Manage accounts" />
     </Track>
   )
 }

--- a/apps/web/src/features/spaces/components/Dashboard/index.tsx
+++ b/apps/web/src/features/spaces/components/Dashboard/index.tsx
@@ -18,7 +18,7 @@ import Track from '@/components/common/Track'
 import { trackEvent } from '@/services/analytics'
 import { MyAccountsFeature, useSpaceAccountsData } from '@/features/myAccounts'
 import { useLoadFeature } from '@/features/__core__'
-import AddAccounts from '@/features/spaces/components/AddAccounts'
+import AddAccountsChooser from '@/features/spaces/components/AddAccountsChooser'
 import { useRouter } from 'next/router'
 import AggregatedBalance from './AggregatedBalances'
 import SafeWidget from '../SafeWidget'
@@ -28,7 +28,7 @@ import useLocalStorage from '@/services/local-storage/useLocalStorage'
 const AddActionsAction = () => {
   return (
     <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-      <AddAccounts />
+      <AddAccountsChooser />
     </Track>
   )
 }
@@ -36,7 +36,7 @@ const AddActionsAction = () => {
 const EmptyStateAddAction = () => {
   return (
     <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.space_dashboard_card}>
-      <AddAccounts buttonVariant="default" buttonLabel="Add account" />
+      <AddAccountsChooser buttonVariant="default" buttonLabel="Add account" />
     </Track>
   )
 }

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/__tests__/OwnedSafesModal.test.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/__tests__/OwnedSafesModal.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, fireEvent } from '@/tests/test-utils'
+import OwnedSafesModal from '../index'
+
+let mockWalletAddress: string | null = '0xWallet'
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: () => (mockWalletAddress ? { address: mockWalletAddress } : null),
+}))
+
+const mockConnectWallet = jest.fn()
+jest.mock('@/components/common/ConnectWallet/useConnectWallet', () => ({
+  __esModule: true,
+  default: () => mockConnectWallet,
+}))
+
+let mockChains: Array<{ chainId: string }> = [{ chainId: '1' }, { chainId: '137' }]
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: () => ({ configs: mockChains }),
+}))
+
+let mockAllOwned: Record<string, string[]> = {}
+let mockOwnedError: unknown = undefined
+let mockOwnedLoading = false
+jest.mock('@/hooks/safes', () => {
+  const actual = jest.requireActual('@/hooks/safes')
+  return {
+    ...actual,
+    useAllOwnedSafes: () => [mockAllOwned, mockOwnedError, mockOwnedLoading] as const,
+    _buildSafeItem: (chainId: string, address: string) => ({
+      chainId,
+      address,
+      name: '',
+      isReadOnly: false,
+      isPinned: false,
+      lastVisited: 0,
+    }),
+    _getMultiChainAccounts: () => [],
+    _getSingleChainAccounts: (items: unknown[]) => items,
+    isMultiChainSafeItem: () => false,
+  }
+})
+
+jest.mock('@/components/common/SpaceSafeBar/AccountsModal/SafeItemCard', () => ({
+  __esModule: true,
+  default: ({ safeItem }: { safeItem: { chainId: string; address: string } }) => (
+    <div data-testid="safe-item-card" data-chain={safeItem.chainId} data-address={safeItem.address} />
+  ),
+}))
+
+jest.mock('@/components/common/SpaceSafeBar/AccountsModal/MultiSafeItemCard', () => ({
+  __esModule: true,
+  default: () => <div data-testid="multi-safe-item-card" />,
+}))
+
+jest.mock('@/components/common/SpaceSafeBar/AccountsModal/shared', () => ({
+  __esModule: true,
+  SafeListSkeleton: () => <div data-testid="safe-list-skeleton" />,
+}))
+
+const noop = () => {}
+
+const undeployedWithOwner = (ownerAddr: string) => ({
+  props: { safeAccountConfig: { owners: [ownerAddr], threshold: 1 } },
+  status: { type: 'AWAITING_EXECUTION' },
+})
+
+describe('OwnedSafesModal', () => {
+  beforeEach(() => {
+    mockWalletAddress = '0xWallet'
+    mockChains = [{ chainId: '1' }, { chainId: '137' }]
+    mockAllOwned = {}
+    mockOwnedError = undefined
+    mockOwnedLoading = false
+    mockConnectWallet.mockClear()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('renders nothing when open is false', () => {
+    const { container } = render(<OwnedSafesModal open={false} onClose={noop} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the connect-wallet prompt when no wallet is connected', () => {
+    mockWalletAddress = null
+
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    expect(screen.getByTestId('owned-safes-connect-wallet-button')).toBeInTheDocument()
+    expect(screen.getByText('Connect your wallet to access all your Safes')).toBeInTheDocument()
+  })
+
+  it('hides the search input and footer when no wallet is connected', () => {
+    mockWalletAddress = null
+
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    expect(screen.queryByTestId('owned-safes-search-input')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('owned-safes-add-existing')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('owned-safes-create-new')).not.toBeInTheDocument()
+  })
+
+  it('closes the modal and triggers connectWallet when the connect button is clicked', () => {
+    mockWalletAddress = null
+    const onClose = jest.fn()
+
+    render(<OwnedSafesModal open onClose={onClose} />)
+
+    fireEvent.click(screen.getByTestId('owned-safes-connect-wallet-button'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(mockConnectWallet).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the footer buttons when a wallet is connected', () => {
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    expect(screen.getByTestId('owned-safes-add-existing')).toBeInTheDocument()
+    expect(screen.getByTestId('owned-safes-create-new')).toBeInTheDocument()
+  })
+
+  it('renders deployed owned Safes returned from the owners endpoint', () => {
+    mockAllOwned = { '1': ['0xSafe1'], '137': ['0xSafe2'] }
+
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    const cards = screen.getAllByTestId('safe-item-card')
+    const addresses = cards.map((c) => c.getAttribute('data-address'))
+    expect(addresses).toContain('0xSafe1')
+    expect(addresses).toContain('0xSafe2')
+  })
+
+  it('renders counterfactual Safes whose owners include the connected wallet', () => {
+    mockAllOwned = {}
+    const undeployed = { '1': { '0xUndeployed': undeployedWithOwner('0xWallet') } }
+    jest.spyOn(require('@/store/slices'), 'selectUndeployedSafes').mockReturnValue(undeployed)
+
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    const cards = screen.getAllByTestId('safe-item-card')
+    expect(cards.some((c) => c.getAttribute('data-address') === '0xUndeployed')).toBe(true)
+  })
+
+  it('excludes counterfactual Safes whose owners do not include the wallet', () => {
+    mockAllOwned = {}
+    const undeployed = { '1': { '0xNotMine': undeployedWithOwner('0xSomeoneElse') } }
+    jest.spyOn(require('@/store/slices'), 'selectUndeployedSafes').mockReturnValue(undeployed)
+
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    expect(screen.queryByTestId('safe-item-card')).not.toBeInTheDocument()
+    expect(screen.getByTestId('owned-safes-empty')).toHaveTextContent('No owned Safe accounts yet')
+  })
+
+  it('filters the list by the search query', () => {
+    mockAllOwned = { '1': ['0xAaa', '0xBbb'] }
+
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    fireEvent.change(screen.getByTestId('owned-safes-search-input'), { target: { value: '0xaaa' } })
+
+    const cards = screen.getAllByTestId('safe-item-card')
+    expect(cards).toHaveLength(1)
+    expect(cards[0]).toHaveAttribute('data-address', '0xAaa')
+  })
+
+  it('shows the empty state when wallet is connected but no owned Safes', () => {
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    expect(screen.getByTestId('owned-safes-empty')).toHaveTextContent('No owned Safe accounts yet')
+  })
+
+  it('shows the loading skeleton while the owners query is loading and no data yet', () => {
+    mockOwnedLoading = true
+    mockAllOwned = {}
+
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    expect(screen.getByTestId('safe-list-skeleton')).toBeInTheDocument()
+  })
+
+  it('shows the error message when the owners query fails and there is no data', () => {
+    mockOwnedError = new Error('boom')
+    mockAllOwned = {}
+
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    expect(screen.getByText('Failed to load owned safes.')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/__tests__/OwnedSafesModal.test.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/__tests__/OwnedSafesModal.test.tsx
@@ -13,6 +13,11 @@ jest.mock('@/components/common/ConnectWallet/useConnectWallet', () => ({
   default: () => mockConnectWallet,
 }))
 
+const mockTrackEvent = jest.fn()
+jest.mock('@/services/analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}))
+
 let mockChains: Array<{ chainId: string }> = [{ chainId: '1' }, { chainId: '137' }]
 jest.mock('@/hooks/useChains', () => ({
   __esModule: true,
@@ -73,6 +78,7 @@ describe('OwnedSafesModal', () => {
     mockOwnedError = undefined
     mockOwnedLoading = false
     mockConnectWallet.mockClear()
+    mockTrackEvent.mockClear()
   })
 
   afterEach(() => {
@@ -189,5 +195,21 @@ describe('OwnedSafesModal', () => {
     render(<OwnedSafesModal open onClose={noop} />)
 
     expect(screen.getByText('Failed to load owned safes.')).toBeInTheDocument()
+  })
+
+  it('tracks ADD_TO_WATCHLIST with the owned_safes_modal label when "Add existing" is clicked', () => {
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    fireEvent.click(screen.getByTestId('owned-safes-add-existing'))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(expect.objectContaining({ label: 'owned_safes_modal' }))
+  })
+
+  it('tracks CREATE_NEW_SAFE with the owned_safes_modal label when "Create new" is clicked', () => {
+    render(<OwnedSafesModal open onClose={noop} />)
+
+    fireEvent.click(screen.getByTestId('owned-safes-create-new'))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(expect.objectContaining({ label: 'owned_safes_modal' }))
   })
 })

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/__tests__/OwnedSafesModal.test.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/__tests__/OwnedSafesModal.test.tsx
@@ -32,13 +32,20 @@ jest.mock('@/hooks/safes', () => {
   return {
     ...actual,
     useAllOwnedSafes: () => [mockAllOwned, mockOwnedError, mockOwnedLoading] as const,
-    _buildSafeItem: (chainId: string, address: string) => ({
-      chainId,
-      address,
-      name: '',
-      isReadOnly: false,
-      isPinned: false,
-      lastVisited: 0,
+    useSafeItemBuilder: () => ({
+      buildSafeItem: (chainId: string, address: string) => ({
+        chainId,
+        address,
+        name: '',
+        isReadOnly: false,
+        isPinned: false,
+        lastVisited: 0,
+      }),
+      walletAddress: mockWalletAddress ?? '',
+      isWalletConnected: !!mockWalletAddress,
+      allOwned: mockAllOwned,
+      ownedError: mockOwnedError,
+      ownedLoading: mockOwnedLoading,
     }),
     _getMultiChainAccounts: () => [],
     _getSingleChainAccounts: (items: unknown[]) => items,

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/__tests__/OwnedSafesModal.test.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/__tests__/OwnedSafesModal.test.tsx
@@ -116,7 +116,7 @@ describe('OwnedSafesModal', () => {
     expect(screen.queryByTestId('owned-safes-create-new')).not.toBeInTheDocument()
   })
 
-  it('closes the modal and triggers connectWallet when the connect button is clicked', () => {
+  it('triggers connectWallet without closing the modal when the connect button is clicked', () => {
     mockWalletAddress = null
     const onClose = jest.fn()
 
@@ -124,8 +124,24 @@ describe('OwnedSafesModal', () => {
 
     fireEvent.click(screen.getByTestId('owned-safes-connect-wallet-button'))
 
-    expect(onClose).toHaveBeenCalledTimes(1)
     expect(mockConnectWallet).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('swaps from the connect-wallet prompt to the owned-safes list once a wallet connects', () => {
+    mockWalletAddress = null
+    mockAllOwned = { '1': ['0xSafe1'] }
+
+    const { rerender } = render(<OwnedSafesModal open onClose={noop} />)
+
+    expect(screen.getByTestId('owned-safes-connect-wallet-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('safe-item-card')).not.toBeInTheDocument()
+
+    mockWalletAddress = '0xWallet'
+    rerender(<OwnedSafesModal open onClose={noop} />)
+
+    expect(screen.queryByTestId('owned-safes-connect-wallet-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('safe-item-card')).toBeInTheDocument()
   })
 
   it('renders the footer buttons when a wallet is connected', () => {

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
@@ -113,7 +113,7 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
         className="flex max-h-[90vh] w-full max-w-[560px] flex-col gap-0 p-0 dark:border dark:border-border"
       >
         <DialogHeader className="shrink-0 border-b border-border/50 px-4 pb-3 pt-4">
-          <DialogTitle className="font-bold">Owned Safe Accounts</DialogTitle>
+          <DialogTitle className="font-bold">Owned Safe accounts</DialogTitle>
         </DialogHeader>
 
         {isWalletConnected && (

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import { Search, CircleFadingPlus, Plus } from 'lucide-react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
+import { Button } from '@/components/ui/button'
+import { AppRoutes } from '@/config/routes'
+import {
+  _buildSafeItem,
+  _getMultiChainAccounts,
+  _getSingleChainAccounts,
+  useAllOwnedSafes,
+  type AllSafeItems,
+  type SafeItem,
+  isMultiChainSafeItem,
+} from '@/hooks/safes'
+import useChains from '@/hooks/useChains'
+import useWallet from '@/hooks/wallets/useWallet'
+import { useAppSelector } from '@/store'
+import { selectAllAddedSafes } from '@/store/addedSafesSlice'
+import { selectAllAddressBooks, selectAllVisitedSafes, selectUndeployedSafes } from '@/store/slices'
+import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { trackEvent } from '@/services/analytics'
+import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics/events/overview'
+import ConnectWalletPrompt from '@/features/spaces/components/SelectSafesOnboarding/components/ConnectWalletPrompt'
+import SafeItemCard from '@/components/common/SpaceSafeBar/AccountsModal/SafeItemCard'
+import MultiSafeItemCard from '@/components/common/SpaceSafeBar/AccountsModal/MultiSafeItemCard'
+import { SafeListSkeleton } from '@/components/common/SpaceSafeBar/AccountsModal/shared'
+
+interface OwnedSafesModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
+  const [search, setSearch] = useState('')
+
+  const wallet = useWallet()
+  const walletAddress = wallet?.address ?? ''
+  const isWalletConnected = walletAddress !== ''
+
+  const { configs } = useChains()
+  const allChainIds = useMemo(() => configs.map((c) => c.chainId), [configs])
+
+  const [allOwned = {}, ownedError, ownedLoading] = useAllOwnedSafes(walletAddress)
+  const allAdded = useAppSelector(selectAllAddedSafes)
+  const allUndeployed = useAppSelector(selectUndeployedSafes)
+  const allVisitedSafes = useAppSelector(selectAllVisitedSafes)
+  const allSafeNames = useAppSelector(selectAllAddressBooks)
+
+  const ownedItems = useMemo<SafeItem[]>(() => {
+    if (!isWalletConnected) return []
+
+    const buildItem = (chainId: string, address: string) =>
+      _buildSafeItem(chainId, address, walletAddress, allAdded, allOwned, allUndeployed, allVisitedSafes, allSafeNames)
+
+    return allChainIds.flatMap((chainId) => {
+      const deployedOwned = allOwned[chainId] ?? []
+
+      const undeployedOwned = Object.entries(allUndeployed[chainId] ?? {})
+        .filter(([, undeployed]) => {
+          const owners = undeployed?.props?.safeAccountConfig?.owners ?? []
+          return owners.some((owner) => sameAddress(owner, walletAddress))
+        })
+        .map(([address]) => address)
+
+      const merged = Array.from(new Set([...deployedOwned, ...undeployedOwned]))
+      return merged.map((address) => buildItem(chainId, address))
+    })
+  }, [isWalletConnected, walletAddress, allChainIds, allOwned, allUndeployed, allAdded, allVisitedSafes, allSafeNames])
+
+  const allItems = useMemo<AllSafeItems>(() => {
+    const multi = _getMultiChainAccounts(ownedItems)
+    const single = _getSingleChainAccounts(ownedItems, multi)
+    return [...multi, ...single].sort((a, b) => (b.lastVisited ?? 0) - (a.lastVisited ?? 0))
+  }, [ownedItems])
+
+  const similarAddresses = useMemo(() => getFlaggedSimilarAddressSet(allItems.map((item) => item.address)), [allItems])
+
+  const filteredItems = useMemo(() => {
+    if (!search.trim()) return allItems
+    const query = search.toLowerCase()
+    return allItems.filter((item) => {
+      const name = item.name?.toLowerCase() ?? ''
+      const address = item.address.toLowerCase()
+      return name.includes(query) || address.includes(query)
+    })
+  }, [allItems, search])
+
+  const searchTracked = useRef(false)
+  useEffect(() => {
+    if (!search.trim()) {
+      searchTracked.current = false
+      return
+    }
+    if (searchTracked.current) return
+    const timer = setTimeout(() => {
+      trackEvent(OVERVIEW_EVENTS.SEARCH)
+      searchTracked.current = true
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [search])
+
+  if (!open) return null
+
+  return (
+    <Dialog open onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent showCloseButton className="flex max-h-[90vh] w-full max-w-[560px] flex-col gap-0 p-0">
+        <DialogHeader className="shrink-0 border-b border-border/50 px-4 pb-3 pt-4">
+          <DialogTitle>Owned Safe Accounts</DialogTitle>
+        </DialogHeader>
+
+        {isWalletConnected && (
+          <div className="shrink-0 px-4 py-3">
+            <InputGroup className="rounded-md border-gray-100 shadow-none">
+              <InputGroupAddon>
+                <Search className="size-4" />
+              </InputGroupAddon>
+              <InputGroupInput
+                placeholder="Search by name or address"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                autoComplete="off"
+                data-testid="owned-safes-search-input"
+              />
+            </InputGroup>
+          </div>
+        )}
+
+        <div
+          className="min-h-0 flex-1 overflow-y-auto px-3 [scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border"
+          data-testid="owned-safes-list"
+        >
+          {!isWalletConnected ? (
+            <ConnectWalletPrompt className="py-8" testId="owned-safes-connect-wallet-button" />
+          ) : ownedError && allItems.length === 0 ? (
+            <p className="px-2 py-6 text-center text-sm text-destructive">Failed to load owned safes.</p>
+          ) : ownedLoading && allItems.length === 0 ? (
+            <SafeListSkeleton />
+          ) : filteredItems.length === 0 ? (
+            <p className="px-2 py-6 text-center text-sm text-muted-foreground" data-testid="owned-safes-empty">
+              {search.trim() ? 'No safes match your search' : 'No owned Safe accounts yet'}
+            </p>
+          ) : (
+            filteredItems.map((item) =>
+              isMultiChainSafeItem(item) ? (
+                <MultiSafeItemCard
+                  key={item.address}
+                  item={item}
+                  isSimilar={similarAddresses.has(item.address.toLowerCase())}
+                  onClose={onClose}
+                />
+              ) : (
+                <SafeItemCard
+                  key={`${item.chainId}:${item.address}`}
+                  safeItem={item}
+                  isSimilar={similarAddresses.has(item.address.toLowerCase())}
+                  onClose={onClose}
+                />
+              ),
+            )
+          )}
+        </div>
+
+        <DialogFooter className="shrink-0 flex-row gap-2 border-t border-border/50 px-4 py-3">
+          <Button
+            render={
+              <Link
+                href={AppRoutes.newSafe.load}
+                onClick={() => {
+                  trackEvent({ ...OVERVIEW_EVENTS.ADD_TO_WATCHLIST, label: OVERVIEW_LABELS.top_bar })
+                  onClose()
+                }}
+              />
+            }
+            variant="secondary"
+            size="lg"
+            className="flex-1"
+            data-testid="owned-safes-add-existing"
+          >
+            <CircleFadingPlus className="size-4" />
+            Add existing
+          </Button>
+          <Button
+            render={
+              <Link
+                href={AppRoutes.newSafe.create}
+                onClick={() => {
+                  trackEvent({ ...OVERVIEW_EVENTS.CREATE_NEW_SAFE, label: OVERVIEW_LABELS.top_bar })
+                  onClose()
+                }}
+              />
+            }
+            variant="default"
+            size="lg"
+            className="flex-1"
+            data-testid="owned-safes-create-new"
+          >
+            <Plus className="size-4 text-green-500" />
+            Create new
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default OwnedSafesModal

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
-import { Search, CircleFadingPlus, Plus } from 'lucide-react'
+import { Search, CircleFadingPlus, Plus, Wallet } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Button } from '@/components/ui/button'
@@ -23,7 +23,8 @@ import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSim
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { trackEvent } from '@/services/analytics'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics/events/overview'
-import ConnectWalletPrompt from '@/features/spaces/components/SelectSafesOnboarding/components/ConnectWalletPrompt'
+import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet'
+import { Typography } from '@/components/ui/typography'
 import SafeItemCard from '@/components/common/SpaceSafeBar/AccountsModal/SafeItemCard'
 import MultiSafeItemCard from '@/components/common/SpaceSafeBar/AccountsModal/MultiSafeItemCard'
 import { SafeListSkeleton } from '@/components/common/SpaceSafeBar/AccountsModal/shared'
@@ -35,6 +36,7 @@ interface OwnedSafesModalProps {
 
 const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
   const [search, setSearch] = useState('')
+  const connectWallet = useConnectWallet()
 
   const wallet = useWallet()
   const walletAddress = wallet?.address ?? ''
@@ -136,7 +138,24 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
           data-testid="owned-safes-list"
         >
           {!isWalletConnected ? (
-            <ConnectWalletPrompt className="py-8" testId="owned-safes-connect-wallet-button" />
+            <div className="flex flex-col items-center justify-center gap-4 py-8">
+              <Wallet className="size-12 text-muted-foreground" />
+              <Typography variant="paragraph" align="center" color="muted">
+                Connect your wallet to access all your Safes
+              </Typography>
+              <Button
+                data-testid="owned-safes-connect-wallet-button"
+                type="button"
+                size="lg"
+                className="w-full max-w-[300px]"
+                onClick={() => {
+                  onClose()
+                  connectWallet()
+                }}
+              >
+                Connect wallet
+              </Button>
+            </div>
           ) : ownedError && allItems.length === 0 ? (
             <p className="px-2 py-6 text-center text-sm text-destructive">Failed to load owned safes.</p>
           ) : ownedLoading && allItems.length === 0 ? (
@@ -166,44 +185,46 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
           )}
         </div>
 
-        <DialogFooter className="shrink-0 flex-row gap-2 border-t border-border/50 px-4 py-3">
-          <Button
-            render={
-              <Link
-                href={AppRoutes.newSafe.load}
-                onClick={() => {
-                  trackEvent({ ...OVERVIEW_EVENTS.ADD_TO_WATCHLIST, label: OVERVIEW_LABELS.top_bar })
-                  onClose()
-                }}
-              />
-            }
-            variant="secondary"
-            size="lg"
-            className="flex-1"
-            data-testid="owned-safes-add-existing"
-          >
-            <CircleFadingPlus className="size-4" />
-            Add existing
-          </Button>
-          <Button
-            render={
-              <Link
-                href={AppRoutes.newSafe.create}
-                onClick={() => {
-                  trackEvent({ ...OVERVIEW_EVENTS.CREATE_NEW_SAFE, label: OVERVIEW_LABELS.top_bar })
-                  onClose()
-                }}
-              />
-            }
-            variant="default"
-            size="lg"
-            className="flex-1"
-            data-testid="owned-safes-create-new"
-          >
-            <Plus className="size-4 text-green-500" />
-            Create new
-          </Button>
-        </DialogFooter>
+        {isWalletConnected && (
+          <DialogFooter className="shrink-0 flex-row gap-2 border-t border-border/50 px-4 py-3">
+            <Button
+              render={
+                <Link
+                  href={AppRoutes.newSafe.load}
+                  onClick={() => {
+                    trackEvent({ ...OVERVIEW_EVENTS.ADD_TO_WATCHLIST, label: OVERVIEW_LABELS.top_bar })
+                    onClose()
+                  }}
+                />
+              }
+              variant="secondary"
+              size="lg"
+              className="flex-1"
+              data-testid="owned-safes-add-existing"
+            >
+              <CircleFadingPlus className="size-4" />
+              Add existing
+            </Button>
+            <Button
+              render={
+                <Link
+                  href={AppRoutes.newSafe.create}
+                  onClick={() => {
+                    trackEvent({ ...OVERVIEW_EVENTS.CREATE_NEW_SAFE, label: OVERVIEW_LABELS.top_bar })
+                    onClose()
+                  }}
+                />
+              }
+              variant="default"
+              size="lg"
+              className="flex-1"
+              data-testid="owned-safes-create-new"
+            >
+              <Plus className="size-4 text-green-500" />
+              Create new
+            </Button>
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
@@ -6,19 +6,16 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/in
 import { Button } from '@/components/ui/button'
 import { AppRoutes } from '@/config/routes'
 import {
-  _buildSafeItem,
   _getMultiChainAccounts,
   _getSingleChainAccounts,
-  useAllOwnedSafes,
+  useSafeItemBuilder,
   type AllSafeItems,
   type SafeItem,
   isMultiChainSafeItem,
 } from '@/hooks/safes'
 import useChains from '@/hooks/useChains'
-import useWallet from '@/hooks/wallets/useWallet'
 import { useAppSelector } from '@/store'
-import { selectAllAddedSafes } from '@/store/addedSafesSlice'
-import { selectAllAddressBooks, selectAllVisitedSafes, selectUndeployedSafes } from '@/store/slices'
+import { selectUndeployedSafes } from '@/store/slices'
 import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { trackEvent } from '@/services/analytics'
@@ -38,24 +35,14 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
   const [search, setSearch] = useState('')
   const connectWallet = useConnectWallet()
 
-  const wallet = useWallet()
-  const walletAddress = wallet?.address ?? ''
-  const isWalletConnected = walletAddress !== ''
+  const { buildSafeItem, walletAddress, isWalletConnected, allOwned, ownedError, ownedLoading } = useSafeItemBuilder()
+  const allUndeployed = useAppSelector(selectUndeployedSafes)
 
   const { configs } = useChains()
   const allChainIds = useMemo(() => configs.map((c) => c.chainId), [configs])
 
-  const [allOwned = {}, ownedError, ownedLoading] = useAllOwnedSafes(walletAddress)
-  const allAdded = useAppSelector(selectAllAddedSafes)
-  const allUndeployed = useAppSelector(selectUndeployedSafes)
-  const allVisitedSafes = useAppSelector(selectAllVisitedSafes)
-  const allSafeNames = useAppSelector(selectAllAddressBooks)
-
   const ownedItems = useMemo<SafeItem[]>(() => {
     if (!isWalletConnected) return []
-
-    const buildItem = (chainId: string, address: string) =>
-      _buildSafeItem(chainId, address, walletAddress, allAdded, allOwned, allUndeployed, allVisitedSafes, allSafeNames)
 
     return allChainIds.flatMap((chainId) => {
       const deployedOwned = allOwned[chainId] ?? []
@@ -68,9 +55,9 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
         .map(([address]) => address)
 
       const merged = Array.from(new Set([...deployedOwned, ...undeployedOwned]))
-      return merged.map((address) => buildItem(chainId, address))
+      return merged.map((address) => buildSafeItem(chainId, address))
     })
-  }, [isWalletConnected, walletAddress, allChainIds, allOwned, allUndeployed, allAdded, allVisitedSafes, allSafeNames])
+  }, [isWalletConnected, walletAddress, allChainIds, allOwned, allUndeployed, buildSafeItem])
 
   const allItems = useMemo<AllSafeItems>(() => {
     const multi = _getMultiChainAccounts(ownedItems)

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
@@ -33,7 +33,17 @@ interface OwnedSafesModalProps {
 
 const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
   const [search, setSearch] = useState('')
+  const [isConnecting, setIsConnecting] = useState(false)
   const connectWallet = useConnectWallet()
+
+  const handleConnectWallet = async () => {
+    setIsConnecting(true)
+    try {
+      await connectWallet()
+    } finally {
+      setIsConnecting(false)
+    }
+  }
 
   const { buildSafeItem, walletAddress, isWalletConnected, allOwned, ownedError, ownedLoading } = useSafeItemBuilder()
   const allUndeployed = useAppSelector(selectUndeployedSafes)
@@ -92,11 +102,13 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
   }, [search])
 
   if (!open) return null
+  if (isConnecting) return null
 
   return (
     <Dialog open onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent
         showCloseButton
+        data-owned-safes-modal
         className="flex max-h-[90vh] w-full max-w-[560px] flex-col gap-0 p-0 dark:border dark:border-border"
       >
         <DialogHeader className="shrink-0 border-b border-border/50 px-4 pb-3 pt-4">
@@ -135,7 +147,7 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
                 type="button"
                 size="lg"
                 className="w-full max-w-[300px]"
-                onClick={() => connectWallet()}
+                onClick={handleConnectWallet}
               >
                 Connect wallet
               </Button>

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
@@ -192,7 +192,7 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
                 <Link
                   href={AppRoutes.newSafe.load}
                   onClick={() => {
-                    trackEvent({ ...OVERVIEW_EVENTS.ADD_TO_WATCHLIST, label: OVERVIEW_LABELS.top_bar })
+                    trackEvent({ ...OVERVIEW_EVENTS.ADD_TO_WATCHLIST, label: OVERVIEW_LABELS.owned_safes_modal })
                     onClose()
                   }}
                 />
@@ -210,7 +210,7 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
                 <Link
                   href={AppRoutes.newSafe.create}
                   onClick={() => {
-                    trackEvent({ ...OVERVIEW_EVENTS.CREATE_NEW_SAFE, label: OVERVIEW_LABELS.top_bar })
+                    trackEvent({ ...OVERVIEW_EVENTS.CREATE_NEW_SAFE, label: OVERVIEW_LABELS.owned_safes_modal })
                     onClose()
                   }}
                 />

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
@@ -135,10 +135,7 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
                 type="button"
                 size="lg"
                 className="w-full max-w-[300px]"
-                onClick={() => {
-                  onClose()
-                  connectWallet()
-                }}
+                onClick={() => connectWallet()}
               >
                 Connect wallet
               </Button>

--- a/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
+++ b/apps/web/src/features/spaces/components/OwnedSafesModal/index.tsx
@@ -106,9 +106,12 @@ const OwnedSafesModal = ({ open, onClose }: OwnedSafesModalProps) => {
 
   return (
     <Dialog open onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent showCloseButton className="flex max-h-[90vh] w-full max-w-[560px] flex-col gap-0 p-0">
+      <DialogContent
+        showCloseButton
+        className="flex max-h-[90vh] w-full max-w-[560px] flex-col gap-0 p-0 dark:border dark:border-border"
+      >
         <DialogHeader className="shrink-0 border-b border-border/50 px-4 pb-3 pt-4">
-          <DialogTitle>Owned Safe Accounts</DialogTitle>
+          <DialogTitle className="font-bold">Owned Safe Accounts</DialogTitle>
         </DialogHeader>
 
         {isWalletConnected && (

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
@@ -5,7 +5,7 @@ jest.mock('../../AddAccountsChooser', () => ({
   __esModule: true,
   default: ({ buttonLabel, entryPoint }: { buttonLabel?: string; entryPoint?: string }) => (
     <button data-testid="add-accounts-chooser" data-entry-point={entryPoint}>
-      {buttonLabel ?? 'Add Accounts'}
+      {buttonLabel ?? 'Add accounts'}
     </button>
   ),
 }))

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import SpaceSafeAccounts from '../index'
+
+jest.mock('../../AddAccountsChooser', () => ({
+  __esModule: true,
+  default: ({ buttonLabel, entryPoint }: { buttonLabel?: string; entryPoint?: string }) => (
+    <button data-testid="add-accounts-chooser" data-entry-point={entryPoint}>
+      {buttonLabel ?? 'Add Accounts'}
+    </button>
+  ),
+}))
+
+jest.mock('@/components/common/Track', () => {
+  const Track = ({ children }: { children: React.ReactNode }) => <>{children}</>
+  Track.displayName = 'Track'
+  return Track
+})
+
+jest.mock('@/features/spaces', () => ({
+  useSpaceSafes: () => ({ allSafes: [], isError: false, error: null, refetch: jest.fn() }),
+  useIsInvited: () => false,
+}))
+
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('@/hooks/safes', () => ({
+  useAllOwnedSafes: () => [{}, undefined, false],
+  getComparator: () => () => 0,
+  _buildSafeItem: jest.fn(),
+  _getMultiChainAccounts: () => [],
+  _getSingleChainAccounts: () => [],
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: () => ({}),
+}))
+
+jest.mock('@/store/orderByPreferenceSlice', () => ({ selectOrderByPreference: jest.fn() }))
+jest.mock('@/store/addedSafesSlice', () => ({ selectAllAddedSafes: jest.fn() }))
+jest.mock('@/store/slices', () => ({
+  selectAllAddressBooks: jest.fn(),
+  selectAllVisitedSafes: jest.fn(),
+  selectUndeployedSafes: jest.fn(),
+}))
+
+jest.mock('../AccountsSafesList', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('../EmptySafeAccounts', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('../../InviteBanner/PreviewInvite', () => ({ __esModule: true, default: () => null }))
+
+describe('SpaceSafeAccounts header CTA', () => {
+  it('renders the AddAccountsChooser with the "Manage accounts" label', () => {
+    render(<SpaceSafeAccounts />)
+
+    expect(screen.getByTestId('add-accounts-chooser')).toHaveTextContent('Manage accounts')
+  })
+
+  it('passes "safe_accounts" as the entryPoint to AddAccountsChooser', () => {
+    render(<SpaceSafeAccounts />)
+
+    expect(screen.getByTestId('add-accounts-chooser')).toHaveAttribute('data-entry-point', 'safe_accounts')
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SpaceSafeAccounts.test.tsx
@@ -29,7 +29,14 @@ jest.mock('@/hooks/wallets/useWallet', () => ({
 jest.mock('@/hooks/safes', () => ({
   useAllOwnedSafes: () => [{}, undefined, false],
   getComparator: () => () => 0,
-  _buildSafeItem: jest.fn(),
+  useSafeItemBuilder: () => ({
+    buildSafeItem: jest.fn(),
+    walletAddress: '',
+    isWalletConnected: false,
+    allOwned: {},
+    ownedError: undefined,
+    ownedLoading: false,
+  }),
   _getMultiChainAccounts: () => [],
   _getSingleChainAccounts: () => [],
 }))

--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -1,4 +1,4 @@
-import AddAccounts from '../AddAccounts'
+import AddAccountsChooser from '../AddAccountsChooser'
 import EmptySafeAccounts from './EmptySafeAccounts'
 import { Stack } from '@mui/material'
 import { Typography } from '@/components/ui/typography'
@@ -18,7 +18,7 @@ import {
 } from '@/hooks/safes'
 import useWallet from '@/hooks/wallets/useWallet'
 import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
-import { useSpaceSafes, useIsAdmin, useIsInvited } from '@/features/spaces'
+import { useSpaceSafes, useIsInvited } from '@/features/spaces'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
 import { TriangleAlert, RotateCw } from 'lucide-react'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
@@ -37,7 +37,6 @@ const _groupAndSort = (
 
 const SpaceSafeAccounts = () => {
   const { allSafes, isError: isSpaceSafesError, error: spaceSafesError, refetch: refetchSpaceSafes } = useSpaceSafes()
-  const isAdmin = useIsAdmin()
   const isInvited = useIsInvited()
 
   // Use same organization logic as onboarding
@@ -80,13 +79,11 @@ const SpaceSafeAccounts = () => {
         <Typography variant="h2" className="font-bold leading-[1] tracking-tight">
           Safe Accounts
         </Typography>
-        {isAdmin && (
-          <Stack direction="row" justifyContent="flex-start">
-            <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>
-              <AddAccounts buttonVariant="default" />
-            </Track>
-          </Stack>
-        )}
+        <Stack direction="row" justifyContent="flex-start">
+          <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>
+            <AddAccountsChooser buttonVariant="default" />
+          </Track>
+        </Stack>
       </div>
 
       {isSpaceSafesError ? (

--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -5,18 +5,14 @@ import { Typography } from '@/components/ui/typography'
 import { useMemo } from 'react'
 import { useAppSelector } from '@/store'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
-import { selectAllAddedSafes } from '@/store/addedSafesSlice'
-import { selectAllAddressBooks, selectAllVisitedSafes, selectUndeployedSafes } from '@/store/slices'
 import {
   type AllSafeItems,
   type SafeItem,
-  _buildSafeItem,
   _getMultiChainAccounts,
   _getSingleChainAccounts,
   getComparator,
-  useAllOwnedSafes,
+  useSafeItemBuilder,
 } from '@/hooks/safes'
-import useWallet from '@/hooks/wallets/useWallet'
 import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
 import { useSpaceSafes, useIsInvited } from '@/features/spaces'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
@@ -42,22 +38,14 @@ const SpaceSafeAccounts = () => {
   // Use same organization logic as onboarding
   const { orderBy } = useAppSelector(selectOrderByPreference)
   const sortComparator = getComparator(orderBy)
-  const { address: walletAddress = '' } = useWallet() || {}
-  const [allOwned = {}] = useAllOwnedSafes(walletAddress)
-  const allAdded = useAppSelector(selectAllAddedSafes)
-  const allUndeployed = useAppSelector(selectUndeployedSafes)
-  const allVisitedSafes = useAppSelector(selectAllVisitedSafes)
-  const allSafeNames = useAppSelector(selectAllAddressBooks)
+  const { buildSafeItem } = useSafeItemBuilder()
 
   const spaceSafeItems = useMemo(() => {
-    const buildItem = (chainId: string, address: string) =>
-      _buildSafeItem(chainId, address, walletAddress, allAdded, allOwned, allUndeployed, allVisitedSafes, allSafeNames)
-
     // Only include safes that are part of the current space
     const spaceSafes = allSafes?.flatMap((item) => ('safes' in item ? item.safes : [item])) || []
 
-    return spaceSafes.map((safe) => buildItem(safe.chainId, safe.address))
-  }, [allAdded, allOwned, allUndeployed, walletAddress, allVisitedSafes, allSafeNames, allSafes])
+    return spaceSafes.map((safe) => buildSafeItem(safe.chainId, safe.address))
+  }, [buildSafeItem, allSafes])
 
   const similarAddresses = useMemo<Set<string>>(
     () => getFlaggedSimilarAddressSet(spaceSafeItems.map((s) => s.address)),

--- a/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/index.tsx
@@ -81,7 +81,7 @@ const SpaceSafeAccounts = () => {
         </Typography>
         <Stack direction="row" justifyContent="flex-start">
           <Track {...SPACE_EVENTS.ADD_ACCOUNTS_MODAL} label={SPACE_LABELS.accounts_page}>
-            <AddAccountsChooser buttonVariant="default" />
+            <AddAccountsChooser buttonVariant="default" buttonLabel="Manage accounts" entryPoint="safe_accounts" />
           </Track>
         </Stack>
       </div>

--- a/apps/web/src/hooks/safes/__tests__/useSafeItemBuilder.test.ts
+++ b/apps/web/src/hooks/safes/__tests__/useSafeItemBuilder.test.ts
@@ -1,0 +1,84 @@
+import * as allOwnedSafes from '../useAllOwnedSafes'
+import * as useWallet from '@/hooks/wallets/useWallet'
+import useSafeItemBuilder from '../useSafeItemBuilder'
+import { renderHook } from '@/tests/test-utils'
+
+describe('useSafeItemBuilder hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(allOwnedSafes, 'default').mockReturnValue([undefined, undefined, false])
+  })
+
+  it('reports isWalletConnected=false and walletAddress="" when no wallet is connected', () => {
+    jest.spyOn(useWallet, 'default').mockReturnValue(null)
+
+    const { result } = renderHook(() => useSafeItemBuilder())
+
+    expect(result.current.isWalletConnected).toBe(false)
+    expect(result.current.walletAddress).toBe('')
+  })
+
+  it('reports isWalletConnected=true and exposes the wallet address when a wallet is connected', () => {
+    jest.spyOn(useWallet, 'default').mockReturnValue({ address: '0xWallet' } as ReturnType<typeof useWallet.default>)
+
+    const { result } = renderHook(() => useSafeItemBuilder())
+
+    expect(result.current.isWalletConnected).toBe(true)
+    expect(result.current.walletAddress).toBe('0xWallet')
+  })
+
+  it('returns an empty owned map when the owners query returned no data', () => {
+    jest.spyOn(useWallet, 'default').mockReturnValue({ address: '0xWallet' } as ReturnType<typeof useWallet.default>)
+    jest.spyOn(allOwnedSafes, 'default').mockReturnValue([undefined, undefined, false])
+
+    const { result } = renderHook(() => useSafeItemBuilder())
+
+    expect(result.current.allOwned).toEqual({})
+  })
+
+  it('forwards ownedError and ownedLoading from useAllOwnedSafes', () => {
+    jest.spyOn(useWallet, 'default').mockReturnValue({ address: '0xWallet' } as ReturnType<typeof useWallet.default>)
+    const boom = new Error('boom')
+    jest.spyOn(allOwnedSafes, 'default').mockReturnValue([undefined, boom, true])
+
+    const { result } = renderHook(() => useSafeItemBuilder())
+
+    expect(result.current.ownedError).toBe(boom)
+    expect(result.current.ownedLoading).toBe(true)
+  })
+
+  it('returns a buildSafeItem that produces a SafeItem with isPinned=true for added safes', () => {
+    jest.spyOn(useWallet, 'default').mockReturnValue({ address: '0xWallet' } as ReturnType<typeof useWallet.default>)
+
+    const { result } = renderHook(() => useSafeItemBuilder(), {
+      initialReduxState: {
+        addedSafes: {
+          '1': {
+            '0xPinned': { owners: [], threshold: 1 },
+          },
+        },
+      },
+    })
+
+    const item = result.current.buildSafeItem('1', '0xPinned')
+
+    expect(item).toMatchObject({
+      chainId: '1',
+      address: '0xPinned',
+      isPinned: true,
+      isReadOnly: true,
+    })
+  })
+
+  it('marks a safe as owned (isReadOnly=false) when its address is in the owners response', () => {
+    jest.spyOn(useWallet, 'default').mockReturnValue({ address: '0xWallet' } as ReturnType<typeof useWallet.default>)
+    jest.spyOn(allOwnedSafes, 'default').mockReturnValue([{ '1': ['0xOwned'] }, undefined, false])
+
+    const { result } = renderHook(() => useSafeItemBuilder())
+
+    const item = result.current.buildSafeItem('1', '0xOwned')
+
+    expect(item.isReadOnly).toBe(false)
+    expect(item.isPinned).toBe(false)
+  })
+})

--- a/apps/web/src/hooks/safes/index.ts
+++ b/apps/web/src/hooks/safes/index.ts
@@ -8,6 +8,7 @@
 // Core hooks
 export { default as useAllOwnedSafes } from './useAllOwnedSafes'
 export { default as useAllSafes, _buildSafeItem, _prepareAddresses } from './useAllSafes'
+export { default as useSafeItemBuilder, type SafeItemBuilder } from './useSafeItemBuilder'
 export {
   useAllSafesGrouped,
   useOwnedSafesGrouped,

--- a/apps/web/src/hooks/safes/useSafeItemBuilder.ts
+++ b/apps/web/src/hooks/safes/useSafeItemBuilder.ts
@@ -1,0 +1,66 @@
+import { useCallback } from 'react'
+import type { AllOwnedSafes } from '@safe-global/store/gateway/types'
+
+const EMPTY_OWNED: AllOwnedSafes = {}
+import { useAppSelector } from '@/store'
+import { selectAllAddedSafes } from '@/store/addedSafesSlice'
+import { selectAllAddressBooks, selectAllVisitedSafes, selectUndeployedSafes } from '@/store/slices'
+import useWallet from '@/hooks/wallets/useWallet'
+import useAllOwnedSafes from './useAllOwnedSafes'
+import { _buildSafeItem, type SafeItem } from './useAllSafes'
+
+export type SafeItemBuilder = (chainId: string, address: string) => SafeItem
+
+export interface UseSafeItemBuilderResult {
+  buildSafeItem: SafeItemBuilder
+  walletAddress: string
+  isWalletConnected: boolean
+  allOwned: ReturnType<typeof useAllOwnedSafes>[0]
+  ownedError: ReturnType<typeof useAllOwnedSafes>[1]
+  ownedLoading: ReturnType<typeof useAllOwnedSafes>[2]
+}
+
+/**
+ * Aggregates the wallet, owners query, and the four Redux slices that
+ * `_buildSafeItem` requires, and returns a memoized `(chainId, address) => SafeItem`
+ * builder. Keeps consumers from re-deriving the same 8-arg call.
+ */
+const useSafeItemBuilder = (): UseSafeItemBuilderResult => {
+  const wallet = useWallet()
+  const walletAddress = wallet?.address ?? ''
+  const isWalletConnected = walletAddress !== ''
+
+  const [allOwned, ownedError, ownedLoading] = useAllOwnedSafes(walletAddress)
+  const allAdded = useAppSelector(selectAllAddedSafes)
+  const allUndeployed = useAppSelector(selectUndeployedSafes)
+  const allVisitedSafes = useAppSelector(selectAllVisitedSafes)
+  const allSafeNames = useAppSelector(selectAllAddressBooks)
+
+  const ownedSafes = allOwned ?? EMPTY_OWNED
+
+  const buildSafeItem = useCallback<SafeItemBuilder>(
+    (chainId, address) =>
+      _buildSafeItem(
+        chainId,
+        address,
+        walletAddress,
+        allAdded,
+        ownedSafes,
+        allUndeployed,
+        allVisitedSafes,
+        allSafeNames,
+      ),
+    [walletAddress, allAdded, ownedSafes, allUndeployed, allVisitedSafes, allSafeNames],
+  )
+
+  return {
+    buildSafeItem,
+    walletAddress,
+    isWalletConnected,
+    allOwned: ownedSafes,
+    ownedError,
+    ownedLoading,
+  }
+}
+
+export default useSafeItemBuilder

--- a/apps/web/src/hooks/safes/useSafeItemBuilder.ts
+++ b/apps/web/src/hooks/safes/useSafeItemBuilder.ts
@@ -15,7 +15,7 @@ export interface UseSafeItemBuilderResult {
   buildSafeItem: SafeItemBuilder
   walletAddress: string
   isWalletConnected: boolean
-  allOwned: ReturnType<typeof useAllOwnedSafes>[0]
+  allOwned: AllOwnedSafes
   ownedError: ReturnType<typeof useAllOwnedSafes>[1]
   ownedLoading: ReturnType<typeof useAllOwnedSafes>[2]
 }

--- a/apps/web/src/pages/new-safe/create.tsx
+++ b/apps/web/src/pages/new-safe/create.tsx
@@ -4,12 +4,17 @@ import type { NextPage } from 'next'
 import CreateSafe from '@/components/new-safe/create'
 import { BRAND_NAME } from '@/config/constants'
 import SafeLogo from '@/components/common/SafeLogo'
+import { AppRoutes } from '@/config/routes'
+import { useCurrentSpaceId } from '@/features/spaces'
 
 const Open: NextPage = () => {
+  const spaceId = useCurrentSpaceId()
+  const logoHref = spaceId ? `${AppRoutes.spaces.index}?spaceId=${spaceId}` : AppRoutes.welcome.index
+
   return (
     <main>
       <div className="fixed top-0 left-0 z-[1300] flex items-center px-6" style={{ height: 'var(--header-height)' }}>
-        <SafeLogo />
+        <SafeLogo href={logoHref} />
       </div>
       <Head>
         <title>{`${BRAND_NAME} – Create Safe Account`}</title>

--- a/apps/web/src/services/analytics/events/overview.ts
+++ b/apps/web/src/services/analytics/events/overview.ts
@@ -272,4 +272,5 @@ export enum OVERVIEW_LABELS {
   settings = 'settings',
   space_list_page = 'space_list_page',
   space_page = 'space_page',
+  owned_safes_modal = 'owned_safes_modal',
 }

--- a/apps/web/src/styles/onboard.css
+++ b/apps/web/src/styles/onboard.css
@@ -46,8 +46,7 @@
   --onboard-warning-600: var(--color-error-main);
   --onboard-warning-700: var(--color-error-dark);
 
-  /* Connect modal */
-  --onboard-modal-z-index: 1301;
+  --onboard-modal-z-index: 1500;
 
   --onboard-modal-backdrop: rgba(99, 102, 105, 0.75);
 
@@ -83,7 +82,7 @@
 
   --account-select-danger-500: var(--onboard-danger-500);
 
-  --onboard-account-select-modal-z-index: 1301;
+  --onboard-account-select-modal-z-index: 1500;
 }
 
 #walletconnect-qrcode-modal {
@@ -103,6 +102,7 @@
 #kv_sdk_container + .ReactModalPortal > div {
   z-index: 1301 !important;
 }
+
 #kv_sdk_container + .ReactModalPortal .ReactModal__Content {
   padding: 0 !important;
 }

--- a/apps/web/src/styles/onboard.css
+++ b/apps/web/src/styles/onboard.css
@@ -46,7 +46,8 @@
   --onboard-warning-600: var(--color-error-main);
   --onboard-warning-700: var(--color-error-dark);
 
-  --onboard-modal-z-index: 1500;
+  /* Connect modal */
+  --onboard-modal-z-index: 1301;
 
   --onboard-modal-backdrop: rgba(99, 102, 105, 0.75);
 
@@ -82,7 +83,12 @@
 
   --account-select-danger-500: var(--onboard-danger-500);
 
-  --onboard-account-select-modal-z-index: 1500;
+  --onboard-account-select-modal-z-index: 1301;
+}
+
+[data-owned-safes-modal],
+[data-slot='dialog-overlay']:has(+ [data-owned-safes-modal]) {
+  z-index: 1200;
 }
 
 #walletconnect-qrcode-modal {


### PR DESCRIPTION
## What it solves

Resolves: [WA-2431](https://linear.app/safe-global/issue/WA-2431/add-all-owned-accounts-modal-and-an-entry-point-to-create-safe)
New "Manage Safe accounts" entry point on Spaces — a chooser dialog with three rows (add to workspace / browse owned Safes / create new Safe) replaces the direct AddAccounts trigger on Dashboard and the SafeAccounts page. Plus a new OwnedSafesModal, return-to-Spaces from `/new-safe/create`, and small UI fixes (Connect Wallet popup, dialog animation).

## How this PR fixes it

- Adds `AddAccountsChooser` (chooser dialog) and `OwnedSafesModal` (owned-Safes browser). Submodals mount lazily — only when the corresponding row is clicked.
- Wires the chooser into `AddAccountsCard`, `Dashboard` (action + empty-state), and `SafeAccounts` in place of direct `AddAccounts` usage. Admin-only gating moves into the chooser row (`Add Safe accounts to this workspace` is disabled for non-admins with tooltip).
- Dashboard buttons relabeled to "Manage accounts" to reflect the chooser's broader scope.
- `/new-safe/create` `SafeLogo` now links back to the current Space when one is active.
- Adds `data-starting-style:opacity-0` / `data-ending-style:opacity-0` to the shared `Dialog` overlay/popup so dialogs fade in/out smoothly.

## How to test it

1. Spaces dashboard (with safes): click "Manage accounts" → chooser opens with 3 rows.
2. Click "See owned Safe accounts" → `OwnedSafesModal` opens; verify search, list, "Add existing" / "Create new" footer buttons.
3. Click "Add Safe accounts to this workspace" as **admin** → AddAccounts picker opens. 
4. **As non-admin (member)** → row disabled with tooltip "You need to be an Admin to add accounts".
5. Click "Create new Safe" → navigates to `/new-safe/create`. Click the Safe logo → returns to the current Space (not `/welcome`).
6. Empty workspace + invited member: confirm the chooser opens but "Add to workspace" is gated.
7. DevTools Network: open Spaces dashboard with wallet connected — no `/owners/{address}/safes` fired by chooser instances until you click "See owned Safe accounts".
8. 
<img width="1089" height="477" alt="image" src="https://github.com/user-attachments/assets/e5c4f0fa-1989-4d10-8404-479506b33d46" />


## Affected flows

- Spaces Dashboard: Manage accounts entry (card, top action, empty state).
- SafeAccounts page: Manage accounts button (now visible to all members, not only admins).
- New flow: Owned Safes browser inside Spaces.
- `/new-safe/create`: Safe logo navigation.

## Blast radius

- New components: `AddAccountsChooser`, `OwnedSafesModal` (consumes underscore-prefixed helpers from `@/hooks/safes` — duplicates patterns in `SpaceSafeBar/AccountsModal` and `AddAccounts`).
- **Shared UI primitive touched**: `src/components/ui/dialog.tsx` — animation classes added globally; affects every Dialog importer (~all dialogs in app).
- `SafeAccounts` no longer gates the CTA on `isAdmin` (responsibility moved into chooser row). Non-admin and invited members now see the button.
- `pages/new-safe/create.tsx` reads `useCurrentSpaceId()` which can fall back to `lastUsedSpace` from Redux — logo may route to a stale space if SIWE expired.
- No RTK endpoint or slice changes.

## Risks / not checked
- Did not run full Cypress suite locally; `[data-testid="add-space-account-button"]` selector unchanged.
- `SecurityEmptyState` still uses the legacy `AddAccounts` trigger directly (not migrated).

## Visual summary

Dashboard CTA reads **Manage accounts**. Clicking opens the chooser dialog (3 rows). "See owned Safe accounts" opens a new modal listing owned Safes with search + footer actions.

## Checklist

- [x] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — see Risks
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — `AddAccountsChooser` (18), `OwnedSafesModal`, `AddAccountsCard`, `AddAccountsButtons`
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
