### PR TITLE
feat(web-tanstack): PWA service worker, offline fallback and SRI

### DIFF
--- a/.github/workflows/web-tanstack-checks.yml
+++ b/.github/workflows/web-tanstack-checks.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-team: ${{ vars.TURBO_TEAM }}
+      # chains.json is a build input reused from apps/web. It's produced by
+      # web's postinstall, which the yarn cache skips on a hit, so generate it
+      # explicitly here.
+      - run: yarn workspace @safe-global/web fetch-chains
       - run: yarn workspace @safe-global/web-tanstack build
       # Assert every emitted JS/CSS chunk matches its recorded sha384 integrity
       # (re-hash after build; fails on tamper or gaps).
@@ -52,4 +56,6 @@ jobs:
         with:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-team: ${{ vars.TURBO_TEAM }}
+      # type-check reuses apps/web source that imports chains.json (see build job).
+      - run: yarn workspace @safe-global/web fetch-chains
       - run: node scripts/verify.mjs --changed --workspace=web-tanstack

--- a/.github/workflows/web-tanstack-checks.yml
+++ b/.github/workflows/web-tanstack-checks.yml
@@ -29,11 +29,10 @@ jobs:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-team: ${{ vars.TURBO_TEAM }}
       - run: yarn workspace @safe-global/web-tanstack build
-      # Phase 6C — assert every emitted JS/CSS chunk matches its recorded
-      # sha384 integrity (re-hash after build; fails on tamper or gaps).
+      # Assert every emitted JS/CSS chunk matches its recorded sha384 integrity
+      # (re-hash after build; fails on tamper or gaps).
       - run: yarn workspace @safe-global/web-tanstack assert:sri
-      # Phase 6A — the build must ship our generated worker, not the stale
-      # publicDir copies (R-PUBLICDIR).
+      # The build must ship our generated worker, not the stale publicDir copies.
       - name: Assert service worker output
         working-directory: apps/web-tanstack
         run: |

--- a/.github/workflows/web-tanstack-checks.yml
+++ b/.github/workflows/web-tanstack-checks.yml
@@ -29,6 +29,19 @@ jobs:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-team: ${{ vars.TURBO_TEAM }}
       - run: yarn workspace @safe-global/web-tanstack build
+      # Phase 6C — assert every emitted JS/CSS chunk matches its recorded
+      # sha384 integrity (re-hash after build; fails on tamper or gaps).
+      - run: yarn workspace @safe-global/web-tanstack assert:sri
+      # Phase 6A — the build must ship our generated worker, not the stale
+      # publicDir copies (R-PUBLICDIR).
+      - name: Assert service worker output
+        working-directory: apps/web-tanstack
+        run: |
+          test -f dist/sw.js || { echo "::error::dist/sw.js missing"; exit 1; }
+          grep -q "addToCacheList\|precache" dist/sw.js || { echo "::error::sw.js has no precache manifest"; exit 1; }
+          test ! -e dist/firebase-messaging-sw.js || { echo "::error::stale firebase-messaging-sw.js shipped"; exit 1; }
+          ! ls dist/workbox-*.js >/dev/null 2>&1 || { echo "::error::stale workbox-*.js shipped"; exit 1; }
+          test -f dist/offline.html || { echo "::error::offline.html missing from precache"; exit 1; }
 
   verify-changed:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ todos/*
 /docs/plans/
 /docs/todos/
 /docs/brainstorms/
+/docs/migration/
 
 .codemod
 .serena

--- a/.prettierignore
+++ b/.prettierignore
@@ -31,6 +31,9 @@ apps/web/src/markdown/privacy/privacy.md
 apps/web/src/markdown/terms/terms.md
 apps/web/src/config/__generated__/
 
+# Web (TanStack)
+apps/web-tanstack/dist
+
 # Utils package
 packages/utils/src/types/contracts/**/*
 

--- a/apps/web-tanstack/package.json
+++ b/apps/web-tanstack/package.json
@@ -44,6 +44,7 @@
     "cross-env": "^7.0.3",
     "cypress": "^15.9.0",
     "eslint": "^9.29.0",
+    "prettier": "^3.6.2",
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.2",
     "vite": "^8.0.13",

--- a/apps/web-tanstack/package.json
+++ b/apps/web-tanstack/package.json
@@ -14,7 +14,8 @@
     "eslint": "eslint",
     "prettier": "prettier --check . --config ../../.prettierrc --ignore-path ../../.prettierignore",
     "prettier:fix": "prettier --write . --config ../../.prettierrc --ignore-path ../../.prettierignore",
-    "test": "echo 'no tests in scaffold yet' && exit 0",
+    "test": "node --test \"plugins/**/*.test.ts\"",
+    "assert:sri": "node scripts/assert-sri.mjs dist",
     "verify": "node ../../scripts/verify.mjs --workspace=web-tanstack",
     "verify:changed": "node ../../scripts/verify.mjs --changed --workspace=web-tanstack",
     "cypress:open": "cross-env TZ=UTC cypress open --e2e",
@@ -27,6 +28,7 @@
     "@safe-global/utils": "workspace:*",
     "@safe-global/web": "workspace:*",
     "@tanstack/react-router": "1.159.4",
+    "firebase": "11.1.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-helmet-async": "^3.0.0",
@@ -45,6 +47,13 @@
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.2",
     "vite": "^8.0.13",
-    "vite-plugin-svgr": "^5.2.0"
+    "vite-plugin-pwa": "^1.3.0",
+    "vite-plugin-svgr": "^5.2.0",
+    "workbox-cacheable-response": "^7.3.0",
+    "workbox-core": "^7.3.0",
+    "workbox-expiration": "^7.3.0",
+    "workbox-precaching": "^7.3.0",
+    "workbox-routing": "^7.3.0",
+    "workbox-strategies": "^7.3.0"
   }
 }

--- a/apps/web-tanstack/plugins/vite-plugin-import-map-integrity.test.ts
+++ b/apps/web-tanstack/plugins/vite-plugin-import-map-integrity.test.ts
@@ -8,7 +8,6 @@ const { sri, injectIntegrity } = __test__
 test('sri produces a sha384 base64 hash with the expected prefix', () => {
   const hash = sri('hello')
   assert.match(hash, /^sha384-[A-Za-z0-9+/]+={0,2}$/)
-  // Deterministic for known input.
   assert.equal(sri('hello'), sri('hello'))
   assert.notEqual(sri('hello'), sri('world'))
 })
@@ -30,7 +29,6 @@ test('import map contains only JS entries and precedes module loads', () => {
   assert.deepEqual(map.integrity, { '/assets/a.js': 'sha384-JS' })
   assert.ok(map.integrity['/assets/a.css'] === undefined, 'css excluded from import map')
 
-  // Import map must come before the first module script.
   assert.ok(out.indexOf('type="importmap"') < out.indexOf('type="module"'))
 })
 

--- a/apps/web-tanstack/plugins/vite-plugin-import-map-integrity.test.ts
+++ b/apps/web-tanstack/plugins/vite-plugin-import-map-integrity.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { __test__ } from './vite-plugin-import-map-integrity.ts'
+
+const { sri, injectIntegrity } = __test__
+
+test('sri produces a sha384 base64 hash with the expected prefix', () => {
+  const hash = sri('hello')
+  assert.match(hash, /^sha384-[A-Za-z0-9+/]+={0,2}$/)
+  // Deterministic for known input.
+  assert.equal(sri('hello'), sri('hello'))
+  assert.notEqual(sri('hello'), sri('world'))
+})
+
+test('injectIntegrity adds integrity to matching tags and an import map', () => {
+  const html = '<head></head><body><script type="module" src="/assets/a.js"></script></body>'
+  const out = injectIntegrity(html, { '/assets/a.js': 'sha384-AAA' })
+
+  assert.ok(out.includes('integrity="sha384-AAA"'), 'entry script gets integrity')
+  assert.ok(out.includes('crossorigin="anonymous"'), 'entry script gets crossorigin')
+  assert.ok(out.includes('<script type="importmap">'), 'import map injected')
+})
+
+test('import map contains only JS entries and precedes module loads', () => {
+  const html = '<head></head><body><script type="module" src="/assets/a.js"></script></body>'
+  const out = injectIntegrity(html, { '/assets/a.js': 'sha384-JS', '/assets/a.css': 'sha384-CSS' })
+
+  const map = JSON.parse(out.match(/<script type="importmap">(.*?)<\/script>/s)![1])
+  assert.deepEqual(map.integrity, { '/assets/a.js': 'sha384-JS' })
+  assert.ok(map.integrity['/assets/a.css'] === undefined, 'css excluded from import map')
+
+  // Import map must come before the first module script.
+  assert.ok(out.indexOf('type="importmap"') < out.indexOf('type="module"'))
+})
+
+test('injectIntegrity does not duplicate an existing crossorigin attribute', () => {
+  const html = '<head></head><script type="module" crossorigin src="/assets/a.js"></script>'
+  const out = injectIntegrity(html, { '/assets/a.js': 'sha384-AAA' })
+
+  assert.equal((out.match(/crossorigin/g) ?? []).length, 1)
+  assert.ok(out.includes('integrity="sha384-AAA"'))
+})
+
+test('injectIntegrity leaves untracked references untouched', () => {
+  const html = '<head></head><script src="https://cdn.example.com/x.js"></script>'
+  const out = injectIntegrity(html, { '/assets/a.js': 'sha384-AAA' })
+
+  assert.ok(!out.includes('integrity="sha384-AAA"'), 'external script not hashed')
+})

--- a/apps/web-tanstack/plugins/vite-plugin-import-map-integrity.ts
+++ b/apps/web-tanstack/plugins/vite-plugin-import-map-integrity.ts
@@ -1,0 +1,98 @@
+import { createHash } from 'node:crypto'
+import type { Plugin } from 'vite'
+
+/**
+ * Subresource Integrity for the Vite build (Phase 6C, Decision 3 / D3-a).
+ *
+ * Legacy `apps/web` protected dynamically-loaded chunks by patching the webpack
+ * runtime — a mechanism Vite has no equivalent for, since Vite loads code-split
+ * chunks via native `import()`. The web-platform replacement is **integrity in
+ * import maps** (Chrome 127+, Safari 18+, Firefox 138+), which the browser
+ * engine enforces for static imports, transitive deps, and lazy `import()`.
+ *
+ * This plugin, in a post-order `generateBundle` (so it sees the FINAL bytes of
+ * every chunk, after minification / any compression plugin):
+ *   1. sha384-hashes every emitted `.js` chunk and `.css` asset,
+ *   2. injects a `<script type="importmap">` carrying the JS `integrity` map,
+ *   3. adds `integrity` + `crossorigin` to the static entry `<script>`,
+ *      `modulepreload` `<link>`s, and stylesheet `<link>`s in `index.html`,
+ *   4. emits `sri-manifest.json` as the source of truth for the CI re-hash
+ *      assertion.
+ *
+ * It NEVER rewrites chunk bytes, so sourcemaps (and the Datadog upload) stay
+ * intact.
+ */
+const sri = (content: string | Uint8Array): string => `sha384-${createHash('sha384').update(content).digest('base64')}`
+
+const injectIntegrity = (html: string, integrity: Record<string, string>): string => {
+  // Add integrity (+ crossorigin) to every <script>/<link> whose src/href is a
+  // hashed asset. Module scripts and modulepreload links are always fetched in
+  // CORS mode, so SRI is enforced even same-origin.
+  let out = html.replace(/<(?:script|link)\b[^>]*>/g, (tag) => {
+    const ref = tag.match(/\b(?:src|href)="([^"]+)"/)
+    const hash = ref && integrity[ref[1]]
+    if (!hash) {
+      return tag
+    }
+    let next = tag
+    if (!/\bintegrity=/.test(next)) {
+      next = next.replace(/\s*\/?>$/, (end) => ` integrity="${hash}"${end}`)
+    }
+    if (!/\bcrossorigin/.test(next)) {
+      next = next.replace(/\s*\/?>$/, (end) => ` crossorigin="anonymous"${end}`)
+    }
+    return next
+  })
+
+  // The import map must precede the first module load, so inject it as the very
+  // first <head> child. Only JS modules belong in the integrity map.
+  const jsIntegrity = Object.fromEntries(Object.entries(integrity).filter(([url]) => url.endsWith('.js')))
+  const importMap = `<script type="importmap">${JSON.stringify({ imports: {}, integrity: jsIntegrity })}</script>`
+  out = out.replace(/<head>/, `<head>${importMap}`)
+
+  return out
+}
+
+export function importMapIntegrity(): Plugin {
+  let base = '/'
+
+  return {
+    name: 'web-tanstack-import-map-integrity',
+    apply: 'build',
+    configResolved(config) {
+      base = config.base || '/'
+    },
+    generateBundle: {
+      // Run after any plugin that mutates chunk bytes (compression, etc.).
+      order: 'post',
+      handler(_options, bundle) {
+        const prefix = base.endsWith('/') ? base : `${base}/`
+        const toUrl = (fileName: string) => `${prefix}${fileName}`
+
+        const integrity: Record<string, string> = {}
+        for (const file of Object.values(bundle)) {
+          if (file.type === 'chunk' && file.fileName.endsWith('.js')) {
+            integrity[toUrl(file.fileName)] = sri(file.code)
+          } else if (file.type === 'asset' && file.fileName.endsWith('.css')) {
+            const source = typeof file.source === 'string' ? file.source : Buffer.from(file.source)
+            integrity[toUrl(file.fileName)] = sri(source)
+          }
+        }
+
+        this.emitFile({
+          type: 'asset',
+          fileName: 'sri-manifest.json',
+          source: JSON.stringify({ integrity }, null, 2),
+        })
+
+        const indexHtml = bundle['index.html']
+        if (indexHtml && indexHtml.type === 'asset' && typeof indexHtml.source === 'string') {
+          indexHtml.source = injectIntegrity(indexHtml.source, integrity)
+        }
+      },
+    },
+  }
+}
+
+// Exported for unit tests.
+export const __test__ = { sri, injectIntegrity }

--- a/apps/web-tanstack/plugins/vite-plugin-import-map-integrity.ts
+++ b/apps/web-tanstack/plugins/vite-plugin-import-map-integrity.ts
@@ -1,33 +1,13 @@
 import { createHash } from 'node:crypto'
 import type { Plugin } from 'vite'
 
-/**
- * Subresource Integrity for the Vite build (Phase 6C, Decision 3 / D3-a).
- *
- * Legacy `apps/web` protected dynamically-loaded chunks by patching the webpack
- * runtime — a mechanism Vite has no equivalent for, since Vite loads code-split
- * chunks via native `import()`. The web-platform replacement is **integrity in
- * import maps** (Chrome 127+, Safari 18+, Firefox 138+), which the browser
- * engine enforces for static imports, transitive deps, and lazy `import()`.
- *
- * This plugin, in a post-order `generateBundle` (so it sees the FINAL bytes of
- * every chunk, after minification / any compression plugin):
- *   1. sha384-hashes every emitted `.js` chunk and `.css` asset,
- *   2. injects a `<script type="importmap">` carrying the JS `integrity` map,
- *   3. adds `integrity` + `crossorigin` to the static entry `<script>`,
- *      `modulepreload` `<link>`s, and stylesheet `<link>`s in `index.html`,
- *   4. emits `sri-manifest.json` as the source of truth for the CI re-hash
- *      assertion.
- *
- * It NEVER rewrites chunk bytes, so sourcemaps (and the Datadog upload) stay
- * intact.
- */
+// Native SRI for the Vite build: integrity hashes live in an import map, which
+// the browser enforces for static imports AND lazy `import()` chunks (a tag
+// `integrity` attribute can't cover dynamic imports). Hashes are computed from
+// final chunk bytes without rewriting them, so sourcemaps stay intact.
 const sri = (content: string | Uint8Array): string => `sha384-${createHash('sha384').update(content).digest('base64')}`
 
 const injectIntegrity = (html: string, integrity: Record<string, string>): string => {
-  // Add integrity (+ crossorigin) to every <script>/<link> whose src/href is a
-  // hashed asset. Module scripts and modulepreload links are always fetched in
-  // CORS mode, so SRI is enforced even same-origin.
   let out = html.replace(/<(?:script|link)\b[^>]*>/g, (tag) => {
     const ref = tag.match(/\b(?:src|href)="([^"]+)"/)
     const hash = ref && integrity[ref[1]]
@@ -44,8 +24,7 @@ const injectIntegrity = (html: string, integrity: Record<string, string>): strin
     return next
   })
 
-  // The import map must precede the first module load, so inject it as the very
-  // first <head> child. Only JS modules belong in the integrity map.
+  // The import map must precede the first module load, so it goes first in <head>.
   const jsIntegrity = Object.fromEntries(Object.entries(integrity).filter(([url]) => url.endsWith('.js')))
   const importMap = `<script type="importmap">${JSON.stringify({ imports: {}, integrity: jsIntegrity })}</script>`
   out = out.replace(/<head>/, `<head>${importMap}`)
@@ -63,7 +42,7 @@ export function importMapIntegrity(): Plugin {
       base = config.base || '/'
     },
     generateBundle: {
-      // Run after any plugin that mutates chunk bytes (compression, etc.).
+      // 'post' so hashes reflect bytes after any chunk-mutating plugin (e.g. compression).
       order: 'post',
       handler(_options, bundle) {
         const prefix = base.endsWith('/') ? base : `${base}/`
@@ -94,5 +73,4 @@ export function importMapIntegrity(): Plugin {
   }
 }
 
-// Exported for unit tests.
 export const __test__ = { sri, injectIntegrity }

--- a/apps/web-tanstack/plugins/vite-plugin-sw-assets.ts
+++ b/apps/web-tanstack/plugins/vite-plugin-sw-assets.ts
@@ -2,24 +2,10 @@ import { readFileSync, existsSync, readdirSync, rmSync } from 'node:fs'
 import path from 'node:path'
 import type { Plugin } from 'vite'
 
-/**
- * Two build-time concerns for the single Vite service worker, kept together
- * because they both bracket the vite-plugin-pwa lifecycle:
- *
- * 1. Emit `offline.html` into the bundle. `publicDir` points at the legacy
- *    `apps/web/public`, and Vite supports only one public dir, so the offline
- *    shell is emitted from source instead of copied. Emitting in
- *    `generateBundle` guarantees it is on disk before vite-plugin-pwa computes
- *    its precache manifest in `closeBundle`.
- *
- * 2. Remove stale service-worker artifacts that `publicDir` copies verbatim
- *    from `apps/web/public` (R-PUBLICDIR): the tracked 0-byte
- *    `firebase-messaging-sw.js` stub and any leftover `workbox-*.js` from a
- *    local `apps/web` build. In injectManifest mode the Workbox runtime is
- *    bundled into `sw.js`, so a separate `workbox-*.js` is always stale. This
- *    runs in `closeBundle`; the plugin must be ordered AFTER `VitePWA` so the
- *    generated `sw.js` already exists.
- */
+// `publicDir` points at the legacy apps/web/public and Vite allows only one, so
+// the offline shell is emitted from source rather than copied, and stale service
+// workers that apps/web/public carries (the 0-byte firebase-messaging-sw.js stub,
+// leftover workbox-*.js from a local apps/web build) are deleted from the output.
 export function swAssets(offlineHtmlPath: string): Plugin {
   let outDir = 'dist'
 
@@ -47,14 +33,10 @@ export function swAssets(offlineHtmlPath: string): Plugin {
         }
       }
 
-      // The single worker is `sw.js`; the FCM logic is merged into it. The
-      // legacy `firebase-messaging-sw.js` must never ship (it would shadow our
-      // worker / trigger the dual-SW reload loop).
       remove('firebase-messaging-sw.js')
       remove('firebase-messaging-sw.js.map')
 
-      // injectManifest bundles Workbox into `sw.js`; any `workbox-*.js` in the
-      // output is a stale copy from `apps/web/public`.
+      // injectManifest bundles Workbox into sw.js, so any workbox-*.js is stale.
       if (existsSync(outDir)) {
         for (const entry of readdirSync(outDir)) {
           if (/^workbox-.*\.js(\.map)?$/.test(entry)) {

--- a/apps/web-tanstack/plugins/vite-plugin-sw-assets.ts
+++ b/apps/web-tanstack/plugins/vite-plugin-sw-assets.ts
@@ -1,0 +1,71 @@
+import { readFileSync, existsSync, readdirSync, rmSync } from 'node:fs'
+import path from 'node:path'
+import type { Plugin } from 'vite'
+
+/**
+ * Two build-time concerns for the single Vite service worker, kept together
+ * because they both bracket the vite-plugin-pwa lifecycle:
+ *
+ * 1. Emit `offline.html` into the bundle. `publicDir` points at the legacy
+ *    `apps/web/public`, and Vite supports only one public dir, so the offline
+ *    shell is emitted from source instead of copied. Emitting in
+ *    `generateBundle` guarantees it is on disk before vite-plugin-pwa computes
+ *    its precache manifest in `closeBundle`.
+ *
+ * 2. Remove stale service-worker artifacts that `publicDir` copies verbatim
+ *    from `apps/web/public` (R-PUBLICDIR): the tracked 0-byte
+ *    `firebase-messaging-sw.js` stub and any leftover `workbox-*.js` from a
+ *    local `apps/web` build. In injectManifest mode the Workbox runtime is
+ *    bundled into `sw.js`, so a separate `workbox-*.js` is always stale. This
+ *    runs in `closeBundle`; the plugin must be ordered AFTER `VitePWA` so the
+ *    generated `sw.js` already exists.
+ */
+export function swAssets(offlineHtmlPath: string): Plugin {
+  let outDir = 'dist'
+
+  return {
+    name: 'web-tanstack-sw-assets',
+    apply: 'build',
+    configResolved(config) {
+      outDir = config.build.outDir
+    },
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'offline.html',
+        source: readFileSync(offlineHtmlPath, 'utf-8'),
+      })
+    },
+    closeBundle() {
+      const removed: string[] = []
+
+      const remove = (fileName: string) => {
+        const target = path.join(outDir, fileName)
+        if (existsSync(target)) {
+          rmSync(target, { force: true })
+          removed.push(fileName)
+        }
+      }
+
+      // The single worker is `sw.js`; the FCM logic is merged into it. The
+      // legacy `firebase-messaging-sw.js` must never ship (it would shadow our
+      // worker / trigger the dual-SW reload loop).
+      remove('firebase-messaging-sw.js')
+      remove('firebase-messaging-sw.js.map')
+
+      // injectManifest bundles Workbox into `sw.js`; any `workbox-*.js` in the
+      // output is a stale copy from `apps/web/public`.
+      if (existsSync(outDir)) {
+        for (const entry of readdirSync(outDir)) {
+          if (/^workbox-.*\.js(\.map)?$/.test(entry)) {
+            remove(entry)
+          }
+        }
+      }
+
+      if (removed.length > 0) {
+        this.info(`Removed stale service-worker artifacts: ${removed.join(', ')}`)
+      }
+    },
+  }
+}

--- a/apps/web-tanstack/scripts/assert-sri.mjs
+++ b/apps/web-tanstack/scripts/assert-sri.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Phase 6C SRI assertion (mirrors the legacy intent of integrity-hashes.cjs).
+//
+// After `vite build`, re-hash every emitted JS/CSS asset and assert it matches
+// the integrity recorded in `dist/sri-manifest.json` AND the `<script
+// type="importmap">` embedded in `dist/index.html`. Also assert no JS chunk is
+// left uncovered. Exits non-zero (failing the build) on any mismatch or gap.
+
+import { createHash } from 'node:crypto'
+import { readFileSync, existsSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+
+const distDir = path.resolve(process.argv[2] ?? 'dist')
+const manifestPath = path.join(distDir, 'sri-manifest.json')
+const indexPath = path.join(distDir, 'index.html')
+
+const fail = (message) => {
+  console.error(`[SRI] ${message}`)
+  process.exit(1)
+}
+
+if (!existsSync(manifestPath)) fail(`Missing ${manifestPath}. Did the import-map-integrity plugin run?`)
+if (!existsSync(indexPath)) fail(`Missing ${indexPath}.`)
+
+const sri = (buf) => `sha384-${createHash('sha384').update(buf).digest('base64')}`
+
+const { integrity } = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+const entries = Object.entries(integrity)
+if (entries.length === 0) fail('sri-manifest.json has no integrity entries.')
+
+// 1. Re-hash every file referenced by the manifest and assert it matches.
+let checked = 0
+for (const [url, expected] of entries) {
+  const filePath = path.join(distDir, url.replace(/^\//, ''))
+  if (!existsSync(filePath)) fail(`Manifest references missing file: ${url}`)
+  const actual = sri(readFileSync(filePath))
+  if (actual !== expected) fail(`Integrity mismatch for ${url}\n  expected ${expected}\n  actual   ${actual}`)
+  checked++
+}
+
+// 2. Assert no JS chunk in dist/assets is left uncovered (no silent gaps).
+const assetsDir = path.join(distDir, 'assets')
+if (existsSync(assetsDir)) {
+  const uncovered = readdirSync(assetsDir)
+    .filter((f) => f.endsWith('.js'))
+    .map((f) => `/assets/${f}`)
+    .filter((url) => !(url in integrity))
+  if (uncovered.length > 0) fail(`JS chunks missing from SRI manifest:\n  ${uncovered.join('\n  ')}`)
+}
+
+// 3. Assert the embedded import map agrees with the manifest (JS entries).
+const html = readFileSync(indexPath, 'utf-8')
+const importMapMatch = html.match(/<script type="importmap">(.*?)<\/script>/s)
+if (!importMapMatch) fail('No <script type="importmap"> found in index.html.')
+const importMap = JSON.parse(importMapMatch[1])
+for (const [url, expected] of entries) {
+  if (!url.endsWith('.js')) continue
+  if (importMap.integrity?.[url] !== expected) {
+    fail(`Import map integrity for ${url} disagrees with sri-manifest.json.`)
+  }
+}
+
+console.log(`[SRI] OK — ${checked} assets verified, import map consistent.`)

--- a/apps/web-tanstack/scripts/assert-sri.mjs
+++ b/apps/web-tanstack/scripts/assert-sri.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Phase 6C SRI assertion (mirrors the legacy intent of integrity-hashes.cjs).
+// SRI assertion (mirrors the legacy intent of integrity-hashes.cjs).
 //
 // After `vite build`, re-hash every emitted JS/CSS asset and assert it matches
 // the integrity recorded in `dist/sri-manifest.json` AND the `<script

--- a/apps/web-tanstack/src/compat/next-image.tsx
+++ b/apps/web-tanstack/src/compat/next-image.tsx
@@ -5,7 +5,15 @@
  */
 import type { ImgHTMLAttributes } from 'react'
 
-export type ImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'placeholder'> & {
+// next/image re-exports this for callers that type their own image props.
+export type StaticImageData = {
+  src: string
+  height: number
+  width: number
+  blurDataURL?: string
+}
+
+export type ImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, 'placeholder' | 'src' | 'width' | 'height'> & {
   src: string | { src: string; width?: number; height?: number }
   width?: number | string
   height?: number | string

--- a/apps/web-tanstack/src/compat/next-image.tsx
+++ b/apps/web-tanstack/src/compat/next-image.tsx
@@ -1,7 +1,6 @@
 /**
- * Compatibility shim for `next/image`.
- * Decision: 9 call-sites total. Plain <img> with the same src/width/height/alt
- * surface, since apps/web already sets `images.unoptimized: true`.
+ * Compatibility shim for `next/image`: a plain <img> with the same
+ * src/width/height/alt surface, since apps/web sets `images.unoptimized: true`.
  */
 import type { ImgHTMLAttributes } from 'react'
 

--- a/apps/web-tanstack/src/compat/next-link.tsx
+++ b/apps/web-tanstack/src/compat/next-link.tsx
@@ -1,12 +1,10 @@
 /**
- * Compatibility shim for `next/link`.
- * See decisions.md (2026-05-22) — temporary cutover scaffolding.
- *
- * Wraps `<a>` with TanStack Router's history-aware navigation. The `passHref`,
- * `legacyBehavior`, `prefetch`, `scroll`, and `shallow` props are accepted
- * and ignored — apps/web/src/pages/403.tsx and a handful of others rely on
- * `passHref legacyBehavior`, which is preserved here by always forwarding
- * `href` to the child anchor (or the cloned child when `legacyBehavior` is set).
+ * Compatibility shim for `next/link`, wrapping `<a>` with TanStack Router's
+ * history-aware navigation. The `passHref`, `legacyBehavior`, `prefetch`,
+ * `scroll`, and `shallow` props are accepted and ignored — apps/web/src/pages/
+ * 403.tsx and a handful of others rely on `passHref legacyBehavior`, which is
+ * preserved here by always forwarding `href` to the child anchor (or the cloned
+ * child when `legacyBehavior` is set).
  */
 import { forwardRef, cloneElement, isValidElement } from 'react'
 import type { AnchorHTMLAttributes, MouseEvent, ReactElement, ReactNode } from 'react'

--- a/apps/web-tanstack/src/compat/next-link.tsx
+++ b/apps/web-tanstack/src/compat/next-link.tsx
@@ -10,11 +10,12 @@
  */
 import { forwardRef, cloneElement, isValidElement } from 'react'
 import type { AnchorHTMLAttributes, MouseEvent, ReactElement, ReactNode } from 'react'
+import type { UrlObject } from 'url'
 import { useNavigate } from '@tanstack/react-router'
 
 export type LinkProps = {
-  href: string | { pathname?: string; query?: Record<string, string | string[] | undefined>; hash?: string }
-  as?: string
+  href: string | UrlObject
+  as?: string | UrlObject
   replace?: boolean
   scroll?: boolean
   shallow?: boolean
@@ -28,13 +29,18 @@ export type LinkProps = {
 function hrefToString(href: LinkProps['href']): string {
   if (typeof href === 'string') return href
   const pathname = href.pathname ?? '/'
-  const params = new URLSearchParams()
-  for (const [k, v] of Object.entries(href.query ?? {})) {
-    if (v == null) continue
-    if (Array.isArray(v)) v.forEach((vv) => params.append(k, String(vv)))
-    else params.append(k, String(v))
+  let qs = ''
+  if (typeof href.query === 'string') {
+    qs = href.query
+  } else if (href.query) {
+    const params = new URLSearchParams()
+    for (const [k, v] of Object.entries(href.query)) {
+      if (v == null) continue
+      if (Array.isArray(v)) v.forEach((vv) => params.append(k, String(vv)))
+      else params.append(k, String(v))
+    }
+    qs = params.toString()
   }
-  const qs = params.toString()
   const hash = href.hash ? `#${href.hash.replace(/^#/, '')}` : ''
   return `${pathname}${qs ? `?${qs}` : ''}${hash}`
 }

--- a/apps/web-tanstack/src/compat/next-resolve-href.ts
+++ b/apps/web-tanstack/src/compat/next-resolve-href.ts
@@ -1,0 +1,38 @@
+/**
+ * Compatibility shim for `next/dist/client/resolve-href`.
+ *
+ * Reused web code (SafeAppCard, useShareSafeAppUrl) calls
+ * `resolveHref(router, urlObject)` to serialise a UrlObject to a string href.
+ * Next's real signature wants a full `NextRouter`; our `next/router` shim
+ * exposes the narrower `NextRouterLike`. The router argument only carries
+ * basePath/locale, which this SPA target doesn't use, so we ignore it and
+ * serialise the href directly.
+ */
+import type { UrlObject } from 'url'
+import type { NextRouterLike } from './next-router'
+
+type Url = string | UrlObject
+
+function toHref(url: Url): string {
+  if (typeof url === 'string') return url
+  const pathname = url.pathname ?? '/'
+  let qs = ''
+  if (typeof url.query === 'string') {
+    qs = url.query
+  } else if (url.query) {
+    const params = new URLSearchParams()
+    for (const [k, v] of Object.entries(url.query)) {
+      if (v == null) continue
+      if (Array.isArray(v)) v.forEach((vv) => params.append(k, String(vv)))
+      else params.append(k, String(v))
+    }
+    qs = params.toString()
+  }
+  const hash = url.hash ? `#${url.hash.replace(/^#/, '')}` : ''
+  return `${pathname}${qs ? `?${qs}` : ''}${hash}`
+}
+
+// Reused call-sites only use the 2-arg `resolveHref(router, href): string` form.
+export function resolveHref(_router: NextRouterLike, href: Url): string {
+  return toHref(href)
+}

--- a/apps/web-tanstack/src/compat/next-router.tsx
+++ b/apps/web-tanstack/src/compat/next-router.tsx
@@ -1,13 +1,7 @@
 /**
- * Compatibility shim for `next/router`.
- *
- * Decided in docs/migration/state/decisions.md (2026-05-22): cross-workspace
- * Next.js imports inside reused apps/web/src/** code are routed to these
- * shims via Vite aliases so we don't have to rewrite 175 call-sites up front.
- *
- * This delegates to TanStack Router primitives. Phase 3 migrators are expected
- * to gradually replace `useRouter()` with native TanStack hooks; until then
- * this gives a working router-shaped object.
+ * Compatibility shim for `next/router`, delegating to TanStack Router. Reused
+ * apps/web/src code imports `next/router`; a Vite alias routes those imports
+ * here so they keep working against a router-shaped object.
  */
 import { useMemo } from 'react'
 import type { UrlObject } from 'url'

--- a/apps/web-tanstack/src/compat/next-router.tsx
+++ b/apps/web-tanstack/src/compat/next-router.tsx
@@ -10,20 +10,32 @@
  * this gives a working router-shaped object.
  */
 import { useMemo } from 'react'
+import type { UrlObject } from 'url'
 import { useNavigate, useRouter as useTanStackRouter, useRouterState } from '@tanstack/react-router'
 
-type Url = string | { pathname?: string; query?: Record<string, string | string[] | undefined>; hash?: string }
+// Mirror next's own `Url` type (string | node's UrlObject) so reused web code
+// that passes a full UrlObject (host, hostname, numeric query values, ...) or
+// next's imported `Url` type type-checks unchanged.
+type Url = string | UrlObject
+
+// next router push/replace/prefetch accept (url, as?, options?).
+type TransitionOptions = { shallow?: boolean; locale?: string | false; scroll?: boolean }
 
 function toHref(url: Url): string {
   if (typeof url === 'string') return url
   const pathname = url.pathname ?? '/'
-  const params = new URLSearchParams()
-  for (const [k, v] of Object.entries(url.query ?? {})) {
-    if (v == null) continue
-    if (Array.isArray(v)) v.forEach((vv) => params.append(k, String(vv)))
-    else params.append(k, String(v))
+  let qs = ''
+  if (typeof url.query === 'string') {
+    qs = url.query
+  } else if (url.query) {
+    const params = new URLSearchParams()
+    for (const [k, v] of Object.entries(url.query)) {
+      if (v == null) continue
+      if (Array.isArray(v)) v.forEach((vv) => params.append(k, String(vv)))
+      else params.append(k, String(v))
+    }
+    qs = params.toString()
   }
-  const qs = params.toString()
   const hash = url.hash ? `#${url.hash.replace(/^#/, '')}` : ''
   return `${pathname}${qs ? `?${qs}` : ''}${hash}`
 }
@@ -51,12 +63,12 @@ export interface NextRouterLike {
   isFallback: boolean
   isPreview: boolean
   query: Record<string, string | string[]>
-  push: (url: Url) => Promise<boolean>
-  replace: (url: Url) => Promise<boolean>
+  push: (url: Url, as?: Url, options?: TransitionOptions) => Promise<boolean>
+  replace: (url: Url, as?: Url, options?: TransitionOptions) => Promise<boolean>
   back: () => void
   forward: () => void
   reload: () => void
-  prefetch: (url: Url) => Promise<void>
+  prefetch: (url: Url, as?: Url, options?: TransitionOptions) => Promise<void>
   beforePopState: (cb: () => boolean) => void
   events: {
     on: (event: string, handler: (...args: unknown[]) => void) => void
@@ -128,11 +140,17 @@ export function withRouter<P extends object>(
   }
 }
 
+// next's default export is the imperatively-usable singleton router. Reused
+// web code reads `router.pathname` off it outside React, so back it with the
+// live location.
 const router = {
   useRouter,
   withRouter,
-  push: async (_url: Url) => true,
-  replace: async (_url: Url) => true,
+  get pathname() {
+    return typeof window !== 'undefined' ? window.location.pathname : '/'
+  },
+  push: async (_url: Url, _as?: Url, _options?: TransitionOptions) => true,
+  replace: async (_url: Url, _as?: Url, _options?: TransitionOptions) => true,
   events: noopEvents,
 }
 

--- a/apps/web-tanstack/src/components/PwaReloadPrompt.tsx
+++ b/apps/web-tanstack/src/components/PwaReloadPrompt.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from 'react'
+import { useRegisterSW } from 'virtual:pwa-register/react'
+
+import { useAppDispatch } from '@/store'
+import { showNotification } from '@/store/notificationsSlice'
+
+/**
+ * Surfaces a non-blocking "new version available" toast when the service
+ * worker has a waiting update (Decision 2 / D2-a). A wallet must never reload
+ * mid-transaction, so the user controls the reload.
+ *
+ * `useRegisterSW` performs the single SW registration — `injectRegister` is
+ * `false` in the VitePWA config so there is no competing auto-injected script.
+ */
+const PwaReloadPrompt = (): null => {
+  const dispatch = useAppDispatch()
+  const {
+    needRefresh: [needRefresh],
+    updateServiceWorker,
+  } = useRegisterSW()
+
+  useEffect(() => {
+    if (!needRefresh) {
+      return
+    }
+
+    dispatch(
+      showNotification({
+        message: 'A new version of Safe is available.',
+        variant: 'info',
+        groupKey: 'pwa-update',
+        link: {
+          onClick: () => updateServiceWorker(true),
+          title: 'Reload',
+        },
+      }),
+    )
+  }, [needRefresh, dispatch, updateServiceWorker])
+
+  return null
+}
+
+export default PwaReloadPrompt

--- a/apps/web-tanstack/src/components/PwaReloadPrompt.tsx
+++ b/apps/web-tanstack/src/components/PwaReloadPrompt.tsx
@@ -29,6 +29,9 @@ const PwaReloadPrompt = (): null => {
         message: 'A new version of Safe is available.',
         variant: 'info',
         groupKey: 'pwa-update',
+        // Persist until the user acts — a wallet update prompt must not vanish
+        // on the default 5s auto-hide.
+        autoHideDuration: null,
         link: {
           onClick: () => updateServiceWorker(true),
           title: 'Reload',

--- a/apps/web-tanstack/src/components/PwaReloadPrompt.tsx
+++ b/apps/web-tanstack/src/components/PwaReloadPrompt.tsx
@@ -4,14 +4,9 @@ import { useRegisterSW } from 'virtual:pwa-register/react'
 import { useAppDispatch } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 
-/**
- * Surfaces a non-blocking "new version available" toast when the service
- * worker has a waiting update (Decision 2 / D2-a). A wallet must never reload
- * mid-transaction, so the user controls the reload.
- *
- * `useRegisterSW` performs the single SW registration — `injectRegister` is
- * `false` in the VitePWA config so there is no competing auto-injected script.
- */
+// A wallet must never reload mid-transaction, so an SW update only surfaces a
+// toast and the user triggers the reload. useRegisterSW is the single SW
+// registration (injectRegister is false in the VitePWA config).
 const PwaReloadPrompt = (): null => {
   const dispatch = useAppDispatch()
   const {
@@ -29,8 +24,7 @@ const PwaReloadPrompt = (): null => {
         message: 'A new version of Safe is available.',
         variant: 'info',
         groupKey: 'pwa-update',
-        // Persist until the user acts — a wallet update prompt must not vanish
-        // on the default 5s auto-hide.
+        // Must not vanish on the default 5s auto-hide — the user has to act on it.
         autoHideDuration: null,
         link: {
           onClick: () => updateServiceWorker(true),

--- a/apps/web-tanstack/src/routes/__root.tsx
+++ b/apps/web-tanstack/src/routes/__root.tsx
@@ -19,6 +19,7 @@ import { makeStore, setStoreInstance, useHydrateStore, useInitStaticChains } fro
 import createEmotionCache from '@/utils/createEmotionCache'
 import MetaTags from '@/components/common/MetaTags'
 import PageLayout from '@/components/common/PageLayout'
+import PwaReloadPrompt from '../components/PwaReloadPrompt'
 import Notifications from '@/components/common/Notifications'
 import CookieAndTermBanner from '@/components/common/CookieAndTermBanner'
 import { CaptchaProvider } from '@/components/common/Captcha'
@@ -161,6 +162,7 @@ function RootShell() {
             <CssBaseline />
             <CaptchaProvider>
               <InitApp />
+              <PwaReloadPrompt />
               <Suspense fallback={null}>
                 <LazyWeb3Init />
               </Suspense>

--- a/apps/web-tanstack/src/service-worker/offline.html
+++ b/apps/web-tanstack/src/service-worker/offline.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <link rel="icon" type="image/svg+xml" href="/favicons/favicon.svg" />
+    <title>Safe – Offline</title>
+    <!--
+      Kept deliberately JS-free and self-contained so it renders even when the
+      main bundle is uncached. Precached by the service worker and served on a
+      failed cold navigation (Workbox setCatchHandler → matchPrecache).
+    -->
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        padding: 24px;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        text-align: center;
+        background: #f4f4f4;
+        color: #121312;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #121312;
+          color: #ffffff;
+        }
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin: 0;
+      }
+      p {
+        max-width: 32rem;
+        margin: 0;
+        opacity: 0.8;
+        line-height: 1.5;
+      }
+      img {
+        width: 64px;
+        height: 64px;
+      }
+    </style>
+  </head>
+  <body>
+    <img src="/images/safe-logo-green.png" alt="Safe" />
+    <h1>You're offline</h1>
+    <p>
+      Safe needs an internet connection to load your accounts and transactions. Check your connection and try again.
+    </p>
+  </body>
+</html>

--- a/apps/web-tanstack/src/service-worker/sw.ts
+++ b/apps/web-tanstack/src/service-worker/sw.ts
@@ -1,12 +1,6 @@
-// Single Vite-built service worker for apps/web-tanstack.
-//
-// Phase 6A: Workbox precaching + runtime CacheFirst + offline fallback.
-// Phase 6B: Firebase Cloud Messaging background push (restores regression
-//           #7568 — the legacy worker was deleted as mis-flagged dead code).
-//
-// This is a SINGLE worker on purpose: registering a second
-// `firebase-messaging-sw.js` triggers the documented vite-plugin-pwa #777
-// reload loop and scope conflicts.
+// One worker handles both Workbox precaching/offline and Firebase Cloud
+// Messaging on purpose: a separate firebase-messaging-sw.js would race this
+// worker (vite-plugin-pwa #777) and fight over scope.
 //
 // Be careful what you import here — every import inflates the worker bundle.
 
@@ -29,7 +23,7 @@ import {
 import { cacheServiceWorkerPushNotificationTrackingEvent } from '@/services/push-notifications/tracking'
 
 declare const self: ServiceWorkerGlobalScope & {
-  // Injected by vite-plugin-pwa (injectManifest mode) at build time.
+  // Injected by vite-plugin-pwa at build time.
   __WB_MANIFEST: Array<{ url: string; revision: string | null } | string>
 }
 // Inlined by vite.config.ts `define`.
@@ -38,35 +32,28 @@ declare const __APP_VERSION__: string
 const OFFLINE_URL = 'offline.html'
 const SAFE_LOGO_ICON = '/images/safe-logo-green.png'
 
-// ---------------------------------------------------------------------------
-// Phase 6A — precaching, routing, offline fallback
-// ---------------------------------------------------------------------------
-
-// Precache the app shell. `self.__WB_MANIFEST` is the required injection point
-// for injectManifest mode.
+// self.__WB_MANIFEST is the injection point vite-plugin-pwa requires.
 precacheAndRoute(self.__WB_MANIFEST)
 cleanupOutdatedCaches()
 
-// SPA navigation fallback: serve the precached `index.html` shell for app
-// routes. The denylist keeps worker/asset URLs from being answered with HTML.
+// Serve the precached index.html shell for SPA routes; the denylist keeps
+// worker/asset URLs from being answered with HTML.
 const navigationRoute = new NavigationRoute(createHandlerBoundToURL('index.html'), {
   denylist: [
     /^\/sw\.js$/,
     /^\/workbox-/,
     /^\/firebase-messaging-sw\.js$/,
     /^\/manifest/,
-    // Anything that looks like a file (has an extension) is an asset, not a route.
+    // any path with a file extension is an asset, not a route
     /\/[^/?]+\.[^/]+$/,
   ],
 })
 registerRoute(navigationRoute)
 
-// CacheFirst for static assets — parity with legacy next-pwa runtimeCaching
-// (1 year / 1000 entries). Cache name is versioned so a new release starts a
-// fresh cache and `cleanupOutdatedCaches()` reclaims the old ones.
 registerRoute(
   ({ request }) => ['image', 'font', 'style', 'script'].includes(request.destination),
   new CacheFirst({
+    // Versioned so a new release starts a fresh cache; cleanupOutdatedCaches reclaims the old ones.
     cacheName: `static-${__APP_VERSION__}`,
     plugins: [
       new CacheableResponsePlugin({ statuses: [0, 200] }),
@@ -79,8 +66,6 @@ registerRoute(
   }),
 )
 
-// Cold offline navigation → precached, JS-free offline shell. Replicates the
-// legacy next-pwa `fallbacks.document` behaviour.
 setCatchHandler(async ({ request }) => {
   if (request.destination === 'document') {
     const offline = await matchPrecache(OFFLINE_URL)
@@ -91,22 +76,16 @@ setCatchHandler(async ({ request }) => {
   return Response.error()
 })
 
-// Let the page activate a waiting worker (D2-a: user-controlled reload prompt).
 self.addEventListener('message', (event) => {
   if (event.data?.type === 'SKIP_WAITING') {
     self.skipWaiting()
   }
 })
 
-// ---------------------------------------------------------------------------
-// Phase 6B — Firebase Cloud Messaging background push (restores #7568)
-// ---------------------------------------------------------------------------
-
 type NotificationData = MessagePayload['data'] & { link: string }
 
-// Registered synchronously (before any async FCM init) so it is attached the
-// moment the worker evaluates — Firebase also attaches a `notificationclick`
-// handler internally, and ours must run first.
+// Registered synchronously so it attaches before Firebase's own
+// notificationclick handler — ours must run first.
 self.addEventListener('notificationclick', (event) => {
   event.notification.close()
   const data = event.notification.data as NotificationData | undefined
@@ -155,5 +134,5 @@ void isSupported()
     })
   })
   .catch(() => {
-    // FCM unsupported in this browser — precaching and offline still work.
+    // FCM unsupported here — precaching/offline still work.
   })

--- a/apps/web-tanstack/src/service-worker/sw.ts
+++ b/apps/web-tanstack/src/service-worker/sw.ts
@@ -1,0 +1,159 @@
+// Single Vite-built service worker for apps/web-tanstack.
+//
+// Phase 6A: Workbox precaching + runtime CacheFirst + offline fallback.
+// Phase 6B: Firebase Cloud Messaging background push (restores regression
+//           #7568 — the legacy worker was deleted as mis-flagged dead code).
+//
+// This is a SINGLE worker on purpose: registering a second
+// `firebase-messaging-sw.js` triggers the documented vite-plugin-pwa #777
+// reload loop and scope conflicts.
+//
+// Be careful what you import here — every import inflates the worker bundle.
+
+/// <reference lib="webworker" />
+
+import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL, matchPrecache } from 'workbox-precaching'
+import { NavigationRoute, registerRoute, setCatchHandler } from 'workbox-routing'
+import { CacheFirst } from 'workbox-strategies'
+import { ExpirationPlugin } from 'workbox-expiration'
+import { CacheableResponsePlugin } from 'workbox-cacheable-response'
+
+import { getMessaging, isSupported, onBackgroundMessage } from 'firebase/messaging/sw'
+import type { MessagePayload } from 'firebase/messaging/sw'
+
+import { initializeFirebaseApp } from '@/services/push-notifications/firebase'
+import {
+  shouldShowServiceWorkerPushNotification,
+  parseServiceWorkerPushNotification,
+} from '@/service-workers/firebase-messaging/notifications'
+import { cacheServiceWorkerPushNotificationTrackingEvent } from '@/services/push-notifications/tracking'
+
+declare const self: ServiceWorkerGlobalScope & {
+  // Injected by vite-plugin-pwa (injectManifest mode) at build time.
+  __WB_MANIFEST: Array<{ url: string; revision: string | null } | string>
+}
+// Inlined by vite.config.ts `define`.
+declare const __APP_VERSION__: string
+
+const OFFLINE_URL = 'offline.html'
+const SAFE_LOGO_ICON = '/images/safe-logo-green.png'
+
+// ---------------------------------------------------------------------------
+// Phase 6A — precaching, routing, offline fallback
+// ---------------------------------------------------------------------------
+
+// Precache the app shell. `self.__WB_MANIFEST` is the required injection point
+// for injectManifest mode.
+precacheAndRoute(self.__WB_MANIFEST)
+cleanupOutdatedCaches()
+
+// SPA navigation fallback: serve the precached `index.html` shell for app
+// routes. The denylist keeps worker/asset URLs from being answered with HTML.
+const navigationRoute = new NavigationRoute(createHandlerBoundToURL('index.html'), {
+  denylist: [
+    /^\/sw\.js$/,
+    /^\/workbox-/,
+    /^\/firebase-messaging-sw\.js$/,
+    /^\/manifest/,
+    // Anything that looks like a file (has an extension) is an asset, not a route.
+    /\/[^/?]+\.[^/]+$/,
+  ],
+})
+registerRoute(navigationRoute)
+
+// CacheFirst for static assets — parity with legacy next-pwa runtimeCaching
+// (1 year / 1000 entries). Cache name is versioned so a new release starts a
+// fresh cache and `cleanupOutdatedCaches()` reclaims the old ones.
+registerRoute(
+  ({ request }) => ['image', 'font', 'style', 'script'].includes(request.destination),
+  new CacheFirst({
+    cacheName: `static-${__APP_VERSION__}`,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({
+        maxEntries: 1000,
+        maxAgeSeconds: 60 * 60 * 24 * 365,
+        purgeOnQuotaError: true,
+      }),
+    ],
+  }),
+)
+
+// Cold offline navigation → precached, JS-free offline shell. Replicates the
+// legacy next-pwa `fallbacks.document` behaviour.
+setCatchHandler(async ({ request }) => {
+  if (request.destination === 'document') {
+    const offline = await matchPrecache(OFFLINE_URL)
+    if (offline) {
+      return offline
+    }
+  }
+  return Response.error()
+})
+
+// Let the page activate a waiting worker (D2-a: user-controlled reload prompt).
+self.addEventListener('message', (event) => {
+  if (event.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Phase 6B — Firebase Cloud Messaging background push (restores #7568)
+// ---------------------------------------------------------------------------
+
+type NotificationData = MessagePayload['data'] & { link: string }
+
+// Registered synchronously (before any async FCM init) so it is attached the
+// moment the worker evaluates — Firebase also attaches a `notificationclick`
+// handler internally, and ours must run first.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const data = event.notification.data as NotificationData | undefined
+  if (!data?.link) {
+    return
+  }
+  cacheServiceWorkerPushNotificationTrackingEvent('opened', data)
+  event.waitUntil(self.clients.openWindow(data.link))
+})
+
+void isSupported()
+  .then((supported) => {
+    if (!supported) {
+      return
+    }
+
+    const app = initializeFirebaseApp()
+    if (!app) {
+      return
+    }
+
+    const messaging = getMessaging(app)
+
+    onBackgroundMessage(messaging, async (payload) => {
+      if (!(await shouldShowServiceWorkerPushNotification(payload))) {
+        return
+      }
+
+      const notification = await parseServiceWorkerPushNotification(payload)
+      if (!notification) {
+        return
+      }
+
+      const data: NotificationData = {
+        ...payload.data,
+        link: notification.link ?? self.location.origin,
+      }
+
+      cacheServiceWorkerPushNotificationTrackingEvent('shown', data)
+
+      await self.registration.showNotification(notification.title || '', {
+        icon: SAFE_LOGO_ICON,
+        body: notification.body,
+        data,
+      })
+    })
+  })
+  .catch(() => {
+    // FCM unsupported in this browser — precaching and offline still work.
+  })

--- a/apps/web-tanstack/src/svg.d.ts
+++ b/apps/web-tanstack/src/svg.d.ts
@@ -1,0 +1,23 @@
+/// <reference types="react" />
+
+// vite-plugin-svgr is configured (include: '**/*.svg') so a bare
+// `import Icon from './x.svg'` resolves to a React component, not a URL string.
+// vite/client declares `*.svg` as a string; for merged ambient wildcard
+// modules the conflicting default export resolves to the first-processed file,
+// so this declaration must be processed before vite/client is referenced.
+// It lives in its own file named to sort before `vite-env.d.ts` (which holds
+// the `/// <reference types="vite/client" />`). If this ever stops winning,
+// `tsc` fails loudly with hundreds of svg errors — it cannot fail silently.
+//
+// This file must stay a *script* (no top-level import/export): ambient
+// wildcard module declarations only win the merge from script files, hence the
+// global `React` namespace (via `export as namespace React`) instead of an
+// import. The index signature mirrors @svgr/webpack's permissive runtime:
+// these components spread arbitrary props onto the underlying <svg>, and
+// reused web code passes extras (alt, width, sx, fontSize, ...).
+declare module '*.svg' {
+  const ReactComponent: React.FC<
+    React.SVGProps<SVGSVGElement> & { title?: string; titleId?: string; [key: string]: unknown }
+  >
+  export default ReactComponent
+}

--- a/apps/web-tanstack/src/vite-env.d.ts
+++ b/apps/web-tanstack/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/apps/web-tanstack/src/vite-env.d.ts
+++ b/apps/web-tanstack/src/vite-env.d.ts
@@ -1,3 +1,21 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/react" />
 /// <reference types="vite-plugin-pwa/client" />
+/// <reference types="react" />
+
+// This file must stay a *script* (no top-level import/export) so the ambient
+// module declarations below stay global; `React` comes from the global
+// namespace (`export as namespace React`) rather than an import.
+
+declare module 'remark-heading-id'
+
+// @mdx-js/rollup compiles `*.md`/`*.mdx` imports to a React component (default
+// export). Used by the terms/cookie/privacy pages.
+declare module '*.md' {
+  const MDXComponent: React.FC<Record<string, unknown>>
+  export default MDXComponent
+}
+declare module '*.mdx' {
+  const MDXComponent: React.FC<Record<string, unknown>>
+  export default MDXComponent
+}

--- a/apps/web-tanstack/tsconfig.json
+++ b/apps/web-tanstack/tsconfig.json
@@ -19,10 +19,17 @@
     "paths": {
       "@/*": ["../web/src/*"],
       "@/public/*": ["../web/public/*"],
+      "@/storybook/*": ["../web/.storybook/*"],
+      "src/*": ["../web/src/*"],
       "@safe-global/theme/*": ["../../packages/theme/src/*"],
       "@safe-global/store/*": ["../../packages/store/src/*"],
       "@safe-global/utils/*": ["../../packages/utils/src/*"],
       "@safe-global/test/*": ["../../config/test/*"],
+      "@safe-global/safe-apps-sdk/dist/types/types/permissions": [
+        "../../node_modules/@safe-global/safe-apps-sdk/dist/types/types/permissions"
+      ],
+      "@gnosis.pm/zodiac/dist/cjs/types/Delay": ["../../node_modules/@gnosis.pm/zodiac/dist/cjs/types/Delay"],
+      "next/dist/client/resolve-href": ["./src/compat/next-resolve-href.ts"],
       "next/router": ["./src/compat/next-router.tsx"],
       "next/link": ["./src/compat/next-link.tsx"],
       "next/head": ["./src/compat/next-head.tsx"],

--- a/apps/web-tanstack/vite.config.ts
+++ b/apps/web-tanstack/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, loadEnv } from 'vite'
+import { VitePWA } from 'vite-plugin-pwa'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import svgr from 'vite-plugin-svgr'
@@ -10,6 +11,8 @@ import remarkGfm from 'remark-gfm'
 import path from 'node:path'
 import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
+import { swAssets } from './plugins/vite-plugin-sw-assets'
+import { importMapIntegrity } from './plugins/vite-plugin-import-map-integrity'
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname)
 const webRoot = path.resolve(__dirname, '../web')
@@ -226,6 +229,40 @@ export default defineConfig(({ mode }) => {
           return null
         },
       },
+      // Phase 6A/6B — single Vite service worker (Workbox precache + offline
+      // fallback + Firebase Cloud Messaging) via injectManifest. The worker is
+      // bundled by Vite, so the `define` block above (process.env, __APP_VERSION__)
+      // and the `@/` resolve aliases apply to it.
+      VitePWA({
+        strategies: 'injectManifest',
+        srcDir: 'src/service-worker',
+        filename: 'sw.ts',
+        registerType: 'prompt',
+        // PwaReloadPrompt's useRegisterSW performs the single registration; no
+        // competing auto-injected script.
+        injectRegister: false,
+        // Reuse the existing safe.webmanifest (linked via MetaTags); don't let
+        // the plugin generate/inject its own manifest.
+        manifest: false,
+        injectManifest: {
+          globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
+          // Never precache the stale publicDir artifacts (R-PUBLICDIR), the
+          // generated worker itself, or sourcemaps.
+          globIgnores: ['firebase-messaging-sw.js', 'workbox-*.js', 'sw.js', '**/*.map'],
+          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+        },
+        devOptions: {
+          enabled: true,
+          type: 'module',
+          navigateFallback: 'index.html',
+        },
+      }),
+      // Emit the JS-free offline shell into the bundle and strip stale SW
+      // artifacts copied from apps/web/public. Ordered AFTER VitePWA so its
+      // cleanup (closeBundle) runs after sw.js is generated.
+      swAssets(path.resolve(__dirname, 'src/service-worker/offline.html')),
+      // Phase 6C — Subresource Integrity via native import-map integrity.
+      importMapIntegrity(),
     ],
   }
 })

--- a/apps/web-tanstack/vite.config.ts
+++ b/apps/web-tanstack/vite.config.ts
@@ -41,6 +41,9 @@ export default defineConfig(({ mode }) => {
   // like dev, gather every NEXT_PUBLIC_* / VITE_* value at build time and
   // inline them as a literal `process.env` object via `define`.
   const loadedEnv = loadEnv(mode, process.cwd(), ['VITE_', 'NEXT_PUBLIC_', 'EXPO_PUBLIC_'])
+  // `NODE_ENV` is typed as a narrow union, but the host shell can set it to
+  // 'cypress' (see comment below). Read it as a plain string so that check holds.
+  const hostNodeEnv = process.env.NODE_ENV as string
   const processEnv = {
     ...loadedEnv,
     // Build-time constants that override / supplement what loadEnv saw.
@@ -52,8 +55,8 @@ export default defineConfig(({ mode }) => {
     // `IS_TEST_E2E` in apps/web/src/config/constants.ts (and the require-login
     // gate it gates) without needing a separate NEXT_PUBLIC_IS_TEST_E2E flag.
     NODE_ENV:
-      process.env.NODE_ENV === 'cypress' || process.env.NODE_ENV === 'test'
-        ? process.env.NODE_ENV
+      hostNodeEnv === 'cypress' || hostNodeEnv === 'test'
+        ? hostNodeEnv
         : mode === 'production'
           ? 'production'
           : 'development',
@@ -122,6 +125,10 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: [
         // Next.js compatibility shims (decisions.md: cross-workspace next/* shimming)
+        {
+          find: 'next/dist/client/resolve-href',
+          replacement: path.resolve(__dirname, 'src/compat/next-resolve-href.ts'),
+        },
         { find: 'next/router', replacement: path.resolve(__dirname, 'src/compat/next-router.tsx') },
         { find: 'next/link', replacement: path.resolve(__dirname, 'src/compat/next-link.tsx') },
         { find: 'next/head', replacement: path.resolve(__dirname, 'src/compat/next-head.tsx') },

--- a/apps/web-tanstack/vite.config.ts
+++ b/apps/web-tanstack/vite.config.ts
@@ -229,10 +229,8 @@ export default defineConfig(({ mode }) => {
           return null
         },
       },
-      // Phase 6A/6B — single Vite service worker (Workbox precache + offline
-      // fallback + Firebase Cloud Messaging) via injectManifest. The worker is
-      // bundled by Vite, so the `define` block above (process.env, __APP_VERSION__)
-      // and the `@/` resolve aliases apply to it.
+      // The worker is bundled by Vite, so the `define` block above (process.env,
+      // __APP_VERSION__) and the `@/` resolve aliases apply to it.
       VitePWA({
         strategies: 'injectManifest',
         srcDir: 'src/service-worker',
@@ -246,8 +244,7 @@ export default defineConfig(({ mode }) => {
         manifest: false,
         injectManifest: {
           globPatterns: ['**/*.{js,css,html,svg,png,ico,webp,woff2}'],
-          // Never precache the stale publicDir artifacts (R-PUBLICDIR), the
-          // generated worker itself, or sourcemaps.
+          // Exclude the stale publicDir service workers, the generated worker, and sourcemaps.
           globIgnores: ['firebase-messaging-sw.js', 'workbox-*.js', 'sw.js', '**/*.map'],
           maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
         },
@@ -257,11 +254,8 @@ export default defineConfig(({ mode }) => {
           navigateFallback: 'index.html',
         },
       }),
-      // Emit the JS-free offline shell into the bundle and strip stale SW
-      // artifacts copied from apps/web/public. Ordered AFTER VitePWA so its
-      // cleanup (closeBundle) runs after sw.js is generated.
+      // Ordered after VitePWA so its cleanup runs once sw.js is generated.
       swAssets(path.resolve(__dirname, 'src/service-worker/offline.html')),
-      // Phase 6C — Subresource Integrity via native import-map integrity.
       importMapIntegrity(),
     ],
   }

--- a/apps/web/knip.json
+++ b/apps/web/knip.json
@@ -10,6 +10,8 @@
     "src/components/common/Mui/index.tsx",
     "src/services/contracts/ContractErrorCodes.ts",
     "src/service-workers/firebase-messaging/webhook-types.ts",
+    "src/service-workers/firebase-messaging/notifications.ts",
+    "src/services/push-notifications/tracking.ts",
     "src/features/counterfactual/contract.ts",
     "src/features/ledger/types.ts",
     "src/features/multichain/types.ts",

--- a/apps/web/src/components/common/Notifications/index.tsx
+++ b/apps/web/src/components/common/Notifications/index.tsx
@@ -72,6 +72,7 @@ const Toast = ({
   onClose,
   id,
   icon = false,
+  autoHideDuration: autoHideDurationOverride,
 }: {
   variant: AlertColor
   onClose: () => void
@@ -89,7 +90,12 @@ const Toast = ({
     onClose()
   }
 
-  const autoHideDuration = variant === 'info' || variant === 'success' ? 5000 : undefined
+  const autoHideDuration =
+    autoHideDurationOverride !== undefined
+      ? (autoHideDurationOverride ?? undefined)
+      : variant === 'info' || variant === 'success'
+        ? 5000
+        : undefined
 
   return (
     <Snackbar open onClose={handleClose} sx={toastStyle} autoHideDuration={autoHideDuration}>

--- a/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
+++ b/apps/web/src/components/tx-flow/flows/ConfirmTx/index.tsx
@@ -23,7 +23,7 @@ const ConfirmTxFlow = ({ txSummary }: { txSummary: Transaction }) => {
 
   return (
     <TxFlow
-      icon={isSwapOrder && SwapIcon}
+      icon={isSwapOrder ? SwapIcon : undefined}
       subtitle={<>{text}&nbsp;</>}
       txId={txId}
       isExecutable={canExecute}

--- a/apps/web/src/features/swap/components/SwapOrderConfirmationView/__snapshots__/index.stories.test.tsx.snap
+++ b/apps/web/src/features/swap/components/SwapOrderConfirmationView/__snapshots__/index.stories.test.tsx.snap
@@ -506,7 +506,7 @@ exports[`./index.stories CustomRecipient 1`] = `
           <div
             class="MuiAlert-icon mui-style-vab54s-MuiAlert-icon"
           >
-            mock-icon
+            <mock-icon />
           </div>
           <div
             class="MuiAlert-message mui-style-zioonp-MuiAlert-message"

--- a/apps/web/src/features/swap/components/SwapOrderConfirmationView/index.tsx
+++ b/apps/web/src/features/swap/components/SwapOrderConfirmationView/index.tsx
@@ -115,7 +115,7 @@ const SwapOrderConfirmation = ({ order, decodedData, settlementContract }: SwapO
                 <EthHashInfo address={receiver} hasExplorer={true} avatarSize={24} />
               </DataRow>
               <div key="recipient">
-                <Alert data-testid="recipient-alert" severity="warning" icon={AlertIcon}>
+                <Alert data-testid="recipient-alert" severity="warning" icon={<AlertIcon />}>
                   <Typography variant="body2">
                     <Typography component="span" sx={{ fontWeight: 'bold' }}>
                       Order recipient address differs from order owner.

--- a/apps/web/src/service-workers/firebase-messaging/notifications.ts
+++ b/apps/web/src/service-workers/firebase-messaging/notifications.ts
@@ -61,7 +61,6 @@ export const _parseServiceWorkerWebhookPushNotification = async (
   }
 }
 
-// Restored for the web-tanstack Vite service worker (see #7568).
 export const shouldShowServiceWorkerPushNotification = async (payload: MessagePayload): Promise<boolean> => {
   if (!isWebhookEvent(payload.data)) {
     return true
@@ -84,7 +83,6 @@ export const shouldShowServiceWorkerPushNotification = async (payload: MessagePa
   return preferencesStore.preferences[type]
 }
 
-// Restored for the web-tanstack Vite service worker (see #7568).
 export const parseServiceWorkerPushNotification = async (
   payload: MessagePayload,
 ): Promise<({ title?: string; link?: string } & NotificationOptions) | undefined> => {

--- a/apps/web/src/service-workers/firebase-messaging/notifications.ts
+++ b/apps/web/src/service-workers/firebase-messaging/notifications.ts
@@ -1,9 +1,18 @@
 // Be careful what you import here as it will increase the service worker bundle size
 
+import { get as getFromIndexedDb } from 'idb-keyval'
+import type { MessagePayload } from 'firebase/messaging'
+
 import { AppRoutes } from '@/config/routes' // Has no internal imports
 import { FIREBASE_IS_PRODUCTION } from '@/services/push-notifications/firebase'
+import {
+  getPushNotificationPrefsKey,
+  createPushNotificationPrefsIndexedDb,
+} from '@/services/push-notifications/preferences'
+import type { PushNotificationPreferences, PushNotificationPrefsKey } from '@/services/push-notifications/preferences'
 import { Notifications } from './notification-mapper'
 import { getChainsConfig, setBaseUrl } from './gateway-utils'
+import { isWebhookEvent } from './webhook-types'
 import type { WebhookEvent } from './webhook-types'
 
 const GATEWAY_URL_PRODUCTION = process.env.NEXT_PUBLIC_GATEWAY_URL_PRODUCTION || 'https://safe-client.safe.global'
@@ -50,4 +59,40 @@ export const _parseServiceWorkerWebhookPushNotification = async (
       link: getLink(data, chain?.shortName),
     }
   }
+}
+
+// Restored for the web-tanstack Vite service worker (see #7568).
+export const shouldShowServiceWorkerPushNotification = async (payload: MessagePayload): Promise<boolean> => {
+  if (!isWebhookEvent(payload.data)) {
+    return true
+  }
+
+  const { chainId, address, type } = payload.data
+
+  const key = getPushNotificationPrefsKey(chainId, address)
+  const store = createPushNotificationPrefsIndexedDb()
+
+  const preferencesStore = await getFromIndexedDb<PushNotificationPreferences[PushNotificationPrefsKey]>(
+    key,
+    store,
+  ).catch(() => null)
+
+  if (!preferencesStore) {
+    return false
+  }
+
+  return preferencesStore.preferences[type]
+}
+
+// Restored for the web-tanstack Vite service worker (see #7568).
+export const parseServiceWorkerPushNotification = async (
+  payload: MessagePayload,
+): Promise<({ title?: string; link?: string } & NotificationOptions) | undefined> => {
+  // Manually dispatched notifications from the Firebase admin panel; displayed as is
+  if (!isWebhookEvent(payload.data)) {
+    return payload.notification
+  }
+
+  // Transaction Service-dispatched notification
+  return _parseServiceWorkerWebhookPushNotification(payload.data)
 }

--- a/apps/web/src/service-workers/firebase-messaging/webhook-types.ts
+++ b/apps/web/src/service-workers/firebase-messaging/webhook-types.ts
@@ -1,5 +1,7 @@
 // Be careful what you import here as it will increase the service worker bundle size
 
+import type { MessagePayload } from 'firebase/messaging'
+
 export enum WebhookType {
   EXECUTED_MULTISIG_TRANSACTION = 'EXECUTED_MULTISIG_TRANSACTION',
   INCOMING_ETHER = 'INCOMING_ETHER',
@@ -106,3 +108,9 @@ export type WebhookEvent =
   | ModuleTransactionEvent
   | ConfirmationRequestEvent
   | SafeCreatedEvent
+
+// Restored for the web-tanstack Vite service worker (see #7568). The single
+// bundled Vite worker is the long-term home for FCM background push.
+export const isWebhookEvent = (data: MessagePayload['data']): data is WebhookEvent => {
+  return Object.values(WebhookType).some((type) => type === data?.type)
+}

--- a/apps/web/src/service-workers/firebase-messaging/webhook-types.ts
+++ b/apps/web/src/service-workers/firebase-messaging/webhook-types.ts
@@ -109,8 +109,6 @@ export type WebhookEvent =
   | ConfirmationRequestEvent
   | SafeCreatedEvent
 
-// Restored for the web-tanstack Vite service worker (see #7568). The single
-// bundled Vite worker is the long-term home for FCM background push.
 export const isWebhookEvent = (data: MessagePayload['data']): data is WebhookEvent => {
   return Object.values(WebhookType).some((type) => type === data?.type)
 }

--- a/apps/web/src/services/push-notifications/tracking.ts
+++ b/apps/web/src/services/push-notifications/tracking.ts
@@ -1,8 +1,9 @@
 // Be careful what you import here as it will increase the service worker bundle size
 
-import { createStore as createIndexedDb } from 'idb-keyval'
+import { createStore as createIndexedDb, update as updateIndexedDb } from 'idb-keyval'
+import type { MessagePayload } from 'firebase/messaging/sw'
 
-import { WebhookType } from '@/service-workers/firebase-messaging/webhook-types'
+import { isWebhookEvent, WebhookType } from '@/service-workers/firebase-messaging/webhook-types'
 
 export type NotificationTrackingKey = `${string}:${WebhookType}`
 
@@ -11,6 +12,11 @@ export type NotificationTracking = {
     shown: number
     opened: number
   }
+}
+
+// Restored for the web-tanstack Vite service worker (see #7568).
+export const getNotificationTrackingKey = (chainId: string, type: WebhookType): NotificationTrackingKey => {
+  return `${chainId}:${type}`
 }
 
 export const parseNotificationTrackingKey = (key: string): { chainId: string; type: WebhookType } => {
@@ -36,4 +42,32 @@ export const createNotificationTrackingIndexedDb = () => {
 export const DEFAULT_WEBHOOK_TRACKING: NotificationTracking[NotificationTrackingKey] = {
   shown: 0,
   opened: 0,
+}
+
+// Restored for the web-tanstack Vite service worker (see #7568).
+export const cacheServiceWorkerPushNotificationTrackingEvent = (
+  property: keyof NotificationTracking[NotificationTrackingKey],
+  data: MessagePayload['data'],
+) => {
+  if (!isWebhookEvent(data)) {
+    return
+  }
+
+  const key = getNotificationTrackingKey(data.chainId, data.type)
+  const store = createNotificationTrackingIndexedDb()
+
+  updateIndexedDb<NotificationTracking[NotificationTrackingKey] | undefined>(
+    key,
+    (notificationCount) => {
+      if (notificationCount) {
+        return {
+          ...notificationCount,
+          [property]: (notificationCount[property] ?? 0) + 1,
+        }
+      }
+
+      return DEFAULT_WEBHOOK_TRACKING
+    },
+    store,
+  ).catch(() => null)
 }

--- a/apps/web/src/services/push-notifications/tracking.ts
+++ b/apps/web/src/services/push-notifications/tracking.ts
@@ -14,7 +14,6 @@ export type NotificationTracking = {
   }
 }
 
-// Restored for the web-tanstack Vite service worker (see #7568).
 export const getNotificationTrackingKey = (chainId: string, type: WebhookType): NotificationTrackingKey => {
   return `${chainId}:${type}`
 }
@@ -44,7 +43,6 @@ export const DEFAULT_WEBHOOK_TRACKING: NotificationTracking[NotificationTracking
   opened: 0,
 }
 
-// Restored for the web-tanstack Vite service worker (see #7568).
 export const cacheServiceWorkerPushNotificationTrackingEvent = (
   property: keyof NotificationTracking[NotificationTrackingKey],
   data: MessagePayload['data'],

--- a/apps/web/src/store/notificationsSlice.ts
+++ b/apps/web/src/store/notificationsSlice.ts
@@ -17,6 +17,9 @@ export type Notification = {
   link?: { href: LinkProps['href']; title: string } | { onClick: () => void; title: string }
   icon?: ReactNode
   onClose?: () => void
+  // Override the variant's default auto-hide: a number sets the duration (ms),
+  // `null` keeps the toast open until the user dismisses it. Omit for default.
+  autoHideDuration?: number | null
 }
 
 export type NotificationState = Notification[]

--- a/docs/solutions/tanstack-pwa-sri-20260602.md
+++ b/docs/solutions/tanstack-pwa-sri-20260602.md
@@ -1,0 +1,109 @@
+---
+module: Web
+date: 2026-06-02
+problem_type: architecture_migration
+component: pwa_service_worker_sri
+symptoms:
+  - 'apps/web-tanstack shipped no service worker, no precache, no offline fallback, no SRI'
+  - 'Stale sw.js / workbox-*.js / firebase-messaging-sw.js copied into dist from apps/web/public'
+  - 'Background push silently broken (regression #7568) since knip removed the FCM worker (PR #7022)'
+  - 'Legacy webpack-runtime SRI patch has no Vite equivalent for native import() chunks'
+root_cause: framework_migration_gap
+resolution_type: feature_reconstruction
+severity: high
+tags: [tanstack, vite, pwa, service-worker, workbox, firebase, fcm, sri, import-map, web]
+---
+
+# TanStack (Vite) PWA, Service Worker, and SRI — Phase 6
+
+How `apps/web-tanstack` regained the PWA / service-worker / SRI behaviour that
+`apps/web` had under next-pwa + a webpack-runtime SRI patch. Captured because
+several of the legacy mechanisms do not port, and the publicDir setup has sharp
+edges.
+
+## What was built
+
+- **Single Vite worker** (`src/service-worker/sw.ts`) via `vite-plugin-pwa`
+  `injectManifest`: Workbox precache + `CacheFirst` for static assets (1y / 1000
+  entries, parity with legacy `runtimeCaching`) + `setCatchHandler` →
+  `matchPrecache('offline.html')` for cold offline navigations.
+- **FCM merged into the same worker** (restores #7568) — never a second
+  `firebase-messaging-sw.js`.
+- **SRI via native import-map integrity** (`plugins/vite-plugin-import-map-integrity.ts`)
+  - a CI re-hash assertion (`scripts/assert-sri.mjs`).
+
+## Gotchas
+
+### 1. `publicDir` points at the _legacy_ app's public folder
+
+`vite.config.ts` sets `publicDir: apps/web/public`, which Vite copies verbatim
+into `dist`. That folder contains a **git-tracked 0-byte `firebase-messaging-sw.js`
+stub** plus (locally) stale `sw.js` / `workbox-*.js` from a previous `apps/web`
+build. Vite supports only one public dir, so:
+
+- `offline.html` is **emitted from source** in a `generateBundle` hook, not placed
+  in a public dir.
+- A `closeBundle` cleanup (ordered **after** `VitePWA`) deletes the stale
+  `firebase-messaging-sw.js` and any `workbox-*.js` from `dist`.
+- `injectManifest.globIgnores` excludes those same files so they never enter the
+  precache manifest.
+
+In injectManifest mode the Workbox runtime is **bundled into `sw.js`**, so any
+separate `workbox-*.js` in `dist` is always stale.
+
+### 2. The deleted FCM worker had a cascade of deleted helpers
+
+knip (PR #7022, regression #7568) removed not just the worker entry but also
+`isWebhookEvent` (webhook-types.ts), `getNotificationTrackingKey` +
+`cacheServiceWorkerPushNotificationTrackingEvent` (tracking.ts), and
+`shouldShowServiceWorkerPushNotification` + `parseServiceWorkerPushNotification`
+(notifications.ts). All were recovered from `git show d24c057e4^` and restored to
+their original `apps/web/src` locations (the post-cut-over home). Because knip
+(scoped to `@safe-global/web`) can't see the cross-workspace web-tanstack
+consumer, those three files are added to `apps/web/knip.json` `ignore` with a
+`// see #7568` comment.
+
+### 3. Native SRI does not cover `import()` — use import maps, not tag attributes
+
+The legacy `SriManifestWebpackPlugin` patched the **webpack runtime** to add an
+`integrity` attribute to dynamically-injected `<script>` tags. Vite loads
+code-split chunks via native `import()`, which no DOM-tag rewrite can protect, so
+tag-only SRI plugins (`sri3`, `@small-tech`) would leave most of the app
+unprotected. The web-platform answer is **`integrity` in an import map**
+(Chrome 127+, Safari 18+, Firefox 138+), which the engine enforces for static
+imports, transitive deps, and lazy `import()`.
+
+The plugin hashes **final** chunk bytes in a `generateBundle` `order: 'post'` hook
+(after minification / any compression), never rewrites chunk bytes (sourcemaps +
+Datadog upload stay intact), and injects the import map as the **first `<head>`
+child** so it precedes any module load. Vite already emits `crossorigin` on its
+module scripts; the plugin only adds `crossorigin` when absent to avoid a
+duplicate attribute.
+
+### 4. Dev vs prod worker divergence
+
+The SRI plugin and the manifest only exist in **production builds**. Always
+validate offline / precache / SRI against `vite preview` (or the CI build), never
+`vite dev`.
+
+### 5. Single registration only
+
+`PwaReloadPrompt` (`useRegisterSW` from `virtual:pwa-register/react`) performs the
+**single** registration, so `injectRegister` is `false` in the VitePWA config —
+otherwise an auto-injected script double-registers. The push client
+(`PushNotifications/logic.ts`) reuses `navigator.serviceWorker.getRegistrations()[0]`,
+which now resolves to our one worker. Registering a second
+`firebase-messaging-sw.js` triggers the documented vite-plugin-pwa #777 reload
+loop.
+
+## Follow-ups (deferred)
+
+- In-browser byte-tamper E2E (needs a `vite preview` serving harness + gating on
+  import-map-integrity-supporting browsers). Build-time `assert-sri.mjs` covers
+  tamper detection in CI today.
+- `es-module-shims` (shim mode) for browsers below the native-support floor, or an
+  explicit native-only decision per analytics.
+- Rewriting `apps/web/AGENTS.md`'s PWA/SW/SRI guidance to the Vite model belongs
+  with the cut-over (apps/web is still next-pwa until then).
+- Wiring SRI into a real prod/IPFS deploy belongs with the parent plan's Phase 8/9
+  (no web-tanstack deploy pipeline exists yet).

--- a/yarn.lock
+++ b/yarn.lock
@@ -14079,6 +14079,7 @@ __metadata:
     cypress: "npm:^15.9.0"
     eslint: "npm:^9.29.0"
     firebase: "npm:11.1.0"
+    prettier: "npm:^3.6.2"
     react: "npm:19.2.0"
     react-dom: "npm:19.2.0"
     react-helmet-async: "npm:^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,6 +240,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10/84da552e51a55795a50b3589116edb2f9e368a647d266380683775f18effd9acd4521b0246bebd0b049a7f32af1f87b1e8475d3bcb665f876bd04ade8da99697
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.27.2":
   version: 7.27.3
   resolution: "@babel/compat-data@npm:7.27.3"
@@ -438,6 +449,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/generator@npm:7.29.7"
+  dependencies:
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10/60fb0432ebeab791b2d68e5fc49da6f8e8b68bcc4751211ccf08ac0101e9dcaddefd0cbbbd488afb1c1517515c7c3e76f63d9b05d06deaeb008afd499488db9c
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.22.5, @babel/helper-annotate-as-pure@npm:^7.25.9, @babel/helper-annotate-as-pure@npm:^7.27.1, @babel/helper-annotate-as-pure@npm:^7.27.3":
   version: 7.27.3
   resolution: "@babel/helper-annotate-as-pure@npm:7.27.3"
@@ -583,6 +607,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 10/e53203e87ae24a45f59639edea0c429bc3c63c6d74f1862fe60a35032d89478e7511d2f34855da0fcb65782668d72e59e93d1de5bc00121ba9bc1aa38f1f0ad3
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-member-expression-to-functions@npm:7.25.9"
@@ -620,6 +651,16 @@ __metadata:
     "@babel/traverse": "npm:^7.27.1"
     "@babel/types": "npm:^7.27.1"
   checksum: 10/58e792ea5d4ae71676e0d03d9fef33e886a09602addc3bd01388a98d87df9fcfd192968feb40ac4aedb7e287ec3d0c17b33e3ecefe002592041a91d8a1998a8d
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.18.6":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10/28ec6f7efd99588d6eebfb25c9f1ccc34cb0cdb0839c4c0f08b3ec0105ccaefbe7e8b4f651f3f55a4f5c4fcb1d979bd32a9b8ee23e3e62163ea22aaa7ee0dfa1
   languageName: node
   linkType: hard
 
@@ -823,6 +864,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 10/4d8ef0ef7105f3d9fe4361137c8f42e5b4c7a52b5380b962762f2a528a1ba89064e2c6236090716ce34b63707b886ae0ebf36b2c2fcc2851f27e652febfc3648
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.25.9, @babel/helper-validator-identifier@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-validator-identifier@npm:7.27.1"
@@ -834,6 +882,13 @@ __metadata:
   version: 7.28.5
   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
   checksum: 10/8e5d9b0133702cfacc7f368bf792f0f8ac0483794877c6dca5fcb73810ee138e27527701826fb58a40a004f3a5ec0a2f3c3dd5e326d262530b119918f3132ba7
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10/2efa42701eb05babf26dff3332109c9e5e1a3400a71fb9e68ee27af28235036a2a72c2494c04bdab3f909075f42a58b2e8271074372bc7f8e79ec02bd364d7a7
   languageName: node
   linkType: hard
 
@@ -970,6 +1025,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10/8d9bfb437af6c97a7f6351840b9ac06b4529ba79d6d3def24d6c2996ab38ff7f1f9d301e868ca84a93a3050fadb3d09dbc5105b24634cd281671ac11eebe8df7
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/da40c5928c95997b01aabe84fc3440881b8f20b866714fefa142961d37e82ffc03fbb9afed706f15f8a688278f95286ca0cea0d87ad6c77600f8c6c45d9824ee
   languageName: node
   linkType: hard
 
@@ -3503,6 +3569,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10/da92f7a5b61e05d2fb3934a44f18cec6006ee3c595116c17a3b44cb9756ecd43205c7360dbfa326fa8f4d00aaeb9e777342a881070d11c2305e9c694bc3ca6ff
+  languageName: node
+  linkType: hard
+
 "@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
   version: 7.26.4
   resolution: "@babel/traverse@npm:7.26.4"
@@ -3593,6 +3670,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/traverse@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    debug: "npm:^4.3.1"
+  checksum: 10/ce24086a7dd8c408cbdb159437d3c8e02464a6d32b320d884fa742e2c5a3344b9342a923c7a371fc1789b4d82a59972a7008b5d8bbc1bc0c5ae42a39b28dc7f6
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.1.6, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.25.2, @babel/types@npm:^7.25.4, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0, @babel/types@npm:^7.26.3, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.26.3
   resolution: "@babel/types@npm:7.26.3"
@@ -3660,6 +3752,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 10/bfc2b211210f3894dcd7e6a33b2d1c32c93495dc1e36b547376aa33441abe551ab4bc1640d4154ee2acd8e46d3bbc925c7224caae02fcaf0e6a771e97fccc661
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10/bd4f5635db1057bd0abeebf93eb3ae38399e152271cea8dce8288350f0afa13ed3e2db2e16e22bd3303068890eec18965a83420539afbe0dde31432b4cf9636d
   languageName: node
   linkType: hard
 
@@ -12785,6 +12887,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-babel@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@rollup/plugin-babel@npm:6.1.0"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.18.6"
+    "@rollup/pluginutils": "npm:^5.0.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+    "@types/babel__core": ^7.1.9
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    "@types/babel__core":
+      optional: true
+    rollup:
+      optional: true
+  checksum: 10/9971648c2c9f2d4b7cec1c35541384414d150d50937af3729eb8ea09fa71ad0e3d11ca10a03e4ae97c0d3d5c3d619e1b693cfe81257b8ad50a4844c88dbaf384
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-node-resolve@npm:^15.2.3":
   version: 15.3.1
   resolution: "@rollup/plugin-node-resolve@npm:15.3.1"
@@ -12803,6 +12924,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-node-resolve@npm:^16.0.3":
+  version: 16.0.3
+  resolution: "@rollup/plugin-node-resolve@npm:16.0.3"
+  dependencies:
+    "@rollup/pluginutils": "npm:^5.0.1"
+    "@types/resolve": "npm:1.20.2"
+    deepmerge: "npm:^4.2.2"
+    is-module: "npm:^1.0.0"
+    resolve: "npm:^1.22.1"
+  peerDependencies:
+    rollup: ^2.78.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10/6848212994adc5c3fcd851eb268ad58b3905c5535272ae51d33a7ac1590ff428d102afe81702e031b0360481798e61efc0194b4ee39b812a3ae274c998f4d424
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-replace@npm:^2.4.1":
   version: 2.4.2
   resolution: "@rollup/plugin-replace@npm:2.4.2"
@@ -12812,6 +12951,21 @@ __metadata:
   peerDependencies:
     rollup: ^1.20.0 || ^2.0.0
   checksum: 10/fc4844c4cd7286013d4ccb51a7a2c86135024e3940797af1af1f24357622c8e874d9a17acfa4be9d2546542a87b68e158cc8d2c1f2a7926d17b9433eea00f6bf
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-replace@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "@rollup/plugin-replace@npm:6.0.3"
+  dependencies:
+    "@rollup/pluginutils": "npm:^5.0.1"
+    magic-string: "npm:^0.30.3"
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10/4a8fde80bfc1fde2cf99c97e0f3184ae0b5585bdd3dbb4d0010bfef7dd1c240a9b21f974a4cbfda3f0d3fc997a1babb747bab692062f46d921cecf59c45a741b
   languageName: node
   linkType: hard
 
@@ -12828,6 +12982,22 @@ __metadata:
     rollup:
       optional: true
   checksum: 10/a5e066ddea55fc8c32188bc8b484cca619713516f10e3a06801881ec98bf37459ca24e5fe8711f93a5fa7f26a6e9132a47bc1a61c01e0b513dfd79a96cdc6eb7
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-terser@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@rollup/plugin-terser@npm:1.0.0"
+  dependencies:
+    serialize-javascript: "npm:^7.0.3"
+    smob: "npm:^1.0.0"
+    terser: "npm:^5.17.4"
+  peerDependencies:
+    rollup: ^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10/eb4389d427d704f10a4d9a8c316fda5d2f8c92419bf24e7cf69497739a10236aa2f3004249b0bbf4290174588a5c274b1653b22e63068cea06f844c8b09aa5cf
   languageName: node
   linkType: hard
 
@@ -12883,9 +13053,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-android-arm-eabi@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.4"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-android-arm64@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-android-arm64@npm:4.57.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-android-arm64@npm:4.60.4"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -12897,9 +13081,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-darwin-arm64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-darwin-x64@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-darwin-x64@npm:4.57.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-darwin-x64@npm:4.60.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -12911,9 +13109,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-freebsd-arm64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.4"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-freebsd-x64@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-freebsd-x64@npm:4.57.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.4"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -12925,9 +13137,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.4"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-arm-musleabihf@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.57.1"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.4"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
@@ -12939,9 +13165,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-arm64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-arm64-musl@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-linux-arm64-musl@npm:4.57.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -12953,9 +13193,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-loong64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.4"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-loong64-musl@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-linux-loong64-musl@npm:4.57.1"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.4"
   conditions: os=linux & cpu=loong64 & libc=musl
   languageName: node
   linkType: hard
@@ -12967,9 +13221,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-ppc64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.4"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-ppc64-musl@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.57.1"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.4"
   conditions: os=linux & cpu=ppc64 & libc=musl
   languageName: node
   linkType: hard
@@ -12981,9 +13249,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-riscv64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.4"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-riscv64-musl@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.57.1"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.4"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
@@ -12995,9 +13277,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-s390x-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.4"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-linux-x64-gnu@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-linux-x64-gnu@npm:4.57.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -13009,9 +13305,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-linux-x64-musl@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-openbsd-x64@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-openbsd-x64@npm:4.57.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.4"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -13023,9 +13333,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-openharmony-arm64@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.4"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-win32-arm64-msvc@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.57.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -13037,6 +13361,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-win32-ia32-msvc@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.4"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-win32-x64-gnu@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-win32-x64-gnu@npm:4.57.1"
@@ -13044,9 +13375,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-win32-x64-gnu@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-win32-x64-msvc@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.57.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.60.4":
+  version: 4.60.4
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -13733,6 +14078,7 @@ __metadata:
     cross-env: "npm:^7.0.3"
     cypress: "npm:^15.9.0"
     eslint: "npm:^9.29.0"
+    firebase: "npm:11.1.0"
     react: "npm:19.2.0"
     react-dom: "npm:19.2.0"
     react-helmet-async: "npm:^3.0.0"
@@ -13740,7 +14086,14 @@ __metadata:
     tailwindcss: "npm:^4.1.18"
     typescript: "npm:~5.9.2"
     vite: "npm:^8.0.13"
+    vite-plugin-pwa: "npm:^1.3.0"
     vite-plugin-svgr: "npm:^5.2.0"
+    workbox-cacheable-response: "npm:^7.3.0"
+    workbox-core: "npm:^7.3.0"
+    workbox-expiration: "npm:^7.3.0"
+    workbox-precaching: "npm:^7.3.0"
+    workbox-routing: "npm:^7.3.0"
+    workbox-strategies: "npm:^7.3.0"
   languageName: unknown
   linkType: soft
 
@@ -18584,6 +18937,18 @@ __metadata:
   peerDependencies:
     tslib: ^2.6.2
   checksum: 10/9429ef54bb46199f340488dd670312e6af4e3c04d574e5e602fdd6563106530b8416b87d4b064fe7acbd5c1ac27d5033ec4f9e678c7df1efb595ca23e0f383b2
+  languageName: node
+  linkType: hard
+
+"@trickfilm400/rollup-plugin-off-main-thread@npm:^3.0.0-pre1":
+  version: 3.0.0-pre1
+  resolution: "@trickfilm400/rollup-plugin-off-main-thread@npm:3.0.0-pre1"
+  dependencies:
+    ejs: "npm:^3.1.10"
+    json5: "npm:^2.2.3"
+    magic-string: "npm:^0.30.21"
+    string.prototype.matchall: "npm:^4.0.12"
+  checksum: 10/2a8a4bd02499310792ccbccdef8fa736a85b0fb5bdb88e7d2d335d4f321db4242f7a4662d5424535976ed3379ece21a5d25a1ea49661099ab8436cd9b1ac1093
   languageName: node
   linkType: hard
 
@@ -27357,6 +27722,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eta@npm:^4.5.1":
+  version: 4.6.0
+  resolution: "eta@npm:4.6.0"
+  checksum: 10/81165789b36be730f94c7d640d44f68c74771a237d017975d53e0eb1bd0ab94c6d7c1a8fb8e94e83014ff90bcac1b44bf0881db8e910df7bc6d30bb6be802ac0
+  languageName: node
+  linkType: hard
+
 "etag@npm:^1.8.1, etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
@@ -28780,6 +29152,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"firebase@npm:11.1.0, firebase@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "firebase@npm:11.1.0"
+  dependencies:
+    "@firebase/analytics": "npm:0.10.10"
+    "@firebase/analytics-compat": "npm:0.2.16"
+    "@firebase/app": "npm:0.10.17"
+    "@firebase/app-check": "npm:0.8.10"
+    "@firebase/app-check-compat": "npm:0.3.17"
+    "@firebase/app-compat": "npm:0.2.47"
+    "@firebase/app-types": "npm:0.9.3"
+    "@firebase/auth": "npm:1.8.1"
+    "@firebase/auth-compat": "npm:0.5.16"
+    "@firebase/data-connect": "npm:0.1.3"
+    "@firebase/database": "npm:1.0.10"
+    "@firebase/database-compat": "npm:2.0.1"
+    "@firebase/firestore": "npm:4.7.5"
+    "@firebase/firestore-compat": "npm:0.3.40"
+    "@firebase/functions": "npm:0.12.0"
+    "@firebase/functions-compat": "npm:0.3.17"
+    "@firebase/installations": "npm:0.6.11"
+    "@firebase/installations-compat": "npm:0.2.11"
+    "@firebase/messaging": "npm:0.12.15"
+    "@firebase/messaging-compat": "npm:0.2.15"
+    "@firebase/performance": "npm:0.6.11"
+    "@firebase/performance-compat": "npm:0.2.11"
+    "@firebase/remote-config": "npm:0.4.11"
+    "@firebase/remote-config-compat": "npm:0.2.11"
+    "@firebase/storage": "npm:0.13.4"
+    "@firebase/storage-compat": "npm:0.3.14"
+    "@firebase/util": "npm:1.10.2"
+    "@firebase/vertexai": "npm:1.0.2"
+  checksum: 10/ff75b0b09b99b5cc28e54f0408a5791f5d96d5d63fb795a514fbb699fbb5ed745b77f0ca715d852bad06c564c22c27ad0303046eca776fcc9cfd000a65f8deb7
+  languageName: node
+  linkType: hard
+
 "firebase@npm:12.2.1":
   version: 12.2.1
   resolution: "firebase@npm:12.2.1"
@@ -28813,42 +29221,6 @@ __metadata:
     "@firebase/storage-compat": "npm:0.4.0"
     "@firebase/util": "npm:1.13.0"
   checksum: 10/5fd586cecc4621fbd04fc0975b167ebe4ba1abf912e8ea7b0cae000a01380ff1ea5153e76de521fa3d245febddf0b3a9e1e251059a19b19602a1b977052a7617
-  languageName: node
-  linkType: hard
-
-"firebase@npm:^11.1.0":
-  version: 11.1.0
-  resolution: "firebase@npm:11.1.0"
-  dependencies:
-    "@firebase/analytics": "npm:0.10.10"
-    "@firebase/analytics-compat": "npm:0.2.16"
-    "@firebase/app": "npm:0.10.17"
-    "@firebase/app-check": "npm:0.8.10"
-    "@firebase/app-check-compat": "npm:0.3.17"
-    "@firebase/app-compat": "npm:0.2.47"
-    "@firebase/app-types": "npm:0.9.3"
-    "@firebase/auth": "npm:1.8.1"
-    "@firebase/auth-compat": "npm:0.5.16"
-    "@firebase/data-connect": "npm:0.1.3"
-    "@firebase/database": "npm:1.0.10"
-    "@firebase/database-compat": "npm:2.0.1"
-    "@firebase/firestore": "npm:4.7.5"
-    "@firebase/firestore-compat": "npm:0.3.40"
-    "@firebase/functions": "npm:0.12.0"
-    "@firebase/functions-compat": "npm:0.3.17"
-    "@firebase/installations": "npm:0.6.11"
-    "@firebase/installations-compat": "npm:0.2.11"
-    "@firebase/messaging": "npm:0.12.15"
-    "@firebase/messaging-compat": "npm:0.2.15"
-    "@firebase/performance": "npm:0.6.11"
-    "@firebase/performance-compat": "npm:0.2.11"
-    "@firebase/remote-config": "npm:0.4.11"
-    "@firebase/remote-config-compat": "npm:0.2.11"
-    "@firebase/storage": "npm:0.13.4"
-    "@firebase/storage-compat": "npm:0.3.14"
-    "@firebase/util": "npm:1.10.2"
-    "@firebase/vertexai": "npm:1.0.2"
-  checksum: 10/ff75b0b09b99b5cc28e54f0408a5791f5d96d5d63fb795a514fbb699fbb5ed745b77f0ca715d852bad06c564c22c27ad0303046eca776fcc9cfd000a65f8deb7
   languageName: node
   linkType: hard
 
@@ -29526,7 +29898,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^11.1.0":
+"glob@npm:^11.0.1, glob@npm:^11.1.0":
   version: 11.1.0
   resolution: "glob@npm:11.1.0"
   dependencies:
@@ -34374,7 +34746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.0, magic-string@npm:^0.30.11, magic-string@npm:^0.30.21":
+"magic-string@npm:^0.30.0, magic-string@npm:^0.30.11, magic-string@npm:^0.30.21, magic-string@npm:^0.30.3":
   version: 0.30.21
   resolution: "magic-string@npm:0.30.21"
   dependencies:
@@ -38568,6 +38940,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-bytes@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "pretty-bytes@npm:6.1.1"
+  checksum: 10/43d29d909d2d88072da2c3d72f8fd0f2d2523c516bfa640aff6e31f596ea1004b6601f4cabc50d14b2cf10e82635ebe5b7d9378f3d5bae1c0067131829421b8a
+  languageName: node
+  linkType: hard
+
 "pretty-error@npm:^4.0.0":
   version: 4.0.0
   resolution: "pretty-error@npm:4.0.0"
@@ -41165,6 +41544,96 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^4.53.3":
+  version: 4.60.4
+  resolution: "rollup@npm:4.60.4"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.60.4"
+    "@rollup/rollup-android-arm64": "npm:4.60.4"
+    "@rollup/rollup-darwin-arm64": "npm:4.60.4"
+    "@rollup/rollup-darwin-x64": "npm:4.60.4"
+    "@rollup/rollup-freebsd-arm64": "npm:4.60.4"
+    "@rollup/rollup-freebsd-x64": "npm:4.60.4"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.60.4"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.60.4"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.60.4"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.60.4"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.60.4"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.60.4"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.60.4"
+    "@rollup/rollup-linux-x64-musl": "npm:4.60.4"
+    "@rollup/rollup-openbsd-x64": "npm:4.60.4"
+    "@rollup/rollup-openharmony-arm64": "npm:4.60.4"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.60.4"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.60.4"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.60.4"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.60.4"
+    "@types/estree": "npm:1.0.8"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10/514d970e68f869c1869caca6027e2beff9e41846817c0ce06bd27e9325ac3d0e45c84a45700451e36e48449cf27ce72354db6c7fd108426448806b0e8fc8ec46
+  languageName: node
+  linkType: hard
+
 "router@npm:^2.2.0":
   version: 2.2.0
   resolution: "router@npm:2.2.0"
@@ -41597,6 +42066,13 @@ __metadata:
   dependencies:
     randombytes: "npm:^2.1.0"
   checksum: 10/445a420a6fa2eaee4b70cbd884d538e259ab278200a2ededd73253ada17d5d48e91fb1f4cd224a236ab62ea7ba0a70c6af29fc93b4f3d3078bf7da1c031fde58
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^7.0.3":
+  version: 7.0.5
+  resolution: "serialize-javascript@npm:7.0.5"
+  checksum: 10/6237c76ef6df3d1ad61dd4a393b71ca758c7654f4d1cf77529e513134c0f0660302e03b7ec88a8f3a3daa79e1f93d6de8218ecbc45e073d7cc6b66284a1d3e83
   languageName: node
   linkType: hard
 
@@ -43770,6 +44246,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinyglobby@npm:^0.2.10, tinyglobby@npm:^0.2.16":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10/5c2c41b572ada38449e7c86a5fe034f204a1dbba577225a761a14f29f48dc3f2fc0d81a6c56fcc67c5a742cc3aa9fb5e2ca18dbf22b610b0bc0e549b34d5a0f8
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.15":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
@@ -43777,16 +44263,6 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10/d72bd826a8b0fa5fa3929e7fe5ba48fceb2ae495df3a231b6c5408cd7d8c00b58ab5a9c2a76ba56a62ee9b5e083626f1f33599734bed1ffc4b792406408f0ca2
-  languageName: node
-  linkType: hard
-
-"tinyglobby@npm:^0.2.16":
-  version: 0.2.16
-  resolution: "tinyglobby@npm:0.2.16"
-  dependencies:
-    fdir: "npm:^6.5.0"
-    picomatch: "npm:^4.0.4"
-  checksum: 10/5c2c41b572ada38449e7c86a5fe034f204a1dbba577225a761a14f29f48dc3f2fc0d81a6c56fcc67c5a742cc3aa9fb5e2ca18dbf22b610b0bc0e549b34d5a0f8
   languageName: node
   linkType: hard
 
@@ -45716,6 +46192,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-plugin-pwa@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "vite-plugin-pwa@npm:1.3.0"
+  dependencies:
+    debug: "npm:^4.3.6"
+    pretty-bytes: "npm:^6.1.1"
+    tinyglobby: "npm:^0.2.10"
+    workbox-build: "npm:^7.4.1"
+    workbox-window: "npm:^7.4.1"
+  peerDependencies:
+    "@vite-pwa/assets-generator": ^1.0.0
+    vite: ^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    workbox-build: ^7.4.1
+    workbox-window: ^7.4.1
+  peerDependenciesMeta:
+    "@vite-pwa/assets-generator":
+      optional: true
+  checksum: 10/80d2fc1197158a69de36bf16df10680e5571d250480d33f70d70857fdcaff0d4e67411b1c439846b90651c1393ba654ec02b216646cb2269656ed2793d1c17df
+  languageName: node
+  linkType: hard
+
 "vite-plugin-storybook-nextjs@npm:^3.1.9":
   version: 3.1.10
   resolution: "vite-plugin-storybook-nextjs@npm:3.1.10"
@@ -46459,12 +46956,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-background-sync@npm:7.4.1":
+  version: 7.4.1
+  resolution: "workbox-background-sync@npm:7.4.1"
+  dependencies:
+    idb: "npm:^7.0.1"
+    workbox-core: "npm:7.4.1"
+  checksum: 10/2ab38dc99a6a444c2e64ed88faa85c8c566ba57f8423a2110da00c2c0e88f6436a7a24b2fbe03378f9166fb28fc86f47476d59df1a78170b672ac39d5043d5ce
+  languageName: node
+  linkType: hard
+
 "workbox-broadcast-update@npm:7.1.0":
   version: 7.1.0
   resolution: "workbox-broadcast-update@npm:7.1.0"
   dependencies:
     workbox-core: "npm:7.1.0"
   checksum: 10/8dd87c05b14c0e7f03711d8a189949d5b16a33c53fc0d252569ba4758e450baca2d1aac45628b4210532c930176b1796a2a917be51000289001e401bdc5d3915
+  languageName: node
+  linkType: hard
+
+"workbox-broadcast-update@npm:7.4.1":
+  version: 7.4.1
+  resolution: "workbox-broadcast-update@npm:7.4.1"
+  dependencies:
+    workbox-core: "npm:7.4.1"
+  checksum: 10/f406acd866c96134bcfd04ae64c0a9c90e7b3c498fc03ace7e3266cc74bbca23677241da8559abc1939ce78bf8e8e38bbde8996ad0d3df603552b8490199d7c2
   languageName: node
   linkType: hard
 
@@ -46558,12 +47074,66 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-build@npm:^7.4.1":
+  version: 7.4.1
+  resolution: "workbox-build@npm:7.4.1"
+  dependencies:
+    "@apideck/better-ajv-errors": "npm:^0.3.1"
+    "@babel/core": "npm:^7.24.4"
+    "@babel/preset-env": "npm:^7.11.0"
+    "@babel/runtime": "npm:^7.11.2"
+    "@rollup/plugin-babel": "npm:^6.1.0"
+    "@rollup/plugin-node-resolve": "npm:^16.0.3"
+    "@rollup/plugin-replace": "npm:^6.0.3"
+    "@rollup/plugin-terser": "npm:^1.0.0"
+    "@trickfilm400/rollup-plugin-off-main-thread": "npm:^3.0.0-pre1"
+    ajv: "npm:^8.6.0"
+    common-tags: "npm:^1.8.0"
+    eta: "npm:^4.5.1"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    fs-extra: "npm:^9.0.1"
+    glob: "npm:^11.0.1"
+    pretty-bytes: "npm:^5.3.0"
+    rollup: "npm:^4.53.3"
+    source-map: "npm:^0.8.0-beta.0"
+    stringify-object: "npm:^3.3.0"
+    strip-comments: "npm:^2.0.1"
+    tempy: "npm:^0.6.0"
+    upath: "npm:^1.2.0"
+    workbox-background-sync: "npm:7.4.1"
+    workbox-broadcast-update: "npm:7.4.1"
+    workbox-cacheable-response: "npm:7.4.1"
+    workbox-core: "npm:7.4.1"
+    workbox-expiration: "npm:7.4.1"
+    workbox-google-analytics: "npm:7.4.1"
+    workbox-navigation-preload: "npm:7.4.1"
+    workbox-precaching: "npm:7.4.1"
+    workbox-range-requests: "npm:7.4.1"
+    workbox-recipes: "npm:7.4.1"
+    workbox-routing: "npm:7.4.1"
+    workbox-strategies: "npm:7.4.1"
+    workbox-streams: "npm:7.4.1"
+    workbox-sw: "npm:7.4.1"
+    workbox-window: "npm:7.4.1"
+  checksum: 10/d4c63509b3b23f5f293d07a3d1376875a077a3660cd267b24f5545e8d102c2350cda9dc5674d289a8dd558c76fa0a1e7f6092e7b207aa683a42cf5a74abf7fb2
+  languageName: node
+  linkType: hard
+
 "workbox-cacheable-response@npm:7.1.0":
   version: 7.1.0
   resolution: "workbox-cacheable-response@npm:7.1.0"
   dependencies:
     workbox-core: "npm:7.1.0"
   checksum: 10/1eb294765256d5010325c702208b8f621ad59a0323981bdd8d9d991b9ab7888f39f9a051f90ba583840168cd3252852511666ddc3db64f20f91c97cbea159796
+  languageName: node
+  linkType: hard
+
+"workbox-cacheable-response@npm:7.4.1, workbox-cacheable-response@npm:^7.3.0":
+  version: 7.4.1
+  resolution: "workbox-cacheable-response@npm:7.4.1"
+  dependencies:
+    workbox-core: "npm:7.4.1"
+  checksum: 10/84e81da01e3162ff24fce20d64ab1c6e4342971c5a8b707ca572a0db4233121a96aa82bc2266a50ac8642d3697c7227b2086e305d2337565ba997f803a9f3dee
   languageName: node
   linkType: hard
 
@@ -46574,6 +47144,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-core@npm:7.4.1, workbox-core@npm:^7.3.0":
+  version: 7.4.1
+  resolution: "workbox-core@npm:7.4.1"
+  checksum: 10/7c6b5d5008b30f4cd87d82ef946bff066ec231784c23b7c455230a100922b5de99cc0baf059a3883babf05fff5a98eaf0f62407a3b6bce2dda280f44412899bd
+  languageName: node
+  linkType: hard
+
 "workbox-expiration@npm:7.1.0":
   version: 7.1.0
   resolution: "workbox-expiration@npm:7.1.0"
@@ -46581,6 +47158,16 @@ __metadata:
     idb: "npm:^7.0.1"
     workbox-core: "npm:7.1.0"
   checksum: 10/45c7a27b217355fc30929482625c43cbfa04c914162a26b92c7e91fcb3a20e9982b50026bf4bb37382a320e1426818e3726b999dce1c8c08d2aa330eee569308
+  languageName: node
+  linkType: hard
+
+"workbox-expiration@npm:7.4.1, workbox-expiration@npm:^7.3.0":
+  version: 7.4.1
+  resolution: "workbox-expiration@npm:7.4.1"
+  dependencies:
+    idb: "npm:^7.0.1"
+    workbox-core: "npm:7.4.1"
+  checksum: 10/5405896b5d93a95a062b8a54f126fc273b5a451d3f36b3a84b725add398c478bd2c7701f10280ff298ac9690016cc4998dcd01033d0d8653cd6d8f3a810ed27a
   languageName: node
   linkType: hard
 
@@ -46596,12 +47183,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-google-analytics@npm:7.4.1":
+  version: 7.4.1
+  resolution: "workbox-google-analytics@npm:7.4.1"
+  dependencies:
+    workbox-background-sync: "npm:7.4.1"
+    workbox-core: "npm:7.4.1"
+    workbox-routing: "npm:7.4.1"
+    workbox-strategies: "npm:7.4.1"
+  checksum: 10/ef37ec21e69ce707e2e4c3b9319d7e58c99b3efef7d44570abf2e7625d7b39ee79db51e6ae7f77b21087634b0e4aba3ada0607bdeb27aeaaf597cb70b04fede2
+  languageName: node
+  linkType: hard
+
 "workbox-navigation-preload@npm:7.1.0":
   version: 7.1.0
   resolution: "workbox-navigation-preload@npm:7.1.0"
   dependencies:
     workbox-core: "npm:7.1.0"
   checksum: 10/e4a2e40f1292b1a5e70c7efe69d280635b211c98577ef88f3941b4627e592bb5b21aae262da74636f06ea1fc61065e3002f41cff12f25b05de0259e2700b6ca8
+  languageName: node
+  linkType: hard
+
+"workbox-navigation-preload@npm:7.4.1":
+  version: 7.4.1
+  resolution: "workbox-navigation-preload@npm:7.4.1"
+  dependencies:
+    workbox-core: "npm:7.4.1"
+  checksum: 10/e7d418eee9ab1a430f91b8d26ed3a9de0bbe7d9177fc28a2b689faeeb09d7013ecaef50a0001eb9870e3afbdadfecf3c9b4d30bb17234c2197f814f3610b242a
   languageName: node
   linkType: hard
 
@@ -46616,12 +47224,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-precaching@npm:7.4.1, workbox-precaching@npm:^7.3.0":
+  version: 7.4.1
+  resolution: "workbox-precaching@npm:7.4.1"
+  dependencies:
+    workbox-core: "npm:7.4.1"
+    workbox-routing: "npm:7.4.1"
+    workbox-strategies: "npm:7.4.1"
+  checksum: 10/69921db9e40b43246365671ecb1e06b579e96791ba90d1b13da51631b680b877329adcf9505717c241c3a2e40d959eace85659bc2df73e12ff85881052457ec6
+  languageName: node
+  linkType: hard
+
 "workbox-range-requests@npm:7.1.0":
   version: 7.1.0
   resolution: "workbox-range-requests@npm:7.1.0"
   dependencies:
     workbox-core: "npm:7.1.0"
   checksum: 10/a92d9c28a1c033a4d9e8a958613f2d44b374ef6f4f7609bf8f574ae5fe41c0800b251fb17f8ca7cd3ebc3c53cdbc22fe5a4c5f0afabd63a5960cbe4333dbbf2a
+  languageName: node
+  linkType: hard
+
+"workbox-range-requests@npm:7.4.1":
+  version: 7.4.1
+  resolution: "workbox-range-requests@npm:7.4.1"
+  dependencies:
+    workbox-core: "npm:7.4.1"
+  checksum: 10/725ddbd139ea98e6bf7e6dc8ea161d97e547199f3a1d5f2aaf1b48119f89a7ded957334566b8621b4f09dc6efc93798aa4d7cb6babd3fb1ea7119fa7af190867
   languageName: node
   linkType: hard
 
@@ -46639,6 +47267,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-recipes@npm:7.4.1":
+  version: 7.4.1
+  resolution: "workbox-recipes@npm:7.4.1"
+  dependencies:
+    workbox-cacheable-response: "npm:7.4.1"
+    workbox-core: "npm:7.4.1"
+    workbox-expiration: "npm:7.4.1"
+    workbox-precaching: "npm:7.4.1"
+    workbox-routing: "npm:7.4.1"
+    workbox-strategies: "npm:7.4.1"
+  checksum: 10/522fd4195e2dd49f66f8f8833dd5098cae770671e440381b4f2b3996466d7f80dce8a2b98c487917a2c72f6f30d6a7be8a3c5b72fe04f4d03df6c12d7472bd89
+  languageName: node
+  linkType: hard
+
 "workbox-routing@npm:7.1.0":
   version: 7.1.0
   resolution: "workbox-routing@npm:7.1.0"
@@ -46648,12 +47290,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-routing@npm:7.4.1, workbox-routing@npm:^7.3.0":
+  version: 7.4.1
+  resolution: "workbox-routing@npm:7.4.1"
+  dependencies:
+    workbox-core: "npm:7.4.1"
+  checksum: 10/684ffa7531784a914681911a245fa0041e8a4fe78d5db0690f7475508b3438c41a591646c58f733b0add24e788952a94128e5061f30158b0926995a9fac5d68c
+  languageName: node
+  linkType: hard
+
 "workbox-strategies@npm:7.1.0":
   version: 7.1.0
   resolution: "workbox-strategies@npm:7.1.0"
   dependencies:
     workbox-core: "npm:7.1.0"
   checksum: 10/52734ecce926ba6c135b5c7cb31906e40ad6bc767c77d45e74414b8adbb980f8a81bc1253af64750ce22202d0f1c4f01161785829cfb7bcb3f59408da9130555
+  languageName: node
+  linkType: hard
+
+"workbox-strategies@npm:7.4.1, workbox-strategies@npm:^7.3.0":
+  version: 7.4.1
+  resolution: "workbox-strategies@npm:7.4.1"
+  dependencies:
+    workbox-core: "npm:7.4.1"
+  checksum: 10/77706d61efbf0fe7b1a3d55901c80c028a01387aebcb9ed4bd9e0622a60473cf63ec9a26d7efbb09c0441f5469153d520101f149d0ba50c2e4293a41c5c860f1
   languageName: node
   linkType: hard
 
@@ -46667,10 +47327,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"workbox-streams@npm:7.4.1":
+  version: 7.4.1
+  resolution: "workbox-streams@npm:7.4.1"
+  dependencies:
+    workbox-core: "npm:7.4.1"
+    workbox-routing: "npm:7.4.1"
+  checksum: 10/5c02eeb8bee6c038f75c87a9d903befc179f4ddb1bd60aeb86d235f9707bad4eed62b458e4b8a92463e05edf86d0b761e238b18b8eb8ea376eee8f3cfa5d012e
+  languageName: node
+  linkType: hard
+
 "workbox-sw@npm:7.1.0":
   version: 7.1.0
   resolution: "workbox-sw@npm:7.1.0"
   checksum: 10/ece8081e41a45e2e42e0be597e5a2a8be8aa25ebf16a496599a76d4a044fc922e0b40d3fcb9c82682db1911b0d6e51e761593922c90f40d11d7b06f7a4b773c7
+  languageName: node
+  linkType: hard
+
+"workbox-sw@npm:7.4.1":
+  version: 7.4.1
+  resolution: "workbox-sw@npm:7.4.1"
+  checksum: 10/86fad480511c88492f0c2400e789348b21a62ef26e14af2de1fc7df59951c04e719c989cbf7ece9859fd1f8cfbdf9e870e21206edad6309ba0180ea4fb12c3b2
   languageName: node
   linkType: hard
 
@@ -46696,6 +47373,16 @@ __metadata:
     "@types/trusted-types": "npm:^2.0.2"
     workbox-core: "npm:7.1.0"
   checksum: 10/2706c55b81857966c28087a2b0ef40b7791e1bd441b880b7525b7e1b4834ae89c4f1bcfdb07cc155487a85f7c566007e1f9edf65539d7f4a52e2ceee48f547b5
+  languageName: node
+  linkType: hard
+
+"workbox-window@npm:7.4.1, workbox-window@npm:^7.4.1":
+  version: 7.4.1
+  resolution: "workbox-window@npm:7.4.1"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.2"
+    workbox-core: "npm:7.4.1"
+  checksum: 10/a7ada2fe012f3b9079257905844d3d84579eefc70d693fce8ca4d86a1431f93d9f69e1217402308763118c7627c7aa56bf2543578e105bf5c91db1b02c3af6f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What it solves

`apps/web-tanstack` (the Vite/TanStack app) shipped without a service worker, precaching, offline fallback, Subresource Integrity, or background push — a regression versus the legacy Next.js app.

Resolves: _no Linear issue_ · closes #7568 for the new app

## How this PR fixes it

A single Vite service worker (vite-plugin-pwa, injectManifest) handles precaching, runtime caching, the offline page, and Firebase background push in one file — a second `firebase-messaging-sw.js` would cause a registration race (vite-pwa#777).

SRI uses native **import-map integrity** rather than tag attributes, so lazy `import()` chunks are covered (a tag-only approach misses them). Hashes are taken from the final chunk bytes without rewriting them, so sourcemaps stay intact; a CI step re-hashes the build and fails on tamper.

Two gotchas worth knowing:
- `publicDir` points at the legacy `apps/web/public`, which carries stale service-worker artifacts (a 0-byte `firebase-messaging-sw.js`, leftover `workbox-*.js`). The build strips them so they can't shadow the generated worker or get precached.
- The worker update surfaces a **persistent** toast (not the default 5s auto-hide) — a wallet must not auto-reload mid-transaction, so the user triggers the reload.

This only restores push for the **new** app. The legacy Next.js site needs its deleted worker entry restored separately (follow-up PR).

## How to test it

1. `yarn workspace @safe-global/web-tanstack build && yarn workspace @safe-global/web-tanstack assert:sri`
2. `yarn workspace @safe-global/web-tanstack preview`, open in Chrome → DevTools ▸ Application ▸ Service Workers shows one worker; Cache Storage holds the shell.
3. Go offline, reload an SPA route (renders from cache); navigate to a never-visited URL (renders `offline.html`).
4. Rebuild, then in the console `navigator.serviceWorker.getRegistration().then(r => r.update())` → a persistent "A new version of Safe is available" toast appears; **Reload** activates the new worker.

## Screenshots

N/A — the only UI is the reload toast (verified via Playwright against `vite preview`).

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻