### PR TITLE
fix(web): exclude Playwright e2e specs from Jest test run

### DIFF
--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -49,8 +49,8 @@ const customJestConfig = {
       statements: 76,
     },
   },
-  // Exclude storybook snapshot tests from main test run - they have their own CI workflow
-  testPathIgnorePatterns: ['/node_modules/', '/.next/', '\\.stories\\.test\\.tsx$'],
+  // Exclude storybook snapshot tests and Playwright e2e specs from main test run - they have their own CI workflows
+  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/e2e/', '\\.stories\\.test\\.tsx$'],
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
> Playwright specs slipped into Jest's net,
> the unit run choked on tests not its own —
> one ignore pattern, and the suite breathes again.

## What it solves

The `Web Unit tests` CI job has been failing on every branch since PR #7952 ("tests: add Playwright e2e framework") merged to `dev`. Jest's default `testMatch` collects the new Playwright `*.spec.ts` files under `apps/web/e2e/`, and Playwright throws when invoked inside Jest ("Playwright Test needs to be invoked via 'yarn playwright test' and excluded from Jest test runs"), failing the whole `yarn test:ci` step.

Resolves: N/A (no Linear issue — CI/test infra fix)

## How this PR fixes it

Adds `'/e2e/'` to `testPathIgnorePatterns` in `apps/web/jest.config.cjs` so Jest no longer collects the Playwright suite. The Playwright runner (`yarn pw:*`) is unaffected — it uses its own `e2e/playwright.config.ts`.

Gotcha: the bug only reproduces with Watchman disabled locally (Watchman crashes `jest --listTests` in some sandboxes), but is always present in CI — which is why it surfaced as a CI-only failure.

## How to test it

1. `cd apps/web`
2. Before the fix: `yarn jest --listTests --watchman=false | grep e2e/tests` lists 3 Playwright specs; running one fails with the Playwright/Jest error.
3. After the fix: the same grep returns nothing, and the collected spec count drops from 607 → 604.
4. `yarn test:ci` no longer fails on the e2e specs.

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — N/A, Jest config change verified via `--listTests`

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).