### PR TITLE
feat(spaces): support email member invites

### DIFF
--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.stories.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Box } from '@mui/material'
+import { useForm } from 'react-hook-form'
+import { createMockStory } from '@/stories/mocks'
+import AddMemberInput from './AddMemberInput'
+
+type FormValues = {
+  identifier: string
+}
+
+const addressBook = {
+  '0x1234567890123456789012345678901234567890': 'Alice',
+  '0x2345678901234567890123456789012345678901': 'Bob',
+  '0x3456789012345678901234567890123456789012': 'Charlie',
+}
+
+const defaultSetup = createMockStory({
+  scenario: 'efSafe',
+  wallet: 'owner',
+  features: { spaces: true },
+  shadcn: true,
+  store: {
+    addressBook: {
+      '1': addressBook,
+    },
+  },
+})
+
+const AddMemberInputStory = ({ error }: { error?: string }) => {
+  const { register, setValue, watch } = useForm<FormValues>({
+    defaultValues: { identifier: '' },
+  })
+
+  return (
+    <Box sx={{ width: 360, minHeight: '50vh', pt: '22vh' }}>
+      <AddMemberInput
+        addressBook={addressBook}
+        error={error}
+        inputProps={register('identifier')}
+        onSelectAddress={(address) => setValue('identifier', address)}
+        value={watch('identifier')}
+      />
+    </Box>
+  )
+}
+
+const meta = {
+  title: 'Features/Spaces/AddMemberInput',
+  component: AddMemberInputStory,
+  decorators: [defaultSetup.decorator],
+  parameters: {
+    layout: 'centered',
+    ...defaultSetup.parameters,
+  },
+} satisfies Meta<typeof AddMemberInputStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithError: Story = {
+  args: {
+    error: 'Enter a valid email, wallet address, or ENS.',
+  },
+}

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
@@ -1,0 +1,144 @@
+import {
+  type ChangeEvent,
+  type FocusEvent,
+  type MouseEvent,
+  type ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { createPortal } from 'react-dom'
+import type { UseFormRegisterReturn } from 'react-hook-form'
+import { isAddress } from 'viem'
+import useNameResolver from '@/components/common/AddressInput/useNameResolver'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import { Field, FieldError, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { EMAIL_IDENTIFIER_MAX_LENGTH, isEmailIdentifier } from './utils'
+import css from './styles.module.css'
+
+type AddressBook = Record<string, string>
+
+type AddMemberInputProps = {
+  addressBook: AddressBook
+  error?: string
+  inputProps: UseFormRegisterReturn<'identifier'>
+  onSelectAddress: (address: string, name: string) => void
+  value: string
+}
+
+const MAX_VISIBLE_OPTIONS = 5
+
+/**
+ * Invite-specific identifier input.
+ *
+ * Unlike AddressBookInput/AddressInput, this accepts either an email or a wallet
+ * identifier. Address-book names and ENS names are resolved to addresses before
+ * submit; emails are kept as email identifiers.
+ */
+const AddMemberInput = ({
+  addressBook,
+  error,
+  inputProps,
+  onSelectAddress,
+  value,
+}: AddMemberInputProps): ReactElement => {
+  const [isOpen, setIsOpen] = useState(false)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const identifier = value.trim()
+  const shouldResolveName = Boolean(identifier && !isEmailIdentifier(identifier) && !isAddress(identifier))
+  const { address: resolvedAddress } = useNameResolver(shouldResolveName ? identifier : '')
+
+  useEffect(() => {
+    if (resolvedAddress) {
+      onSelectAddress(resolvedAddress, identifier)
+    }
+  }, [identifier, onSelectAddress, resolvedAddress])
+
+  const options = useMemo(() => {
+    const query = identifier.toLowerCase()
+
+    if (!query || isAddress(query)) {
+      return []
+    }
+
+    return Object.entries(addressBook)
+      .filter(([address, name]) => {
+        return address.toLowerCase().includes(query) || name.toLowerCase().includes(query)
+      })
+      .slice(0, MAX_VISIBLE_OPTIONS)
+      .map(([address, name]) => ({ address, name }))
+  }, [addressBook, identifier])
+
+  const showOptions = isOpen && options.length > 0
+  const inputRect = inputRef.current?.getBoundingClientRect()
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setIsOpen(true)
+    inputProps.onChange(event)
+  }
+
+  const onFocus = () => {
+    setIsOpen(true)
+  }
+
+  const onBlur = (event: FocusEvent<HTMLInputElement>) => {
+    inputProps.onBlur(event)
+    setIsOpen(false)
+  }
+
+  const onOptionMouseDown = (event: MouseEvent<HTMLButtonElement>, address: string, name: string) => {
+    event.preventDefault()
+    onSelectAddress(address, name)
+    setIsOpen(false)
+  }
+
+  return (
+    <Field className={css.identifierField}>
+      <FieldLabel htmlFor="member-identifier-input">Enter email or wallet address</FieldLabel>
+      <Input
+        id="member-identifier-input"
+        data-testid="member-identifier-input"
+        className={css.identifierInput}
+        maxLength={EMAIL_IDENTIFIER_MAX_LENGTH}
+        {...inputProps}
+        ref={(element) => {
+          inputRef.current = element
+          inputProps.ref(element)
+        }}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={onFocus}
+      />
+      {showOptions && inputRect
+        ? createPortal(
+            <div
+              className={css.identifierOptions}
+              style={{
+                left: inputRect.left,
+                top: inputRect.bottom,
+                width: inputRect.width,
+                zIndex: 'var(--z-overlay, 1500)',
+              }}
+            >
+              {options.map((option) => (
+                <button
+                  className={css.identifierOption}
+                  key={option.address}
+                  onMouseDown={(event) => onOptionMouseDown(event, option.address, option.name)}
+                  type="button"
+                >
+                  <EthHashInfo address={option.address} name={option.name} shortAddress={false} copyAddress={false} />
+                </button>
+              ))}
+            </div>,
+            document.body,
+          )
+        : null}
+      <FieldError data-testid="member-identifier-error">{error}</FieldError>
+    </Field>
+  )
+}
+
+export default AddMemberInput

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.stories.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { mswLoader } from 'msw-storybook-addon'
+import AddMemberModal from '.'
+import { createMockStory } from '@/stories/mocks'
+
+const defaultSetup = createMockStory({
+  scenario: 'efSafe',
+  wallet: 'owner',
+  features: { spaces: true },
+  pathname: '/spaces/members',
+  query: { spaceId: '1' },
+  shadcn: true,
+})
+
+const meta = {
+  title: 'Features/Spaces/AddMemberModal',
+  component: AddMemberModal,
+  loaders: [mswLoader],
+  decorators: [defaultSetup.decorator],
+  parameters: {
+    layout: 'centered',
+    ...defaultSetup.parameters,
+  },
+  args: {
+    onClose: () => {},
+  },
+} satisfies Meta<typeof AddMemberModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.test.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.test.tsx
@@ -1,11 +1,14 @@
-import type * as ReactHookForm from 'react-hook-form'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import type { showNotification } from '@/store/notificationsSlice'
 import AddMemberModal from './index'
 
 const mockDispatch = jest.fn()
 const mockInviteMembers = jest.fn()
+const mockUseAuthGetMeV1Query = jest.fn()
+const mockUseUsersGetWithWalletsV1Query = jest.fn()
+const mockUseAddressBook = jest.fn()
 
 jest.mock('@/services/analytics', () => ({
   trackEvent: jest.fn(),
@@ -24,16 +27,29 @@ jest.mock('@/features/spaces', () => ({
   MemberRole: { MEMBER: 'MEMBER', ADMIN: 'ADMIN' },
 }))
 
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/auth', () => ({
+  useAuthGetMeV1Query: () => mockUseAuthGetMeV1Query(),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/users', () => ({
+  useUsersGetWithWalletsV1Query: () => mockUseUsersGetWithWalletsV1Query(),
+}))
+
 jest.mock('next/router', () => ({
   useRouter: () => ({ push: jest.fn(), pathname: '/spaces/members' }),
 }))
 
 jest.mock('@/store', () => ({
   useAppDispatch: () => mockDispatch,
+  useAppSelector: () => true,
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: jest.fn(),
 }))
 
 jest.mock('@/store/notificationsSlice', () => ({
-  showNotification: (payload: unknown) => ({ type: 'notifications/show', payload }),
+  showNotification: (payload: Parameters<typeof showNotification>[0]) => ({ type: 'notifications/show', payload }),
 }))
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
@@ -42,20 +58,12 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
 
 jest.mock('@/hooks/useAddressBook', () => ({
   __esModule: true,
-  default: () => ({}),
+  default: () => mockUseAddressBook(),
 }))
 
 jest.mock('./MemberInfoForm', () => ({
   __esModule: true,
   default: () => null,
-}))
-
-jest.mock('@/components/common/AddressBookInput', () => ({
-  __esModule: true,
-  default: ({ name }: { name: string }) => {
-    const { register } = (jest.requireActual('react-hook-form') as typeof ReactHookForm).useFormContext()
-    return <input {...register(name, { required: true })} data-testid="member-address-input" />
-  },
 }))
 
 jest.mock('@/components/common/ModalDialog', () => ({
@@ -67,9 +75,22 @@ jest.mock('@/config/routes', () => ({
   AppRoutes: { spaces: { members: '/spaces/members' } },
 }))
 
+jest.mock('@/components/common/EthHashInfo', () => ({
+  __esModule: true,
+  default: ({ name, address }: { name?: string; address: string }) => <div>{name ?? address}</div>,
+}))
+
+jest.mock('@/components/common/AddressInput/useNameResolver', () => ({
+  __esModule: true,
+  default: () => ({ address: undefined, resolverError: undefined, resolving: false }),
+}))
+
 describe('AddMemberModal tracking', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseAuthGetMeV1Query.mockReturnValue({ data: undefined })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: undefined })
+    mockUseAddressBook.mockReturnValue({})
   })
 
   it('tracks WORKSPACE_MEMBER_INVITE_SENT with workspace_id, user_id and role on submit', async () => {
@@ -79,7 +100,7 @@ describe('AddMemberModal tracking', () => {
 
     render(<AddMemberModal onClose={jest.fn()} />)
 
-    fireEvent.change(screen.getByTestId('member-address-input'), {
+    fireEvent.change(screen.getByTestId('member-identifier-input'), {
       target: { value: '0x1234567890123456789012345678901234567890' },
     })
 
@@ -93,6 +114,113 @@ describe('AddMemberModal tracking', () => {
         { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: '42' },
         { workspace_id: '42', user_id: 1, role: 'member' },
       )
+    })
+  })
+
+  it('submits email invites with the email field instead of address', async () => {
+    mockInviteMembers.mockResolvedValue({
+      data: [{ userId: 1, spaceId: 42, name: 'invitee@example.com', role: 'MEMBER', status: 'INVITED' }],
+    })
+
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-identifier-input'), {
+      target: { value: 'invitee@example.com' },
+    })
+
+    const submitButton = screen.getByTestId('add-member-modal-button')
+    await waitFor(() => expect(submitButton).not.toBeDisabled())
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [{ type: 'email', email: 'invitee@example.com', role: 'MEMBER', name: '' }],
+        },
+      })
+    })
+  })
+
+  it('limits the identifier input to the CGW email max length', () => {
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    expect(screen.getByTestId('member-identifier-input')).toHaveAttribute('maxLength', '255')
+  })
+
+  it('shows an error for an invalid identifier', async () => {
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-identifier-input'), {
+      target: { value: 'not-a-wallet-or-email' },
+    })
+
+    expect(await screen.findByTestId('member-identifier-error')).toBeInTheDocument()
+    expect(screen.getByTestId('add-member-modal-button')).toBeDisabled()
+  })
+
+  it("blocks inviting the authenticated user's email", async () => {
+    mockUseAuthGetMeV1Query.mockReturnValue({
+      data: { id: '1', authMethod: 'oidc', email: 'alice@example.com' },
+    })
+
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-identifier-input'), {
+      target: { value: 'ALICE@example.com' },
+    })
+
+    expect(await screen.findByTestId('member-identifier-error')).toBeInTheDocument()
+    expect(screen.getByTestId('add-member-modal-button')).toBeDisabled()
+  })
+
+  it("blocks inviting one of the authenticated user's wallets", async () => {
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({
+      currentData: {
+        id: 1,
+        wallets: [{ id: 1, address: '0x1234567890123456789012345678901234567890' }],
+      },
+    })
+
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-identifier-input'), {
+      target: { value: '0x1234567890123456789012345678901234567890' },
+    })
+
+    expect(await screen.findByTestId('member-identifier-error')).toBeInTheDocument()
+    expect(screen.getByTestId('add-member-modal-button')).toBeDisabled()
+  })
+
+  it('fills the address and name from an address book suggestion', async () => {
+    const address = '0x1234567890123456789012345678901234567890'
+    const name = 'Alice'
+
+    mockUseAddressBook.mockReturnValue({ [address]: name })
+    mockInviteMembers.mockResolvedValue({
+      data: [{ userId: 1, spaceId: 42, name, role: 'MEMBER', status: 'INVITED' }],
+    })
+
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-identifier-input'), {
+      target: { value: 'Ali' },
+    })
+    fireEvent.mouseDown(await screen.findByText(name))
+
+    expect(screen.getByTestId('member-identifier-input')).toHaveValue(address)
+
+    const submitButton = screen.getByTestId('add-member-modal-button')
+    await waitFor(() => expect(submitButton).not.toBeDisabled())
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [{ type: 'wallet', address, role: 'MEMBER', name }],
+        },
+      })
     })
   })
 })

--- a/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
@@ -22,7 +22,7 @@ const MemberInfoForm = ({ isEdit = false }: { isEdit?: boolean }) => {
             value={value}
             onChange={onChange}
             required
-            sx={{ minWidth: '150px', py: 0.5 }}
+            className={css.roleSelect}
             renderValue={(role) => <RoleMenuItem role={role as MemberRole} />}
           >
             <MenuItem value={MemberRole.ADMIN} className={css.menuItem}>

--- a/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
@@ -22,17 +22,16 @@ import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
-import { useAppDispatch } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import MemberInfoForm from './MemberInfoForm'
-import AddressBookInput from '@/components/common/AddressBookInput'
 import useAddressBook from '@/hooks/useAddressBook'
-
-type MemberField = {
-  name: string
-  address: string
-  role: MemberRole
-}
+import { isAuthenticated } from '@/store/authSlice'
+import { useAuthGetMeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { isAddress } from 'viem'
+import { type MemberField, buildInviteUserPayload, getIdentifierValidationError } from './utils'
+import AddMemberInput from './AddMemberInput'
 
 export const RoleMenuItem = ({
   role,
@@ -47,7 +46,7 @@ export const RoleMenuItem = ({
 
   return (
     <Box width="100%" alignItems="center" className={css.roleMenuItem}>
-      <Box sx={{ gridArea: 'icon', display: 'flex', alignItems: 'center' }}>
+      <Box className={css.roleIcon}>
         <SvgIcon mr={1} component={isAdmin ? adminIcon : memberIcon} inheritViewBox fontSize="small" />
       </Box>
       <Typography gridArea="title" fontWeight={hasDescription ? 'bold' : undefined}>
@@ -55,15 +54,13 @@ export const RoleMenuItem = ({
       </Typography>
       {hasDescription && (
         <>
-          <Box gridArea="description">
-            <Typography variant="body2" sx={{ maxWidth: '300px', whiteSpace: 'normal', wordWrap: 'break-word' }}>
-              {isAdmin
-                ? 'Admins can create and delete workspaces, invite members, and more.'
-                : 'Can view the workspace data.'}
+          <Box className={css.roleDescription}>
+            <Typography variant="body2">
+              {isAdmin ? 'Admins can create and delete spaces, invite members, and more.' : 'Can view the space data.'}
             </Typography>
           </Box>
-          <Box gridArea="checkIcon" sx={{ visibility: selected ? 'visible' : 'hidden', mx: 1 }}>
-            <CheckIcon fontSize="small" sx={{ color: 'text.primary' }} />
+          <Box className={selected ? css.roleCheckIcon : css.roleCheckIconHidden}>
+            <CheckIcon fontSize="small" className={css.roleCheckSvg} />
           </Box>
         </>
       )}
@@ -79,29 +76,52 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [inviteMembers] = useMembersInviteUserV1Mutation()
   const addressBook = useAddressBook()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { data: session } = useAuthGetMeV1Query(undefined, { skip: !isUserSignedIn })
+  const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
+  const sessionEmail = session && 'email' in session && typeof session.email === 'string' ? session.email : undefined
 
   const methods = useForm<MemberField>({
     mode: 'onChange',
     defaultValues: {
       name: '',
-      address: '',
+      identifier: '',
       role: MemberRole.MEMBER,
     },
   })
 
-  const { handleSubmit, formState, watch, setValue } = methods
+  const { handleSubmit, formState, register, watch, setValue } = methods
 
-  const addressValue = watch('address')
+  const identifierValue = watch('identifier')
+  const identifierInputProps = register('identifier', {
+    validate: (value) => {
+      return (
+        getIdentifierValidationError({
+          identifier: value,
+          sessionEmail,
+          walletAddresses: currentUser?.wallets?.map((wallet) => wallet.address),
+        }) ?? true
+      )
+    },
+  })
 
   useEffect(() => {
-    const addressBookName = addressBook[addressValue]
+    if (!isAddress(identifierValue)) {
+      return
+    }
+
+    const addressBookName = addressBook[identifierValue]
     if (addressBookName) {
       setValue('name', addressBookName)
     }
-  }, [addressBook, addressValue, setValue])
+  }, [addressBook, identifierValue, setValue])
 
   const onSubmit = handleSubmit(async (data) => {
     setError(undefined)
+
+    if (!data.identifier.trim()) {
+      return
+    }
 
     if (!spaceId) {
       setError('Something went wrong. Please try again.')
@@ -112,7 +132,9 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
       setIsSubmitting(true)
       const response = await inviteMembers({
         spaceId: Number(spaceId),
-        inviteUsersDto: { users: [{ address: data.address, role: data.role, name: data.name }] },
+        inviteUsersDto: {
+          users: [buildInviteUserPayload(data)],
+        },
       })
 
       if (response.data) {
@@ -154,21 +176,21 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
     <ModalDialog open onClose={onClose} dialogTitle="Add member" hideChainIndicator>
       <FormProvider {...methods}>
         <form onSubmit={onSubmit}>
-          <DialogContent sx={{ py: 2 }}>
-            <Typography mb={2}>
-              Invite a signer of the Safe Accounts, or any other wallet address. Anyone in the workspace can see their
-              name.
-            </Typography>
+          <DialogContent sx={{ overflow: 'visible', py: 2 }}>
+            <Typography mb={2}>Invite a member by email or wallet address.</Typography>
 
             <Stack spacing={3}>
               <MemberInfoForm />
 
-              <AddressBookInput
-                data-testid="member-address-input"
-                name="address"
-                label="Address"
-                required
-                showPrefix={false}
+              <AddMemberInput
+                addressBook={addressBook}
+                error={formState.errors.identifier?.message}
+                inputProps={identifierInputProps}
+                onSelectAddress={(address, name) => {
+                  setValue('identifier', address, { shouldDirty: true, shouldValidate: true })
+                  setValue('name', name)
+                }}
+                value={identifierValue}
               />
             </Stack>
 
@@ -187,7 +209,7 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
               data-testid="add-member-modal-button"
               type="submit"
               variant="contained"
-              disabled={!formState.isValid || isSubmitting}
+              disabled={!identifierValue.trim() || !formState.isValid || isSubmitting}
               disableElevation
             >
               {isSubmitting ? <CircularProgress size={20} /> : 'Add member'}

--- a/apps/web/src/features/spaces/components/AddMemberModal/styles.module.css
+++ b/apps/web/src/features/spaces/components/AddMemberModal/styles.module.css
@@ -7,10 +7,90 @@
   column-gap: var(--space-1);
 }
 
+.roleIcon {
+  grid-area: icon;
+  display: flex;
+  align-items: center;
+}
+
+.roleDescription {
+  grid-area: description;
+  max-width: 300px;
+  white-space: normal;
+  overflow-wrap: break-word;
+}
+
+.roleCheckIcon {
+  grid-area: checkIcon;
+  margin: 0 var(--space-1);
+}
+
+.roleCheckIconHidden {
+  composes: roleCheckIcon;
+  visibility: hidden;
+}
+
+.roleCheckSvg {
+  color: var(--color-text-primary);
+}
+
+.roleSelect {
+  min-width: 150px;
+  padding-block: 4px;
+  background-color: var(--color-background-main);
+}
+
 .menuItem:hover {
   background-color: var(--color-background-main) !important;
 }
 
 .menuItem:global(.Mui-selected) {
   background-color: var(--color-background-main);
+}
+
+.identifierField {
+  position: relative;
+}
+
+.identifierInput {
+  border-color: var(--color-border-light);
+  background-color: var(--color-background-paper);
+  color: var(--color-text-primary);
+}
+
+.identifierInput::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.identifierInput:focus-visible {
+  border-color: var(--color-border-main);
+}
+
+.identifierOptions {
+  position: fixed;
+  z-index: var(--z-overlay, 1500);
+  margin-top: 4px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  background-color: var(--color-background-paper);
+  color: var(--color-text-primary);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 12%);
+}
+
+.identifierOption {
+  width: 100%;
+  padding: var(--space-1) var(--space-2);
+  appearance: none;
+  border: 0;
+  background-color: var(--color-background-paper);
+  color: var(--color-text-primary);
+  text-align: left;
+  outline: none;
+}
+
+.identifierOption:hover,
+.identifierOption:focus {
+  background-color: var(--color-background-secondary);
+  outline: none;
 }

--- a/apps/web/src/features/spaces/components/AddMemberModal/utils.test.ts
+++ b/apps/web/src/features/spaces/components/AddMemberModal/utils.test.ts
@@ -1,0 +1,92 @@
+import {
+  EMAIL_IDENTIFIER_MAX_LENGTH,
+  buildInviteUserPayload,
+  getIdentifierValidationError,
+  isEmailIdentifier,
+  normalizeIdentifier,
+} from './utils'
+import { MemberRole } from '../../hooks/useSpaceMembers'
+
+describe('AddMemberModal utils', () => {
+  it('normalizes identifiers by trimming whitespace', () => {
+    expect(normalizeIdentifier('  alice@example.com  ')).toBe('alice@example.com')
+  })
+
+  it('detects email identifiers', () => {
+    expect(isEmailIdentifier('alice@example.com')).toBe(true)
+    expect(isEmailIdentifier('0x1234567890123456789012345678901234567890')).toBe(false)
+  })
+
+  it('builds an email invite payload with lowercased email', () => {
+    expect(
+      buildInviteUserPayload({
+        name: 'Alice',
+        identifier: '  ALICE@Example.com ',
+        role: MemberRole.MEMBER,
+      }),
+    ).toEqual({
+      type: 'email',
+      email: 'alice@example.com',
+      name: 'Alice',
+      role: 'MEMBER',
+    })
+  })
+
+  it('builds a wallet invite payload for addresses', () => {
+    expect(
+      buildInviteUserPayload({
+        name: 'Bob',
+        identifier: '0x1234567890123456789012345678901234567890',
+        role: MemberRole.ADMIN,
+      }),
+    ).toEqual({
+      type: 'wallet',
+      address: '0x1234567890123456789012345678901234567890',
+      name: 'Bob',
+      role: 'ADMIN',
+    })
+  })
+
+  it('returns an error for invalid identifiers', () => {
+    expect(getIdentifierValidationError({ identifier: 'not-valid' })).toBeDefined()
+  })
+
+  it('returns no inline error for empty identifiers', () => {
+    expect(getIdentifierValidationError({ identifier: '' })).toBeUndefined()
+  })
+
+  it('returns an error for self email invites', () => {
+    expect(
+      getIdentifierValidationError({
+        identifier: 'Alice@example.com',
+        sessionEmail: 'alice@example.com',
+      }),
+    ).toBeDefined()
+  })
+
+  it('returns an error for self wallet invites', () => {
+    expect(
+      getIdentifierValidationError({
+        identifier: '0x1234567890123456789012345678901234567890',
+        walletAddresses: ['0x1234567890123456789012345678901234567890'],
+      }),
+    ).toBeDefined()
+  })
+
+  it('returns no error for a valid external email invite', () => {
+    expect(
+      getIdentifierValidationError({
+        identifier: 'invitee@example.com',
+        sessionEmail: 'alice@example.com',
+      }),
+    ).toBeUndefined()
+  })
+
+  it('returns an error for emails longer than the CGW limit', () => {
+    const tooLongEmail = `${'a'.repeat(EMAIL_IDENTIFIER_MAX_LENGTH - '@example.com'.length + 1)}@example.com`
+
+    expect(getIdentifierValidationError({ identifier: tooLongEmail })).toBe(
+      `Email must be ${EMAIL_IDENTIFIER_MAX_LENGTH} characters or less.`,
+    )
+  })
+})

--- a/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
+++ b/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
@@ -1,0 +1,83 @@
+import { isAddress, isAddressEqual } from 'viem'
+import type { MemberRole } from '../../hooks/useSpaceMembers'
+
+export type MemberField = {
+  name: string
+  // Can be an address book name, wallet address, or email.
+  identifier: string
+  role: MemberRole
+}
+
+export type InviteIdentifierPayload =
+  | { type: 'email'; email: string; role: MemberRole; name: string }
+  | { type: 'wallet'; address: string; role: MemberRole; name: string }
+
+export const EMAIL_IDENTIFIER_MAX_LENGTH = 255
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export const isEmailIdentifier = (value: string): boolean => EMAIL_REGEX.test(value)
+
+export const normalizeIdentifier = (value: string): string => value.trim()
+
+export const buildInviteUserPayload = (data: MemberField): InviteIdentifierPayload => {
+  const identifier = normalizeIdentifier(data.identifier)
+
+  if (isEmailIdentifier(identifier)) {
+    return {
+      type: 'email',
+      email: identifier.toLowerCase(),
+      role: data.role,
+      name: data.name,
+    }
+  }
+
+  return {
+    type: 'wallet',
+    address: identifier,
+    role: data.role,
+    name: data.name,
+  }
+}
+
+export const getIdentifierValidationError = ({
+  identifier,
+  sessionEmail,
+  walletAddresses,
+}: {
+  identifier: string
+  sessionEmail?: string
+  walletAddresses?: string[]
+}): string | undefined => {
+  const normalizedIdentifier = normalizeIdentifier(identifier)
+
+  if (!normalizedIdentifier) {
+    return undefined
+  }
+
+  const isEmail = isEmailIdentifier(normalizedIdentifier)
+  const isWalletAddress = isAddress(normalizedIdentifier)
+
+  if (isEmail && normalizedIdentifier.length > EMAIL_IDENTIFIER_MAX_LENGTH) {
+    return `Email must be ${EMAIL_IDENTIFIER_MAX_LENGTH} characters or less.`
+  }
+
+  if (!isEmail && !isWalletAddress) {
+    return 'Enter a valid email, wallet address, or ENS.'
+  }
+
+  if (isEmail && sessionEmail && normalizedIdentifier.toLowerCase() === sessionEmail.toLowerCase()) {
+    return "You can't invite yourself."
+  }
+
+  if (
+    isWalletAddress &&
+    walletAddresses?.some((walletAddress) =>
+      isAddressEqual(walletAddress as `0x${string}`, normalizedIdentifier as `0x${string}`),
+    )
+  ) {
+    return "You can't invite yourself."
+  }
+
+  return undefined
+}

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -66,6 +66,19 @@ describe('useInviteForm tracking', () => {
     fireEvent.click(screen.getByTestId('submit'))
 
     await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [
+            {
+              type: 'wallet',
+              address: '0x1234567890123456789012345678901234567890',
+              name: '0x1234567890123456789012345678901234567890',
+              role: 'MEMBER',
+            },
+          ],
+        },
+      })
       expect(trackEvent).toHaveBeenCalledTimes(1)
       expect(trackEvent).toHaveBeenCalledWith(
         { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: '42' },

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -1,7 +1,10 @@
 import { useState } from 'react'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { isAddress } from 'ethers'
-import { useMembersInviteUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import {
+  type WalletInviteUserDto,
+  useMembersInviteUserV1Mutation,
+} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import { trackEvent } from '@/services/analytics'
@@ -55,7 +58,8 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
     setIsSubmitting(true)
 
     try {
-      const usersToInvite = validMembers.map((member) => ({
+      const usersToInvite: WalletInviteUserDto[] = validMembers.map((member) => ({
+        type: 'wallet',
         address: member.address,
         name: member.address,
         role: member.role,

--- a/apps/web/src/features/spaces/components/Members/index.test.tsx
+++ b/apps/web/src/features/spaces/components/Members/index.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+const mockUseIsAdmin = jest.fn()
+const mockUseIsInvited = jest.fn()
+const mockUseSpaceMembersByStatus = jest.fn()
+const mockUseMembersSearch = jest.fn()
+
+const MEMBER_CREATED_AT = '2026-04-24T00:00:00.000Z'
+
+const memberDto = (overrides: Partial<MemberDto>): MemberDto => ({
+  id: 1,
+  role: 'MEMBER',
+  status: 'ACTIVE',
+  name: 'Alice',
+  alias: null,
+  invitedBy: null,
+  createdAt: MEMBER_CREATED_AT,
+  updatedAt: MEMBER_CREATED_AT,
+  user: { id: 11, status: 'ACTIVE', email: null },
+  ...overrides,
+})
+
+jest.mock('@/features/spaces', () => ({
+  useIsAdmin: () => mockUseIsAdmin(),
+  useIsInvited: () => mockUseIsInvited(),
+  useSpaceMembersByStatus: () => mockUseSpaceMembersByStatus(),
+  useMembersSearch: (members: unknown) => mockUseMembersSearch(members),
+}))
+
+jest.mock('../MembersList', () => ({
+  __esModule: true,
+  default: ({ members }: { members: MemberDto[] }) => (
+    <ul data-testid="members-list">
+      {members.map((member) => (
+        <li key={member.id}>{member.name}</li>
+      ))}
+    </ul>
+  ),
+}))
+
+jest.mock('../AddMemberModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('../InviteBanner/PreviewInvite', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('../SearchInput', () => ({
+  __esModule: true,
+  default: ({ onSearch }: { onSearch: (q: string) => void }) => (
+    <input data-testid="search-input" onChange={(event) => onSearch(event.target.value)} />
+  ),
+}))
+
+jest.mock('@/components/common/Track', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@/services/analytics/events/spaces', () => ({
+  SPACE_LABELS: { members_page: 'members_page' },
+  SPACE_EVENTS: { ADD_MEMBER_MODAL: {} },
+}))
+
+import SpaceMembers from './index'
+
+describe('SpaceMembers pending invitations visibility', () => {
+  const activeMember = memberDto({ id: 1, name: 'Active Alice', status: 'ACTIVE' })
+  const invitedMember = memberDto({ id: 2, name: 'Pending Bob', status: 'INVITED' })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseIsInvited.mockReturnValue(false)
+    mockUseSpaceMembersByStatus.mockReturnValue({
+      activeMembers: [activeMember],
+      invitedMembers: [invitedMember],
+    })
+    mockUseMembersSearch.mockImplementation((members: MemberDto[]) => members)
+  })
+
+  it('shows the pending invitations section to admins', () => {
+    mockUseIsAdmin.mockReturnValue(true)
+
+    render(<SpaceMembers />)
+
+    expect(screen.getByText(/Pending invitations \(1\)/)).toBeInTheDocument()
+    expect(screen.getByText('Pending Bob')).toBeInTheDocument()
+  })
+
+  it('hides the pending invitations section from non-admins', () => {
+    mockUseIsAdmin.mockReturnValue(false)
+
+    render(<SpaceMembers />)
+
+    expect(screen.queryByText(/Pending invitations/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Pending Bob')).not.toBeInTheDocument()
+    expect(screen.getByText('Active Alice')).toBeInTheDocument()
+  })
+
+  it('shows the empty-search state for non-admins when only invitations would match', () => {
+    mockUseIsAdmin.mockReturnValue(false)
+    mockUseMembersSearch.mockImplementation((members: MemberDto[]) =>
+      members.filter((member) => member.status === 'INVITED'),
+    )
+
+    render(<SpaceMembers />)
+
+    fireEvent.change(screen.getByTestId('search-input'), { target: { value: 'Bob' } })
+
+    expect(screen.getByText('Found 0 results')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/Members/index.tsx
+++ b/apps/web/src/features/spaces/components/Members/index.tsx
@@ -1,68 +1,78 @@
-import { Button as ShadcnButton } from '@/components/ui/button'
-import { Plus } from 'lucide-react'
-import { Typography } from '@/components/ui/typography'
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import PlusIcon from '@/public/images/common/plus.svg'
+import { Button, Stack, Typography } from '@mui/material'
 import AddMemberModal from 'src/features/spaces/components/AddMemberModal'
 import { useState } from 'react'
 import MembersList from '../MembersList'
-import { useIsInvited, useSpaceMembersByStatus, useIsAdmin } from '@/features/spaces'
+import { useMembersSearch, useIsInvited, useSpaceMembersByStatus, useIsAdmin } from '@/features/spaces'
 import PreviewInvite from '../InviteBanner/PreviewInvite'
 import { SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import SearchInput from '../SearchInput'
 
 const SpaceMembers = () => {
   const [openAddMembersModal, setOpenAddMembersModal] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
   const { activeMembers, invitedMembers } = useSpaceMembersByStatus()
   const isAdmin = useIsAdmin()
   const isInvited = useIsInvited()
 
+  const filteredMembers = useMembersSearch(activeMembers, searchQuery)
+  const filteredInvites = useMembersSearch(invitedMembers, searchQuery)
+
   return (
     <>
       {isInvited && <PreviewInvite />}
-      <div className="mb-6 flex flex-col gap-6">
-        <Typography variant="h2" className="font-bold leading-[1] tracking-tight">
-          Members
-        </Typography>
+      <Typography variant="h1" mb={3}>
+        Members
+      </Typography>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="flex-start"
+        mb={3}
+        flexWrap="nowrap"
+        gap={2}
+        flexDirection={{ xs: 'column-reverse', sm: 'row' }}
+      >
+        <SearchInput onSearch={setSearchQuery} />
         {isAdmin && (
           <Track {...SPACE_EVENTS.ADD_MEMBER_MODAL} label={SPACE_LABELS.members_page}>
-            <ShadcnButton
+            <Button
               data-testid="add-member-button"
-              size="lg"
-              className="px-4 py-0"
+              variant="contained"
+              startIcon={<PlusIcon />}
               onClick={() => setOpenAddMembersModal(true)}
+              sx={{ whiteSpace: 'nowrap' }}
             >
-              <Plus className="size-4 mr-1 text-green-500" />
               Add member
-            </ShadcnButton>
+            </Button>
           </Track>
         )}
-      </div>
-
-      <Tabs defaultValue="members">
-        <TabsList variant="line" className="flex-wrap h-auto mb-4 sm:mb-0">
-          <TabsTrigger value="members" className="cursor-pointer">
-            Members ({activeMembers.length})
-          </TabsTrigger>
-          <TabsTrigger value="pending" className="cursor-pointer">
-            Pending ({invitedMembers.length})
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="members">
-          <MembersList members={activeMembers} />
-        </TabsContent>
-
-        <TabsContent value="pending">
-          {invitedMembers.length === 0 ? (
-            <div className="bg-card rounded-lg border p-4">
-              <p className="text-muted-foreground text-sm">No pending members.</p>
-            </div>
-          ) : (
-            <MembersList members={invitedMembers} />
-          )}
-        </TabsContent>
-      </Tabs>
+      </Stack>
+      <>
+        {searchQuery && !filteredMembers.length && (!isAdmin || !filteredInvites.length) && (
+          <Typography variant="h5" fontWeight="normal" mb={2} color="primary.light">
+            Found 0 results
+          </Typography>
+        )}
+        {isAdmin && filteredInvites.length > 0 && (
+          <>
+            <Typography variant="h5" fontWeight={700} mb={2}>
+              Pending invitations ({filteredInvites.length})
+            </Typography>
+            <MembersList members={filteredInvites} showEmail />
+          </>
+        )}
+        {filteredMembers.length > 0 && (
+          <>
+            <Typography variant="h5" fontWeight={700} mb={2} mt={1}>
+              All members ({filteredMembers.length})
+            </Typography>
+            <MembersList members={filteredMembers} />
+          </>
+        )}
+      </>
 
       {openAddMembersModal && <AddMemberModal onClose={() => setOpenAddMembersModal(false)} />}
     </>

--- a/apps/web/src/features/spaces/components/MembersList/index.test.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.test.tsx
@@ -1,7 +1,32 @@
-import { render, screen, within } from '@/tests/test-utils'
+import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { memberBuilder, memberUserBuilder } from '@/tests/builders/member'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import MembersList from './index'
+
+const MEMBER_CREATED_AT = '2026-04-24T00:00:00.000Z'
+
+const memberDto = ({
+  user,
+  ...overrides
+}: Omit<Partial<MemberDto>, 'user'> & {
+  user?: Partial<MemberDto['user']>
+}): MemberDto => ({
+  id: 1,
+  role: 'MEMBER',
+  status: 'ACTIVE',
+  name: 'Alice',
+  alias: null,
+  invitedBy: null,
+  createdAt: MEMBER_CREATED_AT,
+  updatedAt: MEMBER_CREATED_AT,
+  user: {
+    id: 11,
+    status: 'ACTIVE',
+    email: null,
+    ...user,
+  },
+  ...overrides,
+})
 
 jest.mock('./MemberName', () => ({
   __esModule: true,
@@ -35,35 +60,48 @@ jest.mock('@/features/spaces', () => ({
 }))
 
 describe('MembersList', () => {
-  it('renders member email and leaves empty email cells blank', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows the email column for invitation rows when enabled', () => {
     render(
       <MembersList
+        showEmail
         members={[
-          memberBuilder()
-            .with({
-              name: 'Alice',
-              user: memberUserBuilder().with({ email: 'alice@example.com' }).build(),
-            })
-            .build(),
-          memberBuilder()
-            .with({
-              id: 2,
-              role: 'ADMIN',
-              status: 'INVITED',
-              name: 'Bob',
-              user: memberUserBuilder().with({ id: 12, status: 'PENDING' }).build(),
-            })
-            .build(),
+          memberDto({
+            id: 2,
+            role: 'ADMIN',
+            status: 'DECLINED',
+            name: 'Bob',
+            user: {
+              id: 12,
+              status: 'PENDING',
+              email: 'bob@example.com',
+            },
+          }),
         ]}
       />,
     )
 
     expect(screen.getByText('Email')).toBeInTheDocument()
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument()
+  })
 
-    const emailCells = screen.getAllByTestId('table-cell-email')
+  it('does not show the email column by default', () => {
+    render(
+      <MembersList
+        members={[
+          memberDto({
+            user: {
+              email: 'alice@example.com',
+            },
+          }),
+        ]}
+      />,
+    )
 
-    expect(emailCells).toHaveLength(2)
-    expect(within(emailCells[0]!).getByText('alice@example.com')).toBeInTheDocument()
-    expect(within(emailCells[1]!).queryByText(/@/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Email')).not.toBeInTheDocument()
+    expect(screen.queryByText('alice@example.com')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/MembersList/index.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.tsx
@@ -6,22 +6,24 @@ import EnhancedTable from '@/components/common/EnhancedTable'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import MemberName from './MemberName'
 import RemoveMemberDialog from './RemoveMemberDialog'
+import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { useIsAdmin, isAdmin as checkIsAdmin, isActiveAdmin, MemberStatus, useAdminCount } from '@/features/spaces'
 import EditMemberDialog from './EditMemberDialog'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 
+type MembersListCell = {
+  content: ReactNode
+  rawValue: string | number | null
+  sticky?: boolean
+}
+
 const headCells = [
   {
     id: 'name',
     label: 'Name',
-    width: '40%',
-  },
-  {
-    id: 'email',
-    label: 'Email',
-    width: '30%',
+    width: '70%',
   },
   {
     id: 'role',
@@ -34,6 +36,20 @@ const headCells = [
     width: '15%',
     sticky: true,
   },
+]
+
+const headCellsWithEmail = [
+  {
+    id: 'name',
+    label: 'Name',
+    width: '40%',
+  },
+  {
+    id: 'email',
+    label: 'Email',
+    width: '30%',
+  },
+  ...headCells.slice(1),
 ]
 
 const EditButton = ({ member, disabled }: { member: MemberDto; disabled: boolean }) => {
@@ -93,7 +109,7 @@ export const RemoveMemberButton = ({
   )
 }
 
-const MembersList = ({ members }: { members: MemberDto[] }) => {
+const MembersList = ({ members, showEmail = false }: { members: MemberDto[]; showEmail?: boolean }) => {
   const isAdmin = useIsAdmin()
   const adminCount = useAdminCount(members)
 
@@ -102,58 +118,68 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
     const isInvite = member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED
     const isDeclined = member.status === MemberStatus.DECLINED
     const isDisabled = isAdmin && isLastAdmin && !isInvite
-    const memberEmail = member.user.email
-
-    return {
-      cells: {
-        name: {
-          rawValue: member.name,
-          content: (
-            <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
-              <MemberName member={member} />
-              {isDeclined && (
-                <Chip
-                  label="Declined"
-                  size="small"
-                  sx={{ backgroundColor: 'error.light', color: 'static.main', borderRadius: 0.5 }}
-                />
-              )}
-            </Stack>
-          ),
-        },
-        email: {
-          rawValue: memberEmail,
-          content: memberEmail ? <Typography variant="body2">{memberEmail}</Typography> : null,
-        },
-        role: {
-          rawValue: member.role,
-          content: (
+    const nameCell = {
+      rawValue: member.name,
+      content: (
+        <Stack direction="row" alignItems="center" justifyContent="left" gap={1}>
+          <MemberName member={member} />
+          {isDeclined && (
             <Chip
+              label="Declined"
               size="small"
-              label={checkIsAdmin(member) ? 'Admin' : 'Member'}
-              sx={{ backgroundColor: 'background.lightgrey', borderRadius: 0.5 }}
+              sx={{ backgroundColor: 'error.light', color: 'static.main', borderRadius: 0.5 }}
             />
-          ),
-        },
-        actions: {
-          rawValue: '',
-          sticky: true,
-          content: isAdmin ? (
-            <div className={tableCss.actions}>
-              {!isInvite && <EditButton member={member} disabled={isDisabled} />}
-              <RemoveMemberButton member={member} disabled={isDisabled} isInvite={isInvite} />
-            </div>
-          ) : null,
-        },
-      },
+          )}
+        </Stack>
+      ),
     }
+
+    const roleCell = {
+      rawValue: member.role,
+      content: (
+        <Chip
+          size="small"
+          label={checkIsAdmin(member) ? 'Admin' : 'Member'}
+          sx={{ backgroundColor: 'background.lightgrey', borderRadius: 0.5 }}
+        />
+      ),
+    }
+
+    const actionsCell = {
+      rawValue: '',
+      sticky: true,
+      content: isAdmin ? (
+        <div className={tableCss.actions}>
+          {!isInvite && <EditButton member={member} disabled={isDisabled} />}
+          <RemoveMemberButton member={member} disabled={isDisabled} isInvite={isInvite} />
+        </div>
+      ) : null,
+    }
+
+    const cells: Record<string, MembersListCell> = showEmail
+      ? {
+          name: nameCell,
+          email: {
+            rawValue: member.user.email,
+            content: member.user.email ? <Typography variant="body2">{member.user.email}</Typography> : null,
+          },
+          role: roleCell,
+          actions: actionsCell,
+        }
+      : {
+          name: nameCell,
+          role: roleCell,
+          actions: actionsCell,
+        }
+
+    return { cells }
   })
 
   if (!rows.length) {
     return null
   }
 
-  return <EnhancedTable rows={rows} headCells={headCells} />
+  return <EnhancedTable rows={rows} headCells={showEmail ? headCellsWithEmail : headCells} />
 }
 
 export default MembersList

--- a/packages/store/scripts/api-schema/schema.json
+++ b/packages/store/scripts/api-schema/schema.json
@@ -9179,9 +9179,15 @@
           "safes"
         ]
       },
-      "InviteUserDto": {
+      "WalletInviteUserDto": {
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "wallet"
+            ]
+          },
           "address": {
             "type": "string"
           },
@@ -9199,7 +9205,42 @@
           }
         },
         "required": [
+          "type",
           "address",
+          "name",
+          "role"
+        ]
+      },
+      "EmailInviteUserDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "email"
+            ]
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "maxLength": 255
+          },
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 30
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "email",
           "name",
           "role"
         ]
@@ -9210,7 +9251,14 @@
           "users": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/InviteUserDto"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/WalletInviteUserDto"
+                },
+                {
+                  "$ref": "#/components/schemas/EmailInviteUserDto"
+                }
+              ]
             }
           }
         },

--- a/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
@@ -507,13 +507,20 @@ export type Invitation = {
   status: 'INVITED' | 'ACTIVE' | 'DECLINED'
   invitedBy: number | null
 }
-export type InviteUserDto = {
+export type WalletInviteUserDto = {
+  type: 'wallet'
   address: string
   name: string
   role: 'ADMIN' | 'MEMBER'
 }
+export type EmailInviteUserDto = {
+  type: 'email'
+  email: string
+  name: string
+  role: 'ADMIN' | 'MEMBER'
+}
 export type InviteUsersDto = {
-  users: InviteUserDto[]
+  users: (WalletInviteUserDto | EmailInviteUserDto)[]
 }
 export type AcceptInviteDto = {
   name: string


### PR DESCRIPTION
Resolves: https://linear.app/safe-global/issue/WA-2052/fe-email-invite-flow-and-pending-invitations-ui

## What it solves

Adds the frontend flow for inviting Space members by email, alongside the existing wallet-address invite path.

The CGW API now accepts discriminated invite identifiers (`type: email` / `type: wallet`), so the wallet needs to collect either an email address or wallet address, send the matching payload shape, and show pending email invitations in the members UI.

Depends on the backend API shape from safe-global/safe-client-gateway#3104.

## How this PR fixes it

- Adds `AddMemberInput`, which supports email input, wallet addresses, ENS names, and address-book suggestions in the same invite modal.
- Builds invite payloads as explicit `email` or `wallet` items for the new CGW schema.
- Keeps wallet invite behavior intact, including ENS/name resolution and address-book entry selection.
- Limits the invite identifier input to 255 characters to match the CGW email limit.
- Shows email addresses only in the pending invitations table, while keeping the active members table focused on member names and wallet addresses.
- Updates the onboarding invite form to send wallet invite payloads with the new `type: wallet` shape.
- Updates generated store types and schema fixtures for the discriminated invite-user request.

## How to test it

1. Open a Space and go to the members screen.
2. Invite a member by wallet address or ENS and confirm the wallet invite still works.
3. Invite a member by email and confirm it appears in the pending invitations table with the email column populated.
4. Confirm the active members table does not show an email column.
5. Try a very long email-like value and confirm the input does not exceed 255 characters.

## Affected flows

- Space member invite modal.
- Pending invitations table.
- Active members table.
- Space onboarding invite form.
- Store-generated CGW invite-user request types.

## Blast radius

- **Add member modal**: input parsing, suggestion handling, validation, and payload building.
- **Members list UI**: table-column rendering differs between active members and pending invitations.
- **Invite onboarding**: wallet invites now include `type: wallet`.
- **Store schema/types**: invite-user request payload now mirrors the CGW discriminated union.
- No mobile app changes.

## Risks / not checked

- Did not run browser E2E against a live CGW email-invite endpoint locally.
- Visual behavior was reviewed through component tests/stories, not a full production-like deployment.
- Backend availability is required for the email invite submit path.

## Validation

- `node node_modules/typescript/bin/tsc --noEmit -p apps/web/tsconfig.json`
- `node node_modules/typescript/bin/tsc --noEmit -p packages/store/tsconfig.json`
- `git diff --check`

## Checklist

- [ ] I've tested the branch on mobile 📱 (web-only change)
- [x] I've documented how it affects the analytics (if at all) 📊 (removed no analytics event; no new event added)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
