### PR TITLE
chore(mobile): use EAS corepack to honor packageManager yarn pin

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -6,6 +6,7 @@
   "build": {
     "base": {
       "node": "24.14.0",
+      "corepack": true,
       "android": {
         "image": "sdk-55"
       },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -33,7 +33,6 @@
     "e2e:metro-ios": "EXPO_PUBLIC_ENV=e2e NODE_ENV=test RN_SRC_EXT=e2e.ts,e2e.tsx expo run:ios --configuration Release",
     "e2e:metro-android": "EXPO_PUBLIC_ENV=e2e NODE_ENV=test RN_SRC_EXT=e2e.ts,e2e.tsx expo run:android",
     "e2e:run": "maestro test e2e",
-    "eas-build-pre-install": "corepack enable && yarn set version 4",
     "android": "expo run:android",
     "ios": "expo run:ios"
   },


### PR DESCRIPTION
> Hook bootstrapped four-dot-latest,
> drifting past our pinned request.
> Corepack reads the field we set —
> local and CI now agree.

## What it solves

EAS builds resolved Yarn to the latest 4.x (currently 4.15) while local resolved to the pinned 4.14.1, because the `eas-build-pre-install` hook ran `yarn set version 4` — a floating tag that ignores the `packageManager` pin in the root `package.json`. This makes CI builds non-reproducible and silently drift on every build.

## How this PR fixes it

Enables EAS Build's native Corepack support (`"corepack": true` in the `base` profile, inherited by all profiles via `extends`) and removes the now-redundant `eas-build-pre-install` hook. With Corepack enabled, EAS reads `packageManager: "yarn@4.14.1+sha512…"` from the **root** `package.json` and pins the exact version — matching local and adding checksum integrity verification that `yarn set version 4` did not provide.

Gotcha: Corepack honors `packageManager` from the repo root (where EAS installs for monorepos), not `apps/mobile/package.json`. The root field is already present, so no further change is needed. `cli.version` (`>= 13.4.2`) is well past where `corepack` support landed.

## How to test it

1. Open this PR with the `mobile-dev-release` label (or merge to `dev`) to trigger an EAS dev build.
2. In the EAS build logs, confirm the install step reports Yarn **4.14.1** (not 4.15.x).
3. Verify `corepack enable` is run automatically by the builder and the build completes successfully.

## Screenshots

N/A - no UI changes

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A["eas-build-pre-install:<br/>yarn set version 4"] -->|floating tag → latest| B["Yarn 4.15.x on EAS"]
    C["root packageManager:<br/>yarn@4.14.1"] -->|corepack| D["Yarn 4.14.1 local"]
    B -. drift .-> D
  end
  subgraph After
    E["eas.json base:<br/>corepack: true"] -->|reads root packageManager| F["Yarn 4.14.1 on EAS"]
    G["root packageManager:<br/>yarn@4.14.1"] -->|corepack| H["Yarn 4.14.1 local"]
    F === H
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).