### PR TITLE
fix(mobile): guard chains-undefined crash and harden chains cache resilience

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import { AssetsContainer } from '@/src/features/Assets'
+import { ScreenErrorBoundary } from '@/src/components/ErrorBoundary'
 
 const HomeScreen = () => {
-  return <AssetsContainer />
+  return (
+    <ScreenErrorBoundary>
+      <AssetsContainer />
+    </ScreenErrorBoundary>
+  )
 }
 
 export default HomeScreen

--- a/apps/mobile/src/app/networks-sheet.tsx
+++ b/apps/mobile/src/app/networks-sheet.tsx
@@ -1,7 +1,15 @@
+import { useRouter } from 'expo-router'
 import { NetworksSheetContainer } from '@/src/features/NetworksSheet'
+import { ScreenErrorBoundary } from '@/src/components/ErrorBoundary'
 
 export const NetworksSheetScreen = () => {
-  return <NetworksSheetContainer />
+  const router = useRouter()
+
+  return (
+    <ScreenErrorBoundary onDismiss={() => router.back()}>
+      <NetworksSheetContainer />
+    </ScreenErrorBoundary>
+  )
 }
 
 export default NetworksSheetScreen

--- a/apps/mobile/src/components/ErrorBoundary/ScreenErrorBoundary.test.tsx
+++ b/apps/mobile/src/components/ErrorBoundary/ScreenErrorBoundary.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { Text } from 'tamagui'
+import { DdRum } from 'expo-datadog'
+import { render, fireEvent } from '@/src/tests/test-utils'
+import { ScreenErrorBoundary } from './ScreenErrorBoundary'
+import Logger from '@/src/utils/logger'
+
+jest.mock('@/src/utils/logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+  LogLevel: { TRACE: 0, INFO: 1, WARN: 2, ERROR: 3 },
+}))
+
+describe('ScreenErrorBoundary', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    // React logs caught render errors to console.error; silence the expected noise.
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    jest.clearAllMocks()
+  })
+
+  it('renders children when there is no error', () => {
+    const { getByText } = render(
+      <ScreenErrorBoundary>
+        <Text>content</Text>
+      </ScreenErrorBoundary>,
+    )
+
+    expect(getByText('content')).toBeTruthy()
+  })
+
+  it('renders a fallback and reports to Datadog when a child throws', () => {
+    const Boom = () => {
+      throw new Error('boom')
+    }
+
+    const { getByTestId } = render(
+      <ScreenErrorBoundary>
+        <Boom />
+      </ScreenErrorBoundary>,
+    )
+
+    expect(getByTestId('screen-error')).toBeTruthy()
+    // Caught errors don't reach the global handler, so the boundary must report to RUM itself.
+    expect(DdRum.addError).toHaveBeenCalled()
+    expect(Logger.error).toHaveBeenCalled()
+  })
+
+  it('shows a dismiss action only when onDismiss is provided and calls it', () => {
+    const onDismiss = jest.fn()
+    const Boom = () => {
+      throw new Error('boom')
+    }
+
+    const { getByTestId } = render(
+      <ScreenErrorBoundary onDismiss={onDismiss}>
+        <Boom />
+      </ScreenErrorBoundary>,
+    )
+
+    fireEvent.press(getByTestId('screen-error-dismiss'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the dismiss action when no onDismiss is provided', () => {
+    const Boom = () => {
+      throw new Error('boom')
+    }
+
+    const { queryByTestId } = render(
+      <ScreenErrorBoundary>
+        <Boom />
+      </ScreenErrorBoundary>,
+    )
+
+    expect(queryByTestId('screen-error-dismiss')).toBeNull()
+  })
+
+  it('recovers when retry is pressed after the child stops throwing', () => {
+    let shouldThrow = true
+    const MaybeBoom = () => {
+      if (shouldThrow) {
+        throw new Error('boom')
+      }
+      return <Text>recovered</Text>
+    }
+
+    const { getByTestId, getByText } = render(
+      <ScreenErrorBoundary>
+        <MaybeBoom />
+      </ScreenErrorBoundary>,
+    )
+
+    expect(getByTestId('screen-error')).toBeTruthy()
+
+    shouldThrow = false
+    fireEvent.press(getByTestId('screen-error-retry'))
+
+    expect(getByText('recovered')).toBeTruthy()
+  })
+})

--- a/apps/mobile/src/components/ErrorBoundary/ScreenErrorBoundary.tsx
+++ b/apps/mobile/src/components/ErrorBoundary/ScreenErrorBoundary.tsx
@@ -1,0 +1,80 @@
+import { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+import { H6, Text, View } from 'tamagui'
+import { DdRum, ErrorSource } from 'expo-datadog'
+import { SafeButton } from '@/src/components/SafeButton'
+import { SafeFontIcon } from '@/src/components/SafeFontIcon/SafeFontIcon'
+import Logger from '@/src/utils/logger'
+
+interface Props {
+  children: ReactNode
+  /** Optional dismiss action (e.g. router.back) — shown alongside Retry on routes that can be left. */
+  onDismiss?: () => void
+}
+
+interface State {
+  hasError: boolean
+}
+
+/**
+ * Visible error boundary for a whole screen/route. Catches render errors, reports them to Datadog
+ * RUM (and the console), and offers a retry instead of unmounting the tree to a blank screen.
+ * Use around critical routes; for non-critical inline UI use SilentErrorBoundary.
+ */
+export class ScreenErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // A caught error never reaches the global ErrorUtils handler, so report it to RUM explicitly,
+    // otherwise this crash class would become invisible in Datadog.
+    DdRum.addError(error.message, ErrorSource.SOURCE, error.stack ?? '', {
+      componentStack: info.componentStack,
+      source: 'ScreenErrorBoundary',
+    })
+    Logger.error('ScreenErrorBoundary caught a render error', error)
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View
+          flex={1}
+          alignItems="center"
+          justifyContent="center"
+          gap="$4"
+          padding="$4"
+          backgroundColor="$background"
+          testID="screen-error"
+        >
+          <SafeFontIcon name="info" size={48} color="$colorSecondary" />
+          <H6 fontWeight={600} textAlign="center">
+            Something went wrong
+          </H6>
+          <Text textAlign="center" color="$colorSecondary" width="80%">
+            We couldn’t display this screen. Please try again.
+          </Text>
+          <View flexDirection="row" gap="$3">
+            <SafeButton secondary textColor="$colorPrimary" onPress={this.handleRetry} testID="screen-error-retry">
+              <SafeFontIcon size={16} name="update" color="$colorPrimary" />
+              Retry
+            </SafeButton>
+            {this.props.onDismiss && (
+              <SafeButton text textColor="$colorPrimary" onPress={this.props.onDismiss} testID="screen-error-dismiss">
+                Go back
+              </SafeButton>
+            )}
+          </View>
+        </View>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/apps/mobile/src/components/ErrorBoundary/index.ts
+++ b/apps/mobile/src/components/ErrorBoundary/index.ts
@@ -1,1 +1,2 @@
 export { SilentErrorBoundary } from './SilentErrorBoundary'
+export { ScreenErrorBoundary } from './ScreenErrorBoundary'

--- a/apps/mobile/src/features/Assets/components/Balance/ChainItems.test.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/ChainItems.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render } from '@/src/tests/test-utils'
+import { ChainItems } from './ChainItems'
+import { createMockChain } from '@safe-global/test'
+
+describe('ChainItems', () => {
+  const chain = createMockChain({ chainId: '1', chainName: 'Ethereum' })
+
+  it('does not crash and still renders the chain when activeChain is undefined', () => {
+    // Regression: a missing chains config left activeChain undefined and threw at `activeChain.chainId`.
+    const { getByText } = render(
+      <ChainItems chainId="1" chains={[chain]} activeChain={undefined} fiatTotal="$100" onSelect={jest.fn()} />,
+    )
+
+    expect(getByText('Ethereum')).toBeTruthy()
+  })
+
+  it('renders the chain when activeChain matches', () => {
+    const { getByText } = render(
+      <ChainItems chainId="1" chains={[chain]} activeChain={chain} fiatTotal="$100" onSelect={jest.fn()} />,
+    )
+
+    expect(getByText('Ethereum')).toBeTruthy()
+  })
+
+  it('renders nothing when the chain is not in the list', () => {
+    const { queryByText } = render(
+      <ChainItems chainId="999" chains={[chain]} activeChain={chain} fiatTotal="$100" onSelect={jest.fn()} />,
+    )
+
+    expect(queryByText('Ethereum')).toBeNull()
+  })
+})

--- a/apps/mobile/src/features/Assets/components/Balance/ChainItems.tsx
+++ b/apps/mobile/src/features/Assets/components/Balance/ChainItems.tsx
@@ -6,7 +6,7 @@ import { SafeFontIcon } from '@/src/components/SafeFontIcon/SafeFontIcon'
 import { TouchableOpacity } from 'react-native'
 
 interface ChainItemsProps {
-  activeChain: Chain
+  activeChain?: Chain
   chains: Chain[]
   chainId: string
   fiatTotal: string
@@ -24,7 +24,7 @@ export function ChainItems({
   isNewlyDiscovered = false,
 }: ChainItemsProps) {
   const chain = chains.find((item) => item.chainId === chainId)
-  const isActive = chainId === activeChain.chainId
+  const isActive = chainId === activeChain?.chainId
 
   const handleChainSelect = () => {
     onSelect(chainId)

--- a/apps/mobile/src/store/__tests__/chainsRehydration.test.ts
+++ b/apps/mobile/src/store/__tests__/chainsRehydration.test.ts
@@ -1,0 +1,64 @@
+import { getStoredState, type Storage } from 'redux-persist'
+import { cgwClient } from '@safe-global/store/gateway/cgwClient'
+import { chainsAdapter } from '@safe-global/store/gateway/chains'
+import { createMockChain } from '@safe-global/test'
+import { CONFIG_SERVICE_KEY } from '@/src/config/constants'
+import { persistTransforms, persistBlacklist } from '../index'
+
+const chainsKey = `getChainsConfigV2("${CONFIG_SERVICE_KEY}")`
+
+type RestoredQuery = { status?: string; data?: { entities?: Record<string, { chainName?: string }> } } | undefined
+type RestoredApi = { queries?: Record<string, RestoredQuery> } | undefined
+
+// Storage stub returning a pre-seeded "persist:root" blob in redux-persist's on-disk format (each
+// top-level slice serialized independently). getStoredState then runs the real read path: deserialize
+// + apply the outbound transforms (cgwClientFilter, then sanitize) in reduceRight order — exactly what
+// happens on a cold start. This replays the incident where the app was killed mid-refetch.
+const seededStorage = (apiSubstate: Record<string, unknown>): Storage => {
+  const blob = JSON.stringify({
+    [cgwClient.reducerPath]: JSON.stringify(apiSubstate),
+    _persist: JSON.stringify({ version: 3, rehydrated: false }),
+  })
+  return {
+    getItem: () => Promise.resolve(blob),
+    setItem: () => Promise.resolve(),
+    removeItem: () => Promise.resolve(),
+  }
+}
+
+const restoreApi = async (apiSubstate: Record<string, unknown>): Promise<RestoredApi> => {
+  const restored = (await getStoredState({
+    key: 'root',
+    version: 3,
+    storage: seededStorage(apiSubstate),
+    blacklist: persistBlacklist,
+    transforms: persistTransforms,
+  })) as Record<string, RestoredApi>
+  return restored[cgwClient.reducerPath]
+}
+
+describe('chains cache rehydration (incident replay)', () => {
+  it('keeps cached chains as a fulfilled entry when the app was killed mid-refetch (pending + data)', async () => {
+    const data = chainsAdapter.setAll(chainsAdapter.getInitialState(), [
+      createMockChain({ chainId: '1', chainName: 'Ethereum' }),
+    ])
+
+    const api = await restoreApi({
+      queries: { [chainsKey]: { status: 'pending', data, fulfilledTimeStamp: 1 } },
+      config: { online: true },
+    })
+
+    const entry = api?.queries?.[chainsKey]
+    expect(entry?.status).toBe('fulfilled')
+    expect(entry?.data?.entities?.['1']?.chainName).toBe('Ethereum')
+  })
+
+  it('drops the entry when the interrupted request had no data (query re-initiates)', async () => {
+    const api = await restoreApi({
+      queries: { [chainsKey]: { status: 'pending', startedTimeStamp: 1 } },
+      config: { online: true },
+    })
+
+    expect(api?.queries?.[chainsKey]).toBeUndefined()
+  })
+})

--- a/apps/mobile/src/store/__tests__/sanitizePendingQueriesTransform.test.ts
+++ b/apps/mobile/src/store/__tests__/sanitizePendingQueriesTransform.test.ts
@@ -42,6 +42,51 @@ describe('sanitizePendingQueriesTransform', () => {
       })
     })
 
+    it('preserves data and rewrites a pending status to fulfilled', () => {
+      // A refetch interrupted by an app kill must keep its last successful data; RTK Query's
+      // rehydration matcher drops non-fulfilled/rejected entries, so the status is rewritten.
+      const data = { ids: ['1'], entities: { '1': { chainId: '1' } } }
+      const state = {
+        queries: {
+          [`getChainsConfigV2("${CONFIG_SERVICE_KEY}")`]: { status: 'pending', data, fulfilledTimeStamp: 123 },
+        },
+        config: { online: true },
+      }
+
+      const result = transform.out(state, cgwClient.reducerPath)
+
+      expect(result).toEqual({
+        queries: {
+          [`getChainsConfigV2("${CONFIG_SERVICE_KEY}")`]: { status: 'fulfilled', data, fulfilledTimeStamp: 123 },
+        },
+        config: { online: true },
+      })
+    })
+
+    it('drops a pending query whose data is null', () => {
+      const state = {
+        queries: {
+          [`getChainsConfigV2("${CONFIG_SERVICE_KEY}")`]: { status: 'pending', data: null },
+        },
+      }
+
+      const result = transform.out(state, cgwClient.reducerPath)
+
+      expect(result).toEqual({ queries: {} })
+    })
+
+    it('drops a pending query whose entity data is empty (an empty chain list is not usable data)', () => {
+      const state = {
+        queries: {
+          [`getChainsConfigV2("${CONFIG_SERVICE_KEY}")`]: { status: 'pending', data: { ids: [], entities: {} } },
+        },
+      }
+
+      const result = transform.out(state, cgwClient.reducerPath)
+
+      expect(result).toEqual({ queries: {} })
+    })
+
     it('preserves queries with fulfilled status', () => {
       const state = {
         queries: {

--- a/apps/mobile/src/store/index.ts
+++ b/apps/mobile/src/store/index.ts
@@ -64,14 +64,28 @@ export const cgwClientFilter = createFilter(
   [`queries.getChainsConfigV2("${CONFIG_SERVICE_KEY}")`, 'config'],
 )
 
-type QueryEntry = { status?: string } | undefined
+type QueryEntry = { status?: string; data?: unknown } | undefined
 type RtkQueryState = {
   queries?: Record<string, QueryEntry>
   [key: string]: unknown
 }
 
-// RTK Query persists status: 'pending' for in-flight requests. If the app is killed mid-request,
-// this stale pending status prevents new requests from being initiated on restart.
+// RTK Query persists status: 'pending' for in-flight requests. If the app is killed mid-refetch,
+// the previous behavior deleted the whole entry on rehydrate — including the last successfully
+// fetched data — which is how a transient backend outage wiped the cached chains. Instead, keep the
+// data and mark the entry 'fulfilled' so it rehydrates as a settled cache hit rather than stuck
+// fetching; the bootstrap force-refetch then refreshes it. Entries with no usable data are dropped
+// so the query re-initiates on the next launch.
+const hasUsableData = (data: unknown): boolean => {
+  if (data === undefined || data === null) {
+    return false
+  }
+  // Entity-adapter state (e.g. chains) is a non-null object even when empty; an empty list is not
+  // "successful data", so treat it the same as no data.
+  const ids = (data as { ids?: unknown[] }).ids
+  return Array.isArray(ids) ? ids.length > 0 : true
+}
+
 export const sanitizePendingQueriesTransform = createTransform<RtkQueryState, RtkQueryState>(
   (inboundState) => inboundState,
   (outboundState) => {
@@ -82,6 +96,9 @@ export const sanitizePendingQueriesTransform = createTransform<RtkQueryState, Rt
     const sanitizedQueries: Record<string, QueryEntry> = {}
     for (const [key, query] of Object.entries(outboundState.queries)) {
       if (query?.status === 'pending') {
+        if (hasUsableData(query.data)) {
+          sanitizedQueries[key] = { ...query, status: 'fulfilled' }
+        }
         continue
       }
       sanitizedQueries[key] = query

--- a/packages/store/src/gateway/chains/__tests__/index.test.ts
+++ b/packages/store/src/gateway/chains/__tests__/index.test.ts
@@ -342,4 +342,48 @@ describe('chains retry functionality', () => {
       expect(result.data?.entities['999']?.chainName).toBe('Test Chain')
     })
   })
+
+  describe('empty responses', () => {
+    it('returns an error instead of caching an empty chains list', async () => {
+      server = setupServer(
+        http.get(`${GATEWAY_URL}/v2/chains`, () => {
+          return HttpResponse.json({ results: [], next: null })
+        }),
+      )
+      server.listen()
+
+      const result = await store.dispatch(
+        apiSliceWithChainsConfig.endpoints.getChainsConfigV2.initiate(CONFIG_SERVICE_KEY),
+      )
+
+      expect(result.isSuccess).toBe(false)
+      expect(result.isError).toBe(true)
+      expect(Object.keys(result.data?.entities ?? {}).length).toBe(0)
+    })
+
+    it('preserves previously cached chains when a later refetch returns empty results', async () => {
+      let returnEmpty = false
+      server = setupServer(
+        http.get(`${GATEWAY_URL}/v2/chains`, () => {
+          return HttpResponse.json({ results: returnEmpty ? [] : mockChains, next: null })
+        }),
+      )
+      server.listen()
+
+      const first = await store.dispatch(
+        apiSliceWithChainsConfig.endpoints.getChainsConfigV2.initiate(CONFIG_SERVICE_KEY),
+      )
+      expect(Object.keys(first.data?.entities ?? {}).length).toBe(3)
+
+      returnEmpty = true
+      await store.dispatch(
+        apiSliceWithChainsConfig.endpoints.getChainsConfigV2.initiate(CONFIG_SERVICE_KEY, { forceRefetch: true }),
+      )
+
+      // The empty refetch must be rejected and must NOT wipe the cached chains.
+      const cached = apiSliceWithChainsConfig.endpoints.getChainsConfigV2.select(CONFIG_SERVICE_KEY)(store.getState())
+      expect(cached.isError).toBe(true)
+      expect(Object.keys(cached.data?.entities ?? {}).length).toBe(3)
+    })
+  })
 })

--- a/packages/store/src/gateway/chains/index.ts
+++ b/packages/store/src/gateway/chains/index.ts
@@ -54,6 +54,14 @@ const getChainsConfigs = async (
     return getChainsConfigs(api, url, serviceKey, nextUrl, nextResults)
   }
 
+  // A successful but empty response would otherwise wipe the cached chains via setAll. Treat it as
+  // an error so RTK Query retains the last successful data instead of overwriting it with nothing.
+  if (nextResults.length === 0) {
+    return {
+      error: { status: 'CUSTOM_ERROR', error: 'Empty chains result' } as FetchBaseQueryError,
+    }
+  }
+
   return { data: chainsAdapter.setAll(initialState, nextResults) }
 }
 


### PR DESCRIPTION
> Missing chains made the selector throw;
> guard the read, stop the cache being wiped,
> and catch the rest with a boundary.

## What it solves

A React render crash (`TypeError: Cannot read property 'chainId' of undefined`) in the mobile network selector (`ChainItems`) whenever the chains config is unavailable. It surfaced en masse during the SSL-pinning outage on 2026-06-12 — backend unreachable → no chains config → `undefined`. It also fixes the underlying reason the chains config got *lost*: the persisted cache was being wiped on a transient outage.

Resolves: [WA-2608](https://linear.app/safe-global/issue/WA-2608)

## How this PR fixes it

Four changes; the non-obvious bits:

- **`ChainItems`** read `activeChain.chainId` before its `if (!chain) return null` guard, and the prop was typed non-optional (`Chain`) while the caller passed `Chain | undefined` — a type lie. Made the prop optional + `activeChain?.chainId`.
- **`sanitizePendingQueriesTransform`** previously *deleted* a persisted query entry when it was killed mid-`pending`, taking the last good data with it. It now rewrites such an entry to `fulfilled` (preserving data). The subtlety: redux-persist restores the cache via its reconciler, and an empty entity-adapter state is a non-null object — so an empty chain list is treated as "no data" and dropped, matching the empty-response guard below.
- **`getChainsConfigs`** — a successful but empty `results: []` response previously passed the array guard and overwrote good chains via `setAll(initialState, [])`. It now returns an error so RTK Query keeps the last successful data.
- **`ScreenErrorBoundary`** (new) — a visible boundary that reports to Datadog RUM (a caught render error never reaches the global handler, so it would otherwise vanish from monitoring) and offers retry/dismiss. Wrapped around the home tab and the networks-sheet route as a backstop for the other ~55 `selectChainById` consumers.

## How to test it

1. Run the unit + integration tests:
   - `yarn workspace @safe-global/mobile test ChainItems sanitizePendingQueriesTransform ScreenErrorBoundary chainsRehydration`
   - `yarn workspace @safe-global/store test src/gateway/chains`
2. On a build from this branch, open the network selector with chains loaded — active chain still highlighted, rows render.
3. Cold-start with the backend unreachable (airplane mode / blocked CGW) — the app renders cached chains (or an empty state), no white screen or crash.
4. Kill the app during the launch chains-refetch, then relaunch — the previously cached chains survive (not wiped).

## Visual summary

```mermaid
flowchart TB
  subgraph Before
    A1[Backend unreachable] --> B1[chains config missing]
    B1 --> C1[persist transform deletes entry<br/>empty 200 overwrites cache]
    C1 --> D1[selectChainById = undefined]
    D1 --> E1[ChainItems reads activeChain.chainId]
    E1 --> F1[💥 TypeError · blank screen]
  end
  subgraph After
    A2[Backend unreachable] --> B2[chains config missing]
    B2 --> C2[transform keeps last data as fulfilled<br/>empty 200 returns error · cache retained]
    C2 --> D2[selectChainById may still be undefined]
    D2 --> E2[ChainItems guards activeChain?.chainId]
    E2 --> F2[renders gracefully]
    D2 -.unforeseen throw.-> G2[ScreenErrorBoundary<br/>fallback + Datadog RUM]
  end
```

## Screenshots

N/A — no intentional UI change (the new error-boundary fallback only renders on an otherwise-blank crash).

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊 — _N/A, no analytics change_
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).
