### PR TITLE
fix: Double space on /home page

### DIFF
--- a/apps/web/src/components/dashboard/index.tsx
+++ b/apps/web/src/components/dashboard/index.tsx
@@ -98,7 +98,7 @@ const Dashboard = (): ReactElement => {
               {!showHnBanner && <AddFundsToGetStarted />}
             </Stack>
           ) : (
-            <Stack minWidth="100%">
+            <Stack minWidth="100%" className={css.hideIfEmpty}>
               <NewsCarousel banners={banners} />
             </Stack>
           )}


### PR DESCRIPTION
## What it solves

Fixes [WA-2465](https://linear.app/safe-global/issue/WA-2465/remove-double-space-under-wallet-banner)

## Screenshots of the different states

<img width="1000" height="2248" alt="M1-mobile-no-banner" src="https://github.com/user-attachments/assets/94c6c2bc-3d24-454c-87c0-67f1805fec39" />
<img width="1000" height="2588" alt="M2-mobile-one-banner" src="https://github.com/user-attachments/assets/8f633729-bcdd-4cee-951b-b230e0da160d" />
<img width="2704" height="1418" alt="wa2465-banner-on" src="https://github.com/user-attachments/assets/e1811ff1-8c67-4398-8765-f5f34345c3db" />
<img width="2880" height="1418" alt="wa2465-fixed-desktop" src="https://github.com/user-attachments/assets/7456427f-0813-49dd-aa5c-63db8fbd7106" />
<img width="1058" height="981" alt="Screenshot 2026-06-03 at 09 04 24" src="https://github.com/user-attachments/assets/afeceb5f-9e98-483d-9533-05289f84aa28" />


