### PR TITLE
fix(web): force counterfactual deployment for multichain Safe creation

### DIFF
--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
@@ -201,4 +201,42 @@ describe('ReviewStep', () => {
 
     expect(getByText(/activate your account/)).toBeInTheDocument()
   })
+
+  it('should never offer relay / pay-now options for multichain safes, even when unauthenticated with relays available (WA-2555)', () => {
+    const mockMultiChain = [
+      {
+        chainId: '100',
+        chainName: 'Gnosis Chain',
+        l2: false,
+        nativeCurrency: { symbol: 'ETH' },
+      },
+      {
+        chainId: '1',
+        chainName: 'Ethereum',
+        l2: false,
+        nativeCurrency: { symbol: 'ETH' },
+      },
+    ] as Chain[]
+    const mockData: NewSafeFormData = {
+      name: 'Test',
+      networks: mockMultiChain,
+      threshold: 1,
+      owners: [{ name: '', address: '0x1' }],
+      saltNonce: 0,
+      safeVersion: LATEST_SAFE_VERSION as SafeVersion,
+    }
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+    jest.spyOn(relay, 'hasRemainingRelays').mockReturnValue(true)
+
+    // No auth redux state => unauthenticated. Previously this coerced the pay method to
+    // PayNow, which surfaced the relay selector for multichain and crashed on "Create".
+    const { queryByText } = render(
+      <ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />,
+    )
+
+    // The counterfactual section is still shown for multichain...
+    expect(queryByText(/activate your account/)).toBeInTheDocument()
+    // ...but the relay execution-method selector must never appear for multichain.
+    expect(queryByText(/Who will pay gas fees:/)).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -248,8 +248,17 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
   const customRPCs = useAppSelector(selectRpc)
 
-  // Derive effective pay method synchronously to avoid one-render gap
-  const effectivePayMethod = !isUserAuthenticated && payMethod === PayMethod.PayLater ? PayMethod.PayNow : payMethod
+  // Multichain Safes can only be deployed counterfactually (same address across networks
+  // via CREATE2 replay) — relay and pay-now are single-chain only. Never coerce multichain
+  // into PayNow: it surfaces relay options that don't apply and advances the creation
+  // stepper once per network, overrunning the step list and crashing. See WA-2555 / WA-2524.
+  // Single chain keeps the prior behaviour: unauthenticated users pay now to avoid the
+  // one-render gap before sign-in.
+  const effectivePayMethod = isMultiChainDeployment
+    ? PayMethod.PayLater
+    : !isUserAuthenticated && payMethod === PayMethod.PayLater
+      ? PayMethod.PayNow
+      : payMethod
 
   const handleBack = () => {
     onBack(data)

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -248,12 +248,8 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
 
   const customRPCs = useAppSelector(selectRpc)
 
-  // Multichain Safes can only be deployed counterfactually (same address across networks
-  // via CREATE2 replay) — relay and pay-now are single-chain only. Never coerce multichain
-  // into PayNow: it surfaces relay options that don't apply and advances the creation
-  // stepper once per network, overrunning the step list and crashing. See WA-2555 / WA-2524.
-  // Single chain keeps the prior behaviour: unauthenticated users pay now to avoid the
-  // one-render gap before sign-in.
+  // Multichain must deploy counterfactually; coercing it to PayNow shows invalid relay
+  // options and crashes the stepper (onSubmit fires per network). See WA-2555 / WA-2524.
   const effectivePayMethod = isMultiChainDeployment
     ? PayMethod.PayLater
     : !isUserAuthenticated && payMethod === PayMethod.PayLater


### PR DESCRIPTION
> Many chains, one address —
> pay-now and relay don't apply,
> so pin it to pay-later;
> the stepper stops overrunning, the crash is gone.

## What it solves

Resolves: https://linear.app/safe-global/issue/WA-2555

In the **old (classic) view**, multichain Safe creation was broken on the Review step:

- It showed **relay payment options** ("Sponsored by Safe" / "Connected wallet") *alongside* the counterfactual "Before we continue…" section — these should never coexist, and relay is a single-chain-only concept.
- Clicking **"Create account"** crashed the whole app with `TypeError: Cannot read properties of undefined (reading 'title')`.

Both symptoms share **one root cause**: `effectivePayMethod` coerced **unauthenticated** users into `PayNow`, which is invalid for multichain.

- `PayNow + canRelay` renders the relay `ExecutionMethodSelector` (the wrong options).
- `PayNow` also routes `createSafe` into the per-network deploy path, which calls `onSubmit` **once per chain**. With N>1 networks the creation stepper advances past its last step, so `steps[activeStep]` becomes `undefined` and `CardStepper` crashes on `currentStep.title`.

The crash mechanism (per-chain `onSubmit`) has existed since multichain landed (#4120), but it was latent: the default Pay-later path navigates away and never calls `onSubmit`. The `effectivePayMethod` forced-PayNow logic (#7875, on `dev`, not yet on `main`) is what pushed the common "unauthenticated + multichain" case into the crashing path — which is why prod doesn't show it yet.

## How this PR fixes it

Multichain Safes can only be deployed counterfactually (same address across networks via CREATE2 replay) — relay and pay-now are single-chain only. So we **never coerce multichain into `PayNow`**; it is always counterfactual `PayLater`. Single-chain behaviour is unchanged.

```ts
// apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
const effectivePayMethod = isMultiChainDeployment
  ? PayMethod.PayLater
  : !isUserAuthenticated && payMethod === PayMethod.PayLater
    ? PayMethod.PayNow
    : payMethod
```

This one lever fixes both symptoms:

- The relay `ExecutionMethodSelector` is gated on `effectivePayMethod === PayMethod.PayNow` → **hidden for multichain**.
- `createSafe` now takes the counterfactual `PayLater` branch (persist + redirect home) and **never** the per-chain `onSubmit` deploy path → the stepper can't overrun → **no crash**.
- `PayNowPayLater` already hides the Pay-now/Pay-later radio for multichain, so there's no "pay with wallet" toggle either.

This matches the intended behaviour documented in the related ticket WA-2524 ("multichain should use counterfactual deployment only").

## How to test it

1. Open the app in the **old/classic view** (e.g. not signed in), go to **Create new Safe Account**.
2. Select **multiple networks** (multichain), add signers, proceed to the **Review** step.
3. **Expected:** no relay options ("Sponsored by Safe" / "Connected wallet") and no "Pay now" toggle — only the counterfactual "Before we continue…" section.
4. Click **"Create account"** → the app **does not crash**; it deploys counterfactually and redirects to the new account.
5. **Regression check (single chain):** create a single-network Safe while unauthenticated → "Pay now" is still offered as before.

Unit test (no auth/wallet needed):

```bash
yarn workspace @safe-global/web test src/components/new-safe/create/steps/ReviewStep/index.test.tsx
```

## Affected flows

- **Multichain Safe creation (classic view)** — Review step no longer shows relay/pay-now options; "Create account" deploys counterfactually instead of crashing.
- **Single-chain Safe creation** — unchanged (unauthenticated still coerced to Pay now; authenticated still defaults to Pay later).

## Blast radius

- **Single file of logic:** `ReviewStep` `effectivePayMethod` derivation — the one value that feeds both the relay `ExecutionMethodSelector` visibility and the `createSafe` deploy-vs-persist branch.
- **Downstream of `effectivePayMethod`, verified no regression:**
  - `ExecutionMethodSelector` (relay) — gated on `=== PayNow`; correctly hidden for multichain.
  - `getDeploymentType` / `getPaymentMethodLabel` (analytics) — multichain now reports `Counterfactual` / `Pay-later`, which is correct.
  - `shouldShowNetworkWarning` — already short-circuits for multichain (`!isMultiChainDeployment`), so no change.
  - `createSafe` PayLater branch (persist + redirect) is taken for multichain; the per-chain `onSubmit` deploy path is no longer reachable for multichain.
- **No** RTK Query / API / slice / feature-flag / persistence / route changes.
- **Web-only** (no shared `packages/**` touched → no mobile impact).
- `PayNowPayLater` is **not** modified (it already hides the radio for multichain).

## Risks / not checked

- The latent per-network `onSubmit` defect (#4120) is **neutralised** for multichain by this fix (the deploy path is no longer reached) but **not removed at its source**. A theoretical multichain-with-counterfactual-disabled path is not reachable via the UI (the bug repro itself proves counterfactual is enabled), so it's left as a possible follow-up rather than bundled here.
- Verified via a component-level unit test that renders the real `ReviewStep` under the exact repro conditions, plus a manual click-through in the running dev env. No Playwright one-shot added (multichain Review requires a connected wallet + multi-network selection).
- Did not test on mobile (web-only change).

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before — multichain coerced to PayNow"]
    A1["Multichain + unauthenticated"] --> B1["effectivePayMethod = PayNow"]
    B1 --> C1["Relay ExecutionMethodSelector shown ❌"]
    B1 --> D1["createSafe deploy path: onSubmit per network"]
    D1 --> E1["activeStep overruns steps[] → steps[4] undefined"]
    E1 --> F1["CardStepper reads currentStep.title → crash 💥"]
  end
  subgraph After["After — multichain pinned to PayLater"]
    A2["Multichain (any auth state)"] --> B2["effectivePayMethod = PayLater"]
    B2 --> C2["Relay selector hidden ✅ (counterfactual only)"]
    B2 --> D2["createSafe PayLater branch: persist + redirect home"]
    D2 --> E2["No per-network onSubmit → stepper stays in bounds ✅"]
  end
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A, web-only change
- [x] I've documented how it affects the analytics (if at all) 📊 — multichain now reports `Counterfactual`/`Pay-later` (correct); no event added/removed
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — `ReviewStep/index.test.tsx`: multichain + unauthenticated + relays → relay selector absent, counterfactual section present
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough … 🎬 — not added; multichain Review needs a connected wallet + multi-network selection. Verified via unit test + manual dev-env walkthrough (see Risks)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).