### PR TITLE
fix: workspace banner responsiveness

### DIFF
--- a/apps/web/src/features/spaces/components/SetupWidget/index.tsx
+++ b/apps/web/src/features/spaces/components/SetupWidget/index.tsx
@@ -171,7 +171,7 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
             >
               <div
                 className={cn('flex flex-col gap-2 px-2 pb-2', {
-                  'sm:flex-row': horizontal,
+                  'sm:grid sm:grid-cols-2 xl:grid-cols-4': horizontal,
                 })}
               >
                 {sortedSteps.map(({ key, label, icon: Icon, activeFn }, index) => {
@@ -189,9 +189,8 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
                       onClick={() => !isCompleted && handleStepClick(key)}
                       onKeyDown={(e) => e.key === 'Enter' && !isCompleted && handleStepClick(key)}
                       className={cn(
-                        'flex items-center gap-4 rounded-3xl p-4 transition-colors',
+                        'flex min-w-0 items-center gap-4 rounded-3xl p-4 transition-colors',
                         isCompleted ? 'cursor-not-allowed bg-muted/50' : 'cursor-pointer bg-muted hover:bg-muted/70',
-                        { 'sm:flex-1': horizontal },
                       )}
                     >
                       <div
@@ -206,7 +205,10 @@ const SetupWidget = ({ onDismiss, horizontal, loading }: SetupWidgetProps): Reac
                           <Icon className="size-5 text-green-500" />
                         )}
                       </div>
-                      <Typography variant="paragraph-bold" className={cn('flex-1', { 'line-through': isCompleted })}>
+                      <Typography
+                        variant="paragraph-bold"
+                        className={cn('min-w-0 flex-1', { 'line-through': isCompleted })}
+                      >
                         {label}
                       </Typography>
                       {!isCompleted && <ChevronRight className="size-5 text-muted-foreground" />}


### PR DESCRIPTION
## Problem

The "Set up your workspace" banner for "Explore workspaces" wasn't correctly setup to scale on all widths. Around the width of a tablet it would overlay the parent element. See here

https://github.com/user-attachments/assets/228e151d-d114-4646-8cee-8a6235c6510b

## Solution

This fix makes the workspace banner work for all widths, see video below


https://github.com/user-attachments/assets/42baee22-a669-400a-a4e8-db8b67f0a07d

