### PR TITLE
fix(web-tanstack): make next/* compat navigation faithful to Next semantics

### DIFF
--- a/apps/web-tanstack/src/compat/next-link.tsx
+++ b/apps/web-tanstack/src/compat/next-link.tsx
@@ -10,6 +10,7 @@ import { forwardRef, cloneElement, isValidElement } from 'react'
 import type { AnchorHTMLAttributes, MouseEvent, ReactElement, ReactNode } from 'react'
 import type { UrlObject } from 'url'
 import { useNavigate } from '@tanstack/react-router'
+import { toHref, toNavigateOptions } from './next-url'
 
 export type LinkProps = {
   href: string | UrlObject
@@ -23,25 +24,6 @@ export type LinkProps = {
   locale?: string | false
   children?: ReactNode
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>
-
-function hrefToString(href: LinkProps['href']): string {
-  if (typeof href === 'string') return href
-  const pathname = href.pathname ?? '/'
-  let qs = ''
-  if (typeof href.query === 'string') {
-    qs = href.query
-  } else if (href.query) {
-    const params = new URLSearchParams()
-    for (const [k, v] of Object.entries(href.query)) {
-      if (v == null) continue
-      if (Array.isArray(v)) v.forEach((vv) => params.append(k, String(vv)))
-      else params.append(k, String(v))
-    }
-    qs = params.toString()
-  }
-  const hash = href.hash ? `#${href.hash.replace(/^#/, '')}` : ''
-  return `${pathname}${qs ? `?${qs}` : ''}${hash}`
-}
 
 const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   {
@@ -62,7 +44,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
   ref,
 ) {
   const navigate = useNavigate()
-  const hrefStr = hrefToString(href)
+  const hrefStr = toHref(href)
 
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     onClick?.(event)
@@ -71,7 +53,7 @@ const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) return
     if (/^https?:|^mailto:|^tel:/i.test(hrefStr)) return
     event.preventDefault()
-    void navigate({ to: hrefStr, replace })
+    void navigate({ ...toNavigateOptions(href), replace })
   }
 
   if (legacyBehavior && isValidElement(children)) {

--- a/apps/web-tanstack/src/compat/next-location.ts
+++ b/apps/web-tanstack/src/compat/next-location.ts
@@ -1,0 +1,37 @@
+/**
+ * Location hooks for the next/* compatibility shims, bound to the RENDERED
+ * route rather than the in-flight one.
+ *
+ * TanStack updates `state.location` at navigation start but swaps
+ * `state.matches` (what `<Matches>` actually renders) only once the
+ * destination route has loaded its lazy chunk and loaders. Next.js updates
+ * `router.query`/`router.pathname` atomically with the page swap, and reused
+ * apps/web guards rely on that — e.g. pages/spaces/index.tsx redirects to
+ * /welcome/spaces whenever `spaceId` is missing from the query. Reading
+ * `state.location` let that guard observe the *destination* query
+ * (`?safe=...`) while the spaces page was still mounted, hijacking the
+ * navigation. Deriving pathname/search from the leaf committed match swaps
+ * both in the same store update as the page itself, restoring Next semantics.
+ */
+import { useRouterState } from '@tanstack/react-router'
+import { stringifyNextQuery } from './next-url'
+
+/** Pathname of the currently rendered route (falls back to the location before the first match). */
+export function useRenderedPathname(): string {
+  return useRouterState({
+    select: (s) => s.matches[s.matches.length - 1]?.pathname ?? s.location.pathname,
+  })
+}
+
+/**
+ * Next-style search string (`''` or `?...`) of the currently rendered route.
+ * Returned as a primitive so subscribers only wake when it actually changes.
+ */
+export function useRenderedSearchStr(): string {
+  return useRouterState({
+    select: (s) => {
+      const leaf = s.matches[s.matches.length - 1]
+      return leaf ? stringifyNextQuery(leaf.search) : (s.location.searchStr ?? '')
+    },
+  })
+}

--- a/apps/web-tanstack/src/compat/next-navigation.tsx
+++ b/apps/web-tanstack/src/compat/next-navigation.tsx
@@ -8,12 +8,9 @@
  * next/router's — no `query`/`pathname`/`asPath`, just navigation methods.
  */
 import { useMemo } from 'react'
-import {
-  useNavigate,
-  useRouter as useTanStackRouter,
-  useRouterState,
-  useParams as useTanStackParams,
-} from '@tanstack/react-router'
+import { useNavigate, useRouter as useTanStackRouter, useParams as useTanStackParams } from '@tanstack/react-router'
+import { useRenderedPathname, useRenderedSearchStr } from './next-location'
+import { toNavigateOptions } from './next-url'
 
 type AppRouterInstance = {
   push: (href: string) => void
@@ -29,8 +26,8 @@ export function useRouter(): AppRouterInstance {
   const tsRouter = useTanStackRouter()
   return useMemo(
     () => ({
-      push: (href) => void navigate({ to: href }),
-      replace: (href) => void navigate({ to: href, replace: true }),
+      push: (href) => void navigate(toNavigateOptions(href)),
+      replace: (href) => void navigate({ ...toNavigateOptions(href), replace: true }),
       refresh: () => {
         if (typeof window !== 'undefined') window.location.reload()
       },
@@ -43,7 +40,7 @@ export function useRouter(): AppRouterInstance {
 }
 
 export function usePathname(): string {
-  return useRouterState({ select: (s) => s.location.pathname })
+  return useRenderedPathname()
 }
 
 export function useSearchParams(): URLSearchParams {
@@ -52,8 +49,9 @@ export function useSearchParams(): URLSearchParams {
   // tick (~50 per nav), which would create a new URLSearchParams instance
   // each time and cascade through every consumer's useEffect/useCallback
   // deps. Selector subscriptions only wake up when the value changes.
-  const searchStr = useRouterState({ select: (s) => s.location.searchStr })
-  return useMemo(() => new URLSearchParams(searchStr ?? ''), [searchStr])
+  // Bound to the rendered matches (see next-location.ts) for Next parity.
+  const searchStr = useRenderedSearchStr()
+  return useMemo(() => new URLSearchParams(searchStr), [searchStr])
 }
 
 export function useParams<T extends Record<string, string> = Record<string, string>>(): T {

--- a/apps/web-tanstack/src/compat/next-resolve-href.ts
+++ b/apps/web-tanstack/src/compat/next-resolve-href.ts
@@ -8,29 +8,8 @@
  * basePath/locale, which this SPA target doesn't use, so we ignore it and
  * serialise the href directly.
  */
-import type { UrlObject } from 'url'
 import type { NextRouterLike } from './next-router'
-
-type Url = string | UrlObject
-
-function toHref(url: Url): string {
-  if (typeof url === 'string') return url
-  const pathname = url.pathname ?? '/'
-  let qs = ''
-  if (typeof url.query === 'string') {
-    qs = url.query
-  } else if (url.query) {
-    const params = new URLSearchParams()
-    for (const [k, v] of Object.entries(url.query)) {
-      if (v == null) continue
-      if (Array.isArray(v)) v.forEach((vv) => params.append(k, String(vv)))
-      else params.append(k, String(v))
-    }
-    qs = params.toString()
-  }
-  const hash = url.hash ? `#${url.hash.replace(/^#/, '')}` : ''
-  return `${pathname}${qs ? `?${qs}` : ''}${hash}`
-}
+import { toHref, type Url } from './next-url'
 
 // Reused call-sites only use the 2-arg `resolveHref(router, href): string` form.
 export function resolveHref(_router: NextRouterLike, href: Url): string {

--- a/apps/web-tanstack/src/compat/next-router.test.tsx
+++ b/apps/web-tanstack/src/compat/next-router.test.tsx
@@ -1,0 +1,172 @@
+import { useEffect } from 'react'
+import { act, render, screen } from '@testing-library/react'
+import {
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  lazyRouteComponent,
+} from '@tanstack/react-router'
+import { parseNextQuery, stringifyNextQuery } from './next-url'
+import { useRouter, type NextRouterLike } from './next-router'
+
+// Regression for the Space dashboard accounts widget: pushing a string href
+// with an inline query whose value contains an unencoded colon
+// (`/home?safe=matic:0x...`) wrote the URL to history but never transitioned
+// router state, so the still-mounted /spaces page redirected to
+// /welcome/spaces. The shim must split the href into `to` + `search`.
+const SAFE_PARAM = 'matic:0x245C153cBa7b65d01706B09a30dEf30190Da1878'
+
+let capturedRouter: NextRouterLike | undefined
+
+const CaptureRouter = ({ label }: { label: string }) => {
+  capturedRouter = useRouter()
+  return <div>{label}</div>
+}
+
+// Mirror the app router's config (trailingSlash + Next-style search serializers).
+const buildTestRouter = (initialEntry: string) => {
+  const rootRoute = createRootRoute({})
+  const homeRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/home',
+    component: () => <CaptureRouter label="home page" />,
+  })
+  const spacesRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/spaces',
+    component: () => <CaptureRouter label="spaces page" />,
+  })
+  return createRouter({
+    routeTree: rootRoute.addChildren([homeRoute, spacesRoute]),
+    history: createMemoryHistory({ initialEntries: [initialEntry] }),
+    trailingSlash: 'never',
+    parseSearch: parseNextQuery,
+    stringifySearch: stringifyNextQuery,
+  })
+}
+
+describe('next-router compat push/replace', () => {
+  beforeEach(() => {
+    capturedRouter = undefined
+  })
+
+  it('navigates for a string href with an inline query containing a raw colon', async () => {
+    const router = buildTestRouter('/spaces?spaceId=abc-123')
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('spaces page')).toBeInTheDocument()
+
+    await act(async () => {
+      await capturedRouter!.push(`/home?safe=${SAFE_PARAM}`)
+    })
+
+    expect(await screen.findByText('home page')).toBeInTheDocument()
+    expect(router.state.location.pathname).toBe('/home')
+    expect(capturedRouter!.pathname).toBe('/home')
+    expect(capturedRouter!.query).toEqual({ safe: SAFE_PARAM })
+  })
+
+  it('navigates for an object href with pathname and query', async () => {
+    const router = buildTestRouter('/spaces?spaceId=abc-123')
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('spaces page')).toBeInTheDocument()
+
+    await act(async () => {
+      await capturedRouter!.push({ pathname: '/home', query: { safe: SAFE_PARAM } })
+    })
+
+    expect(await screen.findByText('home page')).toBeInTheDocument()
+    expect(capturedRouter!.query).toEqual({ safe: SAFE_PARAM })
+  })
+
+  it('replaces the current query instead of merging it', async () => {
+    const router = buildTestRouter('/spaces?spaceId=abc-123')
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('spaces page')).toBeInTheDocument()
+
+    await act(async () => {
+      await capturedRouter!.push(`/home?safe=${SAFE_PARAM}`)
+    })
+
+    expect(capturedRouter!.query).not.toHaveProperty('spaceId')
+  })
+
+  it('does not expose the destination query to the still-mounted page while the route loads', async () => {
+    // Regression: TanStack flips `state.location` at navigation start but only
+    // swaps the rendered matches once the destination's lazy chunk resolves.
+    // Reading `state.location` let pages/spaces/index.tsx observe `?safe=...`
+    // (no spaceId) while still mounted, hijacking the navigation with a
+    // redirect to /welcome/spaces. pathname/query must swap with the page.
+    const queriesSeenBySpacesPage: Array<Record<string, string | string[]>> = []
+    let resolveHomeChunk: (() => void) | undefined
+
+    const rootRoute = createRootRoute({})
+    const spacesRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/spaces',
+      component: function SpacesPage() {
+        const router = useRouter()
+        capturedRouter = router
+        useEffect(() => {
+          queriesSeenBySpacesPage.push(router.query)
+        }, [router.query])
+        return <div>spaces page</div>
+      },
+    })
+    const homeRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/home',
+      component: lazyRouteComponent(
+        () =>
+          new Promise<{ default: () => React.JSX.Element }>((resolve) => {
+            resolveHomeChunk = () => resolve({ default: () => <div>home page</div> })
+          }),
+      ),
+    })
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([spacesRoute, homeRoute]),
+      history: createMemoryHistory({ initialEntries: [`/spaces?spaceId=abc-123`] }),
+      trailingSlash: 'never',
+      parseSearch: parseNextQuery,
+      stringifySearch: stringifyNextQuery,
+    })
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('spaces page')).toBeInTheDocument()
+
+    // Navigate while the destination chunk is unresolved — the navigation
+    // promise stays pending, so don't await it yet.
+    let pushPromise: Promise<boolean> | undefined
+    await act(async () => {
+      pushPromise = capturedRouter!.push(`/home?safe=${SAFE_PARAM}`)
+      // Let any (buggy) intermediate re-renders and effects flush.
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
+
+    expect(screen.getByText('spaces page')).toBeInTheDocument()
+    expect(queriesSeenBySpacesPage).toEqual([{ spaceId: 'abc-123' }])
+
+    await act(async () => {
+      resolveHomeChunk!()
+      await pushPromise
+    })
+
+    expect(await screen.findByText('home page')).toBeInTheDocument()
+    expect(router.state.location.pathname).toBe('/home')
+    // The spaces page never observed the destination query.
+    expect(queriesSeenBySpacesPage).toEqual([{ spaceId: 'abc-123' }])
+  })
+
+  it('replace() navigates without growing the history stack', async () => {
+    const router = buildTestRouter('/spaces?spaceId=abc-123')
+    render(<RouterProvider router={router} />)
+    expect(await screen.findByText('spaces page')).toBeInTheDocument()
+
+    await act(async () => {
+      await capturedRouter!.replace(`/home?safe=${SAFE_PARAM}`)
+    })
+
+    expect(await screen.findByText('home page')).toBeInTheDocument()
+    expect(router.history.length).toBe(1)
+  })
+})

--- a/apps/web-tanstack/src/compat/next-router.tsx
+++ b/apps/web-tanstack/src/compat/next-router.tsx
@@ -4,49 +4,12 @@
  * here so they keep working against a router-shaped object.
  */
 import { useMemo } from 'react'
-import type { UrlObject } from 'url'
-import { useNavigate, useRouter as useTanStackRouter, useRouterState } from '@tanstack/react-router'
-
-// Mirror next's own `Url` type (string | node's UrlObject) so reused web code
-// that passes a full UrlObject (host, hostname, numeric query values, ...) or
-// next's imported `Url` type type-checks unchanged.
-type Url = string | UrlObject
+import { useNavigate, useRouter as useTanStackRouter } from '@tanstack/react-router'
+import { useRenderedPathname, useRenderedSearchStr } from './next-location'
+import { parseNextQuery, toNavigateOptions, type Url } from './next-url'
 
 // next router push/replace/prefetch accept (url, as?, options?).
 type TransitionOptions = { shallow?: boolean; locale?: string | false; scroll?: boolean }
-
-function toHref(url: Url): string {
-  if (typeof url === 'string') return url
-  const pathname = url.pathname ?? '/'
-  let qs = ''
-  if (typeof url.query === 'string') {
-    qs = url.query
-  } else if (url.query) {
-    const params = new URLSearchParams()
-    for (const [k, v] of Object.entries(url.query)) {
-      if (v == null) continue
-      if (Array.isArray(v)) v.forEach((vv) => params.append(k, String(vv)))
-      else params.append(k, String(v))
-    }
-    qs = params.toString()
-  }
-  const hash = url.hash ? `#${url.hash.replace(/^#/, '')}` : ''
-  return `${pathname}${qs ? `?${qs}` : ''}${hash}`
-}
-
-function parseQuery(search: string): Record<string, string | string[]> {
-  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
-  const result: Record<string, string | string[]> = {}
-  for (const [k, v] of params.entries()) {
-    if (k in result) {
-      const existing = result[k]
-      result[k] = Array.isArray(existing) ? [...existing, v] : [existing as string, v]
-    } else {
-      result[k] = v
-    }
-  }
-  return result
-}
 
 export interface NextRouterLike {
   pathname: string
@@ -87,15 +50,17 @@ export function useRouter(): NextRouterLike {
   // navigation, producing the Redux action storm observed in dev. By
   // using `useRouterState({ select })` with primitive selectors, the
   // subscriber only wakes up when the selected value actually changes.
-  const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const href = useRouterState({ select: (s) => s.location.href })
-  const searchStr = useRouterState({ select: (s) => s.location.searchStr })
-  const query = useMemo(() => parseQuery(searchStr ?? ''), [searchStr])
+  //
+  // Both primitives are bound to the RENDERED matches (see next-location.ts)
+  // so pathname/query/asPath swap atomically with the page, like in Next.
+  const pathname = useRenderedPathname()
+  const searchStr = useRenderedSearchStr()
+  const query = useMemo(() => parseNextQuery(searchStr), [searchStr])
 
   return useMemo<NextRouterLike>(
     () => ({
       pathname,
-      asPath: href,
+      asPath: `${pathname}${searchStr}`,
       route: pathname,
       basePath: '',
       isReady: true,
@@ -103,13 +68,11 @@ export function useRouter(): NextRouterLike {
       isPreview: false,
       query,
       push: async (url) => {
-        const next = toHref(url)
-        await navigate({ to: next })
+        await navigate(toNavigateOptions(url))
         return true
       },
       replace: async (url) => {
-        const next = toHref(url)
-        await navigate({ to: next, replace: true })
+        await navigate({ ...toNavigateOptions(url), replace: true })
         return true
       },
       back: () => tsRouter.history.back(),
@@ -121,7 +84,7 @@ export function useRouter(): NextRouterLike {
       beforePopState: () => undefined,
       events: noopEvents,
     }),
-    [navigate, tsRouter, pathname, href, query],
+    [navigate, tsRouter, pathname, searchStr, query],
   )
 }
 

--- a/apps/web-tanstack/src/compat/next-url.test.ts
+++ b/apps/web-tanstack/src/compat/next-url.test.ts
@@ -1,0 +1,108 @@
+import { parseNextQuery, stringifyNextQuery, toHref, toNavigateOptions } from './next-url'
+
+describe('parseNextQuery', () => {
+  it('parses a plain query string', () => {
+    expect(parseNextQuery('safe=matic%3A0x123&chain=matic')).toEqual({ safe: 'matic:0x123', chain: 'matic' })
+  })
+
+  it('accepts a leading question mark', () => {
+    expect(parseNextQuery('?safe=eth%3A0xabc')).toEqual({ safe: 'eth:0xabc' })
+  })
+
+  it('collects repeated keys into arrays', () => {
+    expect(parseNextQuery('id=1&id=2&id=3')).toEqual({ id: ['1', '2', '3'] })
+  })
+
+  it('returns an empty object for an empty string', () => {
+    expect(parseNextQuery('')).toEqual({})
+  })
+})
+
+describe('stringifyNextQuery', () => {
+  it('keeps the chain prefix colon raw in the safe param', () => {
+    // Canonical form matching apps/web's useAdjustUrl — avoids the %3A flash
+    // (commit-then-replaceState) on every navigation.
+    expect(stringifyNextQuery({ safe: 'matic:0x123' })).toBe('?safe=matic:0x123')
+    expect(stringifyNextQuery({ chain: 'eth', safe: 'eth:0xabc' })).toBe('?chain=eth&safe=eth:0xabc')
+  })
+
+  it('keeps colons encoded outside the safe param', () => {
+    expect(stringifyNextQuery({ appUrl: 'https://app.example' })).toBe('?appUrl=https%3A%2F%2Fapp.example')
+  })
+
+  it('keeps the safe param colon encoded when not followed by an address', () => {
+    expect(stringifyNextQuery({ safe: 'foo:bar' })).toBe('?safe=foo%3Abar')
+  })
+
+  it('serializes arrays as repeated keys', () => {
+    expect(stringifyNextQuery({ id: ['1', '2'] })).toBe('?id=1&id=2')
+  })
+
+  it('skips null and undefined values', () => {
+    expect(stringifyNextQuery({ a: '1', b: undefined, c: null })).toBe('?a=1')
+  })
+
+  it('returns an empty string for an empty query', () => {
+    expect(stringifyNextQuery({})).toBe('')
+  })
+
+  it('keeps boolean and number values as plain strings', () => {
+    expect(stringifyNextQuery({ flag: true, page: 2 })).toBe('?flag=true&page=2')
+  })
+})
+
+describe('toHref', () => {
+  it('passes string hrefs through unchanged', () => {
+    expect(toHref('/home?safe=matic:0x123')).toBe('/home?safe=matic:0x123')
+  })
+
+  it('serializes a UrlObject with a canonical query', () => {
+    expect(toHref({ pathname: '/home', query: { safe: 'matic:0x123' } })).toBe('/home?safe=matic:0x123')
+  })
+
+  it('supports a string query', () => {
+    expect(toHref({ pathname: '/home', query: 'safe=eth%3A0xabc' })).toBe('/home?safe=eth%3A0xabc')
+  })
+
+  it('appends a normalized hash', () => {
+    expect(toHref({ pathname: '/settings', hash: '#section' })).toBe('/settings#section')
+    expect(toHref({ pathname: '/settings', hash: 'section' })).toBe('/settings#section')
+  })
+})
+
+describe('toNavigateOptions', () => {
+  it('splits an inline query out of a string href (raw colon in value)', () => {
+    // Regression: the Space dashboard accounts widget pushes this exact shape.
+    // Embedding it in `to` made TanStack commit the href without transitioning
+    // router state, bouncing the user to /welcome/spaces.
+    expect(toNavigateOptions('/home?safe=matic:0x245C153cBa7b65d01706B09a30dEf30190Da1878')).toEqual({
+      to: '/home',
+      search: { safe: 'matic:0x245C153cBa7b65d01706B09a30dEf30190Da1878' },
+      hash: undefined,
+    })
+  })
+
+  it('converts a UrlObject', () => {
+    expect(toNavigateOptions({ pathname: '/spaces', query: { spaceId: 'abc' } })).toEqual({
+      to: '/spaces',
+      search: { spaceId: 'abc' },
+      hash: undefined,
+    })
+  })
+
+  it('clears the search for hrefs without a query', () => {
+    expect(toNavigateOptions('/welcome')).toEqual({ to: '/welcome', search: {}, hash: undefined })
+  })
+
+  it('keeps the current search for hash-only hrefs', () => {
+    expect(toNavigateOptions('#section')).toEqual({ to: '', search: true, hash: 'section' })
+  })
+
+  it('replaces the query for query-only hrefs', () => {
+    expect(toNavigateOptions('?tab=history')).toEqual({ to: '', search: { tab: 'history' }, hash: undefined })
+  })
+
+  it('treats a question mark after the hash as part of the fragment', () => {
+    expect(toNavigateOptions('/page#frag?notaquery')).toEqual({ to: '/page', search: {}, hash: 'frag?notaquery' })
+  })
+})

--- a/apps/web-tanstack/src/compat/next-url.ts
+++ b/apps/web-tanstack/src/compat/next-url.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared URL helpers for the next/* compatibility shims.
+ *
+ * Next.js navigation APIs accept `string | UrlObject` hrefs with the query
+ * embedded in the string (`/home?safe=eth:0x...`). TanStack Router's
+ * `navigate()` does NOT parse a query string out of `to` — the whole string is
+ * treated as a pathname. That mostly "worked" by accident (the committed href
+ * re-parses correctly), but an unencoded `:` in an inline query trips
+ * TanStack's path-param syntax: the href is written to history while router
+ * state never transitions, leaving the previous page mounted (observed as the
+ * Space dashboard's accounts widget bouncing to /welcome/spaces?safe=...).
+ * All shims therefore split hrefs via `toNavigateOptions` and pass `search`
+ * and `hash` to `navigate()` explicitly.
+ */
+import type { UrlObject } from 'url'
+
+export type Url = string | UrlObject
+
+export type NextQuery = Record<string, string | string[]>
+
+/** Parse a Next-style query string; repeated keys become arrays. */
+export function parseNextQuery(search: string): NextQuery {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+  const result: NextQuery = {}
+  for (const [k, v] of params.entries()) {
+    if (k in result) {
+      const existing = result[k]
+      result[k] = Array.isArray(existing) ? [...existing, v] : [existing as string, v]
+    } else {
+      result[k] = v
+    }
+  }
+  return result
+}
+
+/**
+ * Serialize a query object Next-style: arrays become repeated keys
+ * (`?k=a&k=b`), scalars are stringified. Returns `''` or a `?`-prefixed
+ * string, matching TanStack's `stringifySearch` contract.
+ *
+ * The chain prefix colon in `?safe=` stays raw (`safe=eth:0x...`):
+ * URLSearchParams over-encodes it to `%3A` even though `:` is legal in a
+ * query string, and apps/web's useAdjustUrl would then rewrite the URL via
+ * `history.replaceState` — a visible `%3A` flash on every navigation.
+ * Emitting the canonical form directly (same regex as useAdjustUrl) makes
+ * that rewrite a no-op.
+ */
+export function stringifyNextQuery(query: Record<string, unknown>): string {
+  const params = new URLSearchParams()
+  for (const [k, v] of Object.entries(query)) {
+    if (v == null) continue
+    if (Array.isArray(v)) v.forEach((vv) => params.append(k, String(vv)))
+    else params.append(k, String(v))
+  }
+  const qs = params.toString()
+  return qs ? `?${qs}`.replace(/([?&]safe=.+?)%3A(?=0x)/g, '$1:') : ''
+}
+
+/** Serialize a Next `Url` (string | UrlObject) to a string href. */
+export function toHref(url: Url): string {
+  if (typeof url === 'string') return url
+  const pathname = url.pathname ?? '/'
+  let qs = ''
+  if (typeof url.query === 'string') {
+    qs = url.query ? (url.query.startsWith('?') ? url.query : `?${url.query}`) : ''
+  } else if (url.query) {
+    qs = stringifyNextQuery(url.query)
+  }
+  const hash = url.hash ? `#${url.hash.replace(/^#/, '')}` : ''
+  return `${pathname}${qs}${hash}`
+}
+
+export interface CompatNavigateOptions {
+  to: string
+  /** `true` preserves the current search (hash-only navigation), an object replaces it. */
+  search: NextQuery | true
+  hash: string | undefined
+}
+
+/**
+ * Split a Next `Url` into TanStack `navigate()` options. The query never rides
+ * inside `to`; an explicit `search` object replaces the current search params
+ * entirely, mirroring Next's `router.push` semantics.
+ */
+export function toNavigateOptions(url: Url): CompatNavigateOptions {
+  const href = toHref(url)
+  // Strip the hash first: per URL spec everything after `#` (including `?`)
+  // belongs to the fragment.
+  const hashIndex = href.indexOf('#')
+  const hash = hashIndex === -1 ? undefined : href.slice(hashIndex + 1)
+  const base = hashIndex === -1 ? href : href.slice(0, hashIndex)
+  const searchIndex = base.indexOf('?')
+  const to = searchIndex === -1 ? base : base.slice(0, searchIndex)
+  // Hash-only hrefs (`#section`) are relative to the current URL in Next, so
+  // keep the current search. Everything else replaces it, clearing when the
+  // href carries no query of its own.
+  const search = searchIndex === -1 ? (to ? {} : true) : parseNextQuery(base.slice(searchIndex + 1))
+  return { to, search, hash }
+}

--- a/apps/web-tanstack/src/router.tsx
+++ b/apps/web-tanstack/src/router.tsx
@@ -1,4 +1,5 @@
 import { createRouter } from '@tanstack/react-router'
+import { parseNextQuery, stringifyNextQuery } from './compat/next-url'
 import { Route as RootRoute } from './routes/__root'
 
 // Existing
@@ -162,6 +163,12 @@ export const router = createRouter({
   // trailing slash, matching the Next.js semantics 175 reused
   // call-sites expect.
   trailingSlash: 'never',
+  // Next-style search-param semantics for reused apps/web code: values stay
+  // plain strings (TanStack's default JSON-parses `?x=true` into a boolean)
+  // and string[] round-trips as repeated keys (`?k=a&k=b`) — the same shape
+  // the next/router shim exposes as `query`.
+  parseSearch: parseNextQuery,
+  stringifySearch: stringifyNextQuery,
 })
 
 declare module '@tanstack/react-router' {


### PR DESCRIPTION
> Hrefs split in three — to, search, hash —
> query swaps in step with the page it renders,
> one pretty colon, no flash.

## What it solves

Clicking a Safe in the Space dashboard's accounts widget bounced to `/welcome/spaces?safe=...` instead of opening the Safe's dashboard. Additionally, every navigation briefly flashed `%3A` in the URL before being rewritten to `:`.

Resolves: N/A (no Linear issue)

## How this PR fixes it

Three compounding issues in the `next/*` compat shims, all fixed at the compat layer (apps/web source untouched):

1. **Inline queries rode inside `to`.** Next-style string hrefs (`/home?safe=matic:0x...`) were passed whole into TanStack's `navigate({ to })`, which treats the entire string as a pathname. An unencoded `:` in the value made TanStack commit the URL to history **without ever transitioning router state**. Hrefs are now split into `{ to, search, hash }` (new shared `next-url.ts` helpers, also deduping three copies of `toHref`).
2. **`query` updated before the page swap.** The shims exposed `state.location`, which TanStack flips at navigation start — before the destination's lazy chunk loads and the rendered matches swap. The still-mounted `/spaces` page observed the destination query (no `spaceId`) and its guard hijacked the navigation with a redirect. `pathname`/`query`/`asPath` are now derived from the **rendered matches** (`next-location.ts`), so they swap atomically with the page, like in Next. (`pages/index.tsx` already point-fixed this same race with a pathname check — this fixes the class.)
3. **`%3A` flash.** `URLSearchParams` over-encodes the `?safe=` colon, which the reused `useAdjustUrl` then rewrote via `history.replaceState`. The custom Next-style `parseSearch`/`stringifySearch` on the router now emit the canonical form directly (same regex as `useAdjustUrl`), making the rewrite a no-op — one single history write per navigation.

## How to test it

1. `yarn workspace @safe-global/web-tanstack dev`, sign into a workspace with Safes
2. On the workspace **Home** tab, click an account in the **Accounts** widget (expand a multi-chain account and pick a chain) → lands on `/home?safe=<shortName>:<address>` with the Safe dashboard rendered, no redirect to `/welcome/spaces`
3. Click through sidebar links inside the Safe (Assets, Transactions) → URL shows `safe=eth:0x...` immediately, no transient `%3A`
4. Sanity-check the previously-working path: workspace **Safe accounts** tab → click an account → same correct navigation

## Affected flows

- Space dashboard → Accounts widget → open Safe (single- and multi-chain rows) — the broken flow
- Every `router.push/replace` and `<Link>` navigation in web-tanstack (all go through the changed shims)
- URL canonical form for the `?safe=` param on every navigation

## Blast radius

- `next/router`, `next/link`, `next/navigation`, `next/dist/client/resolve-href` compat shims — every reused apps/web call site navigates through these
- Router-level `parseSearch`/`stringifySearch` — search values are now always plain strings/string[] (no JSON auto-parsing); arrays round-trip as repeated keys (`?k=a&k=b`), matching the shim's `query` parser
- `__root.tsx` safe-switch remount key (`useSearch`) — still receives `safe` as a string
- Web-tanstack only; apps/web and mobile untouched

## Risks / not checked

- Did not exercise hash-anchor navigation or duplicate-key query URLs in the browser (covered by unit tests only)
- Did not test reused flows that read `asPath` for non-navigation purposes (hash is no longer included in `asPath`)
- No Playwright one-shot — web-tanstack has no Playwright harness yet (apps/web-only requirement)

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1["router.push('/home?safe=matic:0x…')"] --> B1["navigate({ to: whole string })"]
    B1 --> C1["URL commits, router state stuck"]
    C1 --> D1["/spaces page sees ?safe (no spaceId)"]
    D1 --> E1["guard redirects to /welcome/spaces"]
  end
  subgraph After
    A2["router.push('/home?safe=matic:0x…')"] --> B2["toNavigateOptions → { to, search, hash }"]
    B2 --> C2["navigate matches /home cleanly"]
    C2 --> D2["pathname/query bound to rendered matches"]
    D2 --> E2["query swaps atomically with page → Safe dashboard"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 (N/A — web-tanstack only)
- [x] I've documented how it affects the analytics (if at all) 📊 (no analytics changes)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough under apps/web/e2e/tests/one-shots/ and run it locally — CI records and posts the clickthrough GIF 🎬 (N/A — apps/web-tanstack)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
