### PR TITLE
fix: point "How fees work" link to current gas fees FAQ

### DIFF
--- a/apps/web/src/features/gtf/components/FeesPreview/index.tsx
+++ b/apps/web/src/features/gtf/components/FeesPreview/index.tsx
@@ -26,7 +26,7 @@ const onActivateKey = (open: () => void) => (e: KeyboardEvent) => {
     open()
   }
 }
-const HOW_FEES_WORK_URL = 'https://help.safe.global/en/articles/618701-safe-wallet-gas-fees-faq'
+const HOW_FEES_WORK_URL = 'https://help.safe.global/articles/9993850744-safewallet-gas-fees-faq'
 
 const TotalOutgoingSection = ({ totalOutgoing }: { totalOutgoing: TotalOutgoing }): ReactElement => (
   <div className={css.totalOutgoing}>


### PR DESCRIPTION
Align FeesPreview link with FeeInfoBanner, which already uses the updated help.safe.global FAQ URL.