### PR TITLE
Improve invite dialog name input label UX

### DIFF
--- a/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
@@ -73,7 +73,13 @@ function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClo
         <form onSubmit={onSubmit}>
           <DialogContent sx={{ py: 2 }}>
             <Box mb={2}>
-              <NameInput data-testid="invite-name-input" label="Name" autoFocus name="name" required />
+              <NameInput
+                data-testid="invite-name-input"
+                label="How should we call you?"
+                autoFocus
+                name="name"
+                required
+              />
             </Box>
             <Typography variant="body2" color="text.secondary">
               How is my data processed? Read our <ExternalLink href={AppRoutes.privacy}>privacy policy</ExternalLink>

--- a/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
+++ b/apps/web/src/features/spaces/components/InviteBanner/AcceptInviteDialog.tsx
@@ -75,7 +75,7 @@ function AcceptInviteDialog({ space, onClose }: { space: GetSpaceResponse; onClo
             <Box mb={2}>
               <NameInput
                 data-testid="invite-name-input"
-                label="How should we call you?"
+                label="What should we call you?"
                 autoFocus
                 name="name"
                 required


### PR DESCRIPTION
## What it solves

Improves the user experience of the invite acceptance dialog by providing a more descriptive and friendly label for the name input field.

## How this PR fixes it

Changed the name input label from the generic "Name" to the more conversational "What should we call you?" This provides better context to users about what information is being requested and creates a more welcoming tone in the invite acceptance flow.

## How to test it

1. Navigate to the invite acceptance dialog
2. Verify that the name input field displays the new label "What should we call you?"
3. Confirm the input field still functions normally (accepts text, validates as required, etc.)

## Affected flows

- User accepts a space invite and completes the name input step

## Blast radius

- `AcceptInviteDialog` component in the spaces feature
- No API changes, no shared component modifications
- UI text change only

## Risks / not checked

- Did not verify on mobile (though this is a simple text label change with minimal layout impact)

## Visual summary

The name input field label changes from:
```
Name
```

To:
```
What should we call you?
```

This is a purely cosmetic UX improvement with no functional changes.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [ ] I've listed affected flows and blast radius, and named what I did not verify 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

https://claude.ai/code/session_01RFy7pHGA9RuXqmSk2xTPb6