### PR TITLE
fix(web): show the Create workspace button outside the require-login flag

### DIFF
--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -4,6 +4,9 @@ import type { ReactNode } from 'react'
 import SpacesList from '../index'
 import { useIsRequireLoginEnabled } from '@/hooks/useIsRequireLoginEnabled'
 import { useIsClassicViewFeatureEnabled } from '@/hooks/useClassicView'
+import { trackEvent } from '@/services/analytics'
+import { SPACE_EVENTS } from '@/services/analytics/events/spaces'
+import { WorkspaceCreateEntryPoint } from '@/services/analytics/mixpanel-events'
 
 const mockUseIsRequireLoginEnabled = useIsRequireLoginEnabled as jest.Mock
 const mockUseIsClassicViewFeatureEnabled = useIsClassicViewFeatureEnabled as jest.Mock
@@ -94,7 +97,14 @@ jest.mock('../../SpaceInfoModal', () => ({
 
 jest.mock('next/link', () => ({
   __esModule: true,
-  default: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+  // Spread the rest of the props: Button's `render` prop forwards data-testid,
+  // className and onClick onto the anchor — dropping them hides the button
+  // from queries and swallows click tracking.
+  default: ({ children, href, ...props }: { children: ReactNode; href: string }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
 }))
 
 jest.mock('@/services/analytics', () => ({
@@ -281,6 +291,45 @@ describe('SpacesList — auth/expiry state rendering', () => {
 
     expect(screen.getByTestId('sign-in-options')).toBeInTheDocument()
     expect(screen.queryByTestId('classic-view-link')).not.toBeInTheDocument()
+  })
+
+  // The Create workspace button must be reachable outside the require-login
+  // feature flag too: the classic tabbed layout shows it next to the
+  // Accounts/Workspaces tabs when the user is signed in and has spaces.
+  it('renders the Create workspace button in the classic tabbed layout when signed in with active spaces', async () => {
+    mockUseIsRequireLoginEnabled.mockReturnValue(false)
+    mockUseAppSelector.mockReturnValue(true)
+    mockUseSpacesGetV1Query.mockReturnValue({
+      currentData: [{ uuid: 'uuid-1', name: 'Space 1' }],
+      isFetching: false,
+      error: undefined,
+    })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    expect(screen.getByTestId('accounts-nav')).toBeInTheDocument()
+    const button = screen.getByTestId('create-space-button')
+    expect(button).toBeInTheDocument()
+
+    await userEvent.click(button)
+    expect(trackEvent).toHaveBeenCalledWith(SPACE_EVENTS.WORKSPACE_CREATE_STARTED, {
+      entry_point: WorkspaceCreateEntryPoint.WELCOME,
+    })
+  })
+
+  it('does not render the Create workspace button in the classic tabbed layout when the user has no active spaces', () => {
+    mockUseIsRequireLoginEnabled.mockReturnValue(false)
+    mockUseAppSelector.mockReturnValue(true)
+    mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    // The header button is absent; only the empty-state CTA inside the
+    // No-workspaces card renders (it lives outside the spacesHeader).
+    expect(screen.getByText(/no workspaces found/i)).toBeInTheDocument()
+    expect(screen.getAllByTestId('create-space-button')).toHaveLength(1)
   })
 
   it('disables the Create space button and shows a tooltip when the user has reached the 10-space limit', async () => {

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -211,6 +211,9 @@ const SpacesList = () => {
     setHasSignedIn(true)
   }, [setHasSignedIn])
 
+  const onAddSpaceBtnClick = () =>
+    trackEvent(SPACE_EVENTS.WORKSPACE_CREATE_STARTED, { entry_point: WorkspaceCreateEntryPoint.WELCOME })
+
   // When the require-login gate is ON (or still resolving), /welcome/spaces is
   // the canonical full-screen login page: take over the viewport. When the gate
   // is OFF, classic view is available — fall through to the tabbed layout below
@@ -232,14 +235,7 @@ const SpacesList = () => {
 
             {isUserSignedIn && activeSpaces.length > 0 && (
               <div className="flex gap-4 flex-1 justify-between">
-                <AddSpaceButton
-                  disabled={isAtSpacesLimit}
-                  onClick={() =>
-                    trackEvent(SPACE_EVENTS.WORKSPACE_CREATE_STARTED, {
-                      entry_point: WorkspaceCreateEntryPoint.WELCOME,
-                    })
-                  }
-                />
+                <AddSpaceButton disabled={isAtSpacesLimit} onClick={onAddSpaceBtnClick} />
 
                 {isLoading ? (
                   <Pulse className="h-12 w-12 rounded-full group-data-[collapsible=icon]:w-9" />
@@ -252,6 +248,10 @@ const SpacesList = () => {
         ) : (
           <Box className={css.spacesHeader}>
             <AccountsNavigation />
+
+            {isUserSignedIn && activeSpaces.length > 0 && (
+              <AddSpaceButton disabled={isAtSpacesLimit} onClick={onAddSpaceBtnClick} />
+            )}
           </Box>
         )}
 


### PR DESCRIPTION
> The workspace button, flag-bound no more,
> now greets the classic tabs as before;
> a mock that ate test-ids is fed its props,
> and two new tests guard the button's spots.

## What it solves

Resolves: the "Create workspace" button being unreachable when the require-login feature flag is OFF. It only rendered inside the flag-gated header, so users in the classic tabbed layout had no way to create a workspace from `/welcome/spaces` (outside the empty state).

## How this PR fixes it

- Extracts the create-started tracking callback into `onAddSpaceBtnClick` and renders `AddSpaceButton` in the classic (gate-OFF) `spacesHeader` next to `AccountsNavigation`, for signed-in users with at least one active space. The require-login-ON header keeps its existing button.
- Fixes the `next/link` mock in `SpacesList.test.tsx`: it dropped every prop except `href`, which hid the `data-testid`, `className`, and `onClick` that the shadcn `Button` forwards through its `render` prop — making the enabled button untestable.
- Adds unit tests for the new placement (rendered + tracked on click with active spaces; absent from the header without active spaces).

## How to test it

1. Make sure the require-login gate resolves to OFF (classic view available).
2. Sign in and open `/welcome/spaces` with at least one active space.
3. The "Create workspace" button shows next to the Accounts/Workspaces tabs; clicking it tracks `WORKSPACE_CREATE_STARTED` (entry point `WELCOME`) and navigates to the create-space flow.
4. `yarn workspace @safe-global/web test` — full suite passes (654 suites / 6035 tests locally, also with the CI `test:ci` invocation and `NEXT_PUBLIC_IS_OFFICIAL_HOST=true`).

## Affected flows

- Signed-in user creates a workspace from `/welcome/spaces` in the classic tabbed layout (gate OFF)
- Signed-in user creates a workspace from the full-screen workspace header (gate ON) — unchanged, shared `onAddSpaceBtnClick`

## Blast radius

- `SpacesList` only; `AddSpaceButton` is file-local. The tracking event (`WORKSPACE_CREATE_STARTED`, entry point `WELCOME`) and the 10-space limit/disabled tooltip logic are reused as-is in both layouts.
- No shared hooks, slices, endpoints, or mobile packages touched.

## Risks / not checked

- Did not manually verify the gate-ON full-screen header (covered by existing unit test for the limit/tooltip behavior).
- Did not test on mobile (web-only component).
- Visual alignment of the button inside `spacesHeader` checked via unit render only, not pixel-level.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[SpacesList] -->|require-login ON| B1[Header with AddSpaceButton]
    A1 -->|require-login OFF| C1[AccountsNavigation only - no button]
  end
  subgraph After
    A2[SpacesList] -->|require-login ON| B2[Header with AddSpaceButton]
    A2 -->|require-login OFF| C2[AccountsNavigation + AddSpaceButton]
    B2 --> T[onAddSpaceBtnClick - tracks WORKSPACE_CREATE_STARTED]
    C2 --> T
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough under apps/web/e2e/tests/one-shots/ and run it locally — CI records and posts the clickthrough GIF 🎬

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)