### PR TITLE
feat: rename 'Advanced details' to 'Transaction details' and add Help…

### DIFF
--- a/apps/web/src/components/transactions/TxDetails/Summary/index.test.tsx
+++ b/apps/web/src/components/transactions/TxDetails/Summary/index.test.tsx
@@ -163,7 +163,7 @@ describe('DecodedTx', () => {
       expect(result.queryByText('native transfer')).toBeInTheDocument()
     })
 
-    fireEvent.click(result.getByText('Advanced details'))
+    fireEvent.click(result.getByText('Transaction details'))
 
     await waitFor(() => {
       const dataField = result.queryAllByText('Data').pop()
@@ -218,7 +218,7 @@ describe('DecodedTx', () => {
       expect(result.queryAllByText('Data').pop()).toBeInTheDocument()
     })
 
-    fireEvent.click(result.getByText('Advanced details'))
+    fireEvent.click(result.getByText('Transaction details'))
 
     await waitFor(() => {
       expect(result.queryByText('SafeTxGas')).toBeInTheDocument()
@@ -267,7 +267,7 @@ describe('DecodedTx', () => {
       />,
     )
 
-    fireEvent.click(result.getByText('Advanced details'))
+    fireEvent.click(result.getByText('Transaction details'))
 
     await waitFor(() => {
       expect(result.queryAllByText('transfer').pop()).toBeInTheDocument()
@@ -309,7 +309,7 @@ describe('DecodedTx', () => {
       />,
     )
 
-    fireEvent.click(result.getByText('Advanced details'))
+    fireEvent.click(result.getByText('Transaction details'))
 
     expect(result.queryAllByText('deposit').pop()).toBeInTheDocument()
   })

--- a/apps/web/src/components/tx/ColorCodedTxAccordion/HelpTooltip.tsx
+++ b/apps/web/src/components/tx/ColorCodedTxAccordion/HelpTooltip.tsx
@@ -1,0 +1,34 @@
+import { Tooltip, SvgIcon } from '@mui/material'
+import InfoIcon from '@/public/images/notifications/info.svg'
+import ExternalLink from '@/components/common/ExternalLink'
+
+import { HelpCenterArticle } from '@safe-global/utils/config/constants'
+
+const HelpTooltip = () => (
+  <Tooltip
+    title={
+      <>
+        Always verify transaction details.{' '}
+        <ExternalLink href={HelpCenterArticle.VERIFY_TX_DETAILS}>Learn more</ExternalLink>.
+      </>
+    }
+    arrow
+    placement="top"
+  >
+    <span>
+      <SvgIcon
+        component={InfoIcon}
+        inheritViewBox
+        color="border"
+        fontSize="small"
+        sx={{
+          verticalAlign: 'middle',
+          ml: 0.5,
+          mt: '-1px',
+        }}
+      />
+    </span>
+  </Tooltip>
+)
+
+export default HelpTooltip

--- a/apps/web/src/components/tx/ColorCodedTxAccordion/index.tsx
+++ b/apps/web/src/components/tx/ColorCodedTxAccordion/index.tsx
@@ -16,6 +16,7 @@ import {
 import { trackEvent, MODALS_EVENTS } from '@/services/analytics'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import accordionCss from '@/styles/accordion.module.css'
+import HelpTooltip from '@/components/tx/ColorCodedTxAccordion/HelpTooltip'
 import { useDarkMode } from '@/hooks/useDarkMode'
 
 enum ColorLevel {
@@ -103,7 +104,8 @@ const ColorCodedTxAccordion = ({ txInfo, txData, children, defaultExpanded }: De
       >
         <Stack direction="row" justifyContent="space-between" alignItems="center" width="100%">
           <Typography variant="subtitle2" fontWeight={700} data-testid="tx-advanced-details">
-            Advanced details
+            Transaction details
+            <HelpTooltip />
           </Typography>
 
           {methodLabel && (

--- a/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/web/src/components/tx/ReviewTransactionV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -128,7 +128,17 @@ exports[`ReviewTransaction should display a confirmation screen 1`] = `
                     class="MuiTypography-root MuiTypography-subtitle2 css-8ydk8b-MuiTypography-root"
                     data-testid="tx-advanced-details"
                   >
-                    Advanced details
+                    Transaction details
+                    <span
+                      class=""
+                      data-mui-internal-clone-element="true"
+                    >
+                      <mock-icon
+                        aria-hidden=""
+                        class="MuiSvgIcon-root MuiSvgIcon-colorBorder MuiSvgIcon-fontSizeSmall css-17ibv3e-MuiSvgIcon-root"
+                        focusable="false"
+                      />
+                    </span>
                   </h6>
                 </div>
               </span>

--- a/apps/web/src/features/gtf/components/HistoryFeesAccordion/index.tsx
+++ b/apps/web/src/features/gtf/components/HistoryFeesAccordion/index.tsx
@@ -16,7 +16,7 @@ import { EXECUTION_FEE_TOOLTIP, GAS_FEE_TOOLTIP } from '../shared/tooltips'
 import css from './styles.module.css'
 import accordionCss from '@/styles/accordion.module.css'
 
-// Match ColorCodedTxAccordion ("Advanced details") so both accordions stack with matching
+// Match ColorCodedTxAccordion ("Transaction details") so both accordions stack with matching
 // border + summary background per tx category. CSS vars are theme-aware — no light/dark branch.
 type AccordionPalette = { border: string; bg: string }
 const TX_PALETTE_BY_TYPE: Record<string, AccordionPalette> = {


### PR DESCRIPTION
## What it solves

This pull request updates the transaction details accordion to improve clarity and user guidance. The most important changes include renaming the "Advanced details" section to "Transaction details" throughout the UI and tests, and adding a help tooltip with a link to a knowledge base article to encourage users to verify transaction details.

**UI/UX Improvements:**

* Renamed the accordion label from "Advanced details" to "Transaction details" in the `ColorCodedTxAccordion` component and updated the corresponding comment in `HistoryFeesAccordion` for consistency. [[1]](diffhunk://#diff-43fd63ad746c085ff922e2e97d7c17bacb0373699b11ee4f73c18cc05f1c1b86L106-R108) [[2]](diffhunk://#diff-579fe042a24a5a28d651a1afbbffe4046ea393689e7a35546b474f8d19f5df7fL19-R19)
* Added a `HelpTooltip` component next to the "Transaction details" label, which displays a tooltip with a link to an article about verifying transaction details. [[1]](diffhunk://#diff-85eabefb82ebb5f3145de4322b8b7c26241d2748afd1733ecdad66508023d6c1R1-R34) [[2]](diffhunk://#diff-43fd63ad746c085ff922e2e97d7c17bacb0373699b11ee4f73c18cc05f1c1b86R19) [[3]](diffhunk://#diff-43fd63ad746c085ff922e2e97d7c17bacb0373699b11ee4f73c18cc05f1c1b86L106-R108)

**Test and Snapshot Updates:**

* Updated all relevant test cases and snapshots to reflect the new "Transaction details" label instead of "Advanced details". [[1]](diffhunk://#diff-56520ee647448b8041eef9d069640092aafd2078ab1a5abced3a2543073b4baaL166-R166) [[2]](diffhunk://#diff-56520ee647448b8041eef9d069640092aafd2078ab1a5abced3a2543073b4baaL221-R221) [[3]](diffhunk://#diff-56520ee647448b8041eef9d069640092aafd2078ab1a5abced3a2543073b4baaL270-R270) [[4]](diffhunk://#diff-56520ee647448b8041eef9d069640092aafd2078ab1a5abced3a2543073b4baaL312-R312) [[5]](diffhunk://#diff-07f32b28218195ba3294725ba80f15eadf2242642d7e08693c43557115bb01d2L131-R141)