### PR TITLE
fix: do not block all-tokens balances on portfolio errors

### DIFF
--- a/packages/utils/src/hooks/__tests__/useTotalBalances.test.ts
+++ b/packages/utils/src/hooks/__tests__/useTotalBalances.test.ts
@@ -306,7 +306,7 @@ describe('useTotalBalances', () => {
       expect(result.current.data).toBeDefined()
     })
 
-    it('should show error when either source errors', () => {
+    it('should show error when tx service errors', () => {
       const mockPortfolio = createMockPortfolio()
 
       jest
@@ -320,6 +320,47 @@ describe('useTotalBalances', () => {
       const { result } = renderHook(() => useTotalBalances(allTokensParams))
 
       expect(result.current.error).toBeInstanceOf(Error)
+      expect(result.current.data).toBeUndefined()
+    })
+
+    it('should render tx service balances when portfolio errors', () => {
+      const mockBalances = createMockTxServiceBalances()
+
+      jest
+        .spyOn(portfolioQueries, 'usePortfolioGetPortfolioV1Query')
+        .mockReturnValue(mockQueryResult({ error: new Error('Portfolio error') }))
+
+      jest
+        .spyOn(balancesQueries, 'useBalancesGetBalancesV1Query')
+        .mockReturnValue(mockQueryResult({ currentData: mockBalances }))
+
+      const { result } = renderHook(() => useTotalBalances(allTokensParams))
+
+      // No page-level error: tx service balances are enough to render the token list
+      expect(result.current.error).toBeUndefined()
+      expect(result.current.loading).toBe(false)
+      // Token list comes from tx service
+      expect(result.current.data?.items).toEqual(mockBalances.items)
+      expect(result.current.data?.fiatTotal).toBe('1000')
+      expect(result.current.data?.tokensFiatTotal).toBe('1000')
+      // Portfolio-derived data falls back safely
+      expect(result.current.data?.positions).toBeUndefined()
+      expect(result.current.data?.positionsFiatTotal).toBe('0')
+    })
+
+    it('should keep loading when portfolio errors but tx service has no data yet', () => {
+      jest
+        .spyOn(portfolioQueries, 'usePortfolioGetPortfolioV1Query')
+        .mockReturnValue(mockQueryResult({ error: new Error('Portfolio error') }))
+
+      jest
+        .spyOn(balancesQueries, 'useBalancesGetBalancesV1Query')
+        .mockReturnValue(mockQueryResult({ currentData: undefined }))
+
+      const { result } = renderHook(() => useTotalBalances(allTokensParams))
+
+      expect(result.current.error).toBeUndefined()
+      expect(result.current.loading).toBe(true)
       expect(result.current.data).toBeUndefined()
     })
   })

--- a/packages/utils/src/hooks/__tests__/useTotalBalances.test.ts
+++ b/packages/utils/src/hooks/__tests__/useTotalBalances.test.ts
@@ -346,6 +346,8 @@ describe('useTotalBalances', () => {
       // Portfolio-derived data falls back safely
       expect(result.current.data?.positions).toBeUndefined()
       expect(result.current.data?.positionsFiatTotal).toBe('0')
+      // Still flagged as all-tokens mode so the UI keeps signalling the selected mode
+      expect(result.current.data?.isAllTokensMode).toBe(true)
     })
 
     it('should keep loading when portfolio errors but tx service has no data yet', () => {

--- a/packages/utils/src/hooks/useTotalBalances.ts
+++ b/packages/utils/src/hooks/useTotalBalances.ts
@@ -130,13 +130,19 @@ const buildMergedResult = (opts: {
     return { data: undefined, error: new Error(String(txService.error)), loading: false, ...shared }
   }
 
+  // Query is skipped/uninitialized (not yet "loading"): keep loading to avoid a flash of the empty box.
   if (!txService.balances) {
     return { data: undefined, error: undefined, loading: true, ...shared }
   }
 
   // Portfolio only adds positions/fiatTotal; if it's missing, fall back to tx-service alone.
   if (!portfolio.balances) {
-    return { data: createPortfolioBalances(txService.balances), error: undefined, loading: false, ...shared }
+    return {
+      data: { ...createPortfolioBalances(txService.balances), isAllTokensMode: true },
+      error: undefined,
+      loading: false,
+      ...shared,
+    }
   }
 
   const mergedBalances: PortfolioBalances = {

--- a/packages/utils/src/hooks/useTotalBalances.ts
+++ b/packages/utils/src/hooks/useTotalBalances.ts
@@ -125,13 +125,18 @@ const buildMergedResult = (opts: {
     return { data: undefined, error: undefined, loading: true, ...shared }
   }
 
-  const mergedError = portfolio.error || txService.error
-  if (mergedError) {
-    return { data: undefined, error: new Error(String(mergedError)), loading: false, ...shared }
+  // Tx-service backs the token list here; its error is fatal.
+  if (txService.error) {
+    return { data: undefined, error: new Error(String(txService.error)), loading: false, ...shared }
   }
 
-  if (!portfolio.balances || !txService.balances) {
+  if (!txService.balances) {
     return { data: undefined, error: undefined, loading: true, ...shared }
+  }
+
+  // Portfolio only adds positions/fiatTotal; if it's missing, fall back to tx-service alone.
+  if (!portfolio.balances) {
+    return { data: createPortfolioBalances(txService.balances), error: undefined, loading: false, ...shared }
   }
 
   const mergedBalances: PortfolioBalances = {


### PR DESCRIPTION
> Portfolio falls, the page stayed blank —
> now Transaction Service tokens render on,
> positions drop, the list lives.

## What it solves

Resolves: [WA-2105](https://linear.app/safe-global/issue/WA-2105/do-not-block-all-tokens-balances-on-portfolio-errors)

In **all-tokens** mode the displayed token list comes entirely from the **Transaction Service**; the `/v1/portfolio` endpoint only contributes positions and the aggregate fiat total. Despite that, any portfolio error was promoted to a **page-level balances error** (`data: undefined` + `error` set), which made the Assets page render the full-page "There was an error loading your assets" placeholder — wiping the token list even though Transaction Service data was available and sufficient.

(As a side effect, the original code did `String(rtkQueryError)` on the merged error, turning a structured `{ status, data }` into `"[object Object]"` — so the cause was also unidentifiable. Portfolio outages are observable in CGW, so the client now degrades silently instead.)

## How this PR fixes it

In `buildMergedResult` (the all-tokens path of `useTotalBalances`):

- **Only a Transaction Service error is fatal** — it backs the token list, so without it there's nothing to show.
- **A portfolio failure is non-fatal**: when portfolio data is absent (errored or otherwise), fall back to `createPortfolioBalances(txService.balances)` — the token list renders, `positions` is omitted, `positionsFiatTotal` is `'0'`, and no page-level `error` is raised.
- The portfolio error is **never inspected** — on failure `portfolioData` is `undefined`, so `portfolio.balances` is undefined and the existing "no portfolio balances" branch handles it. The fallback is driven by data presence, not by error-sniffing.
- **Default-tokens mode is unchanged** — `buildMergedResult` only runs in all-tokens mode; default-tokens portfolio errors still flow through the pre-existing `needsPortfolioFallback` path.

## How to test it

1. Enable the portfolio feature and switch the token list to **All tokens** (Settings / token-list toggle).
2. Simulate a `/v1/portfolio` failure (e.g. block/500 the endpoint in devtools).
3. **Expected:** the Assets table still renders the Transaction Service token list. No full-page error placeholder. Positions section is empty.
4. Switch to **Default tokens** with the same portfolio failure → unchanged behavior (silent fallback to TX-service as before).
5. With portfolio **working** in all-tokens mode → totals/positions still merge from portfolio (unchanged).

## Affected flows

- **All-tokens balances rendering when `/v1/portfolio` errors** (primary) — now renders TX-service tokens instead of a page error.
- All-tokens balances with portfolio working — must be unchanged (merge still happens).
- All-tokens balances when **TX-service** errors — still fatal (unchanged).
- Default-tokens balances with portfolio error — unchanged.

## Blast radius

- **`useTotalBalances` (`packages/utils/src/hooks`)** — shared hook. Web consumer: `apps/web/src/hooks/loadables/useLoadBalances.ts` → `useVisibleBalances` → Assets page + dashboard. Only the all-tokens merge branch changed.
- **`PortfolioBalances` shape** — unchanged; reuses existing `createPortfolioBalances` helper.
- No RTK Query / API contract / slice / route changes.
- **Mobile:** `packages/**` is shared, but the hook's mobile consumers go through the same branch logic; behavior change is limited to all-tokens portfolio-error fallback (no mobile-specific code touched).

## Risks / not checked

- Verified by unit tests (21 passing, incl. 2 new regression cases) and by reading the consumer chain to the Assets page — **not** exercised in a running browser or on mobile.
- Did not add client-side observability for portfolio outages by design (confirmed: errors are surfaced via CGW; client degrades silently).
- Did not touch the default-tokens fallback path.

## Visual summary

```mermaid
flowchart TD
  A[all-tokens mode: buildMergedResult] --> B{either source loading?}
  B -->|yes| L[loading]
  B -->|no| C{txService error?}
  C -->|yes| F[FATAL: page error]
  C -->|no| D{txService balances?}
  D -->|no| L
  D -->|yes| E{portfolio balances?}
  E -->|no  ⟵ portfolio errored| G[render TX-service only<br/>positions omitted, no page error]
  E -->|yes| H[merge: TX tokens + portfolio positions/total]
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
