### PR TITLE
Epic auth m2

### DIFF
--- a/apps/web/src/components/common/EnhancedTable/index.tsx
+++ b/apps/web/src/components/common/EnhancedTable/index.tsx
@@ -130,12 +130,13 @@ export type EnhancedTableProps = {
   headCells: EnhancedHeadCell[]
   mobileVariant?: boolean
   compact?: boolean
+  fixedLayout?: boolean
   footer?: ReactNode
 }
 
 const pageSizes = [10, 25, 100]
 
-function EnhancedTable({ rows, headCells, mobileVariant, compact, footer }: EnhancedTableProps) {
+function EnhancedTable({ rows, headCells, mobileVariant, compact, fixedLayout, footer }: EnhancedTableProps) {
   const [order, setOrder] = useState<'asc' | 'desc'>('asc')
   const [orderBy, setOrderBy] = useState<string>('')
   const [page, setPage] = useState<number>(0)
@@ -174,7 +175,11 @@ function EnhancedTable({ rows, headCells, mobileVariant, compact, footer }: Enha
       >
         <Table
           aria-labelledby="tableTitle"
-          className={classNames({ [css.mobileColumn]: mobileVariant, [css.compactTable]: compact })}
+          className={classNames({
+            [css.mobileColumn]: mobileVariant,
+            [css.compactTable]: compact,
+            [css.fixedLayout]: fixedLayout,
+          })}
         >
           <EnhancedTableHead headCells={headCells} order={order} orderBy={orderBy} onRequestSort={handleRequestSort} />
           <TableBody className={css.tableBody}>

--- a/apps/web/src/components/common/EnhancedTable/styles.module.css
+++ b/apps/web/src/components/common/EnhancedTable/styles.module.css
@@ -35,6 +35,10 @@
   background: none !important;
 }
 
+.fixedLayout {
+  table-layout: fixed;
+}
+
 .mobileLabel {
   display: none;
 }

--- a/apps/web/src/components/common/WalletInfo/index.test.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.test.tsx
@@ -2,6 +2,9 @@ import { render } from '@/tests/test-utils'
 import { WalletInfo } from '@/components/common/WalletInfo/index'
 import { type EIP1193Provider, type OnboardAPI } from '@web3-onboard/core'
 import { act } from '@testing-library/react'
+import * as authApi from '@safe-global/store/gateway/AUTO_GENERATED/auth'
+
+const mockAuthLogout = jest.fn()
 
 const mockWallet = {
   address: '0x1234567890123456789012345678901234567890',
@@ -19,6 +22,7 @@ const mockOnboard = {
 describe('WalletInfo', () => {
   beforeEach(() => {
     jest.resetAllMocks()
+    jest.spyOn(authApi, 'useAuthLogoutV1Mutation').mockReturnValue([mockAuthLogout, {} as never])
   })
 
   it('should display the wallet address', () => {
@@ -51,7 +55,7 @@ describe('WalletInfo', () => {
     expect(getByText('Switch wallet')).toBeInTheDocument()
   })
 
-  it('should disconnect the wallet when the button is clicked', () => {
+  it('should disconnect only the wallet, not the auth session, when the button is clicked', () => {
     const { getByText } = render(
       <WalletInfo
         wallet={mockWallet}
@@ -72,6 +76,8 @@ describe('WalletInfo', () => {
     })
 
     expect(mockOnboard.disconnectWallet).toHaveBeenCalled()
+    // Disconnecting the wallet must not end the spaces auth session
+    expect(mockAuthLogout).not.toHaveBeenCalled()
   })
 
   it('calls onSwitch when Switch wallet is clicked', () => {

--- a/apps/web/src/components/common/WalletInfo/index.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.tsx
@@ -6,14 +6,10 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import ChainSwitcher from '@/components/common/ChainSwitcher'
 import useOnboard, { type ConnectedWallet, switchWallet } from '@/hooks/wallets/useOnboard'
 import useAddressBook from '@/hooks/useAddressBook'
-import { useAppDispatch } from '@/store'
 import { useChain } from '@/hooks/useChains'
 import madProps from '@/utils/mad-props'
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 import useChainId from '@/hooks/useChainId'
-import { useAuthLogoutV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
-import { setUnauthenticated } from '@/store/authSlice'
-import { logError, Errors } from '@/services/exceptions'
 import { getNativeTokenDisplay, NATIVE_TOKEN_DISPLAY_DEFAULT } from '@safe-global/utils/utils/chains'
 
 type WalletInfoProps = {
@@ -37,8 +33,6 @@ export const WalletInfo = ({
   onSwitch,
   onDisconnect,
 }: WalletInfoProps) => {
-  const [authLogout] = useAuthLogoutV1Mutation()
-  const dispatch = useAppDispatch()
   const chainInfo = useChain(wallet.chainId)
   const prefix = chainInfo?.shortName
   const { showWalletBalance } = chainInfo ? getNativeTokenDisplay(chainInfo) : NATIVE_TOKEN_DISPLAY_DEFAULT
@@ -51,18 +45,11 @@ export const WalletInfo = ({
     }
   }
 
-  const handleDisconnect = async () => {
+  const handleDisconnect = () => {
     onDisconnect?.()
     onboard?.disconnectWallet({
       label: wallet.label,
     })
-    try {
-      await authLogout()
-      dispatch(setUnauthenticated())
-    } catch (error) {
-      logError(Errors._108, error)
-    }
-
     handleClose()
   }
 

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.stories.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Box } from '@mui/material'
+import { useForm } from 'react-hook-form'
+import { createMockStory } from '@/stories/mocks'
+import AddMemberInput from './AddMemberInput'
+
+type FormValues = {
+  inviteeIdentifier: string
+}
+
+const addressBook = {
+  '0x1234567890123456789012345678901234567890': 'Alice',
+  '0x2345678901234567890123456789012345678901': 'Bob',
+  '0x3456789012345678901234567890123456789012': 'Charlie',
+}
+
+const defaultSetup = createMockStory({
+  scenario: 'efSafe',
+  wallet: 'owner',
+  features: { spaces: true },
+  shadcn: true,
+  store: {
+    addressBook: {
+      '1': addressBook,
+    },
+  },
+})
+
+const AddMemberInputStory = ({ error }: { error?: string }) => {
+  const { register, setValue, watch } = useForm<FormValues>({
+    defaultValues: { inviteeIdentifier: '' },
+  })
+
+  return (
+    <Box sx={{ width: 360, minHeight: '50vh', pt: '22vh' }}>
+      <AddMemberInput
+        error={error}
+        inputProps={register('inviteeIdentifier')}
+        onSelectAddress={(address) => setValue('inviteeIdentifier', address)}
+        value={watch('inviteeIdentifier')}
+      />
+    </Box>
+  )
+}
+
+const meta = {
+  title: 'Features/Spaces/AddMemberInput',
+  component: AddMemberInputStory,
+  decorators: [defaultSetup.decorator],
+  parameters: {
+    layout: 'centered',
+    ...defaultSetup.parameters,
+  },
+} satisfies Meta<typeof AddMemberInputStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithError: Story = {
+  args: {
+    error: 'Enter a valid email, wallet address, or ENS.',
+  },
+}

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
@@ -1,0 +1,166 @@
+import { type ReactElement, useEffect, useMemo, useState } from 'react'
+import { IconButton, InputAdornment, Skeleton, SvgIcon, TextField, Typography } from '@mui/material'
+import Autocomplete from '@mui/material/Autocomplete'
+import classnames from 'classnames'
+import type { UseFormRegisterReturn } from 'react-hook-form'
+import { isAddress } from 'viem'
+import useDebounce from '@safe-global/utils/hooks/useDebounce'
+import useNameResolver from '@/components/common/AddressInput/useNameResolver'
+import useAddressBook from '@/hooks/useAddressBook'
+import { useAddressBookSearch } from '@/features/spaces'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import Identicon from '@/components/common/Identicon'
+import InitialsAvatar from '@/components/common/InitialsAvatar'
+import CaretDownIcon from '@/public/images/common/caret-down.svg'
+import inputCss from '@/styles/inputs.module.css'
+import { EMAIL_MAX_LENGTH, isEmailAddress } from './utils'
+import css from './styles.module.css'
+
+type AddMemberInputProps = {
+  error?: string
+  inputProps: UseFormRegisterReturn<'inviteeIdentifier'>
+  onSelectAddress: (address: string, name: string) => void
+  value: string
+}
+
+type InviteeIdentifierOption = { address: string; name: string }
+
+const MAX_VISIBLE_OPTIONS = 5
+
+// Debounce the email avatar so its color doesn't flicker on every keystroke.
+const AVATAR_DEBOUNCE_MS = 500
+
+/**
+ * Invite-specific input for choosing who to invite.
+ *
+ * Unlike AddressBookInput/AddressInput, this accepts either an email or a wallet
+ * inviteeIdentifier. Address-book names and ENS names are resolved to addresses before
+ * submit; emails are kept as-is.
+ */
+const AddMemberInput = ({ error, inputProps, onSelectAddress, value }: AddMemberInputProps): ReactElement => {
+  const addressBook = useAddressBook()
+  const [isOpen, setIsOpen] = useState(false)
+  const inviteeIdentifier = value.trim()
+  const shouldResolveEns = Boolean(
+    inviteeIdentifier && !isEmailAddress(inviteeIdentifier) && !isAddress(inviteeIdentifier),
+  )
+  const { address: resolvedAddress } = useNameResolver(shouldResolveEns ? inviteeIdentifier : '')
+
+  useEffect(() => {
+    if (resolvedAddress) {
+      onSelectAddress(resolvedAddress, inviteeIdentifier)
+    }
+  }, [inviteeIdentifier, onSelectAddress, resolvedAddress])
+
+  const contacts = useMemo<InviteeIdentifierOption[]>(
+    () => Object.entries(addressBook).map(([address, name]) => ({ address, name })),
+    [addressBook],
+  )
+
+  const matches = useAddressBookSearch(contacts, inviteeIdentifier)
+  const options = useMemo(
+    () => (isAddress(inviteeIdentifier) ? [] : matches.slice(0, MAX_VISIBLE_OPTIONS)),
+    [inviteeIdentifier, matches],
+  )
+
+  const showIdenticon = Boolean(value && !error && isAddress(value))
+
+  // The initials avatar colors itself from the full email, which would change
+  // on every keystroke. Debounce it so the color doesn't flicker while typing.
+  const debouncedIdentifier = useDebounce(inviteeIdentifier, AVATAR_DEBOUNCE_MS)
+  const showInitials = Boolean(debouncedIdentifier && !error && !showIdenticon && isEmailAddress(debouncedIdentifier))
+
+  const renderAvatar = () => {
+    if (showIdenticon) {
+      return <Identicon address={value} size={32} />
+    }
+    if (showInitials) {
+      return <InitialsAvatar name={debouncedIdentifier} size="medium" rounded />
+    }
+    return <Skeleton variant="circular" width={32} height={32} animation={false} />
+  }
+
+  const startAdornment = (
+    <InputAdornment position="start" sx={{ ml: 0, mr: 1 }}>
+      {renderAvatar()}
+    </InputAdornment>
+  )
+
+  const endAdornment =
+    options.length > 0 ? (
+      <InputAdornment position="end">
+        <IconButton
+          className={classnames(css.openButton, { [css.rotated]: isOpen })}
+          color="primary"
+          onClick={() => setIsOpen((open) => !open)}
+          tabIndex={-1}
+        >
+          <SvgIcon component={CaretDownIcon} inheritViewBox fontSize="small" />
+        </IconButton>
+      </InputAdornment>
+    ) : null
+
+  return (
+    <Autocomplete<InviteeIdentifierOption, false, true, true>
+      freeSolo
+      disableClearable
+      openOnFocus
+      open={isOpen && options.length > 0}
+      onOpen={() => setIsOpen(true)}
+      onClose={() => setIsOpen(false)}
+      className={inputCss.input}
+      options={options}
+      // Options are already searched/sliced via useAddressBookSearch.
+      filterOptions={(opts) => opts}
+      getOptionLabel={(option) => (typeof option === 'string' ? option : option.address)}
+      inputValue={value}
+      onInputChange={(_, newValue, reason) => {
+        if (reason === 'input') {
+          inputProps.onChange({ target: { name: inputProps.name, value: newValue } } as never)
+        }
+      }}
+      onChange={(_, option) => {
+        if (option && typeof option !== 'string') {
+          onSelectAddress(option.address, option.name)
+          setIsOpen(false)
+        }
+      }}
+      componentsProps={{ paper: { elevation: 2 } }}
+      renderOption={(props, option) => {
+        const { key, ...rest } = props
+        return (
+          <Typography component="li" variant="body2" {...rest} key={key}>
+            <EthHashInfo address={option.address} name={option.name} shortAddress={false} copyAddress={false} />
+          </Typography>
+        )
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          name={inputProps.name}
+          inputRef={inputProps.ref}
+          onBlur={inputProps.onBlur}
+          label={error || 'Address or email'}
+          required={!error}
+          error={!!error}
+          fullWidth
+          autoComplete="off"
+          spellCheck={false}
+          inputProps={{
+            ...params.inputProps,
+            'data-testid': 'member-invitee-identifier-input',
+            maxLength: EMAIL_MAX_LENGTH,
+          }}
+          InputProps={{
+            ...params.InputProps,
+            startAdornment,
+            endAdornment,
+          }}
+          InputLabelProps={{ shrink: true }}
+        />
+      )}
+    />
+  )
+}
+
+export default AddMemberInput

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
@@ -3,7 +3,7 @@ import { IconButton, InputAdornment, Skeleton, SvgIcon, TextField, Typography } 
 import Autocomplete from '@mui/material/Autocomplete'
 import classnames from 'classnames'
 import type { UseFormRegisterReturn } from 'react-hook-form'
-import { isAddress } from 'viem'
+import { isAddress } from 'ethers'
 import useDebounce from '@safe-global/utils/hooks/useDebounce'
 import useNameResolver from '@/components/common/AddressInput/useNameResolver'
 import useAddressBook from '@/hooks/useAddressBook'
@@ -116,7 +116,7 @@ const AddMemberInput = ({ error, inputProps, onSelectAddress, value }: AddMember
       inputValue={value}
       onInputChange={(_, newValue, reason) => {
         if (reason === 'input') {
-          inputProps.onChange({ target: { name: inputProps.name, value: newValue } } as never)
+          inputProps.onChange({ target: { name: inputProps.name, value: newValue } })
         }
       }}
       onChange={(_, option) => {

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.stories.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { mswLoader } from 'msw-storybook-addon'
+import AddMemberModal from '.'
+import { createMockStory } from '@/stories/mocks'
+
+const defaultSetup = createMockStory({
+  scenario: 'efSafe',
+  wallet: 'owner',
+  features: { spaces: true },
+  pathname: '/spaces/members',
+  query: { spaceId: '1' },
+  shadcn: true,
+})
+
+const meta = {
+  title: 'Features/Spaces/AddMemberModal',
+  component: AddMemberModal,
+  loaders: [mswLoader],
+  decorators: [defaultSetup.decorator],
+  parameters: {
+    layout: 'centered',
+    ...defaultSetup.parameters,
+  },
+  args: {
+    onClose: () => {},
+  },
+} satisfies Meta<typeof AddMemberModal>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.test.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.test.tsx
@@ -1,11 +1,14 @@
-import type * as ReactHookForm from 'react-hook-form'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import type { showNotification } from '@/store/notificationsSlice'
 import AddMemberModal from './index'
 
 const mockDispatch = jest.fn()
 const mockInviteMembers = jest.fn()
+const mockUseAuthGetMeV1Query = jest.fn()
+const mockUseUsersGetWithWalletsV1Query = jest.fn()
+const mockUseAddressBook = jest.fn()
 
 jest.mock('@/services/analytics', () => ({
   trackEvent: jest.fn(),
@@ -22,6 +25,21 @@ jest.mock('@/services/analytics/events/spaces', () => ({
 jest.mock('@/features/spaces', () => ({
   useCurrentSpaceId: () => '11111111-1111-1111-1111-111111111111',
   MemberRole: { MEMBER: 'MEMBER', ADMIN: 'ADMIN' },
+  useAddressBookSearch: (contacts: { name: string; address: string }[], query: string) =>
+    query
+      ? contacts.filter(
+          ({ name, address }) =>
+            name.toLowerCase().includes(query.toLowerCase()) || address.toLowerCase().includes(query.toLowerCase()),
+        )
+      : contacts,
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/auth', () => ({
+  useAuthGetMeV1Query: () => mockUseAuthGetMeV1Query(),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/users', () => ({
+  useUsersGetWithWalletsV1Query: () => mockUseUsersGetWithWalletsV1Query(),
 }))
 
 jest.mock('next/router', () => ({
@@ -30,10 +48,15 @@ jest.mock('next/router', () => ({
 
 jest.mock('@/store', () => ({
   useAppDispatch: () => mockDispatch,
+  useAppSelector: () => true,
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: jest.fn(),
 }))
 
 jest.mock('@/store/notificationsSlice', () => ({
-  showNotification: (payload: unknown) => ({ type: 'notifications/show', payload }),
+  showNotification: (payload: Parameters<typeof showNotification>[0]) => ({ type: 'notifications/show', payload }),
 }))
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
@@ -42,20 +65,12 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
 
 jest.mock('@/hooks/useAddressBook', () => ({
   __esModule: true,
-  default: () => ({}),
+  default: () => mockUseAddressBook(),
 }))
 
 jest.mock('./MemberInfoForm', () => ({
   __esModule: true,
   default: () => null,
-}))
-
-jest.mock('@/components/common/AddressBookInput', () => ({
-  __esModule: true,
-  default: ({ name }: { name: string }) => {
-    const { register } = (jest.requireActual('react-hook-form') as typeof ReactHookForm).useFormContext()
-    return <input {...register(name, { required: true })} data-testid="member-address-input" />
-  },
 }))
 
 jest.mock('@/components/common/ModalDialog', () => ({
@@ -67,9 +82,22 @@ jest.mock('@/config/routes', () => ({
   AppRoutes: { spaces: { members: '/spaces/members' } },
 }))
 
+jest.mock('@/components/common/EthHashInfo', () => ({
+  __esModule: true,
+  default: ({ name, address }: { name?: string; address: string }) => <div>{name ?? address}</div>,
+}))
+
+jest.mock('@/components/common/AddressInput/useNameResolver', () => ({
+  __esModule: true,
+  default: () => ({ address: undefined, resolverError: undefined, resolving: false }),
+}))
+
 describe('AddMemberModal tracking', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseAuthGetMeV1Query.mockReturnValue({ data: undefined })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: undefined })
+    mockUseAddressBook.mockReturnValue({})
   })
 
   it('tracks WORKSPACE_MEMBER_INVITE_SENT with workspace_id, user_id and role on submit', async () => {
@@ -87,7 +115,7 @@ describe('AddMemberModal tracking', () => {
 
     render(<AddMemberModal onClose={jest.fn()} />)
 
-    fireEvent.change(screen.getByTestId('member-address-input'), {
+    fireEvent.change(screen.getByTestId('member-invitee-identifier-input'), {
       target: { value: '0x1234567890123456789012345678901234567890' },
     })
 
@@ -101,6 +129,129 @@ describe('AddMemberModal tracking', () => {
         { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: '11111111-1111-1111-1111-111111111111' },
         { workspace_id: '11111111-1111-1111-1111-111111111111', user_id: 1, role: 'member' },
       )
+    })
+  })
+
+  it('submits email invites with the email field instead of address', async () => {
+    mockInviteMembers.mockResolvedValue({
+      data: [{ userId: 1, spaceId: 42, name: 'invitee@example.com', role: 'MEMBER', status: 'INVITED' }],
+    })
+
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-invitee-identifier-input'), {
+      target: { value: 'invitee@example.com' },
+    })
+
+    const submitButton = screen.getByTestId('add-member-modal-button')
+    await waitFor(() => expect(submitButton).not.toBeDisabled())
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [{ type: 'email', email: 'invitee@example.com', role: 'MEMBER', name: '' }],
+        },
+      })
+    })
+  })
+
+  it('limits the invitee identifier input to the allowed email max length', () => {
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    expect(screen.getByTestId('member-invitee-identifier-input')).toHaveAttribute('maxLength', '255')
+  })
+
+  it('shows an initials avatar for a valid email', async () => {
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-invitee-identifier-input'), {
+      target: { value: 'invitee@example.com' },
+    })
+
+    await waitFor(() => expect(screen.getByText('i')).toBeInTheDocument())
+  })
+
+  it('shows an error for an invalid invitee identifier', async () => {
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-invitee-identifier-input'), {
+      target: { value: 'not-a-wallet-or-email' },
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('member-invitee-identifier-input')).toHaveAttribute('aria-invalid', 'true'),
+    )
+    expect(screen.getByTestId('add-member-modal-button')).toBeDisabled()
+  })
+
+  it("blocks inviting the authenticated user's email", async () => {
+    mockUseAuthGetMeV1Query.mockReturnValue({
+      data: { id: '1', authMethod: 'oidc', email: 'alice@example.com' },
+    })
+
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-invitee-identifier-input'), {
+      target: { value: 'ALICE@example.com' },
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('member-invitee-identifier-input')).toHaveAttribute('aria-invalid', 'true'),
+    )
+    expect(screen.getByTestId('add-member-modal-button')).toBeDisabled()
+  })
+
+  it("blocks inviting one of the authenticated user's wallets", async () => {
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({
+      currentData: {
+        id: 1,
+        wallets: [{ id: 1, address: '0x1234567890123456789012345678901234567890' }],
+      },
+    })
+
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-invitee-identifier-input'), {
+      target: { value: '0x1234567890123456789012345678901234567890' },
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('member-invitee-identifier-input')).toHaveAttribute('aria-invalid', 'true'),
+    )
+    expect(screen.getByTestId('add-member-modal-button')).toBeDisabled()
+  })
+
+  it('fills the address and name from an address book suggestion', async () => {
+    const address = '0x1234567890123456789012345678901234567890'
+    const name = 'Alice'
+
+    mockUseAddressBook.mockReturnValue({ [address]: name })
+    mockInviteMembers.mockResolvedValue({
+      data: [{ userId: 1, spaceId: 42, name, role: 'MEMBER', status: 'INVITED' }],
+    })
+
+    render(<AddMemberModal onClose={jest.fn()} />)
+
+    fireEvent.change(screen.getByTestId('member-invitee-identifier-input'), {
+      target: { value: 'Ali' },
+    })
+    fireEvent.click(await screen.findByRole('option', { name }))
+
+    expect(screen.getByTestId('member-invitee-identifier-input')).toHaveValue(address)
+
+    const submitButton = screen.getByTestId('add-member-modal-button')
+    await waitFor(() => expect(submitButton).not.toBeDisabled())
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [{ type: 'wallet', address, role: 'MEMBER', name }],
+        },
+      })
     })
   })
 })

--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.test.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberModal.test.tsx
@@ -4,6 +4,7 @@ import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import type { showNotification } from '@/store/notificationsSlice'
 import AddMemberModal from './index'
 
+const mockSpaceId = '11111111-1111-1111-1111-111111111111'
 const mockDispatch = jest.fn()
 const mockInviteMembers = jest.fn()
 const mockUseAuthGetMeV1Query = jest.fn()
@@ -23,7 +24,7 @@ jest.mock('@/services/analytics/events/spaces', () => ({
 }))
 
 jest.mock('@/features/spaces', () => ({
-  useCurrentSpaceId: () => '11111111-1111-1111-1111-111111111111',
+  useCurrentSpaceId: () => mockSpaceId,
   MemberRole: { MEMBER: 'MEMBER', ADMIN: 'ADMIN' },
   useAddressBookSearch: (contacts: { name: string; address: string }[], query: string) =>
     query
@@ -105,7 +106,7 @@ describe('AddMemberModal tracking', () => {
       data: [
         {
           userId: 1,
-          spaceId: '11111111-1111-1111-1111-111111111111',
+          spaceId: mockSpaceId,
           name: 'Alice',
           role: 'MEMBER',
           status: 'INVITED',
@@ -126,15 +127,15 @@ describe('AddMemberModal tracking', () => {
     await waitFor(() => {
       expect(trackEvent).toHaveBeenCalledTimes(1)
       expect(trackEvent).toHaveBeenCalledWith(
-        { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: '11111111-1111-1111-1111-111111111111' },
-        { workspace_id: '11111111-1111-1111-1111-111111111111', user_id: 1, role: 'member' },
+        { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: mockSpaceId },
+        { workspace_id: mockSpaceId, user_id: 1, role: 'member' },
       )
     })
   })
 
   it('submits email invites with the email field instead of address', async () => {
     mockInviteMembers.mockResolvedValue({
-      data: [{ userId: 1, spaceId: 42, name: 'invitee@example.com', role: 'MEMBER', status: 'INVITED' }],
+      data: [{ userId: 1, spaceId: mockSpaceId, name: 'invitee@example.com', role: 'MEMBER', status: 'INVITED' }],
     })
 
     render(<AddMemberModal onClose={jest.fn()} />)
@@ -149,7 +150,7 @@ describe('AddMemberModal tracking', () => {
 
     await waitFor(() => {
       expect(mockInviteMembers).toHaveBeenCalledWith({
-        spaceId: 42,
+        spaceId: mockSpaceId,
         inviteUsersDto: {
           users: [{ type: 'email', email: 'invitee@example.com', role: 'MEMBER', name: '' }],
         },
@@ -229,7 +230,7 @@ describe('AddMemberModal tracking', () => {
 
     mockUseAddressBook.mockReturnValue({ [address]: name })
     mockInviteMembers.mockResolvedValue({
-      data: [{ userId: 1, spaceId: 42, name, role: 'MEMBER', status: 'INVITED' }],
+      data: [{ userId: 1, spaceId: mockSpaceId, name, role: 'MEMBER', status: 'INVITED' }],
     })
 
     render(<AddMemberModal onClose={jest.fn()} />)
@@ -247,7 +248,7 @@ describe('AddMemberModal tracking', () => {
 
     await waitFor(() => {
       expect(mockInviteMembers).toHaveBeenCalledWith({
-        spaceId: 42,
+        spaceId: mockSpaceId,
         inviteUsersDto: {
           users: [{ type: 'wallet', address, role: 'MEMBER', name }],
         },

--- a/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/MemberInfoForm.tsx
@@ -22,7 +22,7 @@ const MemberInfoForm = ({ isEdit = false }: { isEdit?: boolean }) => {
             value={value}
             onChange={onChange}
             required
-            sx={{ minWidth: '150px', py: 0.5 }}
+            className={css.roleSelect}
             renderValue={(role) => <RoleMenuItem role={role as MemberRole} />}
           >
             <MenuItem value={MemberRole.ADMIN} className={css.menuItem}>

--- a/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
@@ -22,17 +22,22 @@ import { useRouter } from 'next/router'
 import { AppRoutes } from '@/config/routes'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
-import { useAppDispatch } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
 import { showNotification } from '@/store/notificationsSlice'
 import MemberInfoForm from './MemberInfoForm'
-import AddressBookInput from '@/components/common/AddressBookInput'
 import useAddressBook from '@/hooks/useAddressBook'
-
-type MemberField = {
-  name: string
-  address: string
-  role: MemberRole
-}
+import { isAuthenticated } from '@/store/authSlice'
+import { useAuthGetMeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { isAddress } from 'viem'
+import {
+  type MemberField,
+  buildInviteUserPayload,
+  getInviteeIdentifierValidationError,
+  normalizeInviteeIdentifier,
+} from './utils'
+import AddMemberInput from './AddMemberInput'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
 
 export const RoleMenuItem = ({
   role,
@@ -47,7 +52,7 @@ export const RoleMenuItem = ({
 
   return (
     <Box width="100%" alignItems="center" className={css.roleMenuItem}>
-      <Box sx={{ gridArea: 'icon', display: 'flex', alignItems: 'center' }}>
+      <Box className={css.roleIcon}>
         <SvgIcon mr={1} component={isAdmin ? adminIcon : memberIcon} inheritViewBox fontSize="small" />
       </Box>
       <Typography gridArea="title" fontWeight={hasDescription ? 'bold' : undefined}>
@@ -55,15 +60,13 @@ export const RoleMenuItem = ({
       </Typography>
       {hasDescription && (
         <>
-          <Box gridArea="description">
-            <Typography variant="body2" sx={{ maxWidth: '300px', whiteSpace: 'normal', wordWrap: 'break-word' }}>
-              {isAdmin
-                ? 'Admins can create and delete workspaces, invite members, and more.'
-                : 'Can view the workspace data.'}
+          <Box className={css.roleDescription}>
+            <Typography variant="body2">
+              {isAdmin ? 'Admins can create and delete spaces, invite members, and more.' : 'Can view the space data.'}
             </Typography>
           </Box>
-          <Box gridArea="checkIcon" sx={{ visibility: selected ? 'visible' : 'hidden', mx: 1 }}>
-            <CheckIcon fontSize="small" sx={{ color: 'text.primary' }} />
+          <Box className={selected ? css.roleCheckIcon : css.roleCheckIconHidden}>
+            <CheckIcon fontSize="small" className={css.roleCheckSvg} />
           </Box>
         </>
       )}
@@ -79,29 +82,51 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [inviteMembers] = useMembersInviteUserV1Mutation()
   const addressBook = useAddressBook()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { data: session } = useAuthGetMeV1Query(undefined, { skip: !isUserSignedIn })
+  const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
+  const sessionEmail = session && 'email' in session && typeof session.email === 'string' ? session.email : undefined
 
   const methods = useForm<MemberField>({
     mode: 'onChange',
     defaultValues: {
       name: '',
-      address: '',
+      inviteeIdentifier: '',
       role: MemberRole.MEMBER,
     },
   })
 
-  const { handleSubmit, formState, watch, setValue } = methods
+  const { handleSubmit, formState, register, watch, setValue } = methods
 
-  const addressValue = watch('address')
+  const inviteeIdentifierValue = watch('inviteeIdentifier')
+  const inviteeIdentifierInputProps = register('inviteeIdentifier', {
+    required: true,
+    validate: (value) => {
+      return (
+        getInviteeIdentifierValidationError({
+          inviteeIdentifier: value,
+          sessionEmail,
+          walletAddresses: currentUser?.wallets?.map((wallet) => wallet.address),
+        }) ?? true
+      )
+    },
+  })
 
   useEffect(() => {
-    const addressBookName = addressBook[addressValue]
-    if (addressBookName) {
-      setValue('name', addressBookName)
+    if (!isAddress(inviteeIdentifierValue)) {
+      return
     }
-  }, [addressBook, addressValue, setValue])
+
+    const addressBookName = addressBook[inviteeIdentifierValue]
+    if (addressBookName) {
+      setValue('name', addressBookName, { shouldValidate: true })
+    }
+  }, [addressBook, inviteeIdentifierValue, setValue])
 
   const onSubmit = handleSubmit(async (data) => {
     setError(undefined)
+
+    const inviteeIdentifier = normalizeInviteeIdentifier(data.inviteeIdentifier)
 
     if (!spaceId) {
       setError('Something went wrong. Please try again.')
@@ -112,7 +137,9 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
       setIsSubmitting(true)
       const response = await inviteMembers({
         spaceId: spaceId ?? '',
-        inviteUsersDto: { users: [{ type: 'wallet', address: data.address, role: data.role, name: data.name }] },
+        inviteUsersDto: {
+          users: [buildInviteUserPayload(data)],
+        },
       })
 
       if (response.data) {
@@ -129,7 +156,7 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
 
         dispatch(
           showNotification({
-            message: `Invited ${data.name} to space`,
+            message: `Invited ${data.name || inviteeIdentifier} to space`,
             variant: 'success',
             groupKey: 'invite-member-success',
           }),
@@ -138,9 +165,7 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
         onClose()
       }
       if (response.error) {
-        // @ts-ignore
-        const errorMessage = response.error?.data?.message || 'Invite failed. Please try again.'
-        setError(errorMessage)
+        setError(getRtkQueryErrorMessage(response.error) || 'Invite failed. Please try again.')
       }
     } catch (e) {
       console.error(e)
@@ -154,21 +179,20 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
     <ModalDialog open onClose={onClose} dialogTitle="Add member" hideChainIndicator>
       <FormProvider {...methods}>
         <form onSubmit={onSubmit}>
-          <DialogContent sx={{ py: 2 }}>
-            <Typography mb={2}>
-              Invite a signer of the Safe Accounts, or any other wallet address. Anyone in the workspace can see their
-              name.
-            </Typography>
+          <DialogContent sx={{ overflow: 'visible', py: 2 }}>
+            <Typography mb={2}>Invite a member by email or wallet address.</Typography>
 
             <Stack spacing={3}>
               <MemberInfoForm />
 
-              <AddressBookInput
-                data-testid="member-address-input"
-                name="address"
-                label="Address"
-                required
-                showPrefix={false}
+              <AddMemberInput
+                error={formState.errors.inviteeIdentifier?.message}
+                inputProps={inviteeIdentifierInputProps}
+                onSelectAddress={(address, name) => {
+                  setValue('inviteeIdentifier', address, { shouldValidate: true })
+                  setValue('name', name, { shouldValidate: true })
+                }}
+                value={inviteeIdentifierValue}
               />
             </Stack>
 

--- a/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useState } from 'react'
+import { type ReactElement, useCallback, useEffect, useState } from 'react'
 import {
   Alert,
   Box,
@@ -29,7 +29,7 @@ import useAddressBook from '@/hooks/useAddressBook'
 import { isAuthenticated } from '@/store/authSlice'
 import { useAuthGetMeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
 import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
-import { isAddress } from 'viem'
+import { isAddress } from 'ethers'
 import {
   type MemberField,
   buildInviteUserPayload,
@@ -123,6 +123,14 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
     }
   }, [addressBook, inviteeIdentifierValue, setValue])
 
+  const handleSelectAddress = useCallback(
+    (address: string, name: string) => {
+      setValue('inviteeIdentifier', address, { shouldValidate: true })
+      setValue('name', name, { shouldValidate: true })
+    },
+    [setValue],
+  )
+
   const onSubmit = handleSubmit(async (data) => {
     setError(undefined)
 
@@ -188,10 +196,7 @@ const AddMemberModal = ({ onClose }: { onClose: () => void }): ReactElement => {
               <AddMemberInput
                 error={formState.errors.inviteeIdentifier?.message}
                 inputProps={inviteeIdentifierInputProps}
-                onSelectAddress={(address, name) => {
-                  setValue('inviteeIdentifier', address, { shouldValidate: true })
-                  setValue('name', name, { shouldValidate: true })
-                }}
+                onSelectAddress={handleSelectAddress}
                 value={inviteeIdentifierValue}
               />
             </Stack>

--- a/apps/web/src/features/spaces/components/AddMemberModal/styles.module.css
+++ b/apps/web/src/features/spaces/components/AddMemberModal/styles.module.css
@@ -7,10 +7,52 @@
   column-gap: var(--space-1);
 }
 
+.roleIcon {
+  grid-area: icon;
+  display: flex;
+  align-items: center;
+}
+
+.roleDescription {
+  grid-area: description;
+  max-width: 300px;
+  white-space: normal;
+  overflow-wrap: break-word;
+}
+
+.roleCheckIcon {
+  grid-area: checkIcon;
+  margin: 0 var(--space-1);
+}
+
+.roleCheckIconHidden {
+  grid-area: checkIcon;
+  margin: 0 var(--space-1);
+  visibility: hidden;
+}
+
+.roleCheckSvg {
+  color: var(--color-text-primary);
+}
+
+.roleSelect {
+  min-width: 150px;
+  padding-block: 4px;
+  background-color: var(--color-background-main);
+}
+
 .menuItem:hover {
   background-color: var(--color-background-main) !important;
 }
 
 .menuItem:global(.Mui-selected) {
   background-color: var(--color-background-main);
+}
+
+.openButton svg {
+  transition: transform 0.3s ease-in-out;
+}
+
+.rotated svg {
+  transform: rotate(180deg);
 }

--- a/apps/web/src/features/spaces/components/AddMemberModal/utils.test.ts
+++ b/apps/web/src/features/spaces/components/AddMemberModal/utils.test.ts
@@ -1,0 +1,92 @@
+import {
+  EMAIL_MAX_LENGTH,
+  buildInviteUserPayload,
+  getInviteeIdentifierValidationError,
+  isEmailAddress,
+  normalizeInviteeIdentifier,
+} from './utils'
+import { MemberRole } from '../../hooks/useSpaceMembers'
+
+describe('AddMemberModal utils', () => {
+  it('normalizes invitee identifiers by trimming whitespace', () => {
+    expect(normalizeInviteeIdentifier('  alice@example.com  ')).toBe('alice@example.com')
+  })
+
+  it('detects email invitee identifiers', () => {
+    expect(isEmailAddress('alice@example.com')).toBe(true)
+    expect(isEmailAddress('0x1234567890123456789012345678901234567890')).toBe(false)
+  })
+
+  it('builds an email invite payload with lowercased email', () => {
+    expect(
+      buildInviteUserPayload({
+        name: 'Alice',
+        inviteeIdentifier: '  ALICE@Example.com ',
+        role: MemberRole.MEMBER,
+      }),
+    ).toEqual({
+      type: 'email',
+      email: 'alice@example.com',
+      name: 'Alice',
+      role: 'MEMBER',
+    })
+  })
+
+  it('builds a wallet invite payload for addresses', () => {
+    expect(
+      buildInviteUserPayload({
+        name: 'Bob',
+        inviteeIdentifier: '0x1234567890123456789012345678901234567890',
+        role: MemberRole.ADMIN,
+      }),
+    ).toEqual({
+      type: 'wallet',
+      address: '0x1234567890123456789012345678901234567890',
+      name: 'Bob',
+      role: 'ADMIN',
+    })
+  })
+
+  it('returns an error for invalid invitee identifiers', () => {
+    expect(getInviteeIdentifierValidationError({ inviteeIdentifier: 'not-valid' })).toBeDefined()
+  })
+
+  it('returns no inline error for empty invitee identifiers', () => {
+    expect(getInviteeIdentifierValidationError({ inviteeIdentifier: '' })).toBeUndefined()
+  })
+
+  it('returns an error for self email invites', () => {
+    expect(
+      getInviteeIdentifierValidationError({
+        inviteeIdentifier: 'Alice@example.com',
+        sessionEmail: 'alice@example.com',
+      }),
+    ).toBeDefined()
+  })
+
+  it('returns an error for self wallet invites', () => {
+    expect(
+      getInviteeIdentifierValidationError({
+        inviteeIdentifier: '0x1234567890123456789012345678901234567890',
+        walletAddresses: ['0x1234567890123456789012345678901234567890'],
+      }),
+    ).toBeDefined()
+  })
+
+  it('returns no error for a valid external email invite', () => {
+    expect(
+      getInviteeIdentifierValidationError({
+        inviteeIdentifier: 'invitee@example.com',
+        sessionEmail: 'alice@example.com',
+      }),
+    ).toBeUndefined()
+  })
+
+  it('returns an error for emails longer than the allowed limit', () => {
+    const tooLongEmail = `${'a'.repeat(EMAIL_MAX_LENGTH - '@example.com'.length + 1)}@example.com`
+
+    expect(getInviteeIdentifierValidationError({ inviteeIdentifier: tooLongEmail })).toBe(
+      `Email must be ${EMAIL_MAX_LENGTH} characters or less.`,
+    )
+  })
+})

--- a/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
+++ b/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
@@ -15,7 +15,7 @@ export type InvitePayload = EmailInviteUserDto | WalletInviteUserDto
 export const EMAIL_MAX_LENGTH = 255
 
 const SELF_INVITE_ERROR = "You can't invite yourself."
-const INVALID_IDENTIFIER_ERROR = 'Enter a valid email, wallet address, or ENS.'
+export const INVALID_IDENTIFIER_ERROR = 'Enter a valid email, wallet address, or ENS.'
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 

--- a/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
+++ b/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
@@ -1,4 +1,4 @@
-import { isAddress } from 'viem'
+import { isAddress } from 'ethers'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import type { MemberRole } from '../../hooks/useSpaceMembers'
 import type { EmailInviteUserDto, WalletInviteUserDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'

--- a/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
+++ b/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
@@ -1,0 +1,79 @@
+import { isAddress } from 'viem'
+import { sameAddress } from '@safe-global/utils/utils/addresses'
+import type { MemberRole } from '../../hooks/useSpaceMembers'
+import type { EmailInviteUserDto, WalletInviteUserDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+export type MemberField = {
+  name: string
+  // Can be an address book name, wallet address, or email.
+  inviteeIdentifier: string
+  role: MemberRole
+}
+
+export type InvitePayload = EmailInviteUserDto | WalletInviteUserDto
+
+export const EMAIL_MAX_LENGTH = 255
+
+const SELF_INVITE_ERROR = "You can't invite yourself."
+const INVALID_IDENTIFIER_ERROR = 'Enter a valid email, wallet address, or ENS.'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export const isEmailAddress = (value: string): boolean => EMAIL_REGEX.test(value)
+
+export const normalizeInviteeIdentifier = (value: string): string => value.trim()
+
+export const buildInviteUserPayload = (data: MemberField): InvitePayload => {
+  const inviteeIdentifier = normalizeInviteeIdentifier(data.inviteeIdentifier)
+
+  if (isEmailAddress(inviteeIdentifier)) {
+    return {
+      type: 'email',
+      email: inviteeIdentifier.toLowerCase(),
+      role: data.role,
+      name: data.name,
+    }
+  }
+
+  return {
+    type: 'wallet',
+    address: inviteeIdentifier,
+    role: data.role,
+    name: data.name,
+  }
+}
+
+export const getInviteeIdentifierValidationError = ({
+  inviteeIdentifier,
+  sessionEmail,
+  walletAddresses,
+}: {
+  inviteeIdentifier: string
+  sessionEmail?: string
+  walletAddresses?: string[]
+}): string | undefined => {
+  const normalized = normalizeInviteeIdentifier(inviteeIdentifier)
+
+  if (!normalized) {
+    return undefined
+  }
+
+  if (isEmailAddress(normalized)) {
+    if (normalized.length > EMAIL_MAX_LENGTH) {
+      return `Email must be ${EMAIL_MAX_LENGTH} characters or less.`
+    }
+    if (sessionEmail && normalized.toLowerCase() === sessionEmail.toLowerCase()) {
+      return SELF_INVITE_ERROR
+    }
+    return undefined
+  }
+
+  if (isAddress(normalized)) {
+    if (walletAddresses?.some((walletAddress) => sameAddress(walletAddress, normalized))) {
+      return SELF_INVITE_ERROR
+    }
+    return undefined
+  }
+
+  return INVALID_IDENTIFIER_ERROR
+}

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
@@ -115,13 +115,16 @@ const MemberInviteRow = ({
                 if (isEmailAddress(trimmed)) {
                   if (trimmed.length > EMAIL_MAX_LENGTH) return `Email must be ${EMAIL_MAX_LENGTH} characters or less.`
 
-                  const isDuplicateEmail = members?.some(
-                    (member, i) =>
+                  const isDuplicateEmail = members?.some((member, i) => {
+                    // Trim to match the trimmed-on-submit value
+                    const otherIdentifier = member.identifier?.trim()
+                    return (
                       i !== index &&
-                      member.identifier &&
-                      isEmailAddress(member.identifier) &&
-                      member.identifier.trim().toLowerCase() === trimmed.toLowerCase(),
-                  )
+                      otherIdentifier &&
+                      isEmailAddress(otherIdentifier) &&
+                      otherIdentifier.toLowerCase() === trimmed.toLowerCase()
+                    )
+                  })
                   if (isDuplicateEmail) return 'Email already added'
 
                   return undefined
@@ -135,7 +138,8 @@ const MemberInviteRow = ({
                 if (addressError) return addressError
 
                 const isDuplicate = members?.some(
-                  (member, i) => i !== index && member.identifier && sameAddress(member.identifier, trimmed),
+                  (member, i) =>
+                    i !== index && member.identifier?.trim() && sameAddress(member.identifier.trim(), trimmed),
                 )
                 if (isDuplicate) return 'Address already added'
               },

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Controller } from 'react-hook-form'
 import type { InviteMembersFormValues } from '../hooks/useInviteForm'
+import { EMAIL_MAX_LENGTH, isEmailAddress } from '../../AddMemberModal/utils'
 
 const ROLE_LABELS: Record<MemberRole, string> = {
   [MemberRole.ADMIN]: 'Admin',
@@ -63,19 +64,24 @@ const MemberInviteRow = ({
   onRemove,
 }: MemberInviteRowProps) => {
   const members = useWatch({ control, name: 'members' })
-  const addressValue = members?.[index]?.address ?? ''
-  const fieldErrorMessage = errors?.members?.[index]?.address?.message
+  const identifierValue = members?.[index]?.identifier ?? ''
+  const fieldErrorMessage = errors?.members?.[index]?.identifier?.message
   const debouncedError = useDebounce(fieldErrorMessage, ERROR_DEBOUNCE_MS)
   const displayError = fieldErrorMessage ? debouncedError : undefined
 
   const handleAddressResolved = useCallback(
     (address: string) => {
-      setValue(`members.${index}.address`, address, { shouldValidate: true })
+      setValue(`members.${index}.identifier`, address, { shouldValidate: true })
     },
     [setValue, index],
   )
 
-  const { address: resolvedAddress, resolverError, resolving } = useNameResolver(addressValue)
+  // Emails are not ENS names — don't try to resolve them (it would surface a resolver error).
+  const {
+    address: resolvedAddress,
+    resolverError,
+    resolving,
+  } = useNameResolver(isEmailAddress(identifierValue.trim()) ? '' : identifierValue)
 
   useEffect(() => {
     if (resolvedAddress) handleAddressResolved(resolvedAddress)
@@ -88,33 +94,50 @@ const MemberInviteRow = ({
           <Input
             address
             autoComplete="off"
-            {...register(`members.${index}.address`, {
+            {...register(`members.${index}.identifier`, {
               required: index === 0,
               onChange: () => {
                 const otherFields = members
-                  ?.map((_, i) => (i !== index ? (`members.${i}.address` as const) : null))
-                  .filter(Boolean) as `members.${number}.address`[]
+                  ?.map((_, i) => (i !== index ? (`members.${i}.identifier` as const) : null))
+                  .filter(Boolean) as `members.${number}.identifier`[]
                 if (otherFields?.length) trigger(otherFields)
               },
               validate: (value) => {
-                if (!value?.trim()) return undefined
-                if (isDomain(value)) return undefined
+                const trimmed = value?.trim()
+                if (!trimmed) return undefined
 
-                const addressError = validateEthereumAddress(value, (checksummed) => {
-                  setValue(`members.${index}.address`, checksummed, { shouldValidate: true })
+                if (isEmailAddress(trimmed)) {
+                  if (trimmed.length > EMAIL_MAX_LENGTH) return `Email must be ${EMAIL_MAX_LENGTH} characters or less.`
+
+                  const isDuplicateEmail = members?.some(
+                    (member, i) =>
+                      i !== index &&
+                      member.identifier &&
+                      isEmailAddress(member.identifier) &&
+                      member.identifier.trim().toLowerCase() === trimmed.toLowerCase(),
+                  )
+                  if (isDuplicateEmail) return 'Email already added'
+
+                  return undefined
+                }
+
+                if (isDomain(trimmed)) return undefined
+
+                const addressError = validateEthereumAddress(trimmed, (checksummed) => {
+                  setValue(`members.${index}.identifier`, checksummed, { shouldValidate: true })
                 })
                 if (addressError) return addressError
 
                 const isDuplicate = members?.some(
-                  (member, i) => i !== index && member.address && sameAddress(member.address, value),
+                  (member, i) => i !== index && member.identifier && sameAddress(member.identifier, trimmed),
                 )
                 if (isDuplicate) return 'Address already added'
               },
             })}
-            placeholder="Wallet address or ENS name"
+            placeholder="Email, wallet address or ENS name"
             className={cn('h-11 rounded-lg bg-card px-4', resolving && 'pr-10')}
             error={displayError}
-            data-testid={`invite-address-input-${index}`}
+            data-testid={`invite-identifier-input-${index}`}
           />
           {resolving && (
             <div className="pointer-events-none absolute right-3 top-0 flex h-11 items-center">

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
@@ -13,7 +13,7 @@ import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Controller } from 'react-hook-form'
 import type { InviteMembersFormValues } from '../hooks/useInviteForm'
-import { EMAIL_MAX_LENGTH, isEmailAddress } from '../../AddMemberModal/utils'
+import { EMAIL_MAX_LENGTH, INVALID_IDENTIFIER_ERROR, isEmailAddress } from '../../AddMemberModal/utils'
 
 const ROLE_LABELS: Record<MemberRole, string> = {
   [MemberRole.ADMIN]: 'Admin',
@@ -22,11 +22,17 @@ const ROLE_LABELS: Record<MemberRole, string> = {
 
 const ADDRESS_RE = /^0x[0-9a-f]{40}$/i
 const ERROR_DEBOUNCE_MS = 500
+const INVALID_ADDRESS_ERROR = 'Invalid address'
 
 type AutoChecksumCallback = (checksummed: string) => void
 
 function validateEthereumAddress(value: string, onAutoChecksum: AutoChecksumCallback): string | undefined {
-  if (!ADDRESS_RE.test(value)) return 'Invalid address'
+  // A "0x" prefix signals an address attempt — show the address-specific error rather than the generic one
+  const looksLikeAddress = value.toLowerCase().startsWith('0x')
+
+  if (!ADDRESS_RE.test(value)) {
+    return looksLikeAddress ? INVALID_ADDRESS_ERROR : INVALID_IDENTIFIER_ERROR
+  }
 
   const hex = value.slice(2)
   const hasNoChecksumIntent = hex === hex.toLowerCase() || hex === hex.toUpperCase()
@@ -37,7 +43,7 @@ function validateEthereumAddress(value: string, onAutoChecksum: AutoChecksumCall
     return undefined
   }
 
-  if (!isChecksummedAddress(value)) return 'Invalid address checksum'
+  if (!isChecksummedAddress(value)) return INVALID_ADDRESS_ERROR
 
   return undefined
 }

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
-import useInviteForm from './useInviteForm'
+import useInviteForm, { toInviteName } from './useInviteForm'
 
 const mockInviteMembers = jest.fn()
 const mockOnSuccess = jest.fn()
@@ -42,6 +42,31 @@ const TestComponent = ({ spaceId }: { spaceId: string | undefined }) => {
     </form>
   )
 }
+
+describe('toInviteName', () => {
+  it('keeps wallet addresses and ENS names as-is', () => {
+    expect(toInviteName('0x1234567890123456789012345678901234567890')).toBe(
+      '0x1234567890123456789012345678901234567890',
+    )
+    expect(toInviteName('alice.eth')).toBe('alice.eth')
+  })
+
+  it('derives the name from the email local part', () => {
+    expect(toInviteName('john.doe@example.com')).toBe('john.doe')
+  })
+
+  it('strips characters the backend name validation rejects', () => {
+    expect(toInviteName('john+safe@example.com')).toBe('johnsafe')
+  })
+
+  it('strips leading non-alphanumeric characters', () => {
+    expect(toInviteName('_test@example.com')).toBe('test')
+  })
+
+  it('falls back to a default when nothing valid remains', () => {
+    expect(toInviteName('+++@example.com')).toBe('Member')
+  })
+})
 
 describe('useInviteForm tracking', () => {
   beforeEach(() => {
@@ -90,9 +115,9 @@ describe('useInviteForm tracking', () => {
     })
   })
 
-  it('builds an email invite payload with a lowercased email', async () => {
+  it('builds an email invite payload with a lowercased email and a name derived from the local part', async () => {
     mockInviteMembers.mockResolvedValue({
-      data: [{ userId: 9, spaceId: 42, name: 'Bob@Example.com', role: 'MEMBER', status: 'INVITED' }],
+      data: [{ userId: 9, spaceId: 42, name: 'Bob', role: 'MEMBER', status: 'INVITED' }],
     })
 
     render(<TestComponent spaceId="42" />)
@@ -110,7 +135,7 @@ describe('useInviteForm tracking', () => {
             {
               type: 'email',
               email: 'bob@example.com',
-              name: 'Bob@Example.com',
+              name: 'Bob',
               role: 'MEMBER',
             },
           ],
@@ -139,7 +164,7 @@ describe('useInviteForm tracking', () => {
             {
               type: 'email',
               email: 'dave@example.com',
-              name: 'Dave@Example.com',
+              name: 'Dave',
               role: 'MEMBER',
             },
           ],
@@ -182,7 +207,7 @@ describe('useInviteForm tracking', () => {
             {
               type: 'email',
               email: 'carol@example.com',
-              name: 'Carol@Example.com',
+              name: 'Carol',
               role: 'MEMBER',
             },
           ],

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -4,6 +4,7 @@ import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
 import useInviteForm, { toInviteName } from './useInviteForm'
 
+const mockSpaceId = '11111111-1111-1111-1111-111111111111'
 const mockInviteMembers = jest.fn()
 const mockOnSuccess = jest.fn()
 
@@ -27,7 +28,7 @@ jest.mock('@/features/spaces/hooks/useSpaceMembers', () => ({
 }))
 
 const TestComponent = ({ spaceId }: { spaceId: string | undefined }) => {
-  const { onSubmit, register, fields, append } = useInviteForm(spaceId, mockOnSuccess)
+  const { onSubmit, register, fields, append, isSubmitting } = useInviteForm(spaceId, mockOnSuccess)
   return (
     <form onSubmit={onSubmit}>
       {fields.map((field, index) => (
@@ -36,9 +37,10 @@ const TestComponent = ({ spaceId }: { spaceId: string | undefined }) => {
       <button type="button" data-testid="append" onClick={() => append({ identifier: '', role: MemberRole.MEMBER })}>
         Add
       </button>
-      <button type="submit" data-testid="submit">
+      <button type="submit" data-testid="submit" disabled={isSubmitting}>
         Submit
       </button>
+      <span data-testid="is-submitting">{String(isSubmitting)}</span>
     </form>
   )
 }
@@ -78,7 +80,7 @@ describe('useInviteForm tracking', () => {
       data: [
         {
           userId: 7,
-          spaceId: '11111111-1111-1111-1111-111111111111',
+          spaceId: mockSpaceId,
           name: 'Alice',
           role: 'MEMBER',
           status: 'INVITED',
@@ -86,7 +88,7 @@ describe('useInviteForm tracking', () => {
       ],
     })
 
-    render(<TestComponent spaceId="11111111-1111-1111-1111-111111111111" />)
+    render(<TestComponent spaceId={mockSpaceId} />)
 
     fireEvent.change(screen.getByTestId('address-0'), {
       target: { value: '0x1234567890123456789012345678901234567890' },
@@ -95,7 +97,7 @@ describe('useInviteForm tracking', () => {
 
     await waitFor(() => {
       expect(mockInviteMembers).toHaveBeenCalledWith({
-        spaceId: 42,
+        spaceId: mockSpaceId,
         inviteUsersDto: {
           users: [
             {
@@ -109,18 +111,18 @@ describe('useInviteForm tracking', () => {
       })
       expect(trackEvent).toHaveBeenCalledTimes(1)
       expect(trackEvent).toHaveBeenCalledWith(
-        { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: '11111111-1111-1111-1111-111111111111' },
-        { workspace_id: '11111111-1111-1111-1111-111111111111', user_id: 7, role: 'member', batch_size: 1 },
+        { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: mockSpaceId },
+        { workspace_id: mockSpaceId, user_id: 7, role: 'member', batch_size: 1 },
       )
     })
   })
 
   it('builds an email invite payload with a lowercased email and a name derived from the local part', async () => {
     mockInviteMembers.mockResolvedValue({
-      data: [{ userId: 9, spaceId: 42, name: 'Bob', role: 'MEMBER', status: 'INVITED' }],
+      data: [{ userId: 9, spaceId: mockSpaceId, name: 'Bob', role: 'MEMBER', status: 'INVITED' }],
     })
 
-    render(<TestComponent spaceId="42" />)
+    render(<TestComponent spaceId={mockSpaceId} />)
 
     fireEvent.change(screen.getByTestId('address-0'), {
       target: { value: 'Bob@Example.com' },
@@ -129,7 +131,7 @@ describe('useInviteForm tracking', () => {
 
     await waitFor(() => {
       expect(mockInviteMembers).toHaveBeenCalledWith({
-        spaceId: 42,
+        spaceId: mockSpaceId,
         inviteUsersDto: {
           users: [
             {
@@ -146,10 +148,10 @@ describe('useInviteForm tracking', () => {
 
   it('submits identifiers with surrounding whitespace instead of blocking on "unresolved" names', async () => {
     mockInviteMembers.mockResolvedValue({
-      data: [{ userId: 3, spaceId: 42, name: 'Dave', role: 'MEMBER', status: 'INVITED' }],
+      data: [{ userId: 3, spaceId: mockSpaceId, name: 'Dave', role: 'MEMBER', status: 'INVITED' }],
     })
 
-    render(<TestComponent spaceId="42" />)
+    render(<TestComponent spaceId={mockSpaceId} />)
 
     fireEvent.change(screen.getByTestId('address-0'), {
       target: { value: '  Dave@Example.com  ' },
@@ -158,7 +160,7 @@ describe('useInviteForm tracking', () => {
 
     await waitFor(() => {
       expect(mockInviteMembers).toHaveBeenCalledWith({
-        spaceId: 42,
+        spaceId: mockSpaceId,
         inviteUsersDto: {
           users: [
             {
@@ -176,12 +178,12 @@ describe('useInviteForm tracking', () => {
   it('builds a mixed payload of wallet and email invites in order', async () => {
     mockInviteMembers.mockResolvedValue({
       data: [
-        { userId: 1, spaceId: 42, name: 'wallet', role: 'MEMBER', status: 'INVITED' },
-        { userId: 2, spaceId: 42, name: 'email', role: 'MEMBER', status: 'INVITED' },
+        { userId: 1, spaceId: mockSpaceId, name: 'wallet', role: 'MEMBER', status: 'INVITED' },
+        { userId: 2, spaceId: mockSpaceId, name: 'email', role: 'MEMBER', status: 'INVITED' },
       ],
     })
 
-    render(<TestComponent spaceId="42" />)
+    render(<TestComponent spaceId={mockSpaceId} />)
 
     fireEvent.click(screen.getByTestId('append'))
 
@@ -195,7 +197,7 @@ describe('useInviteForm tracking', () => {
 
     await waitFor(() => {
       expect(mockInviteMembers).toHaveBeenCalledWith({
-        spaceId: 42,
+        spaceId: mockSpaceId,
         inviteUsersDto: {
           users: [
             {
@@ -215,5 +217,55 @@ describe('useInviteForm tracking', () => {
       })
       expect(trackEvent).toHaveBeenCalledTimes(2)
     })
+  })
+})
+
+describe('useInviteForm isSubmitting state', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('keeps isSubmitting true after a successful invite so the spinner persists through navigation', async () => {
+    mockInviteMembers.mockResolvedValue({
+      data: [{ userId: 7, spaceId: mockSpaceId, name: 'Alice', role: 'MEMBER', status: 'INVITED' }],
+    })
+
+    render(<TestComponent spaceId={mockSpaceId} />)
+
+    fireEvent.change(screen.getByTestId('address-0'), {
+      target: { value: '0x1234567890123456789012345678901234567890' },
+    })
+    fireEvent.click(screen.getByTestId('submit'))
+
+    await waitFor(() => expect(mockOnSuccess).toHaveBeenCalled())
+    expect(screen.getByTestId('is-submitting')).toHaveTextContent('true')
+  })
+
+  it('resets isSubmitting when the mutation returns an error', async () => {
+    mockInviteMembers.mockResolvedValue({ error: { status: 500, data: 'boom' } })
+
+    render(<TestComponent spaceId={mockSpaceId} />)
+
+    fireEvent.change(screen.getByTestId('address-0'), {
+      target: { value: '0x1234567890123456789012345678901234567890' },
+    })
+    fireEvent.click(screen.getByTestId('submit'))
+
+    await waitFor(() => expect(screen.getByTestId('is-submitting')).toHaveTextContent('false'))
+    expect(mockOnSuccess).not.toHaveBeenCalled()
+  })
+
+  it('resets isSubmitting when the mutation throws, so the button never stays stuck', async () => {
+    mockInviteMembers.mockRejectedValue(new Error('network down'))
+
+    render(<TestComponent spaceId={mockSpaceId} />)
+
+    fireEvent.change(screen.getByTestId('address-0'), {
+      target: { value: '0x1234567890123456789012345678901234567890' },
+    })
+    fireEvent.click(screen.getByTestId('submit'))
+
+    await waitFor(() => expect(screen.getByTestId('is-submitting')).toHaveTextContent('false'))
+    expect(mockOnSuccess).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
 import useInviteForm from './useInviteForm'
 
 const mockInviteMembers = jest.fn()
@@ -26,12 +27,15 @@ jest.mock('@/features/spaces/hooks/useSpaceMembers', () => ({
 }))
 
 const TestComponent = ({ spaceId }: { spaceId: string | undefined }) => {
-  const { onSubmit, register, fields } = useInviteForm(spaceId, mockOnSuccess)
+  const { onSubmit, register, fields, append } = useInviteForm(spaceId, mockOnSuccess)
   return (
     <form onSubmit={onSubmit}>
       {fields.map((field, index) => (
-        <input key={field.id} data-testid={`address-${index}`} {...register(`members.${index}.address`)} />
+        <input key={field.id} data-testid={`address-${index}`} {...register(`members.${index}.identifier`)} />
       ))}
+      <button type="button" data-testid="append" onClick={() => append({ identifier: '', role: MemberRole.MEMBER })}>
+        Add
+      </button>
       <button type="submit" data-testid="submit">
         Submit
       </button>
@@ -83,6 +87,108 @@ describe('useInviteForm tracking', () => {
         { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: '11111111-1111-1111-1111-111111111111' },
         { workspace_id: '11111111-1111-1111-1111-111111111111', user_id: 7, role: 'member', batch_size: 1 },
       )
+    })
+  })
+
+  it('builds an email invite payload with a lowercased email', async () => {
+    mockInviteMembers.mockResolvedValue({
+      data: [{ userId: 9, spaceId: 42, name: 'Bob@Example.com', role: 'MEMBER', status: 'INVITED' }],
+    })
+
+    render(<TestComponent spaceId="42" />)
+
+    fireEvent.change(screen.getByTestId('address-0'), {
+      target: { value: 'Bob@Example.com' },
+    })
+    fireEvent.click(screen.getByTestId('submit'))
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [
+            {
+              type: 'email',
+              email: 'bob@example.com',
+              name: 'Bob@Example.com',
+              role: 'MEMBER',
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  it('submits identifiers with surrounding whitespace instead of blocking on "unresolved" names', async () => {
+    mockInviteMembers.mockResolvedValue({
+      data: [{ userId: 3, spaceId: 42, name: 'Dave', role: 'MEMBER', status: 'INVITED' }],
+    })
+
+    render(<TestComponent spaceId="42" />)
+
+    fireEvent.change(screen.getByTestId('address-0'), {
+      target: { value: '  Dave@Example.com  ' },
+    })
+    fireEvent.click(screen.getByTestId('submit'))
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [
+            {
+              type: 'email',
+              email: 'dave@example.com',
+              name: 'Dave@Example.com',
+              role: 'MEMBER',
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  it('builds a mixed payload of wallet and email invites in order', async () => {
+    mockInviteMembers.mockResolvedValue({
+      data: [
+        { userId: 1, spaceId: 42, name: 'wallet', role: 'MEMBER', status: 'INVITED' },
+        { userId: 2, spaceId: 42, name: 'email', role: 'MEMBER', status: 'INVITED' },
+      ],
+    })
+
+    render(<TestComponent spaceId="42" />)
+
+    fireEvent.click(screen.getByTestId('append'))
+
+    fireEvent.change(screen.getByTestId('address-0'), {
+      target: { value: '0x1234567890123456789012345678901234567890' },
+    })
+    fireEvent.change(screen.getByTestId('address-1'), {
+      target: { value: 'Carol@Example.com' },
+    })
+    fireEvent.click(screen.getByTestId('submit'))
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [
+            {
+              type: 'wallet',
+              address: '0x1234567890123456789012345678901234567890',
+              name: '0x1234567890123456789012345678901234567890',
+              role: 'MEMBER',
+            },
+            {
+              type: 'email',
+              email: 'carol@example.com',
+              name: 'Carol@Example.com',
+              role: 'MEMBER',
+            },
+          ],
+        },
+      })
+      expect(trackEvent).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -65,6 +65,19 @@ describe('useInviteForm tracking', () => {
     fireEvent.click(screen.getByTestId('submit'))
 
     await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [
+            {
+              type: 'wallet',
+              address: '0x1234567890123456789012345678901234567890',
+              name: '0x1234567890123456789012345678901234567890',
+              role: 'MEMBER',
+            },
+          ],
+        },
+      })
       expect(trackEvent).toHaveBeenCalledTimes(1)
       expect(trackEvent).toHaveBeenCalledWith(
         { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: '11111111-1111-1111-1111-111111111111' },

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -1,7 +1,10 @@
 import { useState } from 'react'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { isAddress } from 'ethers'
-import { useMembersInviteUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import {
+  type WalletInviteUserDto,
+  useMembersInviteUserV1Mutation,
+} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
@@ -53,8 +56,8 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
     setIsSubmitting(true)
 
     try {
-      const usersToInvite = validMembers.map((member) => ({
-        type: 'wallet' as const,
+      const usersToInvite: WalletInviteUserDto[] = validMembers.map((member) => ({
+        type: 'wallet',
         address: member.address,
         name: member.address,
         role: member.role,

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -66,7 +66,6 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
     }
 
     if (validMembers.length === 0) {
-      setIsSubmitting(true)
       onSuccess()
       return
     }

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -18,6 +18,24 @@ export interface InviteMembersFormValues {
   members: MemberInvite[]
 }
 
+/**
+ * The onboarding flow has no dedicated name field, so a display name is derived from the
+ * identifier. Wallet/ENS invites keep using the address as the name (as before); email
+ * invites use the email's local part, sanitized to the alphanumeric-ish characters the
+ * backend's name validation accepts (the raw email's "@" would be rejected).
+ */
+export const toInviteName = (identifier: string): string => {
+  if (!isEmailAddress(identifier)) return identifier
+
+  const localPart = identifier.slice(0, identifier.indexOf('@'))
+  const sanitized = localPart
+    .replace(/[^a-zA-Z0-9 ._-]/g, '')
+    .replace(/^[^a-zA-Z0-9]+/, '')
+    .trim()
+
+  return sanitized || 'Member'
+}
+
 const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
   const [inviteMembers] = useMembersInviteUserV1Mutation()
 
@@ -58,7 +76,11 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
 
     try {
       const usersToInvite: InviteUsersDto['users'] = validMembers.map((member) =>
-        buildInviteUserPayload({ name: member.identifier, inviteeIdentifier: member.identifier, role: member.role }),
+        buildInviteUserPayload({
+          name: toInviteName(member.identifier),
+          inviteeIdentifier: member.identifier,
+          role: member.role,
+        }),
       )
 
       const result = await inviteMembers({

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -1,17 +1,16 @@
 import { useState } from 'react'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { isAddress } from 'ethers'
-import {
-  type WalletInviteUserDto,
-  useMembersInviteUserV1Mutation,
-} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { type InviteUsersDto, useMembersInviteUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
+import { buildInviteUserPayload, isEmailAddress } from '../../AddMemberModal/utils'
 
 interface MemberInvite {
-  address: string
+  // Can be a wallet address, ENS name, or email.
+  identifier: string
   role: MemberRole
 }
 
@@ -28,7 +27,7 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
   const methods = useForm<InviteMembersFormValues>({
     mode: 'onChange',
     defaultValues: {
-      members: [{ address: '', role: MemberRole.MEMBER }],
+      members: [{ identifier: '', role: MemberRole.MEMBER }],
     },
   })
 
@@ -38,9 +37,11 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
   const onSubmit = handleSubmit(async (data) => {
     if (!spaceId) return
 
-    const validMembers = data.members.filter((m) => m.address.trim() !== '')
+    const validMembers = data.members
+      .map((m) => ({ ...m, identifier: m.identifier.trim() }))
+      .filter((m) => m.identifier !== '')
 
-    const hasUnresolvedNames = validMembers.some((m) => !isAddress(m.address))
+    const hasUnresolvedNames = validMembers.some((m) => !isEmailAddress(m.identifier) && !isAddress(m.identifier))
     if (hasUnresolvedNames) {
       setError('Please wait for all ENS names to resolve')
       return
@@ -56,12 +57,9 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
     setIsSubmitting(true)
 
     try {
-      const usersToInvite: WalletInviteUserDto[] = validMembers.map((member) => ({
-        type: 'wallet',
-        address: member.address,
-        name: member.address,
-        role: member.role,
-      }))
+      const usersToInvite: InviteUsersDto['users'] = validMembers.map((member) =>
+        buildInviteUserPayload({ name: member.identifier, inviteeIdentifier: member.identifier, role: member.role }),
+      )
 
       const result = await inviteMembers({
         spaceId,

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -73,6 +73,10 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
     setError(undefined)
     setIsSubmitting(true)
 
+    // On success we hand off to onSuccess(), which navigates away and unmounts the form,
+    // so the spinner stays up through the route change. On every other exit the finally
+    // block resets isSubmitting so a failed/aborted submit can never leave the button stuck.
+    let succeeded = false
     try {
       const usersToInvite: InviteUsersDto['users'] = validMembers.map((member) =>
         buildInviteUserPayload({
@@ -89,7 +93,6 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
 
       if (result.error) {
         setError(getRtkQueryErrorMessage(result.error) || 'Failed to invite members. Please try again.')
-        setIsSubmitting(false)
         return
       }
 
@@ -105,10 +108,12 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
         )
       })
 
+      succeeded = true
       onSuccess()
     } catch {
       setError('Something went wrong inviting members. Please try again.')
-      setIsSubmitting(false)
+    } finally {
+      if (!succeeded) setIsSubmitting(false)
     }
   })
 

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/index.tsx
@@ -70,7 +70,7 @@ const InviteMembersOnboarding = (): ReactElement => {
 
       <button
         type="button"
-        onClick={() => append({ address: '', role: MemberRole.MEMBER })}
+        onClick={() => append({ identifier: '', role: MemberRole.MEMBER })}
         className="flex cursor-pointer items-center justify-center gap-2"
         data-testid="add-another-member"
       >

--- a/apps/web/src/features/spaces/components/Members/index.test.tsx
+++ b/apps/web/src/features/spaces/components/Members/index.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { memberBuilder } from '@/tests/builders/member'
+
+const mockUseIsAdmin = jest.fn()
+const mockUseIsInvited = jest.fn()
+const mockUseSpaceMembersByStatus = jest.fn()
+
+jest.mock('@/features/spaces', () => ({
+  useIsAdmin: () => mockUseIsAdmin(),
+  useIsInvited: () => mockUseIsInvited(),
+  useSpaceMembersByStatus: () => mockUseSpaceMembersByStatus(),
+}))
+
+jest.mock('../MembersList', () => ({
+  __esModule: true,
+  default: ({ members }: { members: MemberDto[] }) => (
+    <ul data-testid="members-list">
+      {members.map((member) => (
+        <li key={member.id}>{member.name}</li>
+      ))}
+    </ul>
+  ),
+}))
+
+jest.mock('../AddMemberModal', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('../InviteBanner/PreviewInvite', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('@/components/common/Track', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@/services/analytics/events/spaces', () => ({
+  SPACE_LABELS: { members_page: 'members_page' },
+  SPACE_EVENTS: { ADD_MEMBER_MODAL: {} },
+}))
+
+import SpaceMembers from './index'
+
+describe('SpaceMembers', () => {
+  const activeMember = memberBuilder().with({ id: 1, name: 'Active Alice', status: 'ACTIVE' }).build()
+  const invitedMember = memberBuilder().with({ id: 2, name: 'Pending Bob', status: 'INVITED' }).build()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseIsInvited.mockReturnValue(false)
+    mockUseIsAdmin.mockReturnValue(true)
+    mockUseSpaceMembersByStatus.mockReturnValue({
+      activeMembers: [activeMember],
+      invitedMembers: [invitedMember],
+    })
+  })
+
+  it('renders the members and pending tabs with counts', () => {
+    render(<SpaceMembers />)
+
+    expect(screen.getByRole('tab', { name: /Members \(1\)/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Pending \(1\)/ })).toBeInTheDocument()
+  })
+
+  it('shows active members in the default tab', () => {
+    render(<SpaceMembers />)
+
+    expect(screen.getByText('Active Alice')).toBeInTheDocument()
+  })
+
+  it('shows invited members after switching to the pending tab', () => {
+    render(<SpaceMembers />)
+
+    fireEvent.click(screen.getByRole('tab', { name: /Pending \(1\)/ }))
+
+    expect(screen.getByText('Pending Bob')).toBeInTheDocument()
+  })
+
+  it('shows an empty state in the pending tab when there are no invitations', () => {
+    mockUseSpaceMembersByStatus.mockReturnValue({
+      activeMembers: [activeMember],
+      invitedMembers: [],
+    })
+
+    render(<SpaceMembers />)
+
+    fireEvent.click(screen.getByRole('tab', { name: /Pending \(0\)/ }))
+
+    expect(screen.getByText('No pending members.')).toBeInTheDocument()
+  })
+
+  it('shows the add member button to admins', () => {
+    render(<SpaceMembers />)
+
+    expect(screen.getByTestId('add-member-button')).toBeInTheDocument()
+  })
+
+  it('hides the add member button from non-admins', () => {
+    mockUseIsAdmin.mockReturnValue(false)
+
+    render(<SpaceMembers />)
+
+    expect(screen.queryByTestId('add-member-button')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/MembersList/MembersList.stories.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/MembersList.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { mswLoader } from 'msw-storybook-addon'
+import { faker } from '@faker-js/faker'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { createMockStory } from '@/stories/mocks'
+import MembersList from './index'
+
+const PAST = faker.date.past().toISOString()
+const FUTURE = faker.date.future().toISOString()
+
+const member = (overrides: Omit<Partial<MemberDto>, 'user'> & { user?: Partial<MemberDto['user']> }): MemberDto => ({
+  id: 1,
+  role: 'MEMBER',
+  status: 'ACTIVE',
+  name: 'Member',
+  alias: null,
+  invitedBy: null,
+  createdAt: faker.date.past().toISOString(),
+  updatedAt: faker.date.recent().toISOString(),
+  ...overrides,
+  user: { id: 99, status: 'ACTIVE', email: null, ...overrides.user },
+})
+
+const defaultSetup = createMockStory({
+  scenario: 'efSafe',
+  wallet: 'owner',
+  features: { spaces: true },
+  pathname: '/spaces/members',
+  query: { spaceId: '1' },
+  shadcn: true,
+})
+
+const meta = {
+  title: 'Features/Spaces/MembersList',
+  component: MembersList,
+  loaders: [mswLoader],
+  decorators: [defaultSetup.decorator],
+  parameters: {
+    layout: 'padded',
+    ...defaultSetup.parameters,
+  },
+} satisfies Meta<typeof MembersList>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const ActiveMembers: Story = {
+  args: {
+    members: [
+      member({ id: 1, role: 'ADMIN', name: 'Admin User', user: { id: 1, email: 'admin@example.com' } }),
+      member({ id: 2, name: 'Alice', user: { id: 42, email: 'alice@example.com' } }),
+    ],
+  },
+}
+
+export const PendingInvites: Story = {
+  args: {
+    members: [
+      // Pending email invite — renewable, "resend the email" tooltip, no Expired chip
+      member({
+        id: 1,
+        status: 'INVITED',
+        name: 'Alice',
+        inviteExpiresAt: FUTURE,
+        user: { id: 42, status: 'PENDING', email: 'alice@example.com' },
+      }),
+      // Expired invite without an email — Expired chip + Renew button
+      member({ id: 2, status: 'INVITED', name: 'Charlie', inviteExpiresAt: PAST, user: { id: 43, status: 'PENDING' } }),
+      // Pending invite without an email, not expired — no Renew, no chip
+      member({ id: 3, status: 'INVITED', name: 'Dana', inviteExpiresAt: FUTURE, user: { id: 44, status: 'PENDING' } }),
+      // Declined invite — Declined chip, no Renew
+      member({ id: 4, status: 'DECLINED', name: 'Eve', user: { id: 45, status: 'PENDING' } }),
+    ],
+  },
+}

--- a/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.stories.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { mswLoader } from 'msw-storybook-addon'
+import { faker } from '@faker-js/faker'
+import type { MemberDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { createMockStory } from '@/stories/mocks'
+import RenewInviteButton from './RenewInviteButton'
+
+const baseMember: MemberDto = {
+  id: 1,
+  role: 'MEMBER',
+  status: 'INVITED',
+  name: 'Bob',
+  alias: null,
+  invitedBy: null,
+  createdAt: faker.date.past().toISOString(),
+  updatedAt: faker.date.recent().toISOString(),
+  user: { id: 42, status: 'PENDING', email: 'bob@example.com' },
+}
+
+const defaultSetup = createMockStory({
+  scenario: 'efSafe',
+  wallet: 'owner',
+  features: { spaces: true },
+  pathname: '/spaces/members',
+  query: { spaceId: '1' },
+  shadcn: true,
+})
+
+const meta = {
+  title: 'Features/Spaces/RenewInviteButton',
+  component: RenewInviteButton,
+  loaders: [mswLoader],
+  decorators: [defaultSetup.decorator],
+  parameters: {
+    layout: 'centered',
+    ...defaultSetup.parameters,
+  },
+} satisfies Meta<typeof RenewInviteButton>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+// Email invite — tooltip offers to resend the email
+export const EmailInvite: Story = {
+  args: {
+    member: baseMember,
+  },
+}
+
+// Invite without an email (e.g. wallet) — tooltip only renews the invitation
+export const NoEmailInvite: Story = {
+  args: {
+    member: { ...baseMember, user: { ...baseMember.user, email: null } },
+  },
+}

--- a/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.test.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.test.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { memberBuilder, memberUserBuilder } from '@/tests/builders/member'
+import RenewInviteButton from './RenewInviteButton'
+
+const mockRenew = jest.fn()
+const mockDispatch = jest.fn()
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useMembersRenewInviteV1Mutation: () => [mockRenew, { isLoading: false }],
+}))
+
+jest.mock('@/features/spaces', () => ({
+  useCurrentSpaceId: () => '123',
+}))
+
+jest.mock('@/store', () => ({
+  useAppDispatch: () => mockDispatch,
+}))
+
+jest.mock('@/store/notificationsSlice', () => ({
+  showNotification: (payload: unknown) => ({ type: 'notifications/showNotification', payload }),
+}))
+
+jest.mock('@/components/common/Track', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+describe('RenewInviteButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const invitedMember = memberBuilder()
+    .with({ status: 'INVITED', name: 'Bob', user: memberUserBuilder().with({ id: 42 }).build() })
+    .build()
+
+  const emailInvitedMember = memberBuilder()
+    .with({
+      status: 'INVITED',
+      name: 'Bob',
+      user: memberUserBuilder().with({ id: 42, email: 'bob@example.com' }).build(),
+    })
+    .build()
+
+  it('renews the invitation and shows a success toast', async () => {
+    mockRenew.mockResolvedValue({ data: {} })
+
+    render(<RenewInviteButton member={invitedMember} />)
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(mockRenew).toHaveBeenCalledWith({ spaceId: 123, userId: 42 })
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ message: 'Invitation renewed for Bob', variant: 'success' }),
+      }),
+    )
+  })
+
+  it('shows an error toast when the renew fails', async () => {
+    mockRenew.mockResolvedValue({ error: { status: 409, data: { message: 'Cannot renew' } } })
+
+    render(<RenewInviteButton member={invitedMember} />)
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ message: 'Cannot renew', variant: 'error' }),
+      }),
+    )
+  })
+
+  it('shows an email-specific tooltip when the invite has an email', async () => {
+    render(<RenewInviteButton member={emailInvitedMember} />)
+
+    await userEvent.hover(screen.getByRole('button'))
+
+    expect(await screen.findByRole('tooltip', { name: 'Renew invitation and resend the email' })).toBeInTheDocument()
+  })
+
+  it('shows the default tooltip when the invite has no email', async () => {
+    render(<RenewInviteButton member={invitedMember} />)
+
+    await userEvent.hover(screen.getByRole('button'))
+
+    expect(await screen.findByRole('tooltip', { name: 'Renew invitation' })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.test.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { memberBuilder, memberUserBuilder } from '@/tests/builders/member'
 import RenewInviteButton from './RenewInviteButton'
 
+const mockSpaceId = '11111111-1111-1111-1111-111111111111'
 const mockRenew = jest.fn()
 const mockDispatch = jest.fn()
 let mockIsLoading = false
@@ -13,7 +14,7 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
 }))
 
 jest.mock('@/features/spaces', () => ({
-  useCurrentSpaceId: () => '123',
+  useCurrentSpaceId: () => mockSpaceId,
 }))
 
 jest.mock('@/store', () => ({
@@ -54,7 +55,7 @@ describe('RenewInviteButton', () => {
 
     await userEvent.click(screen.getByRole('button'))
 
-    expect(mockRenew).toHaveBeenCalledWith({ spaceId: 123, userId: 42 })
+    expect(mockRenew).toHaveBeenCalledWith({ spaceId: mockSpaceId, userId: 42 })
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({ message: 'Invitation renewed for Bob', variant: 'success' }),

--- a/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.test.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.test.tsx
@@ -6,9 +6,10 @@ import RenewInviteButton from './RenewInviteButton'
 
 const mockRenew = jest.fn()
 const mockDispatch = jest.fn()
+let mockIsLoading = false
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
-  useMembersRenewInviteV1Mutation: () => [mockRenew, { isLoading: false }],
+  useMembersRenewInviteV1Mutation: () => [mockRenew, { isLoading: mockIsLoading }],
 }))
 
 jest.mock('@/features/spaces', () => ({
@@ -31,6 +32,7 @@ jest.mock('@/components/common/Track', () => ({
 describe('RenewInviteButton', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockIsLoading = false
   })
 
   const invitedMember = memberBuilder()
@@ -72,6 +74,14 @@ describe('RenewInviteButton', () => {
         payload: expect.objectContaining({ message: 'Cannot renew', variant: 'error' }),
       }),
     )
+  })
+
+  it('disables the button while the renew request is in flight', () => {
+    mockIsLoading = true
+
+    render(<RenewInviteButton member={invitedMember} />)
+
+    expect(screen.getByRole('button')).toBeDisabled()
   })
 
   it('shows an email-specific tooltip when the invite has an email', async () => {

--- a/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.tsx
@@ -1,0 +1,60 @@
+import { Box, IconButton, SvgIcon, Tooltip } from '@mui/material'
+import { type MemberDto, useMembersRenewInviteV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { Send } from 'lucide-react'
+import { useCurrentSpaceId } from '@/features/spaces'
+import { useAppDispatch } from '@/store'
+import { showNotification } from '@/store/notificationsSlice'
+import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
+import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
+import Track from '@/components/common/Track'
+
+const RenewInviteButton = ({ member }: { member: MemberDto }) => {
+  const spaceId = useCurrentSpaceId()
+  const dispatch = useAppDispatch()
+  const [renewInvite, { isLoading }] = useMembersRenewInviteV1Mutation()
+
+  const handleRenew = async () => {
+    if (!spaceId) return
+
+    const { error } = await renewInvite({ spaceId: Number(spaceId), userId: member.user.id })
+
+    if (error) {
+      dispatch(
+        showNotification({
+          message: getRtkQueryErrorMessage(error) || 'Failed to renew the invitation. Please try again.',
+          variant: 'error',
+          groupKey: 'renew-invite-error',
+        }),
+      )
+      return
+    }
+
+    dispatch(
+      showNotification({
+        message: `Invitation renewed for ${member.name}`,
+        variant: 'success',
+        groupKey: 'renew-invite-success',
+      }),
+    )
+  }
+
+  return (
+    <Tooltip title={member.user.email ? 'Renew invitation and resend the email' : 'Renew invitation'} placement="top">
+      <Box component="span">
+        <Track {...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_RENEWED} label={SPACE_LABELS.invite_list}>
+          <IconButton onClick={handleRenew} disabled={isLoading} size="small">
+            <SvgIcon
+              component={Send}
+              inheritViewBox
+              color="border"
+              fontSize="small"
+              sx={{ fill: 'none', transform: 'translate(-0.8px, 0.5px)' }}
+            />
+          </IconButton>
+        </Track>
+      </Box>
+    </Tooltip>
+  )
+}
+
+export default RenewInviteButton

--- a/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/RenewInviteButton.tsx
@@ -16,7 +16,7 @@ const RenewInviteButton = ({ member }: { member: MemberDto }) => {
   const handleRenew = async () => {
     if (!spaceId) return
 
-    const { error } = await renewInvite({ spaceId: Number(spaceId), userId: member.user.id })
+    const { error } = await renewInvite({ spaceId, userId: member.user.id })
 
     if (error) {
       dispatch(

--- a/apps/web/src/features/spaces/components/MembersList/index.test.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.test.tsx
@@ -18,6 +18,11 @@ jest.mock('./EditMemberDialog', () => ({
   default: () => null,
 }))
 
+jest.mock('./RenewInviteButton', () => ({
+  __esModule: true,
+  default: () => <button>Renew invitation</button>,
+}))
+
 jest.mock('@/components/common/Track', () => ({
   __esModule: true,
   default: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -27,8 +32,13 @@ jest.mock('@/features/spaces', () => ({
   useIsAdmin: () => true,
   isAdmin: (member: { role: string }) => member.role === 'ADMIN',
   isActiveAdmin: (member: { role: string; status: string }) => member.role === 'ADMIN' && member.status === 'ACTIVE',
+  isInviteExpired: (member: { status: string; inviteExpiresAt?: string | null }) =>
+    member.status === 'INVITED' &&
+    member.inviteExpiresAt != null &&
+    new Date(member.inviteExpiresAt).getTime() <= Date.now(),
   MemberStatus: {
     INVITED: 'INVITED',
+    ACTIVE: 'ACTIVE',
     DECLINED: 'DECLINED',
   },
   useAdminCount: () => 2,
@@ -88,5 +98,76 @@ describe('MembersList', () => {
 
     await user.hover(emailNode)
     expect(await screen.findByRole('tooltip', { name: longEmail })).toBeInTheDocument()
+  })
+
+  it('shows an Expired chip for a pending invite past its expiry', () => {
+    render(
+      <MembersList
+        members={[
+          memberBuilder()
+            .with({ status: 'INVITED', name: 'Expired Bob', inviteExpiresAt: '2020-01-01T00:00:00.000Z' })
+            .build(),
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Expired')).toBeInTheDocument()
+  })
+
+  it('does not show an Expired chip for active members or unexpired invites', () => {
+    render(
+      <MembersList
+        members={[
+          memberBuilder().with({ status: 'ACTIVE', name: 'Alice' }).build(),
+          memberBuilder()
+            .with({ id: 2, status: 'INVITED', name: 'Future Bob', inviteExpiresAt: '2999-01-01T00:00:00.000Z' })
+            .build(),
+        ]}
+      />,
+    )
+
+    expect(screen.queryByText('Expired')).not.toBeInTheDocument()
+  })
+
+  it('renders the Renew button for pending email invites and for expired invites without an email', () => {
+    render(
+      <MembersList
+        members={[
+          // Active member — never renewable
+          memberBuilder().with({ id: 1, status: 'ACTIVE', name: 'Alice' }).build(),
+          // Pending email invite — renewable
+          memberBuilder()
+            .with({
+              id: 2,
+              status: 'INVITED',
+              name: 'Bob',
+              user: memberUserBuilder().with({ email: 'bob@x.io' }).build(),
+            })
+            .build(),
+          // Expired invite without email — renewable
+          memberBuilder()
+            .with({ id: 3, status: 'INVITED', name: 'Carol', inviteExpiresAt: '2020-01-01T00:00:00.000Z' })
+            .build(),
+          // Declined — never renewable
+          memberBuilder().with({ id: 4, status: 'DECLINED', name: 'Dave' }).build(),
+        ]}
+      />,
+    )
+
+    expect(screen.getAllByRole('button', { name: 'Renew invitation' })).toHaveLength(2)
+  })
+
+  it('does not render the Renew button for an unexpired invite without an email', () => {
+    render(
+      <MembersList
+        members={[
+          memberBuilder()
+            .with({ id: 1, status: 'INVITED', name: 'Bob', inviteExpiresAt: '2999-01-01T00:00:00.000Z' })
+            .build(),
+        ]}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Renew invitation' })).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/MembersList/index.test.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@/tests/test-utils'
+import { render, renderWithUserEvent, screen, within } from '@/tests/test-utils'
 import type { ReactNode } from 'react'
 import { memberBuilder, memberUserBuilder } from '@/tests/builders/member'
 import MembersList from './index'
@@ -65,5 +65,28 @@ describe('MembersList', () => {
     expect(emailCells).toHaveLength(2)
     expect(within(emailCells[0]!).getByText('alice@example.com')).toBeInTheDocument()
     expect(within(emailCells[1]!).queryByText(/@/)).not.toBeInTheDocument()
+  })
+
+  it('wires up noWrap and a hover tooltip for long member emails', async () => {
+    const longEmail = `${'a'.repeat(64)}@${'b'.repeat(186)}.com`
+
+    const { user } = renderWithUserEvent(
+      <MembersList
+        members={[
+          memberBuilder()
+            .with({
+              name: 'Alice',
+              user: memberUserBuilder().with({ email: longEmail }).build(),
+            })
+            .build(),
+        ]}
+      />,
+    )
+
+    const emailNode = screen.getByText(longEmail)
+    expect(emailNode).toHaveClass('MuiTypography-noWrap')
+
+    await user.hover(emailNode)
+    expect(await screen.findByRole('tooltip', { name: longEmail })).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/MembersList/index.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.tsx
@@ -6,8 +6,16 @@ import EnhancedTable from '@/components/common/EnhancedTable'
 import tableCss from '@/components/common/EnhancedTable/styles.module.css'
 import MemberName from './MemberName'
 import RemoveMemberDialog from './RemoveMemberDialog'
+import RenewInviteButton from './RenewInviteButton'
 import { useState } from 'react'
-import { useIsAdmin, isAdmin as checkIsAdmin, isActiveAdmin, MemberStatus, useAdminCount } from '@/features/spaces'
+import {
+  useIsAdmin,
+  isAdmin as checkIsAdmin,
+  isActiveAdmin,
+  isInviteExpired,
+  MemberStatus,
+  useAdminCount,
+} from '@/features/spaces'
 import EditMemberDialog from './EditMemberDialog'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
@@ -99,10 +107,15 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
 
   const rows = members.map((member) => {
     const isLastAdmin = adminCount === 1 && isActiveAdmin(member)
-    const isInvite = member.status === MemberStatus.INVITED || member.status === MemberStatus.DECLINED
+    const isPendingInvite = member.status === MemberStatus.INVITED
     const isDeclined = member.status === MemberStatus.DECLINED
+    const isInvite = isPendingInvite || isDeclined
+    const isExpired = isInviteExpired(member)
     const isDisabled = isAdmin && isLastAdmin && !isInvite
     const memberEmail = member.user.email
+    // Contract: Email invites can always be renewed (resending the email);
+    // wallet invites are only renewed once they have expired.
+    const canRenew = isPendingInvite && (Boolean(memberEmail) || isExpired)
 
     return {
       cells: {
@@ -116,6 +129,13 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
                   label="Declined"
                   size="small"
                   sx={{ backgroundColor: 'error.light', color: 'static.main', borderRadius: 0.5 }}
+                />
+              )}
+              {isExpired && (
+                <Chip
+                  label="Expired"
+                  size="small"
+                  sx={{ backgroundColor: 'warning.main', color: 'static.main', borderRadius: 0.5 }}
                 />
               )}
             </Stack>
@@ -147,6 +167,7 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
           content: isAdmin ? (
             <div className={tableCss.actions}>
               {!isInvite && <EditButton member={member} disabled={isDisabled} />}
+              {canRenew && <RenewInviteButton member={member} />}
               <RemoveMemberButton member={member} disabled={isDisabled} isInvite={isInvite} />
             </div>
           ) : null,

--- a/apps/web/src/features/spaces/components/MembersList/index.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.tsx
@@ -123,7 +123,13 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
         },
         email: {
           rawValue: memberEmail,
-          content: memberEmail ? <Typography variant="body2">{memberEmail}</Typography> : null,
+          content: memberEmail ? (
+            <Tooltip title={memberEmail} placement="top">
+              <Typography variant="body2" noWrap>
+                {memberEmail}
+              </Typography>
+            </Tooltip>
+          ) : null,
         },
         role: {
           rawValue: member.role,
@@ -153,7 +159,7 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
     return null
   }
 
-  return <EnhancedTable rows={rows} headCells={headCells} />
+  return <EnhancedTable rows={rows} headCells={headCells} fixedLayout />
 }
 
 export default MembersList

--- a/apps/web/src/features/spaces/components/MembersList/index.tsx
+++ b/apps/web/src/features/spaces/components/MembersList/index.tsx
@@ -125,7 +125,7 @@ const MembersList = ({ members }: { members: MemberDto[] }) => {
           rawValue: memberEmail,
           content: memberEmail ? (
             <Tooltip title={memberEmail} placement="top">
-              <Typography variant="body2" noWrap>
+              <Typography variant="body2" noWrap sx={{ display: 'inline-block', maxWidth: '100%' }}>
                 {memberEmail}
               </Typography>
             </Tooltip>

--- a/apps/web/src/features/spaces/hooks/__tests__/isInviteExpired.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/isInviteExpired.test.ts
@@ -17,6 +17,11 @@ describe('isInviteExpired', () => {
     expect(isInviteExpired(memberBuilder().with({ status: 'INVITED', inviteExpiresAt: undefined }).build())).toBe(false)
   })
 
+  it('returns false when inviteExpiresAt is a malformed date', () => {
+    const member = memberBuilder().with({ status: 'INVITED', inviteExpiresAt: 'not-a-date' }).build()
+    expect(isInviteExpired(member)).toBe(false)
+  })
+
   it('returns false for non-INVITED members even with a past expiry', () => {
     const past = '2020-01-01T00:00:00.000Z'
     expect(isInviteExpired(memberBuilder().with({ status: 'ACTIVE', inviteExpiresAt: past }).build())).toBe(false)

--- a/apps/web/src/features/spaces/hooks/__tests__/isInviteExpired.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/isInviteExpired.test.ts
@@ -1,0 +1,25 @@
+import { memberBuilder } from '@/tests/builders/member'
+import { isInviteExpired } from '../useSpaceMembers'
+
+describe('isInviteExpired', () => {
+  it('returns true for an INVITED member whose inviteExpiresAt is in the past', () => {
+    const member = memberBuilder().with({ status: 'INVITED', inviteExpiresAt: '2020-01-01T00:00:00.000Z' }).build()
+    expect(isInviteExpired(member)).toBe(true)
+  })
+
+  it('returns false for an INVITED member whose inviteExpiresAt is in the future', () => {
+    const member = memberBuilder().with({ status: 'INVITED', inviteExpiresAt: '2999-01-01T00:00:00.000Z' }).build()
+    expect(isInviteExpired(member)).toBe(false)
+  })
+
+  it('returns false when inviteExpiresAt is null or undefined', () => {
+    expect(isInviteExpired(memberBuilder().with({ status: 'INVITED', inviteExpiresAt: null }).build())).toBe(false)
+    expect(isInviteExpired(memberBuilder().with({ status: 'INVITED', inviteExpiresAt: undefined }).build())).toBe(false)
+  })
+
+  it('returns false for non-INVITED members even with a past expiry', () => {
+    const past = '2020-01-01T00:00:00.000Z'
+    expect(isInviteExpired(memberBuilder().with({ status: 'ACTIVE', inviteExpiresAt: past }).build())).toBe(false)
+    expect(isInviteExpired(memberBuilder().with({ status: 'DECLINED', inviteExpiresAt: past }).build())).toBe(false)
+  })
+})

--- a/apps/web/src/features/spaces/hooks/useAddressBookSearch.ts
+++ b/apps/web/src/features/spaces/hooks/useAddressBookSearch.ts
@@ -1,8 +1,7 @@
 import { useMemo } from 'react'
 import Fuse from 'fuse.js'
-import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 
-const useAddressBookSearch = (contacts: SpaceAddressBookItemDto[], query: string): SpaceAddressBookItemDto[] => {
+const useAddressBookSearch = <T extends { name: string; address: string }>(contacts: T[], query: string): T[] => {
   const fuse = useMemo(
     () =>
       new Fuse(contacts, {

--- a/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
@@ -24,10 +24,13 @@ export const isAdmin = (member: MemberDto) => member.role === MemberRole.ADMIN
 
 export const isActiveAdmin = (member: MemberDto) => isAdmin(member) && member.status === MemberStatus.ACTIVE
 
-export const isInviteExpired = (member: MemberDto): boolean =>
-  member.status === MemberStatus.INVITED &&
-  member.inviteExpiresAt != null &&
-  new Date(member.inviteExpiresAt).getTime() <= Date.now()
+export const isInviteExpired = (member: MemberDto): boolean => {
+  if (member.status !== MemberStatus.INVITED || member.inviteExpiresAt == null) return false
+
+  // Guard NaN explicitly so a malformed date isn't silently treated as not-expired
+  const expiresAt = new Date(member.inviteExpiresAt).getTime()
+  return Number.isFinite(expiresAt) && expiresAt <= Date.now()
+}
 
 const useAllMembers = (spaceId?: string) => {
   const currentSpaceId = useCurrentSpaceId()

--- a/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
@@ -24,6 +24,11 @@ export const isAdmin = (member: MemberDto) => member.role === MemberRole.ADMIN
 
 export const isActiveAdmin = (member: MemberDto) => isAdmin(member) && member.status === MemberStatus.ACTIVE
 
+export const isInviteExpired = (member: MemberDto): boolean =>
+  member.status === MemberStatus.INVITED &&
+  member.inviteExpiresAt != null &&
+  new Date(member.inviteExpiresAt).getTime() <= Date.now()
+
 const useAllMembers = (spaceId?: string) => {
   const currentSpaceId = useCurrentSpaceId()
   const actualSpaceId = spaceId ?? currentSpaceId

--- a/apps/web/src/features/spaces/index.ts
+++ b/apps/web/src/features/spaces/index.ts
@@ -69,6 +69,7 @@ export {
   useIsInvited,
   isAdmin,
   isActiveAdmin,
+  isInviteExpired,
   MemberStatus,
   MemberRole,
 } from './hooks/useSpaceMembers'

--- a/apps/web/src/hooks/wallets/useOnboard.ts
+++ b/apps/web/src/hooks/wallets/useOnboard.ts
@@ -7,12 +7,11 @@ import useChains, { useCurrentChain } from '@/hooks/useChains'
 import ExternalStore from '@safe-global/utils/services/ExternalStore'
 import { logError, Errors } from '@/services/exceptions'
 import { trackEvent, WALLET_EVENTS, MixpanelEventParams } from '@/services/analytics'
-import { useAppSelector, useAppDispatch } from '@/store'
+import { useAppSelector } from '@/store'
 import { selectRpc } from '@/store/settingsSlice'
 import { formatAmount } from '@safe-global/utils/utils/formatNumber'
 import { localItem } from '@/services/local-storage/local'
 import { isWalletConnect, isWalletUnlocked } from '@/utils/wallets'
-import { setUnauthenticated } from '@/store/authSlice'
 import type { EnvState } from '@safe-global/store/settingsSlice'
 
 export type ConnectedWallet = {
@@ -173,7 +172,6 @@ export const useInitOnboard = () => {
   const chain = useCurrentChain()
   const onboard = useStore()
   const customRpc = useAppSelector(selectRpc)
-  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (configs.length > 0 && chain) {
@@ -216,14 +214,13 @@ export const useInitOnboard = () => {
       } else if (lastConnectedWallet) {
         lastConnectedWallet = ''
         saveLastWallet(lastConnectedWallet)
-        dispatch(setUnauthenticated())
       }
     })
 
     return () => {
       walletSubscription.unsubscribe()
     }
-  }, [onboard, dispatch, configs])
+  }, [onboard, configs])
 }
 
 export default useStore

--- a/apps/web/src/services/analytics/events/spaces.ts
+++ b/apps/web/src/services/analytics/events/spaces.ts
@@ -79,6 +79,10 @@ export const SPACE_EVENTS = {
     action: 'Workspace member invite sent',
     category: SPACE_CATEGORY,
   },
+  WORKSPACE_MEMBER_INVITE_RENEWED: {
+    action: 'Workspace member invite renewed',
+    category: SPACE_CATEGORY,
+  },
   ADD_ACCOUNTS_MODAL: {
     action: 'Open add accounts modal',
     category: SPACE_CATEGORY,

--- a/apps/web/src/tests/builders/space.ts
+++ b/apps/web/src/tests/builders/space.ts
@@ -14,6 +14,7 @@ export function spaceMemberBuilder(): IBuilder<SpaceMemberDto> {
     role: 'MEMBER',
     name: faker.person.firstName(),
     invitedBy: faker.number.int({ min: 1, max: 10 }),
+    inviteExpiresAt: null,
     status: 'ACTIVE',
     user: spaceMemberUserBuilder().build(),
   })


### PR DESCRIPTION
> Invites by mail take flight,
> sessions split from the connected wallet,
> expired ones renew.

## What it solves

Epic branch for Auth M2: invitation flow

Spaces/Workspaces Auth Milestone 2: support inviting members by email (in both the members list and the onboarding flow), and decouple the auth session from the connected wallet.

## Main changes

- **Email member invites** — invite Space members by email address (#7983)
- **Email invites in onboarding** — allow email invites during the onboarding flow (#8004)
- **Decouple wallet from auth session** — auth session no longer tied to the connected wallet, WA-2302 (#8008)
- **Renew expired invites** — add a renew button for expired invites (#8022)
- **Onboarding invite step** — UI fix for the onboarding invite step (#8017)
- **Long email truncation** — truncate long member emails with a hover tooltip (#7984)
- Review-comment fixes and test updates (#8048)

## How this PR fixes it

## How to test it

## Affected flows

<!-- The primary user journey(s) this PR intentionally changes. One bullet per flow. Example: "Owner adds a new signer from Settings > Signers". -->

## Blast radius

<!--
List the surfaces touched by this change and who else depends on them. Think in dependency terms, not files.
Include where relevant:
- Shared hooks / components / selectors / slices touched and their known consumers
- RTK Query endpoints / API contracts
- Feature flags / chain configs
- Persistence / cache / migration implications
- Routes or layouts affected indirectly
- Mobile impact (shared packages)
-->

## Risks / not checked

<!--
Be explicit about what you did NOT verify. This exposes false confidence and helps reviewers target their attention.
Example:
- Did not verify behavior with feature flag X disabled
- Did not test on mobile
- Did not exercise the retry / error path manually
-->

## Visual summary

<!-- REQUIRED for AI-authored PRs. Include a Mermaid diagram for architecture/logic changes, a screenshot for UI changes, or both. See AGENTS.md for examples. -->

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
