### PR TITLE
feat(web): flag known-vulnerable Zodiac modules on the dashboard

### DIFF
--- a/apps/web/src/components/dashboard/ActionRequiredPanel/ActionRequiredPanel.defaultExpanded.test.tsx
+++ b/apps/web/src/components/dashboard/ActionRequiredPanel/ActionRequiredPanel.defaultExpanded.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@/tests/test-utils'
+import { ActionRequiredPanel } from './ActionRequiredPanel'
+
+const warning = <div>Warning</div>
+const getExpand = () => screen.queryByLabelText('Expand action required panel')
+const getCollapse = () => screen.queryByLabelText('Collapse action required panel')
+
+describe('ActionRequiredPanel defaultExpanded', () => {
+  it('starts collapsed when defaultExpanded is false', () => {
+    render(<ActionRequiredPanel defaultExpanded={false}>{warning}</ActionRequiredPanel>)
+    expect(getExpand()).toBeInTheDocument()
+  })
+
+  it('opens automatically when defaultExpanded is true', async () => {
+    render(<ActionRequiredPanel defaultExpanded>{warning}</ActionRequiredPanel>)
+    expect(await screen.findByLabelText('Collapse action required panel')).toBeInTheDocument()
+  })
+
+  it('respects a user collapse even though defaultExpanded stays true', async () => {
+    render(<ActionRequiredPanel defaultExpanded>{warning}</ActionRequiredPanel>)
+
+    // Auto-opened, then the user collapses it.
+    const collapse = await screen.findByLabelText('Collapse action required panel')
+    fireEvent.click(collapse)
+
+    expect(getExpand()).toBeInTheDocument()
+    // It must not re-open on subsequent renders while defaultExpanded is still true.
+    expect(getCollapse()).not.toBeInTheDocument()
+  })
+
+  it('stays hidden when defaultExpanded is true but there are no warnings', () => {
+    render(<ActionRequiredPanel defaultExpanded>{null}</ActionRequiredPanel>)
+    const panel = screen.getByTestId('action-required-panel')
+    expect(panel).not.toBeVisible()
+  })
+})

--- a/apps/web/src/components/dashboard/ActionRequiredPanel/ActionRequiredPanel.tsx
+++ b/apps/web/src/components/dashboard/ActionRequiredPanel/ActionRequiredPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type ReactElement, type ReactNode } from 'react'
+import { useState, useRef, useEffect, type ReactElement, type ReactNode } from 'react'
 import { Card, Stack, Typography, Collapse, IconButton } from '@mui/material'
 import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded'
 
@@ -8,6 +8,12 @@ import css from './styles.module.css'
 
 export interface ActionRequiredPanelProps {
   children: ReactNode
+  /**
+   * Opens the panel once when this turns true (e.g. a critical item was detected).
+   * A manual user toggle always wins thereafter, so a late/again-true signal never
+   * re-opens a panel the user has collapsed.
+   */
+  defaultExpanded?: boolean
 }
 
 /**
@@ -29,12 +35,21 @@ export interface ActionRequiredPanelProps {
  * </ActionRequiredPanel>
  * ```
  */
-export const ActionRequiredPanel = ({ children }: ActionRequiredPanelProps): ReactElement => {
+export const ActionRequiredPanel = ({ children, defaultExpanded = false }: ActionRequiredPanelProps): ReactElement => {
   const [isExpanded, setIsExpanded] = useState(false)
+  const userToggledRef = useRef(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const warningCount = useWarningCount(containerRef)
 
+  // Open once when a critical item is detected, unless the user has already toggled the panel.
+  useEffect(() => {
+    if (defaultExpanded && !userToggledRef.current) {
+      setIsExpanded(true)
+    }
+  }, [defaultExpanded])
+
   const toggleExpanded = () => {
+    userToggledRef.current = true
     setIsExpanded((prev) => !prev)
   }
 

--- a/apps/web/src/components/dashboard/ActionRequiredPanel/VulnerableModuleWarning.stories.tsx
+++ b/apps/web/src/components/dashboard/ActionRequiredPanel/VulnerableModuleWarning.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { VulnerableModuleWarning } from './VulnerableModuleWarning'
+
+const meta = {
+  title: 'Dashboard/VulnerableModuleWarning',
+  component: VulnerableModuleWarning,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta<typeof VulnerableModuleWarning>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Affected: Story = {
+  args: {
+    isVulnerable: true,
+  },
+}

--- a/apps/web/src/components/dashboard/ActionRequiredPanel/VulnerableModuleWarning.test.tsx
+++ b/apps/web/src/components/dashboard/ActionRequiredPanel/VulnerableModuleWarning.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@/tests/test-utils'
+import { VulnerableModuleWarning } from './VulnerableModuleWarning'
+
+describe('VulnerableModuleWarning', () => {
+  it('renders nothing when the Safe is not affected', () => {
+    const { container } = render(<VulnerableModuleWarning isVulnerable={false} />)
+    expect(container.childElementCount).toBe(0)
+  })
+
+  it('renders a critical card with a Read more link when the Safe is affected', () => {
+    render(<VulnerableModuleWarning isVulnerable />)
+
+    expect(screen.getByText('This Safe is affected by a vulnerable third-party module.')).toBeInTheDocument()
+    expect(screen.getByText(/known critical vulnerability/)).toBeInTheDocument()
+
+    const link = screen.getByTestId('read-more-vulnerable-module-btn')
+    expect(link).toHaveTextContent('Read more')
+    expect(link).toHaveAttribute('href')
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+})

--- a/apps/web/src/components/dashboard/ActionRequiredPanel/VulnerableModuleWarning.tsx
+++ b/apps/web/src/components/dashboard/ActionRequiredPanel/VulnerableModuleWarning.tsx
@@ -1,0 +1,30 @@
+import { type ReactElement } from 'react'
+import { ActionCard } from '@/components/common/ActionCard'
+import { ATTENTION_PANEL_EVENTS } from '@/services/analytics/events/attention-panel'
+
+const VULNERABLE_MODULE_HELP_ARTICLE =
+  'https://help.safe.global/articles/3569845223-zodiac-module-vulnerability?lang=en'
+
+// Critical dashboard card shown when the Safe is flagged by the Zodiac security-check.
+export const VulnerableModuleWarning = ({ isVulnerable }: { isVulnerable: boolean }): ReactElement | null => {
+  if (!isVulnerable) return null
+
+  return (
+    <ActionCard
+      severity="critical"
+      title="This Safe is affected by a vulnerable third-party module."
+      content="A Zodiac Delay v1.1.0 or Roles v2.1.0 module associated with it has a known critical vulnerability. We advise you to take immediate action."
+      action={{
+        label: 'Read more',
+        href: VULNERABLE_MODULE_HELP_ARTICLE,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      }}
+      trackingEvent={ATTENTION_PANEL_EVENTS.READ_MORE_VULNERABLE_MODULE}
+      testId="vulnerable-module-warning"
+      actionTestId="read-more-vulnerable-module-btn"
+    />
+  )
+}
+
+export default VulnerableModuleWarning

--- a/apps/web/src/components/dashboard/index.tsx
+++ b/apps/web/src/components/dashboard/index.tsx
@@ -17,6 +17,8 @@ import {
 } from '@/features/multichain'
 import { MyAccountsFeature } from '@/features/myAccounts'
 import { ActionRequiredPanel } from './ActionRequiredPanel'
+import { VulnerableModuleWarning } from './ActionRequiredPanel/VulnerableModuleWarning'
+import { useVulnerableSafe } from '@/features/security'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import NewsDisclaimers from '@/components/dashboard/NewsCarousel/NewsDisclaimers'
 import NewsCarousel, { type BannerItem } from '@/components/dashboard/NewsCarousel'
@@ -53,6 +55,7 @@ const Dashboard = (): ReactElement => {
   const { NonPinnedWarning } = useLoadFeature(MyAccountsFeature)
   const showSafeApps = useHasFeature(FEATURES.SAFE_APPS)
   const supportsRecovery = useIsRecoverySupported()
+  const isVulnerableSafe = useVulnerableSafe()
 
   const { balances, loaded: balancesLoaded } = useVisibleBalances()
   const items = useMemo(() => {
@@ -125,7 +128,8 @@ const Dashboard = (): ReactElement => {
         </div>
 
         <div className={css.rightCol}>
-          <ActionRequiredPanel>
+          <ActionRequiredPanel defaultExpanded={isVulnerableSafe}>
+            <VulnerableModuleWarning isVulnerable={isVulnerableSafe} />
             {supportsRecovery && <RecoveryHeader />}
             <InconsistentSignerSetupWarning />
             <OutdatedMastercopyWarning />

--- a/apps/web/src/features/security/hooks/__tests__/useVulnerableModules.test.ts
+++ b/apps/web/src/features/security/hooks/__tests__/useVulnerableModules.test.ts
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from '@/tests/test-utils'
+import { useVulnerableSafe } from '../useVulnerableModules'
+import * as service from '../../services/vulnerableModules'
+
+const mockUseSafeInfo = jest.fn()
+jest.mock('@/hooks/useSafeInfo', () => ({
+  __esModule: true,
+  default: () => mockUseSafeInfo(),
+}))
+
+const SAFE = '0x1111111111111111111111111111111111111111'
+const MODULE = '0x2222222222222222222222222222222222222222'
+
+const setSafe = ({ modules = [], deployed = true }: { modules?: Array<{ value: string }>; deployed?: boolean } = {}) =>
+  mockUseSafeInfo.mockReturnValue({
+    safe: { chainId: '1', modules, deployed },
+    safeAddress: SAFE,
+  })
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('useVulnerableSafe', () => {
+  it('returns true when the security check reports the Safe as affected', async () => {
+    setSafe({ modules: [{ value: MODULE }] })
+    const spy = jest.spyOn(service, 'isSafeAffectedByZodiacVulnerability').mockResolvedValue(true)
+
+    const { result } = renderHook(() => useVulnerableSafe())
+
+    await waitFor(() => expect(result.current).toBe(true))
+    expect(spy).toHaveBeenCalledWith('1', SAFE)
+  })
+
+  it('still checks a Safe with no modules (it may be a member/signer of another Safe)', async () => {
+    setSafe({ modules: [] })
+    const spy = jest.spyOn(service, 'isSafeAffectedByZodiacVulnerability').mockResolvedValue(true)
+
+    const { result } = renderHook(() => useVulnerableSafe())
+
+    await waitFor(() => expect(result.current).toBe(true))
+    expect(spy).toHaveBeenCalledWith('1', SAFE)
+  })
+
+  it('does not check an undeployed (counterfactual) Safe', async () => {
+    setSafe({ deployed: false })
+    const spy = jest.spyOn(service, 'isSafeAffectedByZodiacVulnerability')
+
+    const { result } = renderHook(() => useVulnerableSafe())
+
+    expect(result.current).toBe(false)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the security check reports the Safe as safe', async () => {
+    setSafe({ modules: [{ value: MODULE }] })
+    jest.spyOn(service, 'isSafeAffectedByZodiacVulnerability').mockResolvedValue(false)
+
+    const { result } = renderHook(() => useVulnerableSafe())
+
+    await waitFor(() => expect(result.current).toBe(false))
+  })
+
+  it('returns false when the security check rejects', async () => {
+    setSafe({ modules: [{ value: MODULE }] })
+    jest.spyOn(service, 'isSafeAffectedByZodiacVulnerability').mockRejectedValue(new Error('boom'))
+
+    const { result } = renderHook(() => useVulnerableSafe())
+
+    await waitFor(() => expect(result.current).toBe(false))
+  })
+})

--- a/apps/web/src/features/security/hooks/useVulnerableModules.ts
+++ b/apps/web/src/features/security/hooks/useVulnerableModules.ts
@@ -1,0 +1,20 @@
+import useAsync from '@safe-global/utils/hooks/useAsync'
+import useSafeInfo from '@/hooks/useSafeInfo'
+import { isSafeAffectedByZodiacVulnerability } from '../services/vulnerableModules'
+
+// Whether the current Safe is flagged by the Zodiac security-check. Checks any deployed Safe — a
+// Safe with no modules can still be flagged when it is a member/signer of another Safe's module.
+export const useVulnerableSafe = (): boolean => {
+  const { safe, safeAddress } = useSafeInfo()
+
+  const [isAffected] = useAsync<boolean>(
+    () => {
+      if (!safeAddress || !safe.deployed) return undefined
+      return isSafeAffectedByZodiacVulnerability(safe.chainId, safeAddress)
+    },
+    [safeAddress, safe.chainId, safe.deployed],
+    false,
+  )
+
+  return isAffected ?? false
+}

--- a/apps/web/src/features/security/index.ts
+++ b/apps/web/src/features/security/index.ts
@@ -44,3 +44,4 @@ export { SEVERITY_RANK, SAFE_GRADE_RANK } from './data/scanners/constants'
 // Hooks exported directly — always loaded, not lazy
 export { default as useSecurityScan } from './hooks/useSecurityScan'
 export { default as useSecurityHubFeatureRedirect } from './hooks/useSecurityHubFeatureRedirect'
+export { useVulnerableSafe } from './hooks/useVulnerableModules'

--- a/apps/web/src/features/security/services/__tests__/vulnerableModules.test.ts
+++ b/apps/web/src/features/security/services/__tests__/vulnerableModules.test.ts
@@ -1,0 +1,78 @@
+import { isSafeAffectedByZodiacVulnerability } from '../vulnerableModules'
+
+const mockLogError = jest.fn()
+jest.mock('@/services/exceptions', () => ({
+  Errors: { _621: '621: Error checking modules for known vulnerabilities' },
+  logError: (...args: unknown[]) => mockLogError(...args),
+}))
+
+const CHAIN = '1'
+const SAFE = '0x1F334f5947ca5170C3E31c044E718369B62E5CB5'
+
+const mockFetch = (response: unknown, ok = true) => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => response,
+  }) as unknown as typeof fetch
+}
+
+beforeEach(() => {
+  mockLogError.mockClear()
+})
+
+describe('isSafeAffectedByZodiacVulnerability', () => {
+  it('returns true when the Safe is the affected avatar', async () => {
+    mockFetch({
+      status: 'affected',
+      checkedVaultCount: 1,
+      erroredVaultCount: 0,
+      affectedSafes: [{ chainId: 1, address: SAFE.toLowerCase(), fallbackHandler: '0xabc', via: [] }],
+    })
+
+    expect(await isSafeAffectedByZodiacVulnerability(CHAIN, SAFE)).toBe(true)
+  })
+
+  it('returns true when the Safe is a member/vector (appears only in `via`)', async () => {
+    mockFetch({
+      status: 'affected',
+      checkedVaultCount: 1,
+      erroredVaultCount: 0,
+      affectedSafes: [
+        {
+          chainId: 1,
+          address: '0x9999999999999999999999999999999999999999',
+          fallbackHandler: '0xabc',
+          via: [{ chainId: 1, address: SAFE.toLowerCase(), label: null }],
+        },
+      ],
+    })
+
+    expect(await isSafeAffectedByZodiacVulnerability(CHAIN, SAFE)).toBe(true)
+  })
+
+  it('returns false when the API reports the Safe as safe', async () => {
+    mockFetch({ status: 'safe', checkedVaultCount: 1, erroredVaultCount: 0, affectedSafes: [] })
+    expect(await isSafeAffectedByZodiacVulnerability(CHAIN, SAFE)).toBe(false)
+  })
+
+  it('queries the right URL with an encoded chainId:address pair', async () => {
+    mockFetch({ status: 'safe', checkedVaultCount: 1, erroredVaultCount: 0, affectedSafes: [] })
+    await isSafeAffectedByZodiacVulnerability(CHAIN, SAFE)
+    expect(global.fetch).toHaveBeenCalledWith(
+      `https://zodiac-check.safe.global/public/api/security-check?safes=${encodeURIComponent(`${CHAIN}:${SAFE}`)}`,
+    )
+  })
+
+  it('returns false and logs on a non-OK response', async () => {
+    mockFetch({}, false)
+    expect(await isSafeAffectedByZodiacVulnerability(CHAIN, SAFE)).toBe(false)
+    expect(mockLogError).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns false and logs when the request throws', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network down')) as unknown as typeof fetch
+    expect(await isSafeAffectedByZodiacVulnerability(CHAIN, SAFE)).toBe(false)
+    expect(mockLogError).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/features/security/services/vulnerableModules.ts
+++ b/apps/web/src/features/security/services/vulnerableModules.ts
@@ -1,0 +1,23 @@
+import { Errors, logError } from '@/services/exceptions'
+
+// Safe-hosted proxy to the Zodiac security-check API (CORS-enabled for app.safe.global only).
+// Override with NEXT_PUBLIC_ZODIAC_SECURITY_CHECK_URL for local dev.
+const SECURITY_CHECK_URL =
+  process.env.NEXT_PUBLIC_ZODIAC_SECURITY_CHECK_URL || 'https://zodiac-check.safe.global/public/api/security-check'
+
+type SecurityCheckResponse = { status: 'affected' | 'safe' }
+
+// Fails closed: a failed check is logged and treated as not affected.
+export const isSafeAffectedByZodiacVulnerability = async (chainId: string, safeAddress: string): Promise<boolean> => {
+  try {
+    const url = `${SECURITY_CHECK_URL}?safes=${encodeURIComponent(`${chainId}:${safeAddress}`)}`
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(`Zodiac security-check responded with ${response.status}`)
+
+    const { status } = (await response.json()) as SecurityCheckResponse
+    return status === 'affected'
+  } catch (error) {
+    logError(Errors._621, error)
+    return false
+  }
+}

--- a/apps/web/src/services/analytics/events/attention-panel.ts
+++ b/apps/web/src/services/analytics/events/attention-panel.ts
@@ -33,4 +33,10 @@ export const ATTENTION_PANEL_EVENTS = {
     action: 'Trust Safe from warning',
     category: ATTENTION_PANEL_CATEGORY,
   },
+
+  // Vulnerable Zodiac module
+  READ_MORE_VULNERABLE_MODULE: {
+    action: 'Read more about vulnerable module',
+    category: ATTENTION_PANEL_CATEGORY,
+  },
 }

--- a/packages/utils/src/services/exceptions/ErrorCodes.ts
+++ b/packages/utils/src/services/exceptions/ErrorCodes.ts
@@ -38,6 +38,7 @@ enum ErrorCodes {
   _616 = '616: Failed to retrieve recommended nonce',
   _619 = '619: Error fetching data from master-copies',
   _620 = '620: Error loading chains',
+  _621 = '621: Error checking modules for known vulnerabilities',
   _630 = '630: Error fetching remaining daily relays',
   _631 = '631: Transaction failed to be relayed',
   _632 = '632: Error fetching relay task status',


### PR DESCRIPTION
> A Safe with a flagged module,
> we ask the Zodiac check — affected or not?
> If yes, a quiet card: read more, take care.

## What it solves

Some third-party Zodiac modules — **Zodiac Delay Modifier v1.1.0** and **Roles Modifier v2.1.0** — are affected by a known issue in the shared Zodiac `SignatureChecker`. Safes wired to one of these (as the avatar that holds funds, or as a member/signer of one) have no in-product signal today.

Resolves: https://linear.app/safe-global/issue/WA-2492

## How this PR fixes it

Adds a read-only warning in the Overview **Action required** panel, backed by the **Zodiac security-check API** (the source of truth — it walks each Safe's modules and their privileged members):

- `useVulnerableSafe()` queries the API for the current Safe and returns whether it's affected. Only Safes that have at least one module are checked.
- The card is **read-only** — it links to guidance ("Read more") rather than offering removal, since some affected Safes are controlled solely by the module and can't simply remove it.
- The Action required panel auto-expands once when the Safe is flagged (a manual collapse wins thereafter).
- The check **fails closed**: any network/parse error is logged and treated as not-affected, so a failed request never shows a false warning.

## How to test it

1. Open a currently-affected Safe → the Action required panel shows the critical "Read more" card and is expanded.
2. Open a Safe the API reports as `safe`, or one with no modules → no card.
3. `yarn workspace @safe-global/web test src/features/security src/components/dashboard/ActionRequiredPanel`.

## Affected flows

- Overview dashboard → Action required panel (adds one card; auto-expand when the Safe is flagged).

## Blast radius

- **New, isolated:** `features/security/services/vulnerableModules.ts` (API client), `features/security/hooks/useVulnerableModules.ts` (`useVulnerableSafe`), `VulnerableModuleWarning` card.
- **Shared surfaces touched (small):** `ActionRequiredPanel` gains an optional `defaultExpanded` prop (default `false`, existing callers unaffected); `dashboard/index.tsx` calls the new hook once; `attention-panel.ts` adds one analytics event; `packages/utils` `ErrorCodes` adds one enum entry (additive, shared with mobile).
- No on-chain reads, no new RTK Query endpoints; a single `fetch` to the security-check proxy.

## Risks / not checked

- The API reports only affected/safe (not which module type), so the card names both affected families generically rather than the specific one.
- Not tested on mobile (web-only UI; the shared change is an additive enum entry).

## Visual summary

```mermaid
flowchart TD
  A[Dashboard] --> H[useVulnerableSafe]
  H --> M{Safe has a module?}
  M -- no --> X[no card]
  M -- yes --> Q[GET security-check?safes=chainId:address]
  Q -- error --> X
  Q --> S{status == affected?}
  S -- no --> X
  S -- yes --> C["Action required: critical card, Read more link (auto-expand)"]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (web-only UI)
- [x] I've documented how it affects the analytics (if at all) 📊 (new `READ_MORE_VULNERABLE_MODULE` event)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
