### PR TITLE
fix(web/UI): new info badge when "Show all tokens" toggle is on; UI fixes for the empty Positions page

### DIFF
--- a/apps/web/src/components/balances/TotalAssetValue/index.tsx
+++ b/apps/web/src/components/balances/TotalAssetValue/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Skeleton, Typography, Stack } from '@mui/material'
+import type { SvgIconProps } from '@mui/material'
 import type { ReactNode } from 'react'
 import FiatValue from '@/components/common/FiatValue'
 import TokenAmount from '@/components/common/TokenAmount'
@@ -12,12 +13,14 @@ const TotalAssetValue = ({
   fiatTotal,
   title = 'Total value',
   tooltipTitle,
+  tooltipColor,
   size = 'md',
   action,
 }: {
   fiatTotal: string | number | undefined
   title?: string
   tooltipTitle?: string
+  tooltipColor?: SvgIconProps['color']
   size?: 'md' | 'lg'
   action?: ReactNode
 }) => {
@@ -32,10 +35,10 @@ const TotalAssetValue = ({
 
   return (
     <Box>
-      <Typography fontWeight={700} mb={0.5}>
-        {title}
-        {tooltipTitle && <InfoTooltip title={tooltipTitle} />}
-      </Typography>
+      <Stack direction="row" alignItems="center" mb={0.5}>
+        <Typography fontWeight={700}>{title}</Typography>
+        {tooltipTitle && <InfoTooltip title={tooltipTitle} color={tooltipColor} />}
+      </Stack>
       <Stack direction="row" alignItems="flex-end" justifyContent="space-between">
         <Typography component="div" variant="h1" fontSize={fontSizeValue} lineHeight="1.2" letterSpacing="-0.5px">
           {safe.deployed ? (

--- a/apps/web/src/components/common/InfoTooltip/index.tsx
+++ b/apps/web/src/components/common/InfoTooltip/index.tsx
@@ -1,12 +1,15 @@
 import { SvgIcon, Tooltip } from '@mui/material'
+import type { SvgIconProps } from '@mui/material'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import type { ReactNode } from 'react'
 
 export function InfoTooltip({
   title,
+  color = 'border',
   'data-testid': dataTestId,
 }: {
   title: string | ReactNode
+  color?: SvgIconProps['color']
   'data-testid'?: string
 }) {
   return (
@@ -15,11 +18,12 @@ export function InfoTooltip({
         <SvgIcon
           component={InfoIcon}
           inheritViewBox
-          color="border"
+          color={color}
           fontSize="small"
           sx={{
             verticalAlign: 'middle',
             ml: 0.5,
+            mb: 0.25,
           }}
         />
       </span>

--- a/apps/web/src/features/positions/components/PositionsEmpty/index.tsx
+++ b/apps/web/src/features/positions/components/PositionsEmpty/index.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
-import { Button, Paper, Typography } from '@mui/material'
+import { Box, Button, Paper, Typography } from '@mui/material'
 import DefiIcon from '@/public/images/balances/defi.svg'
 import { AppRoutes } from '@/config/routes'
 import Track from '@/components/common/Track'
@@ -18,7 +18,9 @@ const PositionsEmpty = ({ entryPoint = 'Dashboard' }: PositionsEmptyProps) => {
 
   return (
     <Paper elevation={0} sx={{ p: 3, textAlign: 'center' }}>
-      <DefiIcon />
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <DefiIcon />
+      </Box>
 
       <Typography data-testid="no-tx-text" variant="body1" color="primary.light">
         You have no active DeFi positions yet

--- a/apps/web/src/pages/balances/index.tsx
+++ b/apps/web/src/pages/balances/index.tsx
@@ -71,6 +71,7 @@ const Balances: NextPage = () => {
               fiatTotal={tokensFiatTotal}
               title="Total assets value"
               tooltipTitle={showAllTokens ? 'Total Balance may be different when you show all tokens.' : undefined}
+              tooltipColor="warning"
             />
 
             <Stack direction="column" alignItems="flex-end" gap={0.5}>

--- a/apps/web/src/pages/balances/index.tsx
+++ b/apps/web/src/pages/balances/index.tsx
@@ -15,6 +15,8 @@ import StakingBanner from '@/components/dashboard/StakingBanner'
 import useIsStakingBannerVisible from '@/components/dashboard/StakingBanner/useIsStakingBannerVisible'
 import useLocalStorage from '@/services/local-storage/useLocalStorage'
 import { Box, Stack } from '@mui/material'
+import { useAppSelector } from '@/store'
+import { selectSettings, TOKEN_LISTS } from '@/store/settingsSlice'
 import { BRAND_NAME } from '@/config/constants'
 import { NoFeeCampaignFeature, useIsNoFeeCampaignEnabled } from '@/features/no-fee-campaign'
 import { PortfolioFeature } from '@/features/portfolio'
@@ -33,6 +35,8 @@ const Balances: NextPage = () => {
     'hideNoFeeCampaignAssetsPageBanner',
   )
   const portfolio = useLoadFeature(PortfolioFeature)
+  const settings = useAppSelector(selectSettings)
+  const showAllTokens = settings.tokenList === TOKEN_LISTS.ALL || settings.tokenList === undefined
 
   const tokensFiatTotal = balances.tokensFiatTotal ? Number(balances.tokensFiatTotal) : undefined
 
@@ -66,7 +70,7 @@ const Balances: NextPage = () => {
             <TotalAssetValue
               fiatTotal={tokensFiatTotal}
               title="Total assets value"
-              tooltipTitle="Total from this list only. Portfolio total includes positions and may use other token data."
+              tooltipTitle={showAllTokens ? 'Total Balance may be different when you show all tokens.' : undefined}
             />
 
             <Stack direction="column" alignItems="flex-end" gap={0.5}>

--- a/apps/web/src/tests/pages/balances.test.tsx
+++ b/apps/web/src/tests/pages/balances.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@/tests/test-utils'
 import BalancesPage from '@/pages/balances'
 import { useVisibleBalances } from '@/hooks/useVisibleBalances'
+import { TOKEN_LISTS } from '@/store/settingsSlice'
 
 jest.mock('@/hooks/useVisibleBalances', () => ({
   useVisibleBalances: jest.fn(),
@@ -18,7 +19,7 @@ jest.mock('@/components/balances/AssetsTable', () => ({
 
 jest.mock('@/components/balances/TotalAssetValue', () => ({
   __esModule: true,
-  default: () => <div data-testid="total-asset-value" />,
+  default: ({ tooltipTitle }: { tooltipTitle?: string }) => <div data-testid="total-asset-value">{tooltipTitle}</div>,
 }))
 
 jest.mock('@/components/balances/ManageTokensButton', () => ({
@@ -62,6 +63,18 @@ jest.mock('@/features/__core__', () => ({
   }),
 }))
 
+const DEFAULT_SETTINGS = {
+  currency: 'usd',
+  hiddenTokens: {},
+  tokenList: TOKEN_LISTS.TRUSTED,
+  shortName: { copy: true, qr: true },
+  theme: { darkMode: false },
+  env: { tenderly: { url: '', accessToken: '' }, rpc: {} },
+  signing: { onChainSigning: false, blindSigning: false },
+  transactionExecution: true,
+  curatedNestedSafes: {},
+}
+
 describe('Balances page', () => {
   beforeEach(() => {
     jest.mocked(useVisibleBalances).mockReturnValue({
@@ -92,5 +105,30 @@ describe('Balances page', () => {
     expect(screen.getByTestId('currency-select')).toBeInTheDocument()
     expect(screen.getByText('There was an error loading your assets')).toBeInTheDocument()
     expect(screen.queryByTestId('assets-table')).not.toBeInTheDocument()
+  })
+
+  const tooltipText = 'Total Balance may be different when you show all tokens.'
+
+  const renderWithTokenList = (tokenList: TOKEN_LISTS | undefined) =>
+    render(<BalancesPage />, {
+      initialReduxState: { settings: { ...DEFAULT_SETTINGS, tokenList } } as never,
+    })
+
+  it('shows the total balance tooltip when all tokens are shown', () => {
+    renderWithTokenList(TOKEN_LISTS.ALL)
+
+    expect(screen.getByTestId('total-asset-value')).toHaveTextContent(tooltipText)
+  })
+
+  it('shows the total balance tooltip when the token list is unset', () => {
+    renderWithTokenList(undefined)
+
+    expect(screen.getByTestId('total-asset-value')).toHaveTextContent(tooltipText)
+  })
+
+  it('hides the total balance tooltip when only trusted tokens are shown', () => {
+    renderWithTokenList(TOKEN_LISTS.TRUSTED)
+
+    expect(screen.getByTestId('total-asset-value')).not.toHaveTextContent(tooltipText)
   })
 })


### PR DESCRIPTION
> Show-all-tokens warning,
> amber icon aligned, not gray—
> totals may differ.

## What it solves

Resolves: [WA-2487](https://linear.app/safe-global/issue/WA-2487/update-tooltip-on-show-all-tokens-assets-page)
Resolves: [WA-2067](https://linear.app/safe-global/issue/WA-2067/empty-position-table-the-icon-is-displaced)

- On the Assets page, the "Total assets value" info icon was always shown, used misleading copy, was a low-contrast gray, and sat misaligned below the title.
- The Positions icon was not centered on the empty Positions page.

## How this PR fixes it
1.
- The info icon now renders only when "Manage tokens → Show all tokens" is toggled ON.
- Updated the tooltip copy to "Total Balance may be different when you show all tokens."
- Made the icon a `warning` (amber) color so it stands out, via a new optional `color` prop on `InfoTooltip`.
- Aligned the icon horizontally with the title and nudged it down 2px for optical centering.

2. 
- Open the (empty) Positions page when FF is on.
- The icon on the empty Positions page should be centered, not aligned to the left.


## How to test it

1. Open the Assets page.
2. Open "Manage tokens" and toggle "Show all tokens" ON → the amber info icon appears next to "Total assets value" with the new tooltip text.
3. Toggle it OFF → the icon disappears.

## Affected flows

- Assets page: viewing the total assets value with "Show all tokens" on/off.

## Blast radius

- `InfoTooltip` (shared common component): gained an optional `color` prop, defaulting to `border` — existing usages are unchanged.
- `TotalAssetValue` (used on Assets, Dashboard, Positions): gained an optional `tooltipColor` prop and the title now sits in a centered flex row; visual-only, no behavior change for other consumers.

## Risks / not checked

- Did not test on mobile.
- Analytics unchanged.
- Did not manually verify the Dashboard/Positions `TotalAssetValue` layouts beyond the shared-component change.

## Visual summary

```mermaid
flowchart LR
  A[Show all tokens toggle] -->|ON| B[Render amber InfoTooltip]
  A -->|OFF| C[No tooltip]
  B --> D["Total Balance may be different when you show all tokens."]
```

<img width="675" height="507" alt="image" src="https://github.com/user-attachments/assets/cc3f9bbc-b638-4c2c-b3c9-4df298a01135" />


## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
