### PR TITLE
fix: responsive topbar layout when narrowing the window

### DIFF
--- a/apps/web/src/components/common/Header/Topbar/index.tsx
+++ b/apps/web/src/components/common/Header/Topbar/index.tsx
@@ -91,8 +91,8 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
   return (
     <>
       <header
-        className={`flex flex-wrap ${isSettingsWithoutSafe ? 'items-center' : 'items-start'} gap-y-2 px-6 py-4 bg-secondary dark:bg-background ${
-          showMenuButton ? 'justify-between pl-2' : 'justify-between'
+        className={`@container flex flex-wrap ${isSettingsWithoutSafe ? 'items-center' : 'items-start'} gap-y-2 px-6 py-4 bg-secondary dark:bg-background ${
+          showMenuButton ? 'pl-2' : ''
         }`}
       >
         {showMenuButton ? (
@@ -106,8 +106,11 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
           </Button>
         ) : null}
 
-        {/* Left content: SpaceSafeBar must not shrink so its children stay on one line */}
-        <div className="shrink-0 max-md:order-last flex items-center max-md:basis-full max-md:mt-2">
+        {/* Left content (context): the safe selector must not shrink so its children stay on
+            one line. When the header (container query — accounts for sidebar + route) is too
+            narrow to fit both groups, this drops onto its own full-width row below the actions.
+            Below md (sidebar hidden) the wrapped rows align right; at/above md they align left. */}
+        <div className="shrink-0 flex items-center @max-[1100px]:order-1 @max-[1100px]:basis-full max-[899px]:justify-end">
           {isSettingsWithoutSafe ? (
             <SafeLogo />
           ) : showSpaceSafeBar ? (
@@ -117,8 +120,10 @@ const Topbar = ({ onMenuToggle, onBatchToggle }: TopbarProps): ReactElement => {
           )}
         </div>
 
-        {/* Right content: navigation buttons — wraps to next row when viewport is narrow */}
-        <div className="flex items-center gap-1 shrink-0">
+        {/* Right content (actions): ml-auto pushes it right (page padding) on one row. When the
+            header wraps at/above md (sidebar shown) ml-0 left-aligns it with the context below;
+            below md (sidebar hidden) it keeps ml-auto so the wrapped rows hug the right edge. */}
+        <div className="flex items-center gap-1 shrink-0 ml-auto @max-[1100px]:min-[900px]:ml-0">
           {showSafeToken && (
             <div className="hidden sm:block">
               <SafenetStakingButton />

--- a/apps/web/src/components/common/PageHeader/styles.module.css
+++ b/apps/web/src/components/common/PageHeader/styles.module.css
@@ -10,6 +10,13 @@
   top: calc(var(--header-height) - 76px);
 }
 
+/* In dark mode the page background is black (var(--background), set on .mainSpace),
+   so match it here — otherwise the header's opaque sticky background shows as a
+   lighter strip behind the tabs even when it isn't pinned. */
+[data-theme='dark'] .container {
+  background-color: var(--background);
+}
+
 .title {
   font-weight: 700;
   margin-bottom: var(--space-3);

--- a/apps/web/src/components/common/PageLayout/index.test.tsx
+++ b/apps/web/src/components/common/PageLayout/index.test.tsx
@@ -244,27 +244,4 @@ describe('PageLayout', () => {
       expect(screen.getByTestId('page-content')).toBeInTheDocument()
     })
   })
-
-  describe('settings route padding-top', () => {
-    it('applies the compact main class on settings without a safe address', () => {
-      mockUseSafeAddressFromUrl.mockReturnValue('')
-      const { container } = renderLayout('/settings/notifications')
-      const main = container.querySelector('main, [class*="main"]')
-      expect(main?.className).toMatch(/mainSpaceCompact/)
-    })
-
-    it('does not apply the compact main class on settings with a safe address', () => {
-      mockUseSafeAddressFromUrl.mockReturnValue('0x1234567890abcdef1234567890abcdef12345678')
-      const { container } = renderLayout('/settings/notifications')
-      const main = container.querySelector('main, [class*="main"]')
-      expect(main?.className).not.toMatch(/mainSpaceCompact/)
-    })
-
-    it('does not apply the compact main class on non-settings routes', () => {
-      mockUseSafeAddressFromUrl.mockReturnValue('')
-      const { container } = renderLayout('/home')
-      const main = container.querySelector('main, [class*="main"]')
-      expect(main?.className).not.toMatch(/mainSpaceCompact/)
-    })
-  })
 })

--- a/apps/web/src/components/common/PageLayout/index.tsx
+++ b/apps/web/src/components/common/PageLayout/index.tsx
@@ -19,7 +19,6 @@ import { useRouterGuard } from '@/hooks/useRouterGuard'
 import { useFlowActivationGuard } from '@/hooks/useRouterGuard/activationGuards/useFlowActivationGuard'
 import { useKeyboardObserver } from '@/hooks/useKeyboardObserver'
 import { useIsTopbarElevated } from '@/hooks/useTopbarElevation'
-import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { useIsRequireLoginEnabled } from '@/hooks/useIsRequireLoginEnabled'
 import { useIsAuthGateBlocking } from '@/hooks/useIsAuthGateBlocking'
 import { useIsSignedIn } from '@/hooks/useIsSignedIn'
@@ -68,8 +67,6 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
     (pathname === AppRoutes.welcome.spaces && !isSignedIn)
   const isOnboardingRoute = ONBOARDING_ROUTES.includes(pathname)
   const isSpaceRoute = useIsSpaceRoute()
-  const urlSafeAddress = useSafeAddressFromUrl()
-  const isSettingsWithoutSafe = pathname.startsWith(AppRoutes.settings.index) && !urlSafeAddress
   const parentSafe = useParentSafe()
   const menuToggleHandler = isSidebarRoute ? setSidebarOpen : undefined
 
@@ -99,18 +96,6 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
     <>
       <ClassicViewToast />
 
-      {!hideHeader && (
-        <div
-          className={classnames(css.topbar, {
-            [css.topbarCollapsed]: isSpaceRoute && !isSpacesSidebarExpanded,
-            [css.topbarNoSidebar]: !isSidebarVisible || !isSidebarRoute,
-            [css.topbarElevated]: isTopbarElevated,
-          })}
-        >
-          <Topbar onMenuToggle={menuToggleHandler} onBatchToggle={setBatchOpen} />
-        </div>
-      )}
-
       {isStaticPage && (
         <div className="px-6 py-4">
           <SafeLogo />
@@ -131,10 +116,19 @@ const PageLayout = ({ pathname, children }: { pathname: string; children: ReactE
           [css.mainAnimated]: isSidebarRoute && isAnimated,
           [css.mainNoHeader]: hideHeader,
           [css.mainSpace]: !hideHeader,
-          [css.mainSpaceCompact]: isSettingsWithoutSafe,
           [css.mainSpaceCollapsed]: isSpaceRoute && !isSpacesSidebarExpanded,
         })}
       >
+        {!hideHeader && (
+          <div
+            className={classnames(css.topbar, {
+              [css.topbarElevated]: isTopbarElevated,
+            })}
+          >
+            <Topbar onMenuToggle={menuToggleHandler} onBatchToggle={setBatchOpen} />
+          </div>
+        )}
+
         <div className={css.content}>
           <SafeLoadingError>
             {!hideHeader && parentSafe && <Breadcrumbs />}

--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -1,71 +1,20 @@
 @reference '../../../styles/shadcn.css';
 
+/* The topbar lives in normal flow as the first child of .main, so it pushes the
+   page content down by its own height — no fixed reservation to keep in sync,
+   so it can wrap onto extra rows on narrow viewports without clipping content.
+   .main owns the sidebar offset (padding-left), so the topbar inherits it. */
 .topbar {
-  @apply absolute top-0 right-0 z-[1];
-  left: 230px;
-}
-
-.topbarCollapsed {
-  left: 4rem;
-}
-
-.topbarNoSidebar {
-  left: 0;
-}
-
-.topbarElevated {
-  position: fixed;
-  z-index: 99;
-  left: 0;
+  position: sticky;
+  top: 0;
+  z-index: 2;
   width: 100%;
-  transition: none;
-
-  header {
-    padding-left: 230px;
-  }
 }
 
-.topbarElevated:not(.topbarNoSidebar) header {
-  padding-left: calc(230px + 1.5rem);
-}
-
-.topbarElevated.topbarNoSidebar header {
-  padding-left: 1.5rem;
-}
-
-@media (max-width: 899.95px) {
-  .topbar {
-    left: 0;
-    position: sticky;
-    top: 0;
-  }
-
-  .mainSpace {
-    && {
-      @apply pt-0;
-    }
-  }
-}
-
-.mainSpace {
-  /* we need it in order to have higher importance than the .main class */
-  && {
-    padding-top: var(--topbar-height);
-
-    @media (max-width: 640px) {
-      padding-top: 0;
-    }
-  }
-}
-
-/* Compact variant: settings page without an active safe — topbar collapses
-   to a single row (logo only) so we shrink the reserved space accordingly.
-   The topbar is ~76px tall (header --header-height plus the wallet button row),
-   so we leave one space-3 of breathing room below it. */
-@media (min-width: 900px) {
-  .mainSpace.mainSpaceCompact {
-    padding-top: calc(var(--header-height) + var(--space-3));
-  }
+/* Elevated above a modal backdrop (e.g. tx flow). Stays in flow so the page
+   doesn't shift, just raised. */
+.topbarElevated {
+  z-index: 99;
 }
 
 .main {

--- a/apps/web/src/components/common/PageLayout/styles.module.css
+++ b/apps/web/src/components/common/PageLayout/styles.module.css
@@ -3,10 +3,11 @@
 /* The topbar lives in normal flow as the first child of .main, so it pushes the
    page content down by its own height — no fixed reservation to keep in sync,
    so it can wrap onto extra rows on narrow viewports without clipping content.
-   .main owns the sidebar offset (padding-left), so the topbar inherits it. */
+   .main owns the sidebar offset (padding-left), so the topbar inherits it.
+   It scrolls away with the page (not sticky) so a page's own sticky sub-header
+   — e.g. the Assets tabs — can pin to the top cleanly without overlapping it. */
 .topbar {
-  position: sticky;
-  top: 0;
+  position: relative;
   z-index: 2;
   width: 100%;
 }

--- a/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceChainSelector.tsx
@@ -9,7 +9,7 @@ import { OVERVIEW_EVENTS, trackEvent } from '@/services/analytics'
 
 function SpaceChainSelectorSkeleton() {
   return (
-    <div className="self-stretch sm:order-last flex items-center rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)] px-4">
+    <div className="self-stretch order-last flex items-center rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)] px-4">
       <Skeleton className="size-6 rounded-full" />
     </div>
   )
@@ -53,7 +53,7 @@ function SpaceChainSelector({ isLoading }: { isLoading?: boolean }) {
 
   return (
     <div
-      className="self-stretch sm:order-last flex items-stretch shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)] rounded-lg bg-card"
+      className="self-stretch order-last flex items-stretch shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)] rounded-lg bg-card"
       data-testid="space-chain-selector"
     >
       {isDisabled ? (

--- a/apps/web/src/components/common/SpaceSafeBar/SpaceNestedSafesButton.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceNestedSafesButton.tsx
@@ -48,7 +48,7 @@ function SpaceNestedSafesButton(): ReactElement | null {
 
   return (
     <>
-      <div className="flex self-stretch items-stretch sm:order-1 rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]">
+      <div className="flex self-stretch items-stretch order-1 rounded-lg bg-card shadow-[0px_4px_20px_0px_rgba(0,0,0,0.03)]">
         <Tooltip>
           <TooltipTrigger
             render={

--- a/apps/web/src/components/common/SpaceSafeBar/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/index.tsx
@@ -190,20 +190,27 @@ function SpaceSafeBar() {
         )
 
   return (
-    <div data-testid="safe-level-navigation" className="flex flex-wrap items-center gap-2">
-      {isQualifiedSafe && space && !txFlow && <SpaceBackLink space={space} onClick={handleBackToSpace} />}
-      <SpaceChainSelector isLoading={isLoading} />
+    <div data-testid="safe-level-navigation" className="flex flex-wrap items-center gap-2 max-[899px]:justify-end">
+      {/* Back-link + safe selector are one unit so they never split across rows. Under 430px
+          the group dissolves (display:contents) so the back-link joins the nested/network
+          controls on one row and the safe selector drops to its own full-width row below. */}
+      <div className="flex min-w-0 items-center gap-2 max-[429px]:contents">
+        {isQualifiedSafe && space && !txFlow && <SpaceBackLink space={space} onClick={handleBackToSpace} />}
+        <div className="contents max-[429px]:block max-[429px]:order-[10000] max-[429px]:min-w-0 max-[429px]:basis-full">
+          <SafeSelectorDropdown
+            items={items}
+            selectedItemId={selectedItemId}
+            onItemSelect={handleItemSelect}
+            isLoading={isLoading}
+            isError={isError}
+            onRetry={refetch}
+            header={dropdownHeader}
+            footer={dropdownFooter}
+          />
+        </div>
+      </div>
       <SpaceNestedSafesButton />
-      <SafeSelectorDropdown
-        items={items}
-        selectedItemId={selectedItemId}
-        onItemSelect={handleItemSelect}
-        isLoading={isLoading}
-        isError={isError}
-        onRetry={refetch}
-        header={dropdownHeader}
-        footer={dropdownFooter}
-      />
+      <SpaceChainSelector isLoading={isLoading} />
       <AccountsModal open={accountsModalOpen} onClose={() => setAccountsModalOpen(false)} />
     </div>
   )

--- a/apps/web/src/components/safe-apps/SafeAppsHeader/styles.module.css
+++ b/apps/web/src/components/safe-apps/SafeAppsHeader/styles.module.css
@@ -27,6 +27,14 @@
   padding: 0 var(--space-3);
 }
 
+/* In dark mode the page background is black (var(--background), set on .mainSpace),
+   so match it here — otherwise these opaque backgrounds show as a lighter strip
+   behind the hero and the sticky tabs. */
+[data-theme='dark'] .container,
+[data-theme='dark'] .tabs {
+  background-color: var(--background);
+}
+
 @media (max-width: 599.95px) {
   .tabs {
     padding: 0 24px;

--- a/apps/web/src/components/safe-apps/SafeAppsHeader/styles.module.css
+++ b/apps/web/src/components/safe-apps/SafeAppsHeader/styles.module.css
@@ -1,5 +1,5 @@
 .container {
-  padding: var(--space-12) var(--space-3) 0;
+  padding: var(--space-6) var(--space-3) 0;
   margin-bottom: var(--space-5);
   background-color: var(--color-background-main);
 }


### PR DESCRIPTION
> Topbar leaves its perch,
> scrolls away as tabs take hold—
> dark strips fade to night.

## What it solves

When narrowing the window the topbar wrapped onto extra rows and clipped the dashboard/assets cards; wrapped elements were inconsistently ordered and aligned; on the Assets page the sticky topbar overlapped the sticky tab bar while scrolling; and in dark mode the sticky sub-headers (Assets tabs, Apps hero/tabs) showed a lighter background strip.

Resolves: https://linear.app/safe-global/issue/WA-2509/responsive-layout-is-broken-when-user-narrow-the-window

## How this PR fixes it

The clipping root cause was the topbar being \`position: absolute\` with a fixed \`--topbar-height\` page reservation — when it wrapped it grew past that reservation. It's now a normal-flow first child of \`.main\`, pushing content by its real height (no magic number).

Notable decisions:
- **Wrapping** is driven by a container query on the header (sidebar/route-aware): one row when it fits, else the safe-selector group drops to its own row.
- **Alignment** of wrapped rows is gated on md (900px): left at/above md (sidebar shown), right below md.
- **Grouping**: safe selector first; back-link + selector stay on one row; under 430px the back-link/nested/network controls group on one row with the selector on its own full-width row (uses \`display: contents\` to dissolve the group only at that width).
- **Scroll**: the topbar scrolls away rather than staying pinned, so a page's own sticky sub-header owns the top cleanly.
- **Dark mode**: sticky sub-header backgrounds now use \`var(--background)\` (the black \`.mainSpace\` page bg) so they're invisible at rest and still occlude content when pinned.

## How to test it

1. On a Safe dashboard, slowly narrow from wide to ~360px — Total balance / Pending / Assets cards are never clipped.
2. Wrapped alignment: ≥900px wrapped rows align left; <900px they align right (burger stays top-left).
3. Spaces route under 430px: back-link + nested + network on one row, safe selector on its own full-width row, no horizontal overflow.
4. Assets page: scroll down — only the tab bar pins; the topbar scrolls away (no overlap).
5. Toggle dark mode on Assets and Apps — no lighter strip behind the tabs/hero, before or while scrolling.

## Screenshots

before

https://github.com/user-attachments/assets/904f8cea-ff0c-4e00-abeb-12859caafcc4

after

https://github.com/user-attachments/assets/5a05a68c-379d-461e-93a8-f80ed9be2c85

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).