### PR TITLE
fix(web): correct space onboarding step count when survey is disabled

### DIFF
--- a/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/CreateSpaceOnboarding/index.tsx
@@ -17,16 +17,17 @@ import {
 import { useIsCheckingAccess } from '@/hooks/useRouterGuard'
 import { flattenSafeItems } from '@/hooks/safes'
 import { useSpaceSafes } from '@/features/spaces/hooks/useSpaceSafes'
+import { useOnboardingStepCount } from '@/features/spaces/hooks/useOnboardingStepCount'
 import { AppRoutes } from '@/config/routes'
 import useExistingSpace from './hooks/useExistingSpace'
 import useSpaceSubmit from './hooks/useSpaceSubmit'
 
 const ONBOARDING_STEP = 1
-const TOTAL_STEPS = 4
 const FORM_ID = 'create-space-form'
 
 const CreateSpaceOnboarding = (): ReactElement => {
   const router = useRouter()
+  const totalSteps = useOnboardingStepCount()
   const isCheckingAccess = useIsCheckingAccess() ?? true
 
   const {
@@ -69,7 +70,7 @@ const CreateSpaceOnboarding = (): ReactElement => {
 
   const main = (
     <>
-      <StepCounter currentStep={ONBOARDING_STEP} totalSteps={TOTAL_STEPS} />
+      <StepCounter currentStep={ONBOARDING_STEP} totalSteps={totalSteps} />
 
       <div className="flex flex-col gap-2">
         <Typography variant="h2">Create a Workspace</Typography>

--- a/apps/web/src/features/spaces/components/InviteMembersOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/InviteMembersOnboarding/index.tsx
@@ -13,6 +13,7 @@ import {
   useSafeNameLookup,
 } from '@/features/spaces/components/OnboardingLayout'
 import { useSpaceSafes } from '@/features/spaces/hooks/useSpaceSafes'
+import { useOnboardingStepCount } from '@/features/spaces/hooks/useOnboardingStepCount'
 import { flattenSafeItems } from '@/hooks/safes'
 import MemberInviteRow from './components/MemberInviteRow'
 import useInviteNavigation from './hooks/useInviteNavigation'
@@ -20,10 +21,10 @@ import useInviteForm from './hooks/useInviteForm'
 import { MemberRole } from '@/features/spaces/hooks/useSpaceMembers'
 
 const ONBOARDING_STEP = 3
-const TOTAL_STEPS = 4
 const FORM_ID = 'invite-members-form'
 
 const InviteMembersOnboarding = (): ReactElement => {
+  const totalSteps = useOnboardingStepCount()
   const { spaceId, goBack, redirectToNextStep } = useInviteNavigation()
   const { control, formState, register, setValue, trigger, fields, append, remove, onSubmit, error, isSubmitting } =
     useInviteForm(spaceId, redirectToNextStep)
@@ -39,7 +40,7 @@ const InviteMembersOnboarding = (): ReactElement => {
 
   const main = (
     <form id={FORM_ID} onSubmit={onSubmit} className="flex flex-col gap-6">
-      <StepCounter currentStep={ONBOARDING_STEP} totalSteps={TOTAL_STEPS} />
+      <StepCounter currentStep={ONBOARDING_STEP} totalSteps={totalSteps} />
 
       <div className="flex flex-col gap-2">
         <Typography variant="h2">Invite your team</Typography>

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/__tests__/SelectSafesOnboarding.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/__tests__/SelectSafesOnboarding.test.tsx
@@ -1,10 +1,14 @@
 import { render, screen } from '@/tests/test-utils'
 import SelectSafesOnboarding from '../index'
 import type { AllSafeItems } from '@/hooks/safes'
+import useIsSurveyEnabled from '@/hooks/useIsSurveyEnabled'
 
 jest.mock('../../Sidebar/constants', () => ({
   SAFE_ACCOUNTS_LIMIT: 10,
 }))
+
+jest.mock('@/hooks/useIsSurveyEnabled')
+const mockedUseIsSurveyEnabled = useIsSurveyEnabled as jest.MockedFunction<typeof useIsSurveyEnabled>
 
 // Captured props from OnboardingSafesList renders
 let capturedListProps: Record<string, unknown> = {}
@@ -180,5 +184,29 @@ describe('SelectSafesOnboarding — wallet connection state', () => {
     render(<SelectSafesOnboarding />)
 
     expect(screen.getByTestId('select-safes-skip-link')).toBeInTheDocument()
+  })
+})
+
+describe('SelectSafesOnboarding — step counter reflects the survey flag', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    capturedListProps = {}
+    mockTrustedSafes = []
+    mockOwnedSafes = []
+    mockWalletValue = { address: '0xWallet' }
+  })
+
+  // Regression guard for WA-2537: the survey is the optional last step, so when
+  // SPACE_ONBOARDING_SURVEY is off the always-rendered steps must total 3, not 4.
+  it('shows 3 total steps when the survey is disabled', () => {
+    mockedUseIsSurveyEnabled.mockReturnValue(false)
+    render(<SelectSafesOnboarding />)
+    expect(screen.getByRole('group', { name: 'Step 2 of 3' })).toBeInTheDocument()
+  })
+
+  it('shows 4 total steps when the survey is enabled', () => {
+    mockedUseIsSurveyEnabled.mockReturnValue(true)
+    render(<SelectSafesOnboarding />)
+    expect(screen.getByRole('group', { name: 'Step 2 of 4' })).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/spaces/components/SelectSafesOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafesOnboarding/index.tsx
@@ -15,6 +15,7 @@ import {
 import useWallet from '@/hooks/wallets/useWallet'
 import { type AllSafeItems } from '@/hooks/safes'
 import { useSpaceSafes } from '@/features/spaces/hooks/useSpaceSafes'
+import { useOnboardingStepCount } from '@/features/spaces/hooks/useOnboardingStepCount'
 import OnboardingSafesList from './components/OnboardingSafesList'
 import ConnectWalletHint from '../ConnectWalletHint'
 import useOnboardingNavigation from './hooks/useOnboardingNavigation'
@@ -29,11 +30,11 @@ import {
 } from './utils/deriveSelectedAccounts'
 
 const ONBOARDING_STEP = 2
-const TOTAL_STEPS = 4
 const FORM_ID = 'select-safes-form'
 
 const SelectSafesOnboarding = (): ReactElement => {
   const wallet = useWallet()
+  const totalSteps = useOnboardingStepCount()
   const { spaceId, handleBack, handleSkip, redirectToNextStep } = useOnboardingNavigation()
   const { trustedSafes, ownedSafes, similarAddresses, handleSearch, hasNoSafes } = useOnboardingSafes()
   const allSafes = useMemo<AllSafeItems>(() => [...trustedSafes, ...ownedSafes], [trustedSafes, ownedSafes])
@@ -78,7 +79,7 @@ const SelectSafesOnboarding = (): ReactElement => {
   const main = (
     <FormProvider {...formMethods}>
       <form id={FORM_ID} onSubmit={onSubmit} className="flex flex-col gap-6">
-        <StepCounter currentStep={ONBOARDING_STEP} totalSteps={TOTAL_STEPS} />
+        <StepCounter currentStep={ONBOARDING_STEP} totalSteps={totalSteps} />
 
         <div className="flex flex-col gap-2 shrink-0">
           <Typography variant="h2">Select Safes</Typography>

--- a/apps/web/src/features/spaces/components/SurveyOnboarding/index.tsx
+++ b/apps/web/src/features/spaces/components/SurveyOnboarding/index.tsx
@@ -37,6 +37,10 @@ import { flattenSafeItems } from '@/hooks/safes'
 import SurveyOptionCard from './SurveyOptionCard'
 
 const ONBOARDING_STEP = 4
+// This step only renders when SPACE_ONBOARDING_SURVEY is on (the survey page
+// guards on the flag), so it is always the 4th of 4 steps. The earlier steps,
+// which render regardless of the flag, derive their total from
+// useOnboardingStepCount() instead.
 const TOTAL_STEPS = 4
 const SURVEY_SLUG = 'onboarding'
 

--- a/apps/web/src/features/spaces/hooks/__tests__/useOnboardingStepCount.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useOnboardingStepCount.test.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react'
+import { useOnboardingStepCount } from '../useOnboardingStepCount'
+import useIsSurveyEnabled from '@/hooks/useIsSurveyEnabled'
+
+jest.mock('@/hooks/useIsSurveyEnabled')
+
+const mockedUseIsSurveyEnabled = useIsSurveyEnabled as jest.MockedFunction<typeof useIsSurveyEnabled>
+
+describe('useOnboardingStepCount', () => {
+  it('counts 4 steps when the survey is enabled', () => {
+    mockedUseIsSurveyEnabled.mockReturnValue(true)
+
+    const { result } = renderHook(() => useOnboardingStepCount())
+
+    expect(result.current).toBe(4)
+  })
+
+  it('counts 3 steps when the survey is disabled', () => {
+    mockedUseIsSurveyEnabled.mockReturnValue(false)
+
+    const { result } = renderHook(() => useOnboardingStepCount())
+
+    expect(result.current).toBe(3)
+  })
+
+  it('counts 3 steps while the chain config is still loading (survey defaults OFF)', () => {
+    mockedUseIsSurveyEnabled.mockReturnValue(undefined)
+
+    const { result } = renderHook(() => useOnboardingStepCount())
+
+    expect(result.current).toBe(3)
+  })
+})

--- a/apps/web/src/features/spaces/hooks/useOnboardingStepCount.ts
+++ b/apps/web/src/features/spaces/hooks/useOnboardingStepCount.ts
@@ -1,0 +1,22 @@
+import useIsSurveyEnabled from '@/hooks/useIsSurveyEnabled'
+
+// The Space onboarding flow always has these steps: create Workspace →
+// select Safes → invite members.
+const BASE_STEPS = 3
+
+/**
+ * Total number of steps shown in the Space onboarding step counter.
+ *
+ * The survey is an optional final step gated on the SPACE_ONBOARDING_SURVEY
+ * flag, so it must only be counted when that flag is on — otherwise the
+ * always-rendered steps (create / select / invite) wrongly read "X / 4".
+ *
+ * `useIsSurveyEnabled()` returns `undefined` while the chain config loads; we
+ * treat that (and `false`) as "survey off" since the flag defaults to OFF,
+ * which keeps the counter from flickering 3 → 4 on the common disabled path.
+ */
+export const useOnboardingStepCount = (): number => {
+  return useIsSurveyEnabled() ? BASE_STEPS + 1 : BASE_STEPS
+}
+
+export default useOnboardingStepCount


### PR DESCRIPTION
> Survey switched off, the wizard is three—
> the counter once stubbornly insisted on four.
> Now the total's derived from the flag, and agrees.

## What it solves

Resolves: [WA-2537](https://linear.app/safe-global/issue/WA-2537/workspace-creation-step-counter-is-wrong-when-the-survey-is)

The Space (workspace) onboarding wizard hardcoded its step counter to **"X / 4"** in every step. But the survey is an **optional final step**, gated on the `SPACE_ONBOARDING_SURVEY` chain‑config flag (default **OFF**, and OFF for the current release). When the survey is disabled the flow has only **3** steps, yet steps 1–3 still read "X / 4".

## How this PR fixes it

- Adds a small hook **`useOnboardingStepCount`**: 3 base steps, **+1** only when `useIsSurveyEnabled()` is `true`. While the chain config is still loading (`undefined`) — and when the flag is `false` — it counts **3**, matching the flag's OFF default and avoiding a 3→4 flicker on the common path.
- The three **always‑rendered** steps — Create workspace, Select Safes, Invite members — now derive `totalSteps` from the hook instead of a hardcoded `TOTAL_STEPS = 4`.
- The **survey** step keeps `TOTAL_STEPS = 4` (with a clarifying comment): it only renders when the flag is on, so it is always the 4th of 4 steps.

## How to test it

1. **Survey OFF** (default): start workspace creation → the counter reads **STEP 1 / 3**, **2 / 3**, **3 / 3**, and the flow ends after "Invite members" (no survey step).
2. **Survey ON** (enable `SPACE_ONBOARDING_SURVEY` in chain config): the counter reads **1 / 4 … 4 / 4**, including the survey.
3. **Automated:**
   - `useOnboardingStepCount.test.ts` — returns 4 when the survey is on, 3 when off, 3 while config loads.
   - `SelectSafesOnboarding.test.tsx` — renders **STEP 2 / 3** when the survey is off and **STEP 2 / 4** when on.

## Affected flows

- **Space onboarding** — Create workspace → Select Safes → Invite members (→ Survey, only when enabled). Specifically the step counter shown on each of these screens.

## Blast radius

- **New hook** `useOnboardingStepCount` — a thin wrapper over the existing `useIsSurveyEnabled`, which reads `SPACE_ONBOARDING_SURVEY` from the default chain's config.
- **3 onboarding components** (`CreateSpaceOnboarding`, `SelectSafesOnboarding`, `InviteMembersOnboarding`) — only the `totalSteps` value passed to `StepCounter` changed; no other behaviour.
- **`SurveyOnboarding`** — comment only; still hardcodes 4 (correct by construction).
- **`StepCounter`** — untouched (already a pure prop‑driven component).
- **Feature flag:** `SPACE_ONBOARDING_SURVEY`. No API/RTK‑Query, persistence, cache, migration, or route changes. **No mobile impact** (web‑only feature).

## Risks / not checked

- The **survey‑ON** path was not exercised in a real browser (it requires the flag enabled in chain config); the OFF path is covered by unit + component tests.
- No new component tests for `CreateSpaceOnboarding` / `InviteMembersOnboarding` (they have no existing component‑test harness; the variable logic lives in the unit‑tested hook and the wiring is a one‑line prop pass, compile‑checked).
- No Playwright one‑shot clickthrough added.

## Visual summary

```mermaid
flowchart LR
  F[useIsSurveyEnabled] -->|true| H4["useOnboardingStepCount = 4"]
  F -->|false / undefined| H3["useOnboardingStepCount = 3"]
  H4 --> SC[StepCounter totalSteps]
  H3 --> SC
  SC --> S1["Create / Select / Invite steps:\nSTEP X / 3 (survey off) or X / 4 (survey on)"]
  subgraph Survey step
    direction TB
    SV["SurveyOnboarding: TOTAL_STEPS = 4\n(only renders when flag is on)"]
  end
```
<img width="614" height="605" alt="Screenshot 2026-06-10 at 16 55 19" src="https://github.com/user-attachments/assets/b386e689-40c1-490e-82ff-e62e8a44d0f3" />


## Checklist

- [ ] I've tested the branch on mobile 📱 — _n/a, web‑only feature_
- [x] I've documented how it affects the analytics (if at all) 📊 — _no analytics change_
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough under apps/web/e2e/tests/one-shots/ and run it locally — CI records and posts the clickthrough GIF 🎬 — _not added_

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
