### PR TITLE
fix: update RTK with new invitation DTOs

### DIFF
--- a/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
@@ -112,7 +112,7 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
       setIsSubmitting(true)
       const response = await inviteMembers({
         spaceId: Number(spaceId),
-        inviteUsersDto: { users: [{ address: data.address, role: data.role, name: data.name }] },
+        inviteUsersDto: { users: [{ type: 'wallet', address: data.address, role: data.role, name: data.name }] },
       })
 
       if (response.data) {

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -54,6 +54,7 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
 
     try {
       const usersToInvite = validMembers.map((member) => ({
+        type: 'wallet' as const,
         address: member.address,
         name: member.address,
         role: member.role,

--- a/packages/store/scripts/api-schema/schema.json
+++ b/packages/store/scripts/api-schema/schema.json
@@ -9185,16 +9185,17 @@
           "safes"
         ]
       },
-      "InviteUserDto": {
+      "WalletInviteUserDto": {
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "wallet"
+            ]
+          },
           "address": {
             "type": "string"
-          },
-          "name": {
-            "type": "string",
-            "minLength": 3,
-            "maxLength": 30
           },
           "role": {
             "type": "string",
@@ -9202,12 +9203,52 @@
               "ADMIN",
               "MEMBER"
             ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 30
           }
         },
         "required": [
+          "type",
           "address",
-          "name",
-          "role"
+          "role",
+          "name"
+        ]
+      },
+      "EmailInviteUserDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "email"
+            ]
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "maxLength": 255
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "ADMIN",
+              "MEMBER"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 30
+          }
+        },
+        "required": [
+          "type",
+          "email",
+          "role",
+          "name"
         ]
       },
       "InviteUsersDto": {
@@ -9216,7 +9257,14 @@
           "users": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/InviteUserDto"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/WalletInviteUserDto"
+                },
+                {
+                  "$ref": "#/components/schemas/EmailInviteUserDto"
+                }
+              ]
             }
           }
         },

--- a/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
@@ -508,13 +508,20 @@ export type Invitation = {
   status: 'INVITED' | 'ACTIVE' | 'DECLINED'
   invitedBy: number | null
 }
-export type InviteUserDto = {
+export type WalletInviteUserDto = {
+  type: 'wallet'
   address: string
-  name: string
   role: 'ADMIN' | 'MEMBER'
+  name: string
+}
+export type EmailInviteUserDto = {
+  type: 'email'
+  email: string
+  role: 'ADMIN' | 'MEMBER'
+  name: string
 }
 export type InviteUsersDto = {
-  users: InviteUserDto[]
+  users: (WalletInviteUserDto | EmailInviteUserDto)[]
 }
 export type AcceptInviteDto = {
   name: string


### PR DESCRIPTION
## What it solves

The space-invitation API now distinguishes between wallet and email invitations. The old single `InviteUserDto` (always address-based) no longer matches the gateway schema, which expects a discriminated union (oneOf) keyed on a type field. Without this, invite requests would fail schema validation against the updated CGW.

The current fix only updated types and matches the existing logic to adhere. The proper change will come later as part of Auth M2

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
