### PR TITLE
Adding ENSv2 support in the safe wallet web interface

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -67,6 +67,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.0",
+    "@ensdomains/ethers-patch-v6": "^0.0.5",
     "@gnosis.pm/zodiac": "^4.0.3",
     "@ledgerhq/context-module": "^1.8.0",
     "@ledgerhq/device-management-kit": "^0.9.1",

--- a/apps/web/src/services/ens/index.ts
+++ b/apps/web/src/services/ens/index.ts
@@ -1,3 +1,4 @@
+import '@ensdomains/ethers-patch-v6'
 import { type Provider } from 'ethers'
 import { logError } from '../exceptions'
 import ErrorCodes from '@safe-global/utils/services/exceptions/ErrorCodes'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4866,6 +4866,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ensdomains/ethers-patch-v6@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "@ensdomains/ethers-patch-v6@npm:0.0.5"
+  peerDependencies:
+    ethers: 6
+    typescript: ^5
+  checksum: 10/dd8b14cccacd4f6493922a98741372f9f968471de2429d08d57c86ca62eb46898f8840e6ec2583581b7fca8d359f724f351abbd30ee8afce02a1818a0426206c
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.19.12":
   version: 0.19.12
   resolution: "@esbuild/aix-ppc64@npm:0.19.12"
@@ -13661,6 +13671,7 @@ __metadata:
     "@emotion/react": "npm:^11.14.0"
     "@emotion/server": "npm:^11.11.0"
     "@emotion/styled": "npm:^11.14.0"
+    "@ensdomains/ethers-patch-v6": "npm:^0.0.5"
     "@eslint/eslintrc": "npm:^3.3.1"
     "@eslint/js": "npm:^9.18.0"
     "@faker-js/faker": "npm:^9.0.3"


### PR DESCRIPTION
## What it solves

Resolves:

Makes Safe Wallet web compatible with ENS v2 resolution behavior by patching ethers v6 ENS support.

## How this PR fixes it

Adds `@ensdomains/ethers-patch-v6` and loads it in the web ENS service before `resolveName()` / `lookupAddress()` are used.

## How to test it

- Verify `ur.integration-tests.eth` now resolves to `0x2222...2222`; before this patch it resolved to `0x1111...1111`.

## Affected flows

- ENS forward lookup in address inputs.
- ENS reverse lookup in address displays.

## Blast radius

- Web-only dependency and ENS service import.
- Existing ENS wrapper signatures stay unchanged.
- No Redux, persistence, routes, chain config, API contracts, or mobile code changed.
