### PR TITLE
feat(spaces): bring search back to the account selector dropdown

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
@@ -242,6 +242,33 @@ export const LoadingWithHeaderFooter: Story = {
   args: {} as any,
 }
 
+/** Many safes with header + footer — exercises the scrollbar and the bottom scroll-hint fade. */
+export const ManySafesWithFooter: Story = {
+  render: () => {
+    const items = createMockItems(13)
+    const header = (
+      <div className="flex items-center gap-1 px-4 pt-3 pb-2">
+        <span className="text-sm font-semibold text-secondary-foreground">Safes in this workspace</span>
+      </div>
+    )
+    const footer = (
+      <div className="px-4 py-3">
+        <button className="w-full rounded-md border px-3 py-1.5 text-sm">Explore other Safes &rsaquo;</button>
+      </div>
+    )
+    return (
+      <SafeSelectorDropdown
+        items={items}
+        selectedItemId={items[1].id}
+        onItemSelect={action('Item selected')}
+        header={header}
+        footer={footer}
+      />
+    )
+  },
+  args: {} as any,
+}
+
 /** Error state with header and footer (non-space context). */
 export const ErrorWithHeaderFooter: Story = {
   render: () => {

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/BalanceDisplay.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/BalanceDisplay.tsx
@@ -12,26 +12,32 @@ export interface BalanceDisplayProps {
   showThreshold?: boolean
 }
 
-const BalanceDisplay = ({ balance, threshold, owners, isLoading, showThreshold = true }: BalanceDisplayProps) => (
-  <div className="flex flex-col items-end min-w-0 shrink sm:w-[100px] sm:shrink-0">
-    {balance !== undefined &&
-      (isLoading ? (
-        <Skeleton className="h-4 w-14 rounded" />
-      ) : (
-        <Typography variant="paragraph-mini-medium" color="muted">
-          {balance}
-        </Typography>
-      ))}
-    {showThreshold &&
-      (isLoading ? (
-        <Skeleton className="h-4 w-14 rounded" />
-      ) : (
-        <Badge data-testid="safe-selector-threshold" variant="secondary" className="gap-1">
-          <User className="size-3" />
-          {threshold}/{owners}
-        </Badge>
-      ))}
-  </div>
-)
+const BalanceDisplay = ({ balance, threshold, owners, isLoading, showThreshold = true }: BalanceDisplayProps) => {
+  // A deployed safe always has threshold/owners >= 1, so 0/0 means the overview hasn't loaded yet
+  // (e.g. while switching safes); show a skeleton instead of a misleading "0/0".
+  const thresholdLoading = isLoading || (threshold === 0 && owners === 0)
+
+  return (
+    <div className="flex flex-col items-end min-w-0 shrink sm:w-[100px] sm:shrink-0">
+      {balance !== undefined &&
+        (isLoading ? (
+          <Skeleton className="h-4 w-14 rounded" />
+        ) : (
+          <Typography variant="paragraph-mini-medium" color="muted">
+            {balance}
+          </Typography>
+        ))}
+      {showThreshold &&
+        (thresholdLoading ? (
+          <Skeleton className="h-4 w-14 rounded" />
+        ) : (
+          <Badge data-testid="safe-selector-threshold" variant="secondary" className="gap-1">
+            <User className="size-3" />
+            {threshold}/{owners}
+          </Badge>
+        ))}
+    </div>
+  )
+}
 
 export default BalanceDisplay

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeBalanceBlock.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeBalanceBlock.tsx
@@ -11,6 +11,9 @@ export interface SafeBalanceBlockProps {
 }
 
 function SafeBalanceBlock({ isLoading, balance, threshold, owners, showBalanceDisplay }: SafeBalanceBlockProps) {
+  // 0/0 means the overview hasn't loaded (a deployed safe is always >= 1/1) — keep the skeleton.
+  const thresholdLoading = isLoading || (threshold === 0 && owners === 0)
+
   return (
     <div className="flex flex-col items-end gap-1 py-2 min-w-0 shrink sm:min-w-[90px] sm:shrink-0">
       {isLoading ? (
@@ -21,7 +24,7 @@ function SafeBalanceBlock({ isLoading, balance, threshold, owners, showBalanceDi
         </span>
       )}
       {showBalanceDisplay &&
-        (isLoading ? (
+        (thresholdLoading ? (
           <Skeleton className="h-5 w-12 rounded-full" />
         ) : (
           <BalanceDisplay threshold={threshold} owners={owners} />

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -1,5 +1,5 @@
 import { RotateCw, Search } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { SelectContent, SelectItem } from '@/components/ui/select'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -88,34 +88,49 @@ const SafeDropdownContainer = ({
 
   const showSearch = !isError && items.length > 0
 
-  const scrollRef = useRef<HTMLDivElement>(null)
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const detachScrollRef = useRef<(() => void) | null>(null)
   const [showScrollHint, setShowScrollHint] = useState(false)
 
   // Bottom-fade scroll hint, shown only while more rows lie below the fold.
+  const measureScrollHint = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const hasOverflow = el.scrollHeight > el.clientHeight + 1
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1
+    setShowScrollHint(hasOverflow && !atBottom)
+  }, [])
+
+  // Callback ref so the listeners/observer always bind to the LIVE scroll node. base-ui can remount
+  // the popup content after it sizes the popup async; a plain effect (deps unchanged) would stay
+  // closed over a stale, detached node and leave the hint stuck off. Re-measure next frame too.
+  const attachScrollArea = useCallback(
+    (node: HTMLDivElement | null) => {
+      detachScrollRef.current?.()
+      detachScrollRef.current = null
+      scrollRef.current = node
+      if (!node) return
+      node.addEventListener('scroll', measureScrollHint, { passive: true })
+      const resizeObserver = new ResizeObserver(measureScrollHint)
+      resizeObserver.observe(node)
+      Array.from(node.children).forEach((child) => resizeObserver.observe(child))
+      measureScrollHint()
+      const raf = requestAnimationFrame(measureScrollHint)
+      detachScrollRef.current = () => {
+        cancelAnimationFrame(raf)
+        node.removeEventListener('scroll', measureScrollHint)
+        resizeObserver.disconnect()
+      }
+    },
+    [measureScrollHint],
+  )
+
+  // Re-measure when the rendered rows change (the scroll node itself can stay the same).
   useEffect(() => {
-    const scroller = scrollRef.current
-    if (!scroller) return
-
-    const update = () => {
-      const hasOverflow = scroller.scrollHeight > scroller.clientHeight + 1
-      const atBottom = scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 1
-      setShowScrollHint(hasOverflow && !atBottom)
-    }
-
-    update()
-    // base-ui sizes the popup async (and avatars load late), so the sync measure can miss the
-    // overflow — re-check next frame and on every size change.
-    const raf = requestAnimationFrame(update)
-    scroller.addEventListener('scroll', update, { passive: true })
-    const resizeObserver = new ResizeObserver(update)
-    resizeObserver.observe(scroller)
-    Array.from(scroller.children).forEach((child) => resizeObserver.observe(child))
-    return () => {
-      cancelAnimationFrame(raf)
-      scroller.removeEventListener('scroll', update)
-      resizeObserver.disconnect()
-    }
-  }, [filteredItems.length, isLoading, isError])
+    measureScrollHint()
+    const raf = requestAnimationFrame(measureScrollHint)
+    return () => cancelAnimationFrame(raf)
+  }, [filteredItems.length, isLoading, isError, measureScrollHint])
 
   const renderContent = () => {
     if (isError) {
@@ -162,7 +177,9 @@ const SafeDropdownContainer = ({
       alignOffset={9}
       collisionAvoidance={{ side: 'none', align: 'shift' }}
     >
-      <div className="flex max-h-[min(34rem,var(--available-height))] flex-col">
+      {/* Fallback to 34rem: until base-ui sets --available-height the clamp must still apply, else the
+          list expands to full height, measures as non-overflowing, and the scroll-hint fade is missed. */}
+      <div className="flex max-h-[min(34rem,var(--available-height,34rem))] flex-col">
         {(header || showSearch) && (
           <div className="shrink-0 bg-card">
             {header}
@@ -191,7 +208,7 @@ const SafeDropdownContainer = ({
         )}
 
         <div
-          ref={scrollRef}
+          ref={attachScrollArea}
           data-testid="dropdown-scroll-area"
           className="min-h-0 flex-1 overflow-y-auto overscroll-y-none px-1 [scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border"
         >

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, RotateCw, Search } from 'lucide-react'
+import { RotateCw, Search } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { SelectContent, SelectItem } from '@/components/ui/select'
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
@@ -91,8 +91,8 @@ const SafeDropdownContainer = ({
   const footerRef = useRef<HTMLDivElement>(null)
   const [showScrollHint, setShowScrollHint] = useState(false)
 
-  // Custom scroll hint replaces base-ui's built-in scroll arrows: they sit at `bottom: 0`
-  // (colliding with the sticky footer) and don't animate, so users miss that the list is scrollable.
+  // Custom scroll hint (a bottom fade over the last item) replaces base-ui's built-in scroll arrows,
+  // which sit at `bottom: 0` and collide with the sticky footer. Shown only while more rows lie below.
   useEffect(() => {
     const el = footerRef.current
     if (!el) return
@@ -194,10 +194,12 @@ const SafeDropdownContainer = ({
       {footer && (
         <div ref={footerRef} className="sticky bottom-0 z-10 bg-card">
           {showScrollHint && (
-            <ChevronDown
+            <div
               data-testid="scroll-hint"
               aria-hidden
-              className="pointer-events-none absolute -top-3 left-1/2 size-4 -translate-x-1/2 animate-bounce text-muted-foreground"
+              // Fade to the dropdown's own background. `card` isn't a :root color token (so `to-card`
+              // renders transparent) — reference the actual paper var the card resolves to.
+              className="pointer-events-none absolute inset-x-0 -top-16 h-16 bg-gradient-to-b from-transparent to-[var(--color-background-paper)]"
             />
           )}
           {typeof footer === 'function' ? footer(closeDropdown) : footer}

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -159,7 +159,7 @@ const SafeDropdownContainer = ({
       alignItemWithTrigger={false}
       // outline-hidden: base-ui focuses the popup on open; typing in the search field makes that
       // :focus-visible and would otherwise draw the browser's blue outline around the whole popup.
-      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[min(34rem,var(--available-height))] overflow-y-auto overscroll-y-none bg-card border-0 ring-0 outline-hidden rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
+      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[min(34rem,var(--available-height))] overflow-y-auto overscroll-y-none bg-card border-0 ring-0 outline-hidden rounded-lg px-1 [scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
       sideOffset={20}
       alignOffset={9}
       collisionAvoidance={{ side: 'none', align: 'shift' }}

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -1,11 +1,25 @@
-import { ChevronDown, RotateCw } from 'lucide-react'
+import { ChevronDown, RotateCw, Search } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import { SelectContent, SelectItem } from '@/components/ui/select'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
+import { useSafeNameResolver } from '@/hooks/useAllAddressBooks'
 import SafeItem from './SafeItem'
 import MultiChainSafeItemRow from './MultiChainSafeItemRow'
 import type { SafeItemData } from '../types'
+
+// Matches a safe against a lowercased query by its resolved display name, address, or any of its
+// chains' names/short names. `displayName` is the same name shown in the row (the safe's own name OR
+// its address-book name), so searching also finds safes named only in the address book.
+const matchesSearch = (item: SafeItemData, displayName: string, query: string): boolean => {
+  const name = displayName.toLowerCase()
+  const address = item.address.toLowerCase()
+  if (name.includes(query) || address.includes(query)) return true
+  return item.chains.some(
+    (chain) => chain.chainName?.toLowerCase().includes(query) || chain.shortName?.toLowerCase().includes(query),
+  )
+}
 
 export interface SafeDropdownContainerProps {
   items: SafeItemData[]
@@ -63,8 +77,19 @@ const SafeDropdownContainer = ({
   footer,
   closeDropdown,
 }: SafeDropdownContainerProps) => {
+  const [search, setSearch] = useState('')
+  const query = search.trim().toLowerCase()
+  const resolveName = useSafeNameResolver()
+
   // Multi-chain items stay visible even when currently selected so the user can expand and switch chains.
-  const filteredItems = items.filter((item) => item.chains.length > 1 || item.id !== selectedItemId)
+  const structuralItems = items.filter((item) => item.chains.length > 1 || item.id !== selectedItemId)
+  const filteredItems = query
+    ? structuralItems.filter((item) =>
+        matchesSearch(item, resolveName(item.address, item.chains[0]?.chainId, item.name), query),
+      )
+    : structuralItems
+
+  const showSearch = !isError && items.length > 0
 
   const footerRef = useRef<HTMLDivElement>(null)
   const [showScrollHint, setShowScrollHint] = useState(false)
@@ -102,8 +127,16 @@ const SafeDropdownContainer = ({
       return <DropdownContentError onRetry={onRetry} />
     }
 
-    if (isLoading && filteredItems.length === 0) {
+    if (isLoading && filteredItems.length === 0 && !query) {
       return Array.from({ length: SKELETON_COUNT }, (_, i) => <SafeItemSkeleton key={i} />)
+    }
+
+    if (filteredItems.length === 0) {
+      return (
+        <p className="px-4 py-6 text-center text-sm text-muted-foreground" data-testid="dropdown-empty">
+          {query ? 'No safes match your search' : 'No safes yet'}
+        </p>
+      )
     }
 
     return filteredItems.map((item) => {
@@ -127,12 +160,38 @@ const SafeDropdownContainer = ({
       align="start"
       side="bottom"
       alignItemWithTrigger={false}
-      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[20rem] overflow-y-auto overscroll-y-none bg-card border-0 ring-0 rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
+      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[min(34rem,var(--available-height))] overflow-y-auto overscroll-y-none bg-card border-0 ring-0 rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
       sideOffset={20}
       alignOffset={9}
       collisionAvoidance={{ side: 'none', align: 'shift' }}
     >
-      {header}
+      {(header || showSearch) && (
+        <div className="sticky top-0 z-10 bg-card">
+          {header}
+          {showSearch && (
+            <div className="px-3 pb-2 pt-1">
+              <InputGroup className="rounded-md border-gray-100 shadow-none">
+                <InputGroupAddon>
+                  <Search className="size-4" />
+                </InputGroupAddon>
+                <InputGroupInput
+                  placeholder="Search by name, address or network"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  // Stop keystrokes from reaching base-ui Select's typeahead/navigation handlers on
+                  // the popup, which would otherwise hijack typing. This also keeps arrow/Enter keys
+                  // in the input (no list navigation from the field); Escape still bubbles to close.
+                  onKeyDown={(e) => {
+                    if (e.key !== 'Escape') e.stopPropagation()
+                  }}
+                  autoComplete="off"
+                  data-testid="safe-dropdown-search-input"
+                />
+              </InputGroup>
+            </div>
+          )}
+        </div>
+      )}
       {renderContent()}
       {footer && (
         <div ref={footerRef} className="sticky bottom-0 z-10 bg-card">

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -88,16 +88,13 @@ const SafeDropdownContainer = ({
 
   const showSearch = !isError && items.length > 0
 
-  const footerRef = useRef<HTMLDivElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
   const [showScrollHint, setShowScrollHint] = useState(false)
 
-  // Custom scroll hint (a bottom fade over the last item) replaces base-ui's built-in scroll arrows,
-  // which sit at `bottom: 0` and collide with the sticky footer. Shown only while more rows lie below.
+  // Custom scroll hint: a bottom fade over the last row, shown only while more rows lie below.
+  // The middle list scrolls (not the whole popup) so its scrollbar stays clear of the header/footer.
   useEffect(() => {
-    const el = footerRef.current
-    if (!el) return
-    // base-ui's Popup is the scroll container; reach it via the project's `data-slot` marker.
-    const scroller = el.closest<HTMLElement>('[data-slot="select-content"]')
+    const scroller = scrollRef.current
     if (!scroller) return
 
     const update = () => {
@@ -159,52 +156,63 @@ const SafeDropdownContainer = ({
       alignItemWithTrigger={false}
       // outline-hidden: base-ui focuses the popup on open; typing in the search field makes that
       // :focus-visible and would otherwise draw the browser's blue outline around the whole popup.
-      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[min(34rem,var(--available-height))] overflow-y-auto overscroll-y-none bg-card border-0 ring-0 outline-hidden rounded-lg px-1 [scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
+      // The popup itself doesn't scroll — only the middle list does (see below).
+      className="w-[430px] max-w-[calc(100vw-2rem)] overflow-hidden bg-card border-0 ring-0 outline-hidden rounded-lg [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
       sideOffset={20}
       alignOffset={9}
       collisionAvoidance={{ side: 'none', align: 'shift' }}
     >
-      {(header || showSearch) && (
-        <div className="sticky top-0 z-10 bg-card">
-          {header}
-          {showSearch && (
-            <div className="px-3 pb-2 pt-1">
-              <InputGroup className="rounded-md border-gray-100 shadow-none">
-                <InputGroupAddon>
-                  <Search className="size-4" />
-                </InputGroupAddon>
-                <InputGroupInput
-                  placeholder="Search by name, address or network"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  // Stop keystrokes reaching base-ui Select's typeahead, which would hijack typing.
-                  // Trade-off: arrows/Enter stay in the input (no list nav); Escape still closes.
-                  onKeyDown={(e) => {
-                    if (e.key !== 'Escape') e.stopPropagation()
-                  }}
-                  autoComplete="off"
-                  data-testid="safe-dropdown-search-input"
-                />
-              </InputGroup>
-            </div>
-          )}
+      <div className="flex max-h-[min(34rem,var(--available-height))] flex-col">
+        {(header || showSearch) && (
+          <div className="shrink-0 bg-card">
+            {header}
+            {showSearch && (
+              <div className="px-3 pb-2 pt-1">
+                <InputGroup className="rounded-md border-gray-100 shadow-none">
+                  <InputGroupAddon>
+                    <Search className="size-4" />
+                  </InputGroupAddon>
+                  <InputGroupInput
+                    placeholder="Search by name, address or network"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    // Stop keystrokes reaching base-ui Select's typeahead, which would hijack typing.
+                    // Trade-off: arrows/Enter stay in the input (no list nav); Escape still closes.
+                    onKeyDown={(e) => {
+                      if (e.key !== 'Escape') e.stopPropagation()
+                    }}
+                    autoComplete="off"
+                    data-testid="safe-dropdown-search-input"
+                  />
+                </InputGroup>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div
+          ref={scrollRef}
+          data-testid="dropdown-scroll-area"
+          className="min-h-0 flex-1 overflow-y-auto overscroll-y-none px-1 [scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border"
+        >
+          {renderContent()}
         </div>
-      )}
-      {renderContent()}
-      {footer && (
-        <div ref={footerRef} className="sticky bottom-0 z-10 bg-card">
-          {showScrollHint && (
-            <div
-              data-testid="scroll-hint"
-              aria-hidden
-              // Fade to the dropdown's own background. `card` isn't a :root color token (so `to-card`
-              // renders transparent) — reference the actual paper var the card resolves to.
-              className="pointer-events-none absolute inset-x-0 -top-16 h-16 bg-gradient-to-b from-transparent to-[var(--color-background-paper)]"
-            />
-          )}
-          {typeof footer === 'function' ? footer(closeDropdown) : footer}
-        </div>
-      )}
+
+        {footer && (
+          <div className="relative shrink-0 bg-card">
+            {showScrollHint && (
+              <div
+                data-testid="scroll-hint"
+                aria-hidden
+                // Fade the last visible row into the dropdown background. `card` isn't a :root color
+                // token (so `to-card` renders transparent) — reference the paper var it resolves to.
+                className="pointer-events-none absolute inset-x-0 -top-16 h-16 bg-gradient-to-b from-transparent to-[var(--color-background-paper)]"
+              />
+            )}
+            {typeof footer === 'function' ? footer(closeDropdown) : footer}
+          </div>
+        )}
+      </div>
     </SelectContent>
   )
 }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -9,9 +9,6 @@ import SafeItem from './SafeItem'
 import MultiChainSafeItemRow from './MultiChainSafeItemRow'
 import type { SafeItemData } from '../types'
 
-// Matches a safe against a lowercased query by its resolved display name, address, or any of its
-// chains' names/short names. `displayName` is the same name shown in the row (the safe's own name OR
-// its address-book name), so searching also finds safes named only in the address book.
 const matchesSearch = (item: SafeItemData, displayName: string, query: string): boolean => {
   const name = displayName.toLowerCase()
   const address = item.address.toLowerCase()
@@ -160,7 +157,9 @@ const SafeDropdownContainer = ({
       align="start"
       side="bottom"
       alignItemWithTrigger={false}
-      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[min(34rem,var(--available-height))] overflow-y-auto overscroll-y-none bg-card border-0 ring-0 rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
+      // outline-hidden: base-ui focuses the popup on open; typing in the search field makes that
+      // :focus-visible and would otherwise draw the browser's blue outline around the whole popup.
+      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[min(34rem,var(--available-height))] overflow-y-auto overscroll-y-none bg-card border-0 ring-0 outline-hidden rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
       sideOffset={20}
       alignOffset={9}
       collisionAvoidance={{ side: 'none', align: 'shift' }}
@@ -178,9 +177,8 @@ const SafeDropdownContainer = ({
                   placeholder="Search by name, address or network"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  // Stop keystrokes from reaching base-ui Select's typeahead/navigation handlers on
-                  // the popup, which would otherwise hijack typing. This also keeps arrow/Enter keys
-                  // in the input (no list navigation from the field); Escape still bubbles to close.
+                  // Stop keystrokes reaching base-ui Select's typeahead, which would hijack typing.
+                  // Trade-off: arrows/Enter stay in the input (no list nav); Escape still closes.
                   onKeyDown={(e) => {
                     if (e.key !== 'Escape') e.stopPropagation()
                   }}

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -91,8 +91,7 @@ const SafeDropdownContainer = ({
   const scrollRef = useRef<HTMLDivElement>(null)
   const [showScrollHint, setShowScrollHint] = useState(false)
 
-  // Custom scroll hint: a bottom fade over the last row, shown only while more rows lie below.
-  // The middle list scrolls (not the whole popup) so its scrollbar stays clear of the header/footer.
+  // Bottom-fade scroll hint, shown only while more rows lie below the fold.
   useEffect(() => {
     const scroller = scrollRef.current
     if (!scroller) return
@@ -104,13 +103,15 @@ const SafeDropdownContainer = ({
     }
 
     update()
+    // base-ui sizes the popup async (and avatars load late), so the sync measure can miss the
+    // overflow — re-check next frame and on every size change.
+    const raf = requestAnimationFrame(update)
     scroller.addEventListener('scroll', update, { passive: true })
-    // base-ui sizes the popup async and avatars/logos load late, so the initial
-    // measurement often misses the overflow. Observe size changes to catch up.
     const resizeObserver = new ResizeObserver(update)
     resizeObserver.observe(scroller)
     Array.from(scroller.children).forEach((child) => resizeObserver.observe(child))
     return () => {
+      cancelAnimationFrame(raf)
       scroller.removeEventListener('scroll', update)
       resizeObserver.disconnect()
     }
@@ -156,7 +157,6 @@ const SafeDropdownContainer = ({
       alignItemWithTrigger={false}
       // outline-hidden: base-ui focuses the popup on open; typing in the search field makes that
       // :focus-visible and would otherwise draw the browser's blue outline around the whole popup.
-      // The popup itself doesn't scroll — only the middle list does (see below).
       className="w-[430px] max-w-[calc(100vw-2rem)] overflow-hidden bg-card border-0 ring-0 outline-hidden rounded-lg [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
       sideOffset={20}
       alignOffset={9}

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/BalanceDisplay.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/BalanceDisplay.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import BalanceDisplay from '../BalanceDisplay'
+
+const querySkeleton = (container: HTMLElement) => container.querySelector('[data-slot="skeleton"]')
+
+describe('BalanceDisplay', () => {
+  it('renders the threshold badge when threshold/owners are loaded', () => {
+    const { container } = render(<BalanceDisplay threshold={2} owners={3} />)
+
+    expect(screen.getByTestId('safe-selector-threshold')).toHaveTextContent('2/3')
+    expect(querySkeleton(container)).not.toBeInTheDocument()
+  })
+
+  it('shows a skeleton instead of "0/0" when the overview has not loaded', () => {
+    const { container } = render(<BalanceDisplay threshold={0} owners={0} />)
+
+    expect(screen.queryByTestId('safe-selector-threshold')).not.toBeInTheDocument()
+    expect(container).not.toHaveTextContent('0/0')
+    expect(querySkeleton(container)).toBeInTheDocument()
+  })
+
+  it('shows a skeleton while explicitly loading', () => {
+    const { container } = render(<BalanceDisplay threshold={2} owners={3} isLoading />)
+
+    expect(screen.queryByTestId('safe-selector-threshold')).not.toBeInTheDocument()
+    expect(querySkeleton(container)).toBeInTheDocument()
+  })
+
+  it('renders nothing for the threshold when showThreshold is false', () => {
+    const { container } = render(<BalanceDisplay threshold={0} owners={0} showThreshold={false} />)
+
+    expect(screen.queryByTestId('safe-selector-threshold')).not.toBeInTheDocument()
+    expect(querySkeleton(container)).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
@@ -238,7 +238,7 @@ describe('SafeDropdownContainer', () => {
         />,
       )
 
-      const scroller = screen.getByTestId('select-content')
+      const scroller = screen.getByTestId('dropdown-scroll-area')
       setScrollMetrics(scroller, { scrollHeight: 200, clientHeight: 320, scrollTop: 0 })
       fireScroll(scroller)
 
@@ -255,7 +255,7 @@ describe('SafeDropdownContainer', () => {
         />,
       )
 
-      const scroller = screen.getByTestId('select-content')
+      const scroller = screen.getByTestId('dropdown-scroll-area')
       setScrollMetrics(scroller, { scrollHeight: 1000, clientHeight: 320, scrollTop: 0 })
       fireScroll(scroller)
 
@@ -272,7 +272,7 @@ describe('SafeDropdownContainer', () => {
         />,
       )
 
-      const scroller = screen.getByTestId('select-content')
+      const scroller = screen.getByTestId('dropdown-scroll-area')
       setScrollMetrics(scroller, { scrollHeight: 1000, clientHeight: 320, scrollTop: 0 })
       fireScroll(scroller)
       expect(screen.getByTestId('scroll-hint')).toBeInTheDocument()

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
@@ -1,7 +1,18 @@
 import React, { act } from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import SafeDropdownContainer from '../SafeDropdownContainer'
 import type { SafeItemData } from '../../types'
+
+// Resolver is exercised in its own unit test; here we stub it so the component renders without a
+// store. Default behaviour mirrors production: the safe's own name wins, else the address-book name.
+const mockAddressBookNames: Record<string, string> = {}
+jest.mock('@/hooks/useAllAddressBooks', () => ({
+  useSafeNameResolver:
+    () =>
+    (address: string, _chainId: string | undefined, preferredName?: string): string =>
+      preferredName || mockAddressBookNames[address.toLowerCase()] || '',
+}))
 
 // jsdom doesn't implement ResizeObserver; the component uses one to catch popup
 // size changes. A noop stub is enough since tests drive scroll state explicitly.
@@ -100,6 +111,119 @@ describe('SafeDropdownContainer', () => {
       render(<SafeDropdownContainer items={[createItem()]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
 
       expect(screen.queryByTestId('scroll-hint')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('search', () => {
+    const itemA = createItem({
+      id: '1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      name: 'Alpha Treasury',
+      address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      chains: [{ chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' }],
+    })
+    const itemB = createItem({
+      id: '137:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      name: 'Beta Ops',
+      address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      chains: [{ chainId: '137', chainName: 'Polygon', chainLogoUri: null, shortName: 'matic' }],
+    })
+
+    const renderWithSearch = () =>
+      render(<SafeDropdownContainer items={[itemA, itemB]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
+
+    beforeEach(() => {
+      for (const key of Object.keys(mockAddressBookNames)) delete mockAddressBookNames[key]
+    })
+
+    it('renders the search input when there are items', () => {
+      renderWithSearch()
+      expect(screen.getByTestId('safe-dropdown-search-input')).toBeInTheDocument()
+    })
+
+    it('does not render the search input on error', () => {
+      render(
+        <SafeDropdownContainer
+          items={[itemA]}
+          onItemSelect={jest.fn()}
+          closeDropdown={jest.fn()}
+          isError
+          onRetry={jest.fn()}
+        />,
+      )
+      expect(screen.queryByTestId('safe-dropdown-search-input')).not.toBeInTheDocument()
+    })
+
+    it('filters by name', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'alpha')
+
+      expect(screen.getByText('Alpha Treasury')).toBeInTheDocument()
+      expect(screen.queryByText('Beta Ops')).not.toBeInTheDocument()
+    })
+
+    it('filters by address', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), '0xbbbb')
+
+      expect(screen.getByText('Beta Ops')).toBeInTheDocument()
+      expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
+    })
+
+    it('filters by chain name', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'polygon')
+
+      expect(screen.getByText('Beta Ops')).toBeInTheDocument()
+      expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
+    })
+
+    it('filters by chain short name', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'matic')
+
+      expect(screen.getByText('Beta Ops')).toBeInTheDocument()
+      expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
+    })
+
+    it('filters by the address-book name when the safe itself is unnamed', async () => {
+      const unnamed = createItem({
+        id: '1:0xcccccccccccccccccccccccccccccccccccccccc',
+        name: '',
+        address: '0xcccccccccccccccccccccccccccccccccccccccc',
+        chains: [{ chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' }],
+      })
+      mockAddressBookNames['0xcccccccccccccccccccccccccccccccccccccccc'] = 'Cold Storage'
+
+      render(<SafeDropdownContainer items={[itemA, unnamed]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'cold')
+
+      // The unnamed safe (resolved via address book) survives; the named one is filtered out.
+      expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
+      expect(screen.getByTestId('safe-item')).toBeInTheDocument()
+    })
+
+    it('shows an empty state when nothing matches', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'nonexistent')
+
+      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('No safes match your search')
+      expect(screen.queryByTestId('safe-item')).not.toBeInTheDocument()
+    })
+
+    it('stops character keystrokes from bubbling to the popup (defeats base-ui typeahead) but lets Escape through', () => {
+      const onKeyDownSpy = jest.fn()
+      render(
+        <div onKeyDown={onKeyDownSpy}>
+          <SafeDropdownContainer items={[itemA, itemB]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />
+        </div>,
+      )
+      const input = screen.getByTestId('safe-dropdown-search-input')
+
+      fireEvent.keyDown(input, { key: 'a' })
+      expect(onKeyDownSpy).not.toHaveBeenCalled()
+
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(onKeyDownSpy).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
@@ -118,7 +118,9 @@ function SafeSelectorDropdown({
     >
       <SelectTrigger
         className={cn(
-          '-m-4 flex-1 border-0 shadow-none bg-transparent dark:bg-transparent py-0 pl-6 hover:bg-transparent dark:hover:bg-transparent data-[state=open]:bg-transparent [&_[data-slot=select-value]]:pr-0 relative',
+          // The wrapper's overflow-hidden clips this focus-visible ring into stray top/bottom bars,
+          // so suppress it — the card shows no focus ring by design (wrapper sets focus:ring-0).
+          '-m-4 flex-1 border-0 shadow-none bg-transparent dark:bg-transparent py-0 pl-6 hover:bg-transparent dark:hover:bg-transparent data-[state=open]:bg-transparent focus-visible:ring-0 focus-visible:border-0 [&_[data-slot=select-value]]:pr-0 relative',
           variants.triggerClass,
           isDisabled && 'cursor-not-allowed opacity-50',
         )}

--- a/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
+++ b/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
@@ -2,16 +2,23 @@ import { renderHook } from '@testing-library/react'
 import {
   useMergedAddressBooks,
   useAddressBookItem,
+  useSafeNameResolver,
   ContactSource,
   type ExtendedContact,
 } from '@/hooks/useAllAddressBooks'
+import type { AddressBookSource } from '@/components/common/AddressBookSourceProvider'
 
 let signedIn = false
 let chainId = '1'
 let currentSpaceId = '123'
 let localAddressBook: Record<string, string> = {}
+// Real `selectAllAddressBooks` is keyed by chain (`{ [chainId]: { [address]: name } }`), unlike the
+// flat per-chain `selectAddressBookByChain`. `useSafeNameResolver` reads the former, so it gets its
+// own nested fixture; the per-chain selector keeps returning the flat `localAddressBook`.
+let localAddressBooksByChain: Record<string, Record<string, string>> = {}
 let remoteContacts: ExtendedContact[] = []
 let privateContacts: ExtendedContact[] = []
+let mockAddressBookSource: AddressBookSource = 'merged'
 
 jest.mock('@/store', () => ({
   useAppSelector: (selector: (state: unknown) => unknown) =>
@@ -29,13 +36,17 @@ jest.mock('@/store/authSlice', () => ({
 }))
 
 jest.mock('@/store/addressBookSlice', () => ({
-  selectAllAddressBooks: jest.fn(() => localAddressBook),
+  selectAllAddressBooks: jest.fn(() => localAddressBooksByChain),
   selectAddressBookByChain: jest.fn(() => localAddressBook),
 }))
 
 jest.mock('@/hooks/useAddressBook', () => () => localAddressBook)
 
 jest.mock('@/hooks/useChainId', () => () => chainId)
+
+jest.mock('@/components/common/AddressBookSourceProvider', () => ({
+  useAddressBookSource: () => mockAddressBookSource,
+}))
 
 // Import the mocked hooks
 import { useCurrentSpaceId, useGetSpaceAddressBook, useGetPrivateAddressBook } from '@/features/spaces'
@@ -253,6 +264,115 @@ describe('useAllAddressBooks', () => {
       const { result } = renderHook(() => useAddressBookItem('0xB', undefined))
 
       expect(result.current).toBeUndefined()
+    })
+  })
+
+  describe('useSafeNameResolver', () => {
+    const spaceContact = (name: string, address: string, chainIds = ['1']): ExtendedContact => ({
+      name,
+      address,
+      chainIds,
+      createdBy: '',
+      createdByUserId: 0,
+      lastUpdatedBy: '',
+      lastUpdatedByUserId: 0,
+      createdAt: '',
+      updatedAt: '',
+      source: ContactSource.space,
+    })
+
+    beforeEach(() => {
+      ;(useCurrentSpaceId as jest.Mock).mockReturnValue(currentSpaceId)
+      ;(useGetSpaceAddressBook as jest.Mock).mockImplementation(() => remoteContacts)
+      ;(useGetPrivateAddressBook as jest.Mock).mockImplementation(() => privateContacts)
+      mockAddressBookSource = 'merged'
+    })
+
+    afterEach(() => {
+      remoteContacts = []
+      privateContacts = []
+      localAddressBook = {}
+      localAddressBooksByChain = {}
+      signedIn = false
+      mockAddressBookSource = 'merged'
+      jest.clearAllMocks()
+    })
+
+    it('returns the preferred name verbatim when provided', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Address Book Name', '0xA')]
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      // Preferred name wins over the address book entry.
+      expect(result.current('0xA', '1', 'Preferred Name')).toBe('Preferred Name')
+    })
+
+    it('falls back to the address-book name when no preferred name is given', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Treasury', '0xA')]
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xA', '1')).toBe('Treasury')
+    })
+
+    it('matches the address book case-insensitively', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Treasury', '0xAbCdEf')]
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xabcdef', '1')).toBe('Treasury')
+    })
+
+    it('returns an empty string when nothing matches', () => {
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xUnknown', '1')).toBe('')
+    })
+
+    it('returns an empty string when no chainId is given', () => {
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xA', undefined, '')).toBe('')
+    })
+
+    it('ignores space/private names under the localOnly source', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Treasury', '0xA')]
+      mockAddressBookSource = 'localOnly'
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xA', '1')).toBe('')
+    })
+
+    it('returns the space-book name under the spaceOnly source', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Treasury', '0xA')]
+      mockAddressBookSource = 'spaceOnly'
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xA', '1')).toBe('Treasury')
+    })
+
+    it('resolves a local-only name on the current chain (merged source)', () => {
+      localAddressBooksByChain = { '1': { '0xlocal': 'Local Wallet' } }
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xLocal', '1')).toBe('Local Wallet')
+    })
+
+    it('resolves a local-only name on a NON-current chain (the cross-chain case)', () => {
+      // useChainId() is '1'; this entry lives on chain 137, which the merged map would miss.
+      localAddressBooksByChain = { '137': { '0xremotechain': 'Polygon Wallet' } }
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xRemoteChain', '137')).toBe('Polygon Wallet')
+    })
+
+    it('still resolves cross-chain local names under the localOnly source', () => {
+      remoteContacts = [spaceContact('Should Be Ignored', '0xRemoteChain', ['137'])]
+      localAddressBooksByChain = { '137': { '0xremotechain': 'Polygon Wallet' } }
+      mockAddressBookSource = 'localOnly'
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xRemoteChain', '137')).toBe('Polygon Wallet')
     })
   })
 })

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -169,7 +169,6 @@ export const useAddressBookItem = (address: string, chainId: string | undefined)
  *
  * Needed for list filtering (e.g. the account dropdown search): the visible name often comes
  * from the address book, not the safe's own `name`, so searching the raw name misses those safes.
- * Calls one merged-books hook + the full local books, then resolves each address inline.
  *
  * Keep the source priority below in sync with {@link useSafeDisplayName}/{@link useAddressBookItem}:
  * this is the array-friendly twin of that per-item hook, so the two must resolve names identically.

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -2,7 +2,7 @@ import { useAppSelector } from '@/store'
 import { type AddressBook, selectAddressBookByChain, selectAllAddressBooks } from '@/store/addressBookSlice'
 import { type SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import useChainId from '@/hooks/useChainId'
 import { useGetSpaceAddressBook, useGetPrivateAddressBook } from '@/features/spaces'
 import { useAddressBookSource } from '@/components/common/AddressBookSourceProvider'
@@ -161,6 +161,53 @@ export const useAddressBookItem = (address: string, chainId: string | undefined)
 
     return undefined
   }, [chainId, source, getFromLocal, address, get])
+}
+
+/**
+ * Returns a source-aware resolver for safe display names, mirroring {@link useSafeDisplayName}
+ * (`preferredName > address book`) but usable across many addresses without a hook per item.
+ *
+ * Needed for list filtering (e.g. the account dropdown search): the visible name often comes
+ * from the address book, not the safe's own `name`, so searching the raw name misses those safes.
+ * Calls one merged-books hook + the full local books, then resolves each address inline.
+ *
+ * Keep the source priority below in sync with {@link useSafeDisplayName}/{@link useAddressBookItem}:
+ * this is the array-friendly twin of that per-item hook, so the two must resolve names identically.
+ */
+export const useSafeNameResolver = (): ((
+  address: string,
+  chainId: string | undefined,
+  preferredName?: string,
+) => string) => {
+  const { get } = useMergedAddressBooks()
+  const allLocal = useAppSelector(selectAllAddressBooks)
+  const source = useAddressBookSource()
+
+  // Flatten every chain's local book into a lowercased lookup so names on chains other than the
+  // currently-loaded one still resolve (the merged map only carries the current chain's locals).
+  const localByKey = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const [cid, book] of Object.entries(allLocal)) {
+      for (const [addr, name] of Object.entries(book)) {
+        map.set(addressBookKey(addr, cid), name)
+      }
+    }
+    return map
+  }, [allLocal])
+
+  return useCallback(
+    (address, chainId, preferredName) => {
+      if (preferredName) return preferredName
+      if (!chainId) return ''
+      const localName = localByKey.get(addressBookKey(address, chainId))
+      if (source === 'localOnly') return localName ?? ''
+      const item = get(address, chainId)
+      if (source === 'spaceOnly') return item?.source === ContactSource.space ? (item.name ?? '') : ''
+      // merged: space/private (cross-chain) take priority, then any chain's local
+      return item?.name ?? localName ?? ''
+    },
+    [get, source, localByKey],
+  )
 }
 
 // Returns all local address books

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -167,8 +167,10 @@ export const useAddressBookItem = (address: string, chainId: string | undefined)
  * Returns a source-aware resolver for safe display names, mirroring {@link useSafeDisplayName}
  * (`preferredName > address book`) but usable across many addresses without a hook per item.
  *
- * Needed for list filtering (e.g. the account dropdown search): the visible name often comes
- * from the address book, not the safe's own `name`, so searching the raw name misses those safes.
+ * Use this only to resolve names in bulk inside a loop / filter / sort (e.g. the account dropdown
+ * search) — the visible name often comes from the address book, not the safe's own `name`, so
+ * filtering the raw name misses those safes. For a single name in a component use the lighter
+ * {@link useSafeDisplayName} instead.
  *
  * Keep the source priority below in sync with {@link useSafeDisplayName}/{@link useAddressBookItem}:
  * this is the array-friendly twin of that per-item hook, so the two must resolve names identically.

--- a/apps/web/src/hooks/useSafeDisplayName.ts
+++ b/apps/web/src/hooks/useSafeDisplayName.ts
@@ -1,8 +1,10 @@
 import { useAddressBookItem } from '@/hooks/useAllAddressBooks'
 
 /**
- * Resolves the display name for a Safe address.
- * Priority: preferredName > address book
+ * Resolves the display name for a single Safe address (priority: preferredName > address book).
+ *
+ * Use this when rendering ONE safe's name in a component. To resolve many names at once inside a
+ * loop / filter / sort (where calling a hook per item isn't allowed), use {@link useSafeNameResolver}.
  */
 export const useSafeDisplayName = (address: string, chainId: string, preferredName?: string): string => {
   const addressBookItem = useAddressBookItem(address, chainId)


### PR DESCRIPTION
> Type a name, an address, a chain —
> the list narrows, the last row fades,
> a thin bar marks how far there is to go.

## What it solves

Resolves: [WA-2458](https://linear.app/safe-global/issue/WA-2458/bring-search-back-to-the-accounts-dropdown-visual-effect-to)

The account switcher dropdown lost its search in the new UI. With 100–200 safes, users had to scroll the whole list or detour through **All Accounts** just to find one. The ticket also asks for a scroll affordance ("last account item should fade to hint for scroll").

This brings search back **directly in the dropdown**, adds the scroll-hint fade, and fixes a few rough edges the work surfaced along the way.

## How this PR fixes it

**Search**

- Sticky search field at the top of the dropdown (reuses `InputGroup` / `InputGroupInput` + lucide `Search`, matching `AccountsModal`).
- Filters by **name**, **address**, and **chain name / short name**.
- Search matches the name the user actually **sees**. Row names come from `useSafeDisplayName` (the safe's own name **or** its address-book name, source-aware), so filtering the raw `item.name` missed safes named only in the address book. A new `useSafeNameResolver` hook resolves the same display name for many addresses without a hook-per-item (incl. local names on non-current chains).
- base-ui `Select` runs typeahead on keystrokes; the field stops keystroke propagation so typing isn't hijacked (Escape still closes).

**Scroll affordances**

- The dropdown is restructured into **header / scrollable list / footer** (like `AccountsModal`) so only the middle list scrolls. A **thin scrollbar** shows on the right, confined to the list (no longer running over the search field and footer).
- A **bottom fade** over the last visible row hints there's more to scroll (replaces the old bouncing chevron, per Figma). It fades to the dropdown's real background var (`--color-background-paper`); `to-card` rendered transparent because `card` isn't a `:root` color token.
- The fade is shown only while the list overflows. Because base-ui sizes the popup asynchronously on open, the overflow check is re-run on the next frame (and on resize) so the fade doesn't intermittently go missing.
- Popup max height raised (`20rem` → `min(34rem, var(--available-height))`) for long lists.

**Fixes surfaced by the search field's keyboard focus**

- The trigger's `focus-visible` ring was clipped by the wrapper's `overflow-hidden` into stray top/bottom bars; suppressed (the card shows no focus ring by design).
- The popup showed the browser's blue focus outline when typing focused it; added `outline-hidden`.

**Loading state**

- The threshold/owners badge rendered `0/0` while a safe's overview was still loading (RTK `isLoading` is false during arg-change/refetch). A deployed safe is always `>= 1/1`, so `0/0` is treated as "not loaded" and a skeleton is shown instead — in both the rows and the trigger.

## How to test it

1. Open the account switcher dropdown on an account with several safes.
2. Type part of a **name**, an **address** (`0x…`), or a **chain** (`polygon` / `matic`) → list narrows. Search a safe named **only in the address book** → it's found.
3. Clear the query → full list returns. No match → empty state.
4. With a long list: a **thin scrollbar** shows on the right (only over the list), and the **last row fades**. Scroll to the bottom → fade disappears. Re-open a few times → the fade shows consistently.
5. Switch to a safe whose data isn't cached → the signers badge shows a **skeleton**, not `0/0`.
6. Tab/keyboard into the dropdown and type → no clipped grey bars on the trigger, no blue outline around the popup; Escape closes.

## Affected flows

- Account switcher dropdown: searching/filtering the list (new), scrolling, selecting a safe, expanding multi-chain rows.
- "Trusted Safes" (merged) and "Safes in this workspace" (spaceOnly) header contexts.
- Trigger + rows loading state (signers badge).

## Blast radius

- **`SafeDropdownContainer`** — search state + filtering, three-section scroll layout, fade/scrollbar, scroll-hint detection. Props unchanged.
- **`useSafeNameResolver`** (new export in `hooks/useAllAddressBooks.ts`) — used only by the dropdown filter; mirrors `useSafeDisplayName` / `useAddressBookItem` priority (a "keep in sync" comment marks the intentional duplication). Reads `selectAllAddressBooks` + merged books via existing hooks.
- **`BalanceDisplay` / `SafeBalanceBlock`** — `0/0` → skeleton. Used by the dropdown rows + trigger; a deployed safe is never `0/0`, so safe everywhere.
- **`useSafeDisplayName`** — docs only.
- **`SafeSelectorDropdown` (index)** — trigger focus-ring class only.
- Not touched: `useSpaceSafeSelectorItems`. No API/slice/migration/feature-flag changes. Web-only (`apps/web`); mobile unaffected.

## Risks / not checked

- `useSafeNameResolver` duplicates the source-aware priority logic (mitigated by a sync comment, not abstraction); a future change to display-name priority must touch both.
- No virtualization — relies on search narrowing the rendered set; 200-item raw-scroll perf not profiled.
- Keyboard list navigation from inside the search field is intentionally disabled (arrows/Enter stay in the input).
- Verified manually in the browser; no end-to-end test renders a real store for the address-book-name search path.
- Not tested on mobile (web-only change).

## Visual summary

Dropdown layout — only the middle list scrolls:

```mermaid
flowchart TB
  subgraph Popup["SelectContent popup (overflow-hidden)"]
    H["Header + search field — shrink-0"]
    L["Account list — flex-1, overflow-y-auto<br/>• thin scrollbar (right)<br/>• bottom fade when more rows below"]
    F["Footer (All accounts / Explore) — shrink-0"]
    H --> L --> F
  end
```

Search name resolution (matches what each row displays):

```mermaid
flowchart LR
  Q[query] --> R["useSafeNameResolver(addr, chainId, item.name)"]
  R --> P{preferredName?}
  P -->|yes| N[display name]
  P -->|no| S{address-book source}
  S -->|merged| G["space/private (cross-chain) ?? any-chain local"]
  S -->|spaceOnly| SP[space contact]
  S -->|localOnly| LO[cross-chain local]
  G --> N
  SP --> N
  LO --> N
  N --> M{"name / address / chain matches query?"}
  M -->|yes| K[keep] 
  M -->|no| D[drop]
```

_(UI screenshot of the dropdown — search field, thin scrollbar, bottom fade — to be attached.)_

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A, web-only change
- [x] I've documented how it affects the analytics (if at all) 📊 — no new analytics events
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — resolver unit tests (incl. cross-chain local), dropdown filter/empty/scroll-hint/keystroke tests, BalanceDisplay 0/0→skeleton tests
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).