### PR TITLE
refactor: dedupe safe overview fetches on the space dashboard (drop v1/safes)

### DIFF
--- a/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafesWithQueue.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafesWithQueue.test.ts
@@ -38,9 +38,9 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
   useSpaceSafesGetV1Query: (...args: unknown[]) => mockUseSpaceSafesGetV1Query(...args),
 }))
 
-const mockUseSafesGetSafeOverviewV1Query = jest.fn()
-jest.mock('@safe-global/store/gateway/AUTO_GENERATED/safes', () => ({
-  useSafesGetSafeOverviewV1Query: (...args: unknown[]) => mockUseSafesGetSafeOverviewV1Query(...args),
+const mockUseSafesGetOverviewForManyQuery = jest.fn()
+jest.mock('@safe-global/store/gateway/safes', () => ({
+  useSafesGetOverviewForManyQuery: (...args: unknown[]) => mockUseSafesGetOverviewForManyQuery(...args),
 }))
 
 // ---------------------------------------------------------------------------
@@ -84,7 +84,7 @@ const setupDefaults = ({
     currentData: spaceSafes,
     isFetching: isLoadingSafes,
   })
-  mockUseSafesGetSafeOverviewV1Query.mockReturnValue({
+  mockUseSafesGetOverviewForManyQuery.mockReturnValue({
     currentData: overviews,
     isLoading: isLoadingOverviews,
   })
@@ -132,7 +132,7 @@ describe('useSpaceSafesWithQueue', () => {
     expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith({ spaceId: MOCK_SPACE_UUID }, { skip: false })
   })
 
-  it('should build safes param from space safes response', () => {
+  it('should build safe ids from space safes response', () => {
     setupDefaults({
       spaceSafes: {
         safes: {
@@ -144,30 +144,29 @@ describe('useSpaceSafesWithQueue', () => {
 
     renderHook(() => useSpaceSafesWithQueue())
 
-    const overviewCallArgs = mockUseSafesGetSafeOverviewV1Query.mock.calls[0]
-    expect(overviewCallArgs[0].safes).toBe(`1:${ADDR_1},1:${ADDR_2},137:${ADDR_3}`)
+    const overviewCallArgs = mockUseSafesGetOverviewForManyQuery.mock.calls[0]
+    expect(overviewCallArgs[0].safes).toEqual([`1:${ADDR_1}`, `1:${ADDR_2}`, `137:${ADDR_3}`])
     expect(overviewCallArgs[0].currency).toBe('usd')
     expect(overviewCallArgs[0].trusted).toBe(true)
-    expect(overviewCallArgs[0].excludeSpam).toBe(true)
   })
 
-  it('should skip overview query when safes param is empty', () => {
+  it('should skip overview query when there are no safes', () => {
     setupDefaults()
 
     renderHook(() => useSpaceSafesWithQueue())
 
-    const overviewCallArgs = mockUseSafesGetSafeOverviewV1Query.mock.calls[0]
+    const overviewCallArgs = mockUseSafesGetOverviewForManyQuery.mock.calls[0]
     expect(overviewCallArgs[1]).toEqual({ skip: true })
   })
 
-  it('should not skip overview query when safes param is populated', () => {
+  it('should not skip overview query when there are safes', () => {
     setupDefaults({
       spaceSafes: { safes: { '1': [ADDR_1] } },
     })
 
     renderHook(() => useSpaceSafesWithQueue())
 
-    const overviewCallArgs = mockUseSafesGetSafeOverviewV1Query.mock.calls[0]
+    const overviewCallArgs = mockUseSafesGetOverviewForManyQuery.mock.calls[0]
     expect(overviewCallArgs[1]).toEqual({ skip: false })
   })
 
@@ -242,8 +241,8 @@ describe('useSpaceSafesWithQueue', () => {
 
     renderHook(() => useSpaceSafesWithQueue())
 
-    const overviewCallArgs = mockUseSafesGetSafeOverviewV1Query.mock.calls[0]
-    expect(overviewCallArgs[0].safes).toBe('')
+    const overviewCallArgs = mockUseSafesGetOverviewForManyQuery.mock.calls[0]
+    expect(overviewCallArgs[0].safes).toEqual([])
     expect(overviewCallArgs[1]).toEqual({ skip: true })
   })
 })

--- a/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafesWithQueue.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafesWithQueue.test.ts
@@ -2,23 +2,17 @@ import { renderHook } from '@testing-library/react'
 import { useSpaceSafesWithQueue } from '../useSpaceSafesWithQueue'
 import { faker } from '@faker-js/faker'
 import type { SafeOverview } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
-import type { GetSpaceSafeResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-const MOCK_SPACE_UUID = '11111111-1111-1111-1111-111111111111'
+import type { SafeItem } from '@/hooks/safes'
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
-let mockIsAuthenticated = true
 let mockCurrency = 'usd'
 
-const mockUseCurrentSpaceId = jest.fn()
-jest.mock('../useCurrentSpaceId', () => ({
-  useCurrentSpaceId: () => mockUseCurrentSpaceId(),
-}))
-
-jest.mock('@/store/authSlice', () => ({
-  isAuthenticated: 'isAuthenticated',
+const mockUseSpaceSafes = jest.fn()
+jest.mock('../useSpaceSafes', () => ({
+  useSpaceSafes: () => mockUseSpaceSafes(),
 }))
 
 jest.mock('@/store/settingsSlice', () => ({
@@ -27,20 +21,18 @@ jest.mock('@/store/settingsSlice', () => ({
 
 jest.mock('@/store', () => ({
   useAppSelector: (selector: string) => {
-    if (selector === 'isAuthenticated') return mockIsAuthenticated
     if (selector === 'selectCurrency') return mockCurrency
     return undefined
   },
 }))
 
-const mockUseSpaceSafesGetV1Query = jest.fn()
-jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
-  useSpaceSafesGetV1Query: (...args: unknown[]) => mockUseSpaceSafesGetV1Query(...args),
+jest.mock('@/hooks/safes', () => ({
+  flattenSafeItems: (items: unknown[]) => items,
 }))
 
-const mockUseSafesGetOverviewForManyQuery = jest.fn()
-jest.mock('@safe-global/store/gateway/safes', () => ({
-  useSafesGetOverviewForManyQuery: (...args: unknown[]) => mockUseSafesGetOverviewForManyQuery(...args),
+const mockUseGetMultipleSafeOverviewsQuery = jest.fn()
+jest.mock('@/store/api/gateway', () => ({
+  useGetMultipleSafeOverviewsQuery: (...args: unknown[]) => mockUseGetMultipleSafeOverviewsQuery(...args),
 }))
 
 // ---------------------------------------------------------------------------
@@ -50,6 +42,15 @@ jest.mock('@safe-global/store/gateway/safes', () => ({
 const ADDR_1 = faker.finance.ethereumAddress()
 const ADDR_2 = faker.finance.ethereumAddress()
 const ADDR_3 = faker.finance.ethereumAddress()
+
+const createSafeItem = (chainId: string, address: string): SafeItem => ({
+  chainId,
+  address,
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+})
 
 const createOverview = (overrides: Partial<SafeOverview> = {}): SafeOverview => ({
   address: { value: overrides.address?.value ?? faker.finance.ethereumAddress() },
@@ -62,30 +63,24 @@ const createOverview = (overrides: Partial<SafeOverview> = {}): SafeOverview => 
 })
 
 const setupDefaults = ({
-  spaceId = MOCK_SPACE_UUID,
-  isAuthenticated = true,
-  spaceSafes,
+  safeItems = [],
   isLoadingSafes = false,
   overviews,
   isLoadingOverviews = false,
 }: {
-  spaceId?: string | null
-  isAuthenticated?: boolean
-  spaceSafes?: GetSpaceSafeResponse
+  safeItems?: SafeItem[]
   isLoadingSafes?: boolean
   overviews?: SafeOverview[]
   isLoadingOverviews?: boolean
 } = {}) => {
-  mockUseCurrentSpaceId.mockReturnValue(spaceId)
-  mockIsAuthenticated = isAuthenticated
   mockCurrency = 'usd'
 
-  mockUseSpaceSafesGetV1Query.mockReturnValue({
-    currentData: spaceSafes,
-    isFetching: isLoadingSafes,
+  mockUseSpaceSafes.mockReturnValue({
+    allSafes: safeItems,
+    isLoading: isLoadingSafes,
   })
-  mockUseSafesGetOverviewForManyQuery.mockReturnValue({
-    currentData: overviews,
+  mockUseGetMultipleSafeOverviewsQuery.mockReturnValue({
+    data: overviews,
     isLoading: isLoadingOverviews,
   })
 }
@@ -108,66 +103,16 @@ describe('useSpaceSafesWithQueue', () => {
     expect(result.current.isLoading).toBe(false)
   })
 
-  it('should skip space safes query when not authenticated', () => {
-    setupDefaults({ isAuthenticated: false })
+  it('should query overviews with the flattened space safes and currency', () => {
+    const safeItems = [createSafeItem('1', ADDR_1), createSafeItem('1', ADDR_2), createSafeItem('137', ADDR_3)]
+    setupDefaults({ safeItems })
 
     renderHook(() => useSpaceSafesWithQueue())
 
-    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
-  })
-
-  it('should skip space safes query when no spaceId', () => {
-    setupDefaults({ spaceId: null })
-
-    renderHook(() => useSpaceSafesWithQueue())
-
-    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
-  })
-
-  it('should not skip space safes query when authenticated with spaceId', () => {
-    setupDefaults({ spaceId: MOCK_SPACE_UUID, isAuthenticated: true })
-
-    renderHook(() => useSpaceSafesWithQueue())
-
-    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith({ spaceId: MOCK_SPACE_UUID }, { skip: false })
-  })
-
-  it('should build safe ids from space safes response', () => {
-    setupDefaults({
-      spaceSafes: {
-        safes: {
-          '1': [ADDR_1, ADDR_2],
-          '137': [ADDR_3],
-        },
-      },
+    expect(mockUseGetMultipleSafeOverviewsQuery).toHaveBeenCalledWith({
+      safes: safeItems,
+      currency: 'usd',
     })
-
-    renderHook(() => useSpaceSafesWithQueue())
-
-    const overviewCallArgs = mockUseSafesGetOverviewForManyQuery.mock.calls[0]
-    expect(overviewCallArgs[0].safes).toEqual([`1:${ADDR_1}`, `1:${ADDR_2}`, `137:${ADDR_3}`])
-    expect(overviewCallArgs[0].currency).toBe('usd')
-    expect(overviewCallArgs[0].trusted).toBe(true)
-  })
-
-  it('should skip overview query when there are no safes', () => {
-    setupDefaults()
-
-    renderHook(() => useSpaceSafesWithQueue())
-
-    const overviewCallArgs = mockUseSafesGetOverviewForManyQuery.mock.calls[0]
-    expect(overviewCallArgs[1]).toEqual({ skip: true })
-  })
-
-  it('should not skip overview query when there are safes', () => {
-    setupDefaults({
-      spaceSafes: { safes: { '1': [ADDR_1] } },
-    })
-
-    renderHook(() => useSpaceSafesWithQueue())
-
-    const overviewCallArgs = mockUseSafesGetOverviewForManyQuery.mock.calls[0]
-    expect(overviewCallArgs[1]).toEqual({ skip: false })
   })
 
   it('should return only safes with queued > 0', () => {
@@ -177,7 +122,7 @@ describe('useSpaceSafesWithQueue', () => {
       createOverview({ chainId: '137', address: { value: ADDR_3 }, queued: 1 }),
     ]
     setupDefaults({
-      spaceSafes: { safes: { '1': [ADDR_1, ADDR_2], '137': [ADDR_3] } },
+      safeItems: [createSafeItem('1', ADDR_1), createSafeItem('1', ADDR_2), createSafeItem('137', ADDR_3)],
       overviews,
     })
 
@@ -195,7 +140,7 @@ describe('useSpaceSafesWithQueue', () => {
       createOverview({ chainId: '137', address: { value: ADDR_2 }, queued: 0 }),
     ]
     setupDefaults({
-      spaceSafes: { safes: { '1': [ADDR_1], '137': [ADDR_2] } },
+      safeItems: [createSafeItem('1', ADDR_1), createSafeItem('137', ADDR_2)],
       overviews,
     })
 
@@ -214,7 +159,7 @@ describe('useSpaceSafesWithQueue', () => {
 
   it('should report isLoading when overviews are loading', () => {
     setupDefaults({
-      spaceSafes: { safes: { '1': [ADDR_1] } },
+      safeItems: [createSafeItem('1', ADDR_1)],
       isLoadingOverviews: true,
     })
 
@@ -225,7 +170,7 @@ describe('useSpaceSafesWithQueue', () => {
 
   it('should not be loading when both queries are done', () => {
     setupDefaults({
-      spaceSafes: { safes: { '1': [ADDR_1] } },
+      safeItems: [createSafeItem('1', ADDR_1)],
       overviews: [createOverview({ chainId: '1', address: { value: ADDR_1 }, queued: 0 })],
     })
 
@@ -234,15 +179,11 @@ describe('useSpaceSafesWithQueue', () => {
     expect(result.current.isLoading).toBe(false)
   })
 
-  it('should handle empty safes object', () => {
-    setupDefaults({
-      spaceSafes: { safes: {} },
-    })
+  it('should query with empty safes when the space has none', () => {
+    setupDefaults({ safeItems: [] })
 
     renderHook(() => useSpaceSafesWithQueue())
 
-    const overviewCallArgs = mockUseSafesGetOverviewForManyQuery.mock.calls[0]
-    expect(overviewCallArgs[0].safes).toEqual([])
-    expect(overviewCallArgs[1]).toEqual({ skip: true })
+    expect(mockUseGetMultipleSafeOverviewsQuery).toHaveBeenCalledWith({ safes: [], currency: 'usd' })
   })
 })

--- a/apps/web/src/features/spaces/hooks/useSpaceSafesWithQueue.ts
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafesWithQueue.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useSpaceSafesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import { useSafesGetSafeOverviewV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/safes'
+import { useSafesGetOverviewForManyQuery } from '@safe-global/store/gateway/safes'
 import { useCurrentSpaceId } from './useCurrentSpaceId'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
@@ -18,16 +18,16 @@ export const useSpaceSafesWithQueue = () => {
     { skip: !isUserSignedIn || !spaceId },
   )
 
-  const safesParam = useMemo(() => {
-    if (!spaceSafes?.safes) return ''
-    return Object.entries(spaceSafes.safes)
-      .flatMap(([chainId, addresses]: [string, string[]]) => addresses.map((address) => `${chainId}:${address}`))
-      .join(',')
+  const safeIds = useMemo(() => {
+    if (!spaceSafes?.safes) return []
+    return Object.entries(spaceSafes.safes).flatMap(([chainId, addresses]: [string, string[]]) =>
+      addresses.map((address) => `${chainId}:${address}`),
+    )
   }, [spaceSafes?.safes])
 
-  const { currentData: overviews, isLoading: isLoadingOverviews } = useSafesGetSafeOverviewV1Query(
-    { currency, safes: safesParam, trusted: true, excludeSpam: true },
-    { skip: !safesParam },
+  const { currentData: overviews, isLoading: isLoadingOverviews } = useSafesGetOverviewForManyQuery(
+    { currency, safes: safeIds, trusted: true },
+    { skip: safeIds.length === 0 },
   )
 
   const safesWithQueue = useMemo(() => {

--- a/apps/web/src/features/spaces/hooks/useSpaceSafesWithQueue.ts
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafesWithQueue.ts
@@ -1,34 +1,23 @@
 import { useMemo } from 'react'
-import { useSpaceSafesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
-import { useSafesGetOverviewForManyQuery } from '@safe-global/store/gateway/safes'
-import { useCurrentSpaceId } from './useCurrentSpaceId'
 import { useAppSelector } from '@/store'
-import { isAuthenticated } from '@/store/authSlice'
+import { useGetMultipleSafeOverviewsQuery } from '@/store/api/gateway'
 import { selectCurrency } from '@/store/settingsSlice'
+import { flattenSafeItems } from '@/hooks/safes'
+import { useSpaceSafes } from './useSpaceSafes'
 
 type SafePair = { chainId: string; address: string }
 
 export const useSpaceSafesWithQueue = () => {
-  const spaceId = useCurrentSpaceId()
-  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { allSafes, isLoading: isLoadingSafes } = useSpaceSafes()
   const currency = useAppSelector(selectCurrency)
 
-  const { currentData: spaceSafes, isFetching: isLoadingSafes } = useSpaceSafesGetV1Query(
-    { spaceId: spaceId ?? '' },
-    { skip: !isUserSignedIn || !spaceId },
-  )
-
-  const safeIds = useMemo(() => {
-    if (!spaceSafes?.safes) return []
-    return Object.entries(spaceSafes.safes).flatMap(([chainId, addresses]: [string, string[]]) =>
-      addresses.map((address) => `${chainId}:${address}`),
-    )
-  }, [spaceSafes?.safes])
-
-  const { currentData: overviews, isLoading: isLoadingOverviews } = useSafesGetOverviewForManyQuery(
-    { currency, safes: safeIds, trusted: true },
-    { skip: safeIds.length === 0 },
-  )
+  // Same args as AggregatedBalance so both subscribe to the same cache entry —
+  // the dashboard then only fetches overviews once.
+  const safeItems = useMemo(() => flattenSafeItems(allSafes), [allSafes])
+  const { data: overviews, isLoading: isLoadingOverviews } = useGetMultipleSafeOverviewsQuery({
+    safes: safeItems,
+    currency,
+  })
 
   const safesWithQueue = useMemo(() => {
     if (!overviews) return []


### PR DESCRIPTION
> One dashboard, one overview sweep —
> the queue widget now reads the cache
> the balance header already filled,
> and v1/safes loses its last caller.

## What it solves

The space dashboard fetched Safe overviews **twice** on every load: once via the batched `/v2/safes` fetcher (aggregated balance header, account cards) and once more via the legacy `GET /v1/safes` endpoint (`useSpaceSafesWithQueue`, feeding the pending-transactions widget) — same safes, same data, two endpoints, two caches.

Resolves: N/A (no Linear issue)

## How this PR fixes it

`useSpaceSafesWithQueue` now derives its safe list from `useSpaceSafes()` (same RTK subscription the dashboard already holds) and subscribes to `useGetMultipleSafeOverviewsQuery` with the same args as `AggregatedBalance` — so both resolve to the same cache entry and the dashboard issues a single batched `/v2/safes` sweep. Even if args ever drift, the `SafeOverviewFetcher`'s 300ms batching window still coalesces the requests at the network level.

Behavior notes:
- The hook only reads `queued`/`chainId`/`address`; the queue computation is identical in v1 and v2, so the widget's output is unchanged.
- The implicit `trusted` flag flips `true` → `false` (the batched fetcher's value, chosen in #4495 because chains without default token lists return `fiatTotal: 0` with `trusted: true`). No effect here since `fiatTotal` is unused.
- Side improvement: the overview data behind the pending-tx widget now participates in `SafeOverviews` tag invalidation, so it refreshes after transactions instead of staying stale.

## How to test it

1. Sign in to a space that has safes with pending (queued) transactions.
2. Open the space dashboard — pending transactions widget shows the same safes/transactions as before.
3. In devtools, verify there is a single set of `GET /v2/safes` requests on dashboard load and **no** request to `GET /v1/safes`.

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    AB1[AggregatedBalance] --> F1[batched fetcher] --> V2a[GET /v2/safes]
    Q1[useSpaceSafesWithQueue] -->|separate fetch, same safes| V1[GET /v1/safes]
  end
  subgraph After
    AB2[AggregatedBalance] --> C[shared getMultipleSafeOverviews cache]
    Q2[useSpaceSafesWithQueue] --> C
    C --> F2[batched fetcher] --> V2b[GET /v2/safes]
  end
```

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — hook unit tests rewritten

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).