### PR TITLE
feat(spaces): rework safe selector for workspace context (WA-2462)

### DIFF
--- a/apps/web/src/components/common/SimilarAddressAlert.tsx
+++ b/apps/web/src/components/common/SimilarAddressAlert.tsx
@@ -1,8 +1,13 @@
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
 import { CircleAlert } from 'lucide-react'
 
+/**
+ * Top-of-list warning shown when at least one entry in a safe list has a
+ * visually-similar address to another. Surfaces the address-poisoning risk
+ * before the per-card "High similarity" pill is noticed.
+ */
 const SimilarAddressAlert = () => (
-  <Alert variant="warning">
+  <Alert variant="warning" data-testid="similar-address-alert">
     <CircleAlert />
     <AlertTitle>Similar addresses detected</AlertTitle>
     <AlertDescription>

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/MultiSafeItemCard.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/MultiSafeItemCard.test.tsx
@@ -103,4 +103,23 @@ describe('MultiSafeItemCard', () => {
     expect(screen.getByTestId('sub-item-1')).toBeInTheDocument()
     expect(screen.getByTestId('sub-item-100')).toBeInTheDocument()
   })
+
+  it('renders the pin/unpin button by default', () => {
+    render(<MultiSafeItemCard item={buildMultiItem()} onClose={noopClose} />)
+
+    expect(screen.getByRole('button', { name: /pin safe/i })).toBeInTheDocument()
+  })
+
+  it('hides the pin/unpin button when hidePinControls is set (space-safe context)', () => {
+    render(<MultiSafeItemCard item={buildMultiItem()} onClose={noopClose} hidePinControls />)
+
+    expect(screen.queryByRole('button', { name: /pin safe/i })).not.toBeInTheDocument()
+  })
+
+  it('renders the full address with bolded first/last 4 hex chars when flagged as similar', () => {
+    const { container } = render(<MultiSafeItemCard item={buildMultiItem()} isSimilar onClose={noopClose} />)
+
+    const bolded = Array.from(container.querySelectorAll('b')).map((el) => el.textContent)
+    expect(bolded).toEqual(expect.arrayContaining(['1111', '1111']))
+  })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/MultiSafeItemCard.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/MultiSafeItemCard.tsx
@@ -29,6 +29,7 @@ interface MultiSafeItemCardProps {
   isSimilar?: boolean
   onClose: () => void
   openSafeTrackingLabel?: OVERVIEW_LABELS
+  hidePinControls?: boolean
 }
 
 const MultiSafeItemCard = ({
@@ -36,6 +37,7 @@ const MultiSafeItemCard = ({
   isSimilar,
   onClose,
   openSafeTrackingLabel = OVERVIEW_LABELS.top_bar,
+  hidePinControls = false,
 }: MultiSafeItemCardProps) => {
   const [open, setOpen] = useState(false)
   const currency = useAppSelector(selectCurrency)
@@ -91,7 +93,7 @@ const MultiSafeItemCard = ({
                 {addressBookItem?.name && addressBookItem.source && <NameSourceIcon source={addressBookItem.source} />}
               </div>
               <div className="flex items-center gap-1 min-w-0">
-                <ShortAddressWithTooltip address={address} />
+                <ShortAddressWithTooltip address={address} isSimilar={isSimilar} />
                 <CopyAddressButton address={address} />
               </div>
               {isSimilar && <SimilarityBadge />}
@@ -114,18 +116,24 @@ const MultiSafeItemCard = ({
             </div>
           </CollapsibleTrigger>
 
-          {/* Pin/Unpin toggle — outside trigger so it doesn't toggle the collapsible */}
-          <button
-            type="button"
-            onClick={handleTogglePin}
-            className="shrink-0 rounded p-1 hover:bg-muted"
-            aria-label={isPinned ? 'Unpin safe' : 'Pin safe'}
-          >
-            <Bookmark className={`size-4 ${isPinned ? 'fill-foreground text-foreground' : 'text-muted-foreground'}`} />
-          </button>
+          {!hidePinControls && (
+            <>
+              {/* Pin/Unpin toggle — outside trigger so it doesn't toggle the collapsible */}
+              <button
+                type="button"
+                onClick={handleTogglePin}
+                className="shrink-0 rounded p-1 hover:bg-muted"
+                aria-label={isPinned ? 'Unpin safe' : 'Pin safe'}
+              >
+                <Bookmark
+                  className={`size-4 ${isPinned ? 'fill-foreground text-foreground' : 'text-muted-foreground'}`}
+                />
+              </button>
 
-          {/* Context menu — outside trigger for the same reason */}
-          <PinnedSafeContextMenu address={address} chainId={sortedSafes[0]?.chainId ?? ''} name={displayName} />
+              {/* Context menu — outside trigger for the same reason */}
+              <PinnedSafeContextMenu address={address} chainId={sortedSafes[0]?.chainId ?? ''} name={displayName} />
+            </>
+          )}
         </div>
 
         <CollapsibleContent>

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.test.tsx
@@ -61,4 +61,33 @@ describe('SafeItemCard', () => {
     expect(screen.queryByText('High similarity')).not.toBeInTheDocument()
     expect(screen.getByText('Read-only')).toBeInTheDocument()
   })
+
+  it('renders the pin/unpin button by default', () => {
+    const safeItem = safeItemBuilder().build()
+
+    render(<SafeItemCard safeItem={safeItem} onClose={noopClose} />)
+
+    expect(screen.getByTestId('bookmark-icon')).toBeInTheDocument()
+  })
+
+  it('hides the pin/unpin button when hidePinControls is set (space-safe context)', () => {
+    const safeItem = safeItemBuilder().build()
+
+    render(<SafeItemCard safeItem={safeItem} onClose={noopClose} hidePinControls />)
+
+    expect(screen.queryByTestId('bookmark-icon')).not.toBeInTheDocument()
+  })
+
+  it('renders the full address with bolded first/last 4 hex chars when flagged as similar', () => {
+    const safeItem = safeItemBuilder()
+      .with({
+        address: '0x1234567890123456789012345678901234567890',
+      })
+      .build()
+
+    const { container } = render(<SafeItemCard safeItem={safeItem} isSimilar onClose={noopClose} />)
+
+    const bolded = Array.from(container.querySelectorAll('b')).map((el) => el.textContent)
+    expect(bolded).toEqual(expect.arrayContaining(['1234', '7890']))
+  })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.tsx
@@ -32,6 +32,7 @@ interface SafeItemCardProps {
   isSimilar?: boolean
   onClose: () => void
   openSafeTrackingLabel?: OVERVIEW_LABELS
+  hidePinControls?: boolean
 }
 
 const SafeItemCard = ({
@@ -39,6 +40,7 @@ const SafeItemCard = ({
   isSimilar,
   onClose,
   openSafeTrackingLabel = OVERVIEW_LABELS.top_bar,
+  hidePinControls = false,
 }: SafeItemCardProps) => {
   const dispatch = useAppDispatch()
   const currency = useAppSelector(selectCurrency)
@@ -107,7 +109,7 @@ const SafeItemCard = ({
           {addressBookItem?.name && addressBookItem.source && <NameSourceIcon source={addressBookItem.source} />}
         </div>
         <div className="flex items-center gap-1 min-w-0">
-          <ShortAddressWithTooltip address={safeItem.address} />
+          <ShortAddressWithTooltip address={safeItem.address} isSimilar={isSimilar} />
           <CopyAddressButton address={safeItem.address} />
         </div>
         {isSimilar && <SimilarityBadge />}
@@ -147,21 +149,25 @@ const SafeItemCard = ({
         <div className={mainContentClasses}>{mainContent}</div>
       )}
 
-      {/* Pin/Unpin toggle */}
-      <button
-        type="button"
-        onClick={handleTogglePin}
-        className="shrink-0 rounded p-1 hover:bg-muted"
-        aria-label={safeItem.isPinned ? 'Unpin safe' : 'Pin safe'}
-        data-testid="bookmark-icon"
-      >
-        <Bookmark
-          className={`size-4 ${safeItem.isPinned ? 'fill-foreground text-foreground' : 'text-muted-foreground'}`}
-        />
-      </button>
+      {!hidePinControls && (
+        <>
+          {/* Pin/Unpin toggle */}
+          <button
+            type="button"
+            onClick={handleTogglePin}
+            className="shrink-0 rounded p-1 hover:bg-muted"
+            aria-label={safeItem.isPinned ? 'Unpin safe' : 'Pin safe'}
+            data-testid="bookmark-icon"
+          >
+            <Bookmark
+              className={`size-4 ${safeItem.isPinned ? 'fill-foreground text-foreground' : 'text-muted-foreground'}`}
+            />
+          </button>
 
-      {/* Context menu */}
-      <PinnedSafeContextMenu address={safeItem.address} chainId={safeItem.chainId} name={displayName} />
+          {/* Context menu */}
+          <PinnedSafeContextMenu address={safeItem.address} chainId={safeItem.chainId} name={displayName} />
+        </>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from '@/tests/test-utils'
+import { useIsQualifiedSafe } from '@/features/spaces'
+import type { SafeItem } from '@/hooks/safes'
+import { useAccountsModalItems } from './useAccountsModalItems'
+import AccountsModal from './index'
+
+jest.mock('@/features/spaces', () => ({
+  useIsQualifiedSafe: jest.fn(),
+}))
+
+jest.mock('./useAccountsModalItems', () => ({
+  useAccountsModalItems: jest.fn(),
+}))
+
+jest.mock('./SafeItemCard', () => {
+  const MockSafeItemCard = ({
+    safeItem,
+    hidePinControls,
+  }: {
+    safeItem: { chainId: string; address: string }
+    hidePinControls?: boolean
+  }) => (
+    <div
+      data-testid="safe-item-card-mock"
+      data-key={`${safeItem.chainId}:${safeItem.address}`}
+      data-hide-pin={String(Boolean(hidePinControls))}
+    />
+  )
+  MockSafeItemCard.displayName = 'SafeItemCard'
+  return { __esModule: true, default: MockSafeItemCard }
+})
+
+jest.mock('./MultiSafeItemCard', () => {
+  const MockMultiSafeItemCard = ({
+    item,
+    hidePinControls,
+  }: {
+    item: { address: string }
+    hidePinControls?: boolean
+  }) => (
+    <div
+      data-testid="multi-safe-item-card-mock"
+      data-address={item.address}
+      data-hide-pin={String(Boolean(hidePinControls))}
+    />
+  )
+  MockMultiSafeItemCard.displayName = 'MultiSafeItemCard'
+  return { __esModule: true, default: MockMultiSafeItemCard }
+})
+
+const mockUseIsQualifiedSafe = useIsQualifiedSafe as jest.Mock
+const mockUseAccountsModalItems = useAccountsModalItems as jest.Mock
+
+const safeItem = (chainId: string, address: string, overrides: Partial<SafeItem> = {}): SafeItem => ({
+  chainId,
+  address,
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+  ...overrides,
+})
+
+const ADDR_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+describe('AccountsModal', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockUseAccountsModalItems.mockReturnValue({
+      trustedItems: [],
+      otherItems: [safeItem('1', ADDR_A)],
+      similarAddresses: new Set<string>(),
+      isLoading: false,
+      isOwnedSafesError: false,
+      refetchOwnedSafes: jest.fn(),
+    })
+  })
+
+  it('shows the "All Accounts" dialog title when not in a qualified space', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+
+    render(<AccountsModal open onClose={jest.fn()} />)
+
+    expect(screen.getByText('All Accounts')).toBeInTheDocument()
+  })
+
+  it('shows the "Safes not in this Workspace" dialog title when in a qualified space', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+
+    render(<AccountsModal open onClose={jest.fn()} />)
+
+    expect(screen.getByText('Safes not in this Workspace')).toBeInTheDocument()
+    expect(screen.queryByText('All Accounts')).not.toBeInTheDocument()
+  })
+
+  it('passes hidePinControls=false to cards when not in a qualified space', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+
+    render(<AccountsModal open onClose={jest.fn()} />)
+
+    expect(screen.getByTestId('safe-item-card-mock').getAttribute('data-hide-pin')).toBe('false')
+  })
+
+  it('passes hidePinControls=true to cards when in a qualified space', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+
+    render(<AccountsModal open onClose={jest.fn()} />)
+
+    expect(screen.getByTestId('safe-item-card-mock').getAttribute('data-hide-pin')).toBe('true')
+  })
+
+  it('renders the empty state when no items match', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+    mockUseAccountsModalItems.mockReturnValue({
+      trustedItems: [],
+      otherItems: [],
+      similarAddresses: new Set<string>(),
+      isLoading: false,
+      isOwnedSafesError: false,
+      refetchOwnedSafes: jest.fn(),
+    })
+
+    render(<AccountsModal open onClose={jest.fn()} />)
+
+    expect(screen.getByTestId('empty-pinned-list')).toBeInTheDocument()
+  })
+
+  it('renders the loading skeleton while isLoading is true', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+    mockUseAccountsModalItems.mockReturnValue({
+      trustedItems: [],
+      otherItems: [],
+      similarAddresses: new Set<string>(),
+      isLoading: true,
+      isOwnedSafesError: false,
+      refetchOwnedSafes: jest.fn(),
+    })
+
+    render(<AccountsModal open onClose={jest.fn()} />)
+
+    expect(screen.queryByTestId('empty-pinned-list')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('safe-item-card-mock')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.test.tsx
@@ -123,4 +123,24 @@ describe('AccountsModal', () => {
     expect(screen.queryByTestId('empty-pinned-list')).not.toBeInTheDocument()
     expect(screen.queryByTestId('safe-item-card-mock')).not.toBeInTheDocument()
   })
+
+  it('renders the similar-address warning banner when at least one similar address is detected', () => {
+    mockUseAccountsModalItems.mockReturnValue(
+      buildHookReturn({
+        similarAddresses: new Set([ADDR_A.toLowerCase()]),
+      }),
+    )
+
+    render(<AccountsModal open onClose={jest.fn()} />)
+
+    expect(screen.getByTestId('similar-address-alert')).toBeInTheDocument()
+  })
+
+  it('hides the similar-address warning banner when no similar addresses are detected', () => {
+    mockUseAccountsModalItems.mockReturnValue(buildHookReturn({ similarAddresses: new Set<string>() }))
+
+    render(<AccountsModal open onClose={jest.fn()} />)
+
+    expect(screen.queryByTestId('similar-address-alert')).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.test.tsx
@@ -82,12 +82,12 @@ describe('AccountsModal', () => {
     expect(screen.getByText('All Accounts')).toBeInTheDocument()
   })
 
-  it('shows the "Safes not in this workspace" dialog title when in a qualified space', () => {
+  it('shows the "Explore other Safes" dialog title when in a qualified space', () => {
     mockUseAccountsModalItems.mockReturnValue(buildHookReturn({ isQualifiedSafe: true }))
 
     render(<AccountsModal open onClose={jest.fn()} />)
 
-    expect(screen.getByText('Safes not in this workspace')).toBeInTheDocument()
+    expect(screen.getByText('Explore other Safes')).toBeInTheDocument()
     expect(screen.queryByText('All Accounts')).not.toBeInTheDocument()
   })
 

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.test.tsx
@@ -1,12 +1,7 @@
 import { render, screen } from '@/tests/test-utils'
-import { useIsQualifiedSafe } from '@/features/spaces'
 import type { SafeItem } from '@/hooks/safes'
 import { useAccountsModalItems } from './useAccountsModalItems'
 import AccountsModal from './index'
-
-jest.mock('@/features/spaces', () => ({
-  useIsQualifiedSafe: jest.fn(),
-}))
 
 jest.mock('./useAccountsModalItems', () => ({
   useAccountsModalItems: jest.fn(),
@@ -48,7 +43,6 @@ jest.mock('./MultiSafeItemCard', () => {
   return { __esModule: true, default: MockMultiSafeItemCard }
 })
 
-const mockUseIsQualifiedSafe = useIsQualifiedSafe as jest.Mock
 const mockUseAccountsModalItems = useAccountsModalItems as jest.Mock
 
 const safeItem = (chainId: string, address: string, overrides: Partial<SafeItem> = {}): SafeItem => ({
@@ -63,38 +57,42 @@ const safeItem = (chainId: string, address: string, overrides: Partial<SafeItem>
 
 const ADDR_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
+const buildHookReturn = (overrides: Partial<ReturnType<typeof useAccountsModalItems>> = {}) => ({
+  trustedItems: [],
+  otherItems: [safeItem('1', ADDR_A)],
+  similarAddresses: new Set<string>(),
+  isLoading: false,
+  isOwnedSafesError: false,
+  refetchOwnedSafes: jest.fn(),
+  isQualifiedSafe: false,
+  ...overrides,
+})
+
 describe('AccountsModal', () => {
   beforeEach(() => {
     jest.resetAllMocks()
-    mockUseAccountsModalItems.mockReturnValue({
-      trustedItems: [],
-      otherItems: [safeItem('1', ADDR_A)],
-      similarAddresses: new Set<string>(),
-      isLoading: false,
-      isOwnedSafesError: false,
-      refetchOwnedSafes: jest.fn(),
-    })
+    mockUseAccountsModalItems.mockReturnValue(buildHookReturn())
   })
 
   it('shows the "All Accounts" dialog title when not in a qualified space', () => {
-    mockUseIsQualifiedSafe.mockReturnValue(false)
+    mockUseAccountsModalItems.mockReturnValue(buildHookReturn({ isQualifiedSafe: false }))
 
     render(<AccountsModal open onClose={jest.fn()} />)
 
     expect(screen.getByText('All Accounts')).toBeInTheDocument()
   })
 
-  it('shows the "Safes not in this Workspace" dialog title when in a qualified space', () => {
-    mockUseIsQualifiedSafe.mockReturnValue(true)
+  it('shows the "Safes not in this workspace" dialog title when in a qualified space', () => {
+    mockUseAccountsModalItems.mockReturnValue(buildHookReturn({ isQualifiedSafe: true }))
 
     render(<AccountsModal open onClose={jest.fn()} />)
 
-    expect(screen.getByText('Safes not in this Workspace')).toBeInTheDocument()
+    expect(screen.getByText('Safes not in this workspace')).toBeInTheDocument()
     expect(screen.queryByText('All Accounts')).not.toBeInTheDocument()
   })
 
   it('passes hidePinControls=false to cards when not in a qualified space', () => {
-    mockUseIsQualifiedSafe.mockReturnValue(false)
+    mockUseAccountsModalItems.mockReturnValue(buildHookReturn({ isQualifiedSafe: false }))
 
     render(<AccountsModal open onClose={jest.fn()} />)
 
@@ -102,7 +100,7 @@ describe('AccountsModal', () => {
   })
 
   it('passes hidePinControls=true to cards when in a qualified space', () => {
-    mockUseIsQualifiedSafe.mockReturnValue(true)
+    mockUseAccountsModalItems.mockReturnValue(buildHookReturn({ isQualifiedSafe: true }))
 
     render(<AccountsModal open onClose={jest.fn()} />)
 
@@ -110,15 +108,7 @@ describe('AccountsModal', () => {
   })
 
   it('renders the empty state when no items match', () => {
-    mockUseIsQualifiedSafe.mockReturnValue(false)
-    mockUseAccountsModalItems.mockReturnValue({
-      trustedItems: [],
-      otherItems: [],
-      similarAddresses: new Set<string>(),
-      isLoading: false,
-      isOwnedSafesError: false,
-      refetchOwnedSafes: jest.fn(),
-    })
+    mockUseAccountsModalItems.mockReturnValue(buildHookReturn({ trustedItems: [], otherItems: [] }))
 
     render(<AccountsModal open onClose={jest.fn()} />)
 
@@ -126,15 +116,7 @@ describe('AccountsModal', () => {
   })
 
   it('renders the loading skeleton while isLoading is true', () => {
-    mockUseIsQualifiedSafe.mockReturnValue(false)
-    mockUseAccountsModalItems.mockReturnValue({
-      trustedItems: [],
-      otherItems: [],
-      similarAddresses: new Set<string>(),
-      isLoading: true,
-      isOwnedSafesError: false,
-      refetchOwnedSafes: jest.fn(),
-    })
+    mockUseAccountsModalItems.mockReturnValue(buildHookReturn({ trustedItems: [], otherItems: [], isLoading: true }))
 
     render(<AccountsModal open onClose={jest.fn()} />)
 

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
@@ -10,6 +10,7 @@ import { trackEvent } from '@/services/analytics'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics/events/overview'
 import InlineRetryError from '@/components/common/InlineRetryError'
 import { SafeListSkeleton } from './shared'
+import SimilarAddressAlert from '@/components/common/SimilarAddressAlert'
 import SafeItemCard from './SafeItemCard'
 import MultiSafeItemCard from './MultiSafeItemCard'
 import { useAccountsModalItems } from './useAccountsModalItems'
@@ -116,6 +117,11 @@ const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
             </p>
           ) : (
             <>
+              {similarAddresses.size > 0 && (
+                <div className="px-2 pb-2 pt-1">
+                  <SimilarAddressAlert />
+                </div>
+              )}
               {renderSection('Trusted Safes', trustedItems, {
                 similarAddresses,
                 onClose,

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
@@ -13,10 +13,52 @@ import { SafeListSkeleton } from './shared'
 import SafeItemCard from './SafeItemCard'
 import MultiSafeItemCard from './MultiSafeItemCard'
 import { useAccountsModalItems } from './useAccountsModalItems'
+import type { AllSafeItems } from '@/hooks/safes'
 
 interface AccountsModalProps {
   open: boolean
   onClose: () => void
+}
+
+interface SectionOptions {
+  similarAddresses: Set<string>
+  onClose: () => void
+  hidePinControls: boolean
+  headerPaddingTopClass: string
+  headerTestId?: string
+}
+
+const renderSection = (title: string, items: AllSafeItems, opts: SectionOptions) => {
+  if (items.length === 0) return null
+  return (
+    <>
+      <div
+        className={`flex items-center gap-1.5 px-2 pb-1 ${opts.headerPaddingTopClass}`}
+        data-testid={opts.headerTestId}
+      >
+        <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{title}</span>
+      </div>
+      {items.map((item) =>
+        isMultiChainSafeItem(item) ? (
+          <MultiSafeItemCard
+            key={item.address}
+            item={item}
+            isSimilar={opts.similarAddresses.has(item.address.toLowerCase())}
+            onClose={opts.onClose}
+            hidePinControls={opts.hidePinControls}
+          />
+        ) : (
+          <SafeItemCard
+            key={`${item.chainId}:${item.address}`}
+            safeItem={item}
+            isSimilar={opts.similarAddresses.has(item.address.toLowerCase())}
+            onClose={opts.onClose}
+            hidePinControls={opts.hidePinControls}
+          />
+        ),
+      )}
+    </>
+  )
 }
 
 const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
@@ -74,63 +116,19 @@ const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
             </p>
           ) : (
             <>
-              {trustedItems.length > 0 && (
-                <>
-                  <div className="flex items-center gap-1.5 px-2 pb-1 pt-1" data-testid="pinned-accounts">
-                    <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                      Trusted Safes
-                    </span>
-                  </div>
-                  {trustedItems.map((item) =>
-                    isMultiChainSafeItem(item) ? (
-                      <MultiSafeItemCard
-                        key={item.address}
-                        item={item}
-                        isSimilar={similarAddresses.has(item.address.toLowerCase())}
-                        onClose={onClose}
-                        hidePinControls={isQualifiedSafe}
-                      />
-                    ) : (
-                      <SafeItemCard
-                        key={`${item.chainId}:${item.address}`}
-                        safeItem={item}
-                        isSimilar={similarAddresses.has(item.address.toLowerCase())}
-                        onClose={onClose}
-                        hidePinControls={isQualifiedSafe}
-                      />
-                    ),
-                  )}
-                </>
-              )}
-
-              {otherItems.length > 0 && (
-                <>
-                  <div className="flex items-center gap-1.5 px-2 pb-1 pt-2">
-                    <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                      Other Safes
-                    </span>
-                  </div>
-                  {otherItems.map((item) =>
-                    isMultiChainSafeItem(item) ? (
-                      <MultiSafeItemCard
-                        key={item.address}
-                        item={item}
-                        isSimilar={similarAddresses.has(item.address.toLowerCase())}
-                        onClose={onClose}
-                        hidePinControls={isQualifiedSafe}
-                      />
-                    ) : (
-                      <SafeItemCard
-                        key={`${item.chainId}:${item.address}`}
-                        safeItem={item}
-                        isSimilar={similarAddresses.has(item.address.toLowerCase())}
-                        onClose={onClose}
-                        hidePinControls={isQualifiedSafe}
-                      />
-                    ),
-                  )}
-                </>
-              )}
+              {renderSection('Trusted Safes', trustedItems, {
+                similarAddresses,
+                onClose,
+                hidePinControls: isQualifiedSafe,
+                headerPaddingTopClass: 'pt-1',
+                headerTestId: 'pinned-accounts',
+              })}
+              {renderSection('Other Safes', otherItems, {
+                similarAddresses,
+                onClose,
+                hidePinControls: isQualifiedSafe,
+                headerPaddingTopClass: 'pt-2',
+              })}
             </>
           )}
         </div>

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
@@ -1,22 +1,19 @@
-import { useState, useMemo, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import Link from 'next/link'
 import { Search, CircleFadingPlus, Plus } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Button } from '@/components/ui/button'
 import { AppRoutes } from '@/config/routes'
-import { useAllSafes, useAllSafesGrouped, isMultiChainSafeItem, type AllSafeItems } from '@/hooks/safes'
-import { useOwnersGetAllSafesByOwnerV2Query } from '@safe-global/store/gateway/AUTO_GENERATED/owners'
-import useWallet from '@/hooks/wallets/useWallet'
-import { useAppDispatch } from '@/store'
-import { showNotification } from '@/store/notificationsSlice'
-import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
+import { isMultiChainSafeItem } from '@/hooks/safes'
+import { useIsQualifiedSafe } from '@/features/spaces'
 import { trackEvent } from '@/services/analytics'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics/events/overview'
 import InlineRetryError from '@/components/common/InlineRetryError'
 import { SafeListSkeleton } from './shared'
 import SafeItemCard from './SafeItemCard'
 import MultiSafeItemCard from './MultiSafeItemCard'
+import { useAccountsModalItems } from './useAccountsModalItems'
 
 interface AccountsModalProps {
   open: boolean
@@ -25,76 +22,19 @@ interface AccountsModalProps {
 
 const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
   const [search, setSearch] = useState('')
-  const dispatch = useAppDispatch()
-  const allSafes = useAllSafes()
-  const { address: walletAddress = '' } = useWallet() || {}
-  const { error: ownedSafesError, refetch: refetchOwnedSafes } = useOwnersGetAllSafesByOwnerV2Query(
-    { ownerAddress: walletAddress },
-    { skip: walletAddress === '' },
-  )
-
-  useEffect(() => {
-    if (!open || !ownedSafesError) return
-    dispatch(
-      showNotification({
-        title: 'Failed to load owned safes',
-        message: 'Some of your accounts may be missing. Please try again.',
-        groupKey: 'owned-safes-fetch-error',
-        variant: 'error',
-        link: { onClick: () => void refetchOwnedSafes(), title: 'Retry' },
-      }),
-    )
-  }, [open, ownedSafesError, refetchOwnedSafes, dispatch])
-
-  // Group ALL safes into single/multi-chain
-  const { allSingleSafes, allMultiChainSafes } = useAllSafesGrouped(allSafes ?? [])
-
-  // Merge into ordered list (multi-chain first by lastVisited, then single)
-  const allItems = useMemo<AllSafeItems>(() => {
-    const multi = allMultiChainSafes ?? []
-    const single = allSingleSafes ?? []
-    return [...multi, ...single].sort((a, b) => (b.lastVisited ?? 0) - (a.lastVisited ?? 0))
-  }, [allMultiChainSafes, allSingleSafes])
-
-  const similarAddresses = useMemo(() => getFlaggedSimilarAddressSet(allItems.map((item) => item.address)), [allItems])
-
-  // Apply search filter
-  const filteredItems = useMemo(() => {
-    if (!search.trim()) return allItems
-    const query = search.toLowerCase()
-    return allItems.filter((item) => {
-      const name = item.name?.toLowerCase() ?? ''
-      const address = item.address.toLowerCase()
-      return name.includes(query) || address.includes(query)
-    })
-  }, [allItems, search])
-
-  // Split into trusted and other
-  const trustedItems = useMemo(() => filteredItems.filter((item) => item.isPinned), [filteredItems])
-  const otherItems = useMemo(() => filteredItems.filter((item) => !item.isPinned), [filteredItems])
-
-  // Track search with debounce
-  const searchTracked = useRef(false)
-  useEffect(() => {
-    if (!search.trim()) {
-      searchTracked.current = false
-      return
-    }
-    if (searchTracked.current) return
-    const timer = setTimeout(() => {
-      trackEvent(OVERVIEW_EVENTS.SEARCH)
-      searchTracked.current = true
-    }, 300)
-    return () => clearTimeout(timer)
-  }, [search])
+  const isQualifiedSafe = useIsQualifiedSafe()
+  const { trustedItems, otherItems, similarAddresses, isLoading, isOwnedSafesError, refetchOwnedSafes } =
+    useAccountsModalItems({ search, open })
 
   if (!open) return null
+
+  const isEmpty = trustedItems.length === 0 && otherItems.length === 0
 
   return (
     <Dialog open onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent showCloseButton className="flex max-h-[90vh] w-full max-w-[560px] flex-col gap-0 p-0">
         <DialogHeader className="shrink-0 border-b border-border/50 px-4 pb-3 pt-4">
-          <DialogTitle>All Accounts</DialogTitle>
+          <DialogTitle>{isQualifiedSafe ? 'Safes not in this Workspace' : 'All Accounts'}</DialogTitle>
         </DialogHeader>
 
         <div className="shrink-0 px-4 py-3">
@@ -116,14 +56,14 @@ const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
           className="min-h-0 flex-1 overflow-y-auto px-3 [scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border"
           data-testid="accounts-list"
         >
-          {ownedSafesError && (
+          {isOwnedSafesError && (
             <div className="px-2 pb-2 pt-1">
               <InlineRetryError message="Failed to load owned safes" onRetry={refetchOwnedSafes} />
             </div>
           )}
-          {!allSafes ? (
+          {isLoading ? (
             <SafeListSkeleton />
-          ) : filteredItems.length === 0 ? (
+          ) : isEmpty ? (
             <p className="px-2 py-6 text-center text-sm text-muted-foreground" data-testid="empty-pinned-list">
               {search.trim() ? 'No safes match your search' : 'No safes yet'}
             </p>
@@ -143,6 +83,7 @@ const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
                         item={item}
                         isSimilar={similarAddresses.has(item.address.toLowerCase())}
                         onClose={onClose}
+                        hidePinControls={isQualifiedSafe}
                       />
                     ) : (
                       <SafeItemCard
@@ -150,6 +91,7 @@ const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
                         safeItem={item}
                         isSimilar={similarAddresses.has(item.address.toLowerCase())}
                         onClose={onClose}
+                        hidePinControls={isQualifiedSafe}
                       />
                     ),
                   )}
@@ -170,6 +112,7 @@ const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
                         item={item}
                         isSimilar={similarAddresses.has(item.address.toLowerCase())}
                         onClose={onClose}
+                        hidePinControls={isQualifiedSafe}
                       />
                     ) : (
                       <SafeItemCard
@@ -177,6 +120,7 @@ const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
                         safeItem={item}
                         isSimilar={similarAddresses.has(item.address.toLowerCase())}
                         onClose={onClose}
+                        hidePinControls={isQualifiedSafe}
                       />
                     ),
                   )}

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
@@ -6,7 +6,6 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/in
 import { Button } from '@/components/ui/button'
 import { AppRoutes } from '@/config/routes'
 import { isMultiChainSafeItem } from '@/hooks/safes'
-import { useIsQualifiedSafe } from '@/features/spaces'
 import { trackEvent } from '@/services/analytics'
 import { OVERVIEW_EVENTS, OVERVIEW_LABELS } from '@/services/analytics/events/overview'
 import InlineRetryError from '@/components/common/InlineRetryError'
@@ -22,9 +21,15 @@ interface AccountsModalProps {
 
 const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
   const [search, setSearch] = useState('')
-  const isQualifiedSafe = useIsQualifiedSafe()
-  const { trustedItems, otherItems, similarAddresses, isLoading, isOwnedSafesError, refetchOwnedSafes } =
-    useAccountsModalItems({ search, open })
+  const {
+    trustedItems,
+    otherItems,
+    similarAddresses,
+    isLoading,
+    isOwnedSafesError,
+    refetchOwnedSafes,
+    isQualifiedSafe,
+  } = useAccountsModalItems({ search, open })
 
   if (!open) return null
 
@@ -34,7 +39,7 @@ const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
     <Dialog open onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent showCloseButton className="flex max-h-[90vh] w-full max-w-[560px] flex-col gap-0 p-0">
         <DialogHeader className="shrink-0 border-b border-border/50 px-4 pb-3 pt-4">
-          <DialogTitle>{isQualifiedSafe ? 'Safes not in this Workspace' : 'All Accounts'}</DialogTitle>
+          <DialogTitle>{isQualifiedSafe ? 'Safes not in this workspace' : 'All Accounts'}</DialogTitle>
         </DialogHeader>
 
         <div className="shrink-0 px-4 py-3">

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
@@ -81,7 +81,7 @@ const AccountsModal = ({ open, onClose }: AccountsModalProps) => {
     <Dialog open onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent showCloseButton className="flex max-h-[90vh] w-full max-w-[560px] flex-col gap-0 p-0">
         <DialogHeader className="shrink-0 border-b border-border/50 px-4 pb-3 pt-4">
-          <DialogTitle>{isQualifiedSafe ? 'Safes not in this workspace' : 'All Accounts'}</DialogTitle>
+          <DialogTitle>{isQualifiedSafe ? 'Explore other Safes' : 'All Accounts'}</DialogTitle>
         </DialogHeader>
 
         <div className="shrink-0 px-4 py-3">

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react'
+import { ShortAddressWithTooltip } from './shared'
+
+const ADDRESS = '0xabcd567890123456789012345678901234567890'
+
+describe('ShortAddressWithTooltip', () => {
+  it('renders the shortened address as plain text when not flagged as similar', () => {
+    const { container } = render(<ShortAddressWithTooltip address={ADDRESS} />)
+
+    expect(container.textContent).toContain('0xabcd...7890')
+    expect(container.querySelectorAll('b')).toHaveLength(0)
+  })
+
+  it('renders the shortened address with the first 4 and last 4 hex chars bolded when isSimilar is true', () => {
+    const { container } = render(<ShortAddressWithTooltip address={ADDRESS} isSimilar />)
+
+    const bolded = Array.from(container.querySelectorAll('b')).map((el) => el.textContent)
+    expect(bolded).toEqual(['abcd', '7890'])
+    expect(container.textContent).toContain('0xabcd...7890')
+  })
+})

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx
@@ -155,7 +155,7 @@ export function ShortAddressWithTooltip({
           />
         }
       >
-        {isSimilar ? (
+        {isSimilar && address.startsWith('0x') && address.length >= 10 ? (
           <>
             0x
             <b className="text-foreground">{address.slice(2, 6)}</b>

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx
@@ -131,8 +131,21 @@ const TooltipFullAddress = ({ address }: { address: string }) => {
   )
 }
 
-/** Shortened address; hover shows full address in a tooltip */
-export function ShortAddressWithTooltip({ address, className }: { address: string; className?: string }) {
+/**
+ * Shortened address; hover shows full address in a tooltip.
+ *
+ * When `isSimilar` is true, the two visible hex groups (first 4 and last 4) are
+ * bolded inline so users can compare against another address at a glance.
+ */
+export function ShortAddressWithTooltip({
+  address,
+  className,
+  isSimilar = false,
+}: {
+  address: string
+  className?: string
+  isSimilar?: boolean
+}) {
   return (
     <Tooltip>
       <TooltipTrigger
@@ -142,7 +155,16 @@ export function ShortAddressWithTooltip({ address, className }: { address: strin
           />
         }
       >
-        {shortenAddress(address)}
+        {isSimilar ? (
+          <>
+            0x
+            <b className="text-foreground">{address.slice(2, 6)}</b>
+            ...
+            <b className="text-foreground">{address.slice(-4)}</b>
+          </>
+        ) : (
+          shortenAddress(address)
+        )}
       </TooltipTrigger>
       <TooltipContent
         side="top"

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
@@ -109,6 +109,15 @@ describe('useAccountsModalItems', () => {
     expect(result.current.otherItems).toHaveLength(1)
   })
 
+  it('exposes isQualifiedSafe so callers do not need to call useIsQualifiedSafe themselves', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+    mockUseAllSafes.mockReturnValue([safeItem('1', ADDR_A)])
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(result.current.isQualifiedSafe).toBe(true)
+  })
+
   it('applies search by name and address substring', () => {
     mockUseAllSafes.mockReturnValue([
       safeItem('1', ADDR_A, { name: 'Treasury Safe' }),

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
@@ -1,7 +1,9 @@
 import { renderHook } from '@testing-library/react'
 import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
-import { useAllSafes } from '@/hooks/safes'
+import { useAllSafes, isMultiChainSafeItem } from '@/hooks/safes'
 import type { SafeItem } from '@/hooks/safes'
+import { useOwnersGetAllSafesByOwnerV2Query } from '@safe-global/store/gateway/AUTO_GENERATED/owners'
+import { useAppDispatch } from '@/store'
 import { useAccountsModalItems } from './useAccountsModalItems'
 
 jest.mock('@/features/spaces', () => ({
@@ -28,17 +30,19 @@ jest.mock('@/hooks/safes', () => {
 jest.mock('@/hooks/wallets/useWallet', () => () => ({ address: '' }))
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/owners', () => ({
-  useOwnersGetAllSafesByOwnerV2Query: () => ({ error: undefined, refetch: jest.fn() }),
+  useOwnersGetAllSafesByOwnerV2Query: jest.fn(() => ({ error: undefined, refetch: jest.fn() })),
 }))
 
 jest.mock('@/store', () => ({
-  useAppDispatch: () => jest.fn(),
+  useAppDispatch: jest.fn(),
   useAppSelector: () => ({}),
 }))
 
 const mockUseIsQualifiedSafe = useIsQualifiedSafe as jest.Mock
 const mockUseSpaceSafes = useSpaceSafes as jest.Mock
 const mockUseAllSafes = useAllSafes as jest.Mock
+const mockUseOwnersQuery = useOwnersGetAllSafesByOwnerV2Query as unknown as jest.Mock
+const mockUseAppDispatch = useAppDispatch as unknown as jest.Mock
 
 const safeItem = (chainId: string, address: string, overrides: Partial<SafeItem> = {}): SafeItem => ({
   chainId,
@@ -58,6 +62,8 @@ describe('useAccountsModalItems', () => {
     jest.resetAllMocks()
     mockUseSpaceSafes.mockReturnValue({ allSafes: [] })
     mockUseIsQualifiedSafe.mockReturnValue(false)
+    mockUseOwnersQuery.mockReturnValue({ error: undefined, refetch: jest.fn() })
+    mockUseAppDispatch.mockReturnValue(jest.fn())
   })
 
   it('splits items into trusted (pinned) and other (non-pinned)', () => {
@@ -136,6 +142,47 @@ describe('useAccountsModalItems', () => {
     const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
 
     expect(result.current.isQualifiedSafe).toBe(true)
+  })
+
+  it('degrades a multi-chain safe to single-chain when one of its chains is in the workspace', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+    // ADDR_A is on chains 1 + 100 → would normally group as multi-chain.
+    mockUseAllSafes.mockReturnValue([safeItem('1', ADDR_A), safeItem('100', ADDR_A)])
+    // Workspace contains ADDR_A on chain 1 → chain 1 is excluded, only chain 100 remains.
+    mockUseSpaceSafes.mockReturnValue({
+      allSafes: [safeItem('1', ADDR_A)],
+    })
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(result.current.otherItems).toHaveLength(1)
+    const survivor = result.current.otherItems[0]
+    // After filtering, only one chain instance remains → must be a single-chain SafeItem, not multi.
+    expect(isMultiChainSafeItem(survivor)).toBe(false)
+    expect((survivor as SafeItem).chainId).toBe('100')
+    expect(survivor.address).toBe(ADDR_A)
+  })
+
+  it('does not dispatch the owned-safes error notification while the modal is closed', () => {
+    const dispatch = jest.fn()
+    mockUseAppDispatch.mockReturnValue(dispatch)
+    mockUseOwnersQuery.mockReturnValue({ error: { status: 500 }, refetch: jest.fn() })
+    mockUseAllSafes.mockReturnValue([safeItem('1', ADDR_A)])
+
+    renderHook(() => useAccountsModalItems({ search: '', open: false }))
+
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('dispatches the owned-safes error notification when the modal is open and the query errors', () => {
+    const dispatch = jest.fn()
+    mockUseAppDispatch.mockReturnValue(dispatch)
+    mockUseOwnersQuery.mockReturnValue({ error: { status: 500 }, refetch: jest.fn() })
+    mockUseAllSafes.mockReturnValue([safeItem('1', ADDR_A)])
+
+    renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
   })
 
   it('applies search by name and address substring', () => {

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
@@ -1,0 +1,131 @@
+import { renderHook } from '@testing-library/react'
+import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
+import { useAllSafes } from '@/hooks/safes'
+import type { SafeItem } from '@/hooks/safes'
+import { useAccountsModalItems } from './useAccountsModalItems'
+
+jest.mock('@/features/spaces', () => ({
+  useIsQualifiedSafe: jest.fn(),
+  useSpaceSafes: jest.fn(),
+}))
+
+jest.mock('@/hooks/safes', () => {
+  const actual = jest.requireActual('@/hooks/safes')
+  return {
+    ...actual,
+    useAllSafes: jest.fn(),
+    // Real useAllSafesGrouped internally calls useAllSafes (unmocked path), which needs
+    // Redux/RTK context. Replace it with a pure delegate over the customSafes arg.
+    // Plain function (not jest.fn) so jest.resetAllMocks() doesn't wipe the implementation.
+    useAllSafesGrouped: (customSafes = []) => {
+      const allMultiChainSafes = actual._getMultiChainAccounts(customSafes)
+      const allSingleSafes = actual._getSingleChainAccounts(customSafes, allMultiChainSafes)
+      return { allMultiChainSafes, allSingleSafes }
+    },
+  }
+})
+
+jest.mock('@/hooks/wallets/useWallet', () => () => ({ address: '' }))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/owners', () => ({
+  useOwnersGetAllSafesByOwnerV2Query: () => ({ error: undefined, refetch: jest.fn() }),
+}))
+
+jest.mock('@/store', () => ({
+  useAppDispatch: () => jest.fn(),
+  useAppSelector: () => ({}),
+}))
+
+const mockUseIsQualifiedSafe = useIsQualifiedSafe as jest.Mock
+const mockUseSpaceSafes = useSpaceSafes as jest.Mock
+const mockUseAllSafes = useAllSafes as jest.Mock
+
+const safeItem = (chainId: string, address: string, overrides: Partial<SafeItem> = {}): SafeItem => ({
+  chainId,
+  address,
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+  ...overrides,
+})
+
+const ADDR_A = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const ADDR_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+describe('useAccountsModalItems', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockUseSpaceSafes.mockReturnValue({ allSafes: [] })
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+  })
+
+  it('splits items into trusted (pinned) and other (non-pinned)', () => {
+    mockUseAllSafes.mockReturnValue([
+      safeItem('1', ADDR_A, { isPinned: true }),
+      safeItem('1', ADDR_B, { isPinned: false }),
+    ])
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(result.current.trustedItems).toHaveLength(1)
+    expect(result.current.otherItems).toHaveLength(1)
+    expect((result.current.trustedItems[0] as SafeItem).address).toBe(ADDR_A)
+    expect((result.current.otherItems[0] as SafeItem).address).toBe(ADDR_B)
+  })
+
+  it('reports isLoading when useAllSafes returns undefined', () => {
+    mockUseAllSafes.mockReturnValue(undefined)
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.trustedItems).toHaveLength(0)
+    expect(result.current.otherItems).toHaveLength(0)
+  })
+
+  it('filters out safes already in the current space by exact (chainId, address) match', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+    mockUseAllSafes.mockReturnValue([safeItem('1', ADDR_A), safeItem('100', ADDR_A), safeItem('1', ADDR_B)])
+    // Space contains ADDR_A on chain 1 only.
+    mockUseSpaceSafes.mockReturnValue({
+      allSafes: [safeItem('1', ADDR_A)],
+    })
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    const addresses = result.current.otherItems.map((item) => `${(item as SafeItem).chainId}:${item.address}`)
+    expect(addresses).toEqual(expect.arrayContaining([`100:${ADDR_A}`, `1:${ADDR_B}`]))
+    expect(addresses).not.toContain(`1:${ADDR_A}`)
+  })
+
+  it('does not filter when isQualifiedSafe is false even if useSpaceSafes returns items (defensive)', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+    mockUseAllSafes.mockReturnValue([safeItem('1', ADDR_A)])
+    mockUseSpaceSafes.mockReturnValue({ allSafes: [safeItem('1', ADDR_A)] })
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(result.current.otherItems).toHaveLength(1)
+  })
+
+  it('applies search by name and address substring', () => {
+    mockUseAllSafes.mockReturnValue([
+      safeItem('1', ADDR_A, { name: 'Treasury Safe' }),
+      safeItem('1', ADDR_B, { name: 'Side Vault' }),
+    ])
+
+    const { result, rerender } = renderHook(({ search }) => useAccountsModalItems({ search, open: true }), {
+      initialProps: { search: 'treasury' },
+    })
+    expect(result.current.otherItems).toHaveLength(1)
+    expect((result.current.otherItems[0] as SafeItem).name).toBe('Treasury Safe')
+
+    rerender({ search: ADDR_B.slice(2, 6) })
+    expect(result.current.otherItems).toHaveLength(1)
+    expect((result.current.otherItems[0] as SafeItem).address).toBe(ADDR_B)
+
+    rerender({ search: 'nope' })
+    expect(result.current.otherItems).toHaveLength(0)
+  })
+})

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
@@ -84,6 +84,26 @@ describe('useAccountsModalItems', () => {
     expect(result.current.otherItems).toHaveLength(0)
   })
 
+  it('reports isLoading=true in workspace context while space safes are still loading', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+    mockUseAllSafes.mockReturnValue([safeItem('1', ADDR_A)])
+    mockUseSpaceSafes.mockReturnValue({ allSafes: [], isLoading: true })
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('does not gate on space-safes loading outside workspace context', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+    mockUseAllSafes.mockReturnValue([safeItem('1', ADDR_A)])
+    mockUseSpaceSafes.mockReturnValue({ allSafes: [], isLoading: true })
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(result.current.isLoading).toBe(false)
+  })
+
   it('filters out safes already in the current space by exact (chainId, address) match', () => {
     mockUseIsQualifiedSafe.mockReturnValue(true)
     mockUseAllSafes.mockReturnValue([safeItem('1', ADDR_A), safeItem('100', ADDR_A), safeItem('1', ADDR_B)])

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
@@ -91,9 +91,9 @@ export function useAccountsModalItems({ search, open }: { search: string; open: 
   }, [open, ownedSafesError, refetchOwnedSafes, dispatch])
 
   const filteredAllSafes = useMemo(() => {
-    if (!allSafes || !spaceExclusionKey) return allSafes
-    return allSafes.filter((s) => !spaceExclusionKey.has(`${s.chainId}:${s.address.toLowerCase()}`))
-  }, [allSafes, spaceExclusionKey])
+    if (!allSafes || !isQualifiedSafe) return allSafes
+    return allSafes.filter((s) => !spaceExclusionKey?.has(`${s.chainId}:${s.address.toLowerCase()}`))
+  }, [allSafes, isQualifiedSafe, spaceExclusionKey])
 
   const { allSingleSafes, allMultiChainSafes } = useAllSafesGrouped(filteredAllSafes ?? EMPTY_SAFES)
 

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useRef } from 'react'
+import {
+  useAllSafes,
+  useAllSafesGrouped,
+  flattenSafeItems,
+  type AllSafeItems,
+  type MultiChainSafeItem,
+  type SafeItem,
+} from '@/hooks/safes'
+import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
+import { useOwnersGetAllSafesByOwnerV2Query } from '@safe-global/store/gateway/AUTO_GENERATED/owners'
+import useWallet from '@/hooks/wallets/useWallet'
+import { useAppDispatch } from '@/store'
+import { showNotification } from '@/store/notificationsSlice'
+import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
+import { trackEvent } from '@/services/analytics'
+import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
+
+/**
+ * Assembles the list shown in <AccountsModal />: the user's accounts
+ * (locally pinned + EOA-owned via CGW + counterfactual) grouped into
+ * "Trusted" and "Other" sections, narrowed by search, with address-
+ * poisoning warnings.
+ *
+ * Pipeline:
+ *
+ *   useAllSafes()              → flat SafeItems (per chain)
+ *     │
+ *     ▼  exclude safes already in current space (when isQualifiedSafe)
+ *   filteredFlat
+ *     │
+ *     ▼  useAllSafesGrouped()  → multi + single
+ *   allItems  (merge, sort by lastVisited)
+ *     │
+ *     ▼  apply search (name or address substring)
+ *   filtered
+ *     │
+ *     ▼  split by isPinned
+ *   { trustedItems, otherItems }
+ *
+ * Non-obvious design choices:
+ *
+ *  • Filter BEFORE grouping. A multi-chain safe whose chains straddle
+ *    the space boundary gracefully degrades to single-chain via re-
+ *    grouping; if we filtered after, we'd have to mutate the grouped
+ *    item ourselves.
+ *
+ *  • "Trusted" = locally pinned in addedSafesSlice, NOT space
+ *    membership. A user in a space who never pinned anything sees an
+ *    empty Trusted section.
+ *
+ *  • Similarity is computed on the FILTERED set. A non-space safe
+ *    that resembles a space safe will not be flagged here — known v1
+ *    limitation. Revisit if poisoning attacks against space members
+ *    surface in production.
+ *
+ *  • Owned-safes errors are surfaced (not swallowed) so callers can
+ *    render a retry notification.
+ */
+export function useAccountsModalItems({ search, open }: { search: string; open: boolean }) {
+  const dispatch = useAppDispatch()
+  const allSafes = useAllSafes()
+  const { address: walletAddress = '' } = useWallet() || {}
+  const { error: ownedSafesError, refetch: refetchOwnedSafes } = useOwnersGetAllSafesByOwnerV2Query(
+    { ownerAddress: walletAddress },
+    { skip: walletAddress === '' },
+  )
+
+  const isQualifiedSafe = useIsQualifiedSafe()
+  const { allSafes: spaceSafes } = useSpaceSafes()
+  const spaceExclusionKey = useMemo<Set<string> | null>(() => {
+    if (!isQualifiedSafe) return null
+    const flat = flattenSafeItems(spaceSafes)
+    return new Set(flat.map((s) => `${s.chainId}:${s.address.toLowerCase()}`))
+  }, [isQualifiedSafe, spaceSafes])
+
+  useEffect(() => {
+    if (!open || !ownedSafesError) return
+    dispatch(
+      showNotification({
+        title: 'Failed to load owned safes',
+        message: 'Some of your accounts may be missing. Please try again.',
+        groupKey: 'owned-safes-fetch-error',
+        variant: 'error',
+        link: { onClick: () => void refetchOwnedSafes(), title: 'Retry' },
+      }),
+    )
+  }, [open, ownedSafesError, refetchOwnedSafes, dispatch])
+
+  const filteredAllSafes = useMemo(() => {
+    if (!allSafes || !spaceExclusionKey) return allSafes
+    return allSafes.filter((s) => !spaceExclusionKey.has(`${s.chainId}:${s.address.toLowerCase()}`))
+  }, [allSafes, spaceExclusionKey])
+
+  const { allSingleSafes, allMultiChainSafes } = useAllSafesGrouped(filteredAllSafes ?? [])
+
+  const allItems = useMemo<AllSafeItems>(() => {
+    const multi = allMultiChainSafes ?? []
+    const single = allSingleSafes ?? []
+    return [...multi, ...single].sort((a, b) => (b.lastVisited ?? 0) - (a.lastVisited ?? 0))
+  }, [allMultiChainSafes, allSingleSafes])
+
+  const similarAddresses = useMemo(() => getFlaggedSimilarAddressSet(allItems.map((item) => item.address)), [allItems])
+
+  const filteredItems = useMemo<AllSafeItems>(() => {
+    if (!search.trim()) return allItems
+    const query = search.toLowerCase()
+    return allItems.filter((item: SafeItem | MultiChainSafeItem) => {
+      const name = item.name?.toLowerCase() ?? ''
+      const address = item.address.toLowerCase()
+      return name.includes(query) || address.includes(query)
+    })
+  }, [allItems, search])
+
+  const trustedItems = useMemo<AllSafeItems>(() => filteredItems.filter((item) => item.isPinned), [filteredItems])
+  const otherItems = useMemo<AllSafeItems>(() => filteredItems.filter((item) => !item.isPinned), [filteredItems])
+
+  // Fire SEARCH analytics once per non-empty query (debounced).
+  const searchTracked = useRef(false)
+  useEffect(() => {
+    if (!search.trim()) {
+      searchTracked.current = false
+      return
+    }
+    if (searchTracked.current) return
+    const timer = setTimeout(() => {
+      trackEvent(OVERVIEW_EVENTS.SEARCH)
+      searchTracked.current = true
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [search])
+
+  return {
+    trustedItems,
+    otherItems,
+    similarAddresses,
+    isLoading: !allSafes,
+    isOwnedSafesError: Boolean(ownedSafesError),
+    refetchOwnedSafes,
+  }
+}

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
@@ -70,8 +70,7 @@ export function useAccountsModalItems({ search, open }: { search: string; open: 
   const { allSafes: spaceSafes } = useSpaceSafes()
   const spaceExclusionKey = useMemo<Set<string> | null>(() => {
     if (!isQualifiedSafe) return null
-    const flat = flattenSafeItems(spaceSafes)
-    return new Set(flat.map((s) => `${s.chainId}:${s.address.toLowerCase()}`))
+    return new Set(flattenSafeItems(spaceSafes).map((s) => `${s.chainId}:${s.address.toLowerCase()}`))
   }, [isQualifiedSafe, spaceSafes])
 
   useEffect(() => {
@@ -137,5 +136,6 @@ export function useAccountsModalItems({ search, open }: { search: string; open: 
     isLoading: !allSafes,
     isOwnedSafesError: Boolean(ownedSafesError),
     refetchOwnedSafes,
+    isQualifiedSafe,
   }
 }

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
@@ -6,6 +6,7 @@ import {
   type AllSafeItems,
   type MultiChainSafeItem,
   type SafeItem,
+  type SafeItems,
 } from '@/hooks/safes'
 import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
 import { useOwnersGetAllSafesByOwnerV2Query } from '@safe-global/store/gateway/AUTO_GENERATED/owners'
@@ -15,6 +16,9 @@ import { showNotification } from '@/store/notificationsSlice'
 import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
 import { trackEvent } from '@/services/analytics'
 import { OVERVIEW_EVENTS } from '@/services/analytics/events/overview'
+
+// Stable empty-array reference so `useAllSafesGrouped` memo doesn't re-run on each render while loading.
+const EMPTY_SAFES: SafeItems = []
 
 /**
  * Assembles the list shown in <AccountsModal />: the user's accounts
@@ -91,7 +95,7 @@ export function useAccountsModalItems({ search, open }: { search: string; open: 
     return allSafes.filter((s) => !spaceExclusionKey.has(`${s.chainId}:${s.address.toLowerCase()}`))
   }, [allSafes, spaceExclusionKey])
 
-  const { allSingleSafes, allMultiChainSafes } = useAllSafesGrouped(filteredAllSafes ?? [])
+  const { allSingleSafes, allMultiChainSafes } = useAllSafesGrouped(filteredAllSafes ?? EMPTY_SAFES)
 
   const allItems = useMemo<AllSafeItems>(() => {
     const multi = allMultiChainSafes ?? []
@@ -114,7 +118,9 @@ export function useAccountsModalItems({ search, open }: { search: string; open: 
   const trustedItems = useMemo<AllSafeItems>(() => filteredItems.filter((item) => item.isPinned), [filteredItems])
   const otherItems = useMemo<AllSafeItems>(() => filteredItems.filter((item) => !item.isPinned), [filteredItems])
 
-  // Fire SEARCH analytics once per non-empty query (debounced).
+  // Fire SEARCH analytics once per from-empty search session — re-arms when
+  // the user clears the input. Intentional: avoids spamming the endpoint on
+  // every keystroke while still capturing that the user searched.
   const searchTracked = useRef(false)
   useEffect(() => {
     if (!search.trim()) {

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
@@ -67,7 +67,7 @@ export function useAccountsModalItems({ search, open }: { search: string; open: 
   )
 
   const isQualifiedSafe = useIsQualifiedSafe()
-  const { allSafes: spaceSafes } = useSpaceSafes()
+  const { allSafes: spaceSafes, isLoading: spaceSafesLoading } = useSpaceSafes()
   const spaceExclusionKey = useMemo<Set<string> | null>(() => {
     if (!isQualifiedSafe) return null
     return new Set(flattenSafeItems(spaceSafes).map((s) => `${s.chainId}:${s.address.toLowerCase()}`))
@@ -133,7 +133,10 @@ export function useAccountsModalItems({ search, open }: { search: string; open: 
     trustedItems,
     otherItems,
     similarAddresses,
-    isLoading: !allSafes,
+    // In workspace context the exclusion set depends on space safes — show the skeleton
+    // until both arrive, otherwise the user briefly sees safes that ARE in the workspace
+    // before the filter kicks in (contradicting the "Safes not in this workspace" title).
+    isLoading: !allSafes || (isQualifiedSafe && Boolean(spaceSafesLoading)),
     isOwnedSafesError: Boolean(ownedSafesError),
     refetchOwnedSafes,
     isQualifiedSafe,

--- a/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
@@ -37,16 +37,23 @@ jest.mock('./SpaceChainSelector', () => {
 })
 
 jest.mock('@/features/spaces/components/SafeSelectorDropdown', () => {
-  const MockSafeSelectorDropdown = (props: Record<string, unknown>) => (
-    <div
-      data-testid="safe-selector-dropdown"
-      data-items={JSON.stringify(props.items)}
-      data-error={String(props.isError)}
-      data-selected-item-id={props.selectedItemId as string}
-      data-has-on-item-select={String(typeof props.onItemSelect === 'function')}
-      data-has-on-retry={String(typeof props.onRetry === 'function')}
-    />
-  )
+  const MockSafeSelectorDropdown = (props: Record<string, unknown>) => {
+    const footerFn = props.footer as ((close: () => void) => React.ReactNode) | undefined
+    return (
+      <div
+        data-testid="safe-selector-dropdown"
+        data-items={JSON.stringify(props.items)}
+        data-error={String(props.isError)}
+        data-selected-item-id={props.selectedItemId as string}
+        data-has-on-item-select={String(typeof props.onItemSelect === 'function')}
+        data-has-on-retry={String(typeof props.onRetry === 'function')}
+        data-has-footer={String(typeof props.footer === 'function')}
+      >
+        {props.header as React.ReactNode}
+        {typeof footerFn === 'function' && <div data-testid="dropdown-footer-slot">{footerFn(() => {})}</div>}
+      </div>
+    )
+  }
   MockSafeSelectorDropdown.displayName = 'SafeSelectorDropdown'
   return { __esModule: true, default: MockSafeSelectorDropdown }
 })
@@ -87,7 +94,10 @@ jest.mock('@/hooks/safes', () => ({
   useAllSafes: () => [],
 }))
 
-jest.mock('@/hooks/wallets/useWallet', () => () => null)
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}))
 
 jest.mock('@/components/common/ConnectWallet/useConnectWallet', () => () => jest.fn())
 
@@ -111,6 +121,7 @@ jest.mock('./SpaceBackLink', () => {
 import { usePathname } from 'next/navigation'
 import { useIsQualifiedSafe } from '@/features/spaces'
 import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
+import useWallet from '@/hooks/wallets/useWallet'
 import { useSpaceSafeSelectorItems } from './hooks/useSpaceSafeSelectorItems'
 import { useSpaceBackLink } from './hooks/useSpaceBackLink'
 
@@ -119,6 +130,7 @@ const mockUseIsQualifiedSafe = useIsQualifiedSafe as jest.Mock
 const mockUseSafeAddressFromUrl = useSafeAddressFromUrl as jest.Mock
 const mockUseSpaceSafeSelectorItems = useSpaceSafeSelectorItems as jest.Mock
 const mockUseSpaceBackLink = useSpaceBackLink as jest.Mock
+const mockUseWallet = useWallet as jest.Mock
 
 describe('SpaceSafeBar', () => {
   beforeEach(() => {
@@ -179,6 +191,61 @@ describe('SpaceSafeBar', () => {
     expect(dropdown.getAttribute('data-selected-item-id')).toBe('1:0xSafe1')
     expect(dropdown.getAttribute('data-has-on-item-select')).toBe('true')
     expect(dropdown.getAttribute('data-has-on-retry')).toBe('true')
+  })
+
+  it('passes an All Accounts footer to SafeSelectorDropdown on the Spaces level (WA-2462)', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+    mockUseSpaceBackLink.mockReturnValue({
+      space: { id: 1, name: 'Test Space' },
+      handleBackToSpace: jest.fn(),
+    })
+
+    const { getByTestId } = render(<SpaceSafeBar />)
+    expect(getByTestId('safe-selector-dropdown').getAttribute('data-has-footer')).toBe('true')
+  })
+
+  it('passes a footer to SafeSelectorDropdown when not on the Spaces level', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+
+    const { getByTestId } = render(<SpaceSafeBar />)
+    expect(getByTestId('safe-selector-dropdown').getAttribute('data-has-footer')).toBe('true')
+  })
+
+  it('labels the dropdown footer "All Accounts" when not on the Spaces level (wallet connected)', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+    mockUseWallet.mockReturnValue({ address: '0xWalletOwner' })
+
+    const { getByTestId } = render(<SpaceSafeBar />)
+    expect(getByTestId('all-accounts-btn').textContent).toContain('All Accounts')
+  })
+
+  it('labels the dropdown footer "Safes not in this Workspace" on the Spaces level', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+    mockUseSpaceBackLink.mockReturnValue({
+      space: { id: 1, name: 'Test Space' },
+      handleBackToSpace: jest.fn(),
+    })
+
+    const { getByTestId } = render(<SpaceSafeBar />)
+    expect(getByTestId('all-accounts-btn').textContent).toContain('Safes not in this Workspace')
+  })
+
+  it('renders the "Safes in this Workspace" dropdown header on the Spaces level', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(true)
+    mockUseSpaceBackLink.mockReturnValue({
+      space: { id: 1, name: 'Test Space' },
+      handleBackToSpace: jest.fn(),
+    })
+
+    const { getByTestId } = render(<SpaceSafeBar />)
+    expect(getByTestId('workspace-header').textContent).toBe('Safes in this Workspace')
+  })
+
+  it('does not render the workspace header off the Spaces level', () => {
+    mockUseIsQualifiedSafe.mockReturnValue(false)
+
+    const { queryByTestId } = render(<SpaceSafeBar />)
+    expect(queryByTestId('workspace-header')).not.toBeInTheDocument()
   })
 
   it('renders SpaceBackLink when in space context and space data is available', () => {

--- a/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
@@ -219,7 +219,7 @@ describe('SpaceSafeBar', () => {
     expect(getByTestId('all-accounts-btn').textContent).toContain('All Accounts')
   })
 
-  it('labels the dropdown footer "Safes not in this workspace" on the Spaces level', () => {
+  it('labels the dropdown footer "Explore other Safes" on the Spaces level', () => {
     mockUseIsQualifiedSafe.mockReturnValue(true)
     mockUseSpaceBackLink.mockReturnValue({
       space: { id: 1, name: 'Test Space' },
@@ -227,7 +227,7 @@ describe('SpaceSafeBar', () => {
     })
 
     const { getByTestId } = render(<SpaceSafeBar />)
-    expect(getByTestId('all-accounts-btn').textContent).toContain('Safes not in this workspace')
+    expect(getByTestId('all-accounts-btn').textContent).toContain('Explore other Safes')
   })
 
   it('renders the "Safes in this workspace" dropdown header on the Spaces level', () => {

--- a/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.test.tsx
@@ -219,7 +219,7 @@ describe('SpaceSafeBar', () => {
     expect(getByTestId('all-accounts-btn').textContent).toContain('All Accounts')
   })
 
-  it('labels the dropdown footer "Safes not in this Workspace" on the Spaces level', () => {
+  it('labels the dropdown footer "Safes not in this workspace" on the Spaces level', () => {
     mockUseIsQualifiedSafe.mockReturnValue(true)
     mockUseSpaceBackLink.mockReturnValue({
       space: { id: 1, name: 'Test Space' },
@@ -227,10 +227,10 @@ describe('SpaceSafeBar', () => {
     })
 
     const { getByTestId } = render(<SpaceSafeBar />)
-    expect(getByTestId('all-accounts-btn').textContent).toContain('Safes not in this Workspace')
+    expect(getByTestId('all-accounts-btn').textContent).toContain('Safes not in this workspace')
   })
 
-  it('renders the "Safes in this Workspace" dropdown header on the Spaces level', () => {
+  it('renders the "Safes in this workspace" dropdown header on the Spaces level', () => {
     mockUseIsQualifiedSafe.mockReturnValue(true)
     mockUseSpaceBackLink.mockReturnValue({
       space: { id: 1, name: 'Test Space' },
@@ -238,7 +238,7 @@ describe('SpaceSafeBar', () => {
     })
 
     const { getByTestId } = render(<SpaceSafeBar />)
-    expect(getByTestId('workspace-header').textContent).toBe('Safes in this Workspace')
+    expect(getByTestId('workspace-header').textContent).toBe('Safes in this workspace')
   })
 
   it('does not render the workspace header off the Spaces level', () => {

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -64,7 +64,7 @@ function DropdownWorkspaceHeader() {
   return (
     <div className="flex items-center gap-1 px-4 pt-3 pb-2">
       <span className="text-sm font-semibold text-secondary-foreground" data-testid="workspace-header">
-        Safes in this Workspace
+        Safes in this workspace
       </span>
     </div>
   )
@@ -173,7 +173,7 @@ function SpaceSafeBar() {
       ? (close: () => void) => <ConnectWalletFooter onConnect={connectWallet} onClose={close} />
       : (close: () => void) => (
           <DropdownFooter
-            label={isQualifiedSafe ? 'Safes not in this Workspace' : 'All Accounts'}
+            label={isQualifiedSafe ? 'Safes not in this workspace' : 'All Accounts'}
             onOpen={() => {
               close()
               handleOpenAccountsModal()

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -60,11 +60,21 @@ function DropdownHeader({ isPinned, onPin }: { isPinned: boolean; onPin: () => v
   )
 }
 
-function DropdownFooter({ onOpen }: { onOpen: () => void }) {
+function DropdownWorkspaceHeader() {
+  return (
+    <div className="flex items-center gap-1 px-4 pt-3 pb-2">
+      <span className="text-sm font-semibold text-secondary-foreground" data-testid="workspace-header">
+        Safes in this Workspace
+      </span>
+    </div>
+  )
+}
+
+function DropdownFooter({ onOpen, label }: { onOpen: () => void; label: string }) {
   return (
     <div className="px-4 py-3">
       <Button variant="secondary" size="sm" className="w-full" onClick={onOpen} data-testid="all-accounts-btn">
-        All Accounts
+        {label}
         <ChevronRight className="size-4" />
       </Button>
     </div>
@@ -149,23 +159,27 @@ function SpaceSafeBar() {
     setAccountsModalOpen(true)
   }
 
-  const dropdownHeader = !isQualifiedSafe ? <DropdownHeader isPinned={isPinned} onPin={handleTogglePin} /> : undefined
+  const dropdownHeader = isQualifiedSafe ? (
+    <DropdownWorkspaceHeader />
+  ) : (
+    <DropdownHeader isPinned={isPinned} onPin={handleTogglePin} />
+  )
 
   const hasPinnedSafes = Object.values(addedSafes).some((chain) => Object.keys(chain).length > 0)
   const showConnectWallet = !wallet && !hasPinnedSafes
 
-  const dropdownFooter = !isQualifiedSafe
-    ? showConnectWallet
+  const dropdownFooter =
+    showConnectWallet && !isQualifiedSafe
       ? (close: () => void) => <ConnectWalletFooter onConnect={connectWallet} onClose={close} />
       : (close: () => void) => (
           <DropdownFooter
+            label={isQualifiedSafe ? 'Safes not in this Workspace' : 'All Accounts'}
             onOpen={() => {
               close()
               handleOpenAccountsModal()
             }}
           />
         )
-    : undefined
 
   return (
     <div data-testid="safe-level-navigation" className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -173,7 +173,7 @@ function SpaceSafeBar() {
       ? (close: () => void) => <ConnectWalletFooter onConnect={connectWallet} onClose={close} />
       : (close: () => void) => (
           <DropdownFooter
-            label={isQualifiedSafe ? 'Safes not in this workspace' : 'All Accounts'}
+            label={isQualifiedSafe ? 'Explore other Safes' : 'All Accounts'}
             onOpen={() => {
               close()
               handleOpenAccountsModal()

--- a/apps/web/src/features/spaces/components/AddAccounts/SafesList.tsx
+++ b/apps/web/src/features/spaces/components/AddAccounts/SafesList.tsx
@@ -1,6 +1,6 @@
 import { isMultiChainSafeItem, type AllSafeItems } from '@/hooks/safes'
 import SafeCard from '../SelectSafesOnboarding/components/SafeCard'
-import SimilarAddressAlert from '../SelectSafesOnboarding/components/SimilarAddressAlert'
+import SimilarAddressAlert from '@/components/common/SimilarAddressAlert'
 import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
 import { useMemo } from 'react'
 

--- a/apps/web/src/features/spaces/components/SafeAccounts/AccountsSafesList.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/AccountsSafesList.tsx
@@ -1,7 +1,7 @@
 import { type AllSafeItems, isMultiChainSafeItem } from '@/hooks/safes'
 import SafeCardReadOnly from './SafeCardReadOnly'
 import SafeCardsErrorBoundary from './SafeCardsErrorBoundary'
-import SimilarAddressAlert from '../SelectSafesOnboarding/components/SimilarAddressAlert'
+import SimilarAddressAlert from '@/components/common/SimilarAddressAlert'
 
 interface SafeListProps {
   safes: AllSafeItems

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/OnboardingSafesList.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/OnboardingSafesList.tsx
@@ -1,6 +1,6 @@
 import { type AllSafeItems, isMultiChainSafeItem } from '@/hooks/safes'
 import SafeCard from './SafeCard'
-import SimilarAddressAlert from './SimilarAddressAlert'
+import SimilarAddressAlert from '@/components/common/SimilarAddressAlert'
 import SelectAllToggle, { type SelectAllState } from '@/features/spaces/components/SelectAllToggle/SelectAllToggle'
 
 interface SectionSelectAll {

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/OnboardingSafesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/OnboardingSafesList.test.tsx
@@ -13,7 +13,7 @@ jest.mock('../SafeCard', () => ({
   ),
 }))
 
-jest.mock('../SimilarAddressAlert', () => ({
+jest.mock('@/components/common/SimilarAddressAlert', () => ({
   __esModule: true,
   default: () => <div data-testid="similar-address-alert">Similar addresses detected</div>,
 }))


### PR DESCRIPTION
> Safes in this workspace —
> the rest one button away,
> bold hex catches eyes.

## What it solves

Resolves: [WA-2462](https://linear.app/safe-global/issue/WA-2462)

The safe selector dropdown was missing the "All Accounts" footer button when viewing a safe inside a workspace, so users had no escape hatch to their global account list. While in there, the broader workspace-context UX of the dropdown + the AccountsModal had several gaps:

- No header explaining what the dropdown contents are.
- AccountsModal showed _all_ accounts (including the workspace's own safes) — confusing when launched from a workspace.
- Pin/unpin controls were visible inside workspace context but had no real meaning there.
- No visual cue for poisoning-similar addresses despite the data being computed.

## How this PR fixes it

**Original ticket fix:**

- Show the "All Accounts" footer button in workspace context (was hidden — the WA-2462 proper).

**Scoped UX refinements** (workspace context only — non-workspace UX is unchanged):

- New dropdown header `Safes in this workspace` (replaces the bookmark/Trust header for that context).
- Footer button retitled `Safes not in this workspace`; AccountsModal title matches.
- AccountsModal filters out safes already in the current workspace by exact `(chainId, address)` match. Multi-chain safes whose chains straddle the boundary gracefully degrade via re-grouping.
- AccountsModal hides per-card pin/unpin controls.
- Skeleton stays visible until BOTH `useAllSafes` and `useSpaceSafes` finish — prevents a flash of unfiltered content that contradicts the new title.

**Always-on improvement:**

- `ShortAddressWithTooltip` gained an `isSimilar` prop — when true, renders the shortened form with the first 4 and last 4 hex chars bolded (poisoning-attack visual aid). Strengthens the existing `<SimilarityBadge />`.

**Refactor:**

- AccountsModal's 8-step data pipeline (fetch → space-exclude → group → merge+sort → similarity → search → split) extracted into a `useAccountsModalItems` hook with a top-of-file docstring and dedicated unit tests. Modal shrank from 258 → 162 lines.

## How to test it

1. **WA-2462 proper:** Open a safe that's part of a workspace. Open the safe selector dropdown. There should now be a `Safes not in this workspace` button at the bottom. (Before this PR: no button.)
2. **Workspace header:** Same dropdown. There should be a `Safes in this workspace` header at the top instead of the bookmark/Trust strip.
3. **Modal filter:** Click the button. The opened modal should be titled `Safes not in this workspace` and must not show any safe that's already in your current workspace.
4. **Hidden pin controls:** In the modal, every safe card should be missing the bookmark icon and 3-dot context menu (workspace context only).
5. **Loading guard:** Open the modal cold (right after navigating to a workspace safe, on slow network if possible). You should see the skeleton, _not_ an unfiltered list flashing then re-filtering.
6. **Similar address visual:** If you have two address-poisoning-similar safes pinned, both should show the existing "High similarity" pill AND the shortened address should have its first 4 + last 4 hex chars bolded (e.g. `0x**1234**...**7890**`).
7. **Non-workspace unchanged:** Visit a non-workspace safe. Dropdown should still show `Trusted Safes` header with bookmark + `All Accounts` button + modal title `All Accounts`. No filter applied.
8. **Multi-chain partial workspace:** If a multi-chain safe has chain A in your workspace and chain B not, the modal should show that safe with only chain B visible (auto-downgraded to single-chain item).

## Affected flows

- **Workspace-safe dropdown** — adds header, footer; conditional on `isQualifiedSafe`.
- **AccountsModal opened from a workspace** — items filtered, pin controls hidden, retitled, loading-guarded.
- **Address-similarity warning surface** — strengthened visual on all AccountsModal cards regardless of context (additive, no removal).
- **Non-workspace dropdown / modal** — unchanged.

## Blast radius

- **Direct file scope:** `apps/web/src/components/common/SpaceSafeBar/` subtree only.
- **New hook `useAccountsModalItems`** consumes (read-only): `useAllSafes`, `useSpaceSafes`, `useIsQualifiedSafe`, `useWallet`, `useOwnersGetAllSafesByOwnerV2Query`, `useAllSafesGrouped`. No new dispatch surface beyond the pre-existing notification on owned-safes error (preserved verbatim from the modal).
- **`ShortAddressWithTooltip`** gained an optional prop (`isSimilar?: boolean`, default `false`). Only consumers in this subtree pass it; other consumers (if any) get default `false` — behavior unchanged.
- **Card components** (`SafeItemCard`, `MultiSafeItemCard`) gained `hidePinControls?: boolean` (default `false`). Same backward-compat story.
- **No RTK Query endpoints / API contracts / feature flags / chain configs / persistence migrations touched.**
- **No mobile impact** — all touched files are web-only. No shared package changes.

## Risks / not checked

- **Did not browser-verify the loading-race fix on a real slow network.** The reasoning is code-level (the hook now exposes `isLoading` correctly; hook + UI tests assert it) but a network-throttled walkthrough wasn't done.
- **Similarity detection is computed on the FILTERED set, not the full set.** A non-workspace safe that visually resembles a workspace safe will _not_ be flagged in the modal. Known v1 limitation, documented in the hook's docstring.
- **Did not test on mobile** — these files are web-only; no mobile entry-point consumes them.
- **Did not exercise the `useOwnersGetAllSafesByOwnerV2Query` failure path manually** — the inline `<InlineRetryError />` rendering is preserved from pre-existing code; the new notification dispatch hits the same source.
- **Search analytics tracking** moved into the hook from the modal. No behavioral difference expected but not explicitly tested.

## Visual summary

```mermaid
flowchart TB
    subgraph "useAccountsModalItems pipeline"
        direction TB
        A[useAllSafes<br/>pinned + owned + CF] --> B{isQualifiedSafe?}
        B -- yes --> C[exclude safes in current workspace<br/>by chainId:address.toLowerCase]
        B -- no --> D[pass through]
        C --> E[useAllSafesGrouped<br/>multi-chain auto-degrades if partial]
        D --> E
        E --> F[merge + sort by lastVisited]
        F --> G[similarity set]
        F --> H[apply search]
        H --> I[split by isPinned]
        I --> J[trustedItems / otherItems]
    end

    subgraph "AccountsModal render"
        J --> K[Trusted Safes section]
        J --> L[Other Safes section]
        K --> M{isQualifiedSafe?}
        L --> M
        M -- yes --> N["hide bookmark + context menu<br/>title: 'Safes not in this workspace'"]
        M -- no --> O["keep pin controls<br/>title: 'All Accounts'"]
    end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 _(n/a — web-only)_
- [x] I've documented how it affects the analytics (if at all) 📊 _(no new events; SEARCH event location moved hook-internal, behavior preserved)_
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).