### PR TITLE
fix(web): show missing CF badges

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.test.tsx
@@ -88,8 +88,8 @@ describe('SafeItemCard – undeployed', () => {
     render(<SafeItemCard safeItem={safeItem} onClose={noopClose} />)
 
     const badge = screen.getByText('Not activated')
-    const nameColumn = document.querySelector('.w-\\[160px\\]')
+    const nameColumn = screen.getByTestId('name-column')
 
-    expect(nameColumn?.contains(badge)).toBe(false)
+    expect(nameColumn.contains(badge)).toBe(false)
   })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.test.tsx
@@ -4,7 +4,7 @@ import SafeItemCard from './SafeItemCard'
 
 const defaultSafeItemData = {
   name: undefined,
-  safeOverview: { fiatTotal: 0 },
+  safeOverview: { fiatTotal: 0 } as { fiatTotal: number } | undefined,
   threshold: 1,
   owners: [{ value: '0x0000000000000000000000000000000000000001' }],
   elementRef: { current: null },

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.test.tsx
@@ -2,17 +2,21 @@ import { render, screen } from '@/tests/test-utils'
 import { safeItemBuilder } from '@/tests/builders/safeItem'
 import SafeItemCard from './SafeItemCard'
 
+const defaultSafeItemData = {
+  name: undefined,
+  safeOverview: { fiatTotal: 0 },
+  threshold: 1,
+  owners: [{ value: '0x0000000000000000000000000000000000000001' }],
+  elementRef: { current: null },
+  undeployedSafe: undefined as { status: { status: string } } | undefined,
+  isActivating: false,
+  href: { pathname: '/home', query: { safe: 'eth:0x0000000000000000000000000000000000000000' } },
+}
+
+let mockSafeItemData = { ...defaultSafeItemData }
+
 jest.mock('@/features/myAccounts', () => ({
-  useSafeItemData: () => ({
-    name: undefined,
-    safeOverview: { fiatTotal: 0 },
-    threshold: 1,
-    owners: [{ value: '0x0000000000000000000000000000000000000001' }],
-    elementRef: { current: null },
-    undeployedSafe: undefined,
-    isActivating: false,
-    href: { pathname: '/home', query: { safe: 'eth:0x0000000000000000000000000000000000000000' } },
-  }),
+  useSafeItemData: () => mockSafeItemData,
 }))
 
 jest.mock('@/hooks/useAllAddressBooks', () => ({
@@ -34,6 +38,10 @@ jest.mock('@/services/analytics', () => ({
 
 describe('SafeItemCard', () => {
   const noopClose = jest.fn()
+
+  beforeEach(() => {
+    mockSafeItemData = { ...defaultSafeItemData }
+  })
 
   it('hides read-only badge when high similarity is shown', () => {
     const safeItem = safeItemBuilder()
@@ -60,5 +68,28 @@ describe('SafeItemCard', () => {
 
     expect(screen.queryByText('High similarity')).not.toBeInTheDocument()
     expect(screen.getByText('Read-only')).toBeInTheDocument()
+  })
+})
+
+describe('SafeItemCard – undeployed', () => {
+  const noopClose = jest.fn()
+
+  beforeEach(() => {
+    mockSafeItemData = {
+      ...defaultSafeItemData,
+      safeOverview: undefined,
+      undeployedSafe: { status: { status: 'AWAITING_EXECUTION' } },
+    }
+  })
+
+  it('renders the Not activated badge outside the name column for an undeployed safe', () => {
+    const safeItem = safeItemBuilder().with({ address: '0x1234567890123456789012345678901234567890' }).build()
+
+    render(<SafeItemCard safeItem={safeItem} onClose={noopClose} />)
+
+    const badge = screen.getByText('Not activated')
+    const nameColumn = document.querySelector('.w-\\[160px\\]')
+
+    expect(nameColumn?.contains(badge)).toBe(false)
   })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.tsx
@@ -101,7 +101,7 @@ const SafeItemCard = ({
       </div>
 
       {/* Name + address + optional status badge */}
-      <div className="flex min-w-0 w-[160px] shrink-0 flex-col gap-0.5 overflow-hidden">
+      <div data-testid="name-column" className="flex min-w-0 w-[160px] shrink-0 flex-col gap-0.5 overflow-hidden">
         <div className="flex items-center gap-1 min-w-0">
           <span className="truncate text-sm font-semibold text-foreground">{displayName}</span>
           {addressBookItem?.name && addressBookItem.source && <NameSourceIcon source={addressBookItem.source} />}

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/SafeItemCard.tsx
@@ -111,9 +111,14 @@ const SafeItemCard = ({
           <CopyAddressButton address={safeItem.address} />
         </div>
         {isSimilar && <SimilarityBadge />}
-        {undeployedSafe && <NotActivatedBadge isActivating={isActivating} />}
         {!undeployedSafe && safeItem.isReadOnly && !isSimilar && <ReadOnlyBadge />}
       </div>
+
+      {undeployedSafe && (
+        <div className="shrink-0">
+          <NotActivatedBadge isActivating={isActivating} />
+        </div>
+      )}
 
       {/* Chain logo */}
       <div className="mx-auto shrink-0">

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx
@@ -229,7 +229,7 @@ export function NotActivatedBadge({ isActivating }: { isActivating: boolean }) {
       data-testid="pending-activation-icon"
     >
       <AlertCircle className="size-3 shrink-0" />
-      {isActivating ? 'Activating account' : 'Not activated'}
+      {isActivating ? 'Activating' : 'Not activated'}
     </span>
   )
 }

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
@@ -667,4 +667,29 @@ describe('useSpaceSafeSelectorItems', () => {
     const { result } = renderHook(() => useSpaceSafeSelectorItems())
     expect(result.current.items[0].chains[0].isUndeployed).toBe(false)
   })
+
+  // ── undeployed status mapped per-chain on multi-chain safes ──
+
+  it('maps undeployed/activating status per chain for a multi-chain safe', () => {
+    setupDefaults({
+      allSafes: [multiChainSafe],
+      safeAddress: '0xSafe2',
+      currentChainId: '1',
+      overviews: [
+        { address: { value: '0xSafe2' }, chainId: '137', fiatTotal: '200', threshold: 1, owners: [{ value: '0xO' }] },
+      ],
+    })
+    // Chain '1' is undeployed and activating; chain '137' is deployed.
+    mockUndeployedSafes({ '1': { '0xSafe2': { status: { status: 'PROCESSING' } } } })
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    const chains = result.current.items[0].chains
+    const ethChain = chains.find((c) => c.chainId === '1')
+    const polygonChain = chains.find((c) => c.chainId === '137')
+
+    expect(ethChain?.isUndeployed).toBe(true)
+    expect(ethChain?.isActivating).toBe(true)
+    expect(polygonChain?.isUndeployed).toBe(false)
+    expect(polygonChain?.isActivating).toBe(false)
+  })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSpaceSafeSelectorItems.test.ts
@@ -72,6 +72,7 @@ import useChainId from '@/hooks/useChainId'
 import useChains from '@/hooks/useChains'
 import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
 import { useAppSelector } from '@/store'
+import { selectUndeployedSafes } from '@/features/counterfactual/store/undeployedSafesSlice'
 import useWallet from '@/hooks/wallets/useWallet'
 import { useRouter } from 'next/router'
 
@@ -631,5 +632,39 @@ describe('useSpaceSafeSelectorItems', () => {
     const { result } = renderHook(() => useSpaceSafeSelectorItems())
     expect(result.current.items[0].id).toBe('137:0xSafe2')
     expect(result.current.selectedItemId).toBe('137:0xSafe2')
+  })
+
+  // ── undeployed (counterfactual) status on single-chain safes ──
+
+  const mockUndeployedSafes = (undeployedSafes: Record<string, Record<string, { status: { status: string } }>>) => {
+    ;(useAppSelector as jest.Mock).mockImplementation((selector: unknown) =>
+      selector === selectUndeployedSafes ? undeployedSafes : 'usd',
+    )
+  }
+
+  it('marks a single-chain safe as undeployed when it has a counterfactual entry', () => {
+    setupDefaults({ overviews: [] as never[] })
+    mockUndeployedSafes({ '1': { '0xSafe1': { status: { status: 'AWAITING_EXECUTION' } } } })
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.items[0].chains[0].isUndeployed).toBe(true)
+    expect(result.current.items[0].chains[0].isActivating).toBe(false)
+  })
+
+  it('marks a single-chain safe as activating when its counterfactual status is not awaiting execution', () => {
+    setupDefaults({ overviews: [] as never[] })
+    mockUndeployedSafes({ '1': { '0xSafe1': { status: { status: 'PROCESSING' } } } })
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.items[0].chains[0].isUndeployed).toBe(true)
+    expect(result.current.items[0].chains[0].isActivating).toBe(true)
+  })
+
+  it('leaves a deployed single-chain safe as not undeployed', () => {
+    setupDefaults()
+    mockUndeployedSafes({})
+
+    const { result } = renderHook(() => useSpaceSafeSelectorItems())
+    expect(result.current.items[0].chains[0].isUndeployed).toBe(false)
   })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSpaceSafeSelectorItems.ts
@@ -111,8 +111,10 @@ function buildSingleChainItem(
   overviewsLoading: boolean,
   safe: { threshold: number; owners?: { value: string }[] },
   chainConfigs: Chain[],
+  undeployedSafes: UndeployedSafesState,
 ): SafeItemData {
   const overview = overviews?.find((o) => sameAddress(o.address.value, item.address) && o.chainId === item.chainId)
+  const undeployed = undeployedSafes[item.chainId]?.[item.address]
 
   return {
     id: `${item.chainId}:${item.address}`,
@@ -121,7 +123,12 @@ function buildSingleChainItem(
     ...resolveThresholdAndOwners(isCurrentSafe, safe, overview),
     balance: overview?.fiatTotal ?? '0',
     isLoading: overviewsLoading && !overview,
-    chains: mapChainIds(chainConfigs, [item.chainId]),
+    chains: mapChainIds(chainConfigs, [item.chainId]).map((chain) => ({
+      ...chain,
+      isReadOnly: item.isReadOnly ?? false,
+      isUndeployed: Boolean(undeployed),
+      isActivating: Boolean(undeployed && undeployed.status.status !== PendingSafeStatus.AWAITING_EXECUTION),
+    })),
   }
 }
 
@@ -164,7 +171,7 @@ export function useSpaceSafeSelectorItems() {
         )
       }
 
-      return buildSingleChainItem(item, isCurrentSafe, overviews, overviewsLoading, safe, chainConfigs)
+      return buildSingleChainItem(item, isCurrentSafe, overviews, overviewsLoading, safe, chainConfigs, undeployedSafes)
     })
   }, [allSafes, effectiveSafeAddress, currentChainId, safe, overviews, overviewsLoading, chainConfigs, undeployedSafes])
 

--- a/apps/web/src/features/myAccounts/components/AccountItem/AccountItemStatusChip.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountItem/AccountItemStatusChip.tsx
@@ -18,7 +18,7 @@ const ActivationChip = ({ isActivating }: { isActivating: boolean }) => (
       backgroundColor: isActivating ? 'var(--color-info-light)' : 'var(--color-warning-background)',
     }}
     size="small"
-    label={isActivating ? 'Activating account' : 'Not activated'}
+    label={isActivating ? 'Activating' : 'Not activated'}
     icon={
       isActivating ? (
         <LoopIcon fontSize="small" className={css.pendingLoopIcon} sx={{ mr: '-4px', ml: '4px' }} />

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/AccountWidgetItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/AccountWidgetItem.tsx
@@ -8,6 +8,7 @@ import { AccountItem } from '../AccountItem'
 import type { Account } from './types'
 import Identicon from '@/components/common/Identicon'
 import { shortenAddress } from '@safe-global/utils/utils/formatters'
+import { NotActivatedBadge } from '@/components/common/SpaceSafeBar/AccountsModal/shared'
 
 interface AccountWidgetItemProps {
   account: Account
@@ -49,12 +50,16 @@ const AccountWidgetItem = ({
       }
       actionNode={
         <div className="flex flex-col items-end gap-2">
-          <AccountItem.Balance
-            className="w-full"
-            data-testid="single-account-balance"
-            fiatTotal={account.fiatTotal}
-            isLoading={!account.fiatTotal && loading}
-          />
+          {account.isUndeployed ? (
+            <NotActivatedBadge isActivating={!!account.isActivating} />
+          ) : (
+            <AccountItem.Balance
+              className="w-full"
+              data-testid="single-account-balance"
+              fiatTotal={account.fiatTotal}
+              isLoading={!account.fiatTotal && loading}
+            />
+          )}
           {!account.subAccounts && (
             <Badge variant="secondary" data-testid="single-account-threshold">
               <UserRound className="size-3" />

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/ExpandableAccountItem.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/ExpandableAccountItem.tsx
@@ -5,6 +5,7 @@ import { AccountItem } from '../AccountItem'
 import ChainIndicator from '@/components/common/ChainIndicator'
 import { cn } from '@/utils/cn'
 import { AccountItemContent } from './AccountItemContent'
+import { NotActivatedBadge } from '@/components/common/SpaceSafeBar/AccountsModal/shared'
 import type { Account } from './types'
 
 interface ExpandableAccountItemProps {
@@ -34,7 +35,11 @@ const ExpandableAccountItem = ({
       >
         <AccountItemContent account={account}>
           <div className="flex items-center gap-2">
-            <AccountItem.Balance fiatTotal={account.fiatTotal} isLoading={!account.fiatTotal && loading} />
+            {account.isUndeployed ? (
+              <NotActivatedBadge isActivating={!!account.isActivating} />
+            ) : (
+              <AccountItem.Balance fiatTotal={account.fiatTotal} isLoading={!account.fiatTotal && loading} />
+            )}
           </div>
         </AccountItemContent>
       </CollapsibleTrigger>

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
@@ -200,7 +200,7 @@ describe('AccountsWidget', () => {
     const activatingAccount: Account[] = [{ ...mockAccounts[1], isUndeployed: true, isActivating: true }]
     render(<AccountsWidget accounts={activatingAccount} />)
 
-    expect(screen.getByText('Activating account')).toBeInTheDocument()
+    expect(screen.getByText('Activating')).toBeInTheDocument()
   })
 
   it('renders the Not activated badge for an undeployed multi-chain account', () => {

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/__tests__/AccountsWidget.test.tsx
@@ -188,6 +188,29 @@ describe('AccountsWidget', () => {
     expect(screen.queryByLabelText(/39,950,000/)).not.toBeInTheDocument()
   })
 
+  it('renders the Not activated badge instead of the balance for an undeployed single-chain account', () => {
+    const undeployedAccount: Account[] = [{ ...mockAccounts[1], isUndeployed: true, isActivating: false }]
+    render(<AccountsWidget accounts={undeployedAccount} />)
+
+    expect(screen.getByText('Not activated')).toBeInTheDocument()
+    expect(screen.queryByLabelText('$ 1,200,000.00')).not.toBeInTheDocument()
+  })
+
+  it('renders the Activating badge for an activating single-chain account', () => {
+    const activatingAccount: Account[] = [{ ...mockAccounts[1], isUndeployed: true, isActivating: true }]
+    render(<AccountsWidget accounts={activatingAccount} />)
+
+    expect(screen.getByText('Activating account')).toBeInTheDocument()
+  })
+
+  it('renders the Not activated badge for an undeployed multi-chain account', () => {
+    const undeployedMultichain: Account[] = [{ ...mockAccounts[0], isUndeployed: true, isActivating: false }]
+    render(<AccountsWidget accounts={undeployedMultichain} />)
+
+    expect(screen.getByText('Not activated')).toBeInTheDocument()
+    expect(screen.queryByLabelText('$ 39,950,000.00')).not.toBeInTheDocument()
+  })
+
   it('navigates to the safe home when a single-chain account is clicked', async () => {
     const mockPush = jest.fn()
     render(<AccountsWidget accounts={[mockAccounts[1]]} />, {

--- a/apps/web/src/features/myAccounts/components/AccountsWidget/types.ts
+++ b/apps/web/src/features/myAccounts/components/AccountsWidget/types.ts
@@ -15,4 +15,8 @@ export interface Account {
   owners: string
   highlighted?: boolean
   subAccounts?: SubAccount[]
+  /** True when the safe is counterfactual and not yet deployed on any of its chains. */
+  isUndeployed?: boolean
+  /** True while a counterfactual safe is being activated. */
+  isActivating?: boolean
 }

--- a/apps/web/src/features/myAccounts/hooks/__tests__/useSpaceAccountsData.test.ts
+++ b/apps/web/src/features/myAccounts/hooks/__tests__/useSpaceAccountsData.test.ts
@@ -209,4 +209,76 @@ describe('useSpaceAccountsData', () => {
       expect(result.current.accounts[0].owners).toBe('2/4')
     })
   })
+
+  describe('activation status', () => {
+    const cfState = (address: string, chainId: string, status = 'AWAITING_EXECUTION') => ({
+      undeployedSafes: {
+        [chainId]: {
+          [address]: {
+            props: {
+              safeAccountConfig: { threshold: 1, owners: ['0xOwnerA'] },
+              factoryAddress: '0xFactory',
+              masterCopy: '0xMasterCopy',
+              saltNonce: '0',
+              safeVersion: '1.3.0',
+            },
+            status: { status, type: 'counterfactual' },
+          },
+        },
+      },
+    })
+
+    it('marks a single undeployed safe as not activated', () => {
+      const address = '0xCfSingle'
+      const safes: AllSafeItems = [makeSafeItem({ chainId: '1', address })]
+
+      const { result } = renderHook(() => useSpaceAccountsData(safes), {
+        initialReduxState: cfState(address, '1') as unknown as Partial<RootState>,
+      })
+
+      expect(result.current.accounts[0].isUndeployed).toBe(true)
+      expect(result.current.accounts[0].isActivating).toBe(false)
+    })
+
+    it('marks an undeployed safe with a non-awaiting status as activating', () => {
+      const address = '0xCfActivating'
+      const safes: AllSafeItems = [makeSafeItem({ chainId: '1', address })]
+
+      const { result } = renderHook(() => useSpaceAccountsData(safes), {
+        initialReduxState: cfState(address, '1', 'PROCESSING') as unknown as Partial<RootState>,
+      })
+
+      expect(result.current.accounts[0].isUndeployed).toBe(true)
+      expect(result.current.accounts[0].isActivating).toBe(true)
+    })
+
+    it('does not mark a deployed safe as undeployed', () => {
+      const safes: AllSafeItems = [makeSafeItem({ chainId: '1', address: '0xDeployedOnly' })]
+
+      const { result } = renderHook(() => useSpaceAccountsData(safes))
+
+      expect(result.current.accounts[0].isUndeployed).toBe(false)
+      expect(result.current.accounts[0].isActivating).toBe(false)
+    })
+
+    it('marks a multichain account undeployed only when every chain is undeployed', () => {
+      const address = '0xMultiPartial'
+      const safes: AllSafeItems = [
+        {
+          address,
+          safes: [makeSafeItem({ chainId: '1', address }), makeSafeItem({ chainId: '137', address })],
+          isPinned: false,
+          lastVisited: 0,
+          name: undefined,
+        },
+      ]
+
+      const { result } = renderHook(() => useSpaceAccountsData(safes), {
+        // Only chain '1' is undeployed; '137' is deployed.
+        initialReduxState: cfState(address, '1') as unknown as Partial<RootState>,
+      })
+
+      expect(result.current.accounts[0].isUndeployed).toBe(false)
+    })
+  })
 })

--- a/apps/web/src/features/myAccounts/hooks/useSpaceAccountsData.ts
+++ b/apps/web/src/features/myAccounts/hooks/useSpaceAccountsData.ts
@@ -22,6 +22,7 @@ import type { Account, SubAccount } from '../components/AccountsWidget/types'
 import { getRtkQueryErrorMessage } from '@/utils/rtkQuery'
 import { selectUndeployedSafes } from '@/features/counterfactual/store'
 import type { UndeployedSafesState } from '@safe-global/utils/features/counterfactual/store/types'
+import { PendingSafeStatus } from '@safe-global/utils/features/counterfactual/store/types'
 
 const getLocalName = (address: string, safes: SafeItem[], localAddressBooks: AddressBookState): string => {
   for (const safe of safes) {
@@ -41,6 +42,21 @@ const getCfOwners = (address: string, chainId: string, undeployedSafes: Undeploy
   if (!cfSafe) return undefined
   const { threshold, owners } = cfSafe.props.safeAccountConfig
   return `${threshold}/${owners.length}`
+}
+
+// An account is "not activated" only when none of its chains are deployed yet.
+const getActivationStatus = (
+  safes: SafeItem[],
+  undeployedSafes: UndeployedSafesState,
+): { isUndeployed: boolean; isActivating: boolean } => {
+  const isUndeployed = safes.length > 0 && safes.every((s) => Boolean(undeployedSafes[s.chainId]?.[s.address]))
+  const isActivating =
+    isUndeployed &&
+    safes.some((s) => {
+      const undeployed = undeployedSafes[s.chainId]?.[s.address]
+      return Boolean(undeployed && undeployed.status.status !== PendingSafeStatus.AWAITING_EXECUTION)
+    })
+  return { isUndeployed, isActivating }
 }
 
 const formatMultichainAccount = (
@@ -86,6 +102,7 @@ const formatMultichainAccount = (
     fiatTotal: safeOverviews.length > 0 ? totalFiat.toString() : undefined,
     owners,
     subAccounts,
+    ...getActivationStatus(safe.safes, undeployedSafes),
   }
 }
 
@@ -112,6 +129,7 @@ const formatSingleSafe = (
     safes: [safe],
     fiatTotal: overview?.fiatTotal,
     owners,
+    ...getActivationStatus([safe], undeployedSafes),
   }
 }
 

--- a/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
@@ -196,7 +196,10 @@ const SafeCardReadOnly = ({
           <AccountItem.ChainBadge safes={safes} className="justify-end" />
         </div>
 
-        <div className="flex min-w-0 shrink-0 flex-col items-end gap-2 pl-1 sm:min-w-16 sm:pl-0">
+        <div
+          data-testid="balance-column"
+          className="flex min-w-0 shrink-0 flex-col items-end gap-2 pl-1 sm:min-w-16 sm:pl-0"
+        >
           {!isUndeployed && <FiatBalance value={fiatValue} />}
           {threshold > 0 && <ThresholdBadge threshold={threshold} owners={ownersCount} />}
         </div>

--- a/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/SafeCardReadOnly.tsx
@@ -192,15 +192,12 @@ const SafeCardReadOnly = ({
               </div>
             )
           )}
+          {isUndeployed && <AccountItem.StatusChip undeployedSafe isActivating={isActivating} />}
           <AccountItem.ChainBadge safes={safes} className="justify-end" />
         </div>
 
         <div className="flex min-w-0 shrink-0 flex-col items-end gap-2 pl-1 sm:min-w-16 sm:pl-0">
-          {isUndeployed ? (
-            <AccountItem.StatusChip undeployedSafe isActivating={isActivating} />
-          ) : (
-            <FiatBalance value={fiatValue} />
-          )}
+          {!isUndeployed && <FiatBalance value={fiatValue} />}
           {threshold > 0 && <ThresholdBadge threshold={threshold} owners={ownersCount} />}
         </div>
 

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SafeCardReadOnly.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SafeCardReadOnly.test.tsx
@@ -110,8 +110,8 @@ describe('SafeCardReadOnly', () => {
 
     const chip = screen.getByTestId('pending-activation-chip')
 
-    const balanceColumn = document.querySelector('.flex.min-w-0.shrink-0.flex-col.items-end')
-    expect(balanceColumn?.contains(chip)).toBe(false)
+    const balanceColumn = screen.getByTestId('balance-column')
+    expect(balanceColumn.contains(chip)).toBe(false)
     expect(screen.queryByText(/\$/)).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SafeCardReadOnly.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeAccounts/__tests__/SafeCardReadOnly.test.tsx
@@ -22,7 +22,7 @@ Object.defineProperty(window, 'IntersectionObserver', {
   value: MockIntersectionObserver,
 })
 
-const mockChains = [chainBuilder().with({ chainId: '1', shortName: 'eth' }).build()]
+const mockChains = [chainBuilder().with({ chainId: '1', shortName: 'eth', chainName: 'Ethereum' }).build()]
 
 jest.mock('@/hooks/useChains', () => ({
   __esModule: true,
@@ -90,5 +90,28 @@ describe('SafeCardReadOnly', () => {
     })
 
     expect(screen.getByText(/Not activated/i)).toBeInTheDocument()
+  })
+
+  it('renders the Not activated chip ahead of the chain badge and drops the balance column', () => {
+    const safe = safeItemBuilder().with({ chainId: '1', address: '0xDEADBEEF' }).build()
+
+    render(<SafeCardReadOnly safe={safe} />, {
+      initialReduxState: {
+        undeployedSafes: {
+          '1': {
+            '0xDEADBEEF': {
+              status: { status: 'AWAITING_EXECUTION' },
+              props: { safeAccountConfig: { owners: ['0x111'], threshold: 1 } },
+            },
+          },
+        },
+      } as unknown as Partial<RootState>,
+    })
+
+    const chip = screen.getByTestId('pending-activation-chip')
+
+    const balanceColumn = document.querySelector('.flex.min-w-0.shrink-0.flex-col.items-end')
+    expect(balanceColumn?.contains(chip)).toBe(false)
+    expect(screen.queryByText(/\$/)).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/MultiChainSafeItemRow.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Eye } from 'lucide-react'
+import { Eye } from 'lucide-react'
 import FiatValue from '@/components/common/FiatValue'
 import { Badge } from '@/components/ui/badge'
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible'
@@ -9,6 +9,7 @@ import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
 import SafeInfoDisplay from './SafeInfoDisplay'
 import BalanceDisplay from './BalanceDisplay'
 import ChainLogo from './ChainLogo'
+import NotActivatedBadge from './NotActivatedBadge'
 import type { SafeItemData, SafeItemDataChain } from '../types'
 
 interface MultiChainSafeItemRowProps {
@@ -17,18 +18,7 @@ interface MultiChainSafeItemRowProps {
 
 function StatusBadge({ chain }: { chain: SafeItemDataChain }) {
   if (chain.isUndeployed) {
-    return (
-      <span
-        className="inline-flex w-fit items-center gap-1 rounded-full px-1.5 py-px text-[11px] leading-none"
-        style={{
-          backgroundColor: chain.isActivating ? 'var(--color-info-light)' : 'var(--color-warning-background)',
-          color: chain.isActivating ? 'var(--color-info-dark)' : 'var(--color-warning-main)',
-        }}
-      >
-        <AlertCircle className="size-3 shrink-0" />
-        {chain.isActivating ? 'Activating' : 'Not activated'}
-      </span>
-    )
+    return <NotActivatedBadge isActivating={chain.isActivating} />
   }
   if (chain.isReadOnly) {
     return (

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/NotActivatedBadge.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/NotActivatedBadge.tsx
@@ -1,0 +1,28 @@
+import { AlertCircle } from 'lucide-react'
+import { cn } from '@/utils/cn'
+
+export interface NotActivatedBadgeProps {
+  isActivating?: boolean
+  className?: string
+}
+
+function NotActivatedBadge({ isActivating = false, className }: NotActivatedBadgeProps) {
+  return (
+    <span
+      data-testid="not-activated-badge"
+      className={cn(
+        'inline-flex w-fit items-center gap-1 rounded-full px-1.5 py-px text-[11px] leading-none',
+        className,
+      )}
+      style={{
+        backgroundColor: isActivating ? 'var(--color-info-light)' : 'var(--color-warning-background)',
+        color: isActivating ? 'var(--color-info-dark)' : 'var(--color-warning-main)',
+      }}
+    >
+      <AlertCircle className="size-3 shrink-0" />
+      {isActivating ? 'Activating' : 'Not activated'}
+    </span>
+  )
+}
+
+export default NotActivatedBadge

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeItem.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeItem.tsx
@@ -4,12 +4,15 @@ import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
 import SafeInfoDisplay from './SafeInfoDisplay'
 import BalanceDisplay from './BalanceDisplay'
 import ChainLogo from './ChainLogo'
+import NotActivatedBadge from './NotActivatedBadge'
 import type { SafeItemData } from '../types'
 
 const SafeItem = ({ name, address, threshold, owners, chains, balance, isLoading, parentSafeId }: SafeItemData) => {
   const isNested = Boolean(parentSafeId)
   const chainId = chains[0]?.chainId ?? ''
   const chainShortName = chains[0]?.shortName ?? ''
+  const isUndeployed = Boolean(chains[0]?.isUndeployed)
+  const isActivating = Boolean(chains[0]?.isActivating)
 
   const resolvedName = useSafeDisplayName(address, chainId, name)
 
@@ -32,13 +35,17 @@ const SafeItem = ({ name, address, threshold, owners, chains, balance, isLoading
           </span>
         ))}
       </div>
-      <BalanceDisplay
-        balance={<FiatValue value={balance} />}
-        threshold={threshold}
-        owners={owners}
-        isLoading={isLoading}
-        showThreshold={chains.length <= 1}
-      />
+      {isUndeployed ? (
+        <NotActivatedBadge isActivating={isActivating} className="shrink-0" />
+      ) : (
+        <BalanceDisplay
+          balance={<FiatValue value={balance} />}
+          threshold={threshold}
+          owners={owners}
+          isLoading={isLoading}
+          showThreshold={chains.length <= 1}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeSelectorTriggerContent.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, type KeyboardEvent, type MouseEvent, type PointerEvent } from 'react'
 import { blo } from 'blo'
-import { Copy, Check } from 'lucide-react'
+import { Copy, Check, AlertCircle } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Typography } from '@/components/ui/typography'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -20,6 +20,8 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
   const [copied, setCopied] = useState(false)
   const selectedChain = selectedItem.chains.find((c) => c.chainId === selectedChainId) ?? selectedItem.chains[0]
   const chainShortName = selectedChain?.shortName ?? ''
+  const isUndeployed = Boolean(selectedChain?.isUndeployed)
+  const isActivating = Boolean(selectedChain?.isActivating)
 
   const resolvedName = useSafeDisplayName(selectedItem.address, selectedChainId)
   const { addressWithPrefix, displayName, showAddressLine } = getSafeDisplayInfo(
@@ -94,13 +96,34 @@ function SafeSelectorTriggerContent({ selectedItem, selectedChainId }: SafeSelec
           </div>
         )}
       </div>
-      <SafeBalanceBlock
-        isLoading={selectedItem.isLoading ?? false}
-        balance={selectedItem.balance}
-        threshold={selectedItem.threshold}
-        owners={selectedItem.owners}
-        showBalanceDisplay
-      />
+      {isUndeployed ? (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span
+                tabIndex={0}
+                className="flex shrink-0 items-center"
+                data-testid="safe-selector-not-activated-icon"
+                aria-label={isActivating ? 'Activating' : 'Not activated'}
+              />
+            }
+          >
+            <AlertCircle
+              className="size-4"
+              style={{ color: isActivating ? 'var(--color-info-dark)' : 'var(--color-warning-main)' }}
+            />
+          </TooltipTrigger>
+          <TooltipContent>{isActivating ? 'Activating' : 'Not activated'}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <SafeBalanceBlock
+          isLoading={selectedItem.isLoading ?? false}
+          balance={selectedItem.balance}
+          threshold={selectedItem.threshold}
+          owners={selectedItem.owners}
+          showBalanceDisplay
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeItem.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeItem.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react'
+import SafeItem from '../SafeItem'
+import type { SafeItemData, SafeItemDataChain } from '../../types'
+
+jest.mock('@/hooks/useSafeDisplayName', () => ({
+  useSafeDisplayName: () => 'Test Safe',
+}))
+
+jest.mock('../SafeInfoDisplay', () => {
+  const Mock = () => <div data-testid="safe-info-display" />
+  Mock.displayName = 'SafeInfoDisplay'
+  return { __esModule: true, default: Mock }
+})
+
+jest.mock('../BalanceDisplay', () => {
+  const Mock = () => <div data-testid="balance-display" />
+  Mock.displayName = 'BalanceDisplay'
+  return { __esModule: true, default: Mock }
+})
+
+jest.mock('../ChainLogo', () => {
+  const Mock = ({ chainId }: { chainId: string }) => <div data-testid={`chain-logo-${chainId}`} />
+  Mock.displayName = 'ChainLogo'
+  return { __esModule: true, default: Mock }
+})
+
+jest.mock('@/components/common/FiatValue', () => {
+  const Mock = () => <span />
+  Mock.displayName = 'FiatValue'
+  return { __esModule: true, default: Mock }
+})
+
+const makeChain = (overrides: Partial<SafeItemDataChain> = {}): SafeItemDataChain => ({
+  chainId: '1',
+  chainName: 'Ethereum',
+  chainLogoUri: null,
+  shortName: 'eth',
+  ...overrides,
+})
+
+const createItem = (chain: SafeItemDataChain): SafeItemData => ({
+  id: '1:0xaaa',
+  name: 'Test Safe',
+  address: '0xaaa',
+  threshold: 1,
+  owners: 2,
+  balance: '0',
+  chains: [chain],
+})
+
+describe('SafeItem undeployed state', () => {
+  it('renders the Not activated badge instead of the balance for an undeployed chain', () => {
+    render(<SafeItem {...createItem(makeChain({ isUndeployed: true }))} />)
+
+    expect(screen.getByText('Not activated')).toBeInTheDocument()
+    expect(screen.queryByTestId('balance-display')).not.toBeInTheDocument()
+  })
+
+  it('renders the Activating label for an activating chain', () => {
+    render(<SafeItem {...createItem(makeChain({ isUndeployed: true, isActivating: true }))} />)
+
+    expect(screen.getByText('Activating')).toBeInTheDocument()
+  })
+
+  it('renders the balance for a deployed chain', () => {
+    render(<SafeItem {...createItem(makeChain())} />)
+
+    expect(screen.getByTestId('balance-display')).toBeInTheDocument()
+    expect(screen.queryByText('Not activated')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeSelectorTriggerContent.test.tsx
@@ -67,4 +67,50 @@ describe('SafeSelectorTriggerContent', () => {
     // When no name is resolved, getSafeDisplayInfo falls back to prefixed address
     expect(getByText(/0xabc/)).toBeInTheDocument()
   })
+
+  it('shows the not-activated warning icon instead of the balance when the selected chain is undeployed', () => {
+    const item = createItem({
+      chains: [
+        { chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth', isUndeployed: true },
+        { chainId: '137', chainName: 'Polygon', chainLogoUri: null, shortName: 'matic' },
+      ],
+    })
+
+    const { getByTestId, queryByTestId } = render(
+      <SafeSelectorTriggerContent selectedItem={item} selectedChainId="1" />,
+    )
+
+    expect(getByTestId('safe-selector-not-activated-icon')).toHaveAttribute('aria-label', 'Not activated')
+    expect(queryByTestId('safe-balance-block')).not.toBeInTheDocument()
+  })
+
+  it('shows the activating label when the selected chain is being activated', () => {
+    const item = createItem({
+      chains: [
+        {
+          chainId: '1',
+          chainName: 'Ethereum',
+          chainLogoUri: null,
+          shortName: 'eth',
+          isUndeployed: true,
+          isActivating: true,
+        },
+      ],
+    })
+
+    const { getByTestId } = render(<SafeSelectorTriggerContent selectedItem={item} selectedChainId="1" />)
+
+    expect(getByTestId('safe-selector-not-activated-icon')).toHaveAttribute('aria-label', 'Activating')
+  })
+
+  it('shows the balance when the selected chain is deployed', () => {
+    const item = createItem()
+
+    const { getByTestId, queryByTestId } = render(
+      <SafeSelectorTriggerContent selectedItem={item} selectedChainId="137" />,
+    )
+
+    expect(getByTestId('safe-balance-block')).toBeInTheDocument()
+    expect(queryByTestId('safe-selector-not-activated-icon')).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCardLayout.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/SafeCardLayout.tsx
@@ -91,16 +91,13 @@ export const SafeCardLayout = ({
       </div>
     </div>
 
-    <div className="ml-auto flex shrink-0 items-center justify-end pl-1 sm:pl-2">
+    <div className="ml-auto flex shrink-0 items-center justify-end gap-1.5 pl-1 sm:gap-2 sm:pl-2">
+      {isUndeployed && <AccountItem.StatusChip undeployedSafe isActivating={isActivating} />}
       <AccountItem.ChainBadge safes={safes} className="justify-end" />
     </div>
 
     <div className="flex min-w-0 shrink-0 flex-col items-end gap-2 pl-1 sm:min-w-16 sm:pl-0">
-      {isUndeployed ? (
-        <AccountItem.StatusChip undeployedSafe isActivating={isActivating} />
-      ) : (
-        <FiatBalance value={fiatValue} />
-      )}
+      {!isUndeployed && <FiatBalance value={fiatValue} />}
       {threshold > 0 && <ThresholdBadge threshold={threshold} owners={ownersCount} />}
     </div>
   </button>

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCardLayout.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/components/__tests__/SafeCardLayout.test.tsx
@@ -27,7 +27,7 @@ describe('SafeCardLayout', () => {
     render(<SafeCardLayout {...baseProps} fiatValue="123.45" isUndeployed={false} isActivating={false} />)
 
     expect(screen.queryByText(/Not activated/i)).toBeNull()
-    expect(screen.queryByText(/Activating account/i)).toBeNull()
+    expect(screen.queryByText(/Activating/i)).toBeNull()
   })
 
   it('renders the Not activated chip when the safe is undeployed', () => {
@@ -36,9 +36,9 @@ describe('SafeCardLayout', () => {
     expect(screen.getByText(/Not activated/i)).toBeInTheDocument()
   })
 
-  it('renders the Activating account chip when activation is in flight', () => {
+  it('renders the Activating chip when activation is in flight', () => {
     render(<SafeCardLayout {...baseProps} fiatValue={undefined} isUndeployed isActivating />)
 
-    expect(screen.getByText(/Activating account/i)).toBeInTheDocument()
+    expect(screen.getByText(/Activating/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
> Counterfactual safes, once hidden,
> now wear "Not activated" everywhere they're bidden —
> dropdown, widget, modal, list,
> the badge slides left of the chain logo, no longer missed.

## What it solves

The "Not activated" badge for counterfactual (undeployed) safes was missing or misplaced across several surfaces:

Resolves: [WA-2460](https://linear.app/safe-global/issue/WA-2460/add-a-label-not-activated-to-all-cf-safes)

- **Safe Selector Dropdown** — no undeployed indication on single-chain rows or on the collapsed trigger for the current safe.
- **Safe Accounts widget** (`/spaces?spaceId=`) — single-chain and multichain rows showed a balance but no "Not activated" badge.
- **Safe accounts list** (`/spaces/safe-accounts?spaceId=`) — the badge was displaced to the far right instead of sitting just before the chain logo.
- **Add accounts modal** (`AddAccounts` → `OnboardingSafesList`) and **All Accounts modal** (`AccountsModal` → `SafeItemCard`) — the badge sat in the name/balance column rather than directly before the chain logo.

## How this PR fixes it

- Added a shared `NotActivatedBadge` pill in the dropdown components and refactored `MultiChainSafeItemRow` to use it.
- `useSpaceSafeSelectorItems` → `buildSingleChainItem` now populates `isUndeployed`/`isActivating` per chain (it was multichain-only before), so the single-chain dropdown row (`SafeItem`) renders the badge in place of the balance.
- The dropdown trigger (`SafeSelectorTriggerContent`) shows a small warning icon with a "Not activated" / "Activating" tooltip — per selected chain — in the balance area when the current safe is undeployed.
- `useSpaceAccountsData` now derives `isUndeployed`/`isActivating` on each `Account` (undeployed only when every chain is undeployed). `AccountWidgetItem` and `ExpandableAccountItem` render the badge instead of the balance.
- Moved the badge to sit immediately **before the chain logo** (dropping the balance cell when undeployed) in `SafeCardReadOnly`, `SafeCardLayout`, and `SafeItemCard`.

## How to test it

1. Go to a counterfactual (undeployed) safe.
2. **Safe Selector Dropdown:** open the switcher — the undeployed safe shows "Not activated" on its row; when it's the current safe, the trigger shows a warning icon with a "Not activated" tooltip (per chain for multichain).
3. **Dashboard widget** (`/spaces?spaceId=`): the undeployed account shows the "Not activated" badge instead of a balance.
4. **Safe accounts list** (`/spaces/safe-accounts?spaceId=`): the badge sits just to the left of the chain logo.
5. **Add accounts / All Accounts modals:** the badge sits just before the chain logo.
6. Confirm deployed safes are unaffected (balance + threshold still shown).

## Screenshots
<img width="624" height="266" alt="image" src="https://github.com/user-attachments/assets/ed3255c3-fe72-4453-8533-dab29e733d50" />

<img width="647" height="106" alt="image" src="https://github.com/user-attachments/assets/e450ea90-c15a-41af-9b8b-6ffb61bb753d" />

<img width="686" height="244" alt="image" src="https://github.com/user-attachments/assets/9d645c1b-cf1d-4254-9a38-64f905d3bfd0" />

<img width="1265" height="512" alt="image" src="https://github.com/user-attachments/assets/30631916-b3a4-4708-b9c0-a754c4206e1a" />


## Affected flows

- Switching safes via the Safe Selector Dropdown (single-chain, multichain, current-safe trigger).
- Viewing the Safe Accounts widget on the spaces dashboard.
- Browsing the spaces safe-accounts list.
- Adding / browsing accounts in the Add accounts and All Accounts modals.

## Blast radius

- **Hooks:** `useSpaceSafeSelectorItems` (`buildSingleChainItem`/`buildMultiChainItem`), `useSpaceAccountsData` — consumed by the dropdown and the dashboard/safe-accounts widgets.
- **Types:** `Account` gained optional `isUndeployed`/`isActivating`; `SafeItemDataChain` already carried per-chain flags.
- **Components:** `SafeItem`, `MultiChainSafeItemRow`, `SafeSelectorTriggerContent`, `AccountWidgetItem`, `ExpandableAccountItem`, `SafeCardReadOnly`, `SafeCardLayout`, `SafeItemCard`; new shared `NotActivatedBadge` (dropdown). Reused the existing `NotActivatedBadge` from `SpaceSafeBar/AccountsModal/shared`.
- **No** RTK Query endpoint, feature flag, route, persistence, or shared `packages/**` changes — web-only, no mobile impact.

## Risks / not checked

- No new E2E/Playwright tests; verified via unit tests and component tests only.
- Did not manually exercise the "Activating" (in-progress deployment) state in the live UI — covered by unit tests asserting the `isActivating` branch.
- Did not modify the per-chain layout of expanded multichain sub-rows (`PinnedSafeSubItem`), which intentionally keep the badge under the chain name.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[Undeployed safe] --> B1[Badge missing in dropdown/widget]
    A1 --> C1[Badge far-right, after chain logo]
  end
  subgraph After
    A2[Undeployed safe] --> H[isUndeployed / isActivating<br/>per chain + per account]
    H --> B2[Dropdown row + trigger icon + widget badge]
    H --> C2[Badge rendered before chain logo]
  end
```

## Checklist

- [x] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
