### PR TITLE
feat(spaces): bring search back to the account selector dropdown (backport #8026 to release)

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
@@ -242,6 +242,33 @@ export const LoadingWithHeaderFooter: Story = {
   args: {} as any,
 }
 
+/** Many safes with header + footer — exercises the scrollbar and the bottom scroll-hint fade. */
+export const ManySafesWithFooter: Story = {
+  render: () => {
+    const items = createMockItems(13)
+    const header = (
+      <div className="flex items-center gap-1 px-4 pt-3 pb-2">
+        <span className="text-sm font-semibold text-secondary-foreground">Safes in this workspace</span>
+      </div>
+    )
+    const footer = (
+      <div className="px-4 py-3">
+        <button className="w-full rounded-md border px-3 py-1.5 text-sm">Explore other Safes &rsaquo;</button>
+      </div>
+    )
+    return (
+      <SafeSelectorDropdown
+        items={items}
+        selectedItemId={items[1].id}
+        onItemSelect={action('Item selected')}
+        header={header}
+        footer={footer}
+      />
+    )
+  },
+  args: {} as any,
+}
+
 /** Error state with header and footer (non-space context). */
 export const ErrorWithHeaderFooter: Story = {
   render: () => {

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/BalanceDisplay.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/BalanceDisplay.tsx
@@ -12,26 +12,32 @@ export interface BalanceDisplayProps {
   showThreshold?: boolean
 }
 
-const BalanceDisplay = ({ balance, threshold, owners, isLoading, showThreshold = true }: BalanceDisplayProps) => (
-  <div className="flex flex-col items-end min-w-0 shrink sm:w-[100px] sm:shrink-0">
-    {balance !== undefined &&
-      (isLoading ? (
-        <Skeleton className="h-4 w-14 rounded" />
-      ) : (
-        <Typography variant="paragraph-mini-medium" color="muted">
-          {balance}
-        </Typography>
-      ))}
-    {showThreshold &&
-      (isLoading ? (
-        <Skeleton className="h-4 w-14 rounded" />
-      ) : (
-        <Badge data-testid="safe-selector-threshold" variant="secondary" className="gap-1">
-          <User className="size-3" />
-          {threshold}/{owners}
-        </Badge>
-      ))}
-  </div>
-)
+const BalanceDisplay = ({ balance, threshold, owners, isLoading, showThreshold = true }: BalanceDisplayProps) => {
+  // A deployed safe always has threshold/owners >= 1, so 0/0 means the overview hasn't loaded yet
+  // (e.g. while switching safes); show a skeleton instead of a misleading "0/0".
+  const thresholdLoading = isLoading || (threshold === 0 && owners === 0)
+
+  return (
+    <div className="flex flex-col items-end min-w-0 shrink sm:w-[100px] sm:shrink-0">
+      {balance !== undefined &&
+        (isLoading ? (
+          <Skeleton className="h-4 w-14 rounded" />
+        ) : (
+          <Typography variant="paragraph-mini-medium" color="muted">
+            {balance}
+          </Typography>
+        ))}
+      {showThreshold &&
+        (thresholdLoading ? (
+          <Skeleton className="h-4 w-14 rounded" />
+        ) : (
+          <Badge data-testid="safe-selector-threshold" variant="secondary" className="gap-1">
+            <User className="size-3" />
+            {threshold}/{owners}
+          </Badge>
+        ))}
+    </div>
+  )
+}
 
 export default BalanceDisplay

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeBalanceBlock.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeBalanceBlock.tsx
@@ -11,6 +11,9 @@ export interface SafeBalanceBlockProps {
 }
 
 function SafeBalanceBlock({ isLoading, balance, threshold, owners, showBalanceDisplay }: SafeBalanceBlockProps) {
+  // 0/0 means the overview hasn't loaded (a deployed safe is always >= 1/1) — keep the skeleton.
+  const thresholdLoading = isLoading || (threshold === 0 && owners === 0)
+
   return (
     <div className="flex flex-col items-end gap-1 py-2 min-w-0 shrink sm:min-w-[90px] sm:shrink-0">
       {isLoading ? (
@@ -21,7 +24,7 @@ function SafeBalanceBlock({ isLoading, balance, threshold, owners, showBalanceDi
         </span>
       )}
       {showBalanceDisplay &&
-        (isLoading ? (
+        (thresholdLoading ? (
           <Skeleton className="h-5 w-12 rounded-full" />
         ) : (
           <BalanceDisplay threshold={threshold} owners={owners} />

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -1,11 +1,22 @@
-import { ChevronDown, RotateCw } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { RotateCw, Search } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { SelectContent, SelectItem } from '@/components/ui/select'
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
+import { useSafeNameResolver } from '@/hooks/useAllAddressBooks'
 import SafeItem from './SafeItem'
 import MultiChainSafeItemRow from './MultiChainSafeItemRow'
 import type { SafeItemData } from '../types'
+
+const matchesSearch = (item: SafeItemData, displayName: string, query: string): boolean => {
+  const name = displayName.toLowerCase()
+  const address = item.address.toLowerCase()
+  if (name.includes(query) || address.includes(query)) return true
+  return item.chains.some(
+    (chain) => chain.chainName?.toLowerCase().includes(query) || chain.shortName?.toLowerCase().includes(query),
+  )
+}
 
 export interface SafeDropdownContainerProps {
   items: SafeItemData[]
@@ -63,47 +74,79 @@ const SafeDropdownContainer = ({
   footer,
   closeDropdown,
 }: SafeDropdownContainerProps) => {
-  // Multi-chain items stay visible even when currently selected so the user can expand and switch chains.
-  const filteredItems = items.filter((item) => item.chains.length > 1 || item.id !== selectedItemId)
+  const [search, setSearch] = useState('')
+  const query = search.trim().toLowerCase()
+  const resolveName = useSafeNameResolver()
 
-  const footerRef = useRef<HTMLDivElement>(null)
+  // Multi-chain items stay visible even when currently selected so the user can expand and switch chains.
+  const structuralItems = items.filter((item) => item.chains.length > 1 || item.id !== selectedItemId)
+  const filteredItems = query
+    ? structuralItems.filter((item) =>
+        matchesSearch(item, resolveName(item.address, item.chains[0]?.chainId, item.name), query),
+      )
+    : structuralItems
+
+  const showSearch = !isError && items.length > 0
+
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const detachScrollRef = useRef<(() => void) | null>(null)
   const [showScrollHint, setShowScrollHint] = useState(false)
 
-  // Custom scroll hint replaces base-ui's built-in scroll arrows: they sit at `bottom: 0`
-  // (colliding with the sticky footer) and don't animate, so users miss that the list is scrollable.
-  useEffect(() => {
-    const el = footerRef.current
+  // Bottom-fade scroll hint, shown only while more rows lie below the fold.
+  const measureScrollHint = useCallback(() => {
+    const el = scrollRef.current
     if (!el) return
-    // base-ui's Popup is the scroll container; reach it via the project's `data-slot` marker.
-    const scroller = el.closest<HTMLElement>('[data-slot="select-content"]')
-    if (!scroller) return
+    const hasOverflow = el.scrollHeight > el.clientHeight + 1
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1
+    setShowScrollHint(hasOverflow && !atBottom)
+  }, [])
 
-    const update = () => {
-      const hasOverflow = scroller.scrollHeight > scroller.clientHeight + 1
-      const atBottom = scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 1
-      setShowScrollHint(hasOverflow && !atBottom)
-    }
+  // Callback ref so the listeners/observer always bind to the LIVE scroll node. base-ui can remount
+  // the popup content after it sizes the popup async; a plain effect (deps unchanged) would stay
+  // closed over a stale, detached node and leave the hint stuck off. Re-measure next frame too.
+  const attachScrollArea = useCallback(
+    (node: HTMLDivElement | null) => {
+      detachScrollRef.current?.()
+      detachScrollRef.current = null
+      scrollRef.current = node
+      if (!node) return
+      node.addEventListener('scroll', measureScrollHint, { passive: true })
+      const resizeObserver = new ResizeObserver(measureScrollHint)
+      resizeObserver.observe(node)
+      Array.from(node.children).forEach((child) => resizeObserver.observe(child))
+      measureScrollHint()
+      const raf = requestAnimationFrame(measureScrollHint)
+      detachScrollRef.current = () => {
+        cancelAnimationFrame(raf)
+        node.removeEventListener('scroll', measureScrollHint)
+        resizeObserver.disconnect()
+      }
+    },
+    [measureScrollHint],
+  )
 
-    update()
-    scroller.addEventListener('scroll', update, { passive: true })
-    // base-ui sizes the popup async and avatars/logos load late, so the initial
-    // measurement often misses the overflow. Observe size changes to catch up.
-    const resizeObserver = new ResizeObserver(update)
-    resizeObserver.observe(scroller)
-    Array.from(scroller.children).forEach((child) => resizeObserver.observe(child))
-    return () => {
-      scroller.removeEventListener('scroll', update)
-      resizeObserver.disconnect()
-    }
-  }, [filteredItems.length, isLoading, isError])
+  // Re-measure when the rendered rows change (the scroll node itself can stay the same).
+  useEffect(() => {
+    measureScrollHint()
+    const raf = requestAnimationFrame(measureScrollHint)
+    return () => cancelAnimationFrame(raf)
+  }, [filteredItems.length, isLoading, isError, measureScrollHint])
 
   const renderContent = () => {
     if (isError) {
       return <DropdownContentError onRetry={onRetry} />
     }
 
-    if (isLoading && filteredItems.length === 0) {
+    if (isLoading && filteredItems.length === 0 && !query) {
       return Array.from({ length: SKELETON_COUNT }, (_, i) => <SafeItemSkeleton key={i} />)
+    }
+
+    if (filteredItems.length === 0) {
+      return (
+        <p className="px-4 py-6 text-center text-sm text-muted-foreground" data-testid="dropdown-empty">
+          {query ? 'No safes match your search' : 'No safes yet'}
+        </p>
+      )
     }
 
     return filteredItems.map((item) => {
@@ -127,25 +170,66 @@ const SafeDropdownContainer = ({
       align="start"
       side="bottom"
       alignItemWithTrigger={false}
-      className="w-[430px] max-w-[calc(100vw-2rem)] max-h-[20rem] overflow-y-auto overscroll-y-none bg-card border-0 ring-0 rounded-lg px-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
+      // outline-hidden: base-ui focuses the popup on open; typing in the search field makes that
+      // :focus-visible and would otherwise draw the browser's blue outline around the whole popup.
+      className="w-[430px] max-w-[calc(100vw-2rem)] overflow-hidden bg-card border-0 ring-0 outline-hidden rounded-lg [&_[data-slot=select-scroll-down-button]]:hidden [&_[data-slot=select-scroll-up-button]]:hidden"
       sideOffset={20}
       alignOffset={9}
       collisionAvoidance={{ side: 'none', align: 'shift' }}
     >
-      {header}
-      {renderContent()}
-      {footer && (
-        <div ref={footerRef} className="sticky bottom-0 z-10 bg-card">
-          {showScrollHint && (
-            <ChevronDown
-              data-testid="scroll-hint"
-              aria-hidden
-              className="pointer-events-none absolute -top-3 left-1/2 size-4 -translate-x-1/2 animate-bounce text-muted-foreground"
-            />
-          )}
-          {typeof footer === 'function' ? footer(closeDropdown) : footer}
+      {/* Fallback to 34rem: until base-ui sets --available-height the clamp must still apply, else the
+          list expands to full height, measures as non-overflowing, and the scroll-hint fade is missed. */}
+      <div className="flex max-h-[min(34rem,var(--available-height,34rem))] flex-col">
+        {(header || showSearch) && (
+          <div className="shrink-0 bg-card">
+            {header}
+            {showSearch && (
+              <div className="px-3 pb-2 pt-1">
+                <InputGroup className="rounded-md border-gray-100 shadow-none">
+                  <InputGroupAddon>
+                    <Search className="size-4" />
+                  </InputGroupAddon>
+                  <InputGroupInput
+                    placeholder="Search by name, address or network"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    // Stop keystrokes reaching base-ui Select's typeahead, which would hijack typing.
+                    // Trade-off: arrows/Enter stay in the input (no list nav); Escape still closes.
+                    onKeyDown={(e) => {
+                      if (e.key !== 'Escape') e.stopPropagation()
+                    }}
+                    autoComplete="off"
+                    data-testid="safe-dropdown-search-input"
+                  />
+                </InputGroup>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div
+          ref={attachScrollArea}
+          data-testid="dropdown-scroll-area"
+          className="min-h-0 flex-1 overflow-y-auto overscroll-y-none px-1 [scrollbar-width:thin] [scrollbar-color:var(--border)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border"
+        >
+          {renderContent()}
         </div>
-      )}
+
+        {footer && (
+          <div className="relative shrink-0 bg-card">
+            {showScrollHint && (
+              <div
+                data-testid="scroll-hint"
+                aria-hidden
+                // Fade the last visible row into the dropdown background. `card` isn't a :root color
+                // token (so `to-card` renders transparent) — reference the paper var it resolves to.
+                className="pointer-events-none absolute inset-x-0 -top-16 h-16 bg-gradient-to-b from-transparent to-[var(--color-background-paper)]"
+              />
+            )}
+            {typeof footer === 'function' ? footer(closeDropdown) : footer}
+          </div>
+        )}
+      </div>
     </SelectContent>
   )
 }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/BalanceDisplay.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/BalanceDisplay.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import BalanceDisplay from '../BalanceDisplay'
+
+const querySkeleton = (container: HTMLElement) => container.querySelector('[data-slot="skeleton"]')
+
+describe('BalanceDisplay', () => {
+  it('renders the threshold badge when threshold/owners are loaded', () => {
+    const { container } = render(<BalanceDisplay threshold={2} owners={3} />)
+
+    expect(screen.getByTestId('safe-selector-threshold')).toHaveTextContent('2/3')
+    expect(querySkeleton(container)).not.toBeInTheDocument()
+  })
+
+  it('shows a skeleton instead of "0/0" when the overview has not loaded', () => {
+    const { container } = render(<BalanceDisplay threshold={0} owners={0} />)
+
+    expect(screen.queryByTestId('safe-selector-threshold')).not.toBeInTheDocument()
+    expect(container).not.toHaveTextContent('0/0')
+    expect(querySkeleton(container)).toBeInTheDocument()
+  })
+
+  it('shows a skeleton while explicitly loading', () => {
+    const { container } = render(<BalanceDisplay threshold={2} owners={3} isLoading />)
+
+    expect(screen.queryByTestId('safe-selector-threshold')).not.toBeInTheDocument()
+    expect(querySkeleton(container)).toBeInTheDocument()
+  })
+
+  it('renders nothing for the threshold when showThreshold is false', () => {
+    const { container } = render(<BalanceDisplay threshold={0} owners={0} showThreshold={false} />)
+
+    expect(screen.queryByTestId('safe-selector-threshold')).not.toBeInTheDocument()
+    expect(querySkeleton(container)).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
@@ -1,7 +1,18 @@
 import React, { act } from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import SafeDropdownContainer from '../SafeDropdownContainer'
 import type { SafeItemData } from '../../types'
+
+// Resolver is exercised in its own unit test; here we stub it so the component renders without a
+// store. Default behaviour mirrors production: the safe's own name wins, else the address-book name.
+const mockAddressBookNames: Record<string, string> = {}
+jest.mock('@/hooks/useAllAddressBooks', () => ({
+  useSafeNameResolver:
+    () =>
+    (address: string, _chainId: string | undefined, preferredName?: string): string =>
+      preferredName || mockAddressBookNames[address.toLowerCase()] || '',
+}))
 
 // jsdom doesn't implement ResizeObserver; the component uses one to catch popup
 // size changes. A noop stub is enough since tests drive scroll state explicitly.
@@ -103,6 +114,119 @@ describe('SafeDropdownContainer', () => {
     })
   })
 
+  describe('search', () => {
+    const itemA = createItem({
+      id: '1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      name: 'Alpha Treasury',
+      address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      chains: [{ chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' }],
+    })
+    const itemB = createItem({
+      id: '137:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      name: 'Beta Ops',
+      address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      chains: [{ chainId: '137', chainName: 'Polygon', chainLogoUri: null, shortName: 'matic' }],
+    })
+
+    const renderWithSearch = () =>
+      render(<SafeDropdownContainer items={[itemA, itemB]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
+
+    beforeEach(() => {
+      for (const key of Object.keys(mockAddressBookNames)) delete mockAddressBookNames[key]
+    })
+
+    it('renders the search input when there are items', () => {
+      renderWithSearch()
+      expect(screen.getByTestId('safe-dropdown-search-input')).toBeInTheDocument()
+    })
+
+    it('does not render the search input on error', () => {
+      render(
+        <SafeDropdownContainer
+          items={[itemA]}
+          onItemSelect={jest.fn()}
+          closeDropdown={jest.fn()}
+          isError
+          onRetry={jest.fn()}
+        />,
+      )
+      expect(screen.queryByTestId('safe-dropdown-search-input')).not.toBeInTheDocument()
+    })
+
+    it('filters by name', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'alpha')
+
+      expect(screen.getByText('Alpha Treasury')).toBeInTheDocument()
+      expect(screen.queryByText('Beta Ops')).not.toBeInTheDocument()
+    })
+
+    it('filters by address', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), '0xbbbb')
+
+      expect(screen.getByText('Beta Ops')).toBeInTheDocument()
+      expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
+    })
+
+    it('filters by chain name', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'polygon')
+
+      expect(screen.getByText('Beta Ops')).toBeInTheDocument()
+      expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
+    })
+
+    it('filters by chain short name', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'matic')
+
+      expect(screen.getByText('Beta Ops')).toBeInTheDocument()
+      expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
+    })
+
+    it('filters by the address-book name when the safe itself is unnamed', async () => {
+      const unnamed = createItem({
+        id: '1:0xcccccccccccccccccccccccccccccccccccccccc',
+        name: '',
+        address: '0xcccccccccccccccccccccccccccccccccccccccc',
+        chains: [{ chainId: '1', chainName: 'Ethereum', chainLogoUri: null, shortName: 'eth' }],
+      })
+      mockAddressBookNames['0xcccccccccccccccccccccccccccccccccccccccc'] = 'Cold Storage'
+
+      render(<SafeDropdownContainer items={[itemA, unnamed]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'cold')
+
+      // The unnamed safe (resolved via address book) survives; the named one is filtered out.
+      expect(screen.queryByText('Alpha Treasury')).not.toBeInTheDocument()
+      expect(screen.getByTestId('safe-item')).toBeInTheDocument()
+    })
+
+    it('shows an empty state when nothing matches', async () => {
+      renderWithSearch()
+      await userEvent.type(screen.getByTestId('safe-dropdown-search-input'), 'nonexistent')
+
+      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('No safes match your search')
+      expect(screen.queryByTestId('safe-item')).not.toBeInTheDocument()
+    })
+
+    it('stops character keystrokes from bubbling to the popup (defeats base-ui typeahead) but lets Escape through', () => {
+      const onKeyDownSpy = jest.fn()
+      render(
+        <div onKeyDown={onKeyDownSpy}>
+          <SafeDropdownContainer items={[itemA, itemB]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />
+        </div>,
+      )
+      const input = screen.getByTestId('safe-dropdown-search-input')
+
+      fireEvent.keyDown(input, { key: 'a' })
+      expect(onKeyDownSpy).not.toHaveBeenCalled()
+
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(onKeyDownSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('scroll hint', () => {
     it('hides the hint when content does not overflow', () => {
       render(
@@ -114,7 +238,7 @@ describe('SafeDropdownContainer', () => {
         />,
       )
 
-      const scroller = screen.getByTestId('select-content')
+      const scroller = screen.getByTestId('dropdown-scroll-area')
       setScrollMetrics(scroller, { scrollHeight: 200, clientHeight: 320, scrollTop: 0 })
       fireScroll(scroller)
 
@@ -131,7 +255,7 @@ describe('SafeDropdownContainer', () => {
         />,
       )
 
-      const scroller = screen.getByTestId('select-content')
+      const scroller = screen.getByTestId('dropdown-scroll-area')
       setScrollMetrics(scroller, { scrollHeight: 1000, clientHeight: 320, scrollTop: 0 })
       fireScroll(scroller)
 
@@ -148,7 +272,7 @@ describe('SafeDropdownContainer', () => {
         />,
       )
 
-      const scroller = screen.getByTestId('select-content')
+      const scroller = screen.getByTestId('dropdown-scroll-area')
       setScrollMetrics(scroller, { scrollHeight: 1000, clientHeight: 320, scrollTop: 0 })
       fireScroll(scroller)
       expect(screen.getByTestId('scroll-hint')).toBeInTheDocument()

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/index.tsx
@@ -118,7 +118,9 @@ function SafeSelectorDropdown({
     >
       <SelectTrigger
         className={cn(
-          '-m-4 flex-1 border-0 shadow-none bg-transparent dark:bg-transparent py-0 pl-6 hover:bg-transparent dark:hover:bg-transparent data-[state=open]:bg-transparent [&_[data-slot=select-value]]:pr-0 relative',
+          // The wrapper's overflow-hidden clips this focus-visible ring into stray top/bottom bars,
+          // so suppress it — the card shows no focus ring by design (wrapper sets focus:ring-0).
+          '-m-4 flex-1 border-0 shadow-none bg-transparent dark:bg-transparent py-0 pl-6 hover:bg-transparent dark:hover:bg-transparent data-[state=open]:bg-transparent focus-visible:ring-0 focus-visible:border-0 [&_[data-slot=select-value]]:pr-0 relative',
           variants.triggerClass,
           isDisabled && 'cursor-not-allowed opacity-50',
         )}

--- a/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
+++ b/apps/web/src/hooks/__tests__/useAllAddressBooks.test.ts
@@ -2,16 +2,23 @@ import { renderHook } from '@testing-library/react'
 import {
   useMergedAddressBooks,
   useAddressBookItem,
+  useSafeNameResolver,
   ContactSource,
   type ExtendedContact,
 } from '@/hooks/useAllAddressBooks'
+import type { AddressBookSource } from '@/components/common/AddressBookSourceProvider'
 
 let signedIn = false
 let chainId = '1'
 let currentSpaceId = '123'
 let localAddressBook: Record<string, string> = {}
+// Real `selectAllAddressBooks` is keyed by chain (`{ [chainId]: { [address]: name } }`), unlike the
+// flat per-chain `selectAddressBookByChain`. `useSafeNameResolver` reads the former, so it gets its
+// own nested fixture; the per-chain selector keeps returning the flat `localAddressBook`.
+let localAddressBooksByChain: Record<string, Record<string, string>> = {}
 let remoteContacts: ExtendedContact[] = []
 let privateContacts: ExtendedContact[] = []
+let mockAddressBookSource: AddressBookSource = 'merged'
 
 jest.mock('@/store', () => ({
   useAppSelector: (selector: (state: unknown) => unknown) =>
@@ -29,13 +36,17 @@ jest.mock('@/store/authSlice', () => ({
 }))
 
 jest.mock('@/store/addressBookSlice', () => ({
-  selectAllAddressBooks: jest.fn(() => localAddressBook),
+  selectAllAddressBooks: jest.fn(() => localAddressBooksByChain),
   selectAddressBookByChain: jest.fn(() => localAddressBook),
 }))
 
 jest.mock('@/hooks/useAddressBook', () => () => localAddressBook)
 
 jest.mock('@/hooks/useChainId', () => () => chainId)
+
+jest.mock('@/components/common/AddressBookSourceProvider', () => ({
+  useAddressBookSource: () => mockAddressBookSource,
+}))
 
 // Import the mocked hooks
 import { useCurrentSpaceId, useGetSpaceAddressBook, useGetPrivateAddressBook } from '@/features/spaces'
@@ -253,6 +264,115 @@ describe('useAllAddressBooks', () => {
       const { result } = renderHook(() => useAddressBookItem('0xB', undefined))
 
       expect(result.current).toBeUndefined()
+    })
+  })
+
+  describe('useSafeNameResolver', () => {
+    const spaceContact = (name: string, address: string, chainIds = ['1']): ExtendedContact => ({
+      name,
+      address,
+      chainIds,
+      createdBy: '',
+      createdByUserId: 0,
+      lastUpdatedBy: '',
+      lastUpdatedByUserId: 0,
+      createdAt: '',
+      updatedAt: '',
+      source: ContactSource.space,
+    })
+
+    beforeEach(() => {
+      ;(useCurrentSpaceId as jest.Mock).mockReturnValue(currentSpaceId)
+      ;(useGetSpaceAddressBook as jest.Mock).mockImplementation(() => remoteContacts)
+      ;(useGetPrivateAddressBook as jest.Mock).mockImplementation(() => privateContacts)
+      mockAddressBookSource = 'merged'
+    })
+
+    afterEach(() => {
+      remoteContacts = []
+      privateContacts = []
+      localAddressBook = {}
+      localAddressBooksByChain = {}
+      signedIn = false
+      mockAddressBookSource = 'merged'
+      jest.clearAllMocks()
+    })
+
+    it('returns the preferred name verbatim when provided', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Address Book Name', '0xA')]
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      // Preferred name wins over the address book entry.
+      expect(result.current('0xA', '1', 'Preferred Name')).toBe('Preferred Name')
+    })
+
+    it('falls back to the address-book name when no preferred name is given', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Treasury', '0xA')]
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xA', '1')).toBe('Treasury')
+    })
+
+    it('matches the address book case-insensitively', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Treasury', '0xAbCdEf')]
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xabcdef', '1')).toBe('Treasury')
+    })
+
+    it('returns an empty string when nothing matches', () => {
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xUnknown', '1')).toBe('')
+    })
+
+    it('returns an empty string when no chainId is given', () => {
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xA', undefined, '')).toBe('')
+    })
+
+    it('ignores space/private names under the localOnly source', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Treasury', '0xA')]
+      mockAddressBookSource = 'localOnly'
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xA', '1')).toBe('')
+    })
+
+    it('returns the space-book name under the spaceOnly source', () => {
+      signedIn = true
+      remoteContacts = [spaceContact('Treasury', '0xA')]
+      mockAddressBookSource = 'spaceOnly'
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xA', '1')).toBe('Treasury')
+    })
+
+    it('resolves a local-only name on the current chain (merged source)', () => {
+      localAddressBooksByChain = { '1': { '0xlocal': 'Local Wallet' } }
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xLocal', '1')).toBe('Local Wallet')
+    })
+
+    it('resolves a local-only name on a NON-current chain (the cross-chain case)', () => {
+      // useChainId() is '1'; this entry lives on chain 137, which the merged map would miss.
+      localAddressBooksByChain = { '137': { '0xremotechain': 'Polygon Wallet' } }
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xRemoteChain', '137')).toBe('Polygon Wallet')
+    })
+
+    it('still resolves cross-chain local names under the localOnly source', () => {
+      remoteContacts = [spaceContact('Should Be Ignored', '0xRemoteChain', ['137'])]
+      localAddressBooksByChain = { '137': { '0xremotechain': 'Polygon Wallet' } }
+      mockAddressBookSource = 'localOnly'
+
+      const { result } = renderHook(() => useSafeNameResolver())
+      expect(result.current('0xRemoteChain', '137')).toBe('Polygon Wallet')
     })
   })
 })

--- a/apps/web/src/hooks/useAllAddressBooks.ts
+++ b/apps/web/src/hooks/useAllAddressBooks.ts
@@ -2,7 +2,7 @@ import { useAppSelector } from '@/store'
 import { type AddressBook, selectAddressBookByChain, selectAllAddressBooks } from '@/store/addressBookSlice'
 import { type SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import useChainId from '@/hooks/useChainId'
 import { useGetSpaceAddressBook, useGetPrivateAddressBook } from '@/features/spaces'
 import { useAddressBookSource } from '@/components/common/AddressBookSourceProvider'
@@ -161,6 +161,54 @@ export const useAddressBookItem = (address: string, chainId: string | undefined)
 
     return undefined
   }, [chainId, source, getFromLocal, address, get])
+}
+
+/**
+ * Returns a source-aware resolver for safe display names, mirroring {@link useSafeDisplayName}
+ * (`preferredName > address book`) but usable across many addresses without a hook per item.
+ *
+ * Use this only to resolve names in bulk inside a loop / filter / sort (e.g. the account dropdown
+ * search) — the visible name often comes from the address book, not the safe's own `name`, so
+ * filtering the raw name misses those safes. For a single name in a component use the lighter
+ * {@link useSafeDisplayName} instead.
+ *
+ * Keep the source priority below in sync with {@link useSafeDisplayName}/{@link useAddressBookItem}:
+ * this is the array-friendly twin of that per-item hook, so the two must resolve names identically.
+ */
+export const useSafeNameResolver = (): ((
+  address: string,
+  chainId: string | undefined,
+  preferredName?: string,
+) => string) => {
+  const { get } = useMergedAddressBooks()
+  const allLocal = useAppSelector(selectAllAddressBooks)
+  const source = useAddressBookSource()
+
+  // Flatten every chain's local book into a lowercased lookup so names on chains other than the
+  // currently-loaded one still resolve (the merged map only carries the current chain's locals).
+  const localByKey = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const [cid, book] of Object.entries(allLocal)) {
+      for (const [addr, name] of Object.entries(book)) {
+        map.set(addressBookKey(addr, cid), name)
+      }
+    }
+    return map
+  }, [allLocal])
+
+  return useCallback(
+    (address, chainId, preferredName) => {
+      if (preferredName) return preferredName
+      if (!chainId) return ''
+      const localName = localByKey.get(addressBookKey(address, chainId))
+      if (source === 'localOnly') return localName ?? ''
+      const item = get(address, chainId)
+      if (source === 'spaceOnly') return item?.source === ContactSource.space ? (item.name ?? '') : ''
+      // merged: space/private (cross-chain) take priority, then any chain's local
+      return item?.name ?? localName ?? ''
+    },
+    [get, source, localByKey],
+  )
 }
 
 // Returns all local address books

--- a/apps/web/src/hooks/useSafeDisplayName.ts
+++ b/apps/web/src/hooks/useSafeDisplayName.ts
@@ -1,8 +1,10 @@
 import { useAddressBookItem } from '@/hooks/useAllAddressBooks'
 
 /**
- * Resolves the display name for a Safe address.
- * Priority: preferredName > address book
+ * Resolves the display name for a single Safe address (priority: preferredName > address book).
+ *
+ * Use this when rendering ONE safe's name in a component. To resolve many names at once inside a
+ * loop / filter / sort (where calling a hook per item isn't allowed), use {@link useSafeNameResolver}.
  */
 export const useSafeDisplayName = (address: string, chainId: string, preferredName?: string): string => {
   const addressBookItem = useAddressBookItem(address, chainId)


### PR DESCRIPTION
This feature should be included for current release.
Orginal PR to `dev`:
https://github.com/safe-global/safe-wallet-monorepo/pull/8026

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
