### PR TITLE
fix(spaces): decouple connected wallet from auth session (WA-2302)

### DIFF
--- a/apps/web/src/components/common/WalletInfo/index.test.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.test.tsx
@@ -2,6 +2,9 @@ import { render } from '@/tests/test-utils'
 import { WalletInfo } from '@/components/common/WalletInfo/index'
 import { type EIP1193Provider, type OnboardAPI } from '@web3-onboard/core'
 import { act } from '@testing-library/react'
+import * as authApi from '@safe-global/store/gateway/AUTO_GENERATED/auth'
+
+const mockAuthLogout = jest.fn()
 
 const mockWallet = {
   address: '0x1234567890123456789012345678901234567890',
@@ -19,6 +22,7 @@ const mockOnboard = {
 describe('WalletInfo', () => {
   beforeEach(() => {
     jest.resetAllMocks()
+    jest.spyOn(authApi, 'useAuthLogoutV1Mutation').mockReturnValue([mockAuthLogout, {} as never])
   })
 
   it('should display the wallet address', () => {
@@ -51,7 +55,7 @@ describe('WalletInfo', () => {
     expect(getByText('Switch wallet')).toBeInTheDocument()
   })
 
-  it('should disconnect the wallet when the button is clicked', () => {
+  it('should disconnect only the wallet, not the auth session, when the button is clicked', () => {
     const { getByText } = render(
       <WalletInfo
         wallet={mockWallet}
@@ -72,6 +76,8 @@ describe('WalletInfo', () => {
     })
 
     expect(mockOnboard.disconnectWallet).toHaveBeenCalled()
+    // Disconnecting the wallet must not end the spaces auth session
+    expect(mockAuthLogout).not.toHaveBeenCalled()
   })
 
   it('calls onSwitch when Switch wallet is clicked', () => {

--- a/apps/web/src/components/common/WalletInfo/index.tsx
+++ b/apps/web/src/components/common/WalletInfo/index.tsx
@@ -6,14 +6,10 @@ import EthHashInfo from '@/components/common/EthHashInfo'
 import ChainSwitcher from '@/components/common/ChainSwitcher'
 import useOnboard, { type ConnectedWallet, switchWallet } from '@/hooks/wallets/useOnboard'
 import useAddressBook from '@/hooks/useAddressBook'
-import { useAppDispatch } from '@/store'
 import { useChain } from '@/hooks/useChains'
 import madProps from '@/utils/mad-props'
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 import useChainId from '@/hooks/useChainId'
-import { useAuthLogoutV1Mutation } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
-import { setUnauthenticated } from '@/store/authSlice'
-import { logError, Errors } from '@/services/exceptions'
 import { getNativeTokenDisplay, NATIVE_TOKEN_DISPLAY_DEFAULT } from '@safe-global/utils/utils/chains'
 
 type WalletInfoProps = {
@@ -37,8 +33,6 @@ export const WalletInfo = ({
   onSwitch,
   onDisconnect,
 }: WalletInfoProps) => {
-  const [authLogout] = useAuthLogoutV1Mutation()
-  const dispatch = useAppDispatch()
   const chainInfo = useChain(wallet.chainId)
   const prefix = chainInfo?.shortName
   const { showWalletBalance } = chainInfo ? getNativeTokenDisplay(chainInfo) : NATIVE_TOKEN_DISPLAY_DEFAULT
@@ -51,18 +45,11 @@ export const WalletInfo = ({
     }
   }
 
-  const handleDisconnect = async () => {
+  const handleDisconnect = () => {
     onDisconnect?.()
     onboard?.disconnectWallet({
       label: wallet.label,
     })
-    try {
-      await authLogout()
-      dispatch(setUnauthenticated())
-    } catch (error) {
-      logError(Errors._108, error)
-    }
-
     handleClose()
   }
 

--- a/apps/web/src/hooks/wallets/useOnboard.ts
+++ b/apps/web/src/hooks/wallets/useOnboard.ts
@@ -7,12 +7,11 @@ import useChains, { useCurrentChain } from '@/hooks/useChains'
 import ExternalStore from '@safe-global/utils/services/ExternalStore'
 import { logError, Errors } from '@/services/exceptions'
 import { trackEvent, WALLET_EVENTS, MixpanelEventParams } from '@/services/analytics'
-import { useAppSelector, useAppDispatch } from '@/store'
+import { useAppSelector } from '@/store'
 import { selectRpc } from '@/store/settingsSlice'
 import { formatAmount } from '@safe-global/utils/utils/formatNumber'
 import { localItem } from '@/services/local-storage/local'
 import { isWalletConnect, isWalletUnlocked } from '@/utils/wallets'
-import { setUnauthenticated } from '@/store/authSlice'
 import type { EnvState } from '@safe-global/store/settingsSlice'
 
 export type ConnectedWallet = {
@@ -173,7 +172,6 @@ export const useInitOnboard = () => {
   const chain = useCurrentChain()
   const onboard = useStore()
   const customRpc = useAppSelector(selectRpc)
-  const dispatch = useAppDispatch()
 
   useEffect(() => {
     if (configs.length > 0 && chain) {
@@ -216,14 +214,13 @@ export const useInitOnboard = () => {
       } else if (lastConnectedWallet) {
         lastConnectedWallet = ''
         saveLastWallet(lastConnectedWallet)
-        dispatch(setUnauthenticated())
       }
     })
 
     return () => {
       walletSubscription.unsubscribe()
     }
-  }, [onboard, dispatch, configs])
+  }, [onboard, configs])
 }
 
 export default useStore


### PR DESCRIPTION
> Wallet logs out, but
> the session stays signed in —
> two locks, two keys now.

## What it solves

Resolves: https://linear.app/safe-global/issue/WA-2302/wallet-disconnect

Disconnecting the connected wallet also ended the whole spaces auth session. Disconnect should only disconnect the connected wallet — the wallet connection and the auth session are two separate things.

## How this PR fixes it

The wallet disconnect was tearing down the spaces session via **two** paths, both removed:

1. **`WalletInfo.handleDisconnect`** — the explicit "Disconnect" button called `authLogout()` + `dispatch(setUnauthenticated())`. It now only calls `onboard.disconnectWallet()`.
2. **`useInitOnboard`'s wallet subscription** — dispatched `setUnauthenticated()` on *any* wallet removal. Since `disconnectWallet()` triggers this subscription, fixing only the button would have left the bug half-fixed. The dispatch is removed.

This is safe because the spaces session is a server-side, cookie-backed 24h session reconciled via `/v1/auth/me` (`reconcileAuth`), entirely independent of whether a wallet is connected. The legitimate session-clearing paths are untouched: session expiry (`useSessionExpiryGuard`), logout redirect (`useLogoutCallback`), and a 403 from `/v1/auth/me`.

## How to test it

1. Sign in to a space (wallet + auth session active).
2. Open the wallet popover and click **Disconnect**.
3. Expected: the wallet is disconnected, but you remain signed in to the space (no redirect to sign-in, space data still loads).
4. Also disconnect from the wallet extension directly (not via the button) — the auth session should likewise stay intact.

## Affected flows

- Disconnecting the connected wallet via the account/wallet popover.
- Any wallet-removal event (disconnecting from the extension, locking the wallet) detected by `useInitOnboard`'s subscription.

## Blast radius

- **`WalletInfo` component** (`apps/web/src/components/common/WalletInfo/index.tsx`) — dropped `authLogout` mutation, `setUnauthenticated`, and `useAppDispatch` usage.
- **`useInitOnboard`** (`apps/web/src/hooks/wallets/useOnboard.ts`) — removed the `setUnauthenticated` dispatch and now-unused `dispatch`/`useAppDispatch`. Subscription still tracks and persists the last connected wallet.
- **`setUnauthenticated` action / `authListener`** (spaces + users RTK Query cache invalidation) — no longer triggered by wallet disconnect; still triggered by the real logout/expiry paths.
- No API contract, feature flag, route, or persisted-state changes. Shared packages untouched, so no mobile impact.

## Risks / not checked

- Did not run an end-to-end test against a live backend session (no backend running locally).
- Did not verify whether any analytics relied on the disconnect-triggered logout event (none found in the changed paths).
- Did not test on mobile (no shared code changed; web-only components/hooks).

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    D1[Click Disconnect / wallet removed] --> W1[onboard.disconnectWallet]
    D1 --> A1[authLogout + setUnauthenticated]
    A1 --> S1[Spaces auth session ENDED]
  end
  subgraph After
    D2[Click Disconnect / wallet removed] --> W2[onboard.disconnectWallet]
    D2 -.->|no longer| A2[setUnauthenticated]
    S2[Spaces auth session INTACT<br/>cookie session via /v1/auth/me]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only, no shared code)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics impact)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
