### PR TITLE
fix: update token visibility help article

### DIFF
--- a/packages/utils/src/config/constants.ts
+++ b/packages/utils/src/config/constants.ts
@@ -50,7 +50,7 @@ export const HelpCenterArticle = {
   RELAYING: `${HELP_CENTER_URL}/articles/1901481110-what-is-gas-fee-sponsoring`,
   SAFE_SETUP: `${HELP_CENTER_URL}/articles/1038062742-what-safe-setup-should-i-use`,
   SIGNED_MESSAGES: `${HELP_CENTER_URL}/articles/7507962149-what-are-signed-messages`,
-  SPAM_TOKENS: `${HELP_CENTER_URL}/articles/3481782709-40784-default-token-list-local-hiding-of-spam-tokens`,
+  SPAM_TOKENS: `${HELP_CENTER_URL}/articles/8123132082-token-visibility-spam-protection-and-hiding-tokens?lang=en`,
   SPENDING_LIMITS: `${HELP_CENTER_URL}/articles/3961440620-set-up-and-use-spending-limits`,
   TRANSACTION_GUARD: `${HELP_CENTER_URL}/articles/6757075087-what-is-a-transaction-guard`,
   UNEXPECTED_DELEGATE_CALL: `${HELP_CENTER_URL}/articles/4308960633-why-do-i-see-an-unexpected-delegate-call-warning-in-my-transaction`,


### PR DESCRIPTION
> One shared link changes,
> web and mobile stay aligned,
> current guidance opens.

## What it solves

Resolves the outdated Help Center link for token visibility, spam protection, and hiding tokens in both the web and mobile apps.

## How this PR fixes it

Updates the shared `HelpCenterArticle.SPAM_TOKENS` constant to point to the current token visibility article. Existing web and mobile consumers continue using the shared article registry.

## How to test it

1. Open the token management controls in the web or mobile app.
2. Select the link to learn more about default tokens.
3. Confirm that the token visibility, spam protection, and hiding tokens article opens.

This is a constants-only URL update. No automated tests were added because application behavior and logic are unchanged.

## Affected flows

- Web: a user opens Manage tokens and follows the default-token Help Center link.
- Mobile: a user opens Manage tokens and presses "Learn more" about default tokens.

## Blast radius

- Updates the shared `HelpCenterArticle.SPAM_TOKENS` registry entry.
- Known consumers are the web manage-tokens menu and mobile manage-tokens sheet.
- No API contracts, feature flags, chain configuration, persistence, caching, routes, or analytics are affected.

## Risks / not checked

- Did not manually verify the link on a physical mobile device.
- Did not exercise the external Help Center redirect through browser or device E2E tests.
- Token filtering and hiding behavior is unchanged.

## Visual summary

```mermaid
flowchart LR
  A[HelpCenterArticle.SPAM_TOKENS] --> B[Web manage tokens]
  A --> C[Mobile manage tokens]
  B --> D[Current token visibility article]
  C --> D
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
