### PR TITLE
fix(web-tanstack): drop stale fetch-chains dependency after runtime chains migration

### DIFF
--- a/.github/workflows/web-tanstack-checks.yml
+++ b/.github/workflows/web-tanstack-checks.yml
@@ -31,10 +31,6 @@ jobs:
         with:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-team: ${{ vars.TURBO_TEAM }}
-      # chains.json is a build input reused from apps/web. It's produced by
-      # web's postinstall, which the yarn cache skips on a hit, so generate it
-      # explicitly here.
-      - run: yarn workspace @safe-global/web fetch-chains
       - run: yarn workspace @safe-global/web-tanstack build
       # Assert every emitted JS/CSS chunk matches its recorded sha384 integrity
       # (re-hash after build; fails on tamper or gaps).
@@ -59,6 +55,4 @@ jobs:
         with:
           turbo-token: ${{ secrets.TURBO_TOKEN }}
           turbo-team: ${{ vars.TURBO_TEAM }}
-      # type-check reuses apps/web source that imports chains.json (see build job).
-      - run: yarn workspace @safe-global/web fetch-chains
       - run: node scripts/verify.mjs --changed --workspace=web-tanstack

--- a/apps/web-tanstack/src/compat/require-shim.ts
+++ b/apps/web-tanstack/src/compat/require-shim.ts
@@ -1,21 +1,16 @@
 // Webpack/Next polyfills synchronous `require()` for browser code; Vite does
-// not. Two reused files in apps/web/src use `require()`:
-//   - apps/web/src/store/index.ts:42 — `require('@/config/__generated__/chains.json')`
-//     for build-time static chain seeding (load-bearing: without it, onboard
-//     init fails with "chains[0].rpcUrl is not allowed to be empty")
-//   - apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx:25
+// not. One reused file in apps/web/src uses `require()`:
+//   - apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx:26
 //     — `require('blo')` for blockie avatars
 //
-// Polyfill a global `require` that resolves exactly those two paths. Any other
+// Polyfill a global `require` that resolves exactly that path. Any other
 // path throws so we notice it during migration instead of silently degrading.
 //
 // Imported first thing in main.tsx, before any reused code runs.
 
-import staticChains from '@/config/__generated__/chains.json'
 import * as bloModule from 'blo'
 
 const RESOLVERS: Record<string, unknown> = {
-  '@/config/__generated__/chains.json': staticChains,
   blo: bloModule,
 }
 

--- a/apps/web-tanstack/src/main.tsx
+++ b/apps/web-tanstack/src/main.tsx
@@ -6,9 +6,8 @@ import { Buffer } from 'buffer'
 ;(globalThis as any).Buffer = (globalThis as any).Buffer ?? Buffer
 ;(globalThis as any).global = (globalThis as any).global ?? globalThis
 
-// Sync `require()` polyfill for the two reused files that need it
-// (chains.json for store seeding, 'blo' for blockie avatars). Must run
-// before the store is constructed.
+// Sync `require()` polyfill for the reused file that needs it
+// ('blo' for blockie avatars). Must run before any reused code runs.
 import './compat/require-shim'
 
 import { createRoot } from 'react-dom/client'

--- a/apps/web-tanstack/src/routes/__root.tsx
+++ b/apps/web-tanstack/src/routes/__root.tsx
@@ -15,7 +15,7 @@ import { lazy, memo, Suspense, useMemo, type ReactElement } from 'react'
 import { AppProviders } from '@/pages/_app'
 import { BRAND_NAME } from '@/config/constants'
 import { GATEWAY_URL } from '@/config/gateway'
-import { makeStore, setStoreInstance, useHydrateStore, useInitStaticChains } from '@/store'
+import { makeStore, setStoreInstance, useHydrateStore, useInitChains } from '@/store'
 import createEmotionCache from '@/utils/createEmotionCache'
 import MetaTags from '@/components/common/MetaTags'
 import PageLayout from '@/components/common/PageLayout'
@@ -89,7 +89,7 @@ const TargetedOutreachPopupLoader = () => {
 
 const InitApp = (): null => {
   useHydrateStore(reduxStore)
-  useInitStaticChains()
+  useInitChains()
   useAdjustUrl()
   useGtm()
   useMixpanel()

--- a/apps/web-tanstack/vite.config.ts
+++ b/apps/web-tanstack/vite.config.ts
@@ -214,20 +214,17 @@ export default defineConfig(({ mode }) => {
           jsx: { runtime: 'automatic' },
         },
       }),
-      // Scoped `require()` polyfill. Two reused apps/web files use sync
-      // CommonJS require (chains.json, 'blo'). We can't use a global Vite
+      // Scoped `require()` polyfill. One reused apps/web file uses sync
+      // CommonJS require ('blo'). We can't use a global Vite
       // `define` for `require` because it would rewrite Vite's own client
       // code. Instead, prepend a module-local `const require = ...` only to
-      // those exact files so the call site resolves at runtime through
+      // that exact file so the call site resolves at runtime through
       // `globalThis.__safeBrowserRequire` (installed by compat/require-shim.ts).
       {
         name: 'safe-scoped-require-shim',
         enforce: 'pre',
         transform(code, id) {
-          if (
-            id.includes('apps/web/src/store/index.ts') ||
-            id.includes('apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx')
-          ) {
+          if (id.includes('apps/web/src/components/common/SpaceSafeBar/AccountsModal/shared.tsx')) {
             return {
               code: `const require = globalThis.__safeBrowserRequire;\n${code}`,
               map: null,


### PR DESCRIPTION
> The script was gone, the workflow still called,
> a JSON ghost the shim still held —
> chains now flow at runtime, checks go green.

## What it solves

Every PR touching `apps/web/**`, `apps/web-tanstack/**`, or `packages/**` currently fails the **Web TanStack Checks** workflow with *"Couldn't find a script named fetch-chains"* (e.g. [this run](https://github.com/safe-global/safe-wallet-monorepo/actions/runs/27277489927/job/80562551435?pr=8053)).

Root cause: #7962 moved `apps/web` to runtime chain loading and deleted the `fetch-chains` script, but the tanstack migration (#7994) was developed before that and its rebase didn't pick the change up. Three stale dependencies on the deleted build-time chains mechanism survived the merge:

1. `web-tanstack-checks.yml` called `yarn workspace @safe-global/web fetch-chains` (the CI failure)
2. `require-shim.ts` imported `@/config/__generated__/chains.json` — a file nothing generates or commits anymore
3. `__root.tsx` called `useInitStaticChains`, which #7962 replaced with `useInitChains` (broke type-check — masked in CI because the workflow died at the fetch-chains step first)

Resolves: N/A (CI unblock)

## How this PR fixes it

Aligns web-tanstack with the runtime chains approach: removes both `fetch-chains` workflow steps, drops the dead `chains.json` entry from the `require()` shim (the `blo` entry remains — `AccountsModal/shared.tsx` still needs it), scopes the vite require plugin to that one remaining file, and switches `__root.tsx` to `useInitChains()` — mirroring `_app.tsx:132` exactly, per the file's "intentional copy" contract.

Note: the old shim comment claimed static seeding was "load-bearing" for onboard init. That referred to a `require()` in `store/index.ts` that #7962 removed — web-tanstack reuses that same store code, so it now gets the identical runtime fetch `apps/web` ships. A live wallet-connect smoke in web-tanstack wasn't performed — flagging for review.

## How to test it

1. `yarn workspace @safe-global/web-tanstack type-check` — passes (fails on `dev` with TS2724)
2. `yarn workspace @safe-global/web-tanstack build && yarn workspace @safe-global/web-tanstack assert:sri` — passes (535 assets verified, sw.js + offline.html emitted, no stale workbox/firebase files)
3. CI: the Web TanStack Checks workflow on this PR must go green

## Visual summary

```mermaid
flowchart TB
  subgraph "Before (broken since #7994 merge)"
    W1["web-tanstack-checks.yml"] -->|"yarn web fetch-chains"| X1["❌ script deleted by #7962"]
    S1["require-shim.ts"] -->|"import"| X2["❌ __generated__/chains.json<br/>(never generated)"]
    R1["__root.tsx"] -->|"useInitStaticChains()"| X3["❌ export renamed by #7962"]
  end
  subgraph "After"
    W2["web-tanstack-checks.yml"] --> B2["web-tanstack build directly"]
    S2["require-shim.ts"] --> B3["resolves only 'blo'"]
    R2["__root.tsx"] -->|"useInitChains()"| B4["runtime chains fetch<br/>(same as _app.tsx)"]
  end
```

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A, web-tanstack only
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — N/A: workflow YAML, comments, and a one-hook rename to mirror `_app.tsx`; covered by type-check + CI build job

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).