### PR TITLE
chore: dedupe @babel/helper-module-imports in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -654,7 +654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.18.6":
+"@babel/helper-module-imports@npm:^7.18.6, @babel/helper-module-imports@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/helper-module-imports@npm:7.29.7"
   dependencies:
@@ -671,16 +671,6 @@ __metadata:
     "@babel/traverse": "npm:^7.28.6"
     "@babel/types": "npm:^7.28.6"
   checksum: 10/64b1380d74425566a3c288074d7ce4dea56d775d2d3325a3d4a6df1dca702916c1d268133b6f385de9ba5b822b3c6e2af5d3b11ac88e5453d5698d77264f0ec0
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-imports@npm:^7.29.7":
-  version: 7.29.7
-  resolution: "@babel/helper-module-imports@npm:7.29.7"
-  dependencies:
-    "@babel/traverse": "npm:^7.29.7"
-    "@babel/types": "npm:^7.29.7"
-  checksum: 10/28ec6f7efd99588d6eebfb25c9f1ccc34cb0cdb0839c4c0f08b3ec0105ccaefbe7e8b4f651f3f55a4f5c4fcb1d979bd32a9b8ee23e3e62163ea22aaa7ee0dfa1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> Two lockfile entries, one resolution,
> merged into a single line —
> immutable installs pass again.

## What it solves

After the tanstack migration squash (#7994), `yarn.lock` was left with two separate entries for `@babel/helper-module-imports` (`^7.18.6` and `^7.29.7`) that both resolve to the same version `7.29.7`. CI's `yarn install --immutable` fails on this, since a fresh install would modify the lockfile.

Resolves: N/A (lockfile maintenance)

## How this PR fixes it

Ran `yarn install` and committed the resulting lockfile. The two duplicate entries are deduped into one; no dependency versions change.

## How to test it

1. Check out this branch
2. Run `yarn install --immutable` — it must exit 0 (it fails on `dev` without this change... if CI has the lockfile check enabled)
3. Confirm the diff touches only `yarn.lock` and changes no resolved versions

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1["@babel/helper-module-imports@npm:^7.18.6 → 7.29.7"]
    A2["@babel/helper-module-imports@npm:^7.29.7 → 7.29.7"]
  end
  subgraph After
    B1["@babel/helper-module-imports@npm:^7.18.6, ^7.29.7 → 7.29.7"]
  end
  A1 --> B1
  A2 --> B1
```

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — N/A, lockfile-only

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).