### PR TITLE
fix: update onboarding invite step

### DIFF
--- a/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
+++ b/apps/web/src/features/spaces/components/AddMemberModal/utils.ts
@@ -15,7 +15,7 @@ export type InvitePayload = EmailInviteUserDto | WalletInviteUserDto
 export const EMAIL_MAX_LENGTH = 255
 
 const SELF_INVITE_ERROR = "You can't invite yourself."
-const INVALID_IDENTIFIER_ERROR = 'Enter a valid email, wallet address, or ENS.'
+export const INVALID_IDENTIFIER_ERROR = 'Enter a valid email, wallet address, or ENS.'
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/components/MemberInviteRow.tsx
@@ -13,7 +13,7 @@ import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Controller } from 'react-hook-form'
 import type { InviteMembersFormValues } from '../hooks/useInviteForm'
-import { EMAIL_MAX_LENGTH, isEmailAddress } from '../../AddMemberModal/utils'
+import { EMAIL_MAX_LENGTH, INVALID_IDENTIFIER_ERROR, isEmailAddress } from '../../AddMemberModal/utils'
 
 const ROLE_LABELS: Record<MemberRole, string> = {
   [MemberRole.ADMIN]: 'Admin',
@@ -22,11 +22,17 @@ const ROLE_LABELS: Record<MemberRole, string> = {
 
 const ADDRESS_RE = /^0x[0-9a-f]{40}$/i
 const ERROR_DEBOUNCE_MS = 500
+const INVALID_ADDRESS_ERROR = 'Invalid address'
 
 type AutoChecksumCallback = (checksummed: string) => void
 
 function validateEthereumAddress(value: string, onAutoChecksum: AutoChecksumCallback): string | undefined {
-  if (!ADDRESS_RE.test(value)) return 'Invalid address'
+  // A "0x" prefix signals an address attempt — show the address-specific error rather than the generic one
+  const looksLikeAddress = value.toLowerCase().startsWith('0x')
+
+  if (!ADDRESS_RE.test(value)) {
+    return looksLikeAddress ? INVALID_ADDRESS_ERROR : INVALID_IDENTIFIER_ERROR
+  }
 
   const hex = value.slice(2)
   const hasNoChecksumIntent = hex === hex.toLowerCase() || hex === hex.toUpperCase()
@@ -37,7 +43,7 @@ function validateEthereumAddress(value: string, onAutoChecksum: AutoChecksumCall
     return undefined
   }
 
-  if (!isChecksummedAddress(value)) return 'Invalid address checksum'
+  if (!isChecksummedAddress(value)) return INVALID_ADDRESS_ERROR
 
   return undefined
 }

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { trackEvent } from '@/services/analytics'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
-import useInviteForm from './useInviteForm'
+import useInviteForm, { toInviteName } from './useInviteForm'
 
 const mockInviteMembers = jest.fn()
 const mockOnSuccess = jest.fn()
@@ -43,6 +43,31 @@ const TestComponent = ({ spaceId }: { spaceId: string | undefined }) => {
   )
 }
 
+describe('toInviteName', () => {
+  it('keeps wallet addresses and ENS names as-is', () => {
+    expect(toInviteName('0x1234567890123456789012345678901234567890')).toBe(
+      '0x1234567890123456789012345678901234567890',
+    )
+    expect(toInviteName('alice.eth')).toBe('alice.eth')
+  })
+
+  it('derives the name from the email local part', () => {
+    expect(toInviteName('john.doe@example.com')).toBe('john.doe')
+  })
+
+  it('strips characters the backend name validation rejects', () => {
+    expect(toInviteName('john+safe@example.com')).toBe('johnsafe')
+  })
+
+  it('strips leading non-alphanumeric characters', () => {
+    expect(toInviteName('_test@example.com')).toBe('test')
+  })
+
+  it('falls back to a default when nothing valid remains', () => {
+    expect(toInviteName('+++@example.com')).toBe('Member')
+  })
+})
+
 describe('useInviteForm tracking', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -82,9 +107,9 @@ describe('useInviteForm tracking', () => {
     })
   })
 
-  it('builds an email invite payload with a lowercased email', async () => {
+  it('builds an email invite payload with a lowercased email and a name derived from the local part', async () => {
     mockInviteMembers.mockResolvedValue({
-      data: [{ userId: 9, spaceId: 42, name: 'Bob@Example.com', role: 'MEMBER', status: 'INVITED' }],
+      data: [{ userId: 9, spaceId: 42, name: 'Bob', role: 'MEMBER', status: 'INVITED' }],
     })
 
     render(<TestComponent spaceId="42" />)
@@ -102,7 +127,7 @@ describe('useInviteForm tracking', () => {
             {
               type: 'email',
               email: 'bob@example.com',
-              name: 'Bob@Example.com',
+              name: 'Bob',
               role: 'MEMBER',
             },
           ],
@@ -131,7 +156,7 @@ describe('useInviteForm tracking', () => {
             {
               type: 'email',
               email: 'dave@example.com',
-              name: 'Dave@Example.com',
+              name: 'Dave',
               role: 'MEMBER',
             },
           ],
@@ -174,7 +199,7 @@ describe('useInviteForm tracking', () => {
             {
               type: 'email',
               email: 'carol@example.com',
-              name: 'Carol@Example.com',
+              name: 'Carol',
               role: 'MEMBER',
             },
           ],

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts
@@ -18,6 +18,24 @@ export interface InviteMembersFormValues {
   members: MemberInvite[]
 }
 
+/**
+ * The onboarding flow has no dedicated name field, so a display name is derived from the
+ * identifier. Wallet/ENS invites keep using the address as the name (as before); email
+ * invites use the email's local part, sanitized to the alphanumeric-ish characters the
+ * backend's name validation accepts (the raw email's "@" would be rejected).
+ */
+export const toInviteName = (identifier: string): string => {
+  if (!isEmailAddress(identifier)) return identifier
+
+  const localPart = identifier.slice(0, identifier.indexOf('@'))
+  const sanitized = localPart
+    .replace(/[^a-zA-Z0-9 ._-]/g, '')
+    .replace(/^[^a-zA-Z0-9]+/, '')
+    .trim()
+
+  return sanitized || 'Member'
+}
+
 const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
   const [inviteMembers] = useMembersInviteUserV1Mutation()
 
@@ -58,7 +76,11 @@ const useInviteForm = (spaceId: string | undefined, onSuccess: () => void) => {
 
     try {
       const usersToInvite: InviteUsersDto['users'] = validMembers.map((member) =>
-        buildInviteUserPayload({ name: member.identifier, inviteeIdentifier: member.identifier, role: member.role }),
+        buildInviteUserPayload({
+          name: toInviteName(member.identifier),
+          inviteeIdentifier: member.identifier,
+          role: member.role,
+        }),
       )
 
       const result = await inviteMembers({


### PR DESCRIPTION
> Onboarding email invites: derive a valid name,
> and one honest error for a bad identifier.

## What it solves

Two issues in the space onboarding "Invite your team" step, surfaced after email invites shipped (#8004):

1. **Email invites failed on submit** — the backend rejected the `name` field ("Names must start with a letter or number…"). Onboarding has no name field, so it sent the raw email as the name, and the `@` is invalid.
2. **Misleading validation** — typing a partial email showed "Invalid address" before the `@` was entered.

## How this PR fixes it

- **`toInviteName` helper** ([useInviteForm.ts](apps/web/src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.ts)) derives a backend-valid display name: for emails it uses the local part, sanitized to the allowed charset (`a-z0-9 . _ -`), with a `"Member"` fallback. Wallet/ENS invites keep using the address as the name (unchanged). The invitee can still rename themselves when accepting.
- **Unified error message** — the generic "Invalid address" is switched to be address-shaped specific, and any other input check is replaced with the modal's "Enter a valid email, wallet address, or ENS." (`INVALID_IDENTIFIER_ERROR`, now exported from `AddMemberModal/utils.ts` for reuse). The specific "Invalid address checksum" message is kept, since it only fires on genuinely address-shaped input.

## How to test it

1. Onboarding → step 3 ("Invite your team").
2. Type a partial identifier → message reads "Enter a valid email, wallet address, or ENS." (not "Invalid address").
3. Enter a full email (e.g. `alice@example.com`) and submit → invite succeeds (name derived as `alice`).

Unit tests: `yarn workspace @safe-global/web test src/features/spaces/components/InviteMembersOnboarding/hooks/useInviteForm.test.tsx`

<img width="657" height="438" alt="Screenshot 2026-06-05 at 3 49 44 PM" src="https://github.com/user-attachments/assets/ad50997f-d4a9-4fe5-97aa-baa35b58ae45" />
<img width="657" height="438" alt="Screenshot 2026-06-05 at 3 49 49 PM" src="https://github.com/user-attachments/assets/44a167ba-49bc-402c-9fd5-835654ee8377" />


## Visual summary

```mermaid
flowchart LR
  A[Identifier] --> B{Email?}
  B -->|Yes| C[name = sanitized local part]
  B -->|No| D[name = address -unchanged-]
  C --> E[buildInviteUserPayload]
  D --> E
  F[Invalid input] --> G[Enter a valid email, wallet address, or ENS]
```

## Checklist

- [x] Tests added/updated (`toInviteName` edge cases + updated email payload expectations)
- [x] `type-check`, `lint`, `prettier`, `test` pass
- [x] No new `any`; reuses shared utils
- [ ] N/A — no new E2E

**Affected flows:** onboarding email invites (submit + inline validation). **Blast radius:** `InviteMembersOnboarding/` + one export added to `AddMemberModal/utils.ts` (no behavior change to the modal). **Risks:** `toInviteName` sanitization is inferred from the backend error message (regex lives server-side) — conservative, but worth one manual email-invite check against staging.