### PR TITLE
fix: refetch space data on window focus and stale remounts

### DIFF
--- a/apps/web/src/features/spaces/components/AuthState/index.test.tsx
+++ b/apps/web/src/features/spaces/components/AuthState/index.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react'
 import AuthState from './index'
+import { SPACE_REFRESH_OPTIONS } from '../../hooks/refreshOptions'
 
 const mockUseSpacesGetOneV1Query = jest.fn()
 const mockUseUsersGetWithWalletsV1Query = jest.fn()
@@ -81,7 +82,7 @@ describe('AuthState', () => {
       </AuthState>,
     )
 
-    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true, ...SPACE_REFRESH_OPTIONS })
   })
 
   it('skips the space query when spaceId is empty', () => {
@@ -92,7 +93,7 @@ describe('AuthState', () => {
     )
 
     // Without the guard, Number('') would be 0 and the query would hit /v1/spaces/0
-    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true, ...SPACE_REFRESH_OPTIONS })
   })
 
   it('skips the space query when spaceId is null at runtime (Number(null) is 0)', () => {
@@ -102,7 +103,7 @@ describe('AuthState', () => {
       </AuthState>,
     )
 
-    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true, ...SPACE_REFRESH_OPTIONS })
   })
 
   it('skips the space query when spaceId is undefined at runtime', () => {
@@ -112,7 +113,7 @@ describe('AuthState', () => {
       </AuthState>,
     )
 
-    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true, ...SPACE_REFRESH_OPTIONS })
   })
 
   it('fires the space query with the uuid when authenticated and spaceId is set', () => {
@@ -124,7 +125,7 @@ describe('AuthState', () => {
 
     expect(mockUseSpacesGetOneV1Query).toHaveBeenCalledWith(
       { id: '11111111-1111-1111-1111-111111111111' },
-      { skip: false },
+      { skip: false, ...SPACE_REFRESH_OPTIONS },
     )
   })
 })

--- a/apps/web/src/features/spaces/components/AuthState/index.tsx
+++ b/apps/web/src/features/spaces/components/AuthState/index.tsx
@@ -7,6 +7,7 @@ import { useAppDispatch, useAppSelector } from '@/store'
 import { isAuthenticated, selectIsOidcLoginPending, setLastUsedSpace } from '@/store/authSlice'
 import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+import { SPACE_REFRESH_OPTIONS } from '../../hooks/refreshOptions'
 import { MemberStatus } from '@/features/spaces'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@safe-global/utils/utils/chains'
@@ -17,7 +18,7 @@ const AuthState = ({ spaceId, children }: { spaceId: string; children: ReactNode
   const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
   const { currentData, error, isLoading } = useSpacesGetOneV1Query(
     { id: spaceId },
-    { skip: !isUserSignedIn || !spaceId },
+    { skip: !isUserSignedIn || !spaceId, ...SPACE_REFRESH_OPTIONS },
   )
   const isSpacesFeatureEnabled = useHasFeature(FEATURES.SPACES)
   const isOidcLoginPending = useAppSelector(selectIsOidcLoginPending)

--- a/apps/web/src/features/spaces/hooks/__tests__/useAllMembers.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useAllMembers.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import { useSpaceMembersByStatus, useCurrentMembership } from '../useSpaceMembers'
+import { SPACE_REFRESH_OPTIONS } from '../refreshOptions'
 const MOCK_SPACE_UUID = '11111111-1111-1111-1111-111111111111'
 const MOCK_SPACE_UUID_ALT = '22222222-2222-2222-2222-222222222222'
 
@@ -45,7 +46,10 @@ describe('useAllMembers (via useSpaceMembersByStatus / useCurrentMembership)', (
 
     renderHook(() => useSpaceMembersByStatus())
 
-    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), {
+      skip: true,
+      ...SPACE_REFRESH_OPTIONS,
+    })
   })
 
   it('skips the members query when there is no current spaceId', () => {
@@ -53,7 +57,10 @@ describe('useAllMembers (via useSpaceMembersByStatus / useCurrentMembership)', (
 
     renderHook(() => useSpaceMembersByStatus())
 
-    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(expect.anything(), {
+      skip: true,
+      ...SPACE_REFRESH_OPTIONS,
+    })
   })
 
   it('fires the members query with the spaceId when authenticated and spaceId is set', () => {
@@ -61,7 +68,10 @@ describe('useAllMembers (via useSpaceMembersByStatus / useCurrentMembership)', (
 
     renderHook(() => useSpaceMembersByStatus())
 
-    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith({ spaceId: MOCK_SPACE_UUID }, { skip: false })
+    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(
+      { spaceId: MOCK_SPACE_UUID },
+      { skip: false, ...SPACE_REFRESH_OPTIONS },
+    )
   })
 
   it('prefers the explicit spaceId arg over the current spaceId', () => {
@@ -69,6 +79,9 @@ describe('useAllMembers (via useSpaceMembersByStatus / useCurrentMembership)', (
 
     renderHook(() => useCurrentMembership(MOCK_SPACE_UUID_ALT))
 
-    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith({ spaceId: MOCK_SPACE_UUID_ALT }, { skip: false })
+    expect(mockUseMembersGetUsersV1Query).toHaveBeenCalledWith(
+      { spaceId: MOCK_SPACE_UUID_ALT },
+      { skip: false, ...SPACE_REFRESH_OPTIONS },
+    )
   })
 })

--- a/apps/web/src/features/spaces/hooks/__tests__/useAllMembers.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useAllMembers.test.ts
@@ -84,4 +84,31 @@ describe('useAllMembers (via useSpaceMembersByStatus / useCurrentMembership)', (
       { skip: false, ...SPACE_REFRESH_OPTIONS },
     )
   })
+
+  describe('revoked membership (failed refetch)', () => {
+    const staleMembers = [
+      { status: 'ACTIVE', user: { id: 'u1' } },
+      { status: 'INVITED', user: { id: 'u2' } },
+    ]
+
+    it.each([403, 404])('drops access when the refetch returns %i, ignoring stale data', (status) => {
+      mockUseCurrentSpaceId.mockReturnValue(MOCK_SPACE_UUID)
+      mockUseMembersGetUsersV1Query.mockReturnValue({ data: { members: staleMembers }, error: { status } })
+
+      const { result } = renderHook(() => useSpaceMembersByStatus())
+
+      expect(result.current.activeMembers).toEqual([])
+      expect(result.current.invitedMembers).toEqual([])
+    })
+
+    it('keeps the stale member list on a transient error so a blip does not drop access', () => {
+      mockUseCurrentSpaceId.mockReturnValue(MOCK_SPACE_UUID)
+      mockUseMembersGetUsersV1Query.mockReturnValue({ data: { members: staleMembers }, error: { status: 500 } })
+
+      const { result } = renderHook(() => useSpaceMembersByStatus())
+
+      expect(result.current.activeMembers).toHaveLength(1)
+      expect(result.current.invitedMembers).toHaveLength(1)
+    })
+  })
 })

--- a/apps/web/src/features/spaces/hooks/__tests__/useGetSpaceAddressBook.test.ts
+++ b/apps/web/src/features/spaces/hooks/__tests__/useGetSpaceAddressBook.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import useGetSpaceAddressBook from '../useGetSpaceAddressBook'
+import { SPACE_REFRESH_OPTIONS } from '../refreshOptions'
 const MOCK_SPACE_UUID = '11111111-1111-1111-1111-111111111111'
 
 const mockUseCurrentSpaceId = jest.fn()
@@ -36,7 +37,10 @@ describe('useGetSpaceAddressBook', () => {
 
     renderHook(() => useGetSpaceAddressBook())
 
-    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), {
+      skip: true,
+      ...SPACE_REFRESH_OPTIONS,
+    })
   })
 
   it('skips the query when there is no current spaceId', () => {
@@ -44,7 +48,10 @@ describe('useGetSpaceAddressBook', () => {
 
     renderHook(() => useGetSpaceAddressBook())
 
-    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), {
+      skip: true,
+      ...SPACE_REFRESH_OPTIONS,
+    })
   })
 
   it('skips the query when spaceId is an empty string', () => {
@@ -52,7 +59,10 @@ describe('useGetSpaceAddressBook', () => {
 
     renderHook(() => useGetSpaceAddressBook())
 
-    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(expect.anything(), {
+      skip: true,
+      ...SPACE_REFRESH_OPTIONS,
+    })
   })
 
   it('fires the query with the spaceId when authenticated and spaceId is set', () => {
@@ -62,7 +72,7 @@ describe('useGetSpaceAddressBook', () => {
 
     expect(mockUseAddressBooksGetAddressBookItemsV1Query).toHaveBeenCalledWith(
       { spaceId: MOCK_SPACE_UUID },
-      { skip: false },
+      { skip: false, ...SPACE_REFRESH_OPTIONS },
     )
   })
 

--- a/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import { useSpaceSafes } from '../useSpaceSafes'
+import { SPACE_REFRESH_OPTIONS } from '../refreshOptions'
 const MOCK_SPACE_UUID = '11111111-1111-1111-1111-111111111111'
 
 const mockUseCurrentSpaceId = jest.fn()
@@ -78,7 +79,10 @@ describe('useSpaceSafes', () => {
 
     renderHook(() => useSpaceSafes())
 
-    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(expect.anything(), {
+      skip: true,
+      ...SPACE_REFRESH_OPTIONS,
+    })
   })
 
   it('skips the query when there is no current spaceId', () => {
@@ -86,7 +90,10 @@ describe('useSpaceSafes', () => {
 
     renderHook(() => useSpaceSafes())
 
-    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(expect.anything(), { skip: true })
+    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(expect.anything(), {
+      skip: true,
+      ...SPACE_REFRESH_OPTIONS,
+    })
   })
 
   it('fires the query when authenticated and spaceId is set', () => {
@@ -94,6 +101,9 @@ describe('useSpaceSafes', () => {
 
     renderHook(() => useSpaceSafes())
 
-    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith({ spaceId: MOCK_SPACE_UUID }, { skip: false })
+    expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith(
+      { spaceId: MOCK_SPACE_UUID },
+      { skip: false, ...SPACE_REFRESH_OPTIONS },
+    )
   })
 })

--- a/apps/web/src/features/spaces/hooks/refreshOptions.ts
+++ b/apps/web/src/features/spaces/hooks/refreshOptions.ts
@@ -1,0 +1,12 @@
+/**
+ * Refresh options for space queries whose data can change in other sessions
+ * (e.g. an admin adds/removes accounts, members or contacts).
+ *
+ * - `refetchOnFocus` refetches when the window/tab regains focus.
+ * - `refetchOnMountOrArgChange` refetches on new subscriptions (page navigation)
+ *   when the cached data is older than the given number of seconds.
+ */
+export const SPACE_REFRESH_OPTIONS = {
+  refetchOnFocus: true,
+  refetchOnMountOrArgChange: 30,
+} as const

--- a/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
+++ b/apps/web/src/features/spaces/hooks/useGetSpaceAddressBook.ts
@@ -2,13 +2,14 @@ import { useCurrentSpaceId } from './useCurrentSpaceId'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import { useAddressBooksGetAddressBookItemsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+import { SPACE_REFRESH_OPTIONS } from './refreshOptions'
 
 const useGetSpaceAddressBook = () => {
   const spaceId = useCurrentSpaceId()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: addressBook } = useAddressBooksGetAddressBookItemsV1Query(
     { spaceId: spaceId ?? '' },
-    { skip: !isUserSignedIn || !spaceId },
+    { skip: !isUserSignedIn || !spaceId, ...SPACE_REFRESH_OPTIONS },
   )
 
   return addressBook?.data || []

--- a/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
@@ -5,6 +5,7 @@ import {
 } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useAuthGetMeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
 import { useCurrentSpaceId } from './useCurrentSpaceId'
+import { SPACE_REFRESH_OPTIONS } from './refreshOptions'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
@@ -38,7 +39,7 @@ const useAllMembers = (spaceId?: string) => {
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { data: currentData } = useMembersGetUsersV1Query(
     { spaceId: actualSpaceId ?? '' },
-    { skip: !isUserSignedIn || !actualSpaceId },
+    { skip: !isUserSignedIn || !actualSpaceId, ...SPACE_REFRESH_OPTIONS },
   )
   return currentData?.members || []
 }

--- a/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceMembers.tsx
@@ -4,11 +4,18 @@ import {
   type MemberDto,
 } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import { useAuthGetMeV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/auth'
+import type { FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import type { SerializedError } from '@reduxjs/toolkit'
 import { useCurrentSpaceId } from './useCurrentSpaceId'
 import { SPACE_REFRESH_OPTIONS } from './refreshOptions'
 import { useAppSelector } from '@/store'
 import { isAuthenticated } from '@/store/authSlice'
 import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/users'
+
+// A revoked membership makes the members endpoint return 403, a deleted space 404. Both mean the
+// caller no longer has access. Transient errors (5xx/network) are excluded so a blip doesn't drop access.
+const isMembershipRevoked = (error: FetchBaseQueryError | SerializedError | undefined): boolean =>
+  !!error && 'status' in error && (error.status === 403 || error.status === 404)
 
 export enum MemberStatus {
   INVITED = 'INVITED',
@@ -37,11 +44,14 @@ const useAllMembers = (spaceId?: string) => {
   const currentSpaceId = useCurrentSpaceId()
   const actualSpaceId = spaceId ?? currentSpaceId
   const isUserSignedIn = useAppSelector(isAuthenticated)
-  const { data: currentData } = useMembersGetUsersV1Query(
+  const { data, error } = useMembersGetUsersV1Query(
     { spaceId: actualSpaceId ?? '' },
     { skip: !isUserSignedIn || !actualSpaceId, ...SPACE_REFRESH_OPTIONS },
   )
-  return currentData?.members || []
+  // RTK keeps the last successful `data` on a failed refetch. When our membership is revoked in
+  // another session the refetch 403s, so drop access instead of returning the stale member list.
+  if (isMembershipRevoked(error)) return []
+  return data?.members || []
 }
 
 export const useSpaceMembersByStatus = () => {

--- a/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
@@ -2,6 +2,7 @@ import { useSpaceSafesGetV1Query } from '@safe-global/store/gateway/AUTO_GENERAT
 import { _buildSafeItems, type AllSafeItems, useAllSafesGrouped, useAllOwnedSafes, getComparator } from '@/hooks/safes'
 import { useCurrentSpaceId } from './useCurrentSpaceId'
 import useGetSpaceAddressBook from './useGetSpaceAddressBook'
+import { SPACE_REFRESH_OPTIONS } from './refreshOptions'
 import { mapSpaceContactsToAddressBookState } from '../utils'
 import { useAppSelector } from '@/store'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
@@ -18,7 +19,10 @@ export const useSpaceSafes = () => {
     isError: isSpaceSafesError,
     error: spaceSafesError,
     refetch: refetchSpaceSafes,
-  } = useSpaceSafesGetV1Query({ spaceId: spaceId ?? '' }, { skip: !isUserSignedIn || !spaceId })
+  } = useSpaceSafesGetV1Query(
+    { spaceId: spaceId ?? '' },
+    { skip: !isUserSignedIn || !spaceId, ...SPACE_REFRESH_OPTIONS },
+  )
   const spaceContacts = useGetSpaceAddressBook()
 
   // We are doing this in order to reuse the _buildSafeItems function but only take space contacts into account


### PR DESCRIPTION
> Stale space lists linger on,
> now focus and fresh mounts refetch —
> accounts, members, contacts current.

## What it solves

Workspace data (accounts, members/invites, space address book) edited by an admin in one session stayed stale in other members' sessions until a full page reload — RTK Query's tag invalidation is local to the store that ran the mutation, and no refetch triggers were configured.

Resolves: https://linear.app/safe-global/issue/WA-2564/workspace-changes-require-manual-refresh-in-other-sessions

## How this PR fixes it

Adds a shared `SPACE_REFRESH_OPTIONS` constant (`refetchOnFocus: true`, `refetchOnMountOrArgChange: 30`) applied to the three queries where staleness is harmful: space safes, members, and the space address book.

Non-obvious decisions:

- `refetchOnMountOrArgChange: 30` is a staleness threshold checked only on new subscriptions (page navigation), **not** polling — zero background traffic.
- The spaces sidebar shares the `spaceSafesGetV1` cache entry, so it freshens for free; `SpaceSelectorDropdown` (other spaces' safes, different cache keys) is deliberately left on cache-only behavior.
- All call sites keep serving previous data during refetch, so lists and `useIsAdmin` permission gates don't flash empty.
- Known accepted gap: a user staring at the page without a focus change or navigation still sees stale data (would need polling/push, out of scope per ticket severity).

## How to test it

1. Log in to the same space as admin (browser A) and member (browser B).
2. In browser A, remove a Safe account / add a contact / invite a member.
3. Switch to browser B — the focus event alone should refresh the lists (no reload).
4. In browser B, navigate away from e.g. the address book, wait >30s, navigate back — data refetches.

## Visual summary

```mermaid
flowchart LR
  A[Window refocus] -->|refetchOnFocus| Q
  B[Page navigation<br/>data older than 30s] -->|refetchOnMountOrArgChange| Q
  C[Own mutation] -->|invalidatesTags 'spaces'| Q
  Q[spaceSafes / members /<br/>space address book queries] --> D[Fresh data,<br/>previous data shown while fetching]
```

## Screenshots

N/A - no UI changes

## Checklist

- [ ] I've tested the branch on mobile 📱
- [x] I've documented how it affects the analytics (if at all) 📊 — no analytics impact
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
