### PR TITLE
fix: Close side bar when clicked on mobile/tablet

### DIFF
--- a/apps/web/src/components/common/PageLayout/SideDrawer.tsx
+++ b/apps/web/src/components/common/PageLayout/SideDrawer.tsx
@@ -12,6 +12,7 @@ import useDebounce from '@safe-global/utils/hooks/useDebounce'
 import { useIsSidebarRoute } from '@/hooks/useIsSidebarRoute'
 import { ShadcnProvider } from '@/components/ui/ShadcnProvider'
 import { useDarkMode } from '@/hooks/useDarkMode'
+import { useIsTablet } from '@/hooks/use-tablet'
 
 type SideDrawerProps = {
   isOpen: boolean
@@ -22,7 +23,7 @@ type SideDrawerProps = {
 const SideDrawer = ({ isOpen, onToggle, onSidebarOpenChange }: SideDrawerProps): ReactElement => {
   const { breakpoints } = useTheme()
   const isSmallScreen = useMediaQuery(breakpoints.down('md'))
-  const isTabletDrawer = useMediaQuery('(min-width:768px) and (max-width:899.95px)')
+  const isTabletDrawer = useIsTablet()
   const [, isSafeAppRoute] = useIsSidebarRoute()
   const isDarkMode = useDarkMode()
 

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -22,6 +22,7 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useIsTablet } from '@/hooks/use-tablet'
 import { PanelLeftIcon } from 'lucide-react'
 
 /**
@@ -149,6 +150,7 @@ type SidebarContextProps = {
   openMobile: boolean
   setOpenMobile: (open: boolean) => void
   isMobile: boolean
+  isTablet: boolean
   toggleSidebar: () => void
 }
 
@@ -203,6 +205,7 @@ function SidebarProvider({
   onOpenMobileChange?: (open: boolean) => void
 }) {
   const isMobile = useIsMobile()
+  const isTablet = useIsTablet()
   const initialOpen = useMemo(
     () => getSidebarStateFromCookie(defaultOpen),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- read cookie only once on mount
@@ -249,11 +252,12 @@ function SidebarProvider({
       open,
       setOpen,
       isMobile,
+      isTablet,
       openMobile,
       setOpenMobile,
       toggleSidebar,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+    [state, open, setOpen, isMobile, isTablet, openMobile, setOpenMobile, toggleSidebar],
   )
 
   return (

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/NavItem.tsx
@@ -55,7 +55,7 @@ interface NavItemProps {
 }
 
 export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: NavItemProps): ReactElement => {
-  const { state, isMobile } = useSidebar()
+  const { state, isMobile, isTablet, setOpenMobile } = useSidebar()
 
   if (isLoading || !item) {
     return (
@@ -74,6 +74,9 @@ export const NavItem = ({ item, isSpacesVariant = false, isLoading = false }: Na
       trackEvent({ ...customEvent.event, label: customEvent.label }, customEvent.mixpanelParams)
     }
     trackEvent({ ...OVERVIEW_EVENTS.SIDEBAR_CLICKED }, { [MixpanelEventParams.SIDEBAR_ELEMENT]: item.label })
+    if (isMobile || isTablet) {
+      setOpenMobile(false)
+    }
   }
 
   const menuButton = (

--- a/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/__tests__/NavItem.test.tsx
+++ b/apps/web/src/features/spaces/components/Sidebar/variants/NavItem/__tests__/NavItem.test.tsx
@@ -46,9 +46,17 @@ jest.mock('@/components/ui/tooltip', () => ({
 }))
 
 // Controls the mocked sidebar collapse state per test.
-const mockSidebarState: { state: 'expanded' | 'collapsed'; isMobile: boolean } = {
+const mockSetOpenMobile = jest.fn()
+const mockSidebarState: {
+  state: 'expanded' | 'collapsed'
+  isMobile: boolean
+  isTablet: boolean
+  setOpenMobile: jest.Mock
+} = {
   state: 'expanded',
   isMobile: false,
+  isTablet: false,
+  setOpenMobile: mockSetOpenMobile,
 }
 
 // Mock sidebar UI components
@@ -107,6 +115,7 @@ describe('NavItem', () => {
     jest.clearAllMocks()
     mockSidebarState.state = 'expanded'
     mockSidebarState.isMobile = false
+    mockSidebarState.isTablet = false
   })
 
   it('renders with icon and label', () => {
@@ -270,6 +279,39 @@ describe('NavItem', () => {
 
     const link = screen.getByRole('link')
     expect(link).toHaveAttribute('href', '/transactions')
+  })
+
+  describe('mobile sidebar', () => {
+    it('closes the mobile sidebar when a nav link is clicked', () => {
+      mockSidebarState.isMobile = true
+      render(<NavItem item={baseItem} />)
+      fireEvent.click(screen.getByRole('link'))
+
+      expect(mockSetOpenMobile).toHaveBeenCalledWith(false)
+    })
+
+    it('closes the drawer when a nav link is clicked on tablet', () => {
+      mockSidebarState.isTablet = true
+      render(<NavItem item={baseItem} />)
+      fireEvent.click(screen.getByRole('link'))
+
+      expect(mockSetOpenMobile).toHaveBeenCalledWith(false)
+    })
+
+    it('does not touch the mobile sidebar state on desktop', () => {
+      render(<NavItem item={baseItem} />)
+      fireEvent.click(screen.getByRole('link'))
+
+      expect(mockSetOpenMobile).not.toHaveBeenCalled()
+    })
+
+    it('does not close the mobile sidebar when a disabled item is clicked', () => {
+      mockSidebarState.isMobile = true
+      render(<NavItem item={{ ...baseItem, disabled: true }} />)
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(mockSetOpenMobile).not.toHaveBeenCalled()
+    })
   })
 
   describe('tracking events', () => {

--- a/apps/web/src/hooks/use-tablet.ts
+++ b/apps/web/src/hooks/use-tablet.ts
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+const MOBILE_BREAKPOINT = 768
+// Matches MUI's `md` breakpoint, below which the sidebar drawer is closed by default.
+const TABLET_BREAKPOINT = 900
+
+export function useIsTablet() {
+  const [isTablet, setIsTablet] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(min-width: ${MOBILE_BREAKPOINT}px) and (max-width: ${TABLET_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsTablet(mql.matches)
+    }
+    mql.addEventListener('change', onChange)
+    onChange()
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+
+  return !!isTablet
+}


### PR DESCRIPTION
## Problem

On mobile and tablet screen sizes, when clicking a link in the sidebar on spaces wouldn't close the sidebar. Below are screenrecordings on that behavior on the current dev branch

**mobile**

https://github.com/user-attachments/assets/8effcce1-80b4-48f1-b66d-546eb10b8244

**tablet**

https://github.com/user-attachments/assets/6653f5c6-1520-438b-87eb-a69d82e77b03

## Solution

There already exists a [useIsMobile](https://github.com/safe-global/safe-wallet-monorepo/blob/dev/apps/web/src/hooks/use-mobile.ts) hook. But there wasn't a useIsTablet hook. So I created it.
Now for both mobile and tablet, when a user clicks on a link, the link click closes the sidebar. Here's how it looks:

**mobile**

https://github.com/user-attachments/assets/347fb243-3acc-424b-b707-25598e3063f9


**tablet**

https://github.com/user-attachments/assets/7b575e88-b517-45ef-8df6-549710e48d97



