### PR TITLE
Rename 'dev' script to 'start' in package.json

### DIFF
--- a/apps/web-tanstack/package.json
+++ b/apps/web-tanstack/package.json
@@ -5,7 +5,7 @@
   "license": "GPL-3.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "start": "vite",
     "build": "vite build",
     "preview": "vite preview --port 3001",
     "serve": "sh -c 'npx -y serve dist -p ${PORT:=3001}'",


### PR DESCRIPTION
The command to start ./app/web is `yarn start` so if we want to smoothly move devs over to use tanstack-web, their muscle memory probably guides them to run `yarn start` there too (but it's `yarn dev` ATM)