### PR TITLE
fix(web): Hide checkmark on indeterminate checkbox

### DIFF
--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -39,7 +39,7 @@ function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
     >
       <CheckboxPrimitive.Indicator
         data-slot="checkbox-indicator"
-        className="[&>svg]:size-3.5 grid place-content-center text-current transition-none"
+        className="[&>svg]:size-3.5 grid place-content-center text-current transition-none data-indeterminate:[&>svg]:hidden"
       >
         <CheckIcon />
       </CheckboxPrimitive.Indicator>


### PR DESCRIPTION
> base-ui shows its indicator for checked and mixed alike, so "select all" wore a tick it hadn't earned — one CSS rule, and the half-state goes blank.

Fixes [WA-2387](https://linear.app/safe-global/issue/WA-2387/select-all-checkbox-appears-fully-selected-with-one-account-selected)

## What it solves

Resolves: the "Select all" checkbox rendered a full checkmark in its *indeterminate* state, so selecting one of several accounts made it look like all accounts were selected.

## How this PR fixes it

base-ui renders the `Checkbox.Indicator` for both the `checked` and `indeterminate` states, and we always drew a `CheckIcon`. Added `data-indeterminate:[&>svg]:hidden` so the checkmark is hidden when indeterminate. base-ui doesn't apply `data-checked` styling in that state, so the box correctly reads as empty.

## How to test it

1. Open a Space → Manage accounts → "Add Safe accounts".
2. With ≥2 safes in a section, select exactly one.
3. "Select all" shows `(1/2)` as an **empty box** (previously a checkmark).
4. Select the rest → checkmark; deselect all → empty box.

I navigated to the pages and checked myself
<img width="629" height="630" alt="Screenshot 2026-06-02 at 09 33 17" src="https://github.com/user-attachments/assets/4186d2ea-5a1f-4d6f-ab09-20962782a68e" />
<img width="773" height="679" alt="Screenshot 2026-06-02 at 09 32 13" src="https://github.com/user-attachments/assets/3638808f-0e96-4557-bbd6-baa655ea83c1" />

## Blast radius

- CSS-only change

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only component)
- [x] I've documented how it affects the analytics (if at all) 📊 (none)
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 (CSS-only change)
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
