### PR TITLE
fix: Show cloud icon for when adding team members

### DIFF
--- a/apps/web/src/components/common/AddressBookInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.test.tsx
@@ -2,6 +2,7 @@ import { act } from 'react'
 import { fireEvent, render, waitFor } from '@/tests/test-utils'
 import { FormProvider, useForm } from 'react-hook-form'
 import AddressBookInput from '.'
+import { AddressBookSourceProvider } from '../AddressBookSourceProvider'
 import type { AddressInputProps } from '../AddressInput'
 import * as useChains from '@/hooks/useChains'
 import { faker } from '@faker-js/faker'
@@ -9,6 +10,34 @@ import { chainBuilder } from '@/tests/builders/chains'
 import { FEATURES } from '@safe-global/store/gateway/types'
 import { checksumAddress } from '@safe-global/utils/utils/addresses'
 import type { AddressBook } from '@/store/addressBookSlice'
+import type { SpaceAddressBookItemDto } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { useGetPrivateAddressBook, useGetSpaceAddressBook } from '@/features/spaces'
+
+jest.mock('@/features/spaces/hooks/useGetPrivateAddressBook', () => ({
+  __esModule: true,
+  default: jest.fn((): SpaceAddressBookItemDto[] => []),
+}))
+
+jest.mock('@/features/spaces/hooks/useGetSpaceAddressBook', () => ({
+  __esModule: true,
+  default: jest.fn((): SpaceAddressBookItemDto[] => []),
+}))
+
+const mockUseGetPrivateAddressBook = useGetPrivateAddressBook as jest.MockedFunction<typeof useGetPrivateAddressBook>
+const mockUseGetSpaceAddressBook = useGetSpaceAddressBook as jest.MockedFunction<typeof useGetSpaceAddressBook>
+
+const privateContactBuilder = (overrides: Partial<SpaceAddressBookItemDto> = {}): SpaceAddressBookItemDto => ({
+  name: 'Server Contact',
+  address: checksumAddress(faker.finance.ethereumAddress()),
+  chainIds: ['4'],
+  createdBy: '',
+  createdByUserId: 0,
+  lastUpdatedBy: '',
+  lastUpdatedByUserId: 0,
+  createdAt: '',
+  updatedAt: '',
+  ...overrides,
+})
 
 // We use Rinkeby and chainId 4 here as this is our default url chain (see jest.setup.js)
 const mockChain = chainBuilder()
@@ -96,6 +125,8 @@ describe('AddressBookInput', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseGetPrivateAddressBook.mockReturnValue([])
+    mockUseGetSpaceAddressBook.mockReturnValue([])
     jest.spyOn(useChains, 'default').mockImplementation(() => ({
       configs: [mockChain],
       error: undefined,
@@ -271,5 +302,49 @@ describe('AddressBookInput', () => {
     })
 
     await waitFor(() => expect(utils.queryByText('add it to your address book', { exact: false })).toBeNull())
+  })
+
+  it('should show a cloud icon for a server-stored (private) contact even in a spaceOnly context', async () => {
+    const privateContact = privateContactBuilder({ name: 'Server Contact' })
+    mockUseGetPrivateAddressBook.mockReturnValue([privateContact])
+
+    const name = 'recipient'
+    const SpaceForm = () => {
+      const methods = useForm<{ [name]: string }>({ defaultValues: { [name]: '' }, mode: 'all' })
+      return (
+        <FormProvider {...methods}>
+          <AddressBookSourceProvider source="spaceOnly">
+            <AddressBookInput data-testid={testId} name={name} label="Recipient address" />
+          </AddressBookSourceProvider>
+        </FormProvider>
+      )
+    }
+
+    const utils = render(<SpaceForm />, {
+      initialReduxState: { addressBook: { [mockChain.chainId]: {} } },
+    })
+    const input = utils.getByLabelText('Recipient address', { exact: false }) as HTMLInputElement
+
+    act(() => {
+      fireEvent.mouseDown(input)
+      fireEvent.mouseUp(input)
+    })
+
+    await waitFor(() => expect(utils.getByText('Server Contact', { exact: false })).toBeDefined())
+    expect(utils.getByTestId('CloudOutlinedIcon')).toBeInTheDocument()
+  })
+
+  it('should not show a cloud icon for a local contact', async () => {
+    const { input, utils } = setup('', {
+      [checksumAddress(faker.finance.ethereumAddress())]: 'Local Contact',
+    })
+
+    act(() => {
+      fireEvent.mouseDown(input)
+      fireEvent.mouseUp(input)
+    })
+
+    await waitFor(() => expect(utils.getByText('Local Contact', { exact: false })).toBeDefined())
+    expect(utils.queryByTestId('CloudOutlinedIcon')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/common/AddressBookInput/index.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.tsx
@@ -32,6 +32,7 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
       mergedAddressBook.list.map((entry) => ({
         label: entry.address,
         name: entry.name,
+        source: entry.source,
       })),
     [mergedAddressBook],
   )
@@ -89,7 +90,13 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
               const { key, ...rest } = props
               return (
                 <Typography data-testid="address-item" component="li" variant="body2" {...rest} key={key}>
-                  <EthHashInfo address={option.label} name={option.name} shortAddress={false} copyAddress={false} />
+                  <EthHashInfo
+                    address={option.label}
+                    name={option.name}
+                    shortAddress={false}
+                    copyAddress={false}
+                    addressBookNameSource={option.source}
+                  />
                 </Typography>
               )
             }}


### PR DESCRIPTION
In the "Add member" flow on Workspaces, when typing in a contact, for contacts that are stored in the workspace, but are private, a cloud icon would NOT show next to their name when adding a team member. With @liliya-soroka, we discussed offline that these should have an icon though. Here's the problematic part on staging:

<img width="647" height="585" alt="Screenshot 2026-06-09 at 18 11 08" src="https://github.com/user-attachments/assets/1e36c291-0128-42f4-bd4b-3c4386384d57" />

The cloud icon for private contacts that are stored in the workspace is however implemented to show a cloud icon when selecting recipients for sending a new transaction, an example:
<img width="725" height="538" alt="Screenshot 2026-06-09 at 18 12 52" src="https://github.com/user-attachments/assets/032e882f-5956-4d28-b486-720d857a2b7a" />

Hence, this PR adds showing the cloud icon also for private contacts on the "Add member" dialogue:

