### PR TITLE
chore: auto-update schema hash in build scripts

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -12,9 +12,10 @@
     "prettier:fix": "prettier --write . --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "fetch-schema": "ts-node ./scripts/fetch-schema.ts > scripts/api-schema/schema.json",
     "generate-api": "npx @rtk-query/codegen-openapi scripts/openapi-config.ts",
-    "build": "yarn fetch-schema && yarn generate-api",
-    "build:dev": "NODE_ENV=dev yarn fetch-schema && yarn generate-api",
-    "build:local": "NODE_ENV=local yarn fetch-schema && yarn generate-api",
+    "write-schema-hash": "ts-node scripts/write-schema-hash.ts",
+    "build": "yarn fetch-schema && yarn generate-api && yarn write-schema-hash",
+    "build:dev": "NODE_ENV=dev yarn fetch-schema && yarn generate-api && yarn write-schema-hash",
+    "build:local": "NODE_ENV=local yarn fetch-schema && yarn generate-api && yarn write-schema-hash",
     "check-sync": "ts-node scripts/check-auto-generated-sync.ts"
   },
   "devDependencies": {

--- a/packages/store/scripts/write-schema-hash.ts
+++ b/packages/store/scripts/write-schema-hash.ts
@@ -1,0 +1,13 @@
+import { createHash } from 'crypto'
+import { readFileSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
+
+const SCRIPTS_DIR = __dirname
+const SCHEMA_PATH = resolve(SCRIPTS_DIR, 'api-schema/schema.json')
+const HASH_FILE_PATH = resolve(SCRIPTS_DIR, '../src/gateway/AUTO_GENERATED/.schema-hash')
+
+const contents = readFileSync(SCHEMA_PATH)
+const hash = createHash('sha256').update(contents).digest('hex')
+
+writeFileSync(HASH_FILE_PATH, hash + '\n')
+console.log(`Wrote schema hash to ${HASH_FILE_PATH}`)


### PR DESCRIPTION
## What it solves

Resolves: [WA-2441](https://linear.app/safe-global/issue/WA-2441/add-schema-hash-regeneration-script)
Manual `shasum > .schema-hash` step after every schema fetch - easy to forget, causes spurious `check-auto-generated-sync` failures.

## How this PR fixes it

Adds `scripts/write-schema-hash.ts` and chains it onto `build`, `build:dev`, and `build:local`. The hash is now rewritten whenever AUTO_GENERATED is regenerated, so the two can never drift.

## How to test it

```
yarn workspace @safe-global/store build:dev
yarn workspace @safe-global/store check-sync   # should pass
```

## Affected flows

- `@safe-global/store` build pipeline (`build`, `build:dev`, `build:local`)

## Blast radius

- `packages/store/package.json` scripts only
- New `scripts/write-schema-hash.ts` — no runtime code
- No API contracts, hooks, selectors, or feature flags touched

## Risks / not checked

- Did not run `build` / `build:local` end-to-end (only `build:dev` + `write-schema-hash` standalone)
- No mobile impact (build-time only)

## Visual summary

```mermaid
flowchart LR
  A[fetch-schema] --> B[generate-api] --> C[write-schema-hash]
  C --> D[.schema-hash in sync]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (n/a — build script)
- [ ] I've documented how it affects the analytics (if at all) 📊 (n/a)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (existing `check-sync` covers it)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
