### PR TITLE
fix(web/Spaces): disable CF safes in Swap popup; new Logout btn; add redirect after leaving workspace; minor UI fixes

### DIFF
--- a/apps/web/src/components/common/SpaceSafeBar/SpaceBackLink.test.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceBackLink.test.tsx
@@ -7,7 +7,7 @@ jest.mock('@/utils/colors', () => ({
 }))
 
 describe('SpaceBackLink', () => {
-  const mockSpace = { id: 42, name: 'Acme Corp' }
+  const mockSpace = { name: 'Acme Corp' }
 
   it('renders the first letter of the space name uppercased', () => {
     render(<SpaceBackLink space={mockSpace} onClick={jest.fn()} />)
@@ -30,13 +30,13 @@ describe('SpaceBackLink', () => {
   })
 
   it('handles single-character space name', () => {
-    render(<SpaceBackLink space={{ id: 1, name: 'X' }} onClick={jest.fn()} />)
+    render(<SpaceBackLink space={{ name: 'X' }} onClick={jest.fn()} />)
 
     expect(screen.getByText('X')).toBeInTheDocument()
   })
 
   it('handles lowercase space name by uppercasing the initial', () => {
-    render(<SpaceBackLink space={{ id: 1, name: 'hello' }} onClick={jest.fn()} />)
+    render(<SpaceBackLink space={{ name: 'hello' }} onClick={jest.fn()} />)
 
     expect(screen.getByText('H')).toBeInTheDocument()
   })

--- a/apps/web/src/components/common/SpaceSafeBar/SpaceBackLink.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/SpaceBackLink.tsx
@@ -1,9 +1,10 @@
+import type { GetSpaceResponse } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
 import BackLink from '@/components/common/BackLink'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { getDeterministicColor } from '@/utils/colors'
 
 type SpaceBackLinkProps = {
-  space: { id: number; name: string }
+  space: Pick<GetSpaceResponse, 'name'>
   onClick: () => void
 }
 

--- a/apps/web/src/features/spaces/components/AuthState/index.test.tsx
+++ b/apps/web/src/features/spaces/components/AuthState/index.test.tsx
@@ -5,8 +5,14 @@ const mockUseSpacesGetOneV1Query = jest.fn()
 const mockUseUsersGetWithWalletsV1Query = jest.fn()
 const mockUseHasFeature = jest.fn()
 const mockDispatch = jest.fn()
+const mockReplace = jest.fn()
+const mockIsUnauthorized = jest.fn()
 let mockIsAuthenticated = true
 let mockIsOidcLoginPending = false
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}))
 
 jest.mock('@/store', () => ({
   useAppSelector: (selector: string) => {
@@ -51,7 +57,11 @@ jest.mock('../LoadingState', () => ({
 }))
 
 jest.mock('@/features/spaces/utils', () => ({
-  isUnauthorized: () => false,
+  isUnauthorized: (...args: unknown[]) => mockIsUnauthorized(...args),
+}))
+
+jest.mock('@/config/routes', () => ({
+  AppRoutes: { welcome: { spaces: '/welcome/spaces' } },
 }))
 
 jest.mock('@/features/spaces', () => ({
@@ -63,6 +73,7 @@ describe('AuthState', () => {
     jest.clearAllMocks()
     mockIsAuthenticated = true
     mockIsOidcLoginPending = false
+    mockIsUnauthorized.mockReturnValue(false)
     mockUseHasFeature.mockReturnValue(true)
     mockUseSpacesGetOneV1Query.mockReturnValue({
       currentData: { id: 1, members: [] },
@@ -126,5 +137,75 @@ describe('AuthState', () => {
       { id: '11111111-1111-1111-1111-111111111111' },
       { skip: false },
     )
+  })
+
+  it('redirects to the spaces overview when the space query is unauthorized', () => {
+    mockIsUnauthorized.mockReturnValue(true)
+    mockUseSpacesGetOneV1Query.mockReturnValue({ currentData: undefined, error: { status: 404 }, isLoading: false })
+
+    const { queryByTestId } = render(
+      <AuthState spaceId="7">
+        <div data-testid="children" />
+      </AuthState>,
+    )
+
+    expect(mockReplace).toHaveBeenCalledWith('/welcome/spaces')
+    expect(queryByTestId('children')).toBeNull()
+    expect(queryByTestId('unauthorized')).not.toBeNull()
+  })
+
+  it('redirects to the spaces overview when the current user has declined membership', () => {
+    mockUseSpacesGetOneV1Query.mockReturnValue({
+      currentData: { id: 1, members: [{ user: { id: 'u1' }, status: 'DECLINED' }] },
+      error: undefined,
+      isLoading: false,
+    })
+
+    render(
+      <AuthState spaceId="7">
+        <div data-testid="children" />
+      </AuthState>,
+    )
+
+    expect(mockReplace).toHaveBeenCalledWith('/welcome/spaces')
+  })
+
+  it('does not redirect while the space query is still loading', () => {
+    mockIsUnauthorized.mockReturnValue(true)
+    mockUseSpacesGetOneV1Query.mockReturnValue({ currentData: undefined, error: undefined, isLoading: true })
+
+    const { queryByTestId } = render(
+      <AuthState spaceId="7">
+        <div data-testid="children" />
+      </AuthState>,
+    )
+
+    expect(mockReplace).not.toHaveBeenCalled()
+    expect(queryByTestId('loading')).not.toBeNull()
+  })
+
+  it('does not redirect when the user is signed out', () => {
+    mockIsAuthenticated = false
+    mockIsUnauthorized.mockReturnValue(true)
+
+    const { queryByTestId } = render(
+      <AuthState spaceId="7">
+        <div data-testid="children" />
+      </AuthState>,
+    )
+
+    expect(mockReplace).not.toHaveBeenCalled()
+    expect(queryByTestId('signed-out')).not.toBeNull()
+  })
+
+  it('does not redirect when the user is still authorized', () => {
+    const { queryByTestId } = render(
+      <AuthState spaceId="7">
+        <div data-testid="children" />
+      </AuthState>,
+    )
+
+    expect(mockReplace).not.toHaveBeenCalled()
+    expect(queryByTestId('children')).not.toBeNull()
   })
 })

--- a/apps/web/src/features/spaces/components/AuthState/index.tsx
+++ b/apps/web/src/features/spaces/components/AuthState/index.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useEffect } from 'react'
+import { useRouter } from 'next/router'
 import SignedOutState from '../SignedOutState'
 import { isUnauthorized } from '@/features/spaces/utils'
 import UnauthorizedState from '../UnauthorizedState'
@@ -10,8 +11,10 @@ import { useUsersGetWithWalletsV1Query } from '@safe-global/store/gateway/AUTO_G
 import { MemberStatus } from '@/features/spaces'
 import { useHasFeature } from '@/hooks/useChains'
 import { FEATURES } from '@safe-global/utils/utils/chains'
+import { AppRoutes } from '@/config/routes'
 
 const AuthState = ({ spaceId, children }: { spaceId: string; children: ReactNode }) => {
+  const router = useRouter()
   const dispatch = useAppDispatch()
   const isUserSignedIn = useAppSelector(isAuthenticated)
   const { currentData: currentUser } = useUsersGetWithWalletsV1Query(undefined, { skip: !isUserSignedIn })
@@ -26,17 +29,26 @@ const AuthState = ({ spaceId, children }: { spaceId: string; children: ReactNode
     (member) => member.user.id === currentUser?.id && member.status === MemberStatus.DECLINED,
   )
 
+  const isLoadingState = isLoading || isOidcLoginPending
+  const hasLostAccess = isUserSignedIn && !isLoadingState && (isUnauthorized(error) || isCurrentUserDeclined)
+
   useEffect(() => {
     dispatch(setLastUsedSpace(spaceId))
   }, [dispatch, spaceId])
 
+  useEffect(() => {
+    if (hasLostAccess) {
+      router.replace(AppRoutes.welcome.spaces)
+    }
+  }, [hasLostAccess, router])
+
   if (!isSpacesFeatureEnabled) return null
 
-  if (isLoading || isOidcLoginPending) return <LoadingState />
+  if (isLoadingState) return <LoadingState />
 
   if (!isUserSignedIn) return <SignedOutState />
 
-  if (isUnauthorized(error) || isCurrentUserDeclined) return <UnauthorizedState />
+  if (hasLostAccess) return <UnauthorizedState />
 
   return children
 }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Button } from '@/components/ui/button'
 import { useSafeNameResolver } from '@/hooks/useAllAddressBooks'
 import { useBottomScrollFade } from '@/hooks/useBottomScrollFade'
+import useWallet from '@/hooks/wallets/useWallet'
 import SafeItem from './SafeItem'
 import MultiChainSafeItemRow from './MultiChainSafeItemRow'
 import type { SafeItemData } from '../types'
@@ -78,6 +79,7 @@ const SafeDropdownContainer = ({
   const [search, setSearch] = useState('')
   const query = search.trim().toLowerCase()
   const resolveName = useSafeNameResolver()
+  const wallet = useWallet()
 
   // Multi-chain items stay visible even when currently selected so the user can expand and switch chains.
   const structuralItems = items.filter((item) => item.chains.length > 1 || item.id !== selectedItemId)
@@ -104,7 +106,11 @@ const SafeDropdownContainer = ({
     if (filteredItems.length === 0) {
       return (
         <p className="px-4 py-6 text-center text-sm text-muted-foreground" data-testid="dropdown-empty">
-          {query ? 'No safes match your search' : 'No safes yet'}
+          {query
+            ? 'No safes match your search'
+            : wallet
+              ? 'No safes yet'
+              : 'Connect a wallet to find your Safe Accounts'}
         </p>
       )
     }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
@@ -7,6 +7,12 @@ import type { SafeItemData } from '../../types'
 // Resolver is exercised in its own unit test; here we stub it so the component renders without a
 // store. Default behaviour mirrors production: the safe's own name wins, else the address-book name.
 const mockAddressBookNames: Record<string, string> = {}
+const mockUseWallet = jest.fn()
+jest.mock('@/hooks/wallets/useWallet', () => ({
+  __esModule: true,
+  default: () => mockUseWallet(),
+}))
+
 jest.mock('@/hooks/useAllAddressBooks', () => ({
   useSafeNameResolver:
     () =>
@@ -76,6 +82,28 @@ const fireScroll = (el: HTMLElement) => {
 }
 
 describe('SafeDropdownContainer', () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue({ address: '0x1234567890123456789012345678901234567890' })
+  })
+
+  describe('empty state', () => {
+    it('prompts to connect a wallet when there are no safes and no wallet is connected', () => {
+      mockUseWallet.mockReturnValue(null)
+
+      render(<SafeDropdownContainer items={[]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
+
+      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('Connect a wallet to find your Safe Accounts')
+    })
+
+    it('shows "No safes yet" when there are no safes but a wallet is connected', () => {
+      mockUseWallet.mockReturnValue({ address: '0x1234567890123456789012345678901234567890' })
+
+      render(<SafeDropdownContainer items={[]} onItemSelect={jest.fn()} closeDropdown={jest.fn()} />)
+
+      expect(screen.getByTestId('dropdown-empty')).toHaveTextContent('No safes yet')
+    })
+  })
+
   describe('footer', () => {
     it('renders the footer node when provided', () => {
       render(

--- a/apps/web/src/features/spaces/components/SelectSafeModal/__tests__/index.test.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafeModal/__tests__/index.test.tsx
@@ -1,0 +1,122 @@
+import { render } from '@/tests/test-utils'
+import SelectSafeModal from '../index'
+import { ESafeAction } from '@/features/spaces/store'
+import { FEATURES } from '@safe-global/utils/utils/chains'
+import type { SafeItem } from '@/hooks/safes'
+
+const SWAP_DISABLED_TOOLTIP = 'Swap is not supported on this chain. Try another chain.'
+const SWAP_DISABLED_CF_TOOLTIP = 'This account is not activated yet and cannot swap.'
+
+const deployedSafe: SafeItem = {
+  chainId: '1',
+  address: '0x0000000000000000000000000000000000000001',
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+}
+
+const cfSafe: SafeItem = {
+  chainId: '1',
+  address: '0x0000000000000000000000000000000000000002',
+  isReadOnly: false,
+  isPinned: false,
+  lastVisited: 0,
+  name: undefined,
+}
+
+const cardProps: Array<{ safe: SafeItem; disabled?: boolean; disabledTooltip?: string }> = []
+
+jest.mock('../../SafeAccounts/SafeCardReadOnly', () => ({
+  __esModule: true,
+  default: (props: { safe: SafeItem; disabled?: boolean; disabledTooltip?: string }) => {
+    cardProps.push({ safe: props.safe, disabled: props.disabled, disabledTooltip: props.disabledTooltip })
+    return null
+  },
+}))
+
+jest.mock('../useSafeActionMapper', () => ({
+  __esModule: true,
+  default: () => ({ actionMapper: {}, resetActiveSafe: jest.fn() }),
+}))
+
+const mockUseSpaceSafes = jest.fn()
+jest.mock('@/features/spaces', () => ({
+  __esModule: true,
+  useSpaceSafes: () => mockUseSpaceSafes(),
+}))
+
+const mockUseChains = jest.fn()
+jest.mock('@/hooks/useChains', () => ({
+  __esModule: true,
+  default: () => mockUseChains(),
+}))
+
+const renderModal = (actionType: ESafeAction, undeployedSafes: Record<string, Record<string, unknown>> = {}) =>
+  render(<SelectSafeModal />, {
+    initialReduxState: {
+      safeActionsModal: { opened: true, type: actionType },
+      undeployedSafes,
+    } as never,
+  })
+
+const chainWithSwap = {
+  chainId: '1',
+  chainName: 'Ethereum',
+  shortName: 'eth',
+  features: [FEATURES.NATIVE_SWAPS],
+}
+
+const chainWithoutSwap = {
+  chainId: '137',
+  chainName: 'Polygon',
+  shortName: 'matic',
+  features: [],
+}
+
+const getCardFor = (safe: SafeItem) => cardProps.find((c) => c.safe.address === safe.address)
+
+const cfState = (safe: SafeItem) => ({ [safe.chainId]: { [safe.address]: { status: {} } } })
+
+describe('SelectSafeModal swap disabling', () => {
+  beforeEach(() => {
+    cardProps.length = 0
+    mockUseChains.mockReturnValue({ configs: [chainWithSwap, chainWithoutSwap] })
+    mockUseSpaceSafes.mockReturnValue({ allSafes: [deployedSafe, cfSafe], isLoading: false })
+  })
+
+  it('disables a counterfactual safe with the activation tooltip for the swap action', () => {
+    renderModal(ESafeAction.Swap, cfState(cfSafe))
+
+    const card = getCardFor(cfSafe)
+    expect(card?.disabled).toBe(true)
+    expect(card?.disabledTooltip).toBe(SWAP_DISABLED_CF_TOOLTIP)
+  })
+
+  it('keeps a deployed safe on a swap-supported chain enabled', () => {
+    renderModal(ESafeAction.Swap, cfState(cfSafe))
+
+    const card = getCardFor(deployedSafe)
+    expect(card?.disabled).toBe(false)
+    expect(card?.disabledTooltip).toBeUndefined()
+  })
+
+  it('prefers the unsupported-chain tooltip over the counterfactual one', () => {
+    const cfOnUnsupportedChain: SafeItem = { ...cfSafe, chainId: '137' }
+    mockUseSpaceSafes.mockReturnValue({ allSafes: [cfOnUnsupportedChain], isLoading: false })
+
+    renderModal(ESafeAction.Swap, cfState(cfOnUnsupportedChain))
+
+    const card = getCardFor(cfOnUnsupportedChain)
+    expect(card?.disabled).toBe(true)
+    expect(card?.disabledTooltip).toBe(SWAP_DISABLED_TOOLTIP)
+  })
+
+  it('does not disable a counterfactual safe for non-swap actions', () => {
+    renderModal(ESafeAction.Send, cfState(cfSafe))
+
+    const card = getCardFor(cfSafe)
+    expect(card?.disabled).toBe(false)
+    expect(card?.disabledTooltip).toBeUndefined()
+  })
+})

--- a/apps/web/src/features/spaces/components/SelectSafeModal/index.tsx
+++ b/apps/web/src/features/spaces/components/SelectSafeModal/index.tsx
@@ -6,6 +6,7 @@ import useSearchFilter from '@/hooks/useSearchFilter'
 import useMatchSafe from '@/hooks/useMatchSafe'
 import useChains from '@/hooks/useChains'
 import { useAppDispatch, useAppSelector } from '@/store'
+import { selectUndeployedSafes } from '@/store/slices'
 import {
   ESafeAction,
   selectSafeActionsModalOpen,
@@ -21,6 +22,7 @@ import { safeModalTitles } from './constants'
 import { FEATURES, hasFeature } from '@safe-global/utils/utils/chains'
 
 const SWAP_DISABLED_TOOLTIP = 'Swap is not supported on this chain. Try another chain.'
+const SWAP_DISABLED_CF_TOOLTIP = 'This account is not activated yet and cannot swap.'
 
 const QrModal = dynamic(() => import('@/components/sidebar/QrCodeButton/QrModal'))
 
@@ -33,6 +35,7 @@ const SelectSafeModal = () => {
 
   const { allSafes, isLoading } = useSpaceSafes()
   const { configs: chains } = useChains()
+  const undeployedSafes = useAppSelector(selectUndeployedSafes)
   const flatSafes = useMemo(() => flattenSafeItems(allSafes), [allSafes])
   const matchSafe = useMatchSafe()
   const filteredSafes = useSearchFilter(flatSafes, query, matchSafe)
@@ -46,13 +49,15 @@ const SelectSafeModal = () => {
   }, [resetActiveSafe])
 
   const isSwapAction = actionType === ESafeAction.Swap
-  const isSwapDisabledForSafe = useCallback(
-    (safe: SafeItem) => {
-      if (!isSwapAction) return false
+  const getSwapDisabledTooltip = useCallback(
+    (safe: SafeItem): string | undefined => {
+      if (!isSwapAction) return undefined
       const chain = chains.find((c) => c.chainId === safe.chainId)
-      return !chain || !hasFeature(chain, FEATURES.NATIVE_SWAPS)
+      if (!chain || !hasFeature(chain, FEATURES.NATIVE_SWAPS)) return SWAP_DISABLED_TOOLTIP
+      if (undeployedSafes[safe.chainId]?.[safe.address]) return SWAP_DISABLED_CF_TOOLTIP
+      return undefined
     },
-    [isSwapAction, chains],
+    [isSwapAction, chains, undeployedSafes],
   )
 
   const handleClose = useCallback(() => {
@@ -93,7 +98,7 @@ const SelectSafeModal = () => {
               ) : (
                 <div className="flex flex-col gap-1.5">
                   {filteredSafes.map((safe) => {
-                    const disabled = isSwapDisabledForSafe(safe)
+                    const disabledTooltip = getSwapDisabledTooltip(safe)
                     return (
                       <SafeCardReadOnly
                         key={`${safe.chainId}:${safe.address}`}
@@ -101,8 +106,8 @@ const SelectSafeModal = () => {
                         hideContextMenu
                         showPending={false}
                         onClick={() => void handleSafeClick(safe)}
-                        disabled={disabled}
-                        disabledTooltip={disabled ? SWAP_DISABLED_TOOLTIP : undefined}
+                        disabled={Boolean(disabledTooltip)}
+                        disabledTooltip={disabledTooltip}
                         className="px-4 sm:px-4"
                       />
                     )

--- a/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/__tests__/SpacesList.test.tsx
@@ -332,6 +332,18 @@ describe('SpacesList — auth/expiry state rendering', () => {
     expect(screen.getAllByTestId('create-space-button')).toHaveLength(1)
   })
 
+  it('renders the AccountInfo sign-out menu on the require-login workspace header when the user is signed in with no spaces', () => {
+    mockUseIsRequireLoginEnabled.mockReturnValue(true)
+    mockUseAppSelector.mockReturnValue(true)
+    mockUseSpacesGetV1Query.mockReturnValue({ currentData: [], isFetching: false, error: undefined })
+    mockUseUsersGetWithWalletsV1Query.mockReturnValue({ currentData: { id: 1 } })
+
+    render(<SpacesList />)
+
+    expect(screen.getByText(/no workspaces found/i)).toBeInTheDocument()
+    expect(screen.getByTestId('account-info')).toBeInTheDocument()
+  })
+
   it('disables the Create space button and shows a tooltip when the user has reached the 10-space limit', async () => {
     // The Create workspace button lives in the require-login-ON workspace header.
     mockUseIsRequireLoginEnabled.mockReturnValue(true)

--- a/apps/web/src/features/spaces/components/SpacesList/index.tsx
+++ b/apps/web/src/features/spaces/components/SpacesList/index.tsx
@@ -233,9 +233,13 @@ const SpacesList = () => {
               <SafeLogo alt="Safe logo" width={24} height={24} />
             </div>
 
-            {isUserSignedIn && activeSpaces.length > 0 && (
+            {isUserSignedIn && (
               <div className="flex gap-4 flex-1 justify-between">
-                <AddSpaceButton disabled={isAtSpacesLimit} onClick={onAddSpaceBtnClick} />
+                {activeSpaces.length > 0 ? (
+                  <AddSpaceButton disabled={isAtSpacesLimit} onClick={onAddSpaceBtnClick} />
+                ) : (
+                  <div />
+                )}
 
                 {isLoading ? (
                   <Pulse className="h-12 w-12 rounded-full group-data-[collapsible=icon]:w-9" />


### PR DESCRIPTION
> Spaces gets a logout door,<br>swap greys out the un-deployed,<br>kicked members land safe home.

## What it solves

Resolves: [WA-2563](https://linear.app/safe-global/issue/WA-2563/swaptx-builder-counterfactual-unactivated-safes-should-be-disabled-in)<br>Resolves: [WA-2568](https://linear.app/safe-global/issue/WA-2568/workspace-user-stays-on-workspace-pages-after-leaving-should-redirect)<br>Resolves: [WA-2569](<https://linear.app/safe-global/issue/WA-2569/empty-workspace-screen-no-account-menu-or-sign-out-option-user-is>)<br><br>Several small UX/correctness issues in the Spaces (workspaces) area:

* Users with **no workspaces** had no way to log out from the workspaces overview list.
* The **swap** action in the Safe selector popup offered un-deployed (counterfactual) Safes, which can't swap.
* Members who **lose access** (declined invite / unauthorized) to a workspace saw an `Unauthorized` screen instead of being returned to the overview.
* The Safe selector dropdown copy was unclear when no wallet is connected.
* `SpaceBackLink` typed its `space` prop with an invented `{ id: number; name: string }` shape instead of the generated gateway type.
* Removes leftovers from numeric spaceId

## How this PR fixes it

* **AuthState**: derive `hasLostAccess` (signed-in, not loading, and unauthorized or declined) and `router.replace` to the spaces overview when it becomes true, instead of rendering `UnauthorizedState` in place.
* **SelectSafeModal**: replace the boolean `isSwapDisabledForSafe` with `getSwapDisabledTooltip`, which now also disables un-deployed Safes (`selectUndeployedSafes`) with a dedicated "This account is not activated yet and cannot swap." tooltip.
* **SpacesList**: always render the header action row for signed-in users so the logout button is reachable even when `activeSpaces` is empty (spacer `<div />` stands in for the Add button).
* **SpaceBackLink**: type the `space` prop as `Pick<GetSpaceResponse, 'name'>`, dropping the unused numeric `id`.
* Removes leftovers from numeric spaceId

## How to test it

1. Sign in with an account that has **no workspaces** → confirm a logout control is visible on the overview and works.
2. Open the **Safe selector → Swap**: un-deployed Safes are disabled with the "not activated yet" tooltip; unsupported-chain Safes keep the existing "Swap is not supported on this chain" tooltip.
3. As a member, get **declined / removed** from a workspace you're viewing → you're redirected to the spaces overview, not shown `Unauthorized`.
4. Open the Safe selector with **no wallet connected** → confirm the updated wording.

## Affected flows

* Workspaces overview for users with zero workspaces (logout entry point).
* Swap action from the Safe selector modal.
* Workspace member access loss (declined invite / unauthorized) while viewing a workspace.

## Blast radius

* `AuthState` (`features/spaces/components/AuthState`) — wraps workspace-scoped views; now performs a navigation side-effect on access loss. Consumers relying on the in-place `UnauthorizedState` render will instead see a redirect.
* `SelectSafeModal` (`features/spaces/components/SelectSafeModal`) — reads `selectUndeployedSafes` from the store; disable logic for swap changed from boolean to tooltip-string.
* `SpacesList` header layout — markup change for signed-in users with no spaces.
* `SpaceBackLink` prop type now depends on `GetSpaceResponse` (`@safe-global/store` AUTO_GENERATED) — callers passing a numeric `id` are unaffected (extra prop), callers relying on `id` being read are not.
* No RTK Query endpoint, feature flag, route, or persistence changes. No shared-package (mobile) impact.

## Risks / not checked

* Did not exercise the access-loss redirect against every error variant — covered unauthorized + declined paths via unit tests.

## Visual summary

Sign Out btn when 0 spaces (case: user is invited to a Space and logged themvelsev in): <img src="https://uploads.linear.app/cf187dcd-b206-4218-b688-803174268fff/50cf3821-4c4f-4750-9d45-f8de00cc2918/f9181b9c-0aaa-4b5a-80e4-1712d5342b86?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2NmMTg3ZGNkLWIyMDYtNDIxOC1iNjg4LTgwMzE3NDI2OGZmZi81MGNmMzgyMS00YzRmLTQ3NTAtOWQ0NS1mOGRlMDBjYzI5MTgvZjkxODFiOWMtMGFhYS00YjVhLTgwZTQtMTcxMmQ1MzQyYjg2IiwiaWF0IjoxNzgxNTEwODk4LCJleHAiOjE4MTMwODE0NTh9.GMWtQ9yqkgfETOk0jCxhp5ldaETfybBSJ1pUadNb0DI " alt="image" width="908" data-linear-height="700" />

CF Safes disabled from the Swap popup: <img src="https://uploads.linear.app/cf187dcd-b206-4218-b688-803174268fff/59cae11c-39dd-4973-8a96-5541ff443101/b854f791-a922-4a07-a06f-feeb15d861fa?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2NmMTg3ZGNkLWIyMDYtNDIxOC1iNjg4LTgwMzE3NDI2OGZmZi81OWNhZTExYy0zOWRkLTQ5NzMtOGE5Ni01NTQxZmY0NDMxMDEvYjg1NGY3OTEtYTkyMi00YTA3LWEwNmYtZmVlYjE1ZDg2MWZhIiwiaWF0IjoxNzgxNTEwODk4LCJleHAiOjE4MTMwODE0NTh9.nshorDyilRpXU2kfB9hsz9PoYklDvUHCRn2R8XSn3bY " alt="image" width="597" data-linear-height="610" />

```mermaid
flowchart TD
  A[AuthState mounts] --> B{Signed in & not loading?}
  B -->|No| L[LoadingState / SignedOutState]
  B -->|Yes| C{Unauthorized or Declined?}
  C -->|Yes| R[router.replace → spaces overview]
  C -->|No| K[Render children]

  subgraph Swap selector
    S[Safe in list] --> T{Swap supported on chain?}
    T -->|No| U[Disabled: not supported on chain]
    T -->|Yes| V{Safe deployed?}
    V -->|No| W[Disabled: not activated yet]
    V -->|Yes| X[Enabled]
  end
```

## Checklist

- [X] I've tested the branch on mobile 📱
- [X] I've documented how it affects the analytics (if at all) 📊
- [X] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [X] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough under apps/web/e2e/tests/one-shots/ and run it locally — CI records and posts the clickthrough GIF 🎬

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](<https://safe.global/cla>).