### PR TITLE
fix(web): gate green Security Hub status for n/n Safes on recovery

### DIFF
--- a/apps/web/src/features/security/data/scanners/__tests__/accountSetup.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/accountSetup.test.ts
@@ -1,118 +1,189 @@
 import { accountSetupScanner } from '../accountSetup'
 import { createMockContext } from '../test-helpers'
 
+const DELAY_MODULE = { value: '0xabcdef1234567890abcdef1234567890abcdef12', name: 'Delay Modifier' }
+
+const owners = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({ value: `0x${String(i + 1).padStart(40, '0')}` }))
+
 describe('accountSetupScanner', () => {
-  it('returns critical issue for single signer', async () => {
-    const ctx = createMockContext({
-      owners: [{ value: '0x1111111111111111111111111111111111111111' }],
-      threshold: 1,
+  describe('n/n Safes (threshold === owner count)', () => {
+    it('returns clear for a 1/1 Safe with recovery configured', async () => {
+      const ctx = createMockContext({
+        owners: owners(1),
+        threshold: 1,
+        chainSupportsRecovery: true,
+        modules: [DELAY_MODULE],
+      })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('clear')
+      expect(result.severity).toBe('Low')
+      expect(result.score).toBe(100)
     })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('issue')
-    expect(result.severity).toBe('Critical')
-    expect(result.score).toBe(10)
-  })
 
-  it('returns critical issue for threshold of 1 with multiple owners', async () => {
-    const ctx = createMockContext({ threshold: 1 })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('issue')
-    expect(result.severity).toBe('Critical')
-    expect(result.score).toBe(15)
-  })
-
-  it('recommends adding a signer for a 1/2 Safe (avoids 2/2 single point of failure)', async () => {
-    const ctx = createMockContext({
-      owners: [
-        { value: '0x1111111111111111111111111111111111111111' },
-        { value: '0x2222222222222222222222222222222222222222' },
-      ],
-      threshold: 1,
+    it('returns clear for a 2/2 Safe with recovery configured', async () => {
+      const ctx = createMockContext({
+        owners: owners(2),
+        threshold: 2,
+        chainSupportsRecovery: true,
+        modules: [DELAY_MODULE],
+      })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('clear')
+      expect(result.score).toBe(100)
     })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('issue')
-    expect(result.severity).toBe('Critical')
-    expect(result.score).toBe(15)
-    expect(result.remediation).toContain('Add another signer')
-    expect(result.remediation).not.toContain('2 of 2')
-  })
 
-  it('returns partial for threshold below simple majority', async () => {
-    const ctx = createMockContext({
-      owners: [
-        { value: '0x1111111111111111111111111111111111111111' },
-        { value: '0x2222222222222222222222222222222222222222' },
-        { value: '0x3333333333333333333333333333333333333333' },
-        { value: '0x4444444444444444444444444444444444444444' },
-      ],
-      threshold: 1,
+    it('returns clear for a 3/3 Safe with recovery configured', async () => {
+      const ctx = createMockContext({
+        owners: owners(3),
+        threshold: 3,
+        chainSupportsRecovery: true,
+        modules: [DELAY_MODULE],
+      })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('clear')
     })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('issue')
-    expect(result.severity).toBe('Critical')
-  })
 
-  it('returns partial for threshold below majority (e.g., 2 of 5)', async () => {
-    const ctx = createMockContext({
-      owners: Array.from({ length: 5 }, (_, i) => ({
-        value: `0x${String(i + 1).padStart(40, '0')}`,
-      })),
-      threshold: 2,
+    it('returns an at-risk issue for a 2/2 Safe without recovery on a recovery-capable chain', async () => {
+      const ctx = createMockContext({
+        owners: owners(2),
+        threshold: 2,
+        chainSupportsRecovery: true,
+        modules: null,
+      })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('High')
+      expect(result.score).toBe(40)
+      expect(result.remediation).toContain('recovery')
     })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('partial')
-    expect(result.severity).toBe('Medium')
-  })
 
-  it('returns partial for 2 of 4 (half is not a simple majority)', async () => {
-    const ctx = createMockContext({
-      owners: Array.from({ length: 4 }, (_, i) => ({
-        value: `0x${String(i + 1).padStart(40, '0')}`,
-      })),
-      threshold: 2,
+    it('returns an at-risk issue for a 3/3 Safe without recovery on a recovery-capable chain', async () => {
+      const ctx = createMockContext({
+        owners: owners(3),
+        threshold: 3,
+        chainSupportsRecovery: true,
+        modules: null,
+      })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('High')
+      expect(result.score).toBe(40)
     })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('partial')
-    expect(result.severity).toBe('Medium')
-    expect(result.remediation).toContain('3 of 4')
-  })
 
-  it('returns clear for 3 of 4 (strict majority)', async () => {
-    const ctx = createMockContext({
-      owners: Array.from({ length: 4 }, (_, i) => ({
-        value: `0x${String(i + 1).padStart(40, '0')}`,
-      })),
-      threshold: 3,
+    it('returns an at-risk issue for a 1/1 Safe without recovery on a recovery-capable chain', async () => {
+      const ctx = createMockContext({
+        owners: owners(1),
+        threshold: 1,
+        chainSupportsRecovery: true,
+        modules: null,
+      })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('High')
+      expect(result.score).toBe(40)
     })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('clear')
-    expect(result.severity).toBe('Low')
-  })
 
-  it('recommends 3 of 4 for a 1/4 Safe (strict majority, not half)', async () => {
-    const ctx = createMockContext({
-      owners: Array.from({ length: 4 }, (_, i) => ({
-        value: `0x${String(i + 1).padStart(40, '0')}`,
-      })),
-      threshold: 1,
+    it('does not count an unrecognized module as recovery (2/2 stays an issue)', async () => {
+      const ctx = createMockContext({
+        owners: owners(2),
+        threshold: 2,
+        chainSupportsRecovery: true,
+        modules: [{ value: '0xabcdef1234567890abcdef1234567890abcdef12', name: 'SomeOtherModule' }],
+      })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('High')
     })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('issue')
-    expect(result.remediation).toContain('3 of 4')
+
+    it('returns a critical issue for a 2/2 Safe on a chain without recovery support', async () => {
+      const ctx = createMockContext({
+        owners: owners(2),
+        threshold: 2,
+        chainSupportsRecovery: false,
+        modules: null,
+      })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('Critical')
+      expect(result.score).toBe(10)
+    })
+
+    it('returns a critical issue for a 1/1 Safe on a chain without recovery support', async () => {
+      const ctx = createMockContext({
+        owners: owners(1),
+        threshold: 1,
+        chainSupportsRecovery: false,
+        modules: null,
+      })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('Critical')
+      expect(result.score).toBe(10)
+    })
   })
 
-  it('returns clear for threshold at simple majority', async () => {
-    const ctx = createMockContext({ threshold: 2 })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('clear')
-    expect(result.severity).toBe('Low')
-    expect(result.score).toBe(100)
-  })
+  describe('non-n/n Safes (unchanged behavior)', () => {
+    it('returns critical issue for threshold of 1 with multiple owners', async () => {
+      const ctx = createMockContext({ owners: owners(3), threshold: 1 })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('Critical')
+      expect(result.score).toBe(15)
+    })
 
-  it('returns clear for threshold above simple majority', async () => {
-    const ctx = createMockContext({ threshold: 3 })
-    const result = await accountSetupScanner.scan(ctx)
-    expect(result.status).toBe('clear')
+    it('recommends adding a signer for a 1/2 Safe (avoids 2/2 single point of failure)', async () => {
+      const ctx = createMockContext({ owners: owners(2), threshold: 1 })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('Critical')
+      expect(result.score).toBe(15)
+      expect(result.remediation).toContain('Add another signer')
+      expect(result.remediation).not.toContain('2 of 2')
+    })
+
+    it('returns partial for threshold below majority (e.g., 2 of 5)', async () => {
+      const ctx = createMockContext({ owners: owners(5), threshold: 2 })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('partial')
+      expect(result.severity).toBe('Medium')
+    })
+
+    it('returns partial for 2 of 4 (half is not a simple majority)', async () => {
+      const ctx = createMockContext({ owners: owners(4), threshold: 2 })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('partial')
+      expect(result.severity).toBe('Medium')
+      expect(result.remediation).toContain('3 of 4')
+    })
+
+    it('returns clear for 3 of 4 (strict majority, not n/n)', async () => {
+      const ctx = createMockContext({ owners: owners(4), threshold: 3 })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('clear')
+      expect(result.severity).toBe('Low')
+    })
+
+    it('recommends 3 of 4 for a 1/4 Safe (strict majority, not half)', async () => {
+      const ctx = createMockContext({ owners: owners(4), threshold: 1 })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('issue')
+      expect(result.remediation).toContain('3 of 4')
+    })
+
+    it('returns clear for threshold at simple majority (2 of 3)', async () => {
+      const ctx = createMockContext({ owners: owners(3), threshold: 2 })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('clear')
+      expect(result.severity).toBe('Low')
+      expect(result.score).toBe(100)
+    })
+
+    it('returns clear for threshold above simple majority (4 of 5)', async () => {
+      const ctx = createMockContext({ owners: owners(5), threshold: 4 })
+      const result = await accountSetupScanner.scan(ctx)
+      expect(result.status).toBe('clear')
+    })
   })
 
   it('returns inconclusive when owner data has not loaded yet', async () => {

--- a/apps/web/src/features/security/data/scanners/__tests__/recoveryDetection.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/recoveryDetection.test.ts
@@ -1,0 +1,44 @@
+import { isDelayModifier, hasRecoverySetup } from '../recoveryDetection'
+import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
+
+const ACTIVE_MODULE = '0xabcdef1234567890abcdef1234567890abcdef12'
+
+describe('recoveryDetection', () => {
+  describe('isDelayModifier', () => {
+    it('matches canonical delay modifier names case- and whitespace-insensitively', () => {
+      expect(isDelayModifier('1', ACTIVE_MODULE, 'Delay Modifier')).toBe(true)
+      expect(isDelayModifier('1', ACTIVE_MODULE, 'delay')).toBe(true)
+      expect(isDelayModifier('1', ACTIVE_MODULE, '  Zodiac Delay Modifier ')).toBe(true)
+    })
+
+    it('does not match unrelated module names', () => {
+      expect(isDelayModifier('1', ACTIVE_MODULE, 'SomeOtherModule')).toBe(false)
+    })
+
+    it('returns false for an unknown address with no name', () => {
+      expect(isDelayModifier('1', ACTIVE_MODULE)).toBe(false)
+    })
+  })
+
+  describe('hasRecoverySetup', () => {
+    it('returns false when modules is null', () => {
+      expect(hasRecoverySetup('1', null)).toBe(false)
+    })
+
+    it('returns false when there are no modules', () => {
+      expect(hasRecoverySetup('1', [])).toBe(false)
+    })
+
+    it('ignores zero-address modules even if named like a delay modifier', () => {
+      expect(hasRecoverySetup('1', [{ value: ZERO_ADDRESS, name: 'Delay Modifier' }])).toBe(false)
+    })
+
+    it('returns true when an active delay modifier is present', () => {
+      expect(hasRecoverySetup('1', [{ value: ACTIVE_MODULE, name: 'Delay Modifier' }])).toBe(true)
+    })
+
+    it('returns false when modules exist but none are recognized as recovery', () => {
+      expect(hasRecoverySetup('1', [{ value: ACTIVE_MODULE, name: 'SomeOtherModule' }])).toBe(false)
+    })
+  })
+})

--- a/apps/web/src/features/security/data/scanners/accountSetup.ts
+++ b/apps/web/src/features/security/data/scanners/accountSetup.ts
@@ -1,10 +1,11 @@
 import type { SecurityScanner } from './types'
 import { getSeverityFromScore } from './constants'
+import { hasRecoverySetup } from './recoveryDetection'
 
 export const accountSetupScanner: SecurityScanner = {
   id: 'account_setup',
   scan: async (ctx) => {
-    const { owners, threshold } = ctx
+    const { owners, threshold, modules, chainId, chainSupportsRecovery } = ctx
     const ownerCount = owners.length
     const now = new Date().toISOString()
 
@@ -32,15 +33,48 @@ export const accountSetupScanner: SecurityScanner = {
     // Simple majority = strictly more than half. For even N this is N/2 + 1, not N/2.
     const simpleMajority = Math.floor(ownerCount / 2) + 1
 
-    // Single signer = no multisig protection
-    if (ownerCount === 1) {
-      const score = 10
+    // n/n Safe (threshold === owner count, incl. 1/1): losing any single signer permanently
+    // locks the Safe. Acceptable only when account recovery mitigates that lockout risk.
+    if (threshold === ownerCount) {
+      // Recovery isn't available on this chain — the lockout risk can't be mitigated, so this
+      // is the most severe case.
+      if (!chainSupportsRecovery) {
+        const score = 10
+        return {
+          status: 'issue',
+          severity: getSeverityFromScore(score),
+          score,
+          evidence: [...baseEvidence, 'Losing any signer would permanently lock this Safe'],
+          remediation: 'Add another signer and lower the threshold so losing one key cannot lock this Safe.',
+          lastChecked: now,
+        }
+      }
+
+      // Recovery configured → the lockout risk is mitigated.
+      if (hasRecoverySetup(chainId, modules)) {
+        const score = 100
+        return {
+          status: 'clear',
+          severity: getSeverityFromScore(score),
+          score,
+          evidence: baseEvidence,
+          remediation: '',
+          lastChecked: now,
+        }
+      }
+
+      // Recovery is available but not configured — fixable, so flag as a (non-critical) risk.
+      const score = 40
+      const remediation =
+        ownerCount === 1
+          ? 'Set up account recovery, or add signers, so this Safe cannot be permanently locked if a signer loses access.'
+          : 'Set up account recovery so this Safe can be recovered if a signer loses access.'
       return {
         status: 'issue',
         severity: getSeverityFromScore(score),
         score,
-        evidence: baseEvidence,
-        remediation: 'Add additional signers and increase the threshold for better security.',
+        evidence: [...baseEvidence, 'Losing any signer would permanently lock this Safe'],
+        remediation,
         lastChecked: now,
       }
     }

--- a/apps/web/src/features/security/data/scanners/recovery.ts
+++ b/apps/web/src/features/security/data/scanners/recovery.ts
@@ -1,37 +1,7 @@
-import { ContractVersions, KnownContracts, type SupportedNetworks } from '@gnosis.pm/zodiac'
-import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
 import type { SecurityScanner } from './types'
 import { getSeverityFromScore } from './constants'
-
-/** Canonical names CGW returns for Zodiac Delay Modifier (case- and whitespace-insensitive). */
-const DELAY_MODIFIER_NAMES = ['delay', 'delay modifier', 'zodiac delay modifier']
-
-/**
- * Detect if a module is a Zodiac Delay Modifier (recovery module) without web3 provider.
- *
- * Layer 1: CGW API enriches known contracts with names — exact-match against canonical names.
- * Layer 2: Match address against known Zodiac Delay Modifier deployments per chain.
- */
-const isDelayModifier = (chainId: string, moduleAddress: string, moduleName?: string | null): boolean => {
-  // Layer 1: API-provided name (exact, case-insensitive — substring match was too loose)
-  if (moduleName && DELAY_MODIFIER_NAMES.includes(moduleName.trim().toLowerCase())) {
-    return true
-  }
-
-  // Layer 2: Known Zodiac deployment addresses
-  try {
-    const chainContracts = ContractVersions[Number(chainId) as SupportedNetworks]
-    const delayVersions = chainContracts?.[KnownContracts.DELAY]
-    if (delayVersions) {
-      return Object.values(delayVersions).some((addr) => sameAddress(addr, moduleAddress))
-    }
-  } catch {
-    // Chain not in Zodiac's SupportedNetworks — skip
-  }
-
-  return false
-}
+import { isDelayModifier } from './recoveryDetection'
 
 export const recoveryScanner: SecurityScanner = {
   id: 'recovery',

--- a/apps/web/src/features/security/data/scanners/recoveryDetection.ts
+++ b/apps/web/src/features/security/data/scanners/recoveryDetection.ts
@@ -1,0 +1,46 @@
+import { ContractVersions, KnownContracts, type SupportedNetworks } from '@gnosis.pm/zodiac'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
+
+/** Canonical names CGW returns for Zodiac Delay Modifier (case- and whitespace-insensitive). */
+const DELAY_MODIFIER_NAMES = ['delay', 'delay modifier', 'zodiac delay modifier']
+
+/**
+ * Detect if a module is a Zodiac Delay Modifier (recovery module) without web3 provider.
+ *
+ * Layer 1: CGW API enriches known contracts with names — exact-match against canonical names.
+ * Layer 2: Match address against known Zodiac Delay Modifier deployments per chain.
+ */
+export const isDelayModifier = (chainId: string, moduleAddress: string, moduleName?: string | null): boolean => {
+  // Layer 1: API-provided name (exact, case-insensitive — substring match was too loose)
+  if (moduleName && DELAY_MODIFIER_NAMES.includes(moduleName.trim().toLowerCase())) {
+    return true
+  }
+
+  // Layer 2: Known Zodiac deployment addresses
+  try {
+    const chainContracts = ContractVersions[Number(chainId) as SupportedNetworks]
+    const delayVersions = chainContracts?.[KnownContracts.DELAY]
+    if (delayVersions) {
+      return Object.values(delayVersions).some((addr) => sameAddress(addr, moduleAddress))
+    }
+  } catch {
+    // Chain not in Zodiac's SupportedNetworks — skip
+  }
+
+  return false
+}
+
+/**
+ * Whether the Safe has a confirmed recovery module installed — i.e. an active
+ * (non-zero-address) module recognized as a Zodiac Delay Modifier. Shared by the
+ * recovery scanner and the account-setup n/n gate so "recovery configured" means
+ * the same thing in both.
+ */
+export const hasRecoverySetup = (
+  chainId: string,
+  modules: { value: string; name?: string | null }[] | null,
+): boolean => {
+  const activeModules = (modules ?? []).filter((m) => m.value !== ZERO_ADDRESS)
+  return activeModules.some((m) => isDelayModifier(chainId, m.value, m.name))
+}


### PR DESCRIPTION
> n-of-n locks on a lost key,
> green no longer comes for free,
> recovery set? then clear you'll be,
> else red — at risk, or critically.

## What it solves

Resolves: Security Hub showed a green ("Strong") score and `clear` status for n/n Safes (threshold equals owner count — e.g. 1/1, 2/2, 3/3) even when no account recovery was configured. An n/n Safe has a single point of failure: if any one signer permanently loses access, the threshold can never be met again and the Safe is locked forever. These Safes should only be green when recovery mitigates that lockout risk.

## How this PR fixes it

The `account_setup` scanner now gates an n/n Safe's `clear` (green) status on recovery being configured:

- **Recovery-capable chain + recovery configured** → `clear` (green), score 100
- **Recovery-capable chain + no recovery** → `issue`, score 40 → `High` severity → per-Safe grade `at_risk` (fixable: set up recovery)
- **Chain without recovery support** → `issue`, score 10 → `Critical` severity → grade `critical` (lockout risk can't be mitigated via recovery — most severe)

"Recovery configured" means a confirmed Zodiac Delay Modifier. The detection logic was extracted from `recovery.ts` into a shared `recoveryDetection.ts` (`isDelayModifier` + `hasRecoverySetup`) so both the recovery check and the new n/n gate agree on the same definition. The old `ownerCount === 1` branch was removed — a 1/1 is always n/n, so the gate fully covers it (and a 1/1 with recovery now correctly goes green).

Non-n/n setups (2/3, 3/4, …) are unchanged on every chain.

## How to test it

1. Open Security Hub for an n/n Safe (e.g. 2/2) on a recovery-capable chain (e.g. Polygon) with **no** recovery module → "Account setup" check shows red `issue` ("at risk"), and the Safe no longer scores green on that check.
2. Set up account recovery (Zodiac Delay Modifier) on that Safe → re-scan → "Account setup" check goes green (`clear`).
3. A 1/1 Safe with recovery configured → green; without recovery → red.
4. An n/n Safe on a chain that does not support recovery → red, `critical` severity.
5. A non-n/n Safe (e.g. 2/3) → unchanged behavior.

Unit tests cover all of the above: `accountSetup.test.ts` (18) and `recoveryDetection.test.ts` (8).

## Affected flows

- Security Hub "Account setup" check result for n/n Safes (1/1, 2/2, 3/3, …).
- Per-Safe grade in the Security Hub safes table (`getSafeGrade`): n/n no-recovery → `at_risk`/`critical` instead of `passing`.
- Aggregate security score / strength gauge (`computeSummary`): n/n no-recovery no longer reaches the green band.

## Blast radius

- **`scanners/accountSetup.ts`** — logic change (the n/n gate). Consumed by the scanner registry and all Security Hub views.
- **`scanners/recovery.ts`** — refactor only: now imports `isDelayModifier` from the new shared module. Behavior unchanged (verified by `recovery.test.ts`).
- **`scanners/recoveryDetection.ts`** (new) — `isDelayModifier` (moved verbatim) + `hasRecoverySetup`. Shared by both scanners.
- **Indirect consumers (no code change):** `getSafeGrade` and `computeSummary` simply consume the new `account_setup` result; the change cascades to the per-check row, the per-Safe table grade, and the aggregate gauge.
- No RTK Query endpoints, feature flags, persisted state, routes, or shared packages touched. No mobile impact (change is web-only, under `apps/web/src/features/security`).

## Risks / not checked

- No new E2E/Cypress coverage — relying on unit tests at the scanner contract level.
- UI snapshot/visual rendering of the changed grade is not separately asserted (the score cascade is covered transitively by the grade/summary unit logic).
- Not tested on mobile (feature is web-only).
- Known separate issue (out of scope for this PR): the panel score gauge is purely ratio-based and only caps for `Critical` severity, so a single `High`-severity issue can still show green while the row icon and table show red. Tracked for a follow-up.

## Visual summary

```mermaid
flowchart TD
  A[account_setup scan] --> B{threshold === ownerCount?}
  B -->|no, e.g. 2/3| Z[existing threshold logic — unchanged]
  B -->|yes — n/n| C{chainSupportsRecovery?}
  C -->|no| D[issue · score 10 · Critical → grade critical]
  C -->|yes| E{hasRecoverySetup?}
  E -->|yes| F[clear · score 100 · green]
  E -->|no| G[issue · score 40 · High → grade at_risk]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (web-only feature; N/A)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
