### PR TITLE
feat(spaces): add Introducing Workspace announcement banner on login

### DIFF
--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -2,6 +2,7 @@ import { useLoadFeature } from '@/features/__core__'
 import { MyAccountsFeature } from '@/features/myAccounts'
 import SpaceCard from 'src/features/spaces/components/SpaceCard'
 import SignInOptions from '../SignInOptions'
+import WorkspaceBanner from '../WorkspaceBanner'
 import LocalSafesAlert from './LocalSafesAlert'
 import { useIsRequireLoginEnabled } from '@/hooks/useIsRequireLoginEnabled'
 import { useIsClassicViewFeatureEnabled } from '@/hooks/useClassicView'
@@ -84,20 +85,29 @@ const SignedOutState = ({
         )}
       >
         <div className="flex w-full max-w-[440px] flex-col items-center">
-          <div className="relative w-full rounded-lg bg-card p-8 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_8px_24px_rgba(0,0,0,0.06)]">
-            <div className="mx-auto mb-6 flex size-10 items-center justify-center text-foreground">
-              <SafeMarkIcon className="size-10" />
+          {/* Inline (classic view) keeps the banner in normal flow above the card.
+              The full-screen takeover floats it absolutely so the login card stays
+              vertically centered in the viewport. */}
+          {inline && <WorkspaceBanner className="mb-3" />}
+
+          <div className="relative w-full">
+            {!inline && <WorkspaceBanner className="absolute inset-x-0 bottom-full mb-3" />}
+
+            <div className="relative w-full rounded-lg bg-card p-8 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_8px_24px_rgba(0,0,0,0.06)]">
+              <div className="mx-auto mb-6 flex size-10 items-center justify-center text-foreground">
+                <SafeMarkIcon className="size-10" />
+              </div>
+
+              <ShadcnTypography variant="h3" className="mb-6 text-center">
+                Sign in to your workspace
+              </ShadcnTypography>
+
+              <LocalSafesAlert />
+
+              <SignInOptions afterSignIn={afterSignIn} redirectLoading={redirectLoading} />
+
+              {isClassicViewFeatureEnabled && <ClassicViewLink />}
             </div>
-
-            <ShadcnTypography variant="h3" className="mb-6 text-center">
-              Sign in to your workspace
-            </ShadcnTypography>
-
-            <LocalSafesAlert />
-
-            <SignInOptions afterSignIn={afterSignIn} redirectLoading={redirectLoading} />
-
-            {isClassicViewFeatureEnabled && <ClassicViewLink />}
           </div>
 
           <p className="mt-4 text-center text-xs leading-[18px] text-muted-foreground">

--- a/apps/web/src/features/spaces/components/WorkspaceBanner/__tests__/index.test.tsx
+++ b/apps/web/src/features/spaces/components/WorkspaceBanner/__tests__/index.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@/tests/test-utils'
+import WorkspaceBanner from '../index'
+
+describe('WorkspaceBanner', () => {
+  it('renders the headline and the New tag', () => {
+    render(<WorkspaceBanner />)
+
+    expect(screen.getByText('Introducing Workspace')).toBeInTheDocument()
+    expect(screen.getByText('New')).toBeInTheDocument()
+  })
+
+  it('links the CTA to the announcement blog post in a safe new tab', () => {
+    render(<WorkspaceBanner />)
+
+    const cta = screen.getByRole('link', { name: 'Read the Workspace announcement' })
+    expect(cta).toHaveAttribute('href', 'https://safe.global/blog/mpc-wallet-vs-multisig-what-s-the-difference-')
+    expect(cta).toHaveAttribute('target', '_blank')
+    expect(cta).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('forwards a custom className to the card', () => {
+    const { container } = render(<WorkspaceBanner className="custom-class" />)
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/WorkspaceBanner/index.tsx
+++ b/apps/web/src/features/spaces/components/WorkspaceBanner/index.tsx
@@ -1,0 +1,51 @@
+import { ArrowUpRight, Sparkles } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { cn } from '@/utils/cn'
+import css from './styles.module.css'
+
+const ANNOUNCEMENT_URL = 'https://safe.global/blog/mpc-wallet-vs-multisig-what-s-the-difference-'
+
+const WorkspaceBanner = ({ className }: { className?: string }) => {
+  return (
+    <Card
+      size="sm"
+      className={cn(
+        'w-full gap-0 rounded-lg border border-border bg-card px-4 py-3 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_4px_12px_rgba(0,0,0,0.05)]',
+        css.banner,
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+          <Badge className="relative">
+            <span className={css.shimmer} aria-hidden="true" />
+            <Sparkles className="size-3" />
+            New
+          </Badge>
+          <span className="text-sm font-semibold tracking-[-0.01em] text-foreground">Introducing Workspace</span>
+        </div>
+
+        <Button
+          variant="link"
+          size="sm"
+          className="group h-auto shrink-0 gap-1 px-0 text-xs font-medium"
+          render={
+            <a
+              href={ANNOUNCEMENT_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Read the Workspace announcement"
+            />
+          }
+        >
+          Read announcement
+          <ArrowUpRight className="size-3.5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+        </Button>
+      </div>
+    </Card>
+  )
+}
+
+export default WorkspaceBanner

--- a/apps/web/src/features/spaces/components/WorkspaceBanner/styles.module.css
+++ b/apps/web/src/features/spaces/components/WorkspaceBanner/styles.module.css
@@ -1,0 +1,46 @@
+/* Subtle Safe-mint wash layered over the card. Uses the static brand token
+   (#12ff80, identical in light/dark) at low alpha so it reads as a light-green
+   tint on white and a dark-green tint on the dark card — foreground text stays
+   readable in both. */
+.banner {
+  background-image: linear-gradient(
+    100deg,
+    color-mix(in srgb, var(--color-static-text-brand) 16%, transparent) 0%,
+    color-mix(in srgb, var(--color-static-text-brand) 5%, transparent) 38%,
+    transparent 70%
+  );
+  border-color: color-mix(in srgb, var(--color-static-text-brand) 35%, var(--border));
+}
+
+/* Sweeping highlight across the "New" tag. Scoped to this module so the
+   keyframe name is namespaced and can't leak into the global stylesheet. */
+.shimmer {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    110deg,
+    transparent 25%,
+    color-mix(in srgb, #ffffff 60%, transparent) 50%,
+    transparent 75%
+  );
+  transform: translateX(-120%);
+  animation: shimmer 2.8s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-120%);
+  }
+  55%,
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shimmer {
+    animation: none;
+    display: none;
+  }
+}


### PR DESCRIPTION
> Mint-washed card up top,
> "New" tag shimmers above the gate—
> sign in, bring your team.

## What it solves

When the workspace login gate is turned on, signed-out users hit a full-screen "Sign in to your workspace" takeover with no context for why login suddenly appeared. This adds a compact announcement banner above the login card to introduce Workspaces and link to the announcement, softening the change.

## How this PR fixes it

Adds a new `WorkspaceBanner` (shadcn-only: `Card` + `Badge` + `Button`, lucide icons) and renders it above the signed-out login card in `SpacesList`'s `SignedOutState`.

- **Login panel stays centered.** In the full-screen takeover the banner is absolutely positioned above the card wrapper (`absolute bottom-full`), so it's removed from flow and the card keeps its exact vertical center. In the inline classic-view variant it renders in normal flow (`mb-3`) above the card to avoid overlapping the Accounts/Workspaces tabs.
- **Sleek, compact, single row:** `[✦ New] Introducing Workspace … Read announcement ↗`.
- **Shimmering "New" tag** — a gradient sweep that is disabled under `prefers-reduced-motion`.
- **Subtle Safe-mint wash + tinted border** built from the static brand token (`#12ff80`), layered over `bg-card` at low alpha so it reads as a light-green tint on white and a dark-green tint on the dark card. Light and dark both covered (the subtree is already wrapped in `.shadcn-scope`/`.dark`).
- **CTA** opens the announcement blog post in a new, `rel="noopener noreferrer"` tab.

## How to test it

1. Enable the require-login gate (`REQUIRE_LOGIN` feature) so `/welcome/spaces` shows the full-screen login takeover while signed out.
2. Visit `/welcome/spaces` signed out → the banner appears above the centered "Sign in to your workspace" card; the card stays centered.
3. Toggle dark mode → wash + text remain readable.
4. Enable "reduce motion" in the OS → the New-tag shimmer stops.
5. Click "Read announcement" → opens the blog post in a new tab.
6. Classic-view (gate off) inline variant → banner renders in flow above the inline login card, no overlap with the tabs.

## Affected flows

- Signed-out workspace login on `/welcome/spaces` (full-screen takeover, require-login ON)
- Signed-out inline login on `/welcome/spaces` (classic view, require-login OFF)

## Blast radius

- **New component** `features/spaces/components/WorkspaceBanner` — presentational, no shared-state consumers.
- **Edited** `features/spaces/components/SpacesList/index.tsx` → only the `SignedOutState` render tree (markup wrapping around the existing login card). No logic, hooks, selectors, or data flow changed.
- Uses existing shadcn primitives (`Card`, `Badge`, `Button`) and the existing `--color-static-text-brand` token — no new tokens, no `vars.css` regeneration.
- No RTK Query / API / feature-flag / route / persistence changes. No shared-package (mobile) impact.

## Risks / not checked

- Not tested on mobile (web-only surface; component is web shadcn).
- No analytics added on the CTA click (kept as a plain external link to avoid inventing an event key).
- The CTA URL is the MPC-vs-multisig blog post supplied during implementation and has a trailing `-` — likely a placeholder; swap `ANNOUNCEMENT_URL` when the real "Introducing Workspace" post is live.
- Very short viewports in full-screen mode: an absolutely-positioned banner could theoretically clip above the card top — accepted given the small login card and surrounding padding.


Rendered banner (single row, mint wash, shimmering New tag):
`[✦ New] Introducing Workspace ……………… Read announcement ↗`

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-only shadcn surface)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics added)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
