### PR TITLE
fix(spaces): align counterfactual rows in the account selector dropdown

### DIFF
--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/SafeSelectorDropdown.stories.tsx
@@ -188,6 +188,47 @@ export const WithNestedSafes: Story = {
   args: {} as any,
 }
 
+// A multi-chain "current" safe (so it isn't filtered out of the list) followed by single-chain rows
+// in every activation state: deployed (balance), counterfactual (Inactive) and activating.
+const mixedActivationItems: SafeItemData[] = [
+  createMockSafeItem(0, {
+    id: '1:0xa77de01c5b6f829cbe4604cf71ddc8c4d608b000',
+    name: 'My Safe',
+    address: '0xa77de01c5b6f829cbe4604cf71ddc8c4d608b000',
+    balance: '16780000',
+  }),
+  createMockSafeItem(1, {
+    id: '1:0x1111111111111111111111111111111111111111',
+    name: 'Treasury',
+    address: '0x1111111111111111111111111111111111111111',
+    balance: '8420000',
+    chains: [baseChains[0]],
+  }),
+  createMockSafeItem(2, {
+    id: '100:0x2222222222222222222222222222222222222222',
+    name: 'New counterfactual Safe',
+    address: '0x2222222222222222222222222222222222222222',
+    balance: '0',
+    chains: [{ ...baseChains[1], isUndeployed: true }],
+  }),
+  createMockSafeItem(3, {
+    id: '8453:0x3333333333333333333333333333333333333333',
+    name: 'Activating Safe',
+    address: '0x3333333333333333333333333333333333333333',
+    balance: '0',
+    chains: [{ ...baseChains[2], isUndeployed: true, isActivating: true }],
+  }),
+]
+
+/**
+ * Single-chain rows in mixed activation states. The fiat balance, the "Inactive"/"Activating" status
+ * and the chain logos must all stay column-aligned across deployed and counterfactual rows.
+ */
+export const MixedActivationStates: Story = {
+  render: () => <InteractiveWrapper items={mixedActivationItems} initialItemId={mixedActivationItems[0].id} />,
+  args: {} as any,
+}
+
 /** Dropdown content shows loading skeletons while safe data is being fetched. */
 export const Loading: Story = {
   render: () => (

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/BalanceDisplay.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/BalanceDisplay.tsx
@@ -1,5 +1,6 @@
 import { Typography } from '@/components/ui/typography'
 import { Skeleton } from '@/components/ui/skeleton'
+import RowEndColumn from './RowEndColumn'
 import type { ReactNode } from 'react'
 
 export interface BalanceDisplayProps {
@@ -10,7 +11,7 @@ export interface BalanceDisplayProps {
 // Right-aligned fiat balance for a dropdown row. The threshold/owners badge now lives on the avatar
 // (see ThresholdBadge); this component intentionally renders the balance only.
 const BalanceDisplay = ({ balance, isLoading }: BalanceDisplayProps) => (
-  <div className="flex flex-col items-end min-w-0 shrink sm:w-[100px] sm:shrink-0">
+  <RowEndColumn>
     {balance !== undefined &&
       (isLoading ? (
         <Skeleton className="h-4 w-14 rounded" />
@@ -19,7 +20,7 @@ const BalanceDisplay = ({ balance, isLoading }: BalanceDisplayProps) => (
           {balance}
         </Typography>
       ))}
-  </div>
+  </RowEndColumn>
 )
 
 export default BalanceDisplay

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/RowEndColumn.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/RowEndColumn.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/utils/cn'
+
+// Fixed-width, right-aligned trailing column of a safe row. The fiat balance and the
+// counterfactual activation status both render inside it so the trailing slot keeps a
+// constant width — this keeps the chain logos in one column and lines the status up with
+// the balance across deployed and undeployed rows.
+const RowEndColumn = ({ children, className }: { children?: ReactNode; className?: string }) => (
+  <div
+    data-testid="row-end-column"
+    className={cn('flex flex-col items-end min-w-0 shrink sm:w-[100px] sm:shrink-0', className)}
+  >
+    {children}
+  </div>
+)
+
+export default RowEndColumn

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeItem.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeItem.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/utils/cn'
 import { useSafeDisplayName } from '@/hooks/useSafeDisplayName'
 import SafeInfoDisplay from './SafeInfoDisplay'
 import BalanceDisplay from './BalanceDisplay'
+import RowEndColumn from './RowEndColumn'
 import ChainLogo from './ChainLogo'
 import NotActivatedBadge from '@/components/common/NotActivatedBadge'
 import type { SafeItemData } from '../types'
@@ -36,7 +37,9 @@ const SafeItem = ({ name, address, threshold, owners, chains, balance, isLoading
         ))}
       </div>
       {isUndeployed ? (
-        <NotActivatedBadge isActivating={isActivating} className="shrink-0" />
+        <RowEndColumn>
+          <NotActivatedBadge isActivating={isActivating} />
+        </RowEndColumn>
       ) : (
         <BalanceDisplay balance={<FiatValue value={balance} />} isLoading={isLoading} />
       )}

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/BalanceDisplay.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/BalanceDisplay.test.tsx
@@ -11,6 +11,12 @@ describe('BalanceDisplay', () => {
     expect(querySkeleton(container)).not.toBeInTheDocument()
   })
 
+  it('renders the balance in the shared row-end column (same trailing slot as the activation status)', () => {
+    render(<BalanceDisplay balance="$ 1,234" />)
+
+    expect(screen.getByTestId('row-end-column')).toContainElement(screen.getByText('$ 1,234'))
+  })
+
   it('shows a skeleton while loading', () => {
     const { container } = render(<BalanceDisplay balance="$ 1,234" isLoading />)
 

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeItem.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeItem.test.tsx
@@ -68,4 +68,10 @@ describe('SafeItem undeployed state', () => {
     expect(screen.getByTestId('balance-display')).toBeInTheDocument()
     expect(screen.queryByTestId('not-activated-badge')).not.toBeInTheDocument()
   })
+
+  it('renders the activation status in the shared row-end column (same trailing slot as the balance)', () => {
+    render(<SafeItem {...createItem(makeChain({ isUndeployed: true }))} />)
+
+    expect(screen.getByTestId('row-end-column')).toContainElement(screen.getByTestId('not-activated-badge'))
+  })
 })


### PR DESCRIPTION
> One column held two widths —
> logos slid, the badge ran loose;
> one shared slot, rows realign.

## What it solves

Resolves: [WA-2545](https://linear.app/safe-global/issue/WA-2545)

In the account selector dropdown, **counterfactual (not-yet-deployed) safes rendered misaligned**:

- The chain-logo column did not line up with the logos on deployed rows.
- The "Inactive" / "Activating" status floated at the row edge instead of sitting in the balance column.

Root cause: each row's trailing slot swapped between two **different-width** elements. Deployed safes rendered `BalanceDisplay` — a fixed **100px** right-aligned column (`sm:w-[100px]`). Counterfactual safes rendered `NotActivatedBadge` — a bare **~16px** icon. Because the name/address column is `flex-1` and the trailing element is `shrink-0`, that ~84px width gap pushed the chain logos out of alignment and left the status icon hanging at the far edge.

## How this PR fixes it

- Extracts a shared **`RowEndColumn`** wrapper (the fixed-width, right-aligned trailing column of a safe row).
- `BalanceDisplay` now renders through `RowEndColumn` (same DOM/classes as before — no behavior change).
- `SafeItem` wraps the counterfactual `NotActivatedBadge` in the **same** `RowEndColumn`.

Result: the trailing slot keeps a constant width whether a row shows a balance or an activation status, so chain logos stay in one column and the status lines up with the balance across deployed and counterfactual rows. This matches the approach the accounts modal already uses (`SafeItemCard` wraps both states in a single fixed-width `w-[70px]` column).

## How to test it

**Storybook (deterministic):**

1. `yarn workspace @safe-global/web storybook`
2. Open **Features/Spaces/SafeSelectorDropdown → `MixedActivationStates`**.
3. Click the selector to open the dropdown. It shows single-chain rows in every state: `Treasury` (deployed → balance), `New counterfactual Safe` (→ Inactive), `Activating Safe` (→ Activating).
4. Verify the chain logos line up across all rows and the Inactive/Activating icon sits in the balance column.

**Real app:** open the safe selector with a mix of deployed and counterfactual safes in the list.

## Affected flows

- Account selector dropdown — **single-chain counterfactual safe row** (primary fix: status now in the balance column, logos aligned).
- Account selector dropdown — **single-chain deployed safe row** (must remain aligned; uses the same `RowEndColumn`).

## Blast radius

- **`RowEndColumn`** (new shared wrapper) — consumers: `BalanceDisplay`, `SafeItem`.
- **`BalanceDisplay`** — consumers: `SafeItem` and `MultiChainSafeItemRow` (collapsed trigger). Refactored to render through `RowEndColumn`; identical DOM/classes, so the multi-chain trigger row is unaffected.
- **`SafeItem`** — counterfactual branch now wraps the badge in `RowEndColumn`; deployed branch unchanged.
- No RTK Query endpoints, API contracts, feature flags, chain configs, routes, or persisted/cached state touched.
- **Mobile:** web-only components under `apps/web`; no shared package (`packages/**`) changed → no mobile impact.

## Risks / not checked

- **Mobile / sub-`sm` viewport not verified.** The trailing column relaxes below the `sm` breakpoint (`sm:w-[100px]`), mirroring `BalanceDisplay`'s existing behavior — but not visually confirmed on a device.
- **No Playwright one-shot added.** Alignment was verified by measuring real rendered geometry in the browser (logo column `732–760`, trailing column `772–872`, badge right edge `872` — identical across all three rows) and via the new Storybook story. The automated regression guard is a structural unit test (status + balance both render into the shared `row-end-column`), not a visual/geometry E2E test.
- **Multi-chain expanded sub-rows** use a separate inline `StatusBadge` layout — unchanged and not re-verified.

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before — trailing slot swaps widths"]
    direction LR
    A1["name / address<br/>(flex-1)"] --> B1["chain logos<br/>(shrink-0)"]
    B1 --> C1{"undeployed?"}
    C1 -->|"no"| D1["BalanceDisplay<br/>(100px column)"]
    C1 -->|"yes"| E1["NotActivatedBadge<br/>(~16px icon → logos shift, status floats)"]
  end
  subgraph After["After — one fixed-width slot"]
    direction LR
    A2["name / address<br/>(flex-1)"] --> B2["chain logos<br/>(shrink-0)"]
    B2 --> F2["RowEndColumn<br/>(fixed 100px, right-aligned)"]
    F2 --> D2["balance"]
    F2 --> E2["Inactive / Activating"]
  end
```

**Measured alignment (live DOM geometry, `MixedActivationStates` story):**

| Row | Chain-logo pill (px) | Trailing column (px) | Badge right edge |
| --- | --- | --- | --- |
| Treasury (deployed) | 732 → 760 | 772 → 872 (100) | — (balance) |
| New counterfactual (Inactive) | 732 → 760 | 772 → 872 (100) | 872 |
| Activating Safe | 732 → 760 | 772 → 872 (100) | 872 |

## Checklist

- [ ] I've tested the branch on mobile 📱 — not tested on mobile (see Risks)
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — structural `row-end-column` tests in `SafeItem.test` / `BalanceDisplay.test`
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough under apps/web/e2e/tests/one-shots/ and run it locally 🎬 — not added; alignment verified via measured browser geometry + Storybook story (see Risks)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
