### PR TITLE
fix: Border radius of list items in txs history

### DIFF
--- a/apps/web/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
+++ b/apps/web/src/components/safe-messages/MsgListItem/ExpandableMsgItem.tsx
@@ -11,13 +11,7 @@ import txListItemCss from '@/components/transactions/TxListItem/styles.module.cs
 
 const ExpandableMsgItem = ({ msg, expanded = false }: { msg: MessageItem; expanded?: boolean }): ReactElement => {
   return (
-    <Accordion
-      defaultExpanded={expanded}
-      disableGutters
-      elevation={0}
-      className={txListItemCss.accordion}
-      sx={{ border: 'none', '&:before': { display: 'none' } }}
-    >
+    <Accordion defaultExpanded={expanded} disableGutters elevation={0} className={txListItemCss.listItem}>
       <AccordionSummary
         data-testid="message-item"
         expandIcon={<ExpandMoreIcon />}

--- a/apps/web/src/components/transactions/TxListItem/styles.module.css
+++ b/apps/web/src/components/transactions/TxListItem/styles.module.css
@@ -2,6 +2,11 @@
   border-color: transparent;
 }
 
+.listItem.listItem:not(:last-of-type),
+.listItem.listItem:last-of-type {
+  border-radius: var(--space-2) !important;
+}
+
 .closed:hover,
 .batched {
   background-color: var(--color-secondary-background);


### PR DESCRIPTION
Context:

I told Simon that he can send me screenshots of UI inconsistencies and as part of my week as flex engineer I'll try to fix them as quickly as I can with PRs. So here is one that Simon sent me: 

> the border radius of single (and messages as well) vs bulk transactions is inconsistent. The bulk transaction one has the right one.
> On the tx history (edited)
> <img width="302" height="274" alt="image" src="https://github.com/user-attachments/assets/ca6969b9-24d4-4375-b484-5fbfe7a01d39" />
> can be tested here: /transactions/history?safe=matic:0xb412684F4F0B5d27cC4A4D287F42595aB3ae124D

Before

<img width="1348" height="710" alt="Screenshot 2026-06-03 at 15 23 30" src="https://github.com/user-attachments/assets/07a6d865-a95a-4649-8bc7-5cf608b0b726" />

After

<img width="1350" height="708" alt="Screenshot 2026-06-03 at 15 24 35" src="https://github.com/user-attachments/assets/e7d8ec2b-1d51-4e18-a71b-75fb485d2b0f" />
<img width="1101" height="501" alt="Screenshot 2026-06-03 at 15 31 32" src="https://github.com/user-attachments/assets/2e652c85-7550-4182-91ff-cb88b4f02f61" />


Question for the reviewer:
- I mostly let Claude do the CSS changes, but for someone who is familiar with the codebase more. Is this the best way to do this change, or would there be a better way?

