### PR TITLE
fix(web): reflect selected execution method in Pay now subtitle

### DIFF
--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.test.tsx
@@ -201,4 +201,30 @@ describe('ReviewStep', () => {
 
     expect(getByText(/activate your account/)).toBeInTheDocument()
   })
+
+  it('should update the pay now subtitle when switching the execution method from relay to connected wallet', () => {
+    const mockData: NewSafeFormData = {
+      name: 'Test',
+      networks: [mockChain],
+      threshold: 1,
+      owners: [{ name: '', address: '0x1' }],
+      saltNonce: 0,
+      safeVersion: LATEST_SAFE_VERSION as SafeVersion,
+    }
+    jest.spyOn(useChains, 'useHasFeature').mockReturnValue(true)
+    jest.spyOn(relay, 'hasRemainingRelays').mockReturnValue(true)
+
+    render(<ReviewStep data={mockData} onSubmit={jest.fn()} onBack={jest.fn()} setStep={jest.fn()} />)
+
+    // Pay now is the effective method for unauthenticated users, relay is selected by default
+    expect(screen.getByText('Sponsored free transaction')).toBeInTheDocument()
+
+    // Switch the execution method to the connected wallet
+    act(() => {
+      fireEvent.click(screen.getByRole('radio', { name: /Connected wallet/i }))
+    })
+
+    // The subtitle must no longer advertise a sponsored free transaction
+    expect(screen.queryByText('Sponsored free transaction')).not.toBeInTheDocument()
+  })
 })

--- a/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
+++ b/apps/web/src/components/new-safe/create/steps/ReviewStep/index.tsx
@@ -448,7 +448,7 @@ const ReviewStep = ({ data, onSubmit, onBack, setStep }: StepRenderProps<NewSafe
             <PayNowPayLater
               totalFee={totalFee}
               isMultiChain={isMultiChainDeployment}
-              canRelay={canRelay}
+              willRelay={willRelay}
               payMethod={effectivePayMethod}
               setPayMethod={setPayMethod}
               isUserAuthenticated={isUserAuthenticated}

--- a/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
+++ b/apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
@@ -25,14 +25,14 @@ import { setAuthenticated, SESSION_LIFETIME_MS } from '@/store/authSlice'
 
 const PayNowPayLater = ({
   totalFee,
-  canRelay,
+  willRelay,
   isMultiChain,
   payMethod,
   setPayMethod,
   isUserAuthenticated = true,
 }: {
   totalFee: string
-  canRelay: boolean
+  willRelay: boolean
   isMultiChain: boolean
   payMethod: PayMethod
   setPayMethod: Dispatch<SetStateAction<PayMethod>>
@@ -126,7 +126,7 @@ const PayNowPayLater = ({
                   <Typography className={css.radioTitle}>Pay now</Typography>
                   {showGasFeeEstimation && (
                     <Typography className={css.radioSubtitle} variant="body2" color="text.secondary">
-                      {canRelay ? (
+                      {willRelay ? (
                         'Sponsored free transaction'
                       ) : (
                         <>

--- a/apps/web/src/features/counterfactual/contract.ts
+++ b/apps/web/src/features/counterfactual/contract.ts
@@ -41,7 +41,7 @@ import type {
 // Component prop types (for components with external props)
 export interface PayNowPayLaterProps {
   totalFee: string
-  canRelay: boolean
+  willRelay: boolean
   isMultiChain: boolean
   payMethod: PayMethod
   setPayMethod: Dispatch<SetStateAction<PayMethod>>


### PR DESCRIPTION
> Relay can, but will it?
> the subtitle asked the wrong one —
> swap `canRelay` for `willRelay`,
> "free" now follows the toggle.

## What it solves

Resolves: https://linear.app/safe-global/issue/WA-2557

During **single-chain** Safe creation on a **relay-enabled** network, after selecting **"Pay now"**, switching the gas payer from **"Sponsored by Safe"** to **"Connected wallet"** left the "Pay now" card subtitle stuck on **"Sponsored free transaction"** — even though the estimated fee and wallet balance were shown right below it. The result was a contradiction: the card says *free*, the fee says *you pay*.

It's a cosmetic-but-misleading bug: a user could believe they're getting a sponsored/free transaction when they're actually about to pay gas from their own wallet.

## How this PR fixes it

**Root cause:** the subtitle was derived from the wrong variable.

- `canRelay` = relay is **available** (network supports it + owners have relay credits). It's a static fact and does **not** change when the user toggles the payer.
- `willRelay` = `canRelay && executionMethod === RELAY` = the transaction will **actually** be relayed. This **does** react to the toggle.

The subtitle used `canRelay`, so it stayed `true` after switching to "Connected wallet" (only `willRelay` flips to `false`). The fee line below it already used `willRelay` correctly (`NetworkFee isWaived={willRelay}`) — which is exactly why the two disagreed.

```ts
// apps/web/src/features/counterfactual/components/PayNowPayLater/index.tsx
// before
{canRelay ? 'Sponsored free transaction' : <>≈ {totalFee} {symbol}</>}
// after
{willRelay ? 'Sponsored free transaction' : <>≈ {totalFee} {symbol}</>}
```

The fix feeds the subtitle from `willRelay` so it tracks the selected execution method. Since `canRelay` was used **only** for this subtitle inside `PayNowPayLater`, the prop is **renamed** `canRelay → willRelay` (the misleading name was itself the trigger) and the call site in `ReviewStep` now passes the already-computed `willRelay`.

## How to test it

1. Start **Create new Safe Account** on a **relay-enabled** network (e.g. Sepolia/Gnosis) with a connected wallet that has relay credits.
2. On the **Review** step, select **"Pay now"**.
3. **Expected (default, "Sponsored by Safe"):** the "Pay now" card subtitle reads **"Sponsored free transaction"**.
4. Under **"Who will pay gas fees"**, switch to **"Connected wallet"**.
5. **Expected:** the subtitle updates to the **estimated fee** (`≈ <fee> <symbol>`) and no longer says "Sponsored free transaction".
6. Switch back to **"Sponsored by Safe"** → subtitle returns to "Sponsored free transaction".

**Regression check (non-relay network):** the subtitle shows the estimated fee in both states (unchanged behaviour).

Unit test (no wallet/network needed):

```bash
yarn workspace @safe-global/web test src/components/new-safe/create/steps/ReviewStep/index.test.tsx
```

## Affected flows

- **Single-chain Safe creation, "Pay now"** — the subtitle now reflects the selected payer (sponsored vs. connected wallet) instead of just relay availability.
- **Single-chain, non-relay network** — `canRelay` was already `false`, so `willRelay` is `false` too → subtitle unchanged.
- **Multichain creation** — `PayNowPayLater` hides the radio entirely (`isMultiChain`); the subtitle never renders → unaffected.
- **"Pay later" selected** — uses its own subtitle, independent of this value → unaffected.

## Blast radius

- **Single value swapped:** the "Pay now" subtitle now reads `willRelay` (already computed in `ReviewStep` and already used by the fee line) instead of `canRelay`.
- **Prop renamed across 3 files:** `PayNowPayLater` component, `PayNowPayLaterProps` contract interface, and the `ReviewStep` call site. `canRelay` is still computed in `ReviewStep` (it gates the `ExecutionMethodSelector` and feeds `getWillRelay`), only the subtitle's input changed.
- **No** RTK Query / API / slice / feature-flag / persistence / route changes.
- **No** analytics change (`getPaymentMethodLabel`/`getDeploymentType` read the same `willRelay`/`effectivePayMethod`).
- **Web-only** (no shared `packages/**` touched → no mobile impact).
- The `index.stories.tsx` `PayNowPayLater` story renders a static mock, not the real component → unaffected.

## Risks / not checked

- `NO_FEE_CAMPAIGN` execution method is not reachable in this flow — `ReviewStep` renders `ExecutionMethodSelector` without a `noFeeCampaign` prop, so `executionMethod` is only ever `RELAY` or `WALLET` during Safe creation. `willRelay` therefore captures "sponsored" correctly here.
- Verified via a `ReviewStep` integration test that selects "Pay now" with relays available, then toggles to "Connected wallet" and asserts the subtitle changes. No Playwright one-shot added (the Review step requires a connected wallet + relay credits, which the unit test mocks).
- Not tested on mobile (web-only change).

## Visual summary

```mermaid
flowchart TB
  subgraph Before["Before — subtitle reads canRelay"]
    A1["User picks Pay now<br/>(relay-enabled network)"] --> B1["Toggle: Sponsored by Safe → Connected wallet"]
    B1 --> C1["executionMethod = WALLET"]
    C1 --> D1["willRelay = false<br/>(fee line updates ✅)"]
    C1 --> E1["canRelay = true<br/>(unchanged)"]
    E1 --> F1["Subtitle still 'Sponsored free transaction' ❌<br/>contradicts the fee shown below"]
  end
  subgraph After["After — subtitle reads willRelay"]
    A2["User picks Pay now<br/>(relay-enabled network)"] --> B2["Toggle: Sponsored by Safe → Connected wallet"]
    B2 --> C2["executionMethod = WALLET"]
    C2 --> D2["willRelay = false"]
    D2 --> E2["Subtitle updates to ≈ fee ✅<br/>consistent with the fee line"]
  end
```

https://github.com/user-attachments/assets/0ff29918-66d9-4e78-991d-c9cf8dc6dffd



## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A, web-only change
- [x] I've documented how it affects the analytics (if at all) 📊 — no change; analytics read the same `willRelay`/`effectivePayMethod`
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — `ReviewStep/index.test.tsx`: toggling to "Connected wallet" removes the "Sponsored free transaction" subtitle
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough … 🎬 — not added; Review step needs a connected wallet + relay credits. Verified via unit test (see Risks)

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
