### PR TITLE
fix: Make close button show up on all resolution

### DIFF
--- a/apps/web/src/components/common/TxModalDialog/styles.module.css
+++ b/apps/web/src/components/common/TxModalDialog/styles.module.css
@@ -64,6 +64,16 @@
   }
 }
 
+/* Between 900–1148px the topbar wraps onto a second row (148px instead of
+   --topbar-height) — see Topbar's @max-[1100px] container classes plus its 48px
+   padding. The elevated topbar (z-index 99) paints over the dialog, so start
+   the dialog below it to keep the close button visible and clickable. */
+@media (min-width: 900px) and (max-width: 1147.95px) {
+  .dialog {
+    top: 148px;
+  }
+}
+
 @media (max-width: 899.95px) {
   .dialog {
     left: 0;


### PR DESCRIPTION
## Problem

For tablet-size resolutions, when creating a new transaction, the topbar would overlay the close button of the transaction creation flow. See below:

<img width="1090" height="852" alt="Screenshot 2026-06-11 at 10 22 32" src="https://github.com/user-attachments/assets/8ab5aab9-38f8-4933-a446-eabeba84f7cc" />

So this PR adds a breakpoint for these resolutions to move that close button slightly more down so that it's at all times visible. Screenshot of the fix:

<img width="1086" height="850" alt="Screenshot 2026-06-11 at 10 24 54" src="https://github.com/user-attachments/assets/c1dc464e-d99a-4f10-9023-87e07e1e72d9" />
