### PR TITLE
fix: label priv contact field as "Address or ENS"

### DIFF
--- a/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/AddContactDialog.tsx
@@ -134,7 +134,7 @@ const AddContactDialog = ({
                 {intro && <p className="text-muted-foreground text-sm">{intro}</p>}
 
                 <NameInput name="name" label="Name" required />
-                <AddressInput name="address" label="Address" required showPrefix={false} />
+                <AddressInput name="address" label="Address or ENS" required showPrefix={false} />
 
                 <div>
                   <p className="mb-1 inline-flex items-center gap-1 text-sm font-bold">Select networks</p>

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddContactDialog.test.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/__tests__/AddContactDialog.test.tsx
@@ -69,7 +69,7 @@ const openDialog = () => fireEvent.click(screen.getByRole('button', { name: /add
 
 const fillRequiredFields = () => {
   fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Alice' } })
-  fireEvent.change(screen.getByLabelText('Address'), { target: { value: '0xabc' } })
+  fireEvent.change(screen.getByLabelText('Address or ENS'), { target: { value: '0xabc' } })
 }
 
 describe('AddContactDialog', () => {


### PR DESCRIPTION
In Enterprise Workspace, when we add a private contact, the input field for Address looks like this

<img width="1256" height="1218" alt="image" src="https://github.com/user-attachments/assets/ca6e9210-1786-4d72-992f-646bb49a5d2e" />

But actually one can also write e.g. "vitalik.eth" in that field and the ENS address is then resolved. So a signifier is missing that shows to the user that they can also use ENS names in that field.

How it looks now: 

<img width="620" height="602" alt="image" src="https://github.com/user-attachments/assets/305d4529-2562-42b5-babc-fce2c0cda429" />
