### PR TITLE
feat: multichain Safe creation is counterfactual with Pay now disabled

### DIFF
--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
@@ -165,7 +165,7 @@ describe('ReviewStep', () => {
     expect(getByText(/Who will pay gas fees:/)).toBeInTheDocument()
   })
 
-  it('should display the execution method for counterfactual safes if the user selects pay now and there is relaying', async () => {
+  it('should not display the pay now/pay later block for multichain creation', () => {
     const mockMultiChain = [
       {
         chainId: '100',
@@ -195,10 +195,12 @@ describe('ReviewStep', () => {
     jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
     jest.spyOn(relay, 'hasRemainingRelays').mockReturnValue(true)
 
-    const { getByText } = render(
+    const { queryByTestId, queryByText } = render(
       <ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />,
     )
 
-    expect(getByText(/activate your account/)).toBeInTheDocument()
+    expect(queryByTestId('pay-now-later-message-box')).not.toBeInTheDocument()
+    expect(queryByText('Pay now')).not.toBeInTheDocument()
+    expect(queryByText(/Pay later/)).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
@@ -171,59 +171,60 @@ describe('ReviewStep', () => {
     expect(getByText(/Who will pay gas fees:/)).toBeInTheDocument()
   })
 
-  it('should not display the pay now/pay later block for multichain creation', () => {
-    const mockMultiChain = [
-      {
-        chainId: '100',
-        chainName: 'Gnosis Chain',
-        l2: false,
-        nativeCurrency: {
-          symbol: 'ETH',
-        },
-      },
-      {
-        chainId: '1',
-        chainName: 'Ethereum',
-        l2: false,
-        nativeCurrency: {
-          symbol: 'ETH',
-        },
-      },
-    ] as Chain[]
-    const mockData: NewSafeFormData = {
+  const authReduxState = {
+    auth: {
+      sessionExpiresAt: Date.now() + 60000,
+      lastUsedSpace: null,
+      isStoreHydrated: true,
+      cfSafeSynced: false,
+      isOidcLoginPending: false,
+    },
+  }
+
+  const buildMultiChainData = (): NewSafeFormData => {
+    const chainWithFeatures = { ...mockChain, features: [] } as Chain
+    return {
       name: 'Test',
-      networks: mockMultiChain,
+      networks: [chainWithFeatures, { ...chainWithFeatures, chainId: '1', chainName: 'Ethereum' } as Chain],
       threshold: 1,
       owners: [{ name: '', address: '0x1' }],
       saltNonce: 0,
       safeVersion: LATEST_SAFE_VERSION as SafeVersion,
     }
-    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
-    jest.spyOn(relay, 'hasRemainingRelays').mockReturnValue(true)
+  }
 
-    const { queryByTestId, queryByText } = render(
-      <ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />,
+  it('shows the selector with Pay now disabled for multichain creation', () => {
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+
+    const { getByTestId, getByText } = render(
+      <ReviewStep data={buildMultiChainData()} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />,
+      { initialReduxState: authReduxState },
     )
 
-    expect(queryByTestId('pay-now-later-message-box')).not.toBeInTheDocument()
-    expect(queryByText('Pay now')).not.toBeInTheDocument()
-    expect(queryByText(/Pay later/)).not.toBeInTheDocument()
+    expect(getByTestId('pay-now-later-message-box')).toBeInTheDocument()
+    expect(getByText(/activate your account/)).toBeInTheDocument()
+    expect(getByText(/Start exploring the accounts now/)).toBeInTheDocument()
+    expect(getByText('Not available for multiple networks')).toBeInTheDocument()
+    expect(getByTestId('pay-now-execution-method').querySelector('input')).toBeDisabled()
+    expect(screen.getByRole('radio', { name: /Pay later/i })).toBeChecked()
   })
 
-  it('creates counterfactual safes for multichain even when the user is not authenticated', async () => {
-    const chainWithFeatures = { ...mockChain, features: [] } as Chain
-    const mockMultiChain = [chainWithFeatures, { ...chainWithFeatures, chainId: '1', chainName: 'Ethereum' } as Chain]
-    const mockData: NewSafeFormData = {
-      name: 'Test',
-      networks: mockMultiChain,
-      threshold: 1,
-      owners: [{ name: '', address: '0x1' }],
-      saltNonce: 0,
-      safeVersion: LATEST_SAFE_VERSION as SafeVersion,
-    }
+  it('disables creation for multichain until the user signs in (Pay later writes to the backend)', () => {
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+
+    // No auth state provided -> the user is not authenticated.
+    const { getByTestId } = render(
+      <ReviewStep data={buildMultiChainData()} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />,
+    )
+
+    expect(getByTestId('review-step-next-btn')).toBeDisabled()
+  })
+
+  it('creates counterfactual safes on each network for multichain when authenticated', async () => {
+    const mockData = buildMultiChainData()
 
     jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
-    jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainWithFeatures)
+    jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(mockData.networks[0])
     jest.spyOn(useWallet, 'default').mockReturnValue({ provider: {} } as unknown as ConnectedWallet)
     jest
       .spyOn(createLogic, 'createNewUndeployedSafeWithoutSalt')
@@ -234,16 +235,17 @@ describe('ReviewStep', () => {
       .mockResolvedValue('0x0000000000000000000000000000000000000001')
     const persistSpy = jest.spyOn(cfServices, 'persistCounterfactualSafe').mockResolvedValue({ ok: true })
 
-    // No auth state provided -> the user is not authenticated.
-    render(<ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />)
+    render(<ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />, {
+      initialReduxState: authReduxState,
+    })
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('review-step-next-btn'))
     })
 
-    expect(persistSpy).toHaveBeenCalledTimes(mockMultiChain.length)
+    expect(persistSpy).toHaveBeenCalledTimes(mockData.networks.length)
     expect(persistSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ payMethod: PayMethod.PayLater, isUserAuthenticated: false }),
+      expect.objectContaining({ payMethod: PayMethod.PayLater, isUserAuthenticated: true }),
     )
   })
 })

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
@@ -220,6 +220,17 @@ describe('ReviewStep', () => {
     expect(getByTestId('review-step-next-btn')).toBeDisabled()
   })
 
+  it('does not block multichain creation when counterfactual is disabled', () => {
+    // Counterfactual off -> no PayLater forcing, no sign-in gate (direct deployment path).
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(false)
+
+    const { getByTestId } = render(
+      <ReviewStep data={buildMultiChainData()} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />,
+    )
+
+    expect(getByTestId('review-step-next-btn')).not.toBeDisabled()
+  })
+
   it('creates counterfactual safes on each network for multichain when authenticated', async () => {
     const mockData = buildMultiChainData()
 

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
@@ -10,6 +10,12 @@ import { type ConnectedWallet } from '@/hooks/wallets/useOnboard'
 import { act, fireEvent, screen } from '@testing-library/react'
 import { LATEST_SAFE_VERSION } from '@safe-global/utils/config/constants'
 import { type SafeVersion } from '@safe-global/types-kit'
+import * as cfServices from '@/features/counterfactual/services'
+import * as multichain from '@/features/multichain'
+import * as createLogic from '@/components/new-safe/create/logic'
+import * as web3 from '@/hooks/wallets/web3'
+import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
+import { type ReplayedSafeProps } from '@safe-global/utils/features/counterfactual/store/types'
 
 const mockChain = {
   chainId: '100',
@@ -202,5 +208,42 @@ describe('ReviewStep', () => {
     expect(queryByTestId('pay-now-later-message-box')).not.toBeInTheDocument()
     expect(queryByText('Pay now')).not.toBeInTheDocument()
     expect(queryByText(/Pay later/)).not.toBeInTheDocument()
+  })
+
+  it('creates counterfactual safes for multichain even when the user is not authenticated', async () => {
+    const chainWithFeatures = { ...mockChain, features: [] } as Chain
+    const mockMultiChain = [chainWithFeatures, { ...chainWithFeatures, chainId: '1', chainName: 'Ethereum' } as Chain]
+    const mockData: NewSafeFormData = {
+      name: 'Test',
+      networks: mockMultiChain,
+      threshold: 1,
+      owners: [{ name: '', address: '0x1' }],
+      saltNonce: 0,
+      safeVersion: LATEST_SAFE_VERSION as SafeVersion,
+    }
+
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+    jest.spyOn(useChains, 'useCurrentChain').mockReturnValue(chainWithFeatures)
+    jest.spyOn(useWallet, 'default').mockReturnValue({ provider: {} } as unknown as ConnectedWallet)
+    jest
+      .spyOn(createLogic, 'createNewUndeployedSafeWithoutSalt')
+      .mockReturnValue({ safeAccountConfig: { owners: ['0x1'], threshold: 1 } } as unknown as ReplayedSafeProps)
+    jest.spyOn(web3, 'createWeb3ReadOnly').mockReturnValue({} as ReturnType<typeof web3.createWeb3ReadOnly>)
+    jest
+      .spyOn(multichain, 'predictAddressBasedOnReplayData')
+      .mockResolvedValue('0x0000000000000000000000000000000000000001')
+    const persistSpy = jest.spyOn(cfServices, 'persistCounterfactualSafe').mockResolvedValue({ ok: true })
+
+    // No auth state provided -> the user is not authenticated.
+    render(<ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('review-step-next-btn'))
+    })
+
+    expect(persistSpy).toHaveBeenCalledTimes(mockMultiChain.length)
+    expect(persistSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ payMethod: PayMethod.PayLater, isUserAuthenticated: false }),
+    )
   })
 })

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -250,7 +250,12 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
   const customRPCs = useAppSelector(selectRpc)
 
   // Derive effective pay method synchronously to avoid one-render gap.
-  const effectivePayMethod = getEffectivePayMethod(isMultiChainDeployment, isUserAuthenticated, payMethod)
+  const effectivePayMethod = getEffectivePayMethod(
+    isMultiChainDeployment,
+    isUserAuthenticated,
+    payMethod,
+    isCounterfactualEnabled,
+  )
 
   const handleBack = () => {
     onBack(data)

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -432,20 +432,26 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
     isCounterfactualEnabled,
   )
 
-  const isDisabled = showNetworkWarning || isCreating
+  // Pay later persists counterfactual data to the backend, so it requires an
+  // authenticated session. This only blocks multichain (where Pay now is
+  // disabled and Pay later is forced); single-chain Pay later falls back to
+  // Pay now when not signed in, so effectivePayMethod is never PayLater there.
+  const requiresSignIn = effectivePayMethod === PayMethod.PayLater && !isUserAuthenticated
+  const isDisabled = showNetworkWarning || isCreating || requiresSignIn
 
   return (
     <>
       <Box data-testid="safe-setup-overview" className={layoutCss.row}>
         <SafeSetupOverview name={data.name} owners={data.owners} threshold={data.threshold} networks={data.networks} />
       </Box>
-      {isCounterfactualEnabled && !isMultiChainDeployment && (
+      {isCounterfactualEnabled && (
         <>
           <Divider />
           <Box data-testid="pay-now-later-message-box" className={layoutCss.row}>
             <PayNowPayLater
               totalFee={totalFee}
               canRelay={canRelay}
+              isMultiChain={isMultiChainDeployment}
               payMethod={effectivePayMethod}
               setPayMethod={setPayMethod}
               isUserAuthenticated={isUserAuthenticated}

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -248,8 +248,14 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
   const customRPCs = useAppSelector(selectRpc)
 
-  // Derive effective pay method synchronously to avoid one-render gap
-  const effectivePayMethod = !isUserAuthenticated && payMethod === PayMethod.PayLater ? PayMethod.PayNow : payMethod
+  // Derive effective pay method synchronously to avoid one-render gap.
+  // Multichain creations are always counterfactual (PayLater) — paying upfront
+  // on every network at once isn't offered.
+  const effectivePayMethod = isMultiChainDeployment
+    ? PayMethod.PayLater
+    : !isUserAuthenticated && payMethod === PayMethod.PayLater
+      ? PayMethod.PayNow
+      : payMethod
 
   const handleBack = () => {
     onBack(data)
@@ -438,13 +444,12 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
       <Box data-testid="safe-setup-overview" className={layoutCss.row}>
         <SafeSetupOverview name={data.name} owners={data.owners} threshold={data.threshold} networks={data.networks} />
       </Box>
-      {isCounterfactualEnabled && (
+      {isCounterfactualEnabled && !isMultiChainDeployment && (
         <>
           <Divider />
           <Box data-testid="pay-now-later-message-box" className={layoutCss.row}>
             <PayNowPayLater
               totalFee={totalFee}
-              isMultiChain={isMultiChainDeployment}
               canRelay={canRelay}
               payMethod={effectivePayMethod}
               setPayMethod={setPayMethod}

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -455,7 +455,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
           <Box data-testid="pay-now-later-message-box" className={layoutCss.row}>
             <PayNowPayLater
               totalFee={totalFee}
-              canRelay={canRelay}
+              willRelay={willRelay}
               isMultiChain={isMultiChainDeployment}
               payMethod={effectivePayMethod}
               setPayMethod={setPayMethod}

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -22,6 +22,7 @@ import { getAvailableSaltNonce } from '@/components/new-safe/create/logic/utils'
 import {
   buildTransactionOptions,
   getDeploymentType,
+  getEffectivePayMethod,
   getNetworkLabel,
   getPaymentMethodLabel,
   getThresholdLabel,
@@ -249,13 +250,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
   const customRPCs = useAppSelector(selectRpc)
 
   // Derive effective pay method synchronously to avoid one-render gap.
-  // Multichain creations are always counterfactual (PayLater) — paying upfront
-  // on every network at once isn't offered.
-  const effectivePayMethod = isMultiChainDeployment
-    ? PayMethod.PayLater
-    : !isUserAuthenticated && payMethod === PayMethod.PayLater
-      ? PayMethod.PayNow
-      : payMethod
+  const effectivePayMethod = getEffectivePayMethod(isMultiChainDeployment, isUserAuthenticated, payMethod)
 
   const handleBack = () => {
     onBack(data)

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/utils.test.ts
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/utils.test.ts
@@ -12,20 +12,28 @@ import {
 } from './utils'
 
 describe('getEffectivePayMethod', () => {
-  it('forces PayLater for multichain deployments regardless of selection or auth', () => {
-    expect(getEffectivePayMethod(true, true, PayMethod.PayNow)).toBe(PayMethod.PayLater)
-    expect(getEffectivePayMethod(true, false, PayMethod.PayNow)).toBe(PayMethod.PayLater)
-    expect(getEffectivePayMethod(true, false, PayMethod.PayLater)).toBe(PayMethod.PayLater)
+  it('forces PayLater for multichain deployments when counterfactual is enabled, regardless of selection or auth', () => {
+    expect(getEffectivePayMethod(true, true, PayMethod.PayNow, true)).toBe(PayMethod.PayLater)
+    expect(getEffectivePayMethod(true, false, PayMethod.PayNow, true)).toBe(PayMethod.PayLater)
+    expect(getEffectivePayMethod(true, false, PayMethod.PayLater, true)).toBe(PayMethod.PayLater)
+  })
+
+  it('does not force PayLater for multichain when counterfactual is disabled', () => {
+    // Falls back to the single-chain rule: unauthenticated PayLater -> PayNow.
+    expect(getEffectivePayMethod(true, false, PayMethod.PayLater, false)).toBe(PayMethod.PayNow)
+    expect(getEffectivePayMethod(true, false, PayMethod.PayNow, false)).toBe(PayMethod.PayNow)
+    expect(getEffectivePayMethod(true, false, PayMethod.PayLater, undefined)).toBe(PayMethod.PayNow)
+    expect(getEffectivePayMethod(true, true, PayMethod.PayNow, false)).toBe(PayMethod.PayNow)
   })
 
   it('falls back to PayNow for single-chain PayLater when the user is not authenticated', () => {
-    expect(getEffectivePayMethod(false, false, PayMethod.PayLater)).toBe(PayMethod.PayNow)
+    expect(getEffectivePayMethod(false, false, PayMethod.PayLater, true)).toBe(PayMethod.PayNow)
   })
 
   it('keeps the selected method for single-chain when authenticated', () => {
-    expect(getEffectivePayMethod(false, true, PayMethod.PayLater)).toBe(PayMethod.PayLater)
-    expect(getEffectivePayMethod(false, true, PayMethod.PayNow)).toBe(PayMethod.PayNow)
-    expect(getEffectivePayMethod(false, false, PayMethod.PayNow)).toBe(PayMethod.PayNow)
+    expect(getEffectivePayMethod(false, true, PayMethod.PayLater, true)).toBe(PayMethod.PayLater)
+    expect(getEffectivePayMethod(false, true, PayMethod.PayNow, true)).toBe(PayMethod.PayNow)
+    expect(getEffectivePayMethod(false, false, PayMethod.PayNow, true)).toBe(PayMethod.PayNow)
   })
 })
 

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/utils.test.ts
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/utils.test.ts
@@ -3,12 +3,31 @@ import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
 import {
   buildTransactionOptions,
   getDeploymentType,
+  getEffectivePayMethod,
   getNetworkLabel,
   getPaymentMethodLabel,
   getThresholdLabel,
   getWillRelay,
   shouldShowNetworkWarning,
 } from './utils'
+
+describe('getEffectivePayMethod', () => {
+  it('forces PayLater for multichain deployments regardless of selection or auth', () => {
+    expect(getEffectivePayMethod(true, true, PayMethod.PayNow)).toBe(PayMethod.PayLater)
+    expect(getEffectivePayMethod(true, false, PayMethod.PayNow)).toBe(PayMethod.PayLater)
+    expect(getEffectivePayMethod(true, false, PayMethod.PayLater)).toBe(PayMethod.PayLater)
+  })
+
+  it('falls back to PayNow for single-chain PayLater when the user is not authenticated', () => {
+    expect(getEffectivePayMethod(false, false, PayMethod.PayLater)).toBe(PayMethod.PayNow)
+  })
+
+  it('keeps the selected method for single-chain when authenticated', () => {
+    expect(getEffectivePayMethod(false, true, PayMethod.PayLater)).toBe(PayMethod.PayLater)
+    expect(getEffectivePayMethod(false, true, PayMethod.PayNow)).toBe(PayMethod.PayNow)
+    expect(getEffectivePayMethod(false, false, PayMethod.PayNow)).toBe(PayMethod.PayNow)
+  })
+})
 
 describe('getNetworkLabel', () => {
   it('returns "Network" for a single network', () => {

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/utils.ts
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/utils.ts
@@ -19,16 +19,18 @@ export function getThresholdLabel(threshold: number, ownerCount: number): string
 
 /**
  * Resolves the pay method that is actually used for creation.
- * Multichain creations are always counterfactual (PayLater) — paying upfront on
- * every network at once isn't offered. For single-chain, PayLater requires an
+ * With counterfactual enabled, multichain creations are always counterfactual
+ * (PayLater) — paying upfront on every network at once isn't offered. For
+ * single-chain (or when counterfactual is disabled), PayLater requires an
  * authenticated session, otherwise it falls back to PayNow.
  */
 export function getEffectivePayMethod(
   isMultiChainDeployment: boolean,
   isUserAuthenticated: boolean,
   payMethod: PayMethod,
+  isCounterfactualEnabled?: boolean,
 ): PayMethod {
-  if (isMultiChainDeployment) {
+  if (isMultiChainDeployment && isCounterfactualEnabled) {
     return PayMethod.PayLater
   }
   return !isUserAuthenticated && payMethod === PayMethod.PayLater ? PayMethod.PayNow : payMethod

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/utils.ts
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/utils.ts
@@ -18,6 +18,23 @@ export function getThresholdLabel(threshold: number, ownerCount: number): string
 }
 
 /**
+ * Resolves the pay method that is actually used for creation.
+ * Multichain creations are always counterfactual (PayLater) — paying upfront on
+ * every network at once isn't offered. For single-chain, PayLater requires an
+ * authenticated session, otherwise it falls back to PayNow.
+ */
+export function getEffectivePayMethod(
+  isMultiChainDeployment: boolean,
+  isUserAuthenticated: boolean,
+  payMethod: PayMethod,
+): PayMethod {
+  if (isMultiChainDeployment) {
+    return PayMethod.PayLater
+  }
+  return !isUserAuthenticated && payMethod === PayMethod.PayLater ? PayMethod.PayNow : payMethod
+}
+
+/**
  * Determines whether the deployment type label is "Counterfactual" or "Direct".
  */
 export function getDeploymentType(isCounterfactualEnabled: boolean | undefined, payMethod: PayMethod): string {

--- a/apps/web/src/features/counterfactual/components/PayNowPayLater/PayNowPayLater.test.tsx
+++ b/apps/web/src/features/counterfactual/components/PayNowPayLater/PayNowPayLater.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@/tests/test-utils'
+import PayNowPayLater from './index'
+import { PayMethod } from '@safe-global/utils/features/counterfactual/types'
+import * as useChains from '@/hooks/useChains'
+import * as nativeToken from '@/hooks/useNativeTokenDisplay'
+import { type Chain } from '@safe-global/store/gateway/AUTO_GENERATED/chains'
+
+jest.mock('@/services/siwe/useSiwe', () => ({
+  useSiwe: () => ({ signIn: jest.fn(), loading: false }),
+}))
+
+describe('PayNowPayLater', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(useChains, 'useCurrentChain').mockReturnValue({ nativeCurrency: { symbol: 'ETH' } } as unknown as Chain)
+    jest.spyOn(nativeToken, 'useNativeTokenDisplay').mockReturnValue({
+      showGasFeeEstimation: true,
+      showStablecoinFeeInfo: false,
+    } as unknown as ReturnType<typeof nativeToken.useNativeTokenDisplay>)
+  })
+
+  it('shows "Sponsored free transaction" for Pay now when relay will be used', () => {
+    render(<PayNowPayLater totalFee="0.01" willRelay payMethod={PayMethod.PayNow} setPayMethod={jest.fn()} />)
+
+    expect(screen.getByText('Sponsored free transaction')).toBeInTheDocument()
+  })
+
+  it('shows the fee estimation for Pay now when relay will not be used (connected wallet)', () => {
+    render(<PayNowPayLater totalFee="0.01" willRelay={false} payMethod={PayMethod.PayNow} setPayMethod={jest.fn()} />)
+
+    expect(screen.queryByText('Sponsored free transaction')).not.toBeInTheDocument()
+    expect(screen.getByText(/0\.01 ETH/)).toBeInTheDocument()
+  })
+
+  it('disables Pay now and shows the multichain hint for multichain creation', () => {
+    render(
+      <PayNowPayLater
+        totalFee="0.01"
+        willRelay={false}
+        isMultiChain
+        payMethod={PayMethod.PayLater}
+        setPayMethod={jest.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Not available for multiple networks')).toBeInTheDocument()
+    expect(screen.getByText(/activate your account/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
+++ b/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
@@ -26,12 +26,14 @@ import { setAuthenticated, SESSION_LIFETIME_MS } from '@/store/authSlice'
 const PayNowPayLater = ({
   totalFee,
   canRelay,
+  isMultiChain = false,
   payMethod,
   setPayMethod,
   isUserAuthenticated = true,
 }: {
   totalFee: string
   canRelay: boolean
+  isMultiChain?: boolean
   payMethod: PayMethod
   setPayMethod: Dispatch<SetStateAction<PayMethod>>
   isUserAuthenticated?: boolean
@@ -63,6 +65,12 @@ const PayNowPayLater = ({
       <Typography variant="h4" fontWeight="bold">
         Before we continue...
       </Typography>
+      {isMultiChain && (
+        <ErrorMessage level="info">
+          You will need to <b>activate your account</b> separately on each network. Make sure you have funds on your
+          wallet to pay the network fee.
+        </ErrorMessage>
+      )}
       {showStablecoinFeeInfo && (
         <Box mt={2}>
           <ErrorMessage level="info">
@@ -72,20 +80,32 @@ const PayNowPayLater = ({
         </Box>
       )}
       <List>
+        {isMultiChain && (
+          <ListItem disableGutters>
+            <ListItemIcon className={css.listItem}>
+              <CheckRoundedIcon fontSize="small" color="inherit" />
+            </ListItemIcon>
+            <Typography variant="body2">
+              Start exploring the accounts now, and activate them later to start making transactions
+            </Typography>
+          </ListItem>
+        )}
         <ListItem disableGutters>
           <ListItemIcon className={css.listItem}>
             <CheckRoundedIcon fontSize="small" color="inherit" />
           </ListItemIcon>
           <Typography variant="body2">There will be a one-time activation fee</Typography>
         </ListItem>
-        <ListItem disableGutters>
-          <ListItemIcon className={css.listItem}>
-            <CheckRoundedIcon fontSize="small" color="inherit" />
-          </ListItemIcon>
-          <Typography variant="body2">
-            If you choose to pay later, the fee will be included with the first transaction you make.
-          </Typography>
-        </ListItem>
+        {!isMultiChain && (
+          <ListItem disableGutters>
+            <ListItemIcon className={css.listItem}>
+              <CheckRoundedIcon fontSize="small" color="inherit" />
+            </ListItemIcon>
+            <Typography variant="body2">
+              If you choose to pay later, the fee will be included with the first transaction you make.
+            </Typography>
+          </ListItem>
+        )}
         <ListItem disableGutters>
           <ListItemIcon className={css.listItem}>
             <CheckRoundedIcon fontSize="small" color="inherit" />
@@ -99,20 +119,27 @@ const PayNowPayLater = ({
             data-testid="pay-now-execution-method"
             sx={{ flex: 1 }}
             value={PayMethod.PayNow}
+            disabled={isMultiChain}
             className={classnames(css.radioContainer, { [css.active]: payMethod === PayMethod.PayNow })}
             label={
               <>
                 <Typography className={css.radioTitle}>Pay now</Typography>
-                {showGasFeeEstimation && (
+                {isMultiChain ? (
                   <Typography className={css.radioSubtitle} variant="body2" color="text.secondary">
-                    {canRelay ? (
-                      'Sponsored free transaction'
-                    ) : (
-                      <>
-                        &asymp; {totalFee} {chain?.nativeCurrency.symbol}
-                      </>
-                    )}
+                    Not available for multiple networks
                   </Typography>
+                ) : (
+                  showGasFeeEstimation && (
+                    <Typography className={css.radioSubtitle} variant="body2" color="text.secondary">
+                      {canRelay ? (
+                        'Sponsored free transaction'
+                      ) : (
+                        <>
+                          &asymp; {totalFee} {chain?.nativeCurrency.symbol}
+                        </>
+                      )}
+                    </Typography>
+                  )
                 )}
               </>
             }

--- a/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
+++ b/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
@@ -25,14 +25,14 @@ import { setAuthenticated, SESSION_LIFETIME_MS } from '@/store/authSlice'
 
 const PayNowPayLater = ({
   totalFee,
-  canRelay,
+  willRelay,
   isMultiChain = false,
   payMethod,
   setPayMethod,
   isUserAuthenticated = true,
 }: {
   totalFee: string
-  canRelay: boolean
+  willRelay: boolean
   isMultiChain?: boolean
   payMethod: PayMethod
   setPayMethod: Dispatch<SetStateAction<PayMethod>>
@@ -131,7 +131,7 @@ const PayNowPayLater = ({
                 ) : (
                   showGasFeeEstimation && (
                     <Typography className={css.radioSubtitle} variant="body2" color="text.secondary">
-                      {canRelay ? (
+                      {willRelay ? (
                         'Sponsored free transaction'
                       ) : (
                         <>
@@ -182,9 +182,9 @@ const PayNowPayLater = ({
                   opacity: signingIn ? 0.6 : 1,
                 }}
               >
-                Sign in
+                Sign into a workspace
               </Typography>{' '}
-              to create a Safe without immediate deployment.
+              to create a Safe and activate later.
             </ErrorMessage>
           </Box>
         )}

--- a/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
+++ b/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
@@ -26,14 +26,12 @@ import { setAuthenticated, SESSION_LIFETIME_MS } from '@/store/authSlice'
 const PayNowPayLater = ({
   totalFee,
   canRelay,
-  isMultiChain,
   payMethod,
   setPayMethod,
   isUserAuthenticated = true,
 }: {
   totalFee: string
   canRelay: boolean
-  isMultiChain: boolean
   payMethod: PayMethod
   setPayMethod: Dispatch<SetStateAction<PayMethod>>
   isUserAuthenticated?: boolean
@@ -65,12 +63,6 @@ const PayNowPayLater = ({
       <Typography variant="h4" fontWeight="bold">
         Before we continue...
       </Typography>
-      {isMultiChain && (
-        <ErrorMessage level="info">
-          You will need to <b>activate your account</b> separately on each network. Make sure you have funds on your
-          wallet to pay the network fee.
-        </ErrorMessage>
-      )}
       {showStablecoinFeeInfo && (
         <Box mt={2}>
           <ErrorMessage level="info">
@@ -80,32 +72,20 @@ const PayNowPayLater = ({
         </Box>
       )}
       <List>
-        {isMultiChain && (
-          <ListItem disableGutters>
-            <ListItemIcon className={css.listItem}>
-              <CheckRoundedIcon fontSize="small" color="inherit" />
-            </ListItemIcon>
-            <Typography variant="body2">
-              Start exploring the accounts now, and activate them later to start making transactions
-            </Typography>
-          </ListItem>
-        )}
         <ListItem disableGutters>
           <ListItemIcon className={css.listItem}>
             <CheckRoundedIcon fontSize="small" color="inherit" />
           </ListItemIcon>
           <Typography variant="body2">There will be a one-time activation fee</Typography>
         </ListItem>
-        {!isMultiChain && (
-          <ListItem disableGutters>
-            <ListItemIcon className={css.listItem}>
-              <CheckRoundedIcon fontSize="small" color="inherit" />
-            </ListItemIcon>
-            <Typography variant="body2">
-              If you choose to pay later, the fee will be included with the first transaction you make.
-            </Typography>
-          </ListItem>
-        )}
+        <ListItem disableGutters>
+          <ListItemIcon className={css.listItem}>
+            <CheckRoundedIcon fontSize="small" color="inherit" />
+          </ListItemIcon>
+          <Typography variant="body2">
+            If you choose to pay later, the fee will be included with the first transaction you make.
+          </Typography>
+        </ListItem>
         <ListItem disableGutters>
           <ListItemIcon className={css.listItem}>
             <CheckRoundedIcon fontSize="small" color="inherit" />
@@ -113,77 +93,75 @@ const PayNowPayLater = ({
           <Typography variant="body2">Safe doesn&apos;t profit from the fees.</Typography>
         </ListItem>
       </List>
-      {!isMultiChain && (
-        <FormControl fullWidth>
-          <RadioGroup row value={payMethod} onChange={onChoosePayMethod} className={css.radioGroup}>
-            <FormControlLabel
-              data-testid="pay-now-execution-method"
-              sx={{ flex: 1 }}
-              value={PayMethod.PayNow}
-              className={classnames(css.radioContainer, { [css.active]: payMethod === PayMethod.PayNow })}
-              label={
-                <>
-                  <Typography className={css.radioTitle}>Pay now</Typography>
-                  {showGasFeeEstimation && (
-                    <Typography className={css.radioSubtitle} variant="body2" color="text.secondary">
-                      {canRelay ? (
-                        'Sponsored free transaction'
-                      ) : (
-                        <>
-                          &asymp; {totalFee} {chain?.nativeCurrency.symbol}
-                        </>
-                      )}
-                    </Typography>
-                  )}
-                </>
-              }
-              control={<Radio />}
-            />
-
-            <FormControlLabel
-              data-testid="connected-wallet-execution-method"
-              sx={{ flex: 1 }}
-              value={PayMethod.PayLater}
-              disabled={signingIn}
-              className={classnames(css.radioContainer, {
-                [css.active]: payMethod === PayMethod.PayLater,
-              })}
-              label={
-                <>
-                  <Typography className={css.radioTitle}>
-                    Pay later {signingIn && <CircularProgress size={14} sx={{ ml: 0.5 }} />}
-                  </Typography>
+      <FormControl fullWidth>
+        <RadioGroup row value={payMethod} onChange={onChoosePayMethod} className={css.radioGroup}>
+          <FormControlLabel
+            data-testid="pay-now-execution-method"
+            sx={{ flex: 1 }}
+            value={PayMethod.PayNow}
+            className={classnames(css.radioContainer, { [css.active]: payMethod === PayMethod.PayNow })}
+            label={
+              <>
+                <Typography className={css.radioTitle}>Pay now</Typography>
+                {showGasFeeEstimation && (
                   <Typography className={css.radioSubtitle} variant="body2" color="text.secondary">
-                    {isUserAuthenticated ? 'with the first transaction' : 'Sign in to enable'}
+                    {canRelay ? (
+                      'Sponsored free transaction'
+                    ) : (
+                      <>
+                        &asymp; {totalFee} {chain?.nativeCurrency.symbol}
+                      </>
+                    )}
                   </Typography>
-                </>
-              }
-              control={<Radio />}
-            />
-          </RadioGroup>
-          {!isUserAuthenticated && (
-            <Box mt={1}>
-              <ErrorMessage level="info">
-                <Typography
-                  variant="body2"
-                  component="span"
-                  onClick={signInAndSelectPayLater}
-                  sx={{
-                    color: 'primary.main',
-                    cursor: signingIn ? 'default' : 'pointer',
-                    textDecoration: 'underline',
-                    fontWeight: 'bold',
-                    opacity: signingIn ? 0.6 : 1,
-                  }}
-                >
-                  Sign in
-                </Typography>{' '}
-                to create a Safe without immediate deployment.
-              </ErrorMessage>
-            </Box>
-          )}
-        </FormControl>
-      )}
+                )}
+              </>
+            }
+            control={<Radio />}
+          />
+
+          <FormControlLabel
+            data-testid="connected-wallet-execution-method"
+            sx={{ flex: 1 }}
+            value={PayMethod.PayLater}
+            disabled={signingIn}
+            className={classnames(css.radioContainer, {
+              [css.active]: payMethod === PayMethod.PayLater,
+            })}
+            label={
+              <>
+                <Typography className={css.radioTitle}>
+                  Pay later {signingIn && <CircularProgress size={14} sx={{ ml: 0.5 }} />}
+                </Typography>
+                <Typography className={css.radioSubtitle} variant="body2" color="text.secondary">
+                  {isUserAuthenticated ? 'with the first transaction' : 'Sign in to enable'}
+                </Typography>
+              </>
+            }
+            control={<Radio />}
+          />
+        </RadioGroup>
+        {!isUserAuthenticated && (
+          <Box mt={1}>
+            <ErrorMessage level="info">
+              <Typography
+                variant="body2"
+                component="span"
+                onClick={signInAndSelectPayLater}
+                sx={{
+                  color: 'primary.main',
+                  cursor: signingIn ? 'default' : 'pointer',
+                  textDecoration: 'underline',
+                  fontWeight: 'bold',
+                  opacity: signingIn ? 0.6 : 1,
+                }}
+              >
+                Sign in
+              </Typography>{' '}
+              to create a Safe without immediate deployment.
+            </ErrorMessage>
+          </Box>
+        )}
+      </FormControl>
     </>
   )
 }

--- a/apps/web/src/features/counterfactual/contract.ts
+++ b/apps/web/src/features/counterfactual/contract.ts
@@ -41,7 +41,7 @@ import type {
 // Component prop types (for components with external props)
 export interface PayNowPayLaterProps {
   totalFee: string
-  canRelay: boolean
+  willRelay: boolean
   isMultiChain?: boolean
   payMethod: PayMethod
   setPayMethod: Dispatch<SetStateAction<PayMethod>>

--- a/apps/web/src/features/counterfactual/contract.ts
+++ b/apps/web/src/features/counterfactual/contract.ts
@@ -42,6 +42,7 @@ import type {
 export interface PayNowPayLaterProps {
   totalFee: string
   canRelay: boolean
+  isMultiChain?: boolean
   payMethod: PayMethod
   setPayMethod: Dispatch<SetStateAction<PayMethod>>
   isUserAuthenticated?: boolean

--- a/apps/web/src/features/counterfactual/contract.ts
+++ b/apps/web/src/features/counterfactual/contract.ts
@@ -42,7 +42,6 @@ import type {
 export interface PayNowPayLaterProps {
   totalFee: string
   canRelay: boolean
-  isMultiChain: boolean
   payMethod: PayMethod
   setPayMethod: Dispatch<SetStateAction<PayMethod>>
 }

--- a/apps/web/src/features/counterfactual/contract.ts
+++ b/apps/web/src/features/counterfactual/contract.ts
@@ -44,6 +44,7 @@ export interface PayNowPayLaterProps {
   canRelay: boolean
   payMethod: PayMethod
   setPayMethod: Dispatch<SetStateAction<PayMethod>>
+  isUserAuthenticated?: boolean
 }
 
 export interface CounterfactualFormProps extends SignOrExecuteProps {

--- a/apps/web/src/services/siwe/useSiwe.test.tsx
+++ b/apps/web/src/services/siwe/useSiwe.test.tsx
@@ -1,0 +1,97 @@
+import { renderHook, act } from '@testing-library/react'
+import { useSiwe } from './useSiwe'
+import type { ConnectedWallet } from '@/hooks/wallets/useOnboard'
+
+const mockFetchNonce = jest.fn()
+const mockVerify = jest.fn()
+jest.mock('@safe-global/store/gateway/AUTO_GENERATED/auth', () => ({
+  useLazyAuthGetNonceV1Query: () => [mockFetchNonce],
+  useAuthVerifyV1Mutation: () => [mockVerify],
+}))
+
+const mockUseWeb3 = jest.fn()
+jest.mock('@/hooks/wallets/web3ReadOnly', () => ({
+  useWeb3: () => mockUseWeb3(),
+}))
+
+const mockUseWallet = jest.fn()
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: () => mockUseWallet(),
+}))
+
+const mockCreateWeb3 = jest.fn()
+jest.mock('@/hooks/wallets/web3', () => ({
+  createWeb3: (provider: unknown) => mockCreateWeb3(provider),
+}))
+
+describe('useSiwe', () => {
+  const walletProvider = { request: jest.fn() }
+  const wallet = { label: 'MetaMask', provider: walletProvider } as unknown as ConnectedWallet
+
+  const buildProvider = () => {
+    const signer = {
+      address: '0x0000000000000000000000000000000000000abc',
+      signMessage: jest.fn().mockResolvedValue('0xsig'),
+    }
+    return {
+      getNetwork: jest.fn().mockResolvedValue({ chainId: 1n }),
+      getSigner: jest.fn().mockResolvedValue(signer),
+      send: jest.fn(),
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFetchNonce.mockResolvedValue({ data: { nonce: 'nonce-123' } })
+    mockVerify.mockReturnValue({ data: true })
+    mockUseWallet.mockReturnValue(wallet)
+  })
+
+  it('signs in using the chain-matched provider when available', async () => {
+    const provider = buildProvider()
+    mockUseWeb3.mockReturnValue(provider)
+
+    const { result } = renderHook(() => useSiwe())
+    await act(async () => {
+      await result.current.signIn()
+    })
+
+    expect(mockCreateWeb3).not.toHaveBeenCalled()
+    expect(provider.getSigner).toHaveBeenCalled()
+    expect(mockVerify).toHaveBeenCalledWith(
+      expect.objectContaining({ siweDto: expect.objectContaining({ signature: '0xsig' }) }),
+    )
+  })
+
+  it('builds a provider from the wallet when none is available (wallet on wrong chain)', async () => {
+    // useWeb3 is undefined when the wallet is on a chain other than the current one.
+    mockUseWeb3.mockReturnValue(undefined)
+    const fallbackProvider = buildProvider()
+    mockCreateWeb3.mockReturnValue(fallbackProvider)
+
+    const { result } = renderHook(() => useSiwe())
+    await act(async () => {
+      await result.current.signIn()
+    })
+
+    expect(mockCreateWeb3).toHaveBeenCalledWith(walletProvider)
+    expect(fallbackProvider.getSigner).toHaveBeenCalled()
+    expect(mockVerify).toHaveBeenCalledWith(
+      expect.objectContaining({ siweDto: expect.objectContaining({ signature: '0xsig' }) }),
+    )
+  })
+
+  it('does nothing when no wallet is connected', async () => {
+    mockUseWallet.mockReturnValue(null)
+    mockUseWeb3.mockReturnValue(undefined)
+
+    const { result } = renderHook(() => useSiwe())
+    await act(async () => {
+      await result.current.signIn()
+    })
+
+    expect(mockCreateWeb3).not.toHaveBeenCalled()
+    expect(mockVerify).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/services/siwe/useSiwe.tsx
+++ b/apps/web/src/services/siwe/useSiwe.tsx
@@ -16,11 +16,20 @@ export const useSiwe = () => {
   const [verifyAuthMutation] = useAuthVerifyV1Mutation()
 
   const signIn = useCallback(async () => {
-    if (!provider || !wallet) return
+    if (!wallet) return
 
     setLoading(true)
 
     try {
+      // Prefer the chain-matched provider, but fall back to one built from the
+      // wallet so sign-in works even when the wallet is connected to a chain
+      // other than the current one — SIWE only needs a message signature.
+      let signingProvider = provider
+      if (!signingProvider) {
+        const { createWeb3 } = await import('@/hooks/wallets/web3')
+        signingProvider = createWeb3(wallet.provider)
+      }
+
       const { data } = await fetchNonce()
 
       if (!data) {
@@ -28,13 +37,13 @@ export const useSiwe = () => {
         return
       }
 
-      const [network, signer] = await Promise.all([provider.getNetwork(), provider.getSigner()])
+      const [network, signer] = await Promise.all([signingProvider.getNetwork(), signingProvider.getSigner()])
       const signableMessage = getSignableMessage(signer.address, network.chainId, data.nonce)
 
       let signature
       // Using the signer.signMessage hexlifies the message which doesn't work with the personal_sign of the PK module
       if (isPKWallet(wallet)) {
-        signature = await provider.send('personal_sign', [signableMessage, signer.address.toLowerCase()])
+        signature = await signingProvider.send('personal_sign', [signableMessage, signer.address.toLowerCase()])
       } else {
         signature = await signer.signMessage(signableMessage)
       }


### PR DESCRIPTION
> Multichain create:
> Pay now greyed out,
> sign in, pay later.

## What it solves

Resolves: During multichain Safe creation the "who will pay" choice was misleading — paying upfront (Pay now) on every selected network at once isn't possible, yet it was offered. Multichain creations should be counterfactual (Pay later), and because Pay later persists data to the backend it must require an authenticated session.

## How this PR fixes it

- The Pay now / Pay later selector stays visible for multichain, but **Pay now is disabled** ("Not available for multiple networks") and Pay later is the selected method (`getEffectivePayMethod` forces `PayLater` for multichain).
- Pay later writes counterfactual data to the backend, so it **requires sign-in**. The Create account button stays disabled for multichain until the user authenticates (`requiresSignIn = effectivePayMethod === PayLater && !isUserAuthenticated`). The existing "Sign in to enable" affordance drives the SIWE flow.
- The multichain activation messaging is shown: the "activate your account separately on each network" banner and the "Start exploring the accounts now…" item.
- Single-chain behavior is unchanged: both options selectable, default Pay later, and Pay later still falls back to Pay now when not signed in (so `effectivePayMethod` is never PayLater there and creation is not gated).
- Extracted the pay-method derivation into a pure, unit-tested `getEffectivePayMethod` helper, and aligned the exported `PayNowPayLaterProps` contract with the component props (`isMultiChain?`, `isUserAuthenticated?`).

## How to test it

1. Start new Safe creation and select **two or more networks**.
2. On the review step: the selector is shown, **Pay now is disabled**, Pay later is selected, and the multichain activation messaging is visible.
3. **Not signed in:** the Create account button is disabled; use "Sign in" → after authenticating it becomes enabled.
4. Click **Create account** → a counterfactual Safe is created on each network and you land on the dashboard.
5. **Single network:** both Pay now / Pay later are available and behave exactly as before.

## Affected flows

- New Safe creation — multichain (2+ networks): Pay now disabled, Pay later forced, creation requires sign-in.
- New Safe creation — single chain: unchanged (selector, default Pay later, Pay later→Pay now fallback when unauthenticated).

## Blast radius

- `ReviewStep` (`apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx`) — derives `effectivePayMethod`, gates the Create button with `requiresSignIn`.
- `ReviewStep/utils.ts` — new pure `getEffectivePayMethod` helper (unit-tested).
- `PayNowPayLater` (`apps/web/src/features/counterfactual/components/PayNowPayLater`) — `isMultiChain` disables Pay now and shows multichain messaging. Only consumer is `ReviewStep`.
- `PayNowPayLaterProps` in `counterfactual/contract.ts` — added `isMultiChain?` and `isUserAuthenticated?` to match the component.
- CF persistence (`persistCounterfactualSafe`) path is unchanged.
- No RTK Query, feature flag, route, persistence, or shared-package (mobile) changes.

## Risks / not checked

- Did not exercise the real on-chain / backend CF persistence (mocked in unit tests); relying on unchanged `persistCounterfactualSafe` behavior.
- No Playwright E2E added for multichain creation — covered by unit/component tests instead.
- Multichain creation with the COUNTERFACTUAL feature flag **off** is unchanged (the non-CF execution-method/fee block still renders); not separately re-verified.
- Not tested on mobile (web-only change).

## Visual summary

```mermaid
flowchart TD
  A[ReviewStep] --> B{isMultiChainDeployment?}
  B -->|Yes| C[Pay now disabled, Pay later forced]
  C --> D{Signed in?}
  D -->|No| E[Create button disabled - prompt sign in]
  D -->|Yes| F[Create -> counterfactual Safe on each network]
  B -->|No| G[Both options, default Pay later]
  G --> H[Existing single-chain logic incl. Pay now fallback]
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (web-only change)
- [x] I've documented how it affects the analytics (if at all) 📊 (multichain reports Pay-later / Counterfactual)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
