### PR TITLE
tests: align stale AddAccountsChooser "Create new Safe" assertion (WA-2559)

### DIFF
--- a/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
+++ b/apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx
@@ -192,7 +192,10 @@ describe('AddAccountsChooser', () => {
     fireEvent.click(screen.getByTestId('add-space-account-button'))
     fireEvent.click(screen.getByText('Create new Safe'))
 
-    expect(mockPush).toHaveBeenCalledWith('/new-safe/create')
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: '/new-safe/create',
+      query: { next: '/spaces?spaceId=1' },
+    })
   })
 
   it('lets non-admin members open AccountsModal from "See all Safe accounts"', () => {


### PR DESCRIPTION
> Two PRs merged clean, no conflict in sight,
> but the meaning collided out of view —
> object push meets string assert, suite goes red;
> one assertion realigned, and green's restored.

## What it solves

Resolves: [WA-2559](https://linear.app/safe-global/issue/WA-2559/fix-failing-unit-test-addaccountschooser-stale-create-new-safe)

A unit test fails on `dev` (clean working tree — not introduced by any local change):

```
Test Suites: 1 failed, 662 passed, 663 total
Tests:       1 failed, 6119 passed, 6120 total
```

**Failing test:** `AddAccountsChooser › still navigates to /new-safe/create when at the limit (creation is never blocked)`
**File:** `apps/web/src/features/spaces/components/AddAccountsChooser/__tests__/AddAccountsChooser.test.tsx:195`

```
Expected: "/new-safe/create"
Received: {"pathname": "/new-safe/create", "query": {"next": "/spaces?spaceId=1"}}
```

This is a **semantic (silent) merge conflict** between two individually-green PRs:

- **#8056** changed `handleCreate` in `AddAccountsChooser/index.tsx` to push a router object with a `next` redirect (`{ pathname, query: { next } }`) and updated the **two** string assertions that existed in its base.
- **#8064** had, in parallel, added a **third** test (the at-limit case) asserting the old string form `'/new-safe/create'`.

The back-merge combined them with no textual conflict (the at-limit block is new lines; #8056 edited different lines), but the merged result is logically inconsistent: the component now pushes an object while the at-limit test still asserts a string. Neither PR's CI ever ran the merged tree, so the failure landed silently on `dev`.

## How this PR fixes it

Aligns the at-limit assertion (line 195) with the object form already asserted by its two sibling tests (lines 155 and 215), matching what the component actually pushes:

```diff
-    expect(mockPush).toHaveBeenCalledWith('/new-safe/create')
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: '/new-safe/create',
+      query: { next: '/spaces?spaceId=1' },
+    })
```

No production code changes — the component behavior introduced by #8056 is correct and unchanged.

## How to test it

```bash
yarn workspace @safe-global/web test AddAccountsChooser
```

Expected: `Tests: 23 passed, 23 total`. Full web Jest suite: 0 failures.

## Affected flows

- "Create new Safe" from the AddAccountsChooser when a workspace is at its Safe limit — behavior unchanged; this only re-aligns the test to the existing `next`-redirect navigation.

## Blast radius

- Test-only change. One assertion in one `*.test.tsx` file.
- No shared hooks/components/selectors/slices, no RTK Query endpoints, no feature flags, no routes, no persisted state touched.
- No mobile impact (no shared package touched).

## Risks / not checked

- Did not change or re-verify the production navigation behavior itself (owned by #8056); only the test expectation.
- Did not run the full suite in CI from this branch (verified the targeted suite locally + full suite locally on `dev`).

## Visual summary

```mermaid
flowchart TB
  subgraph P8064["#8064 (parallel PR, CI green)"]
    A1["component pushes STRING"]
    A2["adds at-limit test<br/>asserts STRING ✅"]
  end
  subgraph P8056["#8056 (parallel PR, CI green)"]
    B1["component → pushes OBJECT { pathname, query.next }"]
    B2["updates the 2 string asserts it can see → OBJECT ✅"]
  end
  M["back-merge: clean text merge<br/>(different lines, no conflict)"]
  R["Merged dev:<br/>component=OBJECT, at-limit test=STRING ❌<br/>(no CI ran this combined tree)"]
  F["This PR: at-limit assert → OBJECT ✅<br/>23/23 pass"]
  P8064 --> M
  P8056 --> M
  M --> R
  R --> F
```

## Checklist

- [ ] I've tested the branch on mobile 📱 — N/A (web test-only change)
- [ ] I've documented how it affects the analytics (if at all) 📊 — N/A (no analytics impact)
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻 — this PR fixes the existing unit test
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough 🎬 — N/A (no behavior change; test-only fix)
---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
