### PR TITLE
fix: correct FeePreviewTxData chainId type from number to string

### DIFF
--- a/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.test.tsx
+++ b/apps/web/src/features/gtf/hooks/__tests__/useFeesPreview.test.tsx
@@ -97,7 +97,7 @@ const wethBalance = {
 const mockSuccessfulPreview = {
   data: {
     txData: {
-      chainId: 1,
+      chainId: '1',
       safeAddress: mockSafe.address.value,
       safeTxGas: '2409',
       baseGas: '68568',

--- a/apps/web/src/store/api/gateway/gtfFeePreview.ts
+++ b/apps/web/src/store/api/gateway/gtfFeePreview.ts
@@ -36,7 +36,7 @@ export type FeePreviewTransactionDto = {
 }
 
 export type FeePreviewTxData = {
-  chainId: number
+  chainId: string
   safeAddress: string
   safeTxGas: string
   baseGas: string


### PR DESCRIPTION
## What it solves

Resolves: PLA-1603

## How this PR fixes it

`FeePreviewTxData.chainId` was typed as `number`, inconsistent with the rest of the app where `chainId` is always a `string`. Updated the type and the corresponding test mock fixture.

## How to test it

## Affected flows


## Blast radius

- `FeePreviewTxData` type in `gtfFeePreview.ts` — only the `chainId` field; no consumers read `txData.chainId` from the response (only `safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver` are used downstream)
- `useFeesPreview.test.tsx` mock fixture updated to match

## Risks / not checked

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
