### PR TITLE
feat(mobile): connected dApps management

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -112,7 +112,7 @@ function NavigationStack() {
       <Stack.Screen name="(send)" options={{ headerShown: false }} />
       <Stack.Screen name="wallet-connect-scan" options={{ headerShown: false, presentation: 'modal' }} />
       <Stack.Screen name="wallet-connect-manual" options={{ headerShown: true, title: '' }} />
-      <Stack.Screen name="connected-apps" options={{ headerShown: true, title: 'Connected apps' }} />
+      <Stack.Screen name="connected-apps" options={{ headerShown: true, title: '' }} />
       <Stack.Screen name="safe-shield-details-sheet" options={transparentModalOptions} />
       <Stack.Screen name="import-data" options={{ headerShown: false }} />
       <Stack.Screen name="app-settings" options={{ headerShown: true, title: '' }} />

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -112,6 +112,7 @@ function NavigationStack() {
       <Stack.Screen name="(send)" options={{ headerShown: false }} />
       <Stack.Screen name="wallet-connect-scan" options={{ headerShown: false, presentation: 'modal' }} />
       <Stack.Screen name="wallet-connect-manual" options={{ headerShown: true, title: '' }} />
+      <Stack.Screen name="connected-apps" options={{ headerShown: true, title: 'Connected apps' }} />
       <Stack.Screen name="safe-shield-details-sheet" options={transparentModalOptions} />
       <Stack.Screen name="import-data" options={{ headerShown: false }} />
       <Stack.Screen name="app-settings" options={{ headerShown: true, title: '' }} />

--- a/apps/mobile/src/app/connected-apps.tsx
+++ b/apps/mobile/src/app/connected-apps.tsx
@@ -1,0 +1,5 @@
+import { ConnectedDappsScreen } from '@/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen'
+
+export default function ConnectedAppsScreen() {
+  return <ConnectedDappsScreen />
+}

--- a/apps/mobile/src/features/Settings/Settings.tsx
+++ b/apps/mobile/src/features/Settings/Settings.tsx
@@ -18,6 +18,7 @@ import { Alert } from '@/src/components/Alert'
 
 import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useCopyAndDispatchToast } from '@/src/hooks/useCopyAndDispatchToast'
+import { ConnectedDappsEntry } from '@/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry'
 
 interface SettingsProps {
   data: SafeState
@@ -163,6 +164,7 @@ export const Settings = ({
                       }
                     />
                   </Pressable>
+                  <ConnectedDappsEntry />
                 </View>
 
                 <View backgroundColor="$backgroundDark" padding="$4" borderRadius="$3" gap={'$2'}>

--- a/apps/mobile/src/features/Settings/components/FloatingMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/FloatingMenu.tsx
@@ -3,12 +3,20 @@ import { Pressable } from 'react-native'
 import { MenuAction, MenuView, NativeActionEvent } from '@react-native-menu/menu'
 import { useTheme } from '@/src/theme/hooks/useTheme'
 
+/**
+ * iOS renders destructive menu items in its own system red and ignores titleColor/imageColor;
+ * Android honors them, so we pass this matching value for destructive actions on both platforms.
+ */
+export const NATIVE_MENU_DESTRUCTIVE_COLOR = 'rgb(255,66,69)'
+
 type FloatingMenuProps = {
   onPressAction: (event: NativeActionEvent) => void
   actions: MenuAction[]
   children: React.ReactNode
+  testID?: string
+  accessibilityLabel?: string
 }
-export const FloatingMenu = ({ onPressAction, actions, children }: FloatingMenuProps) => {
+export const FloatingMenu = ({ onPressAction, actions, children, testID, accessibilityLabel }: FloatingMenuProps) => {
   const { themePreference } = useTheme()
 
   return (
@@ -18,7 +26,9 @@ export const FloatingMenu = ({ onPressAction, actions, children }: FloatingMenuP
       actions={actions}
       shouldOpenOnLongPress={false}
     >
-      <Pressable testID={'settings-screen-header-more-settings-button'}>{children}</Pressable>
+      <Pressable testID={testID} accessibilityLabel={accessibilityLabel}>
+        {children}
+      </Pressable>
     </MenuView>
   )
 }

--- a/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
+++ b/apps/mobile/src/features/Settings/components/Navbar/SettingsMenu.tsx
@@ -12,7 +12,7 @@ import { useDefinedActiveSafe } from '@/src/store/hooks/activeSafe'
 import { useEditAccountItem } from '@/src/features/AccountsSheet/AccountItem/hooks/useEditAccountItem'
 import { type Address } from '@/src/types/address'
 import { router } from 'expo-router'
-import { FloatingMenu } from '../FloatingMenu'
+import { FloatingMenu, NATIVE_MENU_DESTRUCTIVE_COLOR } from '../FloatingMenu'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { trackEvent } from '@/src/services/analytics/firebaseAnalytics'
 import { createAppSettingsOpenEvent, createSettingsMenuActionEvent } from '@/src/services/analytics/events/settings'
@@ -28,11 +28,6 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
   const copyAndDispatchToast = useCopyAndDispatchToast()
   const theme = useTheme()
   const color = theme.color.get()
-  // hardcoded to the iOS red
-  // when we set danger to a button, it automatically sets a color that the OS selects
-  // titleColor only works on android and not on iOS
-  // that's why I'm hardcoding the iOS value of the danger text here
-  const colorError = 'rgb(255,66,69)'
 
   if (!safeAddress) {
     return null
@@ -80,6 +75,7 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
         </Pressable>
 
         <FloatingMenu
+          testID="settings-screen-header-more-settings-button"
           onPressAction={({ nativeEvent }) => {
             const action = nativeEvent.event as 'rename' | 'explorer' | 'copy' | 'share' | 'remove'
 
@@ -184,7 +180,7 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
             {
               id: 'remove',
               title: 'Remove account',
-              titleColor: colorError,
+              titleColor: NATIVE_MENU_DESTRUCTIVE_COLOR,
               attributes: {
                 destructive: true,
               },
@@ -192,11 +188,11 @@ export const SettingsMenu = ({ safeAddress }: Props) => {
                 ios: 'trash',
                 android: 'baseline_delete_24',
               }),
-              imageColor: colorError,
+              imageColor: NATIVE_MENU_DESTRUCTIVE_COLOR,
             },
           ]}
         >
-          <Pressable hitSlop={6} testID={'settings-screen-header-more-settings-button'}>
+          <Pressable hitSlop={6}>
             <View
               backgroundColor={'$backgroundSkeleton'}
               alignItems={'center'}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappContextMenu.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappContextMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { Modal, Pressable, StyleSheet, useWindowDimensions } from 'react-native'
-import { Text, XStack, YStack } from 'tamagui'
+import { Modal, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native'
+import { Text, XStack } from 'tamagui'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 
 export type MenuAnchor = { x: number; y: number }
@@ -21,10 +21,7 @@ const MENU_HEIGHT_ESTIMATE = 56
 
 type MenuPlacement = { right: number; top?: number; bottom?: number }
 
-/**
- * Right-aligns the menu to the tapped point and flips it above the tap when anchoring below
- * would run it off the bottom of the window, so the action stays on-screen on the last rows.
- */
+/** Right-aligns the menu to the tapped point, flipping above it when anchoring below would run off the bottom. */
 export const getMenuPlacement = (
   anchor: MenuAnchor,
   window: { width: number; height: number },
@@ -35,50 +32,48 @@ export const getMenuPlacement = (
   return overflowsBottom ? { right, bottom: window.height - anchor.y + GAP } : { right, top: anchor.y + GAP }
 }
 
-/**
- * Overflow menu for a connected-dApp row, rendered in a full-window Modal so a tap anywhere
- * outside dismisses it and only one can be open at a time (the screen owns its single state).
- * Positioned against the tapped point rather than measured layout to stay simple and testable.
- */
+/** Single-open overflow menu in a full-window Modal: outside taps dismiss, the menu itself stays. */
 export const ConnectedDappContextMenu: React.FC<Props> = ({ anchor, onDisconnect, onClose, testID }) => {
   const window = useWindowDimensions()
   const placement = getMenuPlacement(anchor, window)
 
   return (
     <Modal visible transparent animationType="fade" onRequestClose={onClose}>
-      <Pressable style={styles.overlay} onPress={onClose} accessibilityLabel="Close menu">
-        <YStack
-          position="absolute"
-          top={placement.top}
-          bottom={placement.bottom}
-          right={placement.right}
-          width={MENU_WIDTH}
-          backgroundColor="$errorBackground"
-          borderRadius="$2"
-          overflow="hidden"
+      <View style={styles.root}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} accessibilityLabel="Close menu" />
+        {/* The whole menu is the press target so taps on its padding/corners don't reach the backdrop. */}
+        <Pressable
+          onPress={onDisconnect}
+          testID={testID}
+          style={[styles.menu, { top: placement.top, bottom: placement.bottom, right: placement.right }]}
         >
-          <Pressable onPress={onDisconnect} testID={testID}>
-            <XStack
-              paddingHorizontal="$4"
-              paddingVertical="$4"
-              gap="$2"
-              alignItems="center"
-              justifyContent="space-between"
-            >
-              <Text color="$error" fontSize={16}>
-                Disconnect
-              </Text>
-              <SafeFontIcon name="delete" size={24} color="$error" />
-            </XStack>
-          </Pressable>
-        </YStack>
-      </Pressable>
+          <XStack
+            backgroundColor="$errorBackground"
+            borderRadius="$2"
+            overflow="hidden"
+            paddingHorizontal="$4"
+            paddingVertical="$4"
+            gap="$2"
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <Text color="$error" fontSize={16}>
+              Disconnect
+            </Text>
+            <SafeFontIcon name="delete" size={24} color="$error" />
+          </XStack>
+        </Pressable>
+      </View>
     </Modal>
   )
 }
 
 const styles = StyleSheet.create({
-  overlay: {
+  root: {
     flex: 1,
+  },
+  menu: {
+    position: 'absolute',
+    width: MENU_WIDTH,
   },
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappContextMenu.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappContextMenu.tsx
@@ -14,6 +14,26 @@ interface Props {
 }
 
 const MENU_WIDTH = 200
+const GUTTER = 16
+const GAP = 8
+// Single-item menu; enough to decide whether it would overflow the bottom edge.
+const MENU_HEIGHT_ESTIMATE = 56
+
+type MenuPlacement = { right: number; top?: number; bottom?: number }
+
+/**
+ * Right-aligns the menu to the tapped point and flips it above the tap when anchoring below
+ * would run it off the bottom of the window, so the action stays on-screen on the last rows.
+ */
+export const getMenuPlacement = (
+  anchor: MenuAnchor,
+  window: { width: number; height: number },
+  menuHeight: number = MENU_HEIGHT_ESTIMATE,
+): MenuPlacement => {
+  const right = Math.max(GUTTER, window.width - anchor.x)
+  const overflowsBottom = anchor.y + GAP + menuHeight > window.height
+  return overflowsBottom ? { right, bottom: window.height - anchor.y + GAP } : { right, top: anchor.y + GAP }
+}
 
 /**
  * Overflow menu for a connected-dApp row, rendered in a full-window Modal so a tap anywhere
@@ -21,16 +41,17 @@ const MENU_WIDTH = 200
  * Positioned against the tapped point rather than measured layout to stay simple and testable.
  */
 export const ConnectedDappContextMenu: React.FC<Props> = ({ anchor, onDisconnect, onClose, testID }) => {
-  const { width } = useWindowDimensions()
-  const right = Math.max(16, width - anchor.x)
+  const window = useWindowDimensions()
+  const placement = getMenuPlacement(anchor, window)
 
   return (
     <Modal visible transparent animationType="fade" onRequestClose={onClose}>
       <Pressable style={styles.overlay} onPress={onClose} accessibilityLabel="Close menu">
         <YStack
           position="absolute"
-          top={anchor.y + 8}
-          right={right}
+          top={placement.top}
+          bottom={placement.bottom}
+          right={placement.right}
           width={MENU_WIDTH}
           backgroundColor="$errorBackground"
           borderRadius="$2"

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappContextMenu.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappContextMenu.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { Modal, Pressable, StyleSheet, useWindowDimensions } from 'react-native'
+import { Text, XStack, YStack } from 'tamagui'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+
+export type MenuAnchor = { x: number; y: number }
+
+interface Props {
+  /** Window coordinates of the tap that opened the menu; the menu right-aligns to it. */
+  anchor: MenuAnchor
+  onDisconnect: () => void
+  onClose: () => void
+  testID?: string
+}
+
+const MENU_WIDTH = 200
+
+/**
+ * Overflow menu for a connected-dApp row, rendered in a full-window Modal so a tap anywhere
+ * outside dismisses it and only one can be open at a time (the screen owns its single state).
+ * Positioned against the tapped point rather than measured layout to stay simple and testable.
+ */
+export const ConnectedDappContextMenu: React.FC<Props> = ({ anchor, onDisconnect, onClose, testID }) => {
+  const { width } = useWindowDimensions()
+  const right = Math.max(16, width - anchor.x)
+
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose} accessibilityLabel="Close menu">
+        <YStack
+          position="absolute"
+          top={anchor.y + 8}
+          right={right}
+          width={MENU_WIDTH}
+          backgroundColor="$errorBackground"
+          borderRadius="$2"
+          overflow="hidden"
+        >
+          <Pressable onPress={onDisconnect} testID={testID}>
+            <XStack
+              paddingHorizontal="$4"
+              paddingVertical="$4"
+              gap="$2"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Text color="$error" fontSize={16}>
+                Disconnect
+              </Text>
+              <SafeFontIcon name="delete" size={24} color="$error" />
+            </XStack>
+          </Pressable>
+        </YStack>
+      </Pressable>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+  },
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappContextMenu.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappContextMenu.tsx
@@ -1,79 +1,36 @@
 import React from 'react'
-import { Modal, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native'
-import { Text, XStack } from 'tamagui'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon'
-
-export type MenuAnchor = { x: number; y: number }
+import { Platform } from 'react-native'
+import { FloatingMenu, NATIVE_MENU_DESTRUCTIVE_COLOR } from '@/src/features/Settings/components/FloatingMenu'
 
 interface Props {
-  /** Window coordinates of the tap that opened the menu; the menu right-aligns to it. */
-  anchor: MenuAnchor
   onDisconnect: () => void
-  onClose: () => void
+  /** The trigger that opens the native menu (e.g. the row's 3-dots icon). */
+  children: React.ReactNode
   testID?: string
+  accessibilityLabel?: string
 }
 
-const MENU_WIDTH = 200
-const GUTTER = 16
-const GAP = 8
-// Single-item menu; enough to decide whether it would overflow the bottom edge.
-const MENU_HEIGHT_ESTIMATE = 56
-
-type MenuPlacement = { right: number; top?: number; bottom?: number }
-
-/** Right-aligns the menu to the tapped point, flipping above it when anchoring below would run off the bottom. */
-export const getMenuPlacement = (
-  anchor: MenuAnchor,
-  window: { width: number; height: number },
-  menuHeight: number = MENU_HEIGHT_ESTIMATE,
-): MenuPlacement => {
-  const right = Math.max(GUTTER, window.width - anchor.x)
-  const overflowsBottom = anchor.y + GAP + menuHeight > window.height
-  return overflowsBottom ? { right, bottom: window.height - anchor.y + GAP } : { right, top: anchor.y + GAP }
-}
-
-/** Single-open overflow menu in a full-window Modal: outside taps dismiss, the menu itself stays. */
-export const ConnectedDappContextMenu: React.FC<Props> = ({ anchor, onDisconnect, onClose, testID }) => {
-  const window = useWindowDimensions()
-  const placement = getMenuPlacement(anchor, window)
-
-  return (
-    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
-      <View style={styles.root}>
-        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} accessibilityLabel="Close menu" />
-        {/* The whole menu is the press target so taps on its padding/corners don't reach the backdrop. */}
-        <Pressable
-          onPress={onDisconnect}
-          testID={testID}
-          style={[styles.menu, { top: placement.top, bottom: placement.bottom, right: placement.right }]}
-        >
-          <XStack
-            backgroundColor="$errorBackground"
-            borderRadius="$2"
-            overflow="hidden"
-            paddingHorizontal="$4"
-            paddingVertical="$4"
-            gap="$2"
-            alignItems="center"
-            justifyContent="space-between"
-          >
-            <Text color="$error" fontSize={16}>
-              Disconnect
-            </Text>
-            <SafeFontIcon name="delete" size={24} color="$error" />
-          </XStack>
-        </Pressable>
-      </View>
-    </Modal>
-  )
-}
-
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-  },
-  menu: {
-    position: 'absolute',
-    width: MENU_WIDTH,
-  },
-})
+/** Native overflow menu for a connected dApp, consistent with the SettingsMenu. */
+export const ConnectedDappContextMenu: React.FC<Props> = ({ onDisconnect, children, testID, accessibilityLabel }) => (
+  <FloatingMenu
+    testID={testID}
+    accessibilityLabel={accessibilityLabel}
+    onPressAction={({ nativeEvent }) => {
+      if (nativeEvent.event === 'disconnect') {
+        onDisconnect()
+      }
+    }}
+    actions={[
+      {
+        id: 'disconnect',
+        title: 'Disconnect',
+        titleColor: NATIVE_MENU_DESTRUCTIVE_COLOR,
+        attributes: { destructive: true },
+        image: Platform.select({ ios: 'trash', android: 'baseline_delete_24' }),
+        imageColor: NATIVE_MENU_DESTRUCTIVE_COLOR,
+      },
+    ]}
+  >
+    {children}
+  </FloatingMenu>
+)

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
@@ -7,19 +7,17 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import type { VerifyVariant } from '../utils/verifyStatus'
 import { DappIcon } from './DappIcon'
 import { VerifyStatusIcon } from './VerifyStatusIcon'
-import type { MenuAnchor } from './ConnectedDappContextMenu'
+import { ConnectedDappContextMenu } from './ConnectedDappContextMenu'
 
 interface Props {
   session: SessionTypes.Struct
   variant?: VerifyVariant
-  /** Opens the overflow menu for this session, anchored at the tapped point. */
-  onOpenMenu: (session: SessionTypes.Struct, anchor: MenuAnchor) => void
   /** Asks the screen to open the disconnect confirmation for this session. */
   onRequestDisconnect: (session: SessionTypes.Struct) => void
 }
 
-/** A connected-dApp card; the overflow menu is owned by the screen and a left-swipe reveals a trash action. */
-export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onOpenMenu, onRequestDisconnect }) => {
+/** A connected-dApp card; the overflow menu and a left-swipe both route to a disconnect confirmation. */
+export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestDisconnect }) => {
   const meta = session.peer.metadata
   const swipeRef = useRef<SwipeableMethods>(null)
 
@@ -73,14 +71,13 @@ export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onOpenMenu
         <Text flex={1} fontWeight="600" fontSize={14} numberOfLines={1}>
           {meta.name}
         </Text>
-        <Pressable
-          hitSlop={8}
-          onPress={(e) => onOpenMenu(session, { x: e.nativeEvent.pageX, y: e.nativeEvent.pageY })}
-          accessibilityLabel={`Options for ${meta.name}`}
+        <ConnectedDappContextMenu
+          onDisconnect={requestDisconnect}
           testID={`connected-dapp-menu-${session.topic}`}
+          accessibilityLabel={`Options for ${meta.name}`}
         >
           <SafeFontIcon name="options-horizontal" color="$colorSecondary" />
-        </Pressable>
+        </ConnectedDappContextMenu>
       </XStack>
     </ReanimatedSwipeable>
   )

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef } from 'react'
 import { Pressable } from 'react-native'
-import Swipeable from 'react-native-gesture-handler/Swipeable'
+import ReanimatedSwipeable, { type SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable'
 import { Text, View, XStack } from 'tamagui'
 import type { SessionTypes } from '@walletconnect/types'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
@@ -25,7 +25,7 @@ interface Props {
  */
 export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onOpenMenu, onRequestDisconnect }) => {
   const meta = session.peer.metadata
-  const swipeRef = useRef<Swipeable>(null)
+  const swipeRef = useRef<SwipeableMethods>(null)
 
   const requestDisconnect = useCallback(() => {
     swipeRef.current?.close()
@@ -57,7 +57,7 @@ export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onOpenMenu
   )
 
   return (
-    <Swipeable ref={swipeRef} renderRightActions={renderTrash} overshootRight={false}>
+    <ReanimatedSwipeable ref={swipeRef} renderRightActions={renderTrash} overshootRight={false}>
       <XStack
         backgroundColor="$backgroundPaper"
         borderRadius="$2"
@@ -86,6 +86,6 @@ export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onOpenMenu
           <SafeFontIcon name="options-horizontal" color="$colorSecondary" />
         </Pressable>
       </XStack>
-    </Swipeable>
+    </ReanimatedSwipeable>
   )
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
@@ -69,7 +69,7 @@ export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestD
           <View width={40} height={40}>
             <DappIcon url={meta.icons?.[0]} size={40} />
             {variant ? (
-              <View position="absolute" bottom={-2} right={-2}>
+              <View position="absolute" bottom={-8} right={-8}>
                 <VerifyStatusIcon variant={variant} size={16} />
               </View>
             ) : null}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
@@ -18,11 +18,7 @@ interface Props {
   onRequestDisconnect: (session: SessionTypes.Struct) => void
 }
 
-/**
- * One connected-dApp card: brand icon with a verify badge overlay, the dApp name, and a 3-dots
- * trigger. The overflow menu is owned by the screen (so only one opens at a time); a left-swipe
- * reveals a destructive trash action that hands the session back to the screen to confirm.
- */
+/** A connected-dApp card; the overflow menu is owned by the screen and a left-swipe reveals a trash action. */
 export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onOpenMenu, onRequestDisconnect }) => {
   const meta = session.peer.metadata
   const swipeRef = useRef<SwipeableMethods>(null)

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
@@ -1,0 +1,127 @@
+import React, { useCallback, useRef, useState } from 'react'
+import { Pressable } from 'react-native'
+import Swipeable from 'react-native-gesture-handler/Swipeable'
+import { Text, View, XStack, YStack } from 'tamagui'
+import type { SessionTypes } from '@walletconnect/types'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import type { VerifyVariant } from '../utils/verifyStatus'
+import { DappIcon } from './DappIcon'
+import { VerifyStatusIcon } from './VerifyStatusIcon'
+
+interface Props {
+  session: SessionTypes.Struct
+  variant?: VerifyVariant
+  /** Asks the screen to open the disconnect confirmation for this session. */
+  onRequestDisconnect: (session: SessionTypes.Struct) => void
+}
+
+/**
+ * One connected-dApp card: brand icon with a verify badge overlay, the dApp name, and a 3-dots
+ * menu. The overflow menu and a left-swipe both reveal a single destructive "Disconnect" action
+ * that hands the session back to the screen to confirm — matching the Figma flows.
+ */
+export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestDisconnect }) => {
+  const meta = session.peer.metadata
+  const swipeRef = useRef<Swipeable>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  const requestDisconnect = useCallback(() => {
+    setMenuOpen(false)
+    swipeRef.current?.close()
+    onRequestDisconnect(session)
+  }, [onRequestDisconnect, session])
+
+  const renderTrash = useCallback(
+    () => (
+      <View justifyContent="center" paddingLeft="$3">
+        <Pressable
+          onPress={requestDisconnect}
+          accessibilityLabel={`Disconnect ${meta.name}`}
+          testID={`connected-dapp-trash-${session.topic}`}
+        >
+          <View
+            width={40}
+            height={40}
+            borderRadius={200}
+            backgroundColor="$errorBackground"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <SafeFontIcon name="delete" size={20} color="$error" />
+          </View>
+        </Pressable>
+      </View>
+    ),
+    [requestDisconnect, meta.name, session.topic],
+  )
+
+  return (
+    <YStack position="relative">
+      <Swipeable ref={swipeRef} renderRightActions={renderTrash} overshootRight={false}>
+        <XStack
+          backgroundColor="$backgroundPaper"
+          borderRadius="$2"
+          padding="$3"
+          gap="$3"
+          alignItems="center"
+          testID="connected-dapp-row"
+        >
+          <View width={40} height={40}>
+            <DappIcon url={meta.icons?.[0]} size={40} />
+            {variant ? (
+              <View position="absolute" bottom={-2} right={-2}>
+                <VerifyStatusIcon variant={variant} size={16} />
+              </View>
+            ) : null}
+          </View>
+          <Text flex={1} fontWeight="600" fontSize={14} numberOfLines={1}>
+            {meta.name}
+          </Text>
+          <Pressable
+            hitSlop={8}
+            onPress={() => setMenuOpen((open) => !open)}
+            accessibilityLabel={`Options for ${meta.name}`}
+            testID={`connected-dapp-menu-${session.topic}`}
+          >
+            <SafeFontIcon name="options-horizontal" color="$colorSecondary" />
+          </Pressable>
+        </XStack>
+      </Swipeable>
+
+      {menuOpen ? (
+        <>
+          <Pressable
+            style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+            onPress={() => setMenuOpen(false)}
+            accessibilityLabel="Close menu"
+          />
+          <YStack
+            position="absolute"
+            top="$5"
+            right="$3"
+            width={200}
+            backgroundColor="$errorBackground"
+            borderRadius="$2"
+            zIndex={1000}
+            elevation={4}
+          >
+            <Pressable onPress={requestDisconnect} testID={`connected-dapp-disconnect-${session.topic}`}>
+              <XStack
+                paddingHorizontal="$4"
+                paddingVertical="$4"
+                gap="$2"
+                alignItems="center"
+                justifyContent="space-between"
+              >
+                <Text color="$error" fontSize={16}>
+                  Disconnect
+                </Text>
+                <SafeFontIcon name="delete" size={24} color="$error" />
+              </XStack>
+            </Pressable>
+          </YStack>
+        </>
+      ) : null}
+    </YStack>
+  )
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappRow.tsx
@@ -1,32 +1,33 @@
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useRef } from 'react'
 import { Pressable } from 'react-native'
 import Swipeable from 'react-native-gesture-handler/Swipeable'
-import { Text, View, XStack, YStack } from 'tamagui'
+import { Text, View, XStack } from 'tamagui'
 import type { SessionTypes } from '@walletconnect/types'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import type { VerifyVariant } from '../utils/verifyStatus'
 import { DappIcon } from './DappIcon'
 import { VerifyStatusIcon } from './VerifyStatusIcon'
+import type { MenuAnchor } from './ConnectedDappContextMenu'
 
 interface Props {
   session: SessionTypes.Struct
   variant?: VerifyVariant
+  /** Opens the overflow menu for this session, anchored at the tapped point. */
+  onOpenMenu: (session: SessionTypes.Struct, anchor: MenuAnchor) => void
   /** Asks the screen to open the disconnect confirmation for this session. */
   onRequestDisconnect: (session: SessionTypes.Struct) => void
 }
 
 /**
  * One connected-dApp card: brand icon with a verify badge overlay, the dApp name, and a 3-dots
- * menu. The overflow menu and a left-swipe both reveal a single destructive "Disconnect" action
- * that hands the session back to the screen to confirm — matching the Figma flows.
+ * trigger. The overflow menu is owned by the screen (so only one opens at a time); a left-swipe
+ * reveals a destructive trash action that hands the session back to the screen to confirm.
  */
-export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestDisconnect }) => {
+export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onOpenMenu, onRequestDisconnect }) => {
   const meta = session.peer.metadata
   const swipeRef = useRef<Swipeable>(null)
-  const [menuOpen, setMenuOpen] = useState(false)
 
   const requestDisconnect = useCallback(() => {
-    setMenuOpen(false)
     swipeRef.current?.close()
     onRequestDisconnect(session)
   }, [onRequestDisconnect, session])
@@ -56,72 +57,35 @@ export const ConnectedDappRow: React.FC<Props> = ({ session, variant, onRequestD
   )
 
   return (
-    <YStack position="relative">
-      <Swipeable ref={swipeRef} renderRightActions={renderTrash} overshootRight={false}>
-        <XStack
-          backgroundColor="$backgroundPaper"
-          borderRadius="$2"
-          padding="$3"
-          gap="$3"
-          alignItems="center"
-          testID="connected-dapp-row"
+    <Swipeable ref={swipeRef} renderRightActions={renderTrash} overshootRight={false}>
+      <XStack
+        backgroundColor="$backgroundPaper"
+        borderRadius="$2"
+        padding="$3"
+        gap="$3"
+        alignItems="center"
+        testID="connected-dapp-row"
+      >
+        <View width={40} height={40}>
+          <DappIcon url={meta.icons?.[0]} size={40} />
+          {variant ? (
+            <View position="absolute" bottom={-8} right={-8}>
+              <VerifyStatusIcon variant={variant} size={16} />
+            </View>
+          ) : null}
+        </View>
+        <Text flex={1} fontWeight="600" fontSize={14} numberOfLines={1}>
+          {meta.name}
+        </Text>
+        <Pressable
+          hitSlop={8}
+          onPress={(e) => onOpenMenu(session, { x: e.nativeEvent.pageX, y: e.nativeEvent.pageY })}
+          accessibilityLabel={`Options for ${meta.name}`}
+          testID={`connected-dapp-menu-${session.topic}`}
         >
-          <View width={40} height={40}>
-            <DappIcon url={meta.icons?.[0]} size={40} />
-            {variant ? (
-              <View position="absolute" bottom={-8} right={-8}>
-                <VerifyStatusIcon variant={variant} size={16} />
-              </View>
-            ) : null}
-          </View>
-          <Text flex={1} fontWeight="600" fontSize={14} numberOfLines={1}>
-            {meta.name}
-          </Text>
-          <Pressable
-            hitSlop={8}
-            onPress={() => setMenuOpen((open) => !open)}
-            accessibilityLabel={`Options for ${meta.name}`}
-            testID={`connected-dapp-menu-${session.topic}`}
-          >
-            <SafeFontIcon name="options-horizontal" color="$colorSecondary" />
-          </Pressable>
-        </XStack>
-      </Swipeable>
-
-      {menuOpen ? (
-        <>
-          <Pressable
-            style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
-            onPress={() => setMenuOpen(false)}
-            accessibilityLabel="Close menu"
-          />
-          <YStack
-            position="absolute"
-            top="$5"
-            right="$3"
-            width={200}
-            backgroundColor="$errorBackground"
-            borderRadius="$2"
-            zIndex={1000}
-            elevation={4}
-          >
-            <Pressable onPress={requestDisconnect} testID={`connected-dapp-disconnect-${session.topic}`}>
-              <XStack
-                paddingHorizontal="$4"
-                paddingVertical="$4"
-                gap="$2"
-                alignItems="center"
-                justifyContent="space-between"
-              >
-                <Text color="$error" fontSize={16}>
-                  Disconnect
-                </Text>
-                <SafeFontIcon name="delete" size={24} color="$error" />
-              </XStack>
-            </Pressable>
-          </YStack>
-        </>
-      ) : null}
-    </YStack>
+          <SafeFontIcon name="options-horizontal" color="$colorSecondary" />
+        </Pressable>
+      </XStack>
+    </Swipeable>
   )
 }

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
@@ -8,6 +8,7 @@ import { useHasFeature } from '@/src/hooks/useHasFeature'
 import { selectSessionCount } from '../store/walletKitSlice'
 import { SafeListItem } from '@/src/components/SafeListItem/SafeListItem'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { SafeSkeleton } from '@/src/components/SafeSkeleton'
 
 /**
  * Settings row linking to the connected-dApps screen. Hidden entirely unless the
@@ -31,11 +32,15 @@ export const ConnectedDappsEntry: React.FC = () => {
         testID="settings-connected-apps-list-item"
         leftNode={<SafeFontIcon name="link" color="$colorSecondary" />}
         rightNode={
-          <View flexDirection="row" alignItems="center" gap="$2">
-            <Text color="$colorSecondary" testID="connected-apps-count">
-              {count}
-            </Text>
-            <SafeFontIcon name="chevron-right" />
+          <View flexDirection="row" alignItems="center" justifyContent="center">
+            <SafeSkeleton height={17}>
+              <Text minWidth={15} marginRight="$3" color="$colorSecondary" testID="connected-apps-count">
+                {count}
+              </Text>
+            </SafeSkeleton>
+            <View>
+              <SafeFontIcon name="chevron-right" />
+            </View>
           </View>
         }
       />

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Pressable } from 'react-native'
+import { router, type RelativePathString } from 'expo-router'
+import { Text, View } from 'tamagui'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import { useAppSelector } from '@/src/store/hooks'
+import { useHasFeature } from '@/src/hooks/useHasFeature'
+import { selectSessionCount } from '../store/walletKitSlice'
+import { SafeListItem } from '@/src/components/SafeListItem/SafeListItem'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+
+/**
+ * Settings row linking to the connected-dApps screen. Hidden entirely unless the
+ * NATIVE_WALLETCONNECT feature is on and there is at least one live session, so it never
+ * shows a dead "0 apps" entry.
+ */
+export const ConnectedDappsEntry: React.FC = () => {
+  const isEnabled = useHasFeature(FEATURES.NATIVE_WALLETCONNECT) ?? false
+  const count = useAppSelector(selectSessionCount)
+  if (!isEnabled || count === 0) {
+    return null
+  }
+  return (
+    <Pressable
+      style={({ pressed }) => [{ opacity: pressed ? 0.5 : 1.0 }]}
+      onPress={() => router.push('/connected-apps' as RelativePathString)}
+      testID="settings-connected-apps-entry"
+    >
+      <SafeListItem
+        label="Connected apps"
+        testID="settings-connected-apps-list-item"
+        leftNode={<SafeFontIcon name="apps" color="$colorSecondary" />}
+        rightNode={
+          <View flexDirection="row" alignItems="center" gap="$2">
+            <Text color="$colorSecondary" testID="connected-apps-count">
+              {count}
+            </Text>
+            <SafeFontIcon name="chevron-right" />
+          </View>
+        }
+      />
+    </Pressable>
+  )
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
@@ -8,7 +8,6 @@ import { useHasFeature } from '@/src/hooks/useHasFeature'
 import { selectSessionCount } from '../store/walletKitSlice'
 import { SafeListItem } from '@/src/components/SafeListItem/SafeListItem'
 import { SafeFontIcon } from '@/src/components/SafeFontIcon'
-import { SafeSkeleton } from '@/src/components/SafeSkeleton'
 
 /**
  * Settings row linking to the connected-dApps screen. Hidden entirely unless the
@@ -33,14 +32,10 @@ export const ConnectedDappsEntry: React.FC = () => {
         leftNode={<SafeFontIcon name="link" color="$colorSecondary" />}
         rightNode={
           <View flexDirection="row" alignItems="center" justifyContent="center">
-            <SafeSkeleton height={17}>
-              <Text minWidth={15} marginRight="$3" color="$colorSecondary" testID="connected-apps-count">
-                {count}
-              </Text>
-            </SafeSkeleton>
-            <View>
-              <SafeFontIcon name="chevron-right" />
-            </View>
+            <Text minWidth={15} marginRight="$3" color="$colorSecondary" testID="connected-apps-count">
+              {count}
+            </Text>
+            <SafeFontIcon name="chevron-right" />
           </View>
         }
       />

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
@@ -29,7 +29,7 @@ export const ConnectedDappsEntry: React.FC = () => {
       <SafeListItem
         label="Connected apps"
         testID="settings-connected-apps-list-item"
-        leftNode={<SafeFontIcon name="apps" color="$colorSecondary" />}
+        leftNode={<SafeFontIcon name="link" color="$colorSecondary" />}
         rightNode={
           <View flexDirection="row" alignItems="center" gap="$2">
             <Text color="$colorSecondary" testID="connected-apps-count">

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsEntry.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Pressable } from 'react-native'
-import { router, type RelativePathString } from 'expo-router'
+import { router } from 'expo-router'
 import { Text, View } from 'tamagui'
 import { FEATURES } from '@safe-global/utils/utils/chains'
 import { useAppSelector } from '@/src/store/hooks'
@@ -23,7 +23,7 @@ export const ConnectedDappsEntry: React.FC = () => {
   return (
     <Pressable
       style={({ pressed }) => [{ opacity: pressed ? 0.5 : 1.0 }]}
-      onPress={() => router.push('/connected-apps' as RelativePathString)}
+      onPress={() => router.push('/connected-apps')}
       testID="settings-connected-apps-entry"
     >
       <SafeListItem

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
@@ -7,6 +7,7 @@ import { useAppSelector } from '@/src/store/hooks'
 import { selectSessions, selectVerifyByTopic } from '../store/walletKitSlice'
 import { useDisconnectSession } from '../hooks/useDisconnectSession'
 import { ConnectedDappRow } from './ConnectedDappRow'
+import { ConnectedDappContextMenu, type MenuAnchor } from './ConnectedDappContextMenu'
 import { DisconnectConfirmModal } from './DisconnectConfirmModal'
 
 /**
@@ -21,6 +22,9 @@ export const ConnectedDappsScreen: React.FC = () => {
   const { disconnect, busyTopic } = useDisconnectSession()
   const insets = useSafeAreaInsets()
   const [selected, setSelected] = useState<SessionTypes.Struct | null>(null)
+  // Single screen-level menu state: opening one closes any other, and a full-window backdrop
+  // dismisses it on a tap anywhere outside.
+  const [menu, setMenu] = useState<{ session: SessionTypes.Struct; anchor: MenuAnchor } | null>(null)
 
   const handleConfirm = useCallback(async () => {
     if (!selected) {
@@ -30,11 +34,18 @@ export const ConnectedDappsScreen: React.FC = () => {
     setSelected(null)
   }, [selected, disconnect])
 
+  const openMenu = useCallback((session: SessionTypes.Struct, anchor: MenuAnchor) => setMenu({ session, anchor }), [])
+
   const renderItem = useCallback(
     ({ item }: { item: SessionTypes.Struct }) => (
-      <ConnectedDappRow session={item} variant={verifyByTopic[item.topic]} onRequestDisconnect={setSelected} />
+      <ConnectedDappRow
+        session={item}
+        variant={verifyByTopic[item.topic]}
+        onOpenMenu={openMenu}
+        onRequestDisconnect={setSelected}
+      />
     ),
-    [verifyByTopic],
+    [verifyByTopic, openMenu],
   )
 
   return (
@@ -57,6 +68,17 @@ export const ConnectedDappsScreen: React.FC = () => {
           </Text>
         }
       />
+      {menu ? (
+        <ConnectedDappContextMenu
+          anchor={menu.anchor}
+          onClose={() => setMenu(null)}
+          onDisconnect={() => {
+            setSelected(menu.session)
+            setMenu(null)
+          }}
+          testID={`connected-dapp-disconnect-${menu.session.topic}`}
+        />
+      ) : null}
       <DisconnectConfirmModal
         dapp={selected ? { name: selected.peer.metadata.name, iconUrl: selected.peer.metadata.icons?.[0] } : null}
         isBusy={busyTopic === selected?.topic}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
@@ -1,0 +1,88 @@
+import React, { useCallback, useState } from 'react'
+import { FlatList, Pressable } from 'react-native'
+import { Text, XStack, YStack } from 'tamagui'
+import type { SessionTypes } from '@walletconnect/types'
+import { useAppSelector } from '@/src/store/hooks'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon'
+import { selectSessions, selectVerifyByTopic } from '../store/walletKitSlice'
+import { useDisconnectSession } from '../hooks/useDisconnectSession'
+import { DappIcon } from './DappIcon'
+import { VerifyStatusIcon } from './VerifyStatusIcon'
+import { DisconnectConfirmModal } from './DisconnectConfirmModal'
+
+/**
+ * Lists the Safe's live WalletConnect dApp sessions. Each row carries the verify badge
+ * captured at approval and an overflow (3-dots) control that opens the disconnect confirmation.
+ * Disconnecting is delegated to the shared `useDisconnectSession` helper; the confirm sheet
+ * reflects its busy state and the row drops out as soon as the slice mirror updates.
+ */
+export const ConnectedDappsScreen: React.FC = () => {
+  const sessions = useAppSelector(selectSessions)
+  const verifyByTopic = useAppSelector(selectVerifyByTopic)
+  const { disconnect, busyTopic } = useDisconnectSession()
+  const [selected, setSelected] = useState<SessionTypes.Struct | null>(null)
+
+  const handleConfirm = useCallback(async () => {
+    if (!selected) {
+      return
+    }
+    await disconnect(selected.topic, selected.peer.metadata.name)
+    setSelected(null)
+  }, [selected, disconnect])
+
+  const renderItem = useCallback(
+    ({ item }: { item: SessionTypes.Struct }) => {
+      const meta = item.peer.metadata
+      const variant = verifyByTopic[item.topic]
+      return (
+        <XStack gap="$3" paddingVertical="$3" alignItems="center" testID="connected-dapp-row">
+          <DappIcon url={meta.icons?.[0]} size={40} />
+          <YStack flex={1}>
+            <XStack gap="$2" alignItems="center">
+              <Text fontWeight="600" numberOfLines={1}>
+                {meta.name}
+              </Text>
+              {variant ? <VerifyStatusIcon variant={variant} size={16} /> : null}
+            </XStack>
+            {meta.url ? (
+              <Text color="$colorSecondary" numberOfLines={1}>
+                {meta.url}
+              </Text>
+            ) : null}
+          </YStack>
+          <Pressable
+            hitSlop={8}
+            onPress={() => setSelected(item)}
+            accessibilityLabel={`Disconnect ${meta.name}`}
+            testID={`connected-dapp-menu-${item.topic}`}
+          >
+            <SafeFontIcon name="options-horizontal" color="$colorSecondary" />
+          </Pressable>
+        </XStack>
+      )
+    },
+    [verifyByTopic],
+  )
+
+  return (
+    <YStack flex={1}>
+      <FlatList
+        data={sessions}
+        keyExtractor={(s) => s.topic}
+        contentContainerStyle={{ padding: 16 }}
+        renderItem={renderItem}
+        ListEmptyComponent={
+          <Text color="$colorSecondary" textAlign="center" marginTop="$8">
+            No connected apps.
+          </Text>
+        }
+      />
+      <DisconnectConfirmModal
+        dappName={selected?.peer.metadata.name ?? null}
+        isBusy={busyTopic === selected?.topic}
+        onConfirm={handleConfirm}
+        onClose={() => setSelected(null)}
+      />
+    </YStack>
+  )
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
@@ -43,7 +43,7 @@ export const ConnectedDappsScreen: React.FC = () => {
         data={sessions}
         keyExtractor={(s) => s.topic}
         ListHeaderComponent={
-          <YStack gap="$2" paddingVertical="$3">
+          <YStack gap="$2" paddingVertical="$6">
             <H2 fontWeight="600">Connected apps</H2>
             <Text color="$colorSecondary">Third-party apps you've connected to your Safe.</Text>
           </YStack>

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
@@ -1,25 +1,25 @@
 import React, { useCallback, useState } from 'react'
-import { FlatList, Pressable } from 'react-native'
-import { Text, XStack, YStack } from 'tamagui'
+import { FlatList } from 'react-native'
+import { H2, Text, YStack } from 'tamagui'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import type { SessionTypes } from '@walletconnect/types'
 import { useAppSelector } from '@/src/store/hooks'
-import { SafeFontIcon } from '@/src/components/SafeFontIcon'
 import { selectSessions, selectVerifyByTopic } from '../store/walletKitSlice'
 import { useDisconnectSession } from '../hooks/useDisconnectSession'
-import { DappIcon } from './DappIcon'
-import { VerifyStatusIcon } from './VerifyStatusIcon'
+import { ConnectedDappRow } from './ConnectedDappRow'
 import { DisconnectConfirmModal } from './DisconnectConfirmModal'
 
 /**
- * Lists the Safe's live WalletConnect dApp sessions. Each row carries the verify badge
- * captured at approval and an overflow (3-dots) control that opens the disconnect confirmation.
- * Disconnecting is delegated to the shared `useDisconnectSession` helper; the confirm sheet
- * reflects its busy state and the row drops out as soon as the slice mirror updates.
+ * Lists the Safe's live WalletConnect dApp sessions. Each row exposes a 3-dots menu and a
+ * left-swipe, both routing to a shared confirmation sheet; confirming delegates to
+ * `useDisconnectSession`. The row drops out as soon as the slice mirror updates, and a
+ * dApp-initiated `session_delete` removes it silently (handled in the provider, no toast).
  */
 export const ConnectedDappsScreen: React.FC = () => {
   const sessions = useAppSelector(selectSessions)
   const verifyByTopic = useAppSelector(selectVerifyByTopic)
   const { disconnect, busyTopic } = useDisconnectSession()
+  const insets = useSafeAreaInsets()
   const [selected, setSelected] = useState<SessionTypes.Struct | null>(null)
 
   const handleConfirm = useCallback(async () => {
@@ -31,46 +31,26 @@ export const ConnectedDappsScreen: React.FC = () => {
   }, [selected, disconnect])
 
   const renderItem = useCallback(
-    ({ item }: { item: SessionTypes.Struct }) => {
-      const meta = item.peer.metadata
-      const variant = verifyByTopic[item.topic]
-      return (
-        <XStack gap="$3" paddingVertical="$3" alignItems="center" testID="connected-dapp-row">
-          <DappIcon url={meta.icons?.[0]} size={40} />
-          <YStack flex={1}>
-            <XStack gap="$2" alignItems="center">
-              <Text fontWeight="600" numberOfLines={1}>
-                {meta.name}
-              </Text>
-              {variant ? <VerifyStatusIcon variant={variant} size={16} /> : null}
-            </XStack>
-            {meta.url ? (
-              <Text color="$colorSecondary" numberOfLines={1}>
-                {meta.url}
-              </Text>
-            ) : null}
-          </YStack>
-          <Pressable
-            hitSlop={8}
-            onPress={() => setSelected(item)}
-            accessibilityLabel={`Disconnect ${meta.name}`}
-            testID={`connected-dapp-menu-${item.topic}`}
-          >
-            <SafeFontIcon name="options-horizontal" color="$colorSecondary" />
-          </Pressable>
-        </XStack>
-      )
-    },
+    ({ item }: { item: SessionTypes.Struct }) => (
+      <ConnectedDappRow session={item} variant={verifyByTopic[item.topic]} onRequestDisconnect={setSelected} />
+    ),
     [verifyByTopic],
   )
 
   return (
-    <YStack flex={1}>
+    <YStack flex={1} backgroundColor="$background">
       <FlatList
         data={sessions}
         keyExtractor={(s) => s.topic}
-        contentContainerStyle={{ padding: 16 }}
+        ListHeaderComponent={
+          <YStack gap="$2" paddingVertical="$3">
+            <H2 fontWeight="600">Connected apps</H2>
+            <Text color="$colorSecondary">Third-party apps you've connected to your Safe.</Text>
+          </YStack>
+        }
         renderItem={renderItem}
+        ItemSeparatorComponent={() => <YStack height="$2" />}
+        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: insets.bottom + 16 }}
         ListEmptyComponent={
           <Text color="$colorSecondary" textAlign="center" marginTop="$8">
             No connected apps.
@@ -78,7 +58,7 @@ export const ConnectedDappsScreen: React.FC = () => {
         }
       />
       <DisconnectConfirmModal
-        dappName={selected?.peer.metadata.name ?? null}
+        dapp={selected ? { name: selected.peer.metadata.name, iconUrl: selected.peer.metadata.icons?.[0] } : null}
         isBusy={busyTopic === selected?.topic}
         onConfirm={handleConfirm}
         onClose={() => setSelected(null)}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
@@ -30,8 +30,11 @@ export const ConnectedDappsScreen: React.FC = () => {
     if (!selected) {
       return
     }
-    await disconnect(selected.topic, selected.peer.metadata.name)
-    setSelected(null)
+    // Keep the sheet open on failure (the error is toasted) so the user can retry or cancel.
+    const disconnected = await disconnect(selected.topic, selected.peer.metadata.name)
+    if (disconnected) {
+      setSelected(null)
+    }
   }, [selected, disconnect])
 
   const openMenu = useCallback((session: SessionTypes.Struct, anchor: MenuAnchor) => setMenu({ session, anchor }), [])

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
@@ -10,12 +10,7 @@ import { ConnectedDappRow } from './ConnectedDappRow'
 import { ConnectedDappContextMenu, type MenuAnchor } from './ConnectedDappContextMenu'
 import { DisconnectConfirmModal } from './DisconnectConfirmModal'
 
-/**
- * Lists the Safe's live WalletConnect dApp sessions. Each row exposes a 3-dots menu and a
- * left-swipe, both routing to a shared confirmation sheet; confirming delegates to
- * `useDisconnectSession`. The row drops out as soon as the slice mirror updates, and a
- * dApp-initiated `session_delete` removes it silently (handled in the provider, no toast).
- */
+/** Lists live WalletConnect dApp sessions; a 3-dots menu or left-swipe routes to a shared confirm sheet. */
 export const ConnectedDappsScreen: React.FC = () => {
   const sessions = useAppSelector(selectSessions)
   const verifyByTopic = useAppSelector(selectVerifyByTopic)

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/ConnectedDappsScreen.tsx
@@ -7,7 +7,6 @@ import { useAppSelector } from '@/src/store/hooks'
 import { selectSessions, selectVerifyByTopic } from '../store/walletKitSlice'
 import { useDisconnectSession } from '../hooks/useDisconnectSession'
 import { ConnectedDappRow } from './ConnectedDappRow'
-import { ConnectedDappContextMenu, type MenuAnchor } from './ConnectedDappContextMenu'
 import { DisconnectConfirmModal } from './DisconnectConfirmModal'
 
 /** Lists live WalletConnect dApp sessions; a 3-dots menu or left-swipe routes to a shared confirm sheet. */
@@ -17,9 +16,6 @@ export const ConnectedDappsScreen: React.FC = () => {
   const { disconnect, busyTopic } = useDisconnectSession()
   const insets = useSafeAreaInsets()
   const [selected, setSelected] = useState<SessionTypes.Struct | null>(null)
-  // Single screen-level menu state: opening one closes any other, and a full-window backdrop
-  // dismisses it on a tap anywhere outside.
-  const [menu, setMenu] = useState<{ session: SessionTypes.Struct; anchor: MenuAnchor } | null>(null)
 
   const handleConfirm = useCallback(async () => {
     if (!selected) {
@@ -32,18 +28,11 @@ export const ConnectedDappsScreen: React.FC = () => {
     }
   }, [selected, disconnect])
 
-  const openMenu = useCallback((session: SessionTypes.Struct, anchor: MenuAnchor) => setMenu({ session, anchor }), [])
-
   const renderItem = useCallback(
     ({ item }: { item: SessionTypes.Struct }) => (
-      <ConnectedDappRow
-        session={item}
-        variant={verifyByTopic[item.topic]}
-        onOpenMenu={openMenu}
-        onRequestDisconnect={setSelected}
-      />
+      <ConnectedDappRow session={item} variant={verifyByTopic[item.topic]} onRequestDisconnect={setSelected} />
     ),
-    [verifyByTopic, openMenu],
+    [verifyByTopic],
   )
 
   return (
@@ -66,17 +55,6 @@ export const ConnectedDappsScreen: React.FC = () => {
           </Text>
         }
       />
-      {menu ? (
-        <ConnectedDappContextMenu
-          anchor={menu.anchor}
-          onClose={() => setMenu(null)}
-          onDisconnect={() => {
-            setSelected(menu.session)
-            setMenu(null)
-          }}
-          testID={`connected-dapp-disconnect-${menu.session.topic}`}
-        />
-      ) : null}
       <DisconnectConfirmModal
         dapp={selected ? { name: selected.peer.metadata.name, iconUrl: selected.peer.metadata.icons?.[0] } : null}
         isBusy={busyTopic === selected?.topic}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
@@ -19,12 +19,7 @@ export interface DisconnectConfirmModalProps {
   onClose: () => void
 }
 
-/**
- * Controlled confirmation sheet for disconnecting a connected dApp. Presenting is driven by
- * `dapp` (non-null opens it); the last target is retained locally so the icon/name don't flash
- * empty during the close animation. Mirrors the Figma: title, the dApp's icon + name, and a
- * single primary "Disconnect" action — dismissing (swipe / backdrop) routes through `onClose`.
- */
+/** Confirm sheet for disconnecting a dApp; `dapp` drives presenting and the last target is retained so the icon/name don't flash during the close animation. */
 export const DisconnectConfirmModal: React.FC<DisconnectConfirmModalProps> = ({
   dapp,
   isBusy = false,

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
@@ -61,8 +61,8 @@ export const DisconnectConfirmModal: React.FC<DisconnectConfirmModalProps> = ({
       accessible={true}
     >
       <BottomSheetView>
-        <YStack gap="$4" paddingHorizontal="$4" paddingTop="$2" paddingBottom={insets.bottom + 16}>
-          <YStack gap="$3" alignItems="center" testID="disconnect-confirm-modal">
+        <YStack gap="$5" paddingHorizontal="$4" paddingTop="$2" paddingBottom={insets.bottom + 16}>
+          <YStack gap="$5" alignItems="center" testID="disconnect-confirm-modal">
             <Text fontWeight="700" fontSize={16} letterSpacing={-0.1}>
               Disconnect app?
             </Text>
@@ -74,7 +74,7 @@ export const DisconnectConfirmModal: React.FC<DisconnectConfirmModalProps> = ({
             </YStack>
           </YStack>
           <SafeButton
-            primary
+            danger
             width="100%"
             onPress={onConfirm}
             loading={isBusy}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
@@ -1,16 +1,19 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Platform } from 'react-native'
 import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet'
-import { getVariable, H4, Text, useTheme, XStack, YStack } from 'tamagui'
+import { getVariable, Text, useTheme, YStack } from 'tamagui'
 import { FullWindowOverlay } from 'react-native-screens'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { BackdropComponent, BackgroundComponent } from '@/src/components/Dropdown/sheetComponents'
 import { SafeButton } from '@/src/components/SafeButton'
+import { DappIcon } from './DappIcon'
+
+export type DisconnectTarget = { name: string; iconUrl?: string }
 
 export interface DisconnectConfirmModalProps {
-  /** Name of the dApp pending disconnect. `null` keeps the sheet closed. */
-  dappName: string | null
-  /** Disables the actions while the relay teardown is in flight. */
+  /** The dApp pending disconnect. `null` keeps the sheet closed. */
+  dapp: DisconnectTarget | null
+  /** Disables the action while the relay teardown is in flight. */
   isBusy?: boolean
   onConfirm: () => void
   onClose: () => void
@@ -18,12 +21,12 @@ export interface DisconnectConfirmModalProps {
 
 /**
  * Controlled confirmation sheet for disconnecting a connected dApp. Presenting is driven by
- * `dappName` (non-null opens it); the last name is retained locally so the copy doesn't flash
- * empty during the close animation. Swiping the sheet down routes through `onClose` so the
- * parent's selection state resets in lockstep with the SDK.
+ * `dapp` (non-null opens it); the last target is retained locally so the icon/name don't flash
+ * empty during the close animation. Mirrors the Figma: title, the dApp's icon + name, and a
+ * single primary "Disconnect" action — dismissing (swipe / backdrop) routes through `onClose`.
  */
 export const DisconnectConfirmModal: React.FC<DisconnectConfirmModalProps> = ({
-  dappName,
+  dapp,
   isBusy = false,
   onConfirm,
   onClose,
@@ -31,16 +34,16 @@ export const DisconnectConfirmModal: React.FC<DisconnectConfirmModalProps> = ({
   const ref = useRef<BottomSheetModal>(null)
   const insets = useSafeAreaInsets()
   const theme = useTheme()
-  const [displayName, setDisplayName] = useState<string | null>(dappName)
+  const [displayed, setDisplayed] = useState<DisconnectTarget | null>(dapp)
 
   useEffect(() => {
-    if (dappName) {
-      setDisplayName(dappName)
+    if (dapp) {
+      setDisplayed(dapp)
       ref.current?.present()
     } else {
       ref.current?.dismiss()
     }
-  }, [dappName])
+  }, [dapp])
 
   const renderBackdrop = useCallback(() => <BackdropComponent shouldNavigateBack={false} />, [])
 
@@ -58,30 +61,28 @@ export const DisconnectConfirmModal: React.FC<DisconnectConfirmModalProps> = ({
       accessible={true}
     >
       <BottomSheetView>
-        <YStack gap="$4" padding="$4" paddingBottom={insets.bottom + 16} testID="disconnect-confirm-modal">
-          <YStack gap="$2" alignItems="center">
-            <H4 fontWeight="600" letterSpacing={-0.2}>
-              Disconnect dApp?
-            </H4>
-            <Text textAlign="center" color="$colorSecondary">
-              {`You'll no longer be connected to ${displayName ?? 'this app'}.`}
+        <YStack gap="$4" paddingHorizontal="$4" paddingTop="$2" paddingBottom={insets.bottom + 16}>
+          <YStack gap="$3" alignItems="center" testID="disconnect-confirm-modal">
+            <Text fontWeight="700" fontSize={16} letterSpacing={-0.1}>
+              Disconnect app?
             </Text>
+            <YStack gap="$2" alignItems="center">
+              <DappIcon url={displayed?.iconUrl} size={36} />
+              <Text fontWeight="700" fontSize={16} letterSpacing={0.15}>
+                {displayed?.name ?? ''}
+              </Text>
+            </YStack>
           </YStack>
-          <XStack gap="$3" paddingTop="$2">
-            <SafeButton secondary flex={1} onPress={onClose} disabled={isBusy} testID="disconnect-cancel-button">
-              Cancel
-            </SafeButton>
-            <SafeButton
-              danger
-              flex={1}
-              onPress={onConfirm}
-              loading={isBusy}
-              loadingText="Disconnecting"
-              testID="disconnect-confirm-button"
-            >
-              Disconnect
-            </SafeButton>
-          </XStack>
+          <SafeButton
+            primary
+            width="100%"
+            onPress={onConfirm}
+            loading={isBusy}
+            loadingText="Disconnecting"
+            testID="disconnect-confirm-button"
+          >
+            Disconnect
+          </SafeButton>
         </YStack>
       </BottomSheetView>
     </BottomSheetModal>

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
@@ -61,9 +61,9 @@ export const DisconnectConfirmModal: React.FC<DisconnectConfirmModalProps> = ({
             <Text fontWeight="700" fontSize={16} letterSpacing={-0.1}>
               Disconnect app?
             </Text>
-            <YStack gap="$2" alignItems="center">
+            <YStack gap="$2" alignItems="center" alignSelf="stretch">
               <DappIcon url={displayed?.iconUrl} size={36} />
-              <Text fontWeight="700" fontSize={16} letterSpacing={0.15}>
+              <Text fontWeight="700" fontSize={16} letterSpacing={0.15} textAlign="center" alignSelf="stretch">
                 {displayed?.name ?? ''}
               </Text>
             </YStack>

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/DisconnectConfirmModal.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Platform } from 'react-native'
+import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet'
+import { getVariable, H4, Text, useTheme, XStack, YStack } from 'tamagui'
+import { FullWindowOverlay } from 'react-native-screens'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { BackdropComponent, BackgroundComponent } from '@/src/components/Dropdown/sheetComponents'
+import { SafeButton } from '@/src/components/SafeButton'
+
+export interface DisconnectConfirmModalProps {
+  /** Name of the dApp pending disconnect. `null` keeps the sheet closed. */
+  dappName: string | null
+  /** Disables the actions while the relay teardown is in flight. */
+  isBusy?: boolean
+  onConfirm: () => void
+  onClose: () => void
+}
+
+/**
+ * Controlled confirmation sheet for disconnecting a connected dApp. Presenting is driven by
+ * `dappName` (non-null opens it); the last name is retained locally so the copy doesn't flash
+ * empty during the close animation. Swiping the sheet down routes through `onClose` so the
+ * parent's selection state resets in lockstep with the SDK.
+ */
+export const DisconnectConfirmModal: React.FC<DisconnectConfirmModalProps> = ({
+  dappName,
+  isBusy = false,
+  onConfirm,
+  onClose,
+}) => {
+  const ref = useRef<BottomSheetModal>(null)
+  const insets = useSafeAreaInsets()
+  const theme = useTheme()
+  const [displayName, setDisplayName] = useState<string | null>(dappName)
+
+  useEffect(() => {
+    if (dappName) {
+      setDisplayName(dappName)
+      ref.current?.present()
+    } else {
+      ref.current?.dismiss()
+    }
+  }, [dappName])
+
+  const renderBackdrop = useCallback(() => <BackdropComponent shouldNavigateBack={false} />, [])
+
+  return (
+    <BottomSheetModal
+      // @ts-expect-error - FullWindowOverlay is not typed
+      containerComponent={Platform.OS === 'ios' ? FullWindowOverlay : undefined}
+      ref={ref}
+      backgroundComponent={BackgroundComponent}
+      backdropComponent={renderBackdrop}
+      topInset={insets.top}
+      enableDynamicSizing
+      handleIndicatorStyle={{ backgroundColor: getVariable(theme.borderMain) }}
+      onDismiss={onClose}
+      accessible={true}
+    >
+      <BottomSheetView>
+        <YStack gap="$4" padding="$4" paddingBottom={insets.bottom + 16} testID="disconnect-confirm-modal">
+          <YStack gap="$2" alignItems="center">
+            <H4 fontWeight="600" letterSpacing={-0.2}>
+              Disconnect dApp?
+            </H4>
+            <Text textAlign="center" color="$colorSecondary">
+              {`You'll no longer be connected to ${displayName ?? 'this app'}.`}
+            </Text>
+          </YStack>
+          <XStack gap="$3" paddingTop="$2">
+            <SafeButton secondary flex={1} onPress={onClose} disabled={isBusy} testID="disconnect-cancel-button">
+              Cancel
+            </SafeButton>
+            <SafeButton
+              danger
+              flex={1}
+              onPress={onConfirm}
+              loading={isBusy}
+              loadingText="Disconnecting"
+              testID="disconnect-confirm-button"
+            >
+              Disconnect
+            </SafeButton>
+          </XStack>
+        </YStack>
+      </BottomSheetView>
+    </BottomSheetModal>
+  )
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappContextMenu.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappContextMenu.test.tsx
@@ -1,7 +1,28 @@
 import React from 'react'
 import { fireEvent } from '@testing-library/react-native'
 import { render } from '@/src/tests/test-utils'
-import { ConnectedDappContextMenu } from '../ConnectedDappContextMenu'
+import { ConnectedDappContextMenu, getMenuPlacement } from '../ConnectedDappContextMenu'
+
+const WINDOW = { width: 375, height: 800 }
+
+describe('getMenuPlacement', () => {
+  it('anchors below the tap when there is room', () => {
+    const placement = getMenuPlacement({ x: 350, y: 120 }, WINDOW)
+    expect(placement.top).toBe(128)
+    expect(placement.bottom).toBeUndefined()
+  })
+
+  it('flips above the tap when anchoring below would overflow the bottom', () => {
+    const placement = getMenuPlacement({ x: 350, y: 780 }, WINDOW)
+    expect(placement.top).toBeUndefined()
+    expect(placement.bottom).toBe(WINDOW.height - 780 + 8)
+  })
+
+  it('right-aligns to the tap and clamps to a 16px gutter', () => {
+    expect(getMenuPlacement({ x: 300, y: 100 }, WINDOW).right).toBe(75)
+    expect(getMenuPlacement({ x: 374, y: 100 }, WINDOW).right).toBe(16)
+  })
+})
 
 describe('ConnectedDappContextMenu', () => {
   it('disconnects when the Disconnect item is pressed', () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappContextMenu.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappContextMenu.test.tsx
@@ -1,53 +1,60 @@
 import React from 'react'
+import { Text } from 'react-native'
 import { fireEvent } from '@testing-library/react-native'
 import { render } from '@/src/tests/test-utils'
-import { ConnectedDappContextMenu, getMenuPlacement } from '../ConnectedDappContextMenu'
+import { ConnectedDappContextMenu } from '../ConnectedDappContextMenu'
 
-const WINDOW = { width: 375, height: 800 }
-
-describe('getMenuPlacement', () => {
-  it('anchors below the tap when there is room', () => {
-    const placement = getMenuPlacement({ x: 350, y: 120 }, WINDOW)
-    expect(placement.top).toBe(128)
-    expect(placement.bottom).toBeUndefined()
-  })
-
-  it('flips above the tap when anchoring below would overflow the bottom', () => {
-    const placement = getMenuPlacement({ x: 350, y: 780 }, WINDOW)
-    expect(placement.top).toBeUndefined()
-    expect(placement.bottom).toBe(WINDOW.height - 780 + 8)
-  })
-
-  it('right-aligns to the tap and clamps to a 16px gutter', () => {
-    expect(getMenuPlacement({ x: 300, y: 100 }, WINDOW).right).toBe(75)
-    expect(getMenuPlacement({ x: 374, y: 100 }, WINDOW).right).toBe(16)
-  })
+// Stub the native menu: render the trigger plus a pressable per action so we can assert
+// that selecting an action forwards its id to onPressAction.
+jest.mock('@react-native-menu/menu', () => {
+  const { Pressable, Text: RNText } = jest.requireActual('react-native')
+  return {
+    MenuView: ({
+      children,
+      actions,
+      onPressAction,
+    }: {
+      children: React.ReactNode
+      actions: { id: string; title: string }[]
+      onPressAction: (event: { nativeEvent: { event: string } }) => void
+    }) => (
+      <>
+        {children}
+        {actions.map((action) => (
+          <Pressable
+            key={action.id}
+            testID={`menu-action-${action.id}`}
+            onPress={() => onPressAction({ nativeEvent: { event: action.id } })}
+          >
+            <RNText>{action.title}</RNText>
+          </Pressable>
+        ))}
+      </>
+    ),
+  }
 })
 
 describe('ConnectedDappContextMenu', () => {
-  it('disconnects when the Disconnect item is pressed', () => {
-    const onDisconnect = jest.fn()
-    const { getByTestId, getByText } = render(
-      <ConnectedDappContextMenu
-        anchor={{ x: 300, y: 120 }}
-        onDisconnect={onDisconnect}
-        onClose={jest.fn()}
-        testID="menu-disconnect"
-      />,
+  it('renders the trigger and a Disconnect action', () => {
+    const { getByText } = render(
+      <ConnectedDappContextMenu onDisconnect={jest.fn()}>
+        <Text>trigger</Text>
+      </ConnectedDappContextMenu>,
     )
 
+    expect(getByText('trigger')).toBeTruthy()
     expect(getByText('Disconnect')).toBeTruthy()
-    fireEvent.press(getByTestId('menu-disconnect'))
-    expect(onDisconnect).toHaveBeenCalledTimes(1)
   })
 
-  it('closes when the surrounding backdrop is pressed', () => {
-    const onClose = jest.fn()
-    const { getByLabelText } = render(
-      <ConnectedDappContextMenu anchor={{ x: 300, y: 120 }} onDisconnect={jest.fn()} onClose={onClose} />,
+  it('calls onDisconnect when the Disconnect action is selected', () => {
+    const onDisconnect = jest.fn()
+    const { getByTestId } = render(
+      <ConnectedDappContextMenu onDisconnect={onDisconnect}>
+        <Text>trigger</Text>
+      </ConnectedDappContextMenu>,
     )
 
-    fireEvent.press(getByLabelText('Close menu'))
-    expect(onClose).toHaveBeenCalledTimes(1)
+    fireEvent.press(getByTestId('menu-action-disconnect'))
+    expect(onDisconnect).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappContextMenu.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappContextMenu.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { fireEvent } from '@testing-library/react-native'
+import { render } from '@/src/tests/test-utils'
+import { ConnectedDappContextMenu } from '../ConnectedDappContextMenu'
+
+describe('ConnectedDappContextMenu', () => {
+  it('disconnects when the Disconnect item is pressed', () => {
+    const onDisconnect = jest.fn()
+    const { getByTestId, getByText } = render(
+      <ConnectedDappContextMenu
+        anchor={{ x: 300, y: 120 }}
+        onDisconnect={onDisconnect}
+        onClose={jest.fn()}
+        testID="menu-disconnect"
+      />,
+    )
+
+    expect(getByText('Disconnect')).toBeTruthy()
+    fireEvent.press(getByTestId('menu-disconnect'))
+    expect(onDisconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes when the surrounding backdrop is pressed', () => {
+    const onClose = jest.fn()
+    const { getByLabelText } = render(
+      <ConnectedDappContextMenu anchor={{ x: 300, y: 120 }} onDisconnect={jest.fn()} onClose={onClose} />,
+    )
+
+    fireEvent.press(getByLabelText('Close menu'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
@@ -24,32 +24,58 @@ jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
   )
 })
 
+// Stub the native menu: render the trigger plus a pressable per action so the disconnect action
+// is selectable without the native menu internals.
+jest.mock('@react-native-menu/menu', () => {
+  const { Pressable } = jest.requireActual('react-native')
+  return {
+    MenuView: ({
+      children,
+      actions,
+      onPressAction,
+    }: {
+      children: React.ReactNode
+      actions: { id: string }[]
+      onPressAction: (event: { nativeEvent: { event: string } }) => void
+    }) => (
+      <>
+        {children}
+        {actions.map((action) => (
+          <Pressable
+            key={action.id}
+            testID={`menu-action-${action.id}`}
+            onPress={() => onPressAction({ nativeEvent: { event: action.id } })}
+          />
+        ))}
+      </>
+    ),
+  }
+})
+
 const session = (topic: string, name: string): SessionTypes.Struct =>
   ({ topic, peer: { metadata: { name, url: `https://${name}.test`, icons: [] } } }) as unknown as SessionTypes.Struct
 
 describe('ConnectedDappRow', () => {
   it('renders the dApp name', () => {
     const { getByText } = render(
-      <ConnectedDappRow session={session('t1', 'Uniswap')} onOpenMenu={jest.fn()} onRequestDisconnect={jest.fn()} />,
+      <ConnectedDappRow session={session('t1', 'Uniswap')} onRequestDisconnect={jest.fn()} />,
     )
     expect(getByText('Uniswap')).toBeTruthy()
   })
 
-  it('opens the overflow menu anchored at the tapped point', () => {
-    const onOpenMenu = jest.fn()
+  it('requests disconnect from the overflow menu', () => {
+    const onRequest = jest.fn()
     const { getByTestId } = render(
-      <ConnectedDappRow session={session('t1', 'Uniswap')} onOpenMenu={onOpenMenu} onRequestDisconnect={jest.fn()} />,
+      <ConnectedDappRow session={session('t1', 'Uniswap')} onRequestDisconnect={onRequest} />,
     )
 
-    fireEvent.press(getByTestId('connected-dapp-menu-t1'), { nativeEvent: { pageX: 300, pageY: 120 } })
-    expect(onOpenMenu).toHaveBeenCalledWith(expect.objectContaining({ topic: 't1' }), { x: 300, y: 120 })
+    fireEvent.press(getByTestId('menu-action-disconnect'))
+    expect(onRequest).toHaveBeenCalledWith(expect.objectContaining({ topic: 't1' }))
   })
 
   it('requests disconnect from the swipe-left trash action', () => {
     const onRequest = jest.fn()
-    const { getByTestId } = render(
-      <ConnectedDappRow session={session('t2', 'Aave')} onOpenMenu={jest.fn()} onRequestDisconnect={onRequest} />,
-    )
+    const { getByTestId } = render(<ConnectedDappRow session={session('t2', 'Aave')} onRequestDisconnect={onRequest} />)
     fireEvent.press(getByTestId('connected-dapp-trash-t2'))
     expect(onRequest).toHaveBeenCalledWith(expect.objectContaining({ topic: 't2' }))
   })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import type { SessionTypes } from '@walletconnect/types'
+import { render, fireEvent } from '@/src/tests/test-utils'
+import { ConnectedDappRow } from '../ConnectedDappRow'
+
+// Swipeable renders its primary child inline and exposes renderRightActions; render both so the
+// trash action is queryable without driving a real gesture.
+jest.mock('react-native-gesture-handler/Swipeable', () => {
+  const react = jest.requireActual('react')
+  const { View } = jest.requireActual('react-native')
+  return react.forwardRef(
+    (
+      { children, renderRightActions }: { children: React.ReactNode; renderRightActions?: () => React.ReactNode },
+      ref: React.Ref<unknown>,
+    ) => {
+      react.useImperativeHandle(ref, () => ({ close: jest.fn() }))
+      return (
+        <View>
+          {children}
+          {renderRightActions ? renderRightActions() : null}
+        </View>
+      )
+    },
+  )
+})
+
+const session = (topic: string, name: string): SessionTypes.Struct =>
+  ({ topic, peer: { metadata: { name, url: `https://${name}.test`, icons: [] } } }) as unknown as SessionTypes.Struct
+
+describe('ConnectedDappRow', () => {
+  it('renders the dApp name', () => {
+    const { getByText } = render(
+      <ConnectedDappRow session={session('t1', 'Uniswap')} onRequestDisconnect={jest.fn()} />,
+    )
+    expect(getByText('Uniswap')).toBeTruthy()
+  })
+
+  it('opens the 3-dots menu and requests disconnect from it', () => {
+    const onRequest = jest.fn()
+    const { getByTestId, queryByTestId } = render(
+      <ConnectedDappRow session={session('t1', 'Uniswap')} onRequestDisconnect={onRequest} />,
+    )
+
+    expect(queryByTestId('connected-dapp-disconnect-t1')).toBeNull()
+    fireEvent.press(getByTestId('connected-dapp-menu-t1'))
+    fireEvent.press(getByTestId('connected-dapp-disconnect-t1'))
+    expect(onRequest).toHaveBeenCalledWith(expect.objectContaining({ topic: 't1' }))
+  })
+
+  it('requests disconnect from the swipe-left trash action', () => {
+    const onRequest = jest.fn()
+    const { getByTestId } = render(<ConnectedDappRow session={session('t2', 'Aave')} onRequestDisconnect={onRequest} />)
+    fireEvent.press(getByTestId('connected-dapp-trash-t2'))
+    expect(onRequest).toHaveBeenCalledWith(expect.objectContaining({ topic: 't2' }))
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
@@ -3,9 +3,9 @@ import type { SessionTypes } from '@walletconnect/types'
 import { render, fireEvent } from '@/src/tests/test-utils'
 import { ConnectedDappRow } from '../ConnectedDappRow'
 
-// Swipeable renders its primary child inline and exposes renderRightActions; render both so the
-// trash action is queryable without driving a real gesture.
-jest.mock('react-native-gesture-handler/Swipeable', () => {
+// ReanimatedSwipeable renders its primary child inline and exposes renderRightActions; render
+// both so the trash action is queryable without driving a real gesture.
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
   const react = jest.requireActual('react')
   const { View } = jest.requireActual('react-native')
   return react.forwardRef(

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappRow.test.tsx
@@ -30,26 +30,26 @@ const session = (topic: string, name: string): SessionTypes.Struct =>
 describe('ConnectedDappRow', () => {
   it('renders the dApp name', () => {
     const { getByText } = render(
-      <ConnectedDappRow session={session('t1', 'Uniswap')} onRequestDisconnect={jest.fn()} />,
+      <ConnectedDappRow session={session('t1', 'Uniswap')} onOpenMenu={jest.fn()} onRequestDisconnect={jest.fn()} />,
     )
     expect(getByText('Uniswap')).toBeTruthy()
   })
 
-  it('opens the 3-dots menu and requests disconnect from it', () => {
-    const onRequest = jest.fn()
-    const { getByTestId, queryByTestId } = render(
-      <ConnectedDappRow session={session('t1', 'Uniswap')} onRequestDisconnect={onRequest} />,
+  it('opens the overflow menu anchored at the tapped point', () => {
+    const onOpenMenu = jest.fn()
+    const { getByTestId } = render(
+      <ConnectedDappRow session={session('t1', 'Uniswap')} onOpenMenu={onOpenMenu} onRequestDisconnect={jest.fn()} />,
     )
 
-    expect(queryByTestId('connected-dapp-disconnect-t1')).toBeNull()
-    fireEvent.press(getByTestId('connected-dapp-menu-t1'))
-    fireEvent.press(getByTestId('connected-dapp-disconnect-t1'))
-    expect(onRequest).toHaveBeenCalledWith(expect.objectContaining({ topic: 't1' }))
+    fireEvent.press(getByTestId('connected-dapp-menu-t1'), { nativeEvent: { pageX: 300, pageY: 120 } })
+    expect(onOpenMenu).toHaveBeenCalledWith(expect.objectContaining({ topic: 't1' }), { x: 300, y: 120 })
   })
 
   it('requests disconnect from the swipe-left trash action', () => {
     const onRequest = jest.fn()
-    const { getByTestId } = render(<ConnectedDappRow session={session('t2', 'Aave')} onRequestDisconnect={onRequest} />)
+    const { getByTestId } = render(
+      <ConnectedDappRow session={session('t2', 'Aave')} onOpenMenu={jest.fn()} onRequestDisconnect={onRequest} />,
+    )
     fireEvent.press(getByTestId('connected-dapp-trash-t2'))
     expect(onRequest).toHaveBeenCalledWith(expect.objectContaining({ topic: 't2' }))
   })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsEntry.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsEntry.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import type { SessionTypes } from '@walletconnect/types'
+import { renderWithStore, createTestStore, fireEvent } from '@/src/tests/test-utils'
+import { ConnectedDappsEntry } from '../ConnectedDappsEntry'
+
+const mockPush = jest.fn()
+jest.mock('expo-router', () => ({
+  router: { push: (path: string) => mockPush(path) },
+}))
+
+const mockUseHasFeature = jest.fn()
+jest.mock('@/src/hooks/useHasFeature', () => ({
+  useHasFeature: () => mockUseHasFeature(),
+}))
+
+const session = (topic: string): SessionTypes.Struct =>
+  ({ topic, peer: { metadata: { name: topic } } }) as unknown as SessionTypes.Struct
+
+const storeWith = (topics: string[]) =>
+  createTestStore({
+    walletKit: {
+      sessions: Object.fromEntries(topics.map((t) => [t, session(t)])),
+      verifyByTopic: {},
+      pending: [],
+      outstandingRequests: {},
+    },
+  } as never)
+
+describe('ConnectedDappsEntry', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders nothing when the feature flag is off', () => {
+    mockUseHasFeature.mockReturnValue(false)
+    const { queryByTestId } = renderWithStore(<ConnectedDappsEntry />, storeWith(['a']))
+    expect(queryByTestId('settings-connected-apps-entry')).toBeNull()
+  })
+
+  it('renders nothing when there are no connected dApps', () => {
+    mockUseHasFeature.mockReturnValue(true)
+    const { queryByTestId } = renderWithStore(<ConnectedDappsEntry />, storeWith([]))
+    expect(queryByTestId('settings-connected-apps-entry')).toBeNull()
+  })
+
+  it('shows the session count and navigates when pressed', () => {
+    mockUseHasFeature.mockReturnValue(true)
+    const { getByTestId } = renderWithStore(<ConnectedDappsEntry />, storeWith(['a', 'b']))
+
+    expect(getByTestId('connected-apps-count')).toHaveTextContent('2')
+
+    fireEvent.press(getByTestId('settings-connected-apps-entry'))
+    expect(mockPush).toHaveBeenCalledWith('/connected-apps')
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
@@ -9,54 +9,27 @@ jest.mock('../../hooks/useDisconnectSession', () => ({
   useDisconnectSession: () => ({ disconnect: mockDisconnect, busyTopic: mockBusyTopic }),
 }))
 
-// Stub the row: expose a menu trigger (reports an anchor) and a swipe trigger, so the screen's
-// menu + selection wiring is observable without the swipe/gesture internals.
+// Stub the row: expose a menu-disconnect trigger and a swipe trigger, so the screen's selection
+// wiring is observable without the native menu / swipe gesture internals. Both route through
+// onRequestDisconnect, mirroring the real row.
 jest.mock('../ConnectedDappRow', () => {
   const { Text } = jest.requireActual('react-native')
   return {
     ConnectedDappRow: ({
       session,
-      onOpenMenu,
       onRequestDisconnect,
     }: {
       session: { topic: string; peer: { metadata: { name: string } } }
-      onOpenMenu: (s: unknown, anchor: { x: number; y: number }) => void
       onRequestDisconnect: (s: unknown) => void
     }) => (
       <>
-        <Text testID={`row-menu-${session.topic}`} onPress={() => onOpenMenu(session, { x: 0, y: 0 })}>
+        <Text testID={`row-menu-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
           {session.peer.metadata.name}
         </Text>
         <Text testID={`row-swipe-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
           swipe
         </Text>
       </>
-    ),
-  }
-})
-
-// Stub the menu: surface the screen-provided testID + a close trigger so we can assert which
-// session's menu is open and that only one is open at a time.
-jest.mock('../ConnectedDappContextMenu', () => {
-  const { Text, View } = jest.requireActual('react-native')
-  return {
-    ConnectedDappContextMenu: ({
-      testID,
-      onDisconnect,
-      onClose,
-    }: {
-      testID?: string
-      onDisconnect: () => void
-      onClose: () => void
-    }) => (
-      <View testID="context-menu">
-        <Text testID={testID} onPress={onDisconnect}>
-          Disconnect
-        </Text>
-        <Text testID="menu-close" onPress={onClose}>
-          close
-        </Text>
-      </View>
     ),
   }
 })
@@ -111,20 +84,6 @@ describe('ConnectedDappsScreen', () => {
     expect(getByTestId('row-menu-t2')).toBeTruthy()
   })
 
-  it('keeps only one menu open at a time', () => {
-    const { getByTestId, queryByTestId } = renderWithStore(
-      <ConnectedDappsScreen />,
-      storeWith([session('t1', 'Uniswap'), session('t2', 'Aave')]),
-    )
-
-    fireEvent.press(getByTestId('row-menu-t1'))
-    expect(getByTestId('connected-dapp-disconnect-t1')).toBeTruthy()
-
-    fireEvent.press(getByTestId('row-menu-t2'))
-    expect(queryByTestId('connected-dapp-disconnect-t1')).toBeNull()
-    expect(getByTestId('connected-dapp-disconnect-t2')).toBeTruthy()
-  })
-
   it('opens the confirm sheet from the menu and disconnects the selected dApp', async () => {
     const { getByTestId, getByText, queryByTestId } = renderWithStore(
       <ConnectedDappsScreen />,
@@ -134,9 +93,6 @@ describe('ConnectedDappsScreen', () => {
     expect(queryByTestId('confirm-modal')).toBeNull()
 
     fireEvent.press(getByTestId('row-menu-t1'))
-    fireEvent.press(getByTestId('connected-dapp-disconnect-t1'))
-    // Menu closes, confirm sheet opens.
-    expect(queryByTestId('context-menu')).toBeNull()
     expect(getByText('confirm:Uniswap')).toBeTruthy()
 
     await act(async () => {
@@ -155,7 +111,6 @@ describe('ConnectedDappsScreen', () => {
     )
 
     fireEvent.press(getByTestId('row-menu-t1'))
-    fireEvent.press(getByTestId('connected-dapp-disconnect-t1'))
 
     await act(async () => {
       fireEvent.press(getByTestId('confirm-action'))

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import type { SessionTypes } from '@walletconnect/types'
+import { renderWithStore, createTestStore, fireEvent, act } from '@/src/tests/test-utils'
+import { ConnectedDappsScreen } from '../ConnectedDappsScreen'
+
+const mockDisconnect = jest.fn()
+let mockBusyTopic: string | null = null
+jest.mock('../../hooks/useDisconnectSession', () => ({
+  useDisconnectSession: () => ({ disconnect: mockDisconnect, busyTopic: mockBusyTopic }),
+}))
+
+// Stub the confirm sheet: render the pending dApp name and an inline confirm trigger so the
+// screen's selection + confirm wiring is observable without the bottom-sheet internals.
+jest.mock('../DisconnectConfirmModal', () => {
+  const { Text, View } = jest.requireActual('react-native')
+  return {
+    DisconnectConfirmModal: ({ dappName, onConfirm }: { dappName: string | null; onConfirm: () => void }) =>
+      dappName ? (
+        <View testID="confirm-modal">
+          <Text>{`confirm:${dappName}`}</Text>
+          <Text testID="confirm-action" onPress={onConfirm}>
+            confirm
+          </Text>
+        </View>
+      ) : null,
+  }
+})
+
+const session = (topic: string, name: string, url = `https://${name}.test`): SessionTypes.Struct =>
+  ({ topic, peer: { metadata: { name, url, icons: [] } } }) as unknown as SessionTypes.Struct
+
+const storeWith = (sessions: SessionTypes.Struct[]) =>
+  createTestStore({
+    walletKit: {
+      sessions: Object.fromEntries(sessions.map((s) => [s.topic, s])),
+      verifyByTopic: {},
+      pending: [],
+      outstandingRequests: {},
+    },
+  } as never)
+
+describe('ConnectedDappsScreen', () => {
+  beforeEach(() => {
+    mockDisconnect.mockReset().mockResolvedValue(undefined)
+    mockBusyTopic = null
+  })
+
+  it('shows the empty state when there are no sessions', () => {
+    const { getByText } = renderWithStore(<ConnectedDappsScreen />, storeWith([]))
+    expect(getByText('No connected apps.')).toBeTruthy()
+  })
+
+  it('renders a row per connected dApp', () => {
+    const { getByText, getAllByTestId } = renderWithStore(
+      <ConnectedDappsScreen />,
+      storeWith([session('t1', 'Uniswap'), session('t2', 'Aave')]),
+    )
+    expect(getAllByTestId('connected-dapp-row')).toHaveLength(2)
+    expect(getByText('Uniswap')).toBeTruthy()
+    expect(getByText('https://Aave.test')).toBeTruthy()
+  })
+
+  it('opens the confirm sheet and disconnects the selected dApp', async () => {
+    const { getByTestId, getByText, queryByTestId } = renderWithStore(
+      <ConnectedDappsScreen />,
+      storeWith([session('t1', 'Uniswap')]),
+    )
+
+    expect(queryByTestId('confirm-modal')).toBeNull()
+
+    fireEvent.press(getByTestId('connected-dapp-menu-t1'))
+    expect(getByText('confirm:Uniswap')).toBeTruthy()
+
+    await act(async () => {
+      fireEvent.press(getByTestId('confirm-action'))
+    })
+    expect(mockDisconnect).toHaveBeenCalledWith('t1', 'Uniswap')
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
@@ -9,21 +9,54 @@ jest.mock('../../hooks/useDisconnectSession', () => ({
   useDisconnectSession: () => ({ disconnect: mockDisconnect, busyTopic: mockBusyTopic }),
 }))
 
-// Stub the row: expose the name and a trigger that asks the screen to disconnect, so the
-// screen's selection + confirm wiring is observable without the swipe/menu internals.
+// Stub the row: expose a menu trigger (reports an anchor) and a swipe trigger, so the screen's
+// menu + selection wiring is observable without the swipe/gesture internals.
 jest.mock('../ConnectedDappRow', () => {
   const { Text } = jest.requireActual('react-native')
   return {
     ConnectedDappRow: ({
       session,
+      onOpenMenu,
       onRequestDisconnect,
     }: {
       session: { topic: string; peer: { metadata: { name: string } } }
+      onOpenMenu: (s: unknown, anchor: { x: number; y: number }) => void
       onRequestDisconnect: (s: unknown) => void
     }) => (
-      <Text testID={`row-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
-        {session.peer.metadata.name}
-      </Text>
+      <>
+        <Text testID={`row-menu-${session.topic}`} onPress={() => onOpenMenu(session, { x: 0, y: 0 })}>
+          {session.peer.metadata.name}
+        </Text>
+        <Text testID={`row-swipe-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
+          swipe
+        </Text>
+      </>
+    ),
+  }
+})
+
+// Stub the menu: surface the screen-provided testID + a close trigger so we can assert which
+// session's menu is open and that only one is open at a time.
+jest.mock('../ConnectedDappContextMenu', () => {
+  const { Text, View } = jest.requireActual('react-native')
+  return {
+    ConnectedDappContextMenu: ({
+      testID,
+      onDisconnect,
+      onClose,
+    }: {
+      testID?: string
+      onDisconnect: () => void
+      onClose: () => void
+    }) => (
+      <View testID="context-menu">
+        <Text testID={testID} onPress={onDisconnect}>
+          Disconnect
+        </Text>
+        <Text testID="menu-close" onPress={onClose}>
+          close
+        </Text>
+      </View>
     ),
   }
 })
@@ -74,11 +107,25 @@ describe('ConnectedDappsScreen', () => {
       <ConnectedDappsScreen />,
       storeWith([session('t1', 'Uniswap'), session('t2', 'Aave')]),
     )
-    expect(getByTestId('row-t1')).toBeTruthy()
-    expect(getByTestId('row-t2')).toBeTruthy()
+    expect(getByTestId('row-menu-t1')).toBeTruthy()
+    expect(getByTestId('row-menu-t2')).toBeTruthy()
   })
 
-  it('opens the confirm sheet and disconnects the selected dApp', async () => {
+  it('keeps only one menu open at a time', () => {
+    const { getByTestId, queryByTestId } = renderWithStore(
+      <ConnectedDappsScreen />,
+      storeWith([session('t1', 'Uniswap'), session('t2', 'Aave')]),
+    )
+
+    fireEvent.press(getByTestId('row-menu-t1'))
+    expect(getByTestId('connected-dapp-disconnect-t1')).toBeTruthy()
+
+    fireEvent.press(getByTestId('row-menu-t2'))
+    expect(queryByTestId('connected-dapp-disconnect-t1')).toBeNull()
+    expect(getByTestId('connected-dapp-disconnect-t2')).toBeTruthy()
+  })
+
+  it('opens the confirm sheet from the menu and disconnects the selected dApp', async () => {
     const { getByTestId, getByText, queryByTestId } = renderWithStore(
       <ConnectedDappsScreen />,
       storeWith([session('t1', 'Uniswap')]),
@@ -86,12 +133,22 @@ describe('ConnectedDappsScreen', () => {
 
     expect(queryByTestId('confirm-modal')).toBeNull()
 
-    fireEvent.press(getByTestId('row-t1'))
+    fireEvent.press(getByTestId('row-menu-t1'))
+    fireEvent.press(getByTestId('connected-dapp-disconnect-t1'))
+    // Menu closes, confirm sheet opens.
+    expect(queryByTestId('context-menu')).toBeNull()
     expect(getByText('confirm:Uniswap')).toBeTruthy()
 
     await act(async () => {
       fireEvent.press(getByTestId('confirm-action'))
     })
     expect(mockDisconnect).toHaveBeenCalledWith('t1', 'Uniswap')
+  })
+
+  it('opens the confirm sheet from the swipe trash action', () => {
+    const { getByTestId, getByText } = renderWithStore(<ConnectedDappsScreen />, storeWith([session('t1', 'Uniswap')]))
+
+    fireEvent.press(getByTestId('row-swipe-t1'))
+    expect(getByText('confirm:Uniswap')).toBeTruthy()
   })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
@@ -92,7 +92,7 @@ const storeWith = (sessions: SessionTypes.Struct[]) =>
 
 describe('ConnectedDappsScreen', () => {
   beforeEach(() => {
-    mockDisconnect.mockReset().mockResolvedValue(undefined)
+    mockDisconnect.mockReset().mockResolvedValue(true)
     mockBusyTopic = null
   })
 
@@ -143,6 +143,24 @@ describe('ConnectedDappsScreen', () => {
       fireEvent.press(getByTestId('confirm-action'))
     })
     expect(mockDisconnect).toHaveBeenCalledWith('t1', 'Uniswap')
+    // Sheet closes once the disconnect succeeds.
+    expect(queryByTestId('confirm-modal')).toBeNull()
+  })
+
+  it('keeps the confirm sheet open when the disconnect fails', async () => {
+    mockDisconnect.mockResolvedValue(false)
+    const { getByTestId, queryByTestId } = renderWithStore(
+      <ConnectedDappsScreen />,
+      storeWith([session('t1', 'Uniswap')]),
+    )
+
+    fireEvent.press(getByTestId('row-menu-t1'))
+    fireEvent.press(getByTestId('connected-dapp-disconnect-t1'))
+
+    await act(async () => {
+      fireEvent.press(getByTestId('confirm-action'))
+    })
+    expect(queryByTestId('confirm-modal')).toBeTruthy()
   })
 
   it('opens the confirm sheet from the swipe trash action', () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/ConnectedDappsScreen.test.tsx
@@ -9,15 +9,33 @@ jest.mock('../../hooks/useDisconnectSession', () => ({
   useDisconnectSession: () => ({ disconnect: mockDisconnect, busyTopic: mockBusyTopic }),
 }))
 
-// Stub the confirm sheet: render the pending dApp name and an inline confirm trigger so the
-// screen's selection + confirm wiring is observable without the bottom-sheet internals.
+// Stub the row: expose the name and a trigger that asks the screen to disconnect, so the
+// screen's selection + confirm wiring is observable without the swipe/menu internals.
+jest.mock('../ConnectedDappRow', () => {
+  const { Text } = jest.requireActual('react-native')
+  return {
+    ConnectedDappRow: ({
+      session,
+      onRequestDisconnect,
+    }: {
+      session: { topic: string; peer: { metadata: { name: string } } }
+      onRequestDisconnect: (s: unknown) => void
+    }) => (
+      <Text testID={`row-${session.topic}`} onPress={() => onRequestDisconnect(session)}>
+        {session.peer.metadata.name}
+      </Text>
+    ),
+  }
+})
+
+// Stub the confirm sheet: render the pending dApp name + an inline confirm trigger.
 jest.mock('../DisconnectConfirmModal', () => {
   const { Text, View } = jest.requireActual('react-native')
   return {
-    DisconnectConfirmModal: ({ dappName, onConfirm }: { dappName: string | null; onConfirm: () => void }) =>
-      dappName ? (
+    DisconnectConfirmModal: ({ dapp, onConfirm }: { dapp: { name: string } | null; onConfirm: () => void }) =>
+      dapp ? (
         <View testID="confirm-modal">
-          <Text>{`confirm:${dappName}`}</Text>
+          <Text>{`confirm:${dapp.name}`}</Text>
           <Text testID="confirm-action" onPress={onConfirm}>
             confirm
           </Text>
@@ -26,8 +44,8 @@ jest.mock('../DisconnectConfirmModal', () => {
   }
 })
 
-const session = (topic: string, name: string, url = `https://${name}.test`): SessionTypes.Struct =>
-  ({ topic, peer: { metadata: { name, url, icons: [] } } }) as unknown as SessionTypes.Struct
+const session = (topic: string, name: string): SessionTypes.Struct =>
+  ({ topic, peer: { metadata: { name, url: `https://${name}.test`, icons: [] } } }) as unknown as SessionTypes.Struct
 
 const storeWith = (sessions: SessionTypes.Struct[]) =>
   createTestStore({
@@ -45,19 +63,19 @@ describe('ConnectedDappsScreen', () => {
     mockBusyTopic = null
   })
 
-  it('shows the empty state when there are no sessions', () => {
+  it('renders the title and the empty state when there are no sessions', () => {
     const { getByText } = renderWithStore(<ConnectedDappsScreen />, storeWith([]))
+    expect(getByText('Connected apps')).toBeTruthy()
     expect(getByText('No connected apps.')).toBeTruthy()
   })
 
   it('renders a row per connected dApp', () => {
-    const { getByText, getAllByTestId } = renderWithStore(
+    const { getByTestId } = renderWithStore(
       <ConnectedDappsScreen />,
       storeWith([session('t1', 'Uniswap'), session('t2', 'Aave')]),
     )
-    expect(getAllByTestId('connected-dapp-row')).toHaveLength(2)
-    expect(getByText('Uniswap')).toBeTruthy()
-    expect(getByText('https://Aave.test')).toBeTruthy()
+    expect(getByTestId('row-t1')).toBeTruthy()
+    expect(getByTestId('row-t2')).toBeTruthy()
   })
 
   it('opens the confirm sheet and disconnects the selected dApp', async () => {
@@ -68,7 +86,7 @@ describe('ConnectedDappsScreen', () => {
 
     expect(queryByTestId('confirm-modal')).toBeNull()
 
-    fireEvent.press(getByTestId('connected-dapp-menu-t1'))
+    fireEvent.press(getByTestId('row-t1'))
     expect(getByText('confirm:Uniswap')).toBeTruthy()
 
     await act(async () => {

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DisconnectConfirmModal.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DisconnectConfirmModal.test.tsx
@@ -24,35 +24,28 @@ jest.mock('@gorhom/bottom-sheet', () => {
 })
 
 describe('DisconnectConfirmModal', () => {
-  it('shows the dApp name and confirms / cancels via the action buttons', () => {
+  it('shows the title, dApp name, and confirms via the Disconnect button', () => {
     const onConfirm = jest.fn()
-    const onClose = jest.fn()
     const { getByText, getByTestId } = render(
-      <DisconnectConfirmModal dappName="Uniswap" onConfirm={onConfirm} onClose={onClose} />,
+      <DisconnectConfirmModal dapp={{ name: 'Uniswap' }} onConfirm={onConfirm} onClose={jest.fn()} />,
     )
 
-    expect(getByText("You'll no longer be connected to Uniswap.")).toBeTruthy()
-
-    fireEvent.press(getByTestId('disconnect-cancel-button'))
-    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(getByText('Disconnect app?')).toBeTruthy()
+    expect(getByText('Uniswap')).toBeTruthy()
 
     fireEvent.press(getByTestId('disconnect-confirm-button'))
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 
   it('stays closed when no dApp is selected', () => {
-    const { queryByTestId } = render(
-      <DisconnectConfirmModal dappName={null} onConfirm={jest.fn()} onClose={jest.fn()} />,
-    )
-
+    const { queryByTestId } = render(<DisconnectConfirmModal dapp={null} onConfirm={jest.fn()} onClose={jest.fn()} />)
     expect(queryByTestId('disconnect-confirm-modal')).toBeNull()
   })
 
   it('shows the busy label on the confirm action while disconnecting', () => {
     const { getByText, queryByText } = render(
-      <DisconnectConfirmModal dappName="Uniswap" isBusy onConfirm={jest.fn()} onClose={jest.fn()} />,
+      <DisconnectConfirmModal dapp={{ name: 'Uniswap' }} isBusy onConfirm={jest.fn()} onClose={jest.fn()} />,
     )
-
     expect(getByText('Disconnecting')).toBeTruthy()
     expect(queryByText('Disconnect')).toBeNull()
   })

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DisconnectConfirmModal.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DisconnectConfirmModal.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { fireEvent } from '@testing-library/react-native'
+import { render } from '@/src/tests/test-utils'
+import { DisconnectConfirmModal } from '../DisconnectConfirmModal'
+
+// Local mock: gate children on imperative present()/dismiss() (so the closed case renders
+// nothing) and skip the backdrop/background, which the global mock can't satisfy here.
+jest.mock('@gorhom/bottom-sheet', () => {
+  const react = jest.requireActual('react')
+  const { View } = jest.requireActual('react-native')
+  const BottomSheetModal = react.forwardRef(({ children }: { children: React.ReactNode }, ref: React.Ref<unknown>) => {
+    const [open, setOpen] = react.useState(false)
+    react.useImperativeHandle(ref, () => ({ present: () => setOpen(true), dismiss: () => setOpen(false) }))
+    return open ? <View>{children}</View> : null
+  })
+  return {
+    __esModule: true,
+    default: View,
+    BottomSheetModal,
+    BottomSheetModalProvider: View,
+    BottomSheetView: View,
+    useBottomSheet: () => ({ close: jest.fn() }),
+  }
+})
+
+describe('DisconnectConfirmModal', () => {
+  it('shows the dApp name and confirms / cancels via the action buttons', () => {
+    const onConfirm = jest.fn()
+    const onClose = jest.fn()
+    const { getByText, getByTestId } = render(
+      <DisconnectConfirmModal dappName="Uniswap" onConfirm={onConfirm} onClose={onClose} />,
+    )
+
+    expect(getByText("You'll no longer be connected to Uniswap.")).toBeTruthy()
+
+    fireEvent.press(getByTestId('disconnect-cancel-button'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    fireEvent.press(getByTestId('disconnect-confirm-button'))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays closed when no dApp is selected', () => {
+    const { queryByTestId } = render(
+      <DisconnectConfirmModal dappName={null} onConfirm={jest.fn()} onClose={jest.fn()} />,
+    )
+
+    expect(queryByTestId('disconnect-confirm-modal')).toBeNull()
+  })
+
+  it('shows the busy label on the confirm action while disconnecting', () => {
+    const { getByText, queryByText } = render(
+      <DisconnectConfirmModal dappName="Uniswap" isBusy onConfirm={jest.fn()} onClose={jest.fn()} />,
+    )
+
+    expect(getByText('Disconnecting')).toBeTruthy()
+    expect(queryByText('Disconnect')).toBeNull()
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DisconnectConfirmModal.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/components/__tests__/DisconnectConfirmModal.test.tsx
@@ -49,4 +49,15 @@ describe('DisconnectConfirmModal', () => {
     expect(getByText('Disconnecting')).toBeTruthy()
     expect(queryByText('Disconnect')).toBeNull()
   })
+
+  it('updates the shown dApp when the target changes without closing first', () => {
+    const { getByText, queryByText, rerender } = render(
+      <DisconnectConfirmModal dapp={{ name: 'Uniswap' }} onConfirm={jest.fn()} onClose={jest.fn()} />,
+    )
+    expect(getByText('Uniswap')).toBeTruthy()
+
+    rerender(<DisconnectConfirmModal dapp={{ name: 'Aave' }} onConfirm={jest.fn()} onClose={jest.fn()} />)
+    expect(getByText('Aave')).toBeTruthy()
+    expect(queryByText('Uniswap')).toBeNull()
+  })
 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitProvider.test.tsx
+++ b/apps/mobile/src/features/WalletConnect/Wallet/context/__tests__/WalletKitProvider.test.tsx
@@ -40,7 +40,7 @@ jest.mock('../../walletKit', () => ({ getWalletKit: jest.fn(() => Promise.resolv
 
 const renderProvider = () => {
   const store = createTestStore({
-    [walletKitSliceName]: { sessions: {}, pending: [], outstandingRequests: {} },
+    [walletKitSliceName]: { sessions: {}, verifyByTopic: {}, pending: [], outstandingRequests: {} },
   } as never)
   const utils = renderWithStore(
     <WalletKitProvider>

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useApproveProposal.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useApproveProposal.test.ts
@@ -5,7 +5,7 @@ import { getSdkError } from '@walletconnect/utils'
 import type { IWalletKit, WalletKitTypes } from '@reown/walletkit'
 import { renderHookWithStore, createTestStore } from '@/src/tests/test-utils'
 import { useApproveProposal } from '../useApproveProposal'
-import { selectSessions, selectPending } from '../../store/walletKitSlice'
+import { selectSessions, selectPending, selectVerifyByTopic } from '../../store/walletKitSlice'
 import type { RootState } from '@/src/store'
 
 const mockToastShow = jest.fn()
@@ -22,6 +22,7 @@ const makePending = (id: number): { id: number; proposal: WalletKitTypes.Session
       requiredNamespaces: { eip155: { chains: ['eip155:1'], methods: [], events: [] } },
       optionalNamespaces: {},
     },
+    verifyContext: { verified: { validation: 'VALID', origin: 'https://dapp.test', isScam: false } },
   } as unknown as WalletKitTypes.SessionProposal,
 })
 
@@ -54,6 +55,7 @@ describe('useApproveProposal', () => {
     expect(arg.sessionProperties).toBeDefined()
     expect(selectSessions(store.getState() as RootState)).toHaveLength(1)
     expect(selectPending(store.getState() as RootState)).toHaveLength(0)
+    expect(selectVerifyByTopic(store.getState() as RootState)[session.topic]).toBe('verified')
     expect(mockToastShow).toHaveBeenCalledWith('Connected to app', expect.anything())
   })
 

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useDisconnectSession.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useDisconnectSession.test.ts
@@ -1,0 +1,67 @@
+import { act } from '@testing-library/react-native'
+import { getSdkError } from '@walletconnect/utils'
+import type { SessionTypes } from '@walletconnect/types'
+import { renderHookWithStore, createTestStore } from '@/src/tests/test-utils'
+import { useDisconnectSession } from '../useDisconnectSession'
+import { selectSessionsRecord } from '../../store/walletKitSlice'
+import type { RootState } from '@/src/store'
+
+const mockToastShow = jest.fn()
+jest.mock('@tamagui/toast', () => ({ useToastController: () => ({ show: mockToastShow }) }))
+
+const mockDisconnectSession = jest.fn()
+jest.mock('../../walletKit', () => ({
+  getWalletKit: () => Promise.resolve({ disconnectSession: mockDisconnectSession }),
+}))
+
+const session = (topic: string): SessionTypes.Struct =>
+  ({ topic, peer: { metadata: { name: 'dApp' } } }) as unknown as SessionTypes.Struct
+
+const storeWithSession = (topic: string) =>
+  createTestStore({
+    walletKit: {
+      sessions: { [topic]: session(topic) },
+      verifyByTopic: { [topic]: 'verified' },
+      pending: [],
+      outstandingRequests: {},
+    },
+  } as never)
+
+describe('useDisconnectSession', () => {
+  beforeEach(() => {
+    mockToastShow.mockClear()
+    mockDisconnectSession.mockReset()
+  })
+
+  it('tells the relay and removes the session from the slice on success', async () => {
+    mockDisconnectSession.mockResolvedValue(undefined)
+    const store = storeWithSession('topic-1')
+    const { result } = renderHookWithStore(() => useDisconnectSession(), store)
+
+    await act(async () => {
+      await result.current.disconnect('topic-1', 'dApp')
+    })
+
+    expect(mockDisconnectSession).toHaveBeenCalledWith({
+      topic: 'topic-1',
+      reason: getSdkError('USER_DISCONNECTED'),
+    })
+    expect(selectSessionsRecord(store.getState() as RootState)['topic-1']).toBeUndefined()
+    expect(mockToastShow).toHaveBeenCalledWith('dApp disconnected', expect.anything())
+    expect(result.current.busyTopic).toBeNull()
+  })
+
+  it('keeps the session and shows an error toast when the relay call fails', async () => {
+    mockDisconnectSession.mockRejectedValue(new Error('relay down'))
+    const store = storeWithSession('topic-2')
+    const { result } = renderHookWithStore(() => useDisconnectSession(), store)
+
+    await act(async () => {
+      await result.current.disconnect('topic-2', 'dApp')
+    })
+
+    expect(selectSessionsRecord(store.getState() as RootState)['topic-2']).toBeDefined()
+    expect(mockToastShow).toHaveBeenCalledWith('Failed to disconnect', expect.objectContaining({ variant: 'error' }))
+    expect(result.current.busyTopic).toBeNull()
+  })
+})

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useDisconnectSession.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/__tests__/useDisconnectSession.test.ts
@@ -38,10 +38,12 @@ describe('useDisconnectSession', () => {
     const store = storeWithSession('topic-1')
     const { result } = renderHookWithStore(() => useDisconnectSession(), store)
 
+    let returned: boolean | undefined
     await act(async () => {
-      await result.current.disconnect('topic-1', 'dApp')
+      returned = await result.current.disconnect('topic-1', 'dApp')
     })
 
+    expect(returned).toBe(true)
     expect(mockDisconnectSession).toHaveBeenCalledWith({
       topic: 'topic-1',
       reason: getSdkError('USER_DISCONNECTED'),
@@ -51,15 +53,17 @@ describe('useDisconnectSession', () => {
     expect(result.current.busyTopic).toBeNull()
   })
 
-  it('keeps the session and shows an error toast when the relay call fails', async () => {
+  it('resolves false, keeps the session, and shows an error toast when the relay call fails', async () => {
     mockDisconnectSession.mockRejectedValue(new Error('relay down'))
     const store = storeWithSession('topic-2')
     const { result } = renderHookWithStore(() => useDisconnectSession(), store)
 
+    let returned: boolean | undefined
     await act(async () => {
-      await result.current.disconnect('topic-2', 'dApp')
+      returned = await result.current.disconnect('topic-2', 'dApp')
     })
 
+    expect(returned).toBe(false)
     expect(selectSessionsRecord(store.getState() as RootState)['topic-2']).toBeDefined()
     expect(mockToastShow).toHaveBeenCalledWith('Failed to disconnect', expect.objectContaining({ variant: 'error' }))
     expect(result.current.busyTopic).toBeNull()

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useApproveProposal.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useApproveProposal.ts
@@ -9,6 +9,7 @@ import { addSession, removePending } from '../store/walletKitSlice'
 import { buildSafeApprovedNamespaces, buildSafeSessionProperties } from '../services/namespaces'
 import { rejectProposal } from './useSessionProposalHandler'
 import { logWalletKitError } from '../utils/errors'
+import { verifyStatusToVariant } from '../utils/verifyStatus'
 
 type PendingProposal = { id: number; proposal: WalletKitTypes.SessionProposal }
 
@@ -53,7 +54,8 @@ export const useApproveProposal = (walletKit: IWalletKit | null) => {
         // Signal atomic-batch support up front so dApps don't need wallet_getCapabilities first.
         const sessionProperties = buildSafeSessionProperties({ safeAddress: activeSafe.address, supportedChains })
         const session = await walletKit.approveSession({ id, namespaces, sessionProperties })
-        dispatch(addSession(session))
+        const verifyVariant = verifyStatusToVariant(pending.proposal.verifyContext?.verified)
+        dispatch(addSession({ session, verifyVariant }))
         dispatch(removePending({ id, kind: 'proposal' }))
         // WalletKit auto-redirects back to the dApp; surface a success toast on our side.
         toast.show('Connected to app', { native: false, duration: 3000 })

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useDisconnectSession.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useDisconnectSession.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react'
+import { getSdkError } from '@walletconnect/utils'
+import { useToastController } from '@tamagui/toast'
+import { useAppDispatch } from '@/src/store/hooks'
+import { removeSession } from '../store/walletKitSlice'
+import { getWalletKit } from '../walletKit'
+import { logWalletKitError } from '../utils/errors'
+
+/**
+ * Shared teardown for a connected dApp: tell the relay the user disconnected, then drop the
+ * session from the slice. `busyTopic` lets callers disable the row being torn down. On failure
+ * the slice entry is left intact (the relay call is the source of truth) so the user can retry;
+ * the technical error is logged and a generic toast is shown.
+ */
+export const useDisconnectSession = () => {
+  const dispatch = useAppDispatch()
+  const toast = useToastController()
+  const [busyTopic, setBusyTopic] = useState<string | null>(null)
+
+  const disconnect = useCallback(
+    async (topic: string, peerName?: string) => {
+      setBusyTopic(topic)
+      try {
+        const wk = await getWalletKit()
+        await wk.disconnectSession({ topic, reason: getSdkError('USER_DISCONNECTED') })
+        dispatch(removeSession(topic))
+        toast.show(`${peerName ?? 'App'} disconnected`, { native: false, duration: 2500 })
+      } catch (e) {
+        logWalletKitError('disconnectSession failed', e)
+        toast.show('Failed to disconnect', { native: false, duration: 2500, variant: 'error' })
+      } finally {
+        setBusyTopic(null)
+      }
+    },
+    [dispatch, toast],
+  )
+
+  return { disconnect, busyTopic }
+}

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useDisconnectSession.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useDisconnectSession.ts
@@ -8,9 +8,10 @@ import { logWalletKitError } from '../utils/errors'
 
 /**
  * Shared teardown for a connected dApp: tell the relay the user disconnected, then drop the
- * session from the slice. `busyTopic` lets callers disable the row being torn down. On failure
- * the slice entry is left intact (the relay call is the source of truth) so the user can retry;
- * the technical error is logged and a generic toast is shown.
+ * session from the slice. `busyTopic` lets callers disable the row being torn down. Resolves
+ * `true` on success and `false` on failure (the slice entry is left intact since the relay call
+ * is the source of truth) so callers can keep a confirmation open for retry; the technical error
+ * is logged and a generic toast is shown.
  */
 export const useDisconnectSession = () => {
   const dispatch = useAppDispatch()
@@ -18,16 +19,18 @@ export const useDisconnectSession = () => {
   const [busyTopic, setBusyTopic] = useState<string | null>(null)
 
   const disconnect = useCallback(
-    async (topic: string, peerName?: string) => {
+    async (topic: string, peerName?: string): Promise<boolean> => {
       setBusyTopic(topic)
       try {
         const wk = await getWalletKit()
         await wk.disconnectSession({ topic, reason: getSdkError('USER_DISCONNECTED') })
         dispatch(removeSession(topic))
         toast.show(`${peerName ?? 'App'} disconnected`, { native: false, duration: 2500 })
+        return true
       } catch (e) {
         logWalletKitError('disconnectSession failed', e)
         toast.show('Failed to disconnect', { native: false, duration: 2500, variant: 'error' })
+        return false
       } finally {
         setBusyTopic(null)
       }

--- a/apps/mobile/src/features/WalletConnect/Wallet/hooks/useDisconnectSession.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/hooks/useDisconnectSession.ts
@@ -7,11 +7,9 @@ import { getWalletKit } from '../walletKit'
 import { logWalletKitError } from '../utils/errors'
 
 /**
- * Shared teardown for a connected dApp: tell the relay the user disconnected, then drop the
- * session from the slice. `busyTopic` lets callers disable the row being torn down. Resolves
- * `true` on success and `false` on failure (the slice entry is left intact since the relay call
- * is the source of truth) so callers can keep a confirmation open for retry; the technical error
- * is logged and a generic toast is shown.
+ * Disconnects a dApp: tells the relay then drops the session from the slice, returning whether it
+ * succeeded so callers can keep a confirmation open to retry. `busyTopic` tracks a single in-flight
+ * teardown — screen-scoped, one row at a time (use a Set if ever called concurrently per-row).
  */
 export const useDisconnectSession = () => {
   const dispatch = useAppDispatch()

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
@@ -12,6 +12,7 @@ import reducer, {
   selectSessionCount,
   selectCurrentRequest,
   selectOutstandingRequestByHash,
+  selectVerifyByTopic,
   walletKitSliceName,
   type PendingItem,
 } from '../walletKitSlice'
@@ -36,7 +37,7 @@ describe('walletKitSlice reducers', () => {
     let state = reducer(undefined, setSessions({ a: session('a') }))
     expect(Object.keys(state.sessions)).toEqual(['a'])
 
-    state = reducer(state, addSession(session('b')))
+    state = reducer(state, addSession({ session: session('b'), verifyVariant: 'verified' }))
     expect(Object.keys(state.sessions)).toEqual(['a', 'b'])
 
     state = reducer(state, removeSession('a'))
@@ -67,10 +68,38 @@ describe('walletKitSlice reducers', () => {
   })
 
   it('clearWalletKitState resets to initial', () => {
-    let state = reducer(undefined, addSession(session('a')))
+    let state = reducer(undefined, addSession({ session: session('a'), verifyVariant: 'verified' }))
     state = reducer(state, clearWalletKitState())
     expect(state.sessions).toEqual({})
     expect(state.pending).toEqual([])
+  })
+
+  it('addSession records the verify variant; removeSession clears it', () => {
+    let state = reducer(undefined, addSession({ session: session('a'), verifyVariant: 'verified' }))
+    expect(state.verifyByTopic).toEqual({ a: 'verified' })
+
+    state = reducer(state, removeSession('a'))
+    expect(state.verifyByTopic).toEqual({})
+  })
+
+  it('setSessions prunes verifyByTopic to the incoming topics but keeps active ones', () => {
+    let state = reducer(undefined, addSession({ session: session('a'), verifyVariant: 'verified' }))
+    state = reducer(state, addSession({ session: session('b'), verifyVariant: 'malicious' }))
+
+    // Rehydrate: only 'a' is still active -> 'b' is pruned, 'a' is kept.
+    state = reducer(state, setSessions({ a: session('a') }))
+    expect(state.verifyByTopic).toEqual({ a: 'verified' })
+  })
+
+  it('selectVerifyByTopic returns the map', () => {
+    const state = reducer(undefined, addSession({ session: session('a'), verifyVariant: 'verified' }))
+    expect(selectVerifyByTopic({ [walletKitSliceName]: state } as never)).toEqual({ a: 'verified' })
+  })
+
+  it('clear resets verifyByTopic', () => {
+    let state = reducer(undefined, addSession({ session: session('a'), verifyVariant: 'verified' }))
+    state = reducer(state, clearWalletKitState())
+    expect(state.verifyByTopic).toEqual({})
   })
 })
 

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/__tests__/walletKitSlice.test.ts
@@ -91,6 +91,18 @@ describe('walletKitSlice reducers', () => {
     expect(state.verifyByTopic).toEqual({ a: 'verified' })
   })
 
+  it('setSessions with no active sessions prunes verifyByTopic entirely', () => {
+    let state = reducer(undefined, addSession({ session: session('a'), verifyVariant: 'verified' }))
+    // Rehydrate path where getActiveSessions() returns nothing must not leave a growing map.
+    state = reducer(state, setSessions({}))
+    expect(state.verifyByTopic).toEqual({})
+  })
+
+  it('setSessions never adds verifyByTopic entries for restored sessions', () => {
+    const state = reducer(undefined, setSessions({ a: session('a'), b: session('b') }))
+    expect(state.verifyByTopic).toEqual({})
+  })
+
   it('selectVerifyByTopic returns the map', () => {
     const state = reducer(undefined, addSession({ session: session('a'), verifyVariant: 'verified' }))
     expect(selectVerifyByTopic({ [walletKitSliceName]: state } as never)).toEqual({ a: 'verified' })

--- a/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
+++ b/apps/mobile/src/features/WalletConnect/Wallet/store/walletKitSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, type PayloadAction, createSelector } from '@reduxjs/toolki
 import type { SessionTypes } from '@walletconnect/types'
 import type { WalletKitTypes } from '@reown/walletkit'
 import type { RootState } from '@/src/store'
+import type { VerifyVariant } from '@safe-global/utils/features/walletconnect/verify'
 
 // The only session_request methods that need UI / a deferred response. Other methods
 // are answered synchronously and never reach the slice.
@@ -39,12 +40,14 @@ export type OutstandingTxRequest = {
 
 type State = {
   sessions: Record<string, SessionTypes.Struct> // keyed by topic
+  verifyByTopic: Record<string, VerifyVariant> // verify variant captured at approval, keyed by topic
   pending: PendingItem[]
   outstandingRequests: Record<string, OutstandingTxRequest> // keyed by safeTxHash
 }
 
 const initialState: State = {
   sessions: {},
+  verifyByTopic: {},
   pending: [],
   outstandingRequests: {},
 }
@@ -57,13 +60,24 @@ const walletKitSlice = createSlice({
   reducers: {
     setSessions(state, action: PayloadAction<Record<string, SessionTypes.Struct>>) {
       state.sessions = action.payload
+      // Prune verify entries for sessions that are no longer active (e.g. expired while the
+      // app was closed); keep entries for still-active topics so a captured badge survives
+      // rehydrate. We never add entries here — restored sessions carry no verify context.
+      const activeTopics = new Set(Object.keys(action.payload))
+      state.verifyByTopic = Object.fromEntries(
+        Object.entries(state.verifyByTopic).filter(([topic]) => activeTopics.has(topic)),
+      )
     },
-    addSession(state, action: PayloadAction<SessionTypes.Struct>) {
-      state.sessions[action.payload.topic] = action.payload
+    addSession(state, action: PayloadAction<{ session: SessionTypes.Struct; verifyVariant: VerifyVariant }>) {
+      const { session, verifyVariant } = action.payload
+      state.sessions[session.topic] = session
+      state.verifyByTopic[session.topic] = verifyVariant
     },
     removeSession(state, action: PayloadAction<string>) {
       const { [action.payload]: _removed, ...rest } = state.sessions
       state.sessions = rest
+      const { [action.payload]: _removedVerify, ...restVerify } = state.verifyByTopic
+      state.verifyByTopic = restVerify
     },
     setPending(state, action: PayloadAction<PendingItem[]>) {
       state.pending = action.payload
@@ -106,6 +120,7 @@ export const {
 export const selectSessionsRecord = (state: RootState) => state[sliceName].sessions
 export const selectSessions = createSelector(selectSessionsRecord, (s) => Object.values(s))
 export const selectSessionCount = createSelector(selectSessions, (s) => s.length)
+export const selectVerifyByTopic = (state: RootState) => state[sliceName].verifyByTopic
 export const selectPending = (state: RootState) => state[sliceName].pending
 export const selectCurrentRequest = createSelector(selectPending, (p) => p[0] ?? null)
 export const selectOutstandingRequests = (state: RootState) => state[sliceName].outstandingRequests

--- a/apps/mobile/src/store/__tests__/persistConfig.test.ts
+++ b/apps/mobile/src/store/__tests__/persistConfig.test.ts
@@ -1,5 +1,5 @@
 import { cgwClient } from '@safe-global/store/gateway/cgwClient'
-import { persistBlacklist, persistTransforms, cgwClientFilter } from '../index'
+import { persistBlacklist, persistTransforms, cgwClientFilter, walletKitPersistConfig } from '../index'
 
 describe('persistConfig', () => {
   it('should not blacklist cgwClient to allow transform filtering', () => {
@@ -8,5 +8,15 @@ describe('persistConfig', () => {
 
   it('should include cgwClientFilter in transforms', () => {
     expect(persistTransforms).toContain(cgwClientFilter)
+  })
+})
+
+describe('walletKit nested persist', () => {
+  it('persists only verifyByTopic', () => {
+    expect(walletKitPersistConfig.whitelist).toEqual(['verifyByTopic'])
+  })
+
+  it('keeps the walletKit slice in the root blacklist so sessions stay volatile', () => {
+    expect(persistBlacklist).toContain('walletKit')
   })
 })

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -115,6 +115,17 @@ const persistConfig = {
   migrate,
 }
 
+// Sessions/pending stay volatile (walletKit is in the root blacklist) and rehydrate from
+// walletKit.getActiveSessions() on app start. We persist ONLY verifyByTopic so a session's
+// verify badge survives a restart. The nested persistor is flushed by the parent persistStore.
+export const walletKitPersistConfig = {
+  key: walletKitSliceName,
+  storage: reduxStorage,
+  version: 1,
+  whitelist: ['verifyByTopic'],
+}
+const persistedWalletKit = persistReducer(walletKitPersistConfig, walletKit)
+
 const combinedReducer = combineReducers({
   txHistory,
   safes,
@@ -136,7 +147,7 @@ const combinedReducer = combineReducers({
   signerImportFlow,
   executingState,
   draftTx,
-  walletKit,
+  walletKit: persistedWalletKit,
   [web3API.reducerPath]: web3API.reducer,
   [cgwClient.reducerPath]: cgwClient.reducer,
   [hypernativeApi.reducerPath]: hypernativeApi.reducer,


### PR DESCRIPTION
> Sessions listed, a swipe or three dots,
> "Disconnect app?" — one tap,
> relay told, the row falls away.

## What it solves

Resolves: [WA-2320](https://linear.app/safe-global/issue/WA-2320/connected-dapps-management-part-2)

No way existed on mobile to see or manage connected WalletConnect dApps. This adds the **Connected apps** settings entry and management screen.

> **Stacked PR** on `tim/wa-2318-…` (not `dev`) — review/merge the predecessor first. Diff here is only the 16 Part 2 commits.

## How this PR fixes it

- **Settings entry** below Signers (count + chevron), shown only when ≥1 session exists; gated by `NATIVE_WALLETCONNECT`.
- **Connected apps screen** — cards with dApp icon + verify badge, name, 3-dots.
- **Disconnect** via 3-dots menu *or* swipe-left trash → **"Disconnect app?"** confirm sheet → `useDisconnectSession` calls `disconnectSession({ topic, reason: USER_DISCONNECTED })`, drops the session, toasts. The menu is single-open and dismisses on outside tap; the sheet stays open on failure.
- **Verify badge persists**: slice gains a `verifyByTopic` map captured at approval; only that map is persisted (nested `persistReducer`) while sessions stay volatile.

## How to test it

1. Enable `NATIVE_WALLETCONNECT`, connect a dApp (Part 1).
2. Settings → **Connected apps** appears below Signers with the right count.
3. Open it → 3-dots or swipe-left → **Disconnect** → row disappears, toast, dApp reflects it.
4. Open one menu, tap another row's 3-dots → only one open; tap outside → dismisses.
5. Relaunch the app → verify badge on a still-active session persists.

## Affected flows

- View / disconnect connected dApps (menu + swipe), user-initiated
- dApp-initiated `session_delete` → list updates silently (unchanged)
- Session approval now also records the verify variant

## Video 

https://github.com/user-attachments/assets/a20d8968-cbd4-4f13-a913-6ca72dec9536

## Blast radius

- **`walletKit` slice (shared)**: `addSession` payload → `{ session, verifyVariant }`; new `verifyByTopic` + `selectVerifyByTopic`/`selectSessionCount`. Consumers: `useApproveProposal` (updated), `WalletKitProvider` (unchanged path), new screen/entry.
- **Persistence**: `walletKit` stays root-blacklisted; nested `persistReducer` whitelists only `verifyByTopic` (additive, no migration).
- **New route** `connected-apps`; one new Settings row; new shared `@safe-global/utils/verify.ts` (pure). Uses `ReanimatedSwipeable` (deps already present).

## Risks / not checked

- **Not run on device** — gestures, `Modal` anchoring, sheet dismissal are mocked; ticket's manual QA outstanding.
- No analytics changes.
- **Design fidelity (deferred by request)**: confirm button is `danger` vs Figma green; verify badge shows red for `unverified`, not only `malicious`.

## Visual summary

```mermaid
flowchart LR
  S[Settings: Connected apps] --> L[Connected apps screen]
  L -->|3-dots| M[Menu: Disconnect]
  L -->|swipe-left| T[Trash]
  M --> C{Disconnect app?}
  T --> C
  C -->|Confirm| D[useDisconnectSession]
  D -->|relay ok| R[removeSession + toast + close]
  D -->|fails| K[error toast, sheet stays open]
```

> Figma: list `16024-2155`, menu `16204-6150`, swipe `16024-2929`, sheet `16120-3638`, entry `16024-1774`. Device screenshots after manual QA.

## Checklist

- [ ] Tested on mobile 📱 (unit-tested; on-device QA pending)
- [x] Analytics impact documented 📊 (none)
- [x] Unit tests written 🧑‍💻
- [x] Affected flows, blast radius, and not-verified named 🎯

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
