### PR TITLE
Hotfix 1.89.3: fix Spaces login crash (numeric invitedBy)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,7 +2,7 @@
   "name": "@safe-global/web",
   "homepage": "https://github.com/safe-global/safe-wallet-web",
   "license": "GPL-3.0",
-  "version": "1.89.2",
+  "version": "1.89.3",
   "type": "module",
   "scripts": {
     "dev": "cross-env USE_RSPACK=1 next dev",

--- a/apps/web/src/components/common/EmailInfo/index.test.tsx
+++ b/apps/web/src/components/common/EmailInfo/index.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import EmailInfo from '@/components/common/EmailInfo'
+import { faker } from '@faker-js/faker'
+
+describe('EmailInfo', () => {
+  it.each([
+    ['empty string', ''],
+    ['whitespace only', '   '],
+    ['tabs and newlines', '\t\n '],
+  ])('renders nothing when email is %s', (_, email) => {
+    const { container } = render(<EmailInfo email={email} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the email and avatar when email is non-empty', () => {
+    const email = faker.internet.email()
+    const { getByText } = render(<EmailInfo email={email} />)
+    expect(getByText(email)).toBeInTheDocument()
+  })
+
+  it('renders the email with tooltip on hover when showTooltip is true', async () => {
+    const email = faker.internet.email()
+    const { getByText, findByRole } = render(<EmailInfo email={email} showTooltip />)
+
+    await userEvent.hover(getByText(email))
+
+    const tooltip = await findByRole('tooltip')
+    expect(tooltip).toHaveTextContent(email)
+  })
+})

--- a/apps/web/src/components/common/EmailInfo/index.tsx
+++ b/apps/web/src/components/common/EmailInfo/index.tsx
@@ -1,0 +1,41 @@
+import type { ReactElement } from 'react'
+import { Box, Tooltip } from '@mui/material'
+import InitialsAvatar from '@/features/spaces/components/InitialsAvatar'
+import css from './styles.module.css'
+
+export type EmailInfoProps = {
+  email: string
+  size?: 'xsmall' | 'small' | 'medium' | 'large'
+  rounded?: boolean
+  showTooltip?: boolean
+}
+
+const EmailInfo = ({
+  email,
+  size = 'medium',
+  rounded = true,
+  showTooltip = false,
+}: EmailInfoProps): ReactElement | null => {
+  if (!email || !email.trim()) return null
+
+  const emailNode = (
+    <Box component="span" className={css.email}>
+      {email}
+    </Box>
+  )
+
+  return (
+    <div className={css.container}>
+      <InitialsAvatar name={email} size={size} rounded={rounded} />
+      {showTooltip ? (
+        <Tooltip title={email} placement="top" enterDelay={500}>
+          {emailNode}
+        </Tooltip>
+      ) : (
+        emailNode
+      )}
+    </div>
+  )
+}
+
+export default EmailInfo

--- a/apps/web/src/components/common/EmailInfo/styles.module.css
+++ b/apps/web/src/components/common/EmailInfo/styles.module.css
@@ -1,0 +1,14 @@
+.container {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  line-height: 1.4;
+  min-width: 0;
+}
+
+.email {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}

--- a/apps/web/src/features/spaces/components/InviteBanner/Inviter.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/Inviter.tsx
@@ -1,0 +1,36 @@
+import { Box, Stack, Typography, type TypographyProps } from '@mui/material'
+import { isAddress } from 'ethers'
+import EthHashInfo from '@/components/common/EthHashInfo'
+import EmailInfo from '@/components/common/EmailInfo'
+import css from './styles.module.css'
+
+type InviterProps = {
+  invitedByName: string | undefined
+  variant: TypographyProps['variant']
+  avatarSize: number
+}
+
+const Inviter = ({ invitedByName, variant, avatarSize }: InviterProps) => {
+  if (!invitedByName) return null
+
+  return (
+    <Stack direction="row" alignItems="end" spacing={0.75}>
+      <Typography variant={variant}>by</Typography>
+      <Box className={css.inviterName}>
+        {isAddress(invitedByName) ? (
+          <EthHashInfo
+            address={invitedByName}
+            avatarSize={avatarSize}
+            showName={false}
+            showPrefix={false}
+            copyPrefix={false}
+          />
+        ) : (
+          <EmailInfo email={invitedByName} size="small" />
+        )}
+      </Box>
+    </Stack>
+  )
+}
+
+export default Inviter

--- a/apps/web/src/features/spaces/components/InviteBanner/PreviewInvite.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/PreviewInvite.tsx
@@ -1,5 +1,6 @@
 import { Typography, Paper, Box, Stack } from '@mui/material'
 import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 import InitialsAvatar from '../InitialsAvatar'
 import css from './styles.module.css'
 import { useCurrentSpaceId } from '@/features/spaces'
@@ -10,17 +11,17 @@ import { SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import DeclineButton from './DeclineButton'
-import EthHashInfo from '@/components/common/EthHashInfo'
-import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 import { useDarkMode } from '@/hooks/useDarkMode'
+import Inviter from './Inviter'
+import { getInvitedByName } from '@/features/spaces/utils'
 
 const PreviewInvite = () => {
   const isDarkMode = useDarkMode()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const spaceId = useCurrentSpaceId()
-  const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
   const { currentData: space } = useSpacesGetOneV1Query({ id: Number(spaceId) }, { skip: !isUserSignedIn || !spaceId })
-  const invitedBy = space?.members.find((member) => member.user.id === currentUser?.id)?.invitedBy
+  const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
+  const invitedByName = getInvitedByName(space, currentUser?.id)
 
   if (!space) return null
 
@@ -28,34 +29,15 @@ const PreviewInvite = () => {
     <Paper sx={{ p: 2, mb: 4, backgroundColor: isDarkMode ? 'info.background' : 'info.light' }}>
       <Box className={css.previewInviteContent}>
         <InitialsAvatar name={space.name} size="medium" />
-        <Typography variant="body1" color="text.primary" flexGrow={1}>
-          You were invited to join <strong>{space.name}</strong>
-          {invitedBy && (
-            <>
-              {' '}
-              by
-              <Typography
-                component="span"
-                variant="body1"
-                fontWeight={700}
-                color="primary.main"
-                position="relative"
-                top="4px"
-                ml="6px"
-                display="inline-block"
-                sx={{ '> div': { gap: '4px' } }}
-              >
-                <EthHashInfo
-                  address={invitedBy}
-                  avatarSize={20}
-                  showName={false}
-                  showPrefix={false}
-                  copyPrefix={false}
-                />
-              </Typography>
-            </>
-          )}
-        </Typography>
+        <Stack direction="row" alignItems="center" flexWrap="wrap" rowGap={0.5} columnGap={0.5} flexGrow={1}>
+          <Typography variant="body1" color="text.primary">
+            You were invited to join
+          </Typography>
+          <Typography variant="body1" color="text.primary" fontWeight={700}>
+            {space.name}
+          </Typography>
+          <Inviter invitedByName={invitedByName} variant="body1" avatarSize={20} />
+        </Stack>
         <Stack direction="row" spacing={1}>
           <Track {...SPACE_EVENTS.ACCEPT_INVITE} label={SPACE_LABELS.preview_banner}>
             <AcceptButton space={space} />

--- a/apps/web/src/features/spaces/components/InviteBanner/__tests__/Inviter.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/__tests__/Inviter.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { faker } from '@faker-js/faker'
+import { getAddress } from 'ethers'
+import Inviter from '../Inviter'
+
+const VALID_ADDRESS = getAddress(faker.finance.ethereumAddress())
+const EMAIL = faker.internet.email()
+
+jest.mock('@/components/common/EthHashInfo', () => ({
+  __esModule: true,
+  default: ({ address }: { address: string }) => <div data-testid="eth-hash-info">{address}</div>,
+}))
+
+jest.mock('@/components/common/EmailInfo', () => ({
+  __esModule: true,
+  default: ({ email }: { email: string }) => <div data-testid="email-info">{email}</div>,
+}))
+
+describe('Inviter', () => {
+  it.each([undefined, ''])('renders nothing when invitedByName is %p', (invitedByName) => {
+    const { container } = render(<Inviter invitedByName={invitedByName} variant="h4" avatarSize={24} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders EthHashInfo when invitedByName is an Ethereum address', () => {
+    render(<Inviter invitedByName={VALID_ADDRESS} variant="h4" avatarSize={24} />)
+    expect(screen.getByTestId('eth-hash-info')).toHaveTextContent(VALID_ADDRESS)
+    expect(screen.queryByTestId('email-info')).not.toBeInTheDocument()
+  })
+
+  it('renders EmailInfo when invitedByName is not an Ethereum address', () => {
+    render(<Inviter invitedByName={EMAIL} variant="body1" avatarSize={20} />)
+    expect(screen.getByTestId('email-info')).toHaveTextContent(EMAIL)
+    expect(screen.queryByTestId('eth-hash-info')).not.toBeInTheDocument()
+  })
+
+  it('renders the leading " by" prefix when an inviter is present', () => {
+    render(<Inviter invitedByName={EMAIL} variant="body1" avatarSize={20} />)
+    expect(screen.getByText(/by/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/InviteBanner/__tests__/PreviewInvite.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/__tests__/PreviewInvite.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react'
+import PreviewInvite from '../PreviewInvite'
+import { spaceBuilder, spaceMemberBuilder } from '@/tests/builders/space'
+import { faker } from '@faker-js/faker'
+
+const EMAIL = faker.internet.email()
+const CURRENT_USER_ID = 1
+
+const buildSpaceWithInviter = (invitedByName?: string) =>
+  spaceBuilder()
+    .with({
+      members: [
+        spaceMemberBuilder()
+          .with({ user: { id: CURRENT_USER_ID }, invitedByName })
+          .build(),
+      ],
+    })
+    .build()
+
+const mockUseUsersGetWithWalletsV1Query = jest.fn()
+const mockUseSpacesGetOneV1Query = jest.fn()
+const mockUseCurrentSpaceId = jest.fn()
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('@/services/analytics/events/spaces', () => ({
+  SPACE_EVENTS: {
+    ACCEPT_INVITE: { action: 'accept invite', category: 'spaces' },
+    DECLINE_INVITE: { action: 'decline invite', category: 'spaces' },
+  },
+  SPACE_LABELS: { preview_banner: 'preview_banner' },
+}))
+
+jest.mock('@/store', () => ({
+  useAppSelector: jest.fn(() => true),
+  useAppDispatch: () => jest.fn(),
+}))
+
+jest.mock('@/store/authSlice', () => ({
+  isAuthenticated: jest.fn(),
+}))
+
+jest.mock('@/hooks/useDarkMode', () => ({
+  useDarkMode: () => false,
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
+  useSpacesGetOneV1Query: (...args: unknown[]) => mockUseSpacesGetOneV1Query(...args),
+}))
+
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/users', () => ({
+  useUsersGetWithWalletsV1Query: (...args: unknown[]) => mockUseUsersGetWithWalletsV1Query(...args),
+}))
+
+jest.mock('@/features/spaces', () => ({
+  useCurrentSpaceId: () => mockUseCurrentSpaceId(),
+}))
+
+jest.mock('../Inviter', () => ({
+  __esModule: true,
+  default: ({ invitedByName }: { invitedByName: string | undefined }) =>
+    invitedByName ? <div data-testid="inviter">{invitedByName}</div> : null,
+}))
+
+jest.mock('../AcceptButton', () => ({
+  __esModule: true,
+  default: () => <button data-testid="accept-button">Accept</button>,
+}))
+
+jest.mock('../DeclineButton', () => ({
+  __esModule: true,
+  default: () => <button data-testid="decline-button">Decline</button>,
+}))
+
+jest.mock('@/features/spaces/components/InitialsAvatar', () => ({
+  __esModule: true,
+  default: ({ name }: { name: string }) => <div data-testid="initials-avatar" data-name={name} />,
+}))
+
+jest.mock('@/components/common/Track', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+describe('PreviewInvite', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseCurrentSpaceId.mockReturnValue('42')
+    mockUseSpacesGetOneV1Query.mockReturnValue({ currentData: spaceBuilder().build() })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: CURRENT_USER_ID } })
+  })
+
+  it('renders nothing when there is no space loaded', () => {
+    mockUseSpacesGetOneV1Query.mockReturnValue({ currentData: undefined })
+    const { container } = render(<PreviewInvite />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the space name as the invitation target', () => {
+    const space = spaceBuilder().with({ name: 'Test Space' }).build()
+    mockUseSpacesGetOneV1Query.mockReturnValue({ currentData: space })
+    render(<PreviewInvite />)
+    expect(screen.getByText('Test Space')).toBeInTheDocument()
+  })
+
+  it('passes the resolved inviter name through to the Inviter component', () => {
+    mockUseSpacesGetOneV1Query.mockReturnValue({ currentData: buildSpaceWithInviter(EMAIL) })
+    render(<PreviewInvite />)
+    expect(screen.getByTestId('inviter')).toHaveTextContent(EMAIL)
+  })
+
+  it('renders no inviter element when the member has no inviter name', () => {
+    mockUseSpacesGetOneV1Query.mockReturnValue({ currentData: buildSpaceWithInviter(undefined) })
+    render(<PreviewInvite />)
+    expect(screen.queryByTestId('inviter')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/InviteBanner/__tests__/SpaceListInvite.test.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/__tests__/SpaceListInvite.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import SpaceListInvite from '../index'
+import { spaceBuilder } from '@/tests/builders/space'
+import { faker } from '@faker-js/faker'
+
+const EMAIL = faker.internet.email()
+
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+}))
+
+jest.mock('@/services/analytics/events/spaces', () => ({
+  SPACE_EVENTS: {
+    VIEW_INVITING_SPACE: { action: 'view inviting space', category: 'spaces' },
+    ACCEPT_INVITE: { action: 'accept invite', category: 'spaces' },
+    DECLINE_INVITE: { action: 'decline invite', category: 'spaces' },
+  },
+  SPACE_LABELS: { space_list_page: 'space_list_page' },
+}))
+
+jest.mock('../Inviter', () => ({
+  __esModule: true,
+  default: ({ invitedByName }: { invitedByName: string | undefined }) =>
+    invitedByName ? <div data-testid="inviter">{invitedByName}</div> : null,
+}))
+
+jest.mock('../AcceptButton', () => ({
+  __esModule: true,
+  default: () => <button data-testid="accept-button">Accept</button>,
+}))
+
+jest.mock('../DeclineButton', () => ({
+  __esModule: true,
+  default: () => <button data-testid="decline-button">Decline</button>,
+}))
+
+jest.mock('@/features/spaces/components/InitialsAvatar', () => ({
+  __esModule: true,
+  default: ({ name }: { name: string }) => <div data-testid="initials-avatar" data-name={name} />,
+}))
+
+jest.mock('@/components/common/Track', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@/features/spaces', () => ({
+  MemberStatus: { INVITED: 'INVITED', ACTIVE: 'ACTIVE', DECLINED: 'DECLINED' },
+}))
+
+jest.mock('../../SpaceCard', () => ({
+  SpaceSummary: () => <div data-testid="space-summary" />,
+}))
+
+describe('SpaceListInvite', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the space name as the invitation target', () => {
+    const space = spaceBuilder().with({ name: 'Test Space' }).build()
+    render(<SpaceListInvite space={space} invitedByName={undefined} />)
+    expect(screen.getByText('Test Space')).toBeInTheDocument()
+  })
+
+  it('passes the inviter name through to the Inviter component', () => {
+    render(<SpaceListInvite space={spaceBuilder().build()} invitedByName={EMAIL} />)
+    expect(screen.getByTestId('inviter')).toHaveTextContent(EMAIL)
+  })
+
+  it('renders no inviter element when invitedByName is undefined', () => {
+    render(<SpaceListInvite space={spaceBuilder().build()} invitedByName={undefined} />)
+    expect(screen.queryByTestId('inviter')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/InviteBanner/index.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/index.tsx
@@ -6,55 +6,33 @@ import InitialsAvatar from '../InitialsAvatar'
 import Link from 'next/link'
 import { AppRoutes } from '@/config/routes'
 import css from './styles.module.css'
-import EthHashInfo from '@/components/common/EthHashInfo'
-import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
 import { SPACE_EVENTS, SPACE_LABELS } from '@/services/analytics/events/spaces'
 import Track from '@/components/common/Track'
 import AcceptButton from './AcceptButton'
 import DeclineButton from './DeclineButton'
 import { trackEvent } from '@/services/analytics'
-import { useAppSelector } from '@/store'
-import { isAuthenticated } from '@/store/authSlice'
+import Inviter from './Inviter'
 
 type SpaceListInvite = {
   space: GetSpaceResponse
+  invitedByName: string | undefined
 }
 
-const SpaceListInvite = ({ space }: SpaceListInvite) => {
+const SpaceListInvite = ({ space, invitedByName }: SpaceListInvite) => {
   const { id, name, members, safeCount } = space
-  const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
   const numberOfMembers = members.filter((member) => member.status === MemberStatus.ACTIVE).length
-
-  const invitedBy = space.members.find((member) => member.user.id === currentUser?.id)?.invitedBy
 
   return (
     <Card sx={{ p: 2, mb: 2 }}>
-      <Typography variant="h4" fontWeight={700} mb={2} color="primary.light">
-        You were invited to join{' '}
-        <Typography component="span" variant="h4" fontWeight={700} color="primary.main">
+      <Stack direction="row" alignItems="center" flexWrap="wrap" rowGap={0.5} columnGap={0.5} mb={2}>
+        <Typography variant="h4" fontWeight={700} color="primary.light">
+          You were invited to join
+        </Typography>
+        <Typography variant="h4" fontWeight={700} color="primary.main">
           {name}
         </Typography>
-        {invitedBy && (
-          <>
-            {' '}
-            by
-            <Typography
-              component="span"
-              variant="h4"
-              fontWeight={700}
-              color="primary.main"
-              position="relative"
-              top="4px"
-              ml="6px"
-              display="inline-block"
-              sx={{ '> div': { gap: '4px' } }}
-            >
-              <EthHashInfo address={invitedBy} avatarSize={24} showName={false} showPrefix={false} copyPrefix={false} />
-            </Typography>
-          </>
-        )}
-      </Typography>
+        <Inviter invitedByName={invitedByName} variant="h4" avatarSize={24} />
+      </Stack>
 
       <Link href={{ pathname: AppRoutes.spaces.index, query: { spaceId: id } }} passHref legacyBehavior>
         <MUILink

--- a/apps/web/src/features/spaces/components/InviteBanner/styles.module.css
+++ b/apps/web/src/features/spaces/components/InviteBanner/styles.module.css
@@ -22,6 +22,14 @@
   min-height: 32px;
 }
 
+.inviterName {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--color-primary-main);
+  font-weight: 700;
+}
+
 @media (max-width: 600px) {
   .previewInviteContent {
     flex-direction: column;

--- a/apps/web/src/features/spaces/components/SpaceCardNew/SpaceCardNew.stories.tsx
+++ b/apps/web/src/features/spaces/components/SpaceCardNew/SpaceCardNew.stories.tsx
@@ -23,21 +23,21 @@ const mockSpace: GetSpaceResponse = {
   members: [
     {
       name: 'Admin User',
-      invitedBy: 'system',
+      invitedBy: null,
       user: { id: 1 },
       role: MemberRole.ADMIN,
       status: MemberStatus.ACTIVE,
     },
     {
       name: 'Member One',
-      invitedBy: 'admin@example.com',
+      invitedBy: 1,
       user: { id: 2 },
       role: MemberRole.MEMBER,
       status: MemberStatus.ACTIVE,
     },
     {
       name: 'Member Two',
-      invitedBy: 'admin@example.com',
+      invitedBy: 1,
       user: { id: 3 },
       role: MemberRole.MEMBER,
       status: MemberStatus.ACTIVE,

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -17,7 +17,7 @@ import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
 import { trackEvent } from '@/services/analytics'
 import { WorkspaceCreateEntryPoint } from '@/services/analytics/mixpanel-events'
 import SpaceInfoModal from '../SpaceInfoModal'
-import { filterSpacesByStatus } from '@/features/spaces/utils'
+import { filterSpacesByStatus, getInvitedByName } from '@/features/spaces/utils'
 import { AppRoutes } from '@/config/routes'
 import NextLink from 'next/link'
 import { useSignInRedirect } from '@/components/welcome/WelcomeLogin/hooks/useSignInRedirect'
@@ -144,7 +144,11 @@ const SpacesList = () => {
         {isUserSignedIn &&
           pendingInvites.length > 0 &&
           pendingInvites.map((invitingSpace: GetSpaceResponse) => (
-            <SpaceListInvite key={invitingSpace.id} space={invitingSpace} />
+            <SpaceListInvite
+              key={invitingSpace.id}
+              space={invitingSpace}
+              invitedByName={getInvitedByName(invitingSpace, currentUser?.id)}
+            />
           ))}
 
         {isUserSignedIn || (!redirectLoading && pendingInvites.length) ? (

--- a/apps/web/src/features/spaces/utils.test.ts
+++ b/apps/web/src/features/spaces/utils.test.ts
@@ -1,0 +1,39 @@
+import { faker } from '@faker-js/faker'
+import { getInvitedByName } from './utils'
+import { spaceBuilder, spaceMemberBuilder } from '@/tests/builders/space'
+
+const CURRENT_USER_ID = 1
+
+const buildSpaceWithMember = (invitedByName?: string) =>
+  spaceBuilder()
+    .with({
+      members: [
+        spaceMemberBuilder()
+          .with({ user: { id: CURRENT_USER_ID }, invitedByName })
+          .build(),
+      ],
+    })
+    .build()
+
+describe('getInvitedByName', () => {
+  it('returns undefined when no space is provided', () => {
+    expect(getInvitedByName(undefined, CURRENT_USER_ID)).toBeUndefined()
+  })
+
+  it('returns invitedByName for the matching member', () => {
+    const email = faker.internet.email()
+    expect(getInvitedByName(buildSpaceWithMember(email), CURRENT_USER_ID)).toBe(email)
+  })
+
+  it('returns undefined when the current user is not a member', () => {
+    expect(getInvitedByName(buildSpaceWithMember(faker.internet.email()), 999)).toBeUndefined()
+  })
+
+  it('returns undefined when there is no current user id', () => {
+    expect(getInvitedByName(buildSpaceWithMember(faker.internet.email()), undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when the member has no inviter name', () => {
+    expect(getInvitedByName(buildSpaceWithMember(undefined), CURRENT_USER_ID)).toBeUndefined()
+  })
+})

--- a/apps/web/src/features/spaces/utils.ts
+++ b/apps/web/src/features/spaces/utils.ts
@@ -24,6 +24,11 @@ export const filterSpacesByStatus = (
   })
 }
 
+export const getInvitedByName = (
+  space: GetSpaceResponse | undefined,
+  currentUserId: number | undefined,
+): string | undefined => space?.members.find((member) => member.user.id === currentUserId)?.invitedByName
+
 export const getNonDeclinedSpaces = (currentUser: UserWithWallets | undefined, spaces: GetSpaceResponse[]) => {
   const pendingInvites = filterSpacesByStatus(currentUser, spaces || [], MemberStatus.INVITED)
   const activeSpaces = filterSpacesByStatus(currentUser, spaces || [], MemberStatus.ACTIVE)

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -48,7 +48,8 @@ const mapPrivateToContacts = (addressBook: SpaceAddressBookItemDto[]): ExtendedC
   }))
 }
 
-const addressBookKey = (address: string, chainId: string) => `${chainId}:${address.toLowerCase()}`
+const addressBookKey = (address: string, chainId: string) =>
+  `${chainId}:${typeof address === 'string' ? address.toLowerCase() : address}`
 
 export type MergedAddressBook = {
   list: ExtendedContact[]

--- a/apps/web/src/tests/builders/space.ts
+++ b/apps/web/src/tests/builders/space.ts
@@ -1,0 +1,29 @@
+import type { GetSpaceResponse, SpaceMemberDto, UserDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+import { Builder, type IBuilder } from '../Builder'
+import { faker } from '@faker-js/faker'
+
+export function spaceMemberUserBuilder(): IBuilder<UserDto> {
+  return Builder.new<UserDto>().with({
+    id: 1,
+  })
+}
+
+export function spaceMemberBuilder(): IBuilder<SpaceMemberDto> {
+  return Builder.new<SpaceMemberDto>().with({
+    role: 'MEMBER',
+    name: faker.person.firstName(),
+    invitedBy: faker.number.int({ min: 1, max: 10 }),
+    status: 'ACTIVE',
+    user: spaceMemberUserBuilder().build(),
+  })
+}
+
+export function spaceBuilder(): IBuilder<GetSpaceResponse> {
+  return Builder.new<GetSpaceResponse>().with({
+    id: 42,
+    name: faker.company.name(),
+    safeCount: 0,
+    members: [spaceMemberBuilder().build()],
+  })
+}

--- a/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
+++ b/packages/store/src/gateway/AUTO_GENERATED/spaces.ts
@@ -452,7 +452,8 @@ export type UserDto = {
 export type SpaceMemberDto = {
   role: 'ADMIN' | 'MEMBER'
   name: string
-  invitedBy: string
+  invitedBy: number | null
+  invitedByName?: string
   status: 'INVITED' | 'ACTIVE' | 'DECLINED'
   user: UserDto
 }
@@ -491,7 +492,7 @@ export type Invitation = {
   spaceId: number
   role: 'ADMIN' | 'MEMBER'
   status: 'INVITED' | 'ACTIVE' | 'DECLINED'
-  invitedBy?: string | null
+  invitedBy: number | null
 }
 export type InviteUserDto = {
   address: string
@@ -515,7 +516,7 @@ export type MemberDto = {
   status: 'INVITED' | 'ACTIVE' | 'DECLINED'
   name: string
   alias?: string | null
-  invitedBy?: string | null
+  invitedBy: number | null
   createdAt: string
   updatedAt: string
   user: MemberUser


### PR DESCRIPTION
> Numeric userId crashed the login,
> `toLowerCase` choking on an int —
> read invitedByName, guard the render,
> address or email, the banner survives.

> [!IMPORTANT]
> **Hotfix release `1.89.3`.** Targets `main` and bumps `apps/web` from `1.89.2` → `1.89.3`. Merging triggers the tag/release pipeline. The fix is a scoped extraction of the invite-render change from #7970 (already on `dev`).

## What it solves

resolves: https://app.datadoghq.eu/error-tracking/issue/5d0d0614-60a5-11f1-b277-da7ad0900005

Resolves the Spaces login crash on `/welcome/spaces`: `TypeError: e.toLowerCase is not a function`.

CGW PR #3059 (shipped in CGW v1.112.0) changed the space member contract:

- `invitedBy`: was a wallet-address/email **string** → now a numeric **userId** (`number | null`)
- `invitedByName`: **new** string carrying the displayable address/email

The production web release still rendered the inviter with the old code:

```tsx
const invitedBy = space.members.find(...)?.invitedBy   // now a number at runtime
{invitedBy && <EthHashInfo address={invitedBy} … />}   // number passed as `address`
```

`EthHashInfo → useAddressBookItem(invitedBy) → addressBookKey → \`${chainId}:${invitedBy.toLowerCase()}\`` → 💥 `number.toLowerCase is not a function`. Datadog shows ~10 events / ~3 sessions, June 5–8 (handled by the error boundary).

## How this PR fixes it

Routes the invite banners through a new guarded `Inviter` component that reads the new `invitedByName` string and renders `EthHashInfo` for addresses or a new `EmailInfo` component for emails:

```tsx
{isAddress(invitedByName) ? <EthHashInfo address={invitedByName} … /> : <EmailInfo email={invitedByName} … />}
```

`getInvitedByName(space, currentUserId)` extracts the field; the generated `SpaceMemberDto` type is updated to the new contract (`invitedBy: number | null`, `invitedByName?: string`). As defense-in-depth against the next contract desync, `addressBookKey` (behind every `EthHashInfo` in the app) now guards against non-string input.

This is the invite-only subset of **#7970** (`a9b88ff7f`, "feat: Authentication (part of M2)"), which already fully resolves the crash on `dev` but is not on `main`. The auth/OIDC/sidebar remainder of that commit is intentionally excluded.

## How to test it

1. Be a member who was invited to a Space (so `invitedByName` is populated).
2. Open `/welcome/spaces` — the page renders without crashing.
3. The invite banner shows "You were invited to join **\<space\>** by \<inviter\>", where the inviter is an address chip (if `invitedByName` is an address) or an email chip (if it's an email).
4. `yarn workspace @safe-global/web test apps/web/src/features/spaces` — 22 tests pass.

## Affected flows

- Space invite banner on the Spaces list (`SpaceListInvite`)
- Space invite preview banner (`PreviewInvite`) on `/welcome/spaces`
- Inviter display inside the Spaces list invites grid (`SpacesList`)

## Blast radius

- **`packages/store` generated type `SpaceMemberDto`** (+ `Invitation`, `MemberDto`): `invitedBy` retyped `number | null`, `invitedByName?: string` added. Consumers: only the spaces invite render path reads these; `SpaceCardNew.stories.tsx` mock data updated to match.
- **`addressBookKey` in `useAllAddressBooks`**: shared by every `EthHashInfo`/address-book lookup. Change is a non-breaking guard (string path unchanged); hardening only.
- **New `EmailInfo` component** (`@/components/common/EmailInfo`): new, no existing consumers besides `Inviter`.
- No RTK Query endpoint, feature-flag, route, or persistence changes.

## Risks / not checked

- **`store-codegen-check` will fail red** and is expected to be overridden at merge. It regenerates from the **staging** CGW schema, which is ahead of production with unreleased contracts (a `membersRenewInviteV1` endpoint, `inviteExpiresAt`, and a breaking `InviteUserDto` → `WalletInviteUserDto | EmailInviteUserDto` union split). Regenerating to satisfy the check would bake unreleased staging contracts into this production hotfix and force a risky change to `AddMemberModal`'s invite payload. The minimal hand-edit here matches what **production** CGW (v1.112.0) actually serves.
- Not tested on mobile (web-only Spaces view).
- Did not manually exercise the email-inviter branch against a live backend (covered by unit tests with email fixtures).
- Analytics unchanged.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before (crash)"]
    A1[space.members.invitedBy<br/>= number at runtime] --> B1[EthHashInfo address=number]
    B1 --> C1[addressBookKey]
    C1 --> D1["number.toLowerCase()"]
    D1 --> E1["💥 TypeError"]
  end
  subgraph After["After (guarded)"]
    A2[getInvitedByName → invitedByName string] --> B2[Inviter]
    B2 --> C2{isAddress?}
    C2 -->|yes| D2[EthHashInfo]
    C2 -->|no| E2[EmailInfo]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only Spaces view)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics change)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
