### PR TITLE
fix: update gas fee label to 'Max gas fee' for clarity in fees previe…

### DIFF
--- a/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.test.tsx
+++ b/apps/web/src/features/gtf/components/FeesPreview/FeesPreview.test.tsx
@@ -10,7 +10,7 @@ jest.mock('@/hooks/useChains', () => ({
 const defaultProps: FeesPreviewData = {
   canCoverFees: true,
   executionFee: { label: 'Execution fee', isFree: true },
-  gasFee: { label: 'Gas fee', amount: '0.0002733', currency: 'ETH', fiatAmount: '$97.30' },
+  gasFee: { label: 'Max gas fee', amount: '0.0002733', currency: 'ETH', fiatAmount: '$97.30' },
   totalOutgoing: { primary: [{ amount: '0.60126', currency: 'ETH' }], fiatTotal: '$1,768.85' },
   availableGasTokens: [{ address: '0x0000000000000000000000000000000000000000', symbol: 'ETH', logoUri: '' }],
   selectedGasToken: '0x0000000000000000000000000000000000000000',
@@ -49,7 +49,7 @@ describe('FeesPreview', () => {
   it('renders gas fee with fiat', () => {
     render(<FeesPreview {...defaultProps} />)
 
-    expect(screen.getByText('Gas fee')).toBeInTheDocument()
+    expect(screen.getByText('Max gas fee')).toBeInTheDocument()
     expect(screen.getByText('$97.30')).toBeInTheDocument()
   })
 
@@ -89,7 +89,7 @@ describe('FeesPreview', () => {
   it('renders skeleton when loading', () => {
     render(<FeesPreview {...defaultProps} loading />)
 
-    expect(screen.getByText('Gas fee')).toBeInTheDocument()
+    expect(screen.getByText('Max gas fee')).toBeInTheDocument()
     expect(screen.queryByText('0.0002733 ETH')).not.toBeInTheDocument()
   })
 
@@ -109,7 +109,7 @@ describe('FeesPreview', () => {
     const fallbackProps: FeesPreviewData = {
       canCoverFees: false,
       executionFee: { label: 'Execution fee', isFree: true },
-      gasFee: { label: 'Gas fee', amount: '0.0002733', currency: 'ETH' },
+      gasFee: { label: 'Max gas fee', amount: '0.0002733', currency: 'ETH' },
     }
 
     it('does not render payment source selector', () => {
@@ -123,7 +123,7 @@ describe('FeesPreview', () => {
       render(<FeesPreview {...fallbackProps} />)
 
       expect(screen.getByText('FREE')).toBeInTheDocument()
-      expect(screen.getByText('Gas fee')).toBeInTheDocument()
+      expect(screen.getByText('Max gas fee')).toBeInTheDocument()
     })
 
     it('renders signer fallback notice', () => {

--- a/apps/web/src/features/gtf/components/HistoryFeesAccordion/HistoryFeesAccordion.test.tsx
+++ b/apps/web/src/features/gtf/components/HistoryFeesAccordion/HistoryFeesAccordion.test.tsx
@@ -5,7 +5,7 @@ import type { HistoryFeesData } from '../../hooks/useHistoryFeesBreakdown'
 const defaultData: HistoryFeesData = {
   totalFee: { amount: '0.005', currency: 'ETH', fiatAmount: '$15.12' },
   executionFee: { label: 'Execution fee (0.5%)', amount: '0.002730', currency: 'ETH', isFree: true },
-  gasFee: { label: 'Gas fee', amount: '0.005', currency: 'ETH', fiatAmount: '$15.12' },
+  gasFee: { label: 'Max gas fee', amount: '0.005', currency: 'ETH', fiatAmount: '$15.12' },
   paidFrom: 'signer',
 }
 
@@ -24,7 +24,7 @@ describe('HistoryFeesAccordion', () => {
     const data: HistoryFeesData = {
       totalFee: { amount: '0.010', currency: 'ETH', fiatAmount: '$30.00' },
       executionFee: { label: 'Execution fee (0.5%)', amount: '0.002730', currency: 'ETH', isFree: true },
-      gasFee: { label: 'Gas fee', amount: '0.005', currency: 'ETH', fiatAmount: '$15.12' },
+      gasFee: { label: 'Max gas fee', amount: '0.005', currency: 'ETH', fiatAmount: '$15.12' },
       paidFrom: 'signer',
     }
 
@@ -42,7 +42,7 @@ describe('HistoryFeesAccordion', () => {
     expect(screen.getByText('Execution fee (0.5%)')).toBeInTheDocument()
     expect(screen.getByText('FREE')).toBeInTheDocument()
     expect(screen.getByText('0.002730 ETH')).toBeInTheDocument()
-    expect(screen.getByText('Gas fee')).toBeInTheDocument()
+    expect(screen.getByText('Max gas fee')).toBeInTheDocument()
   })
 
   it('renders execution fee with FREE badge and strikethrough using del element', () => {
@@ -60,7 +60,7 @@ describe('HistoryFeesAccordion', () => {
     render(<HistoryFeesAccordion data={defaultData} />)
     fireEvent.click(screen.getByTestId('history-fees-summary'))
 
-    expect(screen.getByText('Gas fee')).toBeInTheDocument()
+    expect(screen.getByText('Max gas fee')).toBeInTheDocument()
     // "0.005 ETH" appears both in the summary and the gas fee row
     expect(screen.getAllByText('0.005 ETH')).toHaveLength(2)
   })
@@ -69,7 +69,7 @@ describe('HistoryFeesAccordion', () => {
     const data: HistoryFeesData = {
       ...defaultData,
       totalFee: { amount: '0.005', currency: 'ETH' },
-      gasFee: { label: 'Gas fee', amount: '0.008', currency: 'ETH' },
+      gasFee: { label: 'Max gas fee', amount: '0.008', currency: 'ETH' },
       paidFrom: 'signer',
     }
 

--- a/apps/web/src/features/gtf/hooks/__tests__/useHistoryFeesBreakdown.test.ts
+++ b/apps/web/src/features/gtf/hooks/__tests__/useHistoryFeesBreakdown.test.ts
@@ -103,7 +103,7 @@ describe('useHistoryFeesBreakdown', () => {
       const { result } = renderHook(() => useHistoryFeesBreakdown(mockSafePaysTx))
 
       await waitFor(() => expect(result.current).not.toBeNull())
-      expect(result.current?.gasFee).toEqual(expect.objectContaining({ label: 'Gas fee', currency: 'WETH' }))
+      expect(result.current?.gasFee).toEqual(expect.objectContaining({ label: 'Max gas fee', currency: 'WETH' }))
       expect(result.current?.gasFee.amount).toMatch(/^0\.0001/)
       expect(result.current?.gasFee.fiatAmount).toBeDefined()
     })
@@ -147,7 +147,7 @@ describe('useHistoryFeesBreakdown', () => {
 
       await waitFor(() => expect(result.current).not.toBeNull())
       expect(result.current?.gasFee).toEqual(
-        expect.objectContaining({ label: 'Gas fee', currency: 'ETH', amount: '0.0024' }),
+        expect.objectContaining({ label: 'Max gas fee', currency: 'ETH', amount: '0.0024' }),
       )
       expect(result.current?.gasFee.fiatAmount).toBeDefined()
       expect(result.current?.executionFee).toEqual({ label: 'Execution fee', isFree: true })

--- a/apps/web/src/features/gtf/hooks/useFeesPreview.ts
+++ b/apps/web/src/features/gtf/hooks/useFeesPreview.ts
@@ -253,7 +253,7 @@ export const useFeesPreview = (): FeesPreviewData => {
       ...base,
       canCoverFees: true,
       gasFee: {
-        label: 'Gas fee',
+        label: 'Max gas fee',
         amount: gasAmount,
         currency: gasSymbol,
         fiatAmount: formatCurrencyMinimal(gasFiatUsd, currency),
@@ -274,7 +274,7 @@ export const useFeesPreview = (): FeesPreviewData => {
         isConfirmation: true,
         isLegacySigned: true,
         canCoverFees: true,
-        gasFee: { label: 'Gas fee', note: 'Calculated at execution' },
+        gasFee: { label: 'Max gas fee', note: 'Calculated at execution' },
         loading: false,
         error: false,
       }
@@ -285,7 +285,7 @@ export const useFeesPreview = (): FeesPreviewData => {
       isLegacySigned: true,
       canCoverFees: true,
       gasFee: {
-        label: 'Gas fee',
+        label: 'Max gas fee',
         amount: getTotalFeeFormatted(gasPrice?.maxFeePerGas, gasLimit, chain),
         currency: nativeSymbol,
       },
@@ -301,7 +301,7 @@ export const useFeesPreview = (): FeesPreviewData => {
       return {
         ...base,
         canCoverFees: true,
-        gasFee: { label: 'Gas fee', note: 'Calculated at execution' },
+        gasFee: { label: 'Max gas fee', note: 'Calculated at execution' },
         loading: false,
         error: false,
       }
@@ -327,7 +327,7 @@ export const useFeesPreview = (): FeesPreviewData => {
       ...base,
       canCoverFees: true,
       gasFee: {
-        label: 'Gas fee',
+        label: 'Max gas fee',
         amount: getTotalFeeFormatted(gasPrice?.maxFeePerGas, gasLimit, chain),
         currency: nativeSymbol,
       },
@@ -343,7 +343,7 @@ export const useFeesPreview = (): FeesPreviewData => {
     return {
       ...base,
       canCoverFees: true,
-      gasFee: { label: 'Gas fee', currency: gasSymbol },
+      gasFee: { label: 'Max gas fee', currency: gasSymbol },
       loading: true,
       error: false,
     }
@@ -377,7 +377,7 @@ export const useFeesPreview = (): FeesPreviewData => {
       ...base,
       canCoverFees: true,
       gasFee: {
-        label: 'Gas fee',
+        label: 'Max gas fee',
         amount: gasAmount,
         currency: gasSymbol,
         fiatAmount: formatCurrencyMinimal(relayCostFiat, relayCostFiatCode),
@@ -399,7 +399,7 @@ export const useFeesPreview = (): FeesPreviewData => {
     return {
       ...base,
       canCoverFees: false,
-      gasFee: { label: 'Gas fee', note: 'Calculated at execution' },
+      gasFee: { label: 'Max gas fee', note: 'Calculated at execution' },
       loading: false,
       error: false,
     }
@@ -409,7 +409,7 @@ export const useFeesPreview = (): FeesPreviewData => {
     ...base,
     canCoverFees: false,
     gasFee: {
-      label: 'Gas fee',
+      label: 'Max gas fee',
       amount: fallbackAmount,
       currency: nativeSymbol,
     },

--- a/apps/web/src/features/gtf/hooks/useHistoryFeesBreakdown.ts
+++ b/apps/web/src/features/gtf/hooks/useHistoryFeesBreakdown.ts
@@ -39,13 +39,13 @@ const buildFees = (
 ): HistoryFeesData => ({
   totalFee: { amount, currency, fiatAmount },
   executionFee: EXECUTION_FEE,
-  gasFee: { label: 'Gas fee', amount, currency, fiatAmount },
+  gasFee: { label: 'Max gas fee', amount, currency, fiatAmount },
   paidFrom,
 })
 
 /**
  * Fee breakdown for executed multisig txs. Execution fee is always "Free" in Phase 2.
- * Gas fee derives from:
+ * Max gas fee derives from:
  *   - Safe-pays → the signed payload (safeTxGas + baseGas × gasPrice) — deterministic.
  *   - Signer-pays → the on-chain tx receipt (gasUsed × gasPrice) — signer wallet's actual cost.
  * Deps are narrowed to scalars so polling `balances` doesn't re-trigger the receipt RPC.


### PR DESCRIPTION
## What it solves

This pull request updates the terminology used for gas fees throughout the fee preview and history breakdown logic. The label "Gas fee" has been changed to "Max gas fee" in all relevant locations to make it clearer to users that the displayed fee represents the maximum possible gas cost, not the actual amount that will necessarily be paid.

Label and terminology updates:

* Updated the `label` property from `'Gas fee'` to `'Max gas fee'` in all returned objects and UI data structures within the `useFeesPreview` hook (`apps/web/src/features/gtf/hooks/useFeesPreview.ts`). [[1]](diffhunk://#diff-48cbe4281a8d984cdd650d24fc5b877b7d342634a3be4a44e171f258ce6f78a1L256-R256) [[2]](diffhunk://#diff-48cbe4281a8d984cdd650d24fc5b877b7d342634a3be4a44e171f258ce6f78a1L277-R277) [[3]](diffhunk://#diff-48cbe4281a8d984cdd650d24fc5b877b7d342634a3be4a44e171f258ce6f78a1L288-R288) [[4]](diffhunk://#diff-48cbe4281a8d984cdd650d24fc5b877b7d342634a3be4a44e171f258ce6f78a1L304-R304) [[5]](diffhunk://#diff-48cbe4281a8d984cdd650d24fc5b877b7d342634a3be4a44e171f258ce6f78a1L330-R330) [[6]](diffhunk://#diff-48cbe4281a8d984cdd650d24fc5b877b7d342634a3be4a44e171f258ce6f78a1L346-R346) [[7]](diffhunk://#diff-48cbe4281a8d984cdd650d24fc5b877b7d342634a3be4a44e171f258ce6f78a1L380-R380) [[8]](diffhunk://#diff-48cbe4281a8d984cdd650d24fc5b877b7d342634a3be4a44e171f258ce6f78a1L402-R402) [[9]](diffhunk://#diff-48cbe4281a8d984cdd650d24fc5b877b7d342634a3be4a44e171f258ce6f78a1L412-R412)
* Changed the `label` from `'Gas fee'` to `'Max gas fee'` in the fee breakdown builder within `useHistoryFeesBreakdown.ts`, and updated related documentation comments to match the new terminology (`apps/web/src/features/gtf/hooks/useHistoryFeesBreakdown.ts`).

These changes ensure consistent and accurate communication of gas fee information to users across the app.

