### PR TITLE
fix: Add tx hash copy icon

### DIFF
--- a/apps/web/public/images/common/hash.svg
+++ b/apps/web/public/images/common/hash.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path fill="none" d="M4 9h16M4 15h16M10 3L8 21m8-18l-2 18"/></svg>

--- a/apps/web/src/components/transactions/TxSigners/index.test.tsx
+++ b/apps/web/src/components/transactions/TxSigners/index.test.tsx
@@ -345,6 +345,52 @@ describe('TxSigners (Audit Log)', () => {
     expect(screen.getByText('Signed (1/2)')).toBeInTheDocument()
   })
 
+  it('copies the transaction hash to clipboard via the hash button', async () => {
+    const writeTextMock = jest.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } })
+
+    const txHash = faker.string.hexadecimal({ length: 64 })
+    const executor = addressExBuilder().build()
+    const { confirmations } = buildConfirmations(2, 2)
+    const txDetails = transactionDetailsBuilder()
+      .with({
+        detailedExecutionInfo: multisigExecutionDetailsBuilder()
+          .with({ confirmations, confirmationsRequired: 2, executor })
+          .build(),
+        txStatus: TransactionStatus.SUCCESS,
+        executedAt: Date.now(),
+        txHash,
+      })
+      .build()
+    const txSummary = safeTxSummaryBuilder().with({ txStatus: TransactionStatus.SUCCESS }).build()
+
+    render(<TxSigners txDetails={txDetails} txSummary={txSummary} isTxFromProposer={false} proposer={ownerAddress} />)
+
+    fireEvent.click(screen.getByTestId('copy-tx-hash-btn'))
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(txHash)
+    })
+  })
+
+  it('disables the hash button when the transaction has no hash yet', () => {
+    const { confirmations } = buildConfirmations(1, 2)
+    const txDetails = transactionDetailsBuilder()
+      .with({
+        detailedExecutionInfo: multisigExecutionDetailsBuilder()
+          .with({ confirmations, confirmationsRequired: 2 })
+          .build(),
+        txStatus: TransactionStatus.AWAITING_CONFIRMATIONS,
+        txHash: null,
+      })
+      .build()
+    const txSummary = safeTxSummaryBuilder().with({ txStatus: TransactionStatus.AWAITING_CONFIRMATIONS }).build()
+
+    render(<TxSigners txDetails={txDetails} txSummary={txSummary} isTxFromProposer={false} proposer={ownerAddress} />)
+
+    expect(screen.queryByTestId('copy-tx-hash-btn')).not.toBeInTheDocument()
+  })
+
   it('copies address to clipboard on click', async () => {
     const writeTextMock = jest.fn().mockResolvedValue(undefined)
     Object.assign(navigator, { clipboard: { writeText: writeTextMock } })

--- a/apps/web/src/components/transactions/TxSigners/index.tsx
+++ b/apps/web/src/components/transactions/TxSigners/index.tsx
@@ -3,7 +3,7 @@ import { type ReactElement } from 'react'
 import { Alert, Box, IconButton, SvgIcon, Tooltip } from '@mui/material'
 import CopyIcon from '@mui/icons-material/ContentCopy'
 import TxConfirmations from '@/components/transactions/TxConfirmations'
-import { AuditRow, AuditLogHeader } from '@/components/common/AuditLog'
+import { AuditRow, AuditLogHeader, useCopyToClipboard } from '@/components/common/AuditLog'
 
 import useWallet from '@/hooks/wallets/useWallet'
 import useIsPending from '@/hooks/useIsPending'
@@ -14,6 +14,7 @@ import {
   isMultisigDetailedExecutionInfo,
 } from '@/utils/transaction-guards'
 import ExplorerFallbackIcon from '@/public/images/common/link.svg'
+import HashIcon from '@/public/images/common/hash.svg'
 
 import useSafeInfo from '@/hooks/useSafeInfo'
 import useTransactionStatus from '@/hooks/useTransactionStatus'
@@ -42,14 +43,41 @@ type TxSignersProps = {
   isExpired?: boolean
 }
 
+const CopyTxHashButton = ({ txHash }: { txHash?: string | null }) => {
+  const [copied, handleCopy] = useCopyToClipboard(txHash)
+
+  if (!txHash) {
+    return (
+      <Tooltip title="Available after execution" placement="top">
+        <span>
+          <IconButton size="small" disabled>
+            <SvgIcon component={HashIcon} inheritViewBox fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Tooltip title={copied ? 'Copied' : 'Copy transaction hash'} placement="top">
+      <IconButton data-testid="copy-tx-hash-btn" size="small" onClick={handleCopy} sx={{ color: 'inherit' }}>
+        <SvgIcon component={HashIcon} inheritViewBox fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  )
+}
+
 const TxAuditLogActions = ({
   txId,
+  txHash,
   explorerLink,
 }: {
   txId: string
+  txHash?: string | null
   explorerLink?: { title: string; href: string }
 }) => (
   <>
+    <CopyTxHashButton txHash={txHash} />
     <TxShareLinkWrapper id={txId} eventLabel={CopyDeeplinkLabels.shareBlock}>
       <Tooltip title="Copy transaction link" placement="top">
         <IconButton data-testid="share-tx-link-btn" size="small" sx={{ color: 'inherit' }}>
@@ -107,7 +135,9 @@ const TxSigners = ({
 
     return (
       <Box data-testid="transaction-actions-list">
-        <AuditLogHeader actions={<TxAuditLogActions txId={txId} explorerLink={explorerLink} />} />
+        <AuditLogHeader
+          actions={<TxAuditLogActions txId={txId} txHash={txDetails.txHash} explorerLink={explorerLink} />}
+        />
         <AuditRow
           label="Executed"
           actionType="executed"
@@ -128,7 +158,9 @@ const TxSigners = ({
 
     return (
       <Box data-testid="transaction-actions-list">
-        <AuditLogHeader actions={<TxAuditLogActions txId={txId} explorerLink={explorerLink} />} />
+        <AuditLogHeader
+          actions={<TxAuditLogActions txId={txId} txHash={txDetails.txHash} explorerLink={explorerLink} />}
+        />
 
         <AuditRow
           label="Created"
@@ -181,7 +213,7 @@ const TxSigners = ({
             requiredConfirmations={confirmationsRequired}
           />
         }
-        actions={<TxAuditLogActions txId={txId} explorerLink={explorerLink} />}
+        actions={<TxAuditLogActions txId={txId} txHash={txDetails.txHash} explorerLink={explorerLink} />}
       />
 
       <AuditRow


### PR DESCRIPTION
- Users complained that it was difficult to copy the transaction hash from the transaction list elements
- They didn't want to do it by clicking on the etherscan link and then extracting it from the URL
- @devpramoth suggested a design where a clickable icon is used to copy just the transaction hash
- A video of how this works and looks like can be found [here](https://safelabsgmbh.slack.com/archives/C069MCS78QL/p1781183536848119?thread_ts=1780999086.920629&cid=C069MCS78QL)
- Hash icon is from shadcn from @devpramoth 

Fixes https://linear.app/safe-global/issue/WA-2556/transaction-hash-on-transaction-page