### PR TITLE
feat(web): flag vulnerable Zodiac modules as critical in Security Hub

### DIFF
--- a/apps/web/src/features/security/data/scanners/__tests__/modules.test.ts
+++ b/apps/web/src/features/security/data/scanners/__tests__/modules.test.ts
@@ -1,7 +1,21 @@
 import { modulesScanner } from '../modules'
 import { createMockContext } from '../test-helpers'
+import { isSafeAffectedByZodiacVulnerability } from '../../../services/vulnerableModules'
+
+jest.mock('../../../services/vulnerableModules', () => ({
+  isSafeAffectedByZodiacVulnerability: jest.fn().mockResolvedValue(false),
+}))
+
+const mockIsAffected = isSafeAffectedByZodiacVulnerability as jest.MockedFunction<
+  typeof isSafeAffectedByZodiacVulnerability
+>
 
 describe('modulesScanner', () => {
+  beforeEach(() => {
+    mockIsAffected.mockReset()
+    mockIsAffected.mockResolvedValue(false)
+  })
+
   it('returns clear when no modules are installed', async () => {
     const result = await modulesScanner.scan(createMockContext({ modules: null }))
     expect(result.status).toBe('clear')
@@ -134,5 +148,60 @@ describe('modulesScanner', () => {
       )
       expect(result.status).toBe('clear')
     }
+  })
+
+  describe('known Zodiac vulnerability', () => {
+    it('does not call the security-check API when there are no modules', async () => {
+      await modulesScanner.scan(createMockContext({ modules: [] }))
+      expect(mockIsAffected).not.toHaveBeenCalled()
+    })
+
+    it('flags a vulnerable Delay module as Critical with a remove CTA', async () => {
+      mockIsAffected.mockResolvedValue(true)
+      const delay = { value: '0x1111111111111111111111111111111111111111', name: 'Delay Modifier' }
+      const result = await modulesScanner.scan(createMockContext({ modules: [delay] }))
+
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('Critical')
+      expect(result.score).toBe(0)
+      expect(result.ctaLabelOverride).toBe('Remove unsupported module')
+      expect(result.vulnerableModules).toEqual([delay.value])
+      expect(result.evidence).toContainEqual({ label: 'Vulnerable module', value: 'Delay Modifier' })
+    })
+
+    it('flags a vulnerable Roles module as Critical', async () => {
+      mockIsAffected.mockResolvedValue(true)
+      const roles = { value: '0x2222222222222222222222222222222222222222', name: 'Roles Modifier' }
+      const result = await modulesScanner.scan(createMockContext({ modules: [roles] }))
+
+      expect(result.severity).toBe('Critical')
+      expect(result.vulnerableModules).toEqual([roles.value])
+    })
+
+    it('returns Critical warning without a remove target when affected via a related Safe', async () => {
+      mockIsAffected.mockResolvedValue(true)
+      // Affected, but no installed module matches Delay/Roles by name (nested case).
+      const result = await modulesScanner.scan(
+        createMockContext({ modules: [{ value: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF' }] }),
+      )
+
+      expect(result.status).toBe('issue')
+      expect(result.severity).toBe('Critical')
+      expect(result.vulnerableModules).toEqual([])
+      expect(result.ctaLabelOverride).toBeUndefined()
+    })
+
+    it('falls back to the trust tiers when the Safe is not affected', async () => {
+      mockIsAffected.mockResolvedValue(false)
+      const result = await modulesScanner.scan(
+        createMockContext({
+          modules: [{ value: '0x1111111111111111111111111111111111111111', name: 'Delay Modifier' }],
+        }),
+      )
+
+      expect(result.status).toBe('clear')
+      expect(result.severity).toBe('Low')
+      expect(result.vulnerableModules).toBeUndefined()
+    })
   })
 })

--- a/apps/web/src/features/security/data/scanners/modules.ts
+++ b/apps/web/src/features/security/data/scanners/modules.ts
@@ -4,6 +4,20 @@ import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { ZERO_ADDRESS } from '@safe-global/utils/utils/constants'
 import type { SecurityScanner } from './types'
 import { getSeverityFromScore } from './constants'
+import { isSafeAffectedByZodiacVulnerability } from '../../services/vulnerableModules'
+
+/**
+ * Module name fragments (case-insensitive) for the Zodiac modules covered by the
+ * known security vulnerability. Used to pick which installed module(s) to offer
+ * for removal when the security-check API reports the Safe as affected.
+ */
+const VULNERABLE_MODULE_NAMES = ['delay', 'roles']
+
+const isVulnerableModuleName = (name?: string | null): boolean => {
+  if (!name) return false
+  const lower = name.toLowerCase()
+  return VULNERABLE_MODULE_NAMES.some((fragment) => lower.includes(fragment))
+}
 
 /** Safe Allowance Module deployment versions to check against. */
 const ALLOWANCE_MODULE_VERSIONS = ['0.1.0', '0.1.1']
@@ -86,10 +100,12 @@ const isKnownModule = (chainId: string, moduleAddress: string, moduleName?: stri
 export const modulesScanner: SecurityScanner = {
   id: 'modules',
   scan: async (ctx) => {
-    const { modules, chainId } = ctx
+    const { modules, chainId, safeAddress } = ctx
     const now = new Date().toISOString()
 
     const activeModules = (modules ?? []).filter((m) => m.value !== ZERO_ADDRESS)
+
+    const moduleLabel = (m: { value: string; name?: string | null }) => m.name || `${m.value.slice(0, 10)}...`
 
     // Tier 1: No modules — perfectly fine for most Safes
     if (activeModules.length === 0) {
@@ -104,10 +120,33 @@ export const modulesScanner: SecurityScanner = {
       }
     }
 
+    // Critical: a known-vulnerable Zodiac module (Delay v1.1.0 / Roles v2.1.0, all
+    // mastercopies) is flagged by the server-side Zodiac security-check. This takes
+    // precedence over the trust tiers below — it is always Critical. Fails closed.
+    const isAffected = await isSafeAffectedByZodiacVulnerability(chainId, safeAddress)
+    if (isAffected) {
+      const vulnerable = activeModules.filter((m) => isVulnerableModuleName(m.name))
+      const score = 0
+      const hasRemovable = vulnerable.length > 0
+      return {
+        status: 'issue',
+        severity: getSeverityFromScore(score),
+        score,
+        evidence: hasRemovable
+          ? vulnerable.map((m) => ({ label: 'Vulnerable module', value: moduleLabel(m) }))
+          : [{ label: 'Status', value: 'Affected by a known Zodiac module vulnerability' }],
+        remediation: hasRemovable
+          ? 'This Safe has a Zodiac module affected by a known security vulnerability. Remove it immediately to protect your funds.'
+          : 'This Safe is affected by a known Zodiac module vulnerability through a related account. Review your setup and remove the affected module.',
+        lastChecked: now,
+        ctaLabelOverride: hasRemovable ? 'Remove unsupported module' : undefined,
+        vulnerableModules: vulnerable.map((m) => m.value),
+      }
+    }
+
     const trusted = activeModules.filter((m) => isKnownModule(chainId, m.value, m.name))
     const untrusted = activeModules.filter((m) => !isKnownModule(chainId, m.value, m.name))
 
-    const moduleLabel = (m: { value: string; name?: string | null }) => m.name || `${m.value.slice(0, 10)}...`
     const trustedEvidence = trusted.map((m) => ({ label: 'Trusted module', value: moduleLabel(m) }))
     const untrustedEvidence = untrusted.map((m) => ({ label: 'Unverified module', value: moduleLabel(m) }))
 

--- a/apps/web/src/features/security/data/scanners/types.ts
+++ b/apps/web/src/features/security/data/scanners/types.ts
@@ -43,6 +43,13 @@ export type ScanResult = {
   lastChecked: string
   ctaLabelOverride?: string
   partner?: 'hypernative'
+  /**
+   * Set by the modules scanner when the Safe is affected by a known Zodiac module
+   * vulnerability. Defined means "affected"; the array holds the installed module
+   * addresses we can offer to remove (empty when the Safe is only implicated via a
+   * related Safe and has no directly removable module).
+   */
+  vulnerableModules?: string[]
 }
 
 export type ScannerId =

--- a/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecurityPanelView.test.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/__tests__/SecurityPanelView.test.tsx
@@ -262,6 +262,69 @@ describe('SecurityPanelView', () => {
       // the passing accordion. The row title flags it; the module name lives in the expanded evidence.
       expect(screen.getByText('Unrecognized module detected')).toBeInTheDocument()
     })
+
+    describe('vulnerable Zodiac modules', () => {
+      const DELAY = '0xcccc000000000000000000000000000000000001'
+
+      it('flags a vulnerable module as Critical with a working remove CTA', () => {
+        const onRemoveModule = jest.fn()
+        renderPanel({
+          scanContext: createMockContext({ modules: [{ value: DELAY, name: 'Delay Modifier' }] }),
+          results: {
+            ...allClearResults,
+            modules: mkResult({
+              status: 'issue',
+              severity: 'Critical',
+              remediation: 'Remove it.',
+              vulnerableModules: [DELAY],
+              ctaLabelOverride: 'Remove unsupported module',
+            }),
+          },
+          onRemoveModule,
+        })
+
+        const row = screen.getByText('Vulnerable module · Delay Modifier')
+        fireEvent.click(row)
+        const button = screen.getByRole('button', { name: /remove unsupported module/i })
+        fireEvent.click(button)
+        expect(onRemoveModule).toHaveBeenCalledWith(DELAY)
+      })
+
+      it('falls back to an external link when no remove handler is provided', () => {
+        renderPanel({
+          scanContext: createMockContext({ modules: [{ value: DELAY, name: 'Delay Modifier' }] }),
+          results: {
+            ...allClearResults,
+            modules: mkResult({
+              status: 'issue',
+              severity: 'Critical',
+              vulnerableModules: [DELAY],
+              ctaLabelOverride: 'Remove unsupported module',
+            }),
+          },
+        })
+
+        fireEvent.click(screen.getByText('Vulnerable module · Delay Modifier'))
+        expect(screen.getByRole('link', { name: /check affected safes/i })).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /remove unsupported module/i })).not.toBeInTheDocument()
+      })
+
+      it('renders a Critical warning without a remove button for the nested (no removable module) case', () => {
+        const onRemoveModule = jest.fn()
+        renderPanel({
+          scanContext: createMockContext({ modules: [{ value: DELAY, name: 'Mystery Module' }] }),
+          results: {
+            ...allClearResults,
+            modules: mkResult({ status: 'issue', severity: 'Critical', vulnerableModules: [] }),
+          },
+          onRemoveModule,
+        })
+
+        // Affected, but no module matched as removable → a single warning row, no remove button.
+        expect(screen.getByText('Vulnerable module detected')).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /remove unsupported module/i })).not.toBeInTheDocument()
+      })
+    })
   })
 
   describe('row expansion', () => {

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityChecksSection.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityChecksSection.tsx
@@ -8,6 +8,7 @@ export type SecurityChecksSectionProps = {
   scanContext: ScanContext
   results: Record<string, ScanResult>
   safeQueryParam?: string
+  onRemoveModule?: (address: string) => void
 }
 
 /** Severity order of the grade groups; the passing group is always rendered last. */
@@ -17,8 +18,9 @@ const SecurityChecksSection = ({
   scanContext,
   results,
   safeQueryParam,
+  onRemoveModule,
 }: SecurityChecksSectionProps): ReactElement | null => {
-  const { isReady, failingRows, passingRows } = useSecurityChecks(scanContext, results, safeQueryParam)
+  const { isReady, failingRows, passingRows } = useSecurityChecks(scanContext, results, safeQueryParam, onRemoveModule)
 
   // Feature not yet loaded — render nothing; the panel skeleton covers this state.
   if (!isReady) return null

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityPanelView.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/SecurityPanelView.tsx
@@ -11,6 +11,7 @@ type SecurityPanelViewProps = {
   isComplete: boolean
   /** The `shortName:address` param used to deep-link a CTA to the correct Safe (e.g., "eth:0x..."). */
   safeQueryParam?: string
+  onRemoveModule?: (address: string) => void
 }
 
 const MotionBox = motion.create(Box)
@@ -26,6 +27,7 @@ const SecurityPanelView = ({
   results,
   isComplete,
   safeQueryParam,
+  onRemoveModule,
 }: SecurityPanelViewProps): ReactElement => {
   const hasResults = Object.keys(results).length > 0
 
@@ -48,7 +50,12 @@ const SecurityPanelView = ({
       >
         <PanelHeader results={results} isComplete={isComplete} />
       </MotionBox>
-      <SecurityChecksSection scanContext={scanContext} results={results} safeQueryParam={safeQueryParam} />
+      <SecurityChecksSection
+        scanContext={scanContext}
+        results={results}
+        safeQueryParam={safeQueryParam}
+        onRemoveModule={onRemoveModule}
+      />
     </Box>
   )
 }

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/useSecurityChecks.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/useSecurityChecks.tsx
@@ -14,7 +14,7 @@ import {
   type SectionRow,
 } from '../primitives'
 import { resolveStatusTone, SeverityIcon, type SeverityTone } from '../../SeverityIcon/SeverityIcon'
-import { ZODIAC_VULNERABILITY_CTA, getModuleRowContent } from '../utils'
+import { VULNERABLE_MODULE_INTRO, ZODIAC_VULNERABILITY_CTA, getModuleRowContent } from '../utils'
 
 export type FailingRow = { key: string; node: ReactNode; grade: SafeGrade }
 
@@ -344,12 +344,7 @@ export const useSecurityChecks = (
                 leadIcon={<SeverityIcon tone={rowTone('issue', severity)} />}
                 accentTone={rowTone('issue', severity)}
                 title="Vulnerable module detected"
-                expandedContent={
-                  <EvidenceList
-                    intro="This Safe is affected by a known Zodiac module vulnerability through a related account. Review your setup and remove the affected module."
-                    cta={ZODIAC_VULNERABILITY_CTA}
-                  />
-                }
+                expandedContent={<EvidenceList intro={VULNERABLE_MODULE_INTRO} cta={ZODIAC_VULNERABILITY_CTA} />}
               />
             ),
           })

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/useSecurityChecks.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/hooks/useSecurityChecks.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useMemo, useState } from 'react'
 import { Button } from '@mui/material'
+import { shortenAddress } from '@safe-global/utils/utils/formatters'
 import type { EvidenceItem, SafeGrade, ScanContext, ScanResult, SecurityGrade } from '@/features/security/types'
 import { SecurityFeature } from '@/features/security'
 import { useLoadFeature } from '@/features/__core__'
@@ -13,6 +14,7 @@ import {
   type SectionRow,
 } from '../primitives'
 import { resolveStatusTone, SeverityIcon, type SeverityTone } from '../../SeverityIcon/SeverityIcon'
+import { ZODIAC_VULNERABILITY_CTA, getModuleRowContent } from '../utils'
 
 export type FailingRow = { key: string; node: ReactNode; grade: SafeGrade }
 
@@ -60,6 +62,8 @@ export const useSecurityChecks = (
   scanContext: ScanContext,
   results: Record<string, ScanResult>,
   safeQueryParam: string | undefined,
+  /** Launches the remove-module tx flow for a vulnerable module (drawer-provided). */
+  onRemoveModule?: (address: string) => void,
 ): UseSecurityChecksResult => {
   const security = useLoadFeature(SecurityFeature)
   const [modulesExpanded, setModulesExpanded] = useState(false)
@@ -82,8 +86,17 @@ export const useSecurityChecks = (
 
     const hasGuard = scanContext.guard !== null && scanContext.guard.value !== zeroAddress
     const hasFallback = scanContext.fallbackHandler !== null && scanContext.fallbackHandler.value !== zeroAddress
-    const activeModules = (scanContext.modules ?? []).filter((m) => m.value !== zeroAddress)
-    const showModuleSummary = activeModules.length > 2 && !modulesExpanded
+    const activeModules = (scanContext.modules ?? [])
+      .filter((m) => m.value !== zeroAddress)
+      // Defensive de-dupe: never render the same module address twice.
+      .filter((m, i, arr) => arr.findIndex((o) => o.value.toLowerCase() === m.value.toLowerCase()) === i)
+    // The Safe is affected by a known Zodiac vulnerability when the modules scanner sets
+    // `vulnerableModules` (an empty array still means "affected" — see the nested case below).
+    const vulnerableModules = results['modules']?.vulnerableModules
+    const isVulnerable = Array.isArray(vulnerableModules)
+    const vulnerableSet = new Set(vulnerableModules ?? [])
+    // Never collapse into a summary when affected — the vulnerable row + remove CTA must stay visible.
+    const showModuleSummary = activeModules.length > 2 && !modulesExpanded && !isVulnerable
 
     const items: SectionRow[] = []
     const iconFor = (r: ScanResult) => <SeverityIcon tone={rowTone(r.status, r.severity)} />
@@ -318,20 +331,43 @@ export const useSecurityChecks = (
         })
       } else {
         const modulesCta = buildCta('modules', modulesResult, safeQueryParam)
+        // Affected but no removable module on this Safe (implicated via a related Safe) — surface a
+        // single Critical warning instead of per-module rows that would have no remove target.
+        if (isVulnerable && vulnerableSet.size === 0) {
+          const severity: SecurityGrade = 'Critical'
+          items.push({
+            key: 'modules-vulnerable-nested',
+            severity,
+            isPassing: false,
+            node: (
+              <Row
+                leadIcon={<SeverityIcon tone={rowTone('issue', severity)} />}
+                accentTone={rowTone('issue', severity)}
+                title="Vulnerable module detected"
+                expandedContent={
+                  <EvidenceList
+                    intro="This Safe is affected by a known Zodiac module vulnerability through a related account. Review your setup and remove the affected module."
+                    cta={ZODIAC_VULNERABILITY_CTA}
+                  />
+                }
+              />
+            ),
+          })
+        }
         activeModules.forEach((mod) => {
-          const trusted = isKnownModuleByName(mod.name)
-          const severity: SecurityGrade = trusted ? 'Low' : 'High'
+          const vulnerable = vulnerableSet.has(mod.value)
+          const trusted = !vulnerable && isKnownModuleByName(mod.name)
+          const severity: SecurityGrade = vulnerable ? 'Critical' : trusted ? 'Low' : 'High'
           const status: ScanResult['status'] = trusted ? 'clear' : 'issue'
-          // Show the module's name as the title for both trusted and unrecognized modules — users
-          // need to identify *which* module when it's flagged. The icon + intro convey the verdict.
-          const title = 'Unrecognized module detected'
+          // Identify which module each row is so multiple flagged modules aren't indistinguishable.
+          const title = vulnerable
+            ? `Vulnerable module · ${mod.name || shortenAddress(mod.value)}`
+            : 'Unrecognized module detected'
           const perModuleEvidence: EvidenceItem[] = [
             { label: 'Address', value: mod.value },
             ...(mod.name ? [{ label: 'Name', value: mod.name }] : []),
           ]
-          const intro = trusted
-            ? 'Recognized Safe ecosystem module.'
-            : "Unrecognized module — not in the known Safe ecosystem deployments. Review carefully and remove if you don't recognize it."
+          const { intro, cta } = getModuleRowContent(mod, { vulnerable, trusted }, modulesCta, onRemoveModule)
           items.push({
             key: `module-${mod.value}`,
             severity,
@@ -341,9 +377,7 @@ export const useSecurityChecks = (
                 leadIcon={<SeverityIcon tone={rowTone(status, severity)} />}
                 accentTone={rowTone(status, severity)}
                 title={title}
-                expandedContent={
-                  <EvidenceList intro={intro} evidence={perModuleEvidence} cta={trusted ? null : modulesCta} />
-                }
+                expandedContent={<EvidenceList intro={intro} evidence={perModuleEvidence} cta={cta} />}
               />
             ),
           })
@@ -407,7 +441,16 @@ export const useSecurityChecks = (
       })),
       passingRows: items.filter((i) => i.isPassing).map(({ key, node }) => ({ key, node })),
     }
-  }, [buildCta, isKnownModuleByName, zeroAddress, scanContext, results, safeQueryParam, modulesExpanded])
+  }, [
+    buildCta,
+    isKnownModuleByName,
+    zeroAddress,
+    scanContext,
+    results,
+    safeQueryParam,
+    modulesExpanded,
+    onRemoveModule,
+  ])
 
   if (!security.$isReady || !buildCta) {
     return { isReady: false, failingRows: [], passingRows: [] }

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/primitives.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/primitives.tsx
@@ -181,7 +181,7 @@ export const EvidenceList = ({
   evidence,
   cta,
 }: {
-  intro?: string
+  intro?: ReactNode
   evidence?: EvidenceItem[]
   cta?: Cta | null
 }): ReactElement | null => {

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/primitives.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/primitives.tsx
@@ -16,7 +16,8 @@ const toneToCssVar = (color: string): string => `var(--color-${color.replace('.'
 
 export type SectionRow = { key: string; severity: SecurityGrade; isPassing: boolean; node: ReactNode }
 
-export type Cta = { label: string; href: string }
+/** A CTA is either a navigation link (`href`) or an in-app action (`onClick`, e.g. open a tx flow). */
+export type Cta = { label: string } & ({ href: string } | { onClick: () => void })
 
 /**
  * A row is considered "passing" (bucketed into the accordion) when the user has no action to take.
@@ -144,18 +145,35 @@ export const makeBuildCta =
     return { label, href: `${def.fixRoute}?safe=${encodeURIComponent(safeQueryParam)}` }
   }
 
-const CtaLink = ({ cta }: { cta: Cta }): ReactElement => (
-  <Link
-    href={cta.href}
-    onClick={(e) => e.stopPropagation()}
-    className="group inline-flex items-center gap-1.5 self-start rounded text-primary no-underline transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
-  >
+const ctaClassName =
+  'group inline-flex items-center gap-1.5 self-start rounded text-primary no-underline transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50'
+
+const CtaBody = ({ label }: { label: string }): ReactElement => (
+  <>
     <Typography variant="paragraph-mini" className="font-bold leading-normal text-inherit group-hover:underline">
-      {cta.label}
+      {label}
     </Typography>
     <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
-  </Link>
+  </>
 )
+
+const CtaLink = ({ cta }: { cta: Cta }): ReactElement =>
+  'href' in cta ? (
+    <Link href={cta.href} onClick={(e) => e.stopPropagation()} className={ctaClassName}>
+      <CtaBody label={cta.label} />
+    </Link>
+  ) : (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        cta.onClick()
+      }}
+      className={ctaClassName}
+    >
+      <CtaBody label={cta.label} />
+    </button>
+  )
 
 /** Expanded-row body: optional intro paragraph + evidence key/value list + optional CTA. */
 export const EvidenceList = ({

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/utils.ts
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/utils.ts
@@ -1,0 +1,42 @@
+import type { Cta } from './primitives'
+
+/**
+ * Fallback CTA for a Zodiac vulnerability when we can't offer an in-app removal —
+ * either no remove handler was provided, or the Safe is only implicated via a
+ * related account (no removable module here). Points at Zodiac's public checker.
+ */
+export const ZODIAC_VULNERABILITY_CTA: Cta = {
+  label: 'Check affected Safes',
+  href: 'https://app.zodiac.eco/public/fallback-handler',
+}
+
+/**
+ * Intro copy + CTA for a single module row, keyed on its verdict:
+ * - vulnerable → remove action (or the external checker when no in-app handler),
+ * - trusted → no CTA,
+ * - unrecognized → the generic "review modules" CTA.
+ */
+export const getModuleRowContent = (
+  module: { value: string; name?: string | null },
+  verdict: { vulnerable: boolean; trusted: boolean },
+  modulesCta: Cta | null,
+  onRemoveModule?: (address: string) => void,
+): { intro: string; cta: Cta | null } => {
+  if (verdict.vulnerable) {
+    return {
+      intro:
+        'This module is affected by a known Zodiac security vulnerability. Remove it immediately to protect your funds.',
+      cta: onRemoveModule
+        ? { label: 'Remove unsupported module', onClick: () => onRemoveModule(module.value) }
+        : ZODIAC_VULNERABILITY_CTA,
+    }
+  }
+  if (verdict.trusted) {
+    return { intro: 'Recognized Safe ecosystem module.', cta: null }
+  }
+  return {
+    intro:
+      "Unrecognized module — not in the known Safe ecosystem deployments. Review carefully and remove if you don't recognize it.",
+    cta: modulesCta,
+  }
+}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/utils.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityPanelView/utils.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type { Cta } from './primitives'
 
 /**
@@ -10,6 +11,15 @@ export const ZODIAC_VULNERABILITY_CTA: Cta = {
   href: 'https://app.zodiac.eco/public/fallback-handler',
 }
 
+/** Shared intro shown for any Zodiac-vulnerability finding (per-module rows and the nested warning). */
+export const VULNERABLE_MODULE_INTRO: ReactNode = (
+  <>
+    <span className="font-bold">This Safe is affected by a vulnerable third-party module.</span> A Zodiac Delay v1.1.0
+    or Roles v2.1.0 module associated with it has a known critical vulnerability. We advise you to take immediate
+    action.
+  </>
+)
+
 /**
  * Intro copy + CTA for a single module row, keyed on its verdict:
  * - vulnerable → remove action (or the external checker when no in-app handler),
@@ -21,11 +31,10 @@ export const getModuleRowContent = (
   verdict: { vulnerable: boolean; trusted: boolean },
   modulesCta: Cta | null,
   onRemoveModule?: (address: string) => void,
-): { intro: string; cta: Cta | null } => {
+): { intro: ReactNode; cta: Cta | null } => {
   if (verdict.vulnerable) {
     return {
-      intro:
-        'This module is affected by a known Zodiac security vulnerability. Remove it immediately to protect your funds.',
+      intro: VULNERABLE_MODULE_INTRO,
       cta: onRemoveModule
         ? { label: 'Remove unsupported module', onClick: () => onRemoveModule(module.value) }
         : ZODIAC_VULNERABILITY_CTA,

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityDrawerContent.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityDrawerContent.tsx
@@ -10,6 +10,7 @@ type SecurityDrawerContentProps = {
   isComplete: boolean
   lastScannedAt: number | null
   safeQueryParam?: string
+  onRemoveModule?: (address: string) => void
 }
 
 /** Tabbed body of the drawer — "Checks" (scan results) and "Details" (placeholder). */
@@ -19,6 +20,7 @@ const SecurityDrawerContent = ({
   isComplete,
   lastScannedAt,
   safeQueryParam,
+  onRemoveModule,
 }: SecurityDrawerContentProps): ReactElement => (
   <Tabs defaultValue="checks" className="flex min-h-0 flex-1 flex-col gap-4 px-6 pb-6">
     <TabsList className="w-fit gap-2">
@@ -38,6 +40,7 @@ const SecurityDrawerContent = ({
           isComplete={isComplete}
           lastScannedAt={lastScannedAt}
           safeQueryParam={safeQueryParam}
+          onRemoveModule={onRemoveModule}
         />
       </TabsContent>
 

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/SecurityReportDrawer.tsx
@@ -1,8 +1,10 @@
-import { type ReactElement, useEffect, useRef } from 'react'
+import { type ReactElement, useCallback, useContext, useEffect, useRef } from 'react'
 import type { ScanContext, ScanResult } from '@/features/security/types'
 import { useSecurityScan } from '@/features/security'
 import { useChain } from '@/hooks/useChains'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
+import { TxModalContext } from '@/components/tx-flow'
+import { RemoveModuleFlow } from '@/components/tx-flow/flows'
 import SecurityDrawerHeader from './SecurityDrawerHeader'
 import SecurityDrawerContent from './SecurityDrawerContent'
 import type { SelectedSafe, SpaceSafeEntry } from '../../types'
@@ -24,8 +26,19 @@ const SecurityReportDrawer = ({
 }: SecurityReportDrawerProps): ReactElement => {
   const { results, isComplete, lastScannedAt } = useSecurityScan(scanContext)
   const chain = useChain(selectedSafe?.chainId ?? '')
+  const { setTxFlow } = useContext(TxModalContext)
   const scanContextRef = useRef(scanContext)
   scanContextRef.current = scanContext
+
+  // Close the report drawer before launching the remove-module tx flow so the tx modal
+  // isn't fighting the sheet for focus, mirroring the Settings → Modules remove action.
+  const handleRemoveModule = useCallback(
+    (address: string) => {
+      onClose()
+      setTxFlow(<RemoveModuleFlow address={address} />)
+    },
+    [onClose, setTxFlow],
+  )
 
   // Forward scan completion to parent
   useEffect(() => {
@@ -60,6 +73,7 @@ const SecurityReportDrawer = ({
               isComplete={isComplete}
               lastScannedAt={lastScannedAt}
               safeQueryParam={chain?.shortName ? `${chain.shortName}:${selectedSafe.address}` : undefined}
+              onRemoveModule={handleRemoveModule}
             />
           </div>
         )}

--- a/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/tabs/SecurityDrawerChecks.tsx
+++ b/apps/web/src/features/spaces/components/SecurityHub/components/SecurityReportDrawer/tabs/SecurityDrawerChecks.tsx
@@ -18,6 +18,7 @@ type SecurityDrawerChecksProps = {
   lastScannedAt: number | null
   /** The `shortName:address` param used to deep-link a CTA to the correct Safe (e.g., "eth:0x..."). */
   safeQueryParam?: string
+  onRemoveModule?: (address: string) => void
 }
 
 /**
@@ -30,6 +31,7 @@ const SecurityDrawerChecks = ({
   isComplete,
   lastScannedAt,
   safeQueryParam,
+  onRemoveModule,
 }: SecurityDrawerChecksProps): ReactElement => {
   const security = useLoadFeature(SecurityFeature)
   const header = usePanelHeader(results, isComplete)
@@ -68,7 +70,12 @@ const SecurityDrawerChecks = ({
         </Card>
       )}
 
-      <SecurityChecksSection scanContext={scanContext} results={results} safeQueryParam={safeQueryParam} />
+      <SecurityChecksSection
+        scanContext={scanContext}
+        results={results}
+        safeQueryParam={safeQueryParam}
+        onRemoveModule={onRemoveModule}
+      />
     </div>
   )
 }


### PR DESCRIPTION
> Affected Safe scanned,
> Zodiac Delay flares red—
> one click sets it free.

## What it solves

Resolves [WA-2456](https://linear.app/safe-global/issue/WA-2456/flag-unsupported-zodiac-modules-as-critical).

The Security Hub "Modules & extensions" check previously treated Zodiac modules as trusted. Safes affected by the known Zodiac module vulnerability (Delay Module v1.1.0 / Roles v2.1.0, all mastercopies) were not flagged, and there was no direct way to remove the offending module from the report.

## Screenshots
<img width="2962" height="1716" alt="image" src="https://github.com/user-attachments/assets/d11a4986-7f56-4d6d-8890-1c66a8210c53" />


## How this PR fixes it

- The **modules scanner** now calls the existing `isSafeAffectedByZodiacVulnerability` service (the Safe-hosted `zodiac-check.safe.global` proxy in front of Zodiac's `app.zodiac.eco/public/api/security-check`). **No client-side RPC, no hardcoded addresses** — the endpoint does the mastercopy bytecode match (Delay v1.1.0 / Roles v2.1.0) and the nested Safe-as-module/fallback-handler checks server-side. Fails closed.
- When a Safe is **affected**, the modules check returns **Critical** and exposes the offending module addresses via a new `ScanResult.vulnerableModules` field.
- The drawer renders each vulnerable module as a Critical row (distinguished by name/short address) with a **"Remove unsupported module"** CTA that opens the existing `RemoveModuleFlow` via `setTxFlow` (closing the drawer first, mirroring Settings → Modules). For the nested case (affected via a related Safe, no removable module here) it shows a Critical warning + a link to Zodiac's public checker instead.
- The `Cta` primitive gained an `onClick` action variant alongside the existing link variant; installed modules are de-duplicated by address defensively.

The check runs inside the workspace **auto-scan** (only for Safes that have modules, sequentially, cached per Safe) so the table's aggregate grade and the drawer stay consistent.

### Known trade-off

The API reports affected at the **Safe level**, not per module, so on an affected Safe we flag every installed module whose name matches `delay`/`roles`. Surgical per-module precision would require the API to return the offending module address or an on-chain mastercopy check.

## How to test it

Real affected Safes aren't indexed by CGW, so use a local stub:

1. In `apps/web/src/features/security/services/vulnerableModules.ts`, temporarily `return true` for one of your test Safe addresses (revert before merge).
2. Use a Safe with a Zodiac Delay/Roles module installed (e.g. one with Account Recovery configured — recovery installs a Delay Modifier).
3. Open the Security Hub → that Safe's report drawer → the modules check shows **Critical**, the module row reads `Vulnerable module · <name>`, and the **Remove unsupported module** CTA opens the remove-module flow.

Automated coverage: `apps/web/src/features/security/data/scanners/__tests__/modules.test.ts` and `apps/web/src/features/spaces/components/SecurityHub/__tests__/SecurityPanelView.test.tsx`.

## Visual summary

```mermaid
flowchart TD
  A[modules scanner: chainId, safeAddress, modules] --> B{isSafeAffectedByZodiacVulnerability}
  B -->|affected| C[match Delay/Roles modules by name]
  C -->|module found| D[Critical + vulnerableModules + 'Remove unsupported module']
  C -->|none on this Safe| E[Critical warning, no removable module]
  B -->|safe| F[existing trusted/untrusted tiers]
  D --> G[drawer per-module rows]
  E --> G
  G -->|vulnerable| H[CTA -> close drawer -> setTxFlow RemoveModuleFlow]
  G -->|nested| I[warning + link to Zodiac checker]
```



## Checklist

- [x] I've tested the changes (unit/component) and verified they work as expected.
- [x] `verify:changed:web` passes (type-check, lint, prettier, tests).
- [x] I've added/updated tests where applicable.
- [ ] I've added a changelog entry if required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)