### PR TITLE
feat(web): unify Safe list sorting order (WA-2567)

### DIFF
--- a/apps/web/src/components/common/SafeListSortToggle/index.test.tsx
+++ b/apps/web/src/components/common/SafeListSortToggle/index.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@/tests/test-utils'
+import SafeListSortToggle from '.'
+
+// The popup/menu open state is verified in the browser: base-ui menus don't open in jsdom
+// (the repo mocks dropdown-menu elsewhere), so here we cover that the trigger mounts and
+// reflects the persisted order preference.
+describe('SafeListSortToggle', () => {
+  it('renders the trigger reflecting the default sort option (Name)', () => {
+    render(<SafeListSortToggle />)
+
+    const trigger = screen.getByTestId('safe-list-sort-toggle')
+    expect(trigger).toBeInTheDocument()
+    expect(trigger).toHaveTextContent('Name')
+  })
+})

--- a/apps/web/src/components/common/SafeListSortToggle/index.tsx
+++ b/apps/web/src/components/common/SafeListSortToggle/index.tsx
@@ -1,0 +1,66 @@
+import { ArrowDownUp, ChevronDown } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { OrderByOption, selectOrderByPreference, setOrderByPreference } from '@/store/orderByPreferenceSlice'
+
+const labels: Record<OrderByOption, string> = {
+  [OrderByOption.NAME]: 'Name',
+  [OrderByOption.LAST_VISITED]: 'Most recent',
+}
+
+/**
+ * Sort control for the Safe lists (account selector dropdown + All accounts modal).
+ * Reads/writes the shared, persisted orderByPreference so every Safe list stays in sync.
+ */
+const SafeListSortToggle = () => {
+  const dispatch = useAppDispatch()
+  const { orderBy } = useAppSelector(selectOrderByPreference)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="outline"
+            // Match the adjacent search InputGroup exactly: h-9, rounded-md, border-gray-100, shadow-none.
+            // Fixed width so the trigger doesn't grow/shrink between "Name" and "Most recent".
+            size="default"
+            className="h-9 w-[160px] shrink-0 justify-between gap-1.5 rounded-md border-gray-100 shadow-none text-muted-foreground"
+            data-testid="safe-list-sort-toggle"
+          />
+        }
+      >
+        <span className="flex items-center gap-1.5 whitespace-nowrap">
+          <ArrowDownUp className="size-4 shrink-0" />
+          {labels[orderBy]}
+        </span>
+        <ChevronDown className="size-4 shrink-0 opacity-60" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-40">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={orderBy}
+            onValueChange={(value) => dispatch(setOrderByPreference({ orderBy: value as OrderByOption }))}
+          >
+            <DropdownMenuRadioItem value={OrderByOption.NAME}>{labels[OrderByOption.NAME]}</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value={OrderByOption.LAST_VISITED}>
+              {labels[OrderByOption.LAST_VISITED]}
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export default SafeListSortToggle

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/index.tsx
@@ -20,6 +20,7 @@ import useConnectWallet from '@/components/common/ConnectWallet/useConnectWallet
 import SafeItemCard from './SafeItemCard'
 import MultiSafeItemCard from './MultiSafeItemCard'
 import { useAccountsModalItems } from './useAccountsModalItems'
+import SafeListSortToggle from '@/components/common/SafeListSortToggle'
 import type { AllSafeItems } from '@/hooks/safes'
 
 interface AccountsModalProps {
@@ -123,8 +124,8 @@ const AccountsModal = ({ open, onClose, trackingLabel = OVERVIEW_LABELS.top_bar 
           <DialogTitle>{isQualifiedSafe ? 'Explore other Safes' : 'All Accounts'}</DialogTitle>
         </DialogHeader>
 
-        <div className="shrink-0 px-4 py-3">
-          <InputGroup className="rounded-md border-gray-100 shadow-none">
+        <div className="flex shrink-0 items-center gap-2 px-4 py-3">
+          <InputGroup className="flex-1 rounded-md border-gray-100 shadow-none">
             <InputGroupAddon>
               <Search className="size-4" />
             </InputGroupAddon>
@@ -136,6 +137,7 @@ const AccountsModal = ({ open, onClose, trackingLabel = OVERVIEW_LABELS.top_bar 
               data-testid="accounts-search-input"
             />
           </InputGroup>
+          <SafeListSortToggle />
         </div>
 
         <div

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.test.ts
@@ -33,9 +33,11 @@ jest.mock('@safe-global/store/gateway/AUTO_GENERATED/owners', () => ({
   useOwnersGetAllSafesByOwnerV2Query: jest.fn(() => ({ error: undefined, refetch: jest.fn() })),
 }))
 
+// Plain let (not jest.fn) so jest.resetAllMocks() doesn't wipe it; controls the order preference.
+let mockOrderBy = 'name'
 jest.mock('@/store', () => ({
   useAppDispatch: jest.fn(),
-  useAppSelector: () => ({}),
+  useAppSelector: () => ({ orderBy: mockOrderBy }),
 }))
 
 const mockUseIsQualifiedSafe = useIsQualifiedSafe as jest.Mock
@@ -60,6 +62,7 @@ const ADDR_B = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 describe('useAccountsModalItems', () => {
   beforeEach(() => {
     jest.resetAllMocks()
+    mockOrderBy = 'name'
     mockUseSpaceSafes.mockReturnValue({ allSafes: [] })
     mockUseIsQualifiedSafe.mockReturnValue(false)
     mockUseOwnersQuery.mockReturnValue({ error: undefined, refetch: jest.fn() })
@@ -203,5 +206,29 @@ describe('useAccountsModalItems', () => {
 
     rerender({ search: 'nope' })
     expect(result.current.otherItems).toHaveLength(0)
+  })
+
+  it('sorts within the trusted section A→Z when ordering by Name', () => {
+    mockOrderBy = 'name'
+    mockUseAllSafes.mockReturnValue([
+      safeItem('1', ADDR_A, { isPinned: true, name: 'Zeta' }),
+      safeItem('1', ADDR_B, { isPinned: true, name: 'Alpha' }),
+    ])
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(result.current.trustedItems.map((s) => (s as SafeItem).name)).toEqual(['Alpha', 'Zeta'])
+  })
+
+  it('sorts within the trusted section by most-recent when ordering by Last visited', () => {
+    mockOrderBy = 'lastVisited'
+    mockUseAllSafes.mockReturnValue([
+      safeItem('1', ADDR_A, { isPinned: true, name: 'Older', lastVisited: 100 }),
+      safeItem('1', ADDR_B, { isPinned: true, name: 'Newer', lastVisited: 200 }),
+    ])
+
+    const { result } = renderHook(() => useAccountsModalItems({ search: '', open: true }))
+
+    expect(result.current.trustedItems.map((s) => (s as SafeItem).name)).toEqual(['Newer', 'Older'])
   })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/AccountsModal/useAccountsModalItems.ts
@@ -3,6 +3,7 @@ import {
   useAllSafes,
   useAllSafesGrouped,
   flattenSafeItems,
+  getComparator,
   type AllSafeItems,
   type MultiChainSafeItem,
   type SafeItem,
@@ -11,7 +12,8 @@ import {
 import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
 import { useOwnersGetAllSafesByOwnerV2Query } from '@safe-global/store/gateway/AUTO_GENERATED/owners'
 import useWallet from '@/hooks/wallets/useWallet'
-import { useAppDispatch } from '@/store'
+import { useAppDispatch, useAppSelector } from '@/store'
+import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import { showNotification } from '@/store/notificationsSlice'
 import { getFlaggedSimilarAddressSet } from '@safe-global/utils/utils/addressSimilarity'
 import { trackEvent } from '@/services/analytics'
@@ -34,7 +36,7 @@ const EMPTY_SAFES: SafeItems = []
  *   filteredFlat
  *     │
  *     ▼  useAllSafesGrouped()  → multi + single
- *   allItems  (merge, sort by lastVisited)
+ *   allItems  (merge, sort by order preference — Name or Most recent)
  *     │
  *     ▼  apply search (name or address substring)
  *   filtered
@@ -64,6 +66,8 @@ const EMPTY_SAFES: SafeItems = []
 export function useAccountsModalItems({ search, open }: { search: string; open: boolean }) {
   const dispatch = useAppDispatch()
   const allSafes = useAllSafes()
+  const { orderBy } = useAppSelector(selectOrderByPreference)
+  const comparator = useMemo(() => getComparator(orderBy), [orderBy])
   const { address: walletAddress = '' } = useWallet() || {}
   const { error: ownedSafesError, refetch: refetchOwnedSafes } = useOwnersGetAllSafesByOwnerV2Query(
     { ownerAddress: walletAddress },
@@ -100,8 +104,8 @@ export function useAccountsModalItems({ search, open }: { search: string; open: 
   const allItems = useMemo<AllSafeItems>(() => {
     const multi = allMultiChainSafes ?? []
     const single = allSingleSafes ?? []
-    return [...multi, ...single].sort((a, b) => (b.lastVisited ?? 0) - (a.lastVisited ?? 0))
-  }, [allMultiChainSafes, allSingleSafes])
+    return [...multi, ...single].sort(comparator)
+  }, [allMultiChainSafes, allSingleSafes, comparator])
 
   const similarAddresses = useMemo(() => getFlaggedSimilarAddressSet(allItems.map((item) => item.address)), [allItems])
 

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSafeBarSafes.test.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/__tests__/useSafeBarSafes.test.ts
@@ -41,6 +41,14 @@ const mockGrouped = jest.fn<{ allMultiChainSafes: MultiChainSafeItem[]; allSingl
 jest.mock('@/hooks/safes', () => ({
   useAllSafes: () => mockAllSafes(),
   useAllSafesGrouped: (items: SafeItem[]) => mockGrouped(items),
+  // Real comparator so ordering is exercised; types are erased at runtime.
+  getComparator: jest.requireActual('@/hooks/safes/comparators').getComparator,
+}))
+
+const mockOrderBy = jest.fn(() => 'name')
+jest.mock('@/store', () => ({
+  useAppSelector: (selector: (state: unknown) => unknown) =>
+    selector({ orderByPreference: { orderBy: mockOrderBy() } }),
 }))
 
 const mockIsSpaceRoute = jest.fn(() => false)
@@ -69,6 +77,7 @@ describe('useSafeBarSafes', () => {
     mockSafeAddress.mockReturnValue('0xCurrentSafe')
     mockReduxSafeAddress.mockReturnValue('')
     mockChainId.mockReturnValue('1')
+    mockOrderBy.mockReturnValue('name')
     mockAllSafes.mockReturnValue(undefined)
     // Default: pass-through. Tests needing multi-chain grouping override per-case.
     mockGrouped.mockImplementation((items: SafeItem[]) => ({
@@ -318,5 +327,33 @@ describe('useSafeBarSafes', () => {
     expect(current.address).toBe('0xMultiSafe')
     expect(current.safes).toHaveLength(2)
     expect(result.current.dropdownSafes[1].address).toBe('0xOtherPinned')
+  })
+
+  it('sorts the non-current safes alphabetically when ordering by Name', () => {
+    mockOrderBy.mockReturnValue('name')
+    const current = createSafe('0xCurrent', false)
+    const zeta = { ...createSafe('0xZeta', true), name: 'Zeta' }
+    const alpha = { ...createSafe('0xAlpha', true), name: 'Alpha' }
+    mockAllSafes.mockReturnValue([current, zeta, alpha])
+    mockSafeAddress.mockReturnValue('0xCurrent')
+
+    const { result } = renderHook(() => useSafeBarSafes())
+
+    // Current first, then the rest A→Z.
+    expect(result.current.dropdownSafes.map((s) => s.address)).toEqual(['0xCurrent', '0xAlpha', '0xZeta'])
+  })
+
+  it('sorts the non-current safes by most-recent when ordering by Last visited', () => {
+    mockOrderBy.mockReturnValue('lastVisited')
+    const current = createSafe('0xCurrent', false)
+    const older = { ...createSafe('0xOlder', true), lastVisited: 100 }
+    const newer = { ...createSafe('0xNewer', true), lastVisited: 200 }
+    mockAllSafes.mockReturnValue([current, older, newer])
+    mockSafeAddress.mockReturnValue('0xCurrent')
+
+    const { result } = renderHook(() => useSafeBarSafes())
+
+    // Current first, then most-recently-visited first.
+    expect(result.current.dropdownSafes.map((s) => s.address)).toEqual(['0xCurrent', '0xNewer', '0xOlder'])
   })
 })

--- a/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
+++ b/apps/web/src/components/common/SpaceSafeBar/hooks/useSafeBarSafes.ts
@@ -1,12 +1,32 @@
 import { useMemo } from 'react'
 import { useIsQualifiedSafe, useSpaceSafes } from '@/features/spaces'
-import { useAllSafes, useAllSafesGrouped, type AllSafeItems } from '@/hooks/safes'
-import type { SafeItem } from '@/hooks/safes'
+import { useAllSafes, useAllSafesGrouped, getComparator, type AllSafeItems } from '@/hooks/safes'
+import type { SafeItem, MultiChainSafeItem } from '@/hooks/safes'
+import { useAppSelector } from '@/store'
+import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
 import useChainId from '@/hooks/useChainId'
 import useSafeInfo from '@/hooks/useSafeInfo'
 import { useIsSpaceRoute } from '@/hooks/useIsSpaceRoute'
 import { useSafeAddressFromUrl } from '@/hooks/useSafeAddressFromUrl'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
+
+/**
+ * Orders a dropdown list consistently across space / non-space contexts:
+ * the current safe is pinned to the front (a multi-chain current safe renders on top;
+ * a single-chain current safe is hidden from the list by SafeDropdownContainer and
+ * only shown in the trigger), and every other account is sorted by the chosen comparator.
+ */
+const orderDropdownSafes = (
+  items: AllSafeItems,
+  safeAddress: string,
+  comparator: ReturnType<typeof getComparator>,
+  current: SafeItem | MultiChainSafeItem | undefined,
+): AllSafeItems => {
+  const rest = (safeAddress ? items.filter((s) => !sameAddress(s.address, safeAddress)) : items)
+    .slice()
+    .sort(comparator)
+  return safeAddress && current ? [current, ...rest] : rest
+}
 
 /**
  * Returns appropriate safe lists for the SafeBar based on context.
@@ -29,6 +49,9 @@ export function useSafeBarSafes() {
   const currentChainId = useChainId()
 
   const allSafeItems = useAllSafes()
+
+  const { orderBy } = useAppSelector(selectOrderByPreference)
+  const comparator = useMemo(() => getComparator(orderBy), [orderBy])
 
   const pinnedItems = useMemo(() => allSafeItems?.filter((s) => s.isPinned) ?? [], [allSafeItems])
 
@@ -67,12 +90,19 @@ export function useSafeBarSafes() {
   // deployed on (pinned, owned, or counterfactual); other safes stay pinned-only.
   // Pin state stays decoupled — bookmark drives it, navigating doesn't auto-pin.
   const dropdownSafes = useMemo<AllSafeItems>(() => {
-    if (!safeAddress) return pinnedSafes
-    const current = allKnownSafes.find((s) => sameAddress(s.address, safeAddress)) ?? fallbackCurrentSafe
-    if (!current) return pinnedSafes
-    const otherPinned = pinnedSafes.filter((s) => !sameAddress(s.address, safeAddress))
-    return [current, ...otherPinned]
-  }, [pinnedSafes, allKnownSafes, safeAddress, fallbackCurrentSafe])
+    const current = safeAddress
+      ? (allKnownSafes.find((s) => sameAddress(s.address, safeAddress)) ?? fallbackCurrentSafe)
+      : undefined
+    return orderDropdownSafes(pinnedSafes, safeAddress, comparator, current)
+  }, [pinnedSafes, allKnownSafes, safeAddress, fallbackCurrentSafe, comparator])
+
+  // Space context: same ordering rule, applied to the space's safes.
+  const spaceDropdownSafes = useMemo<AllSafeItems>(() => {
+    const current = safeAddress
+      ? (spaceSafes.find((s) => sameAddress(s.address, safeAddress)) ?? fallbackCurrentSafe)
+      : undefined
+    return orderDropdownSafes(spaceSafes, safeAddress, comparator, current)
+  }, [spaceSafes, safeAddress, fallbackCurrentSafe, comparator])
 
   // Same for chain selector.
   const chainSelectorSafes = useMemo<AllSafeItems>(() => {
@@ -84,7 +114,7 @@ export function useSafeBarSafes() {
   }, [allKnownSafes, safeAddress, fallbackCurrentSafe])
 
   return {
-    dropdownSafes: isInSpaceContext ? spaceSafes : dropdownSafes,
+    dropdownSafes: isInSpaceContext ? spaceDropdownSafes : dropdownSafes,
     chainSelectorSafes: isInSpaceContext ? spaceSafes : chainSelectorSafes,
   }
 }

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -8,6 +8,7 @@ import { useSafeNameResolver } from '@/hooks/useAllAddressBooks'
 import { useBottomScrollFade } from '@/hooks/useBottomScrollFade'
 import SafeItem from './SafeItem'
 import MultiChainSafeItemRow from './MultiChainSafeItemRow'
+import SafeListSortToggle from '@/components/common/SafeListSortToggle'
 import type { SafeItemData } from '../types'
 
 const matchesSearch = (item: SafeItemData, displayName: string, query: string): boolean => {
@@ -144,8 +145,8 @@ const SafeDropdownContainer = ({
           <div className="shrink-0 bg-card">
             {header}
             {showSearch && (
-              <div className="px-3 pb-2 pt-1">
-                <InputGroup className="rounded-md border-gray-100 shadow-none">
+              <div className="flex items-center gap-2 px-3 pb-2 pt-1">
+                <InputGroup className="flex-1 rounded-md border-gray-100 shadow-none">
                   <InputGroupAddon>
                     <Search className="size-4" />
                   </InputGroupAddon>
@@ -162,6 +163,7 @@ const SafeDropdownContainer = ({
                     data-testid="safe-dropdown-search-input"
                   />
                 </InputGroup>
+                <SafeListSortToggle />
               </div>
             )}
           </div>

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/SafeDropdownContainer.tsx
@@ -151,7 +151,7 @@ const SafeDropdownContainer = ({
                     <Search className="size-4" />
                   </InputGroupAddon>
                   <InputGroupInput
-                    placeholder="Search by name, address or network"
+                    placeholder="by name, address or network"
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     // Stop keystrokes reaching base-ui Select's typeahead, which would hijack typing.

--- a/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
+++ b/apps/web/src/features/spaces/components/SafeSelectorDropdown/components/__tests__/SafeDropdownContainer.test.tsx
@@ -49,6 +49,12 @@ jest.mock('../MultiChainSafeItemRow', () => ({
   default: ({ item }: { item: SafeItemData }) => <div data-testid="multi-chain-row">{item.name}</div>,
 }))
 
+// Redux-backed; stubbed here so the container test doesn't need a store.
+jest.mock('@/components/common/SafeListSortToggle', () => ({
+  __esModule: true,
+  default: () => <div data-testid="safe-list-sort-toggle" />,
+}))
+
 const createItem = (overrides: Partial<SafeItemData> = {}): SafeItemData => ({
   id: '1:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
   name: 'Safe A',

--- a/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
+++ b/apps/web/src/features/spaces/hooks/__tests__/useSpaceSafes.test.tsx
@@ -9,6 +9,7 @@ const mockUseWallet = jest.fn()
 const mockUseAllOwnedSafes = jest.fn()
 const mockUseAllSafesGrouped = jest.fn()
 let mockIsAuthenticated = true
+let mockLocalAddressBook: Record<string, Record<string, string>> = {}
 
 jest.mock('../useCurrentSpaceId', () => ({
   useCurrentSpaceId: () => mockUseCurrentSpaceId(),
@@ -23,6 +24,8 @@ jest.mock('@/store', () => ({
   useAppSelector: (selector: string) => {
     if (selector === 'isAuthenticated') return mockIsAuthenticated
     if (selector === 'selectOrderByPreference') return { orderBy: 'name' }
+    if (selector === 'selectAllAddressBooks') return mockLocalAddressBook
+    if (selector === 'selectAllVisitedSafes') return {}
     return undefined
   },
 }))
@@ -33,6 +36,11 @@ jest.mock('@/store/authSlice', () => ({
 
 jest.mock('@/store/orderByPreferenceSlice', () => ({
   selectOrderByPreference: 'selectOrderByPreference',
+}))
+
+jest.mock('@/store/slices', () => ({
+  selectAllAddressBooks: 'selectAllAddressBooks',
+  selectAllVisitedSafes: 'selectAllVisitedSafes',
 }))
 
 jest.mock('@safe-global/store/gateway/AUTO_GENERATED/spaces', () => ({
@@ -59,6 +67,7 @@ describe('useSpaceSafes', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockIsAuthenticated = true
+    mockLocalAddressBook = {}
     mockUseGetSpaceAddressBook.mockReturnValue([])
     mockUseWallet.mockReturnValue({ address: '0xabc' })
     mockUseAllOwnedSafes.mockReturnValue([{}])
@@ -95,5 +104,30 @@ describe('useSpaceSafes', () => {
     renderHook(() => useSpaceSafes())
 
     expect(mockUseSpaceSafesGetV1Query).toHaveBeenCalledWith({ spaceId: MOCK_SPACE_UUID }, { skip: false })
+  })
+
+  // Regression: address-book-named safes must sort by their displayed name. Without folding the
+  // user's address book into the name source, `name` is empty here and "Name" sorting no-ops.
+  it('merges the local address book under space contacts when building safe items', () => {
+    mockUseCurrentSpaceId.mockReturnValue(MOCK_SPACE_UUID)
+    mockUseSpaceSafesGetV1Query.mockReturnValue({
+      currentData: { safes: { '1': ['0xA'] } },
+      isLoading: false,
+      isError: false,
+      error: undefined,
+      refetch: jest.fn(),
+    })
+    mockLocalAddressBook = { '1': { '0xA': 'Local Name' } }
+    mockUseGetSpaceAddressBook.mockReturnValue([]) // no space contact for 0xA
+
+    renderHook(() => useSpaceSafes())
+
+    const { _buildSafeItems } = jest.requireMock('@/hooks/safes') as { _buildSafeItems: jest.Mock }
+    expect(_buildSafeItems).toHaveBeenCalledWith(
+      { '1': ['0xA'] },
+      expect.objectContaining({ '1': { '0xA': 'Local Name' } }),
+      expect.anything(),
+      expect.anything(),
+    )
   })
 })

--- a/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
+++ b/apps/web/src/features/spaces/hooks/useSpaceSafes.tsx
@@ -5,6 +5,8 @@ import useGetSpaceAddressBook from './useGetSpaceAddressBook'
 import { mapSpaceContactsToAddressBookState } from '../utils'
 import { useAppSelector } from '@/store'
 import { selectOrderByPreference } from '@/store/orderByPreferenceSlice'
+import { selectAllAddressBooks, selectAllVisitedSafes } from '@/store/slices'
+import merge from 'lodash/merge'
 import { useMemo } from 'react'
 import { isAuthenticated } from '@/store/authSlice'
 import useWallet from '@/hooks/wallets/useWallet'
@@ -20,13 +22,21 @@ export const useSpaceSafes = () => {
     refetch: refetchSpaceSafes,
   } = useSpaceSafesGetV1Query({ spaceId: spaceId ?? '' }, { skip: !isUserSignedIn || !spaceId })
   const spaceContacts = useGetSpaceAddressBook()
+  const localAddressBook = useAppSelector(selectAllAddressBooks)
 
-  // We are doing this in order to reuse the _buildSafeItems function but only take space contacts into account
-  const addressBooks = mapSpaceContactsToAddressBookState(spaceContacts)
+  // Space contacts take priority but fall back to the user's address book, so the name used for
+  // sorting matches the name actually displayed (the row resolves via the address book too — see
+  // useSafeDisplayName). Without the fallback, address-book-named safes have an empty `name` here
+  // and "Name" sorting silently no-ops on them.
+  const addressBooks = useMemo(
+    () => merge({}, localAddressBook, mapSpaceContactsToAddressBookState(spaceContacts)),
+    [localAddressBook, spaceContacts],
+  )
 
   const { address: walletAddress = '' } = useWallet() || {}
   const [allOwned = {}] = useAllOwnedSafes(walletAddress)
-  const safeItems = currentData ? _buildSafeItems(currentData.safes, addressBooks, allOwned) : []
+  const allVisitedSafes = useAppSelector(selectAllVisitedSafes)
+  const safeItems = currentData ? _buildSafeItems(currentData.safes, addressBooks, allOwned, allVisitedSafes) : []
   const safes = useAllSafesGrouped(safeItems)
   const { orderBy } = useAppSelector(selectOrderByPreference)
   const sortComparator = getComparator(orderBy)

--- a/apps/web/src/hooks/safes/useAllSafesGrouped.ts
+++ b/apps/web/src/hooks/safes/useAllSafesGrouped.ts
@@ -4,6 +4,7 @@ import useAllSafes, { type SafeItem, type SafeItems } from './useAllSafes'
 import { useMemo } from 'react'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
 import { type AddressBookState, selectAllAddressBooks } from '@/store/addressBookSlice'
+import type { VisitedSafesState } from '@/store/slices'
 import useWallet from '@/hooks/wallets/useWallet'
 import useAllOwnedSafes from './useAllOwnedSafes'
 import { useAppSelector } from '@/store'
@@ -45,6 +46,7 @@ export function _buildSafeItems(
   safes: Record<string, string[] | null>,
   allSafeNames: AddressBookState,
   allOwned?: AllOwnedSafes,
+  allVisitedSafes?: VisitedSafesState,
 ): SafeItem[] {
   const result: SafeItem[] = []
 
@@ -54,13 +56,14 @@ export function _buildSafeItems(
     addresses?.forEach((address) => {
       const isReadOnly = !!allOwned && !(allOwned[chainId] || []).includes(address)
       const name = allSafeNames[chainId]?.[address]
+      const lastVisited = allVisitedSafes?.[chainId]?.[address]?.lastVisited || 0
 
       result.push({
         chainId,
         address,
         isReadOnly,
         isPinned: false,
-        lastVisited: 0,
+        lastVisited,
         name,
       })
     })

--- a/apps/web/src/store/__tests__/index.test.ts
+++ b/apps/web/src/store/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { _hydrationReducer } from '@/store'
+import { OrderByOption, ORDER_BY_RESET_VERSION } from '@/store/orderByPreferenceSlice'
 
 describe('store', () => {
   describe('hydrationReducer', () => {
@@ -143,6 +144,38 @@ describe('store', () => {
       expect(mergedState === initialState).toBeFalsy()
       // @ts-expect-error demo state
       expect(mergedState === persistedState).toBeFalsy()
+    })
+
+    it('resets orderByPreference to the A→Z default once for users on the old default', () => {
+      const persistedState = { orderByPreference: { orderBy: OrderByOption.LAST_VISITED } }
+      const initialState = { orderByPreference: { orderBy: OrderByOption.NAME } }
+
+      const mergedState = _hydrationReducer(initialState, {
+        type: '@@HYDRATE',
+        payload: persistedState,
+      })
+
+      expect(mergedState.orderByPreference).toEqual({
+        orderBy: OrderByOption.NAME,
+        resetVersion: ORDER_BY_RESET_VERSION,
+      })
+    })
+
+    it('keeps the saved order once the one-time reset has already been applied', () => {
+      const persistedState = {
+        orderByPreference: { orderBy: OrderByOption.LAST_VISITED, resetVersion: ORDER_BY_RESET_VERSION },
+      }
+      const initialState = { orderByPreference: { orderBy: OrderByOption.NAME } }
+
+      const mergedState = _hydrationReducer(initialState, {
+        type: '@@HYDRATE',
+        payload: persistedState,
+      })
+
+      expect(mergedState.orderByPreference).toEqual({
+        orderBy: OrderByOption.LAST_VISITED,
+        resetVersion: ORDER_BY_RESET_VERSION,
+      })
     })
   })
 })

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -143,6 +143,16 @@ export const _hydrationReducer: typeof rootReducer = (state, action) => {
       nextState[slices.batchSlice.name] = migrateBatchTxs(nextState[slices.batchSlice.name])
     }
 
+    // One-time reset to the new default order (WA-2567 made "Name" / A→Z the default).
+    // Guarded on the slice being present so it only touches a real store, not synthetic state.
+    const orderByState = nextState[slices.orderByPreferenceSlice.name]
+    if (orderByState && orderByState.resetVersion !== slices.ORDER_BY_RESET_VERSION) {
+      nextState[slices.orderByPreferenceSlice.name] = {
+        orderBy: slices.OrderByOption.NAME,
+        resetVersion: slices.ORDER_BY_RESET_VERSION,
+      }
+    }
+
     // Mark the store as hydrated so guards wait for persisted auth state.
     // Reset cfSafeSynced so consumers wait for a fresh backend sync each page load.
     // Reset isOidcLoginPending to avoid stale state from a previous session.

--- a/apps/web/src/store/orderByPreferenceSlice.test.ts
+++ b/apps/web/src/store/orderByPreferenceSlice.test.ts
@@ -1,0 +1,30 @@
+import {
+  orderByPreferenceSlice,
+  setOrderByPreference,
+  selectOrderByPreference,
+  OrderByOption,
+  ORDER_BY_RESET_VERSION,
+} from './orderByPreferenceSlice'
+import type { RootState } from '@/store'
+
+describe('orderByPreferenceSlice', () => {
+  const { reducer } = orderByPreferenceSlice
+
+  it('defaults to Name (A→Z)', () => {
+    const state = reducer(undefined, { type: '@@INIT' })
+    expect(state.orderBy).toBe(OrderByOption.NAME)
+  })
+
+  it('updates the order preference', () => {
+    const state = reducer(undefined, setOrderByPreference({ orderBy: OrderByOption.LAST_VISITED }))
+    expect(state.orderBy).toBe(OrderByOption.LAST_VISITED)
+  })
+
+  it('selector falls back to the Name default when the slice is absent', () => {
+    expect(selectOrderByPreference({} as RootState).orderBy).toBe(OrderByOption.NAME)
+  })
+
+  it('exposes a numeric reset version for the one-time A→Z migration', () => {
+    expect(typeof ORDER_BY_RESET_VERSION).toBe('number')
+  })
+})

--- a/apps/web/src/store/orderByPreferenceSlice.ts
+++ b/apps/web/src/store/orderByPreferenceSlice.ts
@@ -7,9 +7,13 @@ export enum OrderByOption {
   LAST_VISITED = 'lastVisited',
 }
 
-export type OrderByPreferenceState = { orderBy: OrderByOption }
+// Bump to force every user back to the default order once (see _hydrationReducer).
+// WA-2567 set the default to A→Z; this resets users still on the previous default.
+export const ORDER_BY_RESET_VERSION = 1
 
-const initialState: OrderByPreferenceState = { orderBy: OrderByOption.LAST_VISITED }
+export type OrderByPreferenceState = { orderBy: OrderByOption; resetVersion?: number }
+
+const initialState: OrderByPreferenceState = { orderBy: OrderByOption.NAME }
 
 export const orderByPreferenceSlice = createSlice({
   name: 'orderByPreference',


### PR DESCRIPTION
> Two ways to sort, one shared switch:
> Name from A→Z (now the default), or most-recently-seen on top —
> dropdown and modal finally agree on one order.

## What it solves

Resolves: https://linear.app/safe-global/issue/WA-2567/unify-sorting-order-for-safe-lists

The Safe lists sorted inconsistently depending on context and surface:

- **Account selector dropdown — space mode**: sorted via the comparator, but `lastVisited` was hardcoded to `0`, so **"Most recent" was a no-op**, and **"Name" sorted by an empty key** for address-book-named safes (so e.g. `XYZ` appeared before `ABC`).
- **Account selector dropdown — non-space mode**: not sorted by the preference at all (current safe pinned, then pinned safes in raw address order).
- **All accounts modal**: hardcoded `lastVisited` descending, ignored the user preference.
- The default was **Last visited**, and these surfaces had **no sort control**.

Net: order shifted depending on whether the current safe was a member of the current Space, and differed between the dropdown, the modal, and the My accounts page.

## How this PR fixes it

- **Shared sort control** (`SafeListSortToggle`, shadcn) right of the search box in the **account selector dropdown** and the **All accounts modal**, reading/writing the persisted `orderByPreference`.
- **Default flips to Name (A→Z)**; a **one-time, version-gated reset** in `_hydrationReducer` (mirrors the existing `termsVersion` reset) moves existing users off the old `Last visited` default. Their later choice persists normally.
- **Dropdown unified (both modes)**: the current safe is pinned to the top, the rest sorted by the chosen comparator — **by account** (a multi-chain account is one row).
- **Space-mode fixes**: real `lastVisited` (read from the `visitedSafes` slice via `_buildSafeItems`) so "Most recent" actually orders; and the user's address book is folded into the name source (space contacts take priority) so **"Name" sorts by the name actually displayed**.
- **Modal**: sorts **within** the `Trusted Safes` / `Other Safes` sections by the preference.

## How to test it

1. Open a Safe. Open the **account selector dropdown** (top bar) and the **All accounts modal** — each has a `Sort by` control to the right of the search box.
2. Toggle **Name ↔ Most recent**: both surfaces reorder consistently, and the choice **persists across reload** (and across tabs).
3. In a workspace, named safes sort **A→Z by their displayed name** (`ABC` before `XYZ`); unnamed safes sort last; the current safe stays on top.
4. **Most recent**: visit a few safes, reopen — they order by most-recently-visited first.
5. As an existing user (previously on `Last visited`), you land on **A→Z once** (forced reset), after which your own choice sticks.

## Affected flows

- Account selector dropdown ordering — space and non-space contexts.
- All accounts modal ordering — within the Trusted / Other sections.
- Sort-preference persistence and cross-tab broadcast.
- My accounts page ordering — inherits the new A→Z default (no toggle added there by design).

## Blast radius

- **`orderByPreferenceSlice`** — default changed to `NAME` + new `resetVersion`; persisted and broadcast. Consumers: My accounts (v1/v2), Spaces SafeAccounts page, onboarding, the dropdown, the modal.
- **`_hydrationReducer`** (`store/index.ts`) — one-time order reset on hydrate (guarded on the slice being present).
- **`_buildSafeItems`** (`useAllSafesGrouped`) — new **optional** `allVisitedSafes` param; only `useSpaceSafes` passes it. `useOwnedSafesGrouped` is unchanged (still `lastVisited: 0`).
- **`useSafeBarSafes`**, **`useSpaceSafes`**, **`useAccountsModalItems`** — ordering logic.
- No RTK Query endpoint / API contract changes. No new feature flag. No mobile (shared-package) changes.

## Risks / not checked

- The sort control is a base-ui `dropdown-menu` nested inside the base-ui `Select` popup (dropdown surface) — **verified visually**; base-ui menus don't open in jsdom, so the open-state isn't unit-tested (the repo mocks `dropdown-menu` in tests).
- The one-time reset **overrides** anyone who previously chose `Most recent` (intended per product).
- The name-source fix folds in the **local** address book; a safe named **only** in a *private* space address book (not space contacts, not local) would still sort by an empty key — rare edge, easy follow-up.
- **Not tested on mobile** (web-only surfaces).
- **No Playwright one-shot** clickthrough added yet.

## Visual summary

<img width="469" height="454" alt="Screenshot 2026-06-15 at 09 46 25" src="https://github.com/user-attachments/assets/bf882ac3-4343-4d09-b764-ec80d7f94941" />
<img width="597" height="600" alt="Screenshot 2026-06-15 at 09 46 30" src="https://github.com/user-attachments/assets/e64e65d1-6b13-4550-a9ea-04fa827c3b42" />


```mermaid
flowchart TD
  T["SafeListSortToggle<br/>(Name / Most recent)"] -->|writes| P[("orderByPreference<br/>persisted · default Name")]
  H["_hydrationReducer"] -->|one-time reset to Name| P
  P --> C{"getComparator(orderBy)"}
  C --> D["Dropdown · useSafeBarSafes<br/>current pinned top + rest sorted<br/>(space &amp; non-space, by account)"]
  C --> M["All accounts modal<br/>sorted within Trusted / Other"]
  D --> R1["SafeDropdownContainer renders"]
  M --> R2["AccountsModal renders"]
```

> _UI: attach a screenshot of the dropdown + modal showing the `Sort by` control to the right of the search box (toggle open with Name / Most recent)._

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [x] I've written a unit/e2e test for it (if applicable) 🧑‍💻
- [x] I've listed affected flows and blast radius, and named what I did not verify 🎯
- [ ] For web feature/bugfix PRs, I've added a Playwright one-shot happy-path clickthrough under apps/web/e2e/tests/one-shots/ and run it locally — CI records and posts the clickthrough GIF 🎬

---

## CLA signature

With the submission of this Pull Request, I confirm that I have read and agree to the terms of the [Contributor License Agreement](https://safe.global/cla).

🤖 Generated with [Claude Code](https://claude.com/claude-code)