### PR TITLE
fix: only show sidebar nav tooltips when collapsed and fix Settings item

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -539,7 +539,7 @@ function SidebarGroupLabel({ className, render, ...props }: useRender.ComponentP
     props: mergeProps<'div'>(
       {
         className: cn(
-          'text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0',
+          'text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:pointer-events-none focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0',
           className,
         ),
       },

--- a/apps/web/src/features/spaces/components/Sidebar/types.ts
+++ b/apps/web/src/features/spaces/components/Sidebar/types.ts
@@ -18,6 +18,10 @@ export interface SidebarGroupConfig {
 export interface ResolvedSidebarItem extends Omit<SidebarItemConfig, 'isActive' | 'activeMemberOnly'> {
   isActive: boolean
   disabled: boolean
+  /** Renders a warning dot on the icon (e.g. Settings when the Safe is outdated). */
+  indicator?: boolean
+  /** Overrides the default data-testid (used by items rendered outside the config-driven list). */
+  testId?: string
   link: { pathname: string; query: { spaceId?: string | null; safe?: string } }
 }
 

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
@@ -65,7 +65,7 @@ export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: Na
     )
   }
 
-  const dataTestId = isSpacesVariant ? getSidebarItemTestId(item.label) : 'sidebar-list-item'
+  const dataTestId = item.testId ?? (isSpacesVariant ? getSidebarItemTestId(item.label) : 'sidebar-list-item')
 
   const handleClick = () => {
     if (item.disabled) return
@@ -87,7 +87,14 @@ export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: Na
       onClick={handleClick}
     >
       <div className={item.isActive ? css.activeIcon : undefined}>
-        <item.icon />
+        {item.indicator ? (
+          <span className="relative">
+            <item.icon />
+            <span className={css.outdatedDot} aria-hidden />
+          </span>
+        ) : (
+          <item.icon />
+        )}
       </div>
       <span className="truncate group-data-[collapsible=icon]:hidden">{item.label}</span>
     </SidebarMenuButton>

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 import Link from 'next/link'
-import { SidebarMenuItem, SidebarMenuButton } from '@/components/ui/sidebar'
+import { SidebarMenuItem, SidebarMenuButton, useSidebar } from '@/components/ui/sidebar'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/utils/cn'
 import type { ResolvedSidebarItem } from '../../types'
@@ -55,6 +55,8 @@ interface NavItemProps {
 }
 
 export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: NavItemProps): ReactElement => {
+  const { state, isMobile } = useSidebar()
+
   if (isLoading || !item) {
     return (
       <SidebarMenuItem>
@@ -84,24 +86,25 @@ export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: Na
       data-testid={dataTestId}
       onClick={handleClick}
     >
-      <Tooltip>
-        <TooltipTrigger render={<div />} className="flex min-w-0 cursor-pointer items-center gap-3">
-          <div className={item.isActive ? css.activeIcon : undefined}>
-            <item.icon />
-          </div>
-          <span className="truncate group-data-[collapsible=icon]:hidden">{item.label}</span>
-        </TooltipTrigger>
-        <TooltipContent side="right">{item.label}</TooltipContent>
-      </Tooltip>
+      <div className={item.isActive ? css.activeIcon : undefined}>
+        <item.icon />
+      </div>
+      <span className="truncate group-data-[collapsible=icon]:hidden">{item.label}</span>
     </SidebarMenuButton>
   )
 
-  const interactive = isSpacesVariant ? (
-    menuButton
-  ) : (
+  // Disabled Safe nav items always explain why they're inactive; for every other item the
+  // label tooltip is redundant while the sidebar is expanded, so it only shows when collapsed.
+  const showsDisabledReason = item.disabled && !isSpacesVariant
+  const tooltipContent = showsDisabledReason ? 'You need to activate your Safe first.' : item.label
+  const isTooltipHidden = showsDisabledReason ? false : state !== 'collapsed' || isMobile
+
+  const interactive = (
     <Tooltip>
       <TooltipTrigger render={<span className="block w-full" />}>{menuButton}</TooltipTrigger>
-      {item.disabled && <TooltipContent side="right">You need to activate your Safe first.</TooltipContent>}
+      <TooltipContent side="right" hidden={isTooltipHidden}>
+        {tooltipContent}
+      </TooltipContent>
     </Tooltip>
   )
 

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/__tests__/NavItem.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/__tests__/NavItem.test.tsx
@@ -165,6 +165,36 @@ describe('NavItem', () => {
     expect(screen.getByText('You need to activate your Safe first.')).toBeInTheDocument()
   })
 
+  it('applies the active icon style when active', () => {
+    const { container } = render(<NavItem item={{ ...baseItem, isActive: true }} />)
+
+    expect(container.querySelector('.activeIcon')).toBeInTheDocument()
+  })
+
+  it('does not apply the active icon style when inactive', () => {
+    const { container } = render(<NavItem item={baseItem} />)
+
+    expect(container.querySelector('.activeIcon')).not.toBeInTheDocument()
+  })
+
+  it('renders an indicator dot on the icon when item.indicator is set', () => {
+    const { container } = render(<NavItem item={{ ...baseItem, indicator: true }} />)
+
+    expect(container.querySelector('.outdatedDot')).toBeInTheDocument()
+  })
+
+  it('does not render an indicator dot by default', () => {
+    const { container } = render(<NavItem item={baseItem} />)
+
+    expect(container.querySelector('.outdatedDot')).not.toBeInTheDocument()
+  })
+
+  it('uses item.testId as the data-testid when provided', () => {
+    render(<NavItem item={{ ...baseItem, testId: 'sidebar-settings-item' }} />)
+
+    expect(screen.getByTestId('sidebar-settings-item')).toBeInTheDocument()
+  })
+
   it('uses per-label test id when isSpacesVariant', () => {
     render(<NavItem item={baseItem} isSpacesVariant />)
 

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/__tests__/NavItem.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/__tests__/NavItem.test.tsx
@@ -41,11 +41,19 @@ jest.mock('@/components/ui/tooltip', () => ({
   TooltipTrigger: ({ children, className }: { children: ReactNode; className?: string }) => (
     <div className={className}>{children}</div>
   ),
-  TooltipContent: ({ children }: { children: ReactNode }) => <div role="tooltip">{children}</div>,
+  TooltipContent: ({ children, hidden }: { children: ReactNode; hidden?: boolean }) =>
+    hidden ? null : <div role="tooltip">{children}</div>,
 }))
+
+// Controls the mocked sidebar collapse state per test.
+const mockSidebarState: { state: 'expanded' | 'collapsed'; isMobile: boolean } = {
+  state: 'expanded',
+  isMobile: false,
+}
 
 // Mock sidebar UI components
 jest.mock('@/components/ui/sidebar', () => ({
+  useSidebar: () => mockSidebarState,
   SidebarMenuItem: ({ children, className }: { children: ReactNode; className?: string }) => (
     <div className={className}>{children}</div>
   ),
@@ -97,6 +105,8 @@ describe('NavItem', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockSidebarState.state = 'expanded'
+    mockSidebarState.isMobile = false
   })
 
   it('renders with icon and label', () => {
@@ -124,6 +134,33 @@ describe('NavItem', () => {
   it('shows tooltip when disabled', () => {
     const disabledItem = { ...baseItem, disabled: true }
     render(<NavItem item={disabledItem} />)
+
+    expect(screen.getByText('You need to activate your Safe first.')).toBeInTheDocument()
+  })
+
+  it('does not show the label tooltip when the sidebar is expanded', () => {
+    render(<NavItem item={baseItem} />)
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
+  it('shows the label tooltip when the sidebar is collapsed to icons', () => {
+    mockSidebarState.state = 'collapsed'
+    render(<NavItem item={baseItem} />)
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Home')
+  })
+
+  it('does not show the label tooltip when collapsed on mobile', () => {
+    mockSidebarState.state = 'collapsed'
+    mockSidebarState.isMobile = true
+    render(<NavItem item={baseItem} />)
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+
+  it('shows the activation tooltip for a disabled item even when expanded', () => {
+    render(<NavItem item={{ ...baseItem, disabled: true }} />)
 
     expect(screen.getByText('You need to activate your Safe first.')).toBeInTheDocument()
   })

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
@@ -10,6 +10,7 @@ import {
   SidebarMenu,
   SidebarMenuItem,
   SidebarMenuButton,
+  useSidebar,
 } from '@/components/ui/sidebar'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import css from '../../styles.module.css'
@@ -39,6 +40,7 @@ export const SafeSidebarVariant = ({
   isLoading = false,
 }: SafeSidebarVariantProps): ReactElement => {
   const router = useRouter()
+  const { state, isMobile } = useSidebar()
   const { safe } = useSafeInfo()
   const isCounterfactualSafe = useIsCounterfactualSafe()
   const isHydrated = useSidebarHydrated()
@@ -95,25 +97,27 @@ export const SafeSidebarVariant = ({
                   <NavItem key={item?.href ?? `skeleton-main-${index}`} item={item} isLoading={isLoading} />
                 ))}
                 <SidebarMenuItem>
-                  <SidebarMenuButton
-                    size="lg"
-                    isActive={isSettingsActive}
-                    disabled={isLoading}
-                    className={`h-9 gap-3 ${css.sidebarInteractive} ${css.sidebarNavItem}`}
-                    render={!isLoading ? <Link href={settingsHref} /> : undefined}
-                    data-testid="sidebar-settings-item"
-                  >
-                    <Tooltip>
-                      <TooltipTrigger render={<span />} className="flex min-w-0 cursor-pointer items-center gap-3">
-                        <span className="relative">
-                          <Settings className="text-muted-foreground" />
+                  <Tooltip>
+                    <TooltipTrigger render={<span className="block w-full" />}>
+                      <SidebarMenuButton
+                        size="lg"
+                        isActive={isSettingsActive}
+                        disabled={isLoading}
+                        className={`h-9 gap-3 ${css.sidebarInteractive} ${css.sidebarNavItem}`}
+                        render={!isLoading ? <Link href={settingsHref} /> : undefined}
+                        data-testid="sidebar-settings-item"
+                      >
+                        <span className={`relative ${isSettingsActive ? css.activeIcon : ''}`}>
+                          <Settings />
                           {isOutdated && <span className={css.outdatedDot} aria-hidden />}
                         </span>
                         <span className="truncate group-data-[collapsible=icon]:hidden">Settings</span>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">Settings</TooltipContent>
-                    </Tooltip>
-                  </SidebarMenuButton>
+                      </SidebarMenuButton>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" hidden={state !== 'collapsed' || isMobile}>
+                      Settings
+                    </TooltipContent>
+                  </Tooltip>
                 </SidebarMenuItem>
               </SidebarMenu>
             </SidebarGroupContent>

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/SafeSidebarVariant.tsx
@@ -9,17 +9,13 @@ import {
   SidebarGroupContent,
   SidebarMenu,
   SidebarMenuItem,
-  SidebarMenuButton,
-  useSidebar,
 } from '@/components/ui/sidebar'
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import css from '../../styles.module.css'
-import type { SafeSidebarVariantProps } from '../../types'
+import type { ResolvedSidebarItem, SafeSidebarVariantProps } from '../../types'
 import { AppRoutes } from '@/config/routes'
 import { NavItem } from '../NavItem'
 import { SidebarActionButton } from '../../NewTransactionButton'
 import { SafeSidebarWorkspaceHeader } from '../SafeSidebarWorkspaceHeader'
-import Link from 'next/link'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { ImplementationVersionState } from '@safe-global/store/gateway/types'
 import { isNonCriticalUpdate } from '@safe-global/utils/utils/chains'
@@ -40,7 +36,6 @@ export const SafeSidebarVariant = ({
   isLoading = false,
 }: SafeSidebarVariantProps): ReactElement => {
   const router = useRouter()
-  const { state, isMobile } = useSidebar()
   const { safe } = useSafeInfo()
   const isCounterfactualSafe = useIsCounterfactualSafe()
   const isHydrated = useSidebarHydrated()
@@ -56,6 +51,19 @@ export const SafeSidebarVariant = ({
     query: safeAddress ? { safe: safeAddress } : {},
   }
   const isSettingsActive = router.pathname.startsWith(AppRoutes.settings.index)
+
+  // Settings lives in the main nav group but isn't config-driven: its outdated indicator and
+  // active state depend on the current Safe. Render it through NavItem so styling stays in sync.
+  const settingsItem: ResolvedSidebarItem = {
+    icon: Settings,
+    label: 'Settings',
+    href: AppRoutes.settings.setup,
+    link: settingsHref,
+    isActive: isSettingsActive,
+    disabled: false,
+    indicator: isOutdated,
+    testId: 'sidebar-settings-item',
+  }
 
   const shouldRenderWorkspaceHeaderGroup =
     workspaceHeader.variant === 'backToSpace' || (isUserSignedIn && !(isHydrated && isCounterfactualSafe))
@@ -96,29 +104,7 @@ export const SafeSidebarVariant = ({
                 {displayMainNavItems.map((item, index) => (
                   <NavItem key={item?.href ?? `skeleton-main-${index}`} item={item} isLoading={isLoading} />
                 ))}
-                <SidebarMenuItem>
-                  <Tooltip>
-                    <TooltipTrigger render={<span className="block w-full" />}>
-                      <SidebarMenuButton
-                        size="lg"
-                        isActive={isSettingsActive}
-                        disabled={isLoading}
-                        className={`h-9 gap-3 ${css.sidebarInteractive} ${css.sidebarNavItem}`}
-                        render={!isLoading ? <Link href={settingsHref} /> : undefined}
-                        data-testid="sidebar-settings-item"
-                      >
-                        <span className={`relative ${isSettingsActive ? css.activeIcon : ''}`}>
-                          <Settings />
-                          {isOutdated && <span className={css.outdatedDot} aria-hidden />}
-                        </span>
-                        <span className="truncate group-data-[collapsible=icon]:hidden">Settings</span>
-                      </SidebarMenuButton>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" hidden={state !== 'collapsed' || isMobile}>
-                      Settings
-                    </TooltipContent>
-                  </Tooltip>
-                </SidebarMenuItem>
+                <NavItem item={settingsItem} isLoading={isLoading} />
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
@@ -78,22 +78,17 @@ jest.mock('@/utils/colors', () => ({
 }))
 
 jest.mock('../../NavItem', () => ({
-  NavItem: ({ item }: { item: ResolvedSidebarItem }) => (
-    <div data-testid={`sidebar-item-${item.label.toLowerCase()}`}>
-      {item.label}
-      {!!item.badge && <span aria-label={`${item.badge} ${item.label} notifications`}>{item.badge}</span>}
-    </div>
-  ),
+  NavItem: ({ item }: { item: ResolvedSidebarItem | null }) =>
+    item ? (
+      <div data-testid={item.testId ?? `sidebar-item-${item.label.toLowerCase()}`} data-active={item.isActive}>
+        {item.label}
+        {!!item.badge && <span aria-label={`${item.badge} ${item.label} notifications`}>{item.badge}</span>}
+        {item.indicator && <span aria-hidden />}
+      </div>
+    ) : null,
 }))
 
-// Controls the mocked sidebar collapse state per test.
-const mockSidebarState: { state: 'expanded' | 'collapsed'; isMobile: boolean } = {
-  state: 'expanded',
-  isMobile: false,
-}
-
 jest.mock('@/components/ui/sidebar', () => ({
-  useSidebar: () => mockSidebarState,
   SidebarContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarGroupLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -133,8 +128,7 @@ jest.mock('@/components/ui/sidebar', () => ({
 jest.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ children }: { children: ReactNode }) => <span>{children}</span>,
-  TooltipContent: ({ children, hidden }: { children: ReactNode; hidden?: boolean }) =>
-    hidden ? null : <div role="tooltip">{children}</div>,
+  TooltipContent: () => null,
 }))
 
 jest.mock('@/components/ui/avatar', () => ({
@@ -231,8 +225,6 @@ describe('SafeSidebarVariant', () => {
     mockUseSidebarHydrated.mockReturnValue(true)
     mockUseAppSelector.mockReturnValue(true)
     mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: CURRENT_USER_ID } })
-    mockSidebarState.state = 'expanded'
-    mockSidebarState.isMobile = false
   })
 
   it('renders all navigation sections', () => {
@@ -591,61 +583,6 @@ describe('SafeSidebarVariant', () => {
 
       const settingsButton = screen.getByTestId('sidebar-settings-item')
       expect(settingsButton).toHaveAttribute('data-active', 'true')
-    })
-
-    it('applies the active icon colour to Settings when active', () => {
-      const mockRouter = jest.requireMock('next/router').useRouter as jest.Mock
-      mockRouter.mockReturnValue({ push: jest.fn(), query: { safe: '0x123' }, pathname: AppRoutes.settings.setup })
-
-      render(
-        <SafeSidebarVariant
-          workspaceHeader={createBackHeader()}
-          mainNavItems={mockMainNavItems}
-          defiGroup={mockDefiGroup}
-        />,
-      )
-
-      const settingsButton = screen.getByTestId('sidebar-settings-item')
-      expect(settingsButton.querySelector('.activeIcon')).toBeInTheDocument()
-    })
-
-    it('does not apply the active icon colour to Settings when inactive', () => {
-      render(
-        <SafeSidebarVariant
-          workspaceHeader={createBackHeader()}
-          mainNavItems={mockMainNavItems}
-          defiGroup={mockDefiGroup}
-        />,
-      )
-
-      const settingsButton = screen.getByTestId('sidebar-settings-item')
-      expect(settingsButton.querySelector('.activeIcon')).not.toBeInTheDocument()
-    })
-
-    it('hides the Settings tooltip when the sidebar is expanded', () => {
-      render(
-        <SafeSidebarVariant
-          workspaceHeader={createBackHeader()}
-          mainNavItems={mockMainNavItems}
-          defiGroup={mockDefiGroup}
-        />,
-      )
-
-      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
-    })
-
-    it('shows the Settings tooltip when the sidebar is collapsed to icons', () => {
-      mockSidebarState.state = 'collapsed'
-
-      render(
-        <SafeSidebarVariant
-          workspaceHeader={createBackHeader()}
-          mainNavItems={mockMainNavItems}
-          defiGroup={mockDefiGroup}
-        />,
-      )
-
-      expect(screen.getByRole('tooltip')).toHaveTextContent('Settings')
     })
 
     it('marks Settings as active when on settings sub-tab page', () => {

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SafeSidebarVariant/__tests__/SafeSidebarVariant.test.tsx
@@ -86,7 +86,14 @@ jest.mock('../../NavItem', () => ({
   ),
 }))
 
+// Controls the mocked sidebar collapse state per test.
+const mockSidebarState: { state: 'expanded' | 'collapsed'; isMobile: boolean } = {
+  state: 'expanded',
+  isMobile: false,
+}
+
 jest.mock('@/components/ui/sidebar', () => ({
+  useSidebar: () => mockSidebarState,
   SidebarContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarGroupLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -126,7 +133,8 @@ jest.mock('@/components/ui/sidebar', () => ({
 jest.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ children }: { children: ReactNode }) => <span>{children}</span>,
-  TooltipContent: () => null,
+  TooltipContent: ({ children, hidden }: { children: ReactNode; hidden?: boolean }) =>
+    hidden ? null : <div role="tooltip">{children}</div>,
 }))
 
 jest.mock('@/components/ui/avatar', () => ({
@@ -223,6 +231,8 @@ describe('SafeSidebarVariant', () => {
     mockUseSidebarHydrated.mockReturnValue(true)
     mockUseAppSelector.mockReturnValue(true)
     mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: CURRENT_USER_ID } })
+    mockSidebarState.state = 'expanded'
+    mockSidebarState.isMobile = false
   })
 
   it('renders all navigation sections', () => {
@@ -581,6 +591,61 @@ describe('SafeSidebarVariant', () => {
 
       const settingsButton = screen.getByTestId('sidebar-settings-item')
       expect(settingsButton).toHaveAttribute('data-active', 'true')
+    })
+
+    it('applies the active icon colour to Settings when active', () => {
+      const mockRouter = jest.requireMock('next/router').useRouter as jest.Mock
+      mockRouter.mockReturnValue({ push: jest.fn(), query: { safe: '0x123' }, pathname: AppRoutes.settings.setup })
+
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createBackHeader()}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      const settingsButton = screen.getByTestId('sidebar-settings-item')
+      expect(settingsButton.querySelector('.activeIcon')).toBeInTheDocument()
+    })
+
+    it('does not apply the active icon colour to Settings when inactive', () => {
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createBackHeader()}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      const settingsButton = screen.getByTestId('sidebar-settings-item')
+      expect(settingsButton.querySelector('.activeIcon')).not.toBeInTheDocument()
+    })
+
+    it('hides the Settings tooltip when the sidebar is expanded', () => {
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createBackHeader()}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+
+    it('shows the Settings tooltip when the sidebar is collapsed to icons', () => {
+      mockSidebarState.state = 'collapsed'
+
+      render(
+        <SafeSidebarVariant
+          workspaceHeader={createBackHeader()}
+          mainNavItems={mockMainNavItems}
+          defiGroup={mockDefiGroup}
+        />,
+      )
+
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Settings')
     })
 
     it('marks Settings as active when on settings sub-tab page', () => {

--- a/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarVariant/__tests__/SpacesSidebarVariant.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/SpacesSidebarVariant/__tests__/SpacesSidebarVariant.test.tsx
@@ -13,6 +13,7 @@ jest.mock('@/components/ui/tooltip', () => ({
 }))
 
 jest.mock('@/components/ui/sidebar', () => ({
+  useSidebar: () => ({ state: 'expanded', isMobile: false }),
   SidebarContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   SidebarGroupLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,


### PR DESCRIPTION
> Tooltips on the rail,
> hush when wide, whisper when thin —
> the cog clicks once more.

## What it solves

Sidebar nav items showed their label tooltip on hover even when the sidebar was **expanded** (redundant with the already-visible label), and the tooltip was anchored to the icon rather than the button. The **Settings** item had three extra bugs: its tooltip always showed, its icon didn't turn green when active, and — when the sidebar was collapsed to icons — the cog was neither clickable nor hoverable.

Resolves: https://linear.app/safe-global/issue/WA-2375/remove-redundant-tooltips-from-sidebar-menu-items

## How this PR fixes it

- Label tooltips now only render when the sidebar is collapsed to icons (`state === 'collapsed' && \!isMobile`) and are anchored to the whole button via a wrapping `TooltipTrigger`. The disabled-Safe message ("You need to activate your Safe first.") is preserved and still shows regardless of collapse state.
- Settings was a bespoke `SidebarMenuButton` that hadn't been migrated to the `NavItem` tooltip pattern — it kept the old always-on, icon-anchored tooltip and never applied the `activeIcon` (green) style. It now mirrors `NavItem`.
- **The non-obvious one:** the collapsed cog being un-clickable was *not* a Settings bug. In icon mode `SidebarGroupLabel` gets `-mt-8` + `opacity-0` but keeps its 32px height and pointer events, so the invisible "Defi" group label sits directly on top of the last item above it (Settings) and swallows hover/click. Fixed by adding `group-data-[collapsible=icon]:pointer-events-none` to `SidebarGroupLabel` — a decorative label should never intercept pointer events. (Note: the `tooltip` prop built into `SidebarMenuButton` can't be used here because it replaces the `render` prop we need for the Next `Link`.)

## How to test it

1. Open a Safe and expand the sidebar — hover any nav item (e.g. Transactions, Settings); **no** tooltip should appear.
2. Collapse the sidebar (Toggle Sidebar) to icons — hover an item; the label tooltip appears to the right, vertically centered on the button.
3. With the sidebar collapsed, hover and **click** the Settings cog — the tooltip shows and the click navigates to Settings.
4. Navigate into Settings — the Settings cog icon turns green like other active items.

## Screenshots

https://github.com/user-attachments/assets/d49ba231-89f4-430d-bfab-fc68613d7605


| State | Behaviour |
| --- | --- |
| Expanded, hover | No tooltip (label already visible) |
| Collapsed, hover | "Settings"/label tooltip anchored to the button |
| Active | Settings cog icon rendered green |

```mermaid
flowchart TB
  subgraph Before
    A1[Hover nav item] --> B1[Tooltip always shown, anchored to icon]
    C1[Collapsed: Defi group label -mt-8 overlaps Settings] --> D1[Cog not clickable / no tooltip]
  end
  subgraph After
    A2[Hover nav item] --> B2{Sidebar collapsed?}
    B2 -->|No| E2[No tooltip]
    B2 -->|Yes| F2[Tooltip anchored to button]
    C2[Group label pointer-events-none when collapsed] --> D2[Cog clickable + tooltip works]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics changes
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — added NavItem + SafeSidebarVariant tests

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
