### PR TITLE
feat: add devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+
+# Dev container image for safe-client-gateway.
+# Production image is unchanged and lives at the repo-root Dockerfile.
+# Microsoft only publishes major-version tags for this image, so we pin by
+# digest to keep dev environments reproducible. Production currently uses
+# Node 24.11.0; refresh the digest periodically (or via Renovate/Dependabot)
+# to pick up the latest 24.x patch.
+FROM mcr.microsoft.com/devcontainers/typescript-node:24-bookworm@sha256:14484cf5f183867fbdddd69db1991ee9a82fc50ff378f40344dcc31824eb834e
+
+# Microsoft's image runs as the `node` user by default; switch to root
+# for system installs and to enable Corepack.
+USER root
+
+# Install postgres-client for inspecting db / db-test from inside the container.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Activate Corepack so Yarn 4.14.1 (pinned in .yarnrc.yml) resolves the
+# project-managed release on first install.
+RUN corepack enable
+
+USER node

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,38 @@
+<!-- SPDX-License-Identifier: FSL-1.1-MIT -->
+
+# Dev Container
+
+A ready-to-use, reproducible development environment for the Safe{Wallet} monorepo. It runs Node 24 (pinned by digest), Yarn 4 via Corepack, and ships the editor extensions and Claude Code setup the team uses.
+
+## Prerequisites
+
+- **Docker** running on your host — Docker Desktop (macOS/Windows) or Docker Engine (Linux).
+- An IDE with Dev Container support, plus the matching extension (see below).
+
+## Open in your IDE
+
+The Dev Containers feature is **IDE-specific**. Install the extension that matches your editor — they are not interchangeable.
+
+### VS Code
+
+1. Install the **Dev Containers** extension (`ms-vscode-remote.remote-containers`).
+2. Open this repo, then run **Dev Containers: Reopen in Container** from the Command Palette (`Cmd/Ctrl+Shift+P`).
+
+### Cursor
+
+Cursor **cannot** use Microsoft's `ms-vscode-remote.remote-containers` extension — Microsoft licenses it for use only in official Microsoft products. Cursor ships its own equivalent:
+
+1. Install the **Dev Containers** extension published for Cursor from Cursor's Extensions marketplace (do not install the Microsoft one).
+2. Run **Dev Containers: Reopen in Container** from Cursor's Command Palette.
+
+> Both IDEs are supported by the container scripts — `post-attach.sh` resolves the bundled `claude` CLI from either the VS Code (`.vscode-server`) or Cursor (`.cursor-server`) extension directory automatically.
+
+## Lifecycle
+
+- **[`post-create.sh`](./post-create.sh)** — runs once after the container is created: enables Corepack and runs `yarn install --immutable` (with a raised Node heap ceiling to avoid OOM).
+- **[`post-attach.sh`](./post-attach.sh)** — runs on every attach: puts the bundled `claude` CLI on `PATH` and installs the official Claude Code marketplace + `superpowers` plugin (idempotent).
+
+## Resources & ports
+
+- Port **3000** is forwarded for the web app (`yarn workspace @safe-global/web dev`).
+- Memory/CPU limits (16 GB / 4 CPUs) are set in [`docker-compose.yml`](./docker-compose.yml). These only apportion what the Docker VM already has — raise the VM ceiling in **Docker Desktop → Settings → Resources** first if needed.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Safe Wallet Monorepo Dev Container",
+  "dockerComposeFile": ["./docker-compose.yml"],
+  "service": "devcontainer",
+  "workspaceFolder": "/workspaces/safe-wallet-monorepo",
+  "remoteUser": "node",
+  "forwardPorts": [3000],
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "postAttachCommand": ".devcontainer/post-attach.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": ["biomejs.biome", "Anthropic.claude-code", "openai.chatgpt"],
+      "settings": {
+        "editor.defaultFormatter": "biomejs.biome",
+        "editor.formatOnSave": true,
+        "claudeCode.initialPermissionMode": "auto"
+      }
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+
+# Dev container Compose file.
+# This is the only Compose file referenced from devcontainer.json, so the
+# Compose project directory is .devcontainer/. Paths below use '..' to
+# reach the repo root.
+services:
+  devcontainer:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      # Workspace bind mount; ':cached' improves macOS file-system perf.
+      - ..:/workspaces/safe-wallet-monorepo:cached
+      # Persist Claude Code auth/config across container rebuilds.
+      # If the host directory does not exist Docker creates an empty one.
+      # ${HOME:?...} fails fast with a clear error if HOME is unset (e.g. CI).
+      - ${HOME:?HOME must be set to mount the Claude config volume}/.claude-docker:/home/node/.claude
+      # SSH agent forwarding:
+      #   - Docker Desktop (macOS/Windows): SSH_AUTH_SOCK is unset on the host,
+      #     so the default /run/host-services/ssh-auth.sock magic path is used.
+      #   - Linux: export SSH_AUTH_SOCK on the host (usually already set by your
+      #     agent) and Compose bind-mounts it into the container.
+      - ${SSH_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/ssh-agent
+    environment:
+      - SSH_AUTH_SOCK=/ssh-agent
+      - NEXT_PUBLIC_INFURA_TOKEN
+      - NEXT_PUBLIC_WC_PROJECT_ID
+      - NEXT_PUBLIC_IS_OFFICIAL_HOST
+      - NEXT_PUBLIC_PROD_MIXPANEL_TOKEN
+      - NEXT_PUBLIC_STAGING_MIXPANEL_TOKEN
+    # Keep the container alive for VS Code to attach to.
+    command: sleep infinity
+    working_dir: /workspaces/safe-wallet-monorepo
+    # Reservations/limits within the Docker Desktop VM. Raise the VM's own
+    # Memory/CPU/Disk ceiling in Docker Desktop → Settings → Resources first;
+    # these only apportion what the VM already has. The legacy top-level
+    # mem_limit/cpus apply outside Swarm in every Compose version; the
+    # `deploy:` block is duplicated for modern compose CLIs.
+    mem_limit: 16g
+    mem_reservation: 8g
+    cpus: 4
+    deploy:
+      resources:
+        limits:
+          memory: 16G
+          cpus: 4
+        reservations:
+          memory: 8G
+          cpus: 4

--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-MIT
+
+# Runs every time VS Code attaches to the devcontainer.
+# By this point the Anthropic.claude-code extension is installed, so its
+# bundled `claude` CLI is available on PATH and we can use it to manage
+# plugins. Everything below is idempotent so re-runs on every attach are
+# safe and cheap.
+set -euo pipefail
+
+if ! command -v claude >/dev/null 2>&1; then
+  # The Anthropic.claude-code VS Code extension ships a bundled `claude`
+  # binary but does not add it to PATH. Resolve the newest installed
+  # version (path includes version + arch, so glob-and-sort). Prefer the
+  # VS Code server dir; fall back to Cursor's server dir when absent.
+  CLAUDE_BIN=$(ls -1d /home/node/.vscode-server/extensions/anthropic.claude-code-*/resources/native-binary/claude 2>/dev/null | sort -V | tail -1)
+  if [ -z "$CLAUDE_BIN" ]; then
+    CLAUDE_BIN=$(ls -1d /home/node/.cursor-server/extensions/anthropic.claude-code-*/resources/native-binary/claude 2>/dev/null | sort -V | tail -1)
+  fi
+  if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
+    export PATH="$(dirname "$CLAUDE_BIN"):$PATH"
+  fi
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "[devcontainer] 'claude' CLI not found on PATH — skipping plugin install."
+  echo "[devcontainer] Open the Anthropic.claude-code extension once, then reload to retry."
+  exit 0
+fi
+
+# Install Anthropic's official marketplace and the superpowers plugin.
+# Both commands are no-ops when already present.
+claude plugin marketplace add anthropics/claude-plugins-official || true
+claude plugin install superpowers@claude-plugins-official || true

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-MIT
+
+# Runs once after the devcontainer is created.
+# Keep this idempotent so re-running it is safe.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "[devcontainer] Activating Corepack..."
+corepack enable
+
+echo "[devcontainer] Installing dependencies..."
+# Yarn 4 install in this monorepo can spike past Node's default ~4 GB old-space.
+# Lift the heap ceiling so the install doesn't OOM inside the container.
+NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=6144" yarn install --immutable
+
+echo "[devcontainer] Setup complete."

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,6 +8,22 @@ enableScripts: false
 
 nodeLinker: node-modules
 
+# The devcontainer (.devcontainer/) bind-mounts node_modules from the host,
+# so installs on macOS must also fetch Linux native bindings (and vice versa)
+# or modules like @rspack/binding fail to load inside the container.
+supportedArchitectures:
+  os:
+    - current
+    - linux
+    - darwin
+  cpu:
+    - current
+    - arm64
+    - x64
+  libc:
+    - current
+    - glibc
+
 # eslint-config-next requires next at runtime but doesn't declare it as
 # a peer dependency. Without this, Yarn hoists eslint-config-next to root
 # where it can't resolve next (which lives in apps/web/node_modules/).


### PR DESCRIPTION
 > Dockerfile, compose, scripts—
  > a container spins up the repo,
  > dev starts in one command.

  ## What it solves

  Adds a ready-to-use **dev container** so contributors can spin up a consistent, fully-provisioned development environment without manual local setup.

  ## How this PR fixes it

  - Adds `.devcontainer/` with `Dockerfile`, `devcontainer.json`, `docker-compose.yml`, and `post-create.sh` / `post-attach.sh` lifecycle scripts
  - Adds `README.md` documenting usage
  - Updates `.yarnrc.yml` to support the containerized Yarn 4 setup

  ## How to test it

  1. Open the repo in VS Code → "Reopen in Container"
  2. Confirm the container builds, `post-create`/`post-attach` run, and `yarn install` completes
  3. Verify `yarn workspace @safe-global/web dev` runs inside the container

  ## Visual summary

  ```mermaid
  flowchart LR
    A[devcontainer.json] --> B[docker-compose.yml]
    B --> C[Dockerfile]
    C --> D[post-create.sh]
    D --> E[post-attach.sh]
    E --> F[Ready dev env]
```

  Checklist

  - [x] Only staged devcontainer files committed
  - [x] CI green