### PR TITLE
fix(spaces): truncate long member emails in members list

### DIFF
--- a/apps/web/src/components/common/EnhancedTable/index.tsx
+++ b/apps/web/src/components/common/EnhancedTable/index.tsx
@@ -130,12 +130,13 @@ export type EnhancedTableProps = {
   headCells: EnhancedHeadCell[]
   mobileVariant?: boolean
   compact?: boolean
+  fixedLayout?: boolean
   footer?: ReactNode
 }
 
 const pageSizes = [10, 25, 100]
 
-function EnhancedTable({ rows, headCells, mobileVariant, compact, footer }: EnhancedTableProps) {
+function EnhancedTable({ rows, headCells, mobileVariant, compact, fixedLayout, footer }: EnhancedTableProps) {
   const [order, setOrder] = useState<'asc' | 'desc'>('asc')
   const [orderBy, setOrderBy] = useState<string>('')
   const [page, setPage] = useState<number>(0)
@@ -174,7 +175,11 @@ function EnhancedTable({ rows, headCells, mobileVariant, compact, footer }: Enha
       >
         <Table
           aria-labelledby="tableTitle"
-          className={classNames({ [css.mobileColumn]: mobileVariant, [css.compactTable]: compact })}
+          className={classNames({
+            [css.mobileColumn]: mobileVariant,
+            [css.compactTable]: compact,
+            [css.fixedLayout]: fixedLayout,
+          })}
         >
           <EnhancedTableHead headCells={headCells} order={order} orderBy={orderBy} onRequestSort={handleRequestSort} />
           <TableBody className={css.tableBody}>

--- a/apps/web/src/components/common/EnhancedTable/styles.module.css
+++ b/apps/web/src/components/common/EnhancedTable/styles.module.css
@@ -35,6 +35,10 @@
   background: none !important;
 }
 
+.fixedLayout {
+  table-layout: fixed;
+}
+
 .mobileLabel {
   display: none;
 }

--- a/apps/web/src/features/spaces/components/MembersList/index.test.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@/tests/test-utils'
+import { render, renderWithUserEvent, screen, within } from '@/tests/test-utils'
 import type { ReactNode } from 'react'
 import { memberBuilder, memberUserBuilder } from '@/tests/builders/member'
 import MembersList from './index'
@@ -65,5 +65,28 @@ describe('MembersList', () => {
     expect(emailCells).toHaveLength(2)
     expect(within(emailCells[0]!).getByText('alice@example.com')).toBeInTheDocument()
     expect(within(emailCells[1]!).queryByText(/@/)).not.toBeInTheDocument()
+  })
+
+  it('wires up noWrap and a hover tooltip for long member emails', async () => {
+    const longEmail = `${'a'.repeat(64)}@${'b'.repeat(186)}.com`
+
+    const { user } = renderWithUserEvent(
+      <MembersList
+        members={[
+          memberBuilder()
+            .with({
+              name: 'Alice',
+              user: memberUserBuilder().with({ email: longEmail }).build(),
+            })
+            .build(),
+        ]}
+      />,
+    )
+
+    const emailNode = screen.getByText(longEmail)
+    expect(emailNode).toHaveClass('MuiTypography-noWrap')
+
+    await user.hover(emailNode)
+    expect(await screen.findByRole('tooltip', { name: longEmail })).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/MembersList/index.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.tsx
@@ -123,7 +123,13 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
         },
         email: {
           rawValue: memberEmail,
-          content: memberEmail ? <Typography variant="body2">{memberEmail}</Typography> : null,
+          content: memberEmail ? (
+            <Tooltip title={memberEmail} placement="top">
+              <Typography variant="body2" noWrap>
+                {memberEmail}
+              </Typography>
+            </Tooltip>
+          ) : null,
         },
         role: {
           rawValue: member.role,
@@ -153,7 +159,7 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
     return null
   }
 
-  return <EnhancedTable rows={rows} headCells={headCells} />
+  return <EnhancedTable rows={rows} headCells={headCells} fixedLayout />
 }
 
 export default MembersList


### PR DESCRIPTION
> Long emails stretched the table —
> Tooltip on hover, ellipsis with no-wrap,
> Fixed layout keeps the columns true.

## What it solves

Follow-up to #7720 ([WA-2029](https://linear.app/safe-global/issue/WA-2029/fe-email-identity-visibility)).

After the email column was added to the Spaces members list, long email addresses (the schema accepts up to 255 chars) stretch the table beyond its container, pushing the name/role/actions columns off-screen and breaking the page layout.

## How this PR fixes it

- Wraps the email cell in a MUI `Tooltip` + `<Typography noWrap>` so long emails ellipsize while the full address remains accessible on hover.
- Adds an opt-in `fixedLayout` flag to `EnhancedTable` that switches the underlying `<Table>` to `table-layout: fixed`, so the percentage widths declared in `headCells` become real column widths instead of growable hints.
- `MembersList` opts in; no other `EnhancedTable` consumers are touched.

The CSS class lives in `EnhancedTable/styles.module.css`, matching the existing pattern used by `compact` and `mobileVariant`.

## How to test it

1. Open a Space with at least one member whose email is much longer than the column width (a ~200-char email shows the effect clearly).
2. ✅ The email cell shows the start of the address followed by an ellipsis.
3. ✅ The members table fits its container — name, role, and actions columns stay in their lanes.
4. Hover the truncated email.
5. ✅ A tooltip appears showing the full address.
6. Confirm members with no email still show an empty cell, not a stray tooltip.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

