### PR TITLE
fix: Accounts and Pending on same horizontal line

### DIFF
--- a/apps/web/src/features/spaces/components/SafeWidget/SafeWidgetRoot.tsx
+++ b/apps/web/src/features/spaces/components/SafeWidget/SafeWidgetRoot.tsx
@@ -27,7 +27,7 @@ const SafeWidgetRoot = ({
       className={cn('flex h-full min-h-0 flex-col rounded-xl bg-card p-1', className)}
     >
       <div className="flex shrink-0 items-center px-6 justify-between pb-3 pt-6">
-        <div className={cn('flex items-center', onTitleClick && 'cursor-pointer')} onClick={onTitleClick}>
+        <div className={cn('flex min-h-10 items-center', onTitleClick && 'cursor-pointer')} onClick={onTitleClick}>
           <Typography variant="h4">{title}</Typography>
         </div>
         {action && <div className="flex items-center">{action}</div>}


### PR DESCRIPTION
Current alignment of "Accounts" and "Pending" headlines of islands on dashboard (screenshot from staging)

<img width="801" height="166" alt="Screenshot 2026-06-12 at 14 14 26" src="https://github.com/user-attachments/assets/f440ea56-01f0-4370-8091-be5bd04796c9" />

## Screenshot of proposed fix

<img width="950" height="452" alt="Screenshot 2026-06-12 at 14 15 51" src="https://github.com/user-attachments/assets/d399f6fa-5e24-4ba4-bf02-baedadf6c369" />
