### PR TITLE
Update label text in AddMemberInput component

### DIFF
--- a/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
+++ b/apps/web/src/features/spaces/components/AddMemberModal/AddMemberInput.tsx
@@ -140,7 +140,7 @@ const AddMemberInput = ({ error, inputProps, onSelectAddress, value }: AddMember
           name={inputProps.name}
           inputRef={inputProps.ref}
           onBlur={inputProps.onBlur}
-          label={error || 'Address or email'}
+          label={error || 'Address, email or ENS'}
           required={!error}
           error={!!error}
           fullWidth


### PR DESCRIPTION
When opening the "Add member" modal, we only show "Address or email" as an option. But ENS names are also resolved in that form. A user can e.g. type vitalik.eth and that address will get resolved