### PR TITLE
fix(mobile): let EAS corepack honor root packageManager yarn pin

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -6,7 +6,6 @@
   "build": {
     "base": {
       "node": "24.14.0",
-      "corepack": true,
       "android": {
         "image": "sdk-55"
       },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -33,6 +33,7 @@
     "e2e:metro-ios": "EXPO_PUBLIC_ENV=e2e NODE_ENV=test RN_SRC_EXT=e2e.ts,e2e.tsx expo run:ios --configuration Release",
     "e2e:metro-android": "EXPO_PUBLIC_ENV=e2e NODE_ENV=test RN_SRC_EXT=e2e.ts,e2e.tsx expo run:android",
     "e2e:run": "maestro test e2e",
+    "eas-build-pre-install": "corepack enable",
     "android": "expo run:android",
     "ios": "expo run:ios"
   },


### PR DESCRIPTION
> Corepack-true picked pnpm,
> the builder image said: already here.
> Drop the flag, just enable —
> root packageManager, hash and all, stays clear.

## What it solves

The previous attempt (#7967) set `"corepack": true` in `eas.json` to stop EAS Yarn drifting to the latest 4.x. It broke the build: in this monorepo the EAS build runs from `apps/mobile/` (which has no `packageManager` field and no lockfile), so EAS misdetects the package manager as **pnpm@10.28.2** and its redundant `npm -g install pnpm` collides with the pnpm binary already in the builder image:

```
Enabling corepack
Installing pnpm@10.28.2
npm error code EEXIST ... /Users/expo/.nvm/.../bin/pnpm already exists
Failed to install pnpm 10.28.2
```

This is a known eas-cli bug (expo/eas-cli#3148, #2978).

## How this PR fixes it

Remove `"corepack": true` and use a plain `corepack enable` pre-install hook. Corepack then resolves the nearest `packageManager` field — the **root** `package.json`'s `yarn@4.14.1+sha512…` — and **verifies the sha512 integrity hash** before using it.

This gives a single source of truth (root `packageManager`, no duplicated version string), keeps integrity verification (which both `yarn set version 4` and a bare `yarn set version 4.14.1` lacked), and mirrors exactly how local already resolves Yarn (no `yarnPath`, no `.yarn/releases` binary — `yarn --version` → 4.14.1 via corepack).

Gotcha / why not `corepack: true`: EAS's own corepack handling does a redundant global package-manager install that both misdetects the manager in this monorepo layout and double-installs over the corepack shim. A plain `corepack enable` hook sidesteps that path entirely.

## How to test it

1. Apply the `mobile-dev-release` label to this PR to trigger an EAS dev build (or merge to `dev`).
2. In the EAS build logs, confirm the **install step reports Yarn 4.14.1** (not 4.15.x, and not pnpm).
3. Confirm the build no longer fails at the "Enabling corepack / Installing pnpm" step and completes successfully.

## Screenshots

N/A - no UI changes

## Visual summary

```mermaid
flowchart TB
  subgraph "Attempt #7967 (broken)"
    A["eas.json corepack: true"] -->|"EAS detects PM in apps/mobile<br/>(no field/lockfile)"| B["fallback: pnpm@10.28.2"]
    B -->|"npm -g install pnpm<br/>over corepack shim"| C["EEXIST 💥"]
  end
  subgraph "This PR (fixed)"
    D["eas-build-pre-install:<br/>corepack enable"] -->|"resolves nearest packageManager"| E["root package.json<br/>yarn@4.14.1+sha512"]
    E -->|"download + verify hash"| F["Yarn 4.14.1 ✓"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
