### PR TITLE
feat: allow email invites in onboarding flow

### DIFF
--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Controller } from 'react-hook-form'
 import type { InviteMembersFormValues } from '../hooks/useInviteForm'
+import { EMAIL_MAX_LENGTH, isEmailAddress } from '../../AddMemberModal/utils'
 
 const ROLE_LABELS: Record<MemberRole, string> = {
   [MemberRole.ADMIN]: 'Admin',
@@ -63,19 +64,24 @@ const MemberInviteRow = ({
   onRemove,
 }: MemberInviteRowProps) => {
   const members = useWatch({ control, name: 'members' })
-  const addressValue = members?.[index]?.address ?? ''
-  const fieldErrorMessage = errors?.members?.[index]?.address?.message
+  const identifierValue = members?.[index]?.identifier ?? ''
+  const fieldErrorMessage = errors?.members?.[index]?.identifier?.message
   const debouncedError = useDebounce(fieldErrorMessage, ERROR_DEBOUNCE_MS)
   const displayError = fieldErrorMessage ? debouncedError : undefined
 
   const handleAddressResolved = useCallback(
     (address: string) => {
-      setValue(`members.${index}.address`, address, { shouldValidate: true })
+      setValue(`members.${index}.identifier`, address, { shouldValidate: true })
     },
     [setValue, index],
   )
 
-  const { address: resolvedAddress, resolverError, resolving } = useNameResolver(addressValue)
+  // Emails are not ENS names — don't try to resolve them (it would surface a resolver error).
+  const {
+    address: resolvedAddress,
+    resolverError,
+    resolving,
+  } = useNameResolver(isEmailAddress(identifierValue.trim()) ? '' : identifierValue)
 
   useEffect(() => {
     if (resolvedAddress) handleAddressResolved(resolvedAddress)
@@ -88,33 +94,50 @@ const MemberInviteRow = ({
           <Input
             address
             autoComplete="off"
-            {...register(`members.${index}.address`, {
+            {...register(`members.${index}.identifier`, {
               required: index === 0,
               onChange: () => {
                 const otherFields = members
-                  ?.map((_, i) => (i !== index ? (`members.${i}.address` as const) : null))
-                  .filter(Boolean) as `members.${number}.address`[]
+                  ?.map((_, i) => (i !== index ? (`members.${i}.identifier` as const) : null))
+                  .filter(Boolean) as `members.${number}.identifier`[]
                 if (otherFields?.length) trigger(otherFields)
               },
               validate: (value) => {
-                if (!value?.trim()) return undefined
-                if (isDomain(value)) return undefined
+                const trimmed = value?.trim()
+                if (!trimmed) return undefined
 
-                const addressError = validateEthereumAddress(value, (checksummed) => {
-                  setValue(`members.${index}.address`, checksummed, { shouldValidate: true })
+                if (isEmailAddress(trimmed)) {
+                  if (trimmed.length > EMAIL_MAX_LENGTH) return `Email must be ${EMAIL_MAX_LENGTH} characters or less.`
+
+                  const isDuplicateEmail = members?.some(
+                    (member, i) =>
+                      i !== index &&
+                      member.identifier &&
+                      isEmailAddress(member.identifier) &&
+                      member.identifier.trim().toLowerCase() === trimmed.toLowerCase(),
+                  )
+                  if (isDuplicateEmail) return 'Email already added'
+
+                  return undefined
+                }
+
+                if (isDomain(trimmed)) return undefined
+
+                const addressError = validateEthereumAddress(trimmed, (checksummed) => {
+                  setValue(`members.${index}.identifier`, checksummed, { shouldValidate: true })
                 })
                 if (addressError) return addressError
 
                 const isDuplicate = members?.some(
-                  (member, i) => i !== index && member.address && sameAddress(member.address, value),
+                  (member, i) => i !== index && member.identifier && sameAddress(member.identifier, trimmed),
                 )
                 if (isDuplicate) return 'Address already added'
               },
             })}
-            placeholder="Wallet address or ENS name"
+            placeholder="Email, wallet address or ENS name"
             className={cn('h-11 rounded-lg bg-card px-4', resolving && 'pr-10')}
             error={displayError}
-            data-testid={`invite-address-input-${index}`}
+            data-testid={`invite-identifier-input-${index}`}
           />
           {resolving && (
             <div className="pointer-events-none absolute right-3 top-0 flex h-11 items-center">

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
 import useInviteForm from './useInviteForm'
 
 const mockInviteMembers = jest.fn()
@@ -26,12 +27,15 @@ jest.mock('@/features/spaces/hooks/useSpaceMembers', () => ({
 }))
 
 const TestComponent = ({ spaceId }: { spaceId: string | undefined }) => {
-  const { onSubmit, register, fields } = useInviteForm(spaceId, mockOnSuccess)
+  const { onSubmit, register, fields, append } = useInviteForm(spaceId, mockOnSuccess)
   return (
     <form onSubmit={onSubmit}>
       {fields.map((field, index) => (
-        <input key={field.id} data-testid={`address-${index}`} {...register(`members.${index}.address`)} />
+        <input key={field.id} data-testid={`address-${index}`} {...register(`members.${index}.identifier`)} />
       ))}
+      <button type="button" data-testid="append" onClick={() => append({ identifier: '', role: MemberRole.MEMBER })}>
+        Add
+      </button>
       <button type="submit" data-testid="submit">
         Submit
       </button>
@@ -75,6 +79,79 @@ describe('useInviteForm tracking', () => {
         { ...SPACE_EVENTS.WORKSPACE_MEMBER_INVITE_SENT, label: '42' },
         { workspace_id: '42', user_id: 7, role: 'member', batch_size: 1 },
       )
+    })
+  })
+
+  it('builds an email invite payload with a lowercased email', async () => {
+    mockInviteMembers.mockResolvedValue({
+      data: [{ userId: 9, spaceId: 42, name: 'Bob@Example.com', role: 'MEMBER', status: 'INVITED' }],
+    })
+
+    render(<TestComponent spaceId="42" />)
+
+    fireEvent.change(screen.getByTestId('address-0'), {
+      target: { value: 'Bob@Example.com' },
+    })
+    fireEvent.click(screen.getByTestId('submit'))
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [
+            {
+              type: 'email',
+              email: 'bob@example.com',
+              name: 'Bob@Example.com',
+              role: 'MEMBER',
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  it('builds a mixed payload of wallet and email invites in order', async () => {
+    mockInviteMembers.mockResolvedValue({
+      data: [
+        { userId: 1, spaceId: 42, name: 'wallet', role: 'MEMBER', status: 'INVITED' },
+        { userId: 2, spaceId: 42, name: 'email', role: 'MEMBER', status: 'INVITED' },
+      ],
+    })
+
+    render(<TestComponent spaceId="42" />)
+
+    fireEvent.click(screen.getByTestId('append'))
+
+    fireEvent.change(screen.getByTestId('address-0'), {
+      target: { value: '0x1234567890123456789012345678901234567890' },
+    })
+    fireEvent.change(screen.getByTestId('address-1'), {
+      target: { value: 'Carol@Example.com' },
+    })
+    fireEvent.click(screen.getByTestId('submit'))
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [
+            {
+              type: 'wallet',
+              address: '0x1234567890123456789012345678901234567890',
+              name: '0x1234567890123456789012345678901234567890',
+              role: 'MEMBER',
+            },
+            {
+              type: 'email',
+              email: 'carol@example.com',
+              name: 'Carol@Example.com',
+              role: 'MEMBER',
+            },
+          ],
+        },
+      })
+      expect(trackEvent).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -111,6 +111,35 @@ describe('useInviteForm tracking', () => {
     })
   })
 
+  it('submits identifiers with surrounding whitespace instead of blocking on "unresolved" names', async () => {
+    mockInviteMembers.mockResolvedValue({
+      data: [{ userId: 3, spaceId: 42, name: 'Dave', role: 'MEMBER', status: 'INVITED' }],
+    })
+
+    render(<TestComponent spaceId="42" />)
+
+    fireEvent.change(screen.getByTestId('address-0'), {
+      target: { value: '  Dave@Example.com  ' },
+    })
+    fireEvent.click(screen.getByTestId('submit'))
+
+    await waitFor(() => {
+      expect(mockInviteMembers).toHaveBeenCalledWith({
+        spaceId: 42,
+        inviteUsersDto: {
+          users: [
+            {
+              type: 'email',
+              email: 'dave@example.com',
+              name: 'Dave@Example.com',
+              role: 'MEMBER',
+            },
+          ],
+        },
+      })
+    })
+  })
+
   it('builds a mixed payload of wallet and email invites in order', async () => {
     mockInviteMembers.mockResolvedValue({
       data: [

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -1,17 +1,16 @@
 import { useState } from 'react'
 import { useForm, useFieldArray } from 'react-hook-form'
 import { isAddress } from 'ethers'
-import {
-  type WalletInviteUserDto,
-  useMembersInviteUserV1Mutation,
-} from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { type InviteUsersDto, useMembersInviteUserV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
+import { buildInviteUserPayload, isEmailAddress } from '../../AddMemberModal/utils'
 
 interface MemberInvite {
-  address: string
+  // Can be a wallet address, ENS name, or email.
+  identifier: string
   role: MemberRole
 }
 
@@ -28,7 +27,7 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
   const methods = useForm<InviteMembersFormValues>({
     mode: 'onChange',
     defaultValues: {
-      members: [{ address: '', role: MemberRole.MEMBER }],
+      members: [{ identifier: '', role: MemberRole.MEMBER }],
     },
   })
 
@@ -38,9 +37,9 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
   const onSubmit = handleSubmit(async (data) => {
     if (!spaceId) return
 
-    const validMembers = data.members.filter((m) => m.address.trim() !== '')
+    const validMembers = data.members.filter((m) => m.identifier.trim() !== '')
 
-    const hasUnresolvedNames = validMembers.some((m) => !isAddress(m.address))
+    const hasUnresolvedNames = validMembers.some((m) => !isEmailAddress(m.identifier) && !isAddress(m.identifier))
     if (hasUnresolvedNames) {
       setError('Please wait for all ENS names to resolve')
       return
@@ -56,12 +55,9 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
     setIsSubmitting(true)
 
     try {
-      const usersToInvite: WalletInviteUserDto[] = validMembers.map((member) => ({
-        type: 'wallet',
-        address: member.address,
-        name: member.address,
-        role: member.role,
-      }))
+      const usersToInvite: InviteUsersDto['users'] = validMembers.map((member) =>
+        buildInviteUserPayload({ name: member.identifier, inviteeIdentifier: member.identifier, role: member.role }),
+      )
 
       const result = await inviteMembers({
         spaceId: Number(spaceId),

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -37,7 +37,9 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
   const onSubmit = handleSubmit(async (data) => {
     if (!spaceId) return
 
-    const validMembers = data.members.filter((m) => m.identifier.trim() !== '')
+    const validMembers = data.members
+      .map((m) => ({ ...m, identifier: m.identifier.trim() }))
+      .filter((m) => m.identifier !== '')
 
     const hasUnresolvedNames = validMembers.some((m) => !isEmailAddress(m.identifier) && !isAddress(m.identifier))
     if (hasUnresolvedNames) {

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/index.tsx
@@ -69,7 +69,7 @@ const InviteMembersOnboarding = (): ReactElement => {
 
       <button
         type="button"
-        onClick={() => append({ address: '', role: MemberRole.MEMBER })}
+        onClick={() => append({ identifier: '', role: MemberRole.MEMBER })}
         className="flex cursor-pointer items-center justify-center gap-2"
         data-testid="add-another-member"
       >


### PR DESCRIPTION
> Onboarding's invite step learns email,
> validates, lowercases, builds the DTO,
> wallet or address, one field for both.

## What it solves [WA-2488](https://linear.app/safe-global/issue/WA-2488/update-invitation-form-in-the-onboarding-flow)

The new `AddMemberModal` (members page) lets you invite people by **email** or wallet address/ENS, but the **space onboarding** "Invite your team" step (step 3 of 4) still accepted wallet addresses and ENS names only. This brings the onboarding step to parity so new spaces can invite teammates by email during setup.

## How this PR fixes it

- Each invite row now accepts an **email, wallet address, or ENS name**. Validation branches on email first (format via the shared `isEmailAddress`, length cap via `EMAIL_MAX_LENGTH`, case-insensitive duplicate-email check), then falls through to the existing ENS/address path unchanged.
- ENS resolution is **skipped for emails**, so typing an email no longer surfaces a "Failed to resolve ENS name" error.
- On submit, payloads are built with the modal's shared `buildInviteUserPayload`, emitting an `email` DTO (lowercased) or a `wallet` DTO per row. The "wait for ENS to resolve" guard now treats emails as already-resolved.
- The form field was renamed `address` → `identifier` since it no longer holds only an address (test-id `invite-address-input` → `invite-identifier-input`; nothing external referenced the old one).
- **No duplicated logic**: reuses `isEmailAddress`, `EMAIL_MAX_LENGTH`, and `buildInviteUserPayload` from `AddMemberModal/utils.ts` — the single source of truth shipped with the modal feature.

## How to test it

1. Start the create-space onboarding and reach step 3 ("Invite your team").
2. In a row, enter an email (e.g. `alice@example.com`) → no ENS error, the form is valid.
3. Click "Add another", enter a wallet address or ENS in the second row.
4. Continue → both invites are sent, preserving order; email is lowercased in the request.
5. Edge cases: invalid string shows an error; duplicate email (case-insensitive) shows "Email already added"; over-long email shows the length error.

Unit tests: `yarn workspace @safe-global/web test src/features/spaces/components/InviteMembersOnboarding` (wallet, email, and mixed-invite cases).

## Visual summary

```mermaid
flowchart TD
  A[Invite row input] --> B{Identifier type?}
  B -->|Email| C[Validate format + length + dup email]
  C --> D[Build email DTO -lowercased-]
  B -->|ENS name| E[Resolve via useNameResolver]
  E --> F[Build wallet DTO]
  B -->|Wallet address| G[Validate + auto-checksum + dup address]
  G --> F
  D --> H[membersInviteUserV1]
  F --> H
```

## Checklist

- [x] Code follows the style guidelines
- [x] Tests added/updated (unit: wallet, email, mixed invites)
- [x] `type-check`, `lint`, `prettier`, `test` pass
- [x] No new `any`, no duplicated logic (shared utils reused)
- [ ] N/A — no new E2E (Cypress is legacy; onboarding invite step is currently skipped in E2E — flagged, deferred)

**Affected flows:** space onboarding invite step (wallet/ENS path unchanged, email added).
**Blast radius:** contained to `InviteMembersOnboarding/` — all consumers live in that folder; `AddMemberModal` is import-only (no behavior change).
**Risks / not checked:** self-invite checks (own email/wallet) intentionally NOT added to onboarding — it never had them and lacks the session/user queries the modal uses; no Playwright/Cypress added.