### PR TITLE
fix: web-tanstack port, 3001 to 3000

### DIFF
--- a/apps/web-tanstack/vite.config.ts
+++ b/apps/web-tanstack/vite.config.ts
@@ -66,11 +66,11 @@ export default defineConfig(({ mode }) => {
     publicDir: path.resolve(webRoot, 'public'),
     envPrefix: ['VITE_', 'NEXT_PUBLIC_'],
     server: {
-      port: 3001,
+      port: 3000,
       strictPort: true,
     },
     preview: {
-      port: 3001,
+      port: 3000,
       strictPort: true,
     },
     // Eagerly pre-bundle the heavy MUI / web3 / Redux subgraph. By default Vite


### PR DESCRIPTION
Both Daniel and I had some issues with running web-tanstack on port 3001 with CGW, so it makes more sense to run it just on port 3000