### PR TITLE
feat(web): Improved address book dropdown

### DIFF
--- a/apps/web/e2e/src/data/constants.ts
+++ b/apps/web/e2e/src/data/constants.ts
@@ -43,7 +43,50 @@ export const SAFES = {
   SEP_STATIC_SAFE_1: 'sep:0x6E834E9D04ad6b26e1525dE1a37BFd9b215f40B7',
   /** 1/2 Safe — use for multi-owner and tx queue tests */
   SEP_STATIC_SAFE_2: 'sep:0xc2F3645bfd395516d1a18CA6ad9298299d328C01',
+  /** Safe owned by OWNER_4 — for tx-creation flows needing a connected owner (mirrors Cypress SEP_STATIC_SAFE_6) */
+  SEP_OWNER_4_SAFE: 'sep:0xBf30F749FC027a5d79c4710D988F0D3C8e217A4F',
 } as const
+
+// ---------------------------------------------------------------------------
+// Address book seed data (for tests that seed a local contact via localStorage)
+// ---------------------------------------------------------------------------
+
+/** Deterministic local address-book contact to select in the recipient dropdown */
+export const AB_LOCAL_CONTACT = {
+  name: 'E2E Vitalik',
+  address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+} as const
+
+/**
+ * Mixed contacts for the recipient-dropdown property tests.
+ * - Local contacts are seeded via localStorage (CI starts with an empty browser).
+ * - Workspace contacts are injected by mocking the spaces address-book API.
+ * Addresses are distinct and DIGIT-ONLY (no a–f), so they are checksum-neutral:
+ * the value selected from the dropdown matches the address-book key regardless of
+ * checksum casing, so the read-only "selected" chip always renders.
+ */
+export const DROPDOWN_TEST_SPACE = {
+  // Legacy numeric space id — accepted by the backend's LegacySpaceIdPipe and what
+  // the Cypress spaces mocks use. `lastUsedSpace` is seeded to this so it resolves.
+  id: '1',
+  name: 'E2E Workspace',
+} as const
+
+export const DROPDOWN_LOCAL_CONTACTS = [
+  { name: 'E2E Local One', address: '0x1111111111111111111111111111111111111111' },
+  { name: 'E2E Local Two', address: '0x2222222222222222222222222222222222222222' },
+  { name: 'E2E Local Three', address: '0x3333333333333333333333333333333333333333' },
+  { name: 'E2E Local Four', address: '0x7777777777777777777777777777777777777777' },
+  { name: 'E2E Local Five', address: '0x8888888888888888888888888888888888888888' },
+] as const
+
+export const DROPDOWN_WORKSPACE_CONTACTS = [
+  { name: 'E2E Workspace Alice', address: '0x4444444444444444444444444444444444444444' },
+  { name: 'E2E Workspace Bob', address: '0x5555555555555555555555555555555555555555' },
+  { name: 'E2E Workspace Carol', address: '0x6666666666666666666666666666666666666666' },
+  { name: 'E2E Workspace Dave', address: '0x9999999999999999999999999999999999999999' },
+  { name: 'E2E Workspace Erin', address: '0x1212121212121212121212121212121212121212' },
+] as const
 
 // ---------------------------------------------------------------------------
 // Test wallet addresses

--- a/apps/web/e2e/tests/one-shots/recipient-dropdown-selection.spec.ts
+++ b/apps/web/e2e/tests/one-shots/recipient-dropdown-selection.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '../../src/fixtures/test.fixture'
+import { SAFES, AB_LOCAL_CONTACT, CHAIN_IDS, LS_NAMESPACE } from '../../src/data/constants'
+
+test.describe('Recipient dropdown — address book selection', { tag: '@one-shot' }, () => {
+  test('should fill the recipient field with the contact address when a dropdown entry is selected', async ({
+    safePage,
+    walletPage,
+    credentials,
+  }) => {
+    // 1. Seed a single local address-book contact for the Safe's chain so the
+    //    dropdown has a deterministic entry to select.
+    await safePage.addInitScript(
+      ({ key, chainId, address, name }) => {
+        window.localStorage.setItem(key, JSON.stringify({ [chainId]: { [address]: name } }))
+      },
+      {
+        key: `${LS_NAMESPACE}addressBook`,
+        chainId: CHAIN_IDS.sepolia,
+        address: AB_LOCAL_CONTACT.address,
+        name: AB_LOCAL_CONTACT.name,
+      },
+    )
+
+    // 2. Open the Safe and connect the owner wallet (enables "New transaction").
+    await safePage.goto(`/home?safe=${SAFES.SEP_OWNER_4_SAFE}`)
+    await walletPage.acceptCookies()
+    await walletPage.connectWallet(credentials.OWNER_4_PRIVATE_KEY)
+    await expect(walletPage.accountCenter).toBeVisible()
+
+    // 3. Open the Send-tokens flow.
+    await safePage.getByTestId('new-tx-btn').click()
+    await safePage.getByTestId('send-tokens-btn').click()
+
+    // 4. Open the recipient address-book dropdown.
+    const recipientInput = safePage.getByLabel(/Recipient address/)
+    await expect(recipientInput).toBeVisible()
+    await recipientInput.click()
+
+    // 5. The seeded contact appears in the dropdown — select it.
+    const option = safePage.getByText(AB_LOCAL_CONTACT.name)
+    await expect(option).toBeVisible()
+    await option.click()
+
+    // 6. The selected contact's address is now shown in the recipient field.
+    const selectedRecipient = safePage.getByTestId('address-book-recipient')
+    await expect(selectedRecipient).toBeVisible()
+    await expect(selectedRecipient).toContainText(AB_LOCAL_CONTACT.address)
+    await expect(selectedRecipient).toContainText(AB_LOCAL_CONTACT.name)
+  })
+})

--- a/apps/web/e2e/tests/regression/recipient-dropdown-caret-toggle.spec.ts
+++ b/apps/web/e2e/tests/regression/recipient-dropdown-caret-toggle.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression — the caret on the recipient input toggles the dropdown.
+ *
+ * Clicking the caret opens the address-book dropdown; clicking it again closes
+ * it. The caret only renders when there are visible options, so a couple of local
+ * contacts are seeded via localStorage (no workspace/auth needed). The wallet
+ * (OWNER_4, owner of the Safe) is connected so "New transaction" is enabled.
+ *
+ * Open/closed state is read from the combobox's `aria-expanded`.
+ *
+ * Run: yarn workspace @safe-global/web pw:test recipient-dropdown-caret-toggle
+ * Tag: @regression — runs under the chromium project, on demand.
+ */
+import { test, expect } from '../../src/fixtures/test.fixture'
+import { SAFES, CHAIN_IDS, LS_NAMESPACE } from '../../src/data/constants'
+
+// Digit-only (checksum-neutral) local contacts so the dropdown has options.
+const LOCAL_CONTACTS = {
+  '0x1111111111111111111111111111111111111111': 'E2E Caret One',
+  '0x2222222222222222222222222222222222222222': 'E2E Caret Two',
+}
+
+test.describe('Recipient dropdown — caret toggle', { tag: '@regression' }, () => {
+  test('should open the dropdown on caret click and close it on a second click', async ({
+    safePage,
+    walletPage,
+    credentials,
+  }) => {
+    // Seed local contacts so there are visible options (the caret only shows then).
+    await safePage.addInitScript(
+      ({ ns, chainId, book }) => {
+        window.localStorage.setItem(`${ns}addressBook`, JSON.stringify({ [chainId]: book }))
+      },
+      { ns: LS_NAMESPACE, chainId: CHAIN_IDS.sepolia, book: LOCAL_CONTACTS },
+    )
+
+    // Open the Safe and connect the owner wallet (enables "New transaction").
+    await safePage.goto(`/home?safe=${SAFES.SEP_OWNER_4_SAFE}`)
+    await walletPage.acceptCookies()
+    await walletPage.connectWallet(credentials.OWNER_4_PRIVATE_KEY)
+    await expect(walletPage.accountCenter).toBeVisible()
+
+    // Open the Send-tokens flow.
+    await expect(safePage.getByTestId('new-tx-btn')).toBeEnabled()
+    await safePage.getByTestId('new-tx-btn').click()
+    await safePage.getByTestId('send-tokens-btn').click()
+
+    const recipient = safePage.getByRole('combobox', { name: /Recipient address/ })
+    const caret = safePage.getByTestId('address-book-toggle')
+    await expect(recipient).toBeVisible()
+    await expect(caret).toBeVisible()
+
+    // Dropdown starts closed.
+    await expect(recipient).toHaveAttribute('aria-expanded', 'false')
+
+    // First caret click opens it.
+    await caret.click()
+    await expect(recipient).toHaveAttribute('aria-expanded', 'true')
+    await expect(safePage.getByTestId('address-item').filter({ hasText: 'E2E Caret One' })).toBeVisible()
+
+    // Second caret click closes it.
+    await caret.click()
+    await expect(recipient).toHaveAttribute('aria-expanded', 'false')
+  })
+})

--- a/apps/web/e2e/tests/regression/recipient-dropdown-network-filter.spec.ts
+++ b/apps/web/e2e/tests/regression/recipient-dropdown-network-filter.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression — the recipient dropdown only suggests contacts configured for the
+ * chain the transaction is on.
+ *
+ * Sending on Sepolia must never surface a contact that only exists on mainnet or
+ * polygon, even when those contacts are in the (workspace) address book. Workspace
+ * contacts carry explicit `chainIds`; the dropdown filters by the current chain.
+ * Local contacts are stored per chain, so only the current chain's are ever loaded.
+ *
+ * Setup is explicit and inline (no shared mock helper): a faked Spaces session via
+ * localStorage + a mocked `/v1/auth/me` (so the session-expiry guard doesn't clear
+ * it), plus mocked spaces endpoints that return workspace contacts spread across
+ * Sepolia / mainnet / polygon. The wallet (OWNER_4, owner of the Safe) is connected
+ * so "New transaction" is enabled.
+ *
+ * Run: yarn workspace @safe-global/web pw:test recipient-dropdown-network-filter
+ * Tag: @regression — runs under the chromium project, on demand.
+ */
+import { test, expect } from '../../src/fixtures/test.fixture'
+import { SAFES, CHAIN_IDS, LS_NAMESPACE, DROPDOWN_TEST_SPACE } from '../../src/data/constants'
+
+const SIGNER = '0x1234567890123456789012345678901234567890'
+
+// Digit-only addresses are checksum-neutral (no a–f), so the selected value
+// matches the address-book key regardless of casing.
+const LOCAL_SEPOLIA = { name: 'Local Sepolia', address: '0x1111111111111111111111111111111111111111' }
+const LOCAL_MAINNET = { name: 'Local Mainnet', address: '0x2222222222222222222222222222222222222222' }
+
+const WORKSPACE_CONTACTS = [
+  { name: 'WS Sepolia Only', address: '0x4444444444444444444444444444444444444444', chainIds: [CHAIN_IDS.sepolia] },
+  { name: 'WS Multichain', address: '0x5555555555555555555555555555555555555555', chainIds: [CHAIN_IDS.sepolia, CHAIN_IDS.ethereum] }, // prettier-ignore
+  { name: 'WS Mainnet Only', address: '0x6666666666666666666666666666666666666666', chainIds: [CHAIN_IDS.ethereum] },
+  { name: 'WS Polygon Only', address: '0x9999999999999999999999999999999999999999', chainIds: [CHAIN_IDS.polygon] },
+]
+
+// Contacts that should appear when sending on Sepolia, and those that must not.
+const VISIBLE_ON_SEPOLIA = ['Local Sepolia', 'WS Sepolia Only', 'WS Multichain']
+const HIDDEN_ON_SEPOLIA = ['Local Mainnet', 'WS Mainnet Only', 'WS Polygon Only']
+
+const SPACE = {
+  id: Number(DROPDOWN_TEST_SPACE.id),
+  uuid: DROPDOWN_TEST_SPACE.id,
+  name: DROPDOWN_TEST_SPACE.name,
+  status: 'ACTIVE',
+  safeCount: 1,
+  members: [{ id: 1, role: 'ADMIN', name: 'Admin', status: 'ACTIVE', user: { id: 1, status: 'ACTIVE' } }],
+}
+
+test.describe('Recipient dropdown — network filtering', { tag: '@regression' }, () => {
+  test('should only suggest contacts on the transaction chain (Sepolia), never mainnet or polygon', async ({
+    safePage,
+    walletPage,
+    credentials,
+  }) => {
+    // Fake a Spaces session and seed local contacts on two chains. Only the
+    // Sepolia local contact should ever load (locals are stored per chain).
+    await safePage.addInitScript(
+      ({ ns, spaceId, localBook }) => {
+        window.localStorage.setItem(
+          `${ns}auth`,
+          JSON.stringify({
+            sessionExpiresAt: Date.now() + 24 * 60 * 60 * 1000,
+            lastUsedSpace: spaceId,
+            isStoreHydrated: false,
+            cfSafeSynced: false,
+            isOidcLoginPending: false,
+          }),
+        )
+        window.localStorage.setItem(`${ns}addressBook`, JSON.stringify(localBook))
+      },
+      {
+        ns: LS_NAMESPACE,
+        spaceId: DROPDOWN_TEST_SPACE.id,
+        localBook: {
+          [CHAIN_IDS.sepolia]: { [LOCAL_SEPOLIA.address]: LOCAL_SEPOLIA.name },
+          [CHAIN_IDS.ethereum]: { [LOCAL_MAINNET.address]: LOCAL_MAINNET.name },
+        },
+      },
+    )
+
+    // Mock auth + spaces endpoints. The workspace address book returns contacts
+    // across chains; the frontend is what filters them down to the tx chain.
+    await safePage.route(/\/v1\/auth\/me(\?.*)?$/, (route) =>
+      route.fulfill({ json: { id: '1', authMethod: 'siwe', signerAddress: SIGNER } }),
+    )
+    await safePage.route(/\/v1\/users(\?.*)?$/, (route) =>
+      route.fulfill({ json: { id: 1, status: 1, wallets: [{ id: 1, address: SIGNER }] } }),
+    )
+    await safePage.route(/\/v1\/spaces\/[^/]+\/address-book(\?.*)?$/, (route) =>
+      route.fulfill({
+        json: {
+          spaceId: DROPDOWN_TEST_SPACE.id,
+          spaceUuid: DROPDOWN_TEST_SPACE.id,
+          data: WORKSPACE_CONTACTS.map((c) => ({
+            name: c.name,
+            address: c.address,
+            chainIds: c.chainIds,
+            createdBy: '',
+            createdByUserId: 0,
+            lastUpdatedBy: '',
+            lastUpdatedByUserId: 0,
+            createdAt: '',
+            updatedAt: '',
+          })),
+        },
+      }),
+    )
+    await safePage.route(/\/v1\/spaces\/[^/]+\/members(\?.*)?$/, (route) => route.fulfill({ json: SPACE.members }))
+    await safePage.route(/\/v1\/spaces\/[^/]+\/safes(\?.*)?$/, (route) => route.fulfill({ json: { safes: {} } }))
+    await safePage.route(/\/v1\/spaces\/[^/]+(\?.*)?$/, (route) => route.fulfill({ json: SPACE }))
+    await safePage.route(/\/v1\/spaces(\?.*)?$/, (route) => route.fulfill({ json: [SPACE] }))
+
+    // Open a Sepolia Safe and connect the owner wallet (enables "New transaction").
+    await safePage.goto(`/home?safe=${SAFES.SEP_OWNER_4_SAFE}`)
+    await walletPage.acceptCookies()
+    await walletPage.connectWallet(credentials.OWNER_4_PRIVATE_KEY)
+    await expect(walletPage.accountCenter).toBeVisible()
+
+    // Open the Send-tokens flow and the recipient dropdown.
+    await expect(safePage.getByTestId('new-tx-btn')).toBeEnabled()
+    await safePage.getByTestId('new-tx-btn').click()
+    await safePage.getByTestId('send-tokens-btn').click()
+    await safePage.getByRole('combobox', { name: /Recipient address/ }).click()
+
+    // Wait for the dropdown to populate (the first Sepolia contact renders).
+    const optionByName = (name: string) => safePage.getByTestId('address-item').filter({ hasText: name })
+    await expect(optionByName('WS Sepolia Only')).toBeVisible()
+
+    // Sepolia-eligible contacts are suggested.
+    for (const name of VISIBLE_ON_SEPOLIA) {
+      await expect(optionByName(name)).toBeVisible()
+    }
+
+    // Contacts only on other networks are never suggested.
+    for (const name of HIDDEN_ON_SEPOLIA) {
+      await expect(optionByName(name)).toHaveCount(0)
+    }
+  })
+})

--- a/apps/web/e2e/tests/regression/recipient-dropdown-random-selection.spec.ts
+++ b/apps/web/e2e/tests/regression/recipient-dropdown-random-selection.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Regression — recipient dropdown reliably populates the field for any contact,
+ * across both the workspace and local groups.
+ *
+ * The improved recipient dropdown groups contacts into "Contacts of <workspace>"
+ * (server/space) and "Local contacts" (this browser). This test proves the core
+ * wiring property: selecting ANY entry, from EITHER group, always sets the
+ * recipient field to that entry's address — repeated across every entry so a
+ * stale / wrong-value regression on re-selection is caught.
+ *
+ * Deterministic setup (ports Cypress `spaces_address_book_import.cy.js`'s
+ * `setupSpacesAuth`): a SiWE session is faked via localStorage + a mocked
+ * `/v1/auth/me` (without that mock the session-expiry guard's probe 403s against
+ * staging and clears the session — which is exactly why a plain seed fails). The
+ * spaces endpoints are mocked to inject a workspace and its contacts; local
+ * contacts are seeded via localStorage. The wallet (OWNER_4, owner of the Safe)
+ * is connected so "New transaction" is enabled. No real sign-in, no real
+ * workspace required.
+ *
+ * The per-contact assertion is data-driven: it reads each rendered option's
+ * address from the dropdown and verifies the field matches after selection.
+ *
+ * Run: yarn workspace @safe-global/web pw:test recipient-dropdown-random-selection
+ * Tag: @regression — runs under the chromium project, on demand.
+ */
+import { test, expect } from '../../src/fixtures/test.fixture'
+import type { Page } from '@playwright/test'
+import {
+  SAFES,
+  CHAIN_IDS,
+  LS_NAMESPACE,
+  DROPDOWN_TEST_SPACE,
+  DROPDOWN_LOCAL_CONTACTS,
+  DROPDOWN_WORKSPACE_CONTACTS,
+} from '../../src/data/constants'
+
+const ADDRESS_RE = /0x[a-fA-F0-9]{40}/
+
+const SIGNER = '0x1234567890123456789012345678901234567890'
+
+const SPACE = {
+  id: Number(DROPDOWN_TEST_SPACE.id),
+  uuid: DROPDOWN_TEST_SPACE.id,
+  name: DROPDOWN_TEST_SPACE.name,
+  status: 'ACTIVE',
+  safeCount: 1,
+  members: [{ id: 1, role: 'ADMIN', name: 'Admin', status: 'ACTIVE', user: { id: 1, status: 'ACTIVE' } }],
+}
+
+const WORKSPACE_ADDRESS_BOOK = {
+  spaceId: DROPDOWN_TEST_SPACE.id,
+  spaceUuid: DROPDOWN_TEST_SPACE.id,
+  data: DROPDOWN_WORKSPACE_CONTACTS.map((c) => ({
+    name: c.name,
+    address: c.address,
+    chainIds: [CHAIN_IDS.sepolia],
+    createdBy: '',
+    createdByUserId: 0,
+    lastUpdatedBy: '',
+    lastUpdatedByUserId: 0,
+    createdAt: '',
+    updatedAt: '',
+  })),
+}
+
+/**
+ * Fakes an authenticated Spaces session and injects a deterministic workspace +
+ * contacts by mocking the auth/users/spaces GET endpoints. Everything else
+ * (chains, safe info) hits the real CGW. Mirrors Cypress `setupSpacesAuth`.
+ */
+async function mockSpacesSession(page: Page): Promise<void> {
+  await page.addInitScript(
+    ({ ns, spaceId, chainId, localContacts }) => {
+      window.localStorage.setItem(
+        `${ns}auth`,
+        JSON.stringify({
+          sessionExpiresAt: Date.now() + 24 * 60 * 60 * 1000,
+          lastUsedSpace: spaceId,
+          isStoreHydrated: false,
+          cfSafeSynced: false,
+          isOidcLoginPending: false,
+        }),
+      )
+      const book = Object.fromEntries(localContacts.map((c) => [c.address, c.name]))
+      window.localStorage.setItem(`${ns}addressBook`, JSON.stringify({ [chainId]: book }))
+    },
+    {
+      ns: LS_NAMESPACE,
+      spaceId: DROPDOWN_TEST_SPACE.id,
+      chainId: CHAIN_IDS.sepolia,
+      localContacts: DROPDOWN_LOCAL_CONTACTS.map((c) => ({ name: c.name, address: c.address })),
+    },
+  )
+
+  // Keeps the session-expiry guard's probe from 403-ing and clearing the session.
+  await page.route(/\/v1\/auth\/me(\?.*)?$/, (route) =>
+    route.fulfill({ json: { id: '1', authMethod: 'siwe', signerAddress: SIGNER } }),
+  )
+  await page.route(/\/v1\/users(\?.*)?$/, (route) =>
+    route.fulfill({ json: { id: 1, status: 1, wallets: [{ id: 1, address: SIGNER }] } }),
+  )
+  await page.route(/\/v1\/spaces\/[^/]+\/address-book(\?.*)?$/, (route) =>
+    route.fulfill({ json: WORKSPACE_ADDRESS_BOOK }),
+  )
+  await page.route(/\/v1\/spaces\/[^/]+\/members(\?.*)?$/, (route) => route.fulfill({ json: SPACE.members }))
+  await page.route(/\/v1\/spaces\/[^/]+\/safes(\?.*)?$/, (route) => route.fulfill({ json: { safes: {} } }))
+  await page.route(/\/v1\/spaces\/[^/]+(\?.*)?$/, (route) => route.fulfill({ json: SPACE }))
+  await page.route(/\/v1\/spaces(\?.*)?$/, (route) => route.fulfill({ json: [SPACE] }))
+}
+
+test.describe('Recipient dropdown — selection updates the field', { tag: '@regression' }, () => {
+  test('should set the recipient field to the chosen address for every workspace and local contact', async ({
+    safePage,
+    walletPage,
+    credentials,
+  }) => {
+    await mockSpacesSession(safePage)
+
+    // Open the Safe and connect the owner wallet (enables "New transaction").
+    await safePage.goto(`/home?safe=${SAFES.SEP_OWNER_4_SAFE}`)
+    await walletPage.acceptCookies()
+    await walletPage.connectWallet(credentials.OWNER_4_PRIVATE_KEY)
+    await expect(walletPage.accountCenter).toBeVisible()
+
+    // Open the Send-tokens flow.
+    await expect(safePage.getByTestId('new-tx-btn')).toBeEnabled()
+    await safePage.getByTestId('new-tx-btn').click()
+    await safePage.getByTestId('send-tokens-btn').click()
+
+    // The editable input is a combobox; once a contact is selected the field
+    // switches to a read-only chip (the input becomes visibility:hidden, so the
+    // combobox role disappears) — hence two separate locators.
+    const combo = safePage.getByRole('combobox', { name: /Recipient address/ })
+    const selectedChip = safePage.getByTestId('address-book-recipient')
+
+    await expect(combo).toBeVisible()
+    await combo.click()
+
+    // Mixed setup must be present: both the workspace and local groups render.
+    await expect(safePage.getByTestId('contact-group-header').filter({ hasText: 'Contacts of' })).toBeVisible()
+    await expect(safePage.getByTestId('contact-group-header').filter({ hasText: 'Local contacts' })).toBeVisible()
+
+    // Read each rendered option's address (data-driven; the input row has no
+    // address and is filtered out). renderOption and renderInput share the
+    // "address-item" testid, so we key off the presence of a 40-hex address.
+    const addresses = await safePage.getByTestId('address-item').evaluateAll((els, re) => {
+      const pattern = new RegExp(re)
+      return els.map((el) => (el.textContent || '').match(pattern)?.[0]).filter((a): a is string => Boolean(a))
+    }, ADDRESS_RE.source)
+
+    expect(addresses.length).toBe(DROPDOWN_LOCAL_CONTACTS.length + DROPDOWN_WORKSPACE_CONTACTS.length)
+
+    // Close the dropdown so each iteration starts from the same closed state.
+    await combo.press('Escape')
+
+    // Select each contact in turn; the field must always reflect the choice.
+    for (const address of addresses) {
+      // If a contact is already selected, click its read-only chip to reset back
+      // to the editable (visible) combobox — clicking the chip triggers the
+      // field's resetName, which clears the value and re-shows the input.
+      if (await selectedChip.isVisible().catch(() => false)) {
+        await selectedChip.click()
+      }
+      await combo.click() // field is empty + closed here, so this opens the dropdown
+
+      const option = safePage.getByTestId('address-item').filter({ hasText: address }).first()
+      await expect(option).toBeVisible()
+      await option.click()
+
+      // The selected address is shown in the read-only chip (the user-visible
+      // confirmation). Value may carry a chain prefix and differing case.
+      await expect(selectedChip).toContainText(new RegExp(address, 'i'))
+    }
+  })
+})

--- a/apps/web/src/components/common/AddressBookInput/RecipientGroupHeader.tsx
+++ b/apps/web/src/components/common/AddressBookInput/RecipientGroupHeader.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react'
+import { Box, Tooltip, Typography } from '@mui/material'
+import { Building2, HardDrive, Info } from 'lucide-react'
+import { ContactSource } from '@/hooks/useAllAddressBooks'
+import css from './styles.module.css'
+
+const RecipientGroupHeader = ({
+  source,
+  workspaceName,
+  count,
+}: {
+  source: ContactSource
+  workspaceName?: string
+  count: number
+}): ReactElement => {
+  const isSpace = source === ContactSource.space
+  const Icon = isSpace ? Building2 : HardDrive
+
+  return (
+    <Box className={css.groupHeader} data-testid="contact-group-header">
+      <Icon size={14} className={css.groupIcon} />
+
+      <Typography variant="caption" fontWeight={700} noWrap className={css.groupLabel}>
+        {isSpace ? (
+          <>
+            Contacts of
+            {workspaceName ? (
+              /* Pill styling is a spoofing defense: user-provided names render in a
+                 visual container that typed text cannot reproduce */
+              <span className={css.nameBadge}>{workspaceName}</span>
+            ) : (
+              ' your Workspace'
+            )}
+          </>
+        ) : (
+          'Local contacts'
+        )}
+      </Typography>
+
+      <Tooltip
+        title={
+          isSpace
+            ? `Shared with everyone in ${workspaceName ?? 'your workspace'}. Only Workspace admins can add or change these contacts.`
+            : 'Saved only in this browser, from your old address book. Not shared with your workspace.'
+        }
+        placement="top"
+      >
+        <Info size={14} className={css.groupInfoIcon} />
+      </Tooltip>
+
+      <Typography variant="caption" color="text.secondary" className={css.groupCount}>
+        {count}
+      </Typography>
+    </Box>
+  )
+}
+
+export default RecipientGroupHeader

--- a/apps/web/src/components/common/AddressBookInput/RecipientOption.tsx
+++ b/apps/web/src/components/common/AddressBookInput/RecipientOption.tsx
@@ -1,0 +1,82 @@
+import type { ReactElement } from 'react'
+import { Box, Tooltip, Typography, useMediaQuery } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { HardDrive } from 'lucide-react'
+import Identicon from '@/components/common/Identicon'
+import InitialsAvatar from '@/components/common/InitialsAvatar'
+import { isValidAddress } from '@safe-global/utils/utils/validation'
+import { ContactSource } from '@/hooks/useAllAddressBooks'
+import { formatExactTime, formatRelativeTime, getProvenanceLine, type RecipientContact } from './provenance'
+import css from './styles.module.css'
+
+const RecipientOption = ({
+  contact,
+  prefix,
+  memberName,
+  resolveName,
+}: {
+  contact: RecipientContact
+  prefix?: string
+  memberName?: string
+  resolveName?: (address: string) => string
+}): ReactElement => {
+  const theme = useTheme()
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'))
+  const provenance = getProvenanceLine(contact, memberName, resolveName)
+  const relativeTime = provenance?.timestamp ? formatRelativeTime(provenance.timestamp) : undefined
+  const exactTime = provenance?.timestamp ? formatExactTime(provenance.timestamp) : undefined
+
+  return (
+    <Box className={css.option}>
+      <Identicon address={contact.address} size={40} />
+
+      <Box className={css.optionMain}>
+        <Typography variant="body2" fontWeight={600} noWrap>
+          {contact.name}
+        </Typography>
+
+        {/* The tooltip is only needed when the address is shortened — on large screens it is fully visible */}
+        <Tooltip title={isSmallScreen ? contact.address : ''} placement="top">
+          <Typography variant="caption" component="div" className={css.optionAddress}>
+            {prefix ? <b>{prefix}:</b> : null}
+            {/* Bold the first 4 and last 4 hex chars. On narrow viewports the middle
+                collapses to an ellipsis; on wide ones the full address is shown. */}
+            {contact.address.slice(0, 2)}
+            <b>{contact.address.slice(2, 6)}</b>
+            {isSmallScreen ? '…' : contact.address.slice(6, -4)}
+            <b>{contact.address.slice(-4)}</b>
+          </Typography>
+        </Tooltip>
+
+        {provenance && (
+          <Typography variant="caption" component="div" color="text.secondary" className={css.provenance}>
+            {contact.source === ContactSource.local && <HardDrive size={12} className={css.provenanceIcon} />}
+            {contact.source !== ContactSource.local &&
+              contact.createdBy &&
+              (memberName ? (
+                <InitialsAvatar name={memberName} size="xxsmall" rounded />
+              ) : isValidAddress(contact.createdBy) ? (
+                <Identicon address={contact.createdBy} size={16} />
+              ) : null)}
+            <span>{provenance.text}</span>
+            {provenance.actor && (
+              /* Pill styling is a spoofing defense: user-provided names render in a
+                 visual container that typed text cannot reproduce */
+              <span className={`${css.provenanceActor} ${css.nameBadge}`}>{provenance.actor}</span>
+            )}
+            {relativeTime && (
+              <>
+                <span>·</span>
+                <Tooltip title={exactTime} placement="top">
+                  <span className={css.relativeTime}>{relativeTime}</span>
+                </Tooltip>
+              </>
+            )}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+export default RecipientOption

--- a/apps/web/src/components/common/AddressBookInput/index.test.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.test.tsx
@@ -1,5 +1,5 @@
 import { act } from 'react'
-import { fireEvent, render, waitFor } from '@/tests/test-utils'
+import { fireEvent, render, waitFor, within } from '@/tests/test-utils'
 import { FormProvider, useForm } from 'react-hook-form'
 import AddressBookInput from '.'
 import { AddressBookSourceProvider } from '../AddressBookSourceProvider'
@@ -297,7 +297,7 @@ describe('AddressBookInput', () => {
     await waitFor(() => expect(utils.queryByText('add it to your address book', { exact: false })).toBeNull())
   })
 
-  it('should show a cloud icon for a server-stored (space) contact in a spaceOnly context', async () => {
+  it('should group a server-stored (space) contact under the workspace header with the workspace icon', async () => {
     const spaceContact = spaceContactBuilder({ name: 'Server Contact' })
     mockUseGetSpaceAddressBook.mockReturnValue([spaceContact])
 
@@ -323,11 +323,20 @@ describe('AddressBookInput', () => {
       fireEvent.mouseUp(input)
     })
 
-    await waitFor(() => expect(utils.getByText('Server Contact', { exact: false })).toBeDefined())
-    expect(utils.getByTestId('CloudOutlinedIcon')).toBeInTheDocument()
+    // Scope to the space contact's own group. Persisted local contacts from other
+    // tests can leak into the listbox via localStorage, so assert on this group.
+    const option = await waitFor(() => utils.getByText('Server Contact', { exact: false }))
+    const groupEl = option.closest('.groupList')!.closest('li') as HTMLElement
+    const group = within(groupEl)
+
+    // Workspace source: "Contacts of …" header with the building (workspace) icon,
+    // not the local hard-drive icon.
+    expect(group.getByText('Contacts of', { exact: false })).toBeInTheDocument()
+    expect(groupEl.querySelector('.lucide-building-2')).toBeInTheDocument()
+    expect(groupEl.querySelector('.lucide-hard-drive')).not.toBeInTheDocument()
   })
 
-  it('should not show a cloud icon for a local contact', async () => {
+  it('should group a local contact under the local contacts header with the local icon', async () => {
     const { input, utils } = setup('', {
       [checksumAddress(faker.finance.ethereumAddress())]: 'Local Contact',
     })
@@ -337,7 +346,15 @@ describe('AddressBookInput', () => {
       fireEvent.mouseUp(input)
     })
 
-    await waitFor(() => expect(utils.getByText('Local Contact', { exact: false })).toBeDefined())
-    expect(utils.queryByTestId('CloudOutlinedIcon')).not.toBeInTheDocument()
+    // Scope to the contact's own group (see note above).
+    const option = await waitFor(() => utils.getByText('Local Contact', { exact: true }))
+    const groupEl = option.closest('.groupList')!.closest('li') as HTMLElement
+    const group = within(groupEl)
+
+    // Local source: "Local contacts" header with the hard-drive icon, not the
+    // building (workspace) icon.
+    expect(group.getByText('Local contacts')).toBeInTheDocument()
+    expect(groupEl.querySelector('.lucide-hard-drive')).toBeInTheDocument()
+    expect(groupEl.querySelector('.lucide-building-2')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/common/AddressBookInput/index.tsx
+++ b/apps/web/src/components/common/AddressBookInput/index.tsx
@@ -1,16 +1,21 @@
-import { type ReactElement, useState, useMemo } from 'react'
+import { type ReactElement, useState, useMemo, Children } from 'react'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { SvgIcon, Typography } from '@mui/material'
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete'
 import AddressInput, { type AddressInputProps } from '../AddressInput'
-import EthHashInfo from '../EthHashInfo'
 import InfoIcon from '@/public/images/notifications/info.svg'
 import EntryDialog from '@/components/address-book/EntryDialog'
 import css from './styles.module.css'
 import inputCss from '@/styles/inputs.module.css'
 import { isValidAddress } from '@safe-global/utils/utils/validation'
 import { sameAddress } from '@safe-global/utils/utils/addresses'
-import { useMergedAddressBooks } from '@/hooks/useAllAddressBooks'
+import { useMergedAddressBooks, useSafeNameResolver, type ContactSource } from '@/hooks/useAllAddressBooks'
+import { useCurrentChain } from '@/hooks/useChains'
+import useChainId from '@/hooks/useChainId'
+import { useMemberNameResolver } from '@/features/spaces'
+import RecipientOption from './RecipientOption'
+import RecipientGroupHeader from './RecipientGroupHeader'
+import useWorkspaceName from './useWorkspaceName'
 
 const abFilterOptions = createFilterOptions({
   stringify: (option: { label: string; name: string }) => option.name + ' ' + option.label,
@@ -23,18 +28,27 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
   const [open, setOpen] = useState(false)
   const [openAddressBook, setOpenAddressBook] = useState<boolean>(false)
   const mergedAddressBook = useMergedAddressBooks()
+  const workspaceName = useWorkspaceName()
+  const prefix = useCurrentChain()?.shortName
+  const chainId = useChainId()
+  const resolveSafeName = useSafeNameResolver()
+  const resolveMemberName = useMemberNameResolver()
 
   const { setValue, control } = useFormContext()
   const addressValue = useWatch({ name, control })
 
   const allAddressBookEntries = useMemo(
     () =>
-      mergedAddressBook.list.map((entry) => ({
-        label: entry.address,
-        name: entry.name,
-        source: entry.source,
-      })),
-    [mergedAddressBook],
+      mergedAddressBook.list
+        // Only suggest contacts configured for the chain we are sending on
+        .filter((entry) => entry.chainIds.includes(chainId))
+        .map((entry) => ({
+          label: entry.address,
+          name: entry.name,
+          source: entry.source,
+          contact: entry,
+        })),
+    [mergedAddressBook, chainId],
   )
 
   const hasVisibleOptions = useMemo(
@@ -73,6 +87,9 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
           <Autocomplete
             {...field}
             className={inputCss.input}
+            open={open}
+            onOpen={() => setOpen(true)}
+            onClose={() => setOpen(false)}
             disableClearable
             disabled={props.disabled}
             readOnly={props.InputProps?.readOnly}
@@ -86,16 +103,27 @@ const AddressBookInput = ({ name, canAdd, ...props }: AddressInputProps & { canA
                 elevation: 2,
               },
             }}
+            ListboxProps={{ className: css.listbox }}
+            groupBy={(option) => option.source}
+            renderGroup={(params) => (
+              <li key={params.key}>
+                <RecipientGroupHeader
+                  source={params.group as ContactSource}
+                  workspaceName={workspaceName}
+                  count={Children.count(params.children)}
+                />
+                <ul className={css.groupList}>{params.children}</ul>
+              </li>
+            )}
             renderOption={(props, option) => {
               const { key, ...rest } = props
               return (
                 <Typography data-testid="address-item" component="li" variant="body2" {...rest} key={key}>
-                  <EthHashInfo
-                    address={option.label}
-                    name={option.name}
-                    shortAddress={false}
-                    copyAddress={false}
-                    addressBookNameSource={option.source}
+                  <RecipientOption
+                    contact={option.contact}
+                    prefix={prefix}
+                    memberName={resolveMemberName(option.contact.createdByUserId)}
+                    resolveName={(address) => resolveSafeName(address, chainId)}
                   />
                 </Typography>
               )

--- a/apps/web/src/components/common/AddressBookInput/provenance.ts
+++ b/apps/web/src/components/common/AddressBookInput/provenance.ts
@@ -1,0 +1,50 @@
+import { ContactSource, type ExtendedContact } from '@/hooks/useAllAddressBooks'
+import { formatTimeInWords } from '@safe-global/utils/utils/date'
+
+export type RecipientContact = ExtendedContact
+
+const parseTimestamp = (timestamp?: string): number | undefined => {
+  if (!timestamp) return undefined
+  const time = Date.parse(timestamp)
+  return Number.isNaN(time) ? undefined : time
+}
+
+export const formatRelativeTime = (timestamp: string): string | undefined => {
+  const time = parseTimestamp(timestamp)
+  return time === undefined ? undefined : formatTimeInWords(time)
+}
+
+export const formatExactTime = (timestamp: string): string | undefined => {
+  const time = parseTimestamp(timestamp)
+  return time === undefined
+    ? undefined
+    : new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(time)
+}
+
+export type ProvenanceLine = {
+  text: string
+  actor?: string
+  timestamp?: string
+}
+
+export const getProvenanceLine = (
+  contact: RecipientContact,
+  memberName?: string,
+  resolveName?: (address: string) => string,
+): ProvenanceLine | undefined => {
+  if (contact.source === ContactSource.local) {
+    return { text: 'Saved on this device' }
+  }
+
+  if (contact.createdBy) {
+    // Prefer the space member name, then an address book name; otherwise show the
+    // raw actor value (name, email, or address) as-is — the UI ellipsizes it
+    return {
+      text: 'Added by',
+      actor: memberName || resolveName?.(contact.createdBy) || contact.createdBy,
+      timestamp: contact.createdAt || undefined,
+    }
+  }
+
+  return undefined
+}

--- a/apps/web/src/components/common/AddressBookInput/styles.module.css
+++ b/apps/web/src/components/common/AddressBookInput/styles.module.css
@@ -1,3 +1,124 @@
+/* The listbox keeps its 8px top padding (compensated by the sticky header's top: -8px)
+   but drops the bottom one so the last option's hover reaches the dropdown edge */
+.listbox {
+  padding-bottom: 0 !important;
+}
+
+.groupHeader {
+  position: sticky;
+  /* compensate the MuiAutocomplete-listbox top padding so the header sticks flush */
+  top: -8px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  background-color: var(--color-background-main);
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.groupIcon {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+}
+
+.groupInfoIcon {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  cursor: help;
+}
+
+.groupCount {
+  margin-left: auto;
+}
+
+.groupLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--space-1) / 2);
+  min-width: 0;
+}
+
+/* Container for user-provided names (workspace, creator). The pill background and
+   border cannot be reproduced by characters typed into a name field, so a malicious
+   name cannot visually impersonate surrounding UI copy. */
+.nameBadge {
+  display: inline-block;
+  max-width: 100%;
+  padding: 0 calc(var(--space-1) * 0.75);
+  background-color: var(--color-background-paper);
+  border: 1px solid var(--color-border-light);
+  border-radius: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.groupList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.groupList li + li {
+  border-top: 1px solid var(--color-border-light);
+}
+
+/* Match the prototype's .ab-row: 12px vertical / 16px horizontal padding.
+   !important overrides MUI's .MuiAutocomplete-option padding. */
+.groupList li {
+  padding: 12px 16px !important;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-width: 0;
+}
+
+.optionMain {
+  flex: 1;
+  min-width: 0;
+}
+
+.optionAddress {
+  font-family: 'SF Mono', ui-monospace, 'Roboto Mono', monospace;
+  font-size: 12.5px;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.provenance {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--space-1) / 2);
+  white-space: nowrap;
+  min-width: 0;
+  margin-top: 4px;
+}
+
+/* Long actor values (full addresses, long names) ellipsize instead of wrapping */
+.provenanceActor {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.provenanceIcon {
+  font-size: 12px;
+}
+
+.relativeTime {
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+  cursor: help;
+}
+
 .unknownAddress {
   margin-top: calc(-1 * var(--space-2));
   padding: 20px 12px 4px;

--- a/apps/web/src/components/common/AddressBookInput/useWorkspaceName.ts
+++ b/apps/web/src/components/common/AddressBookInput/useWorkspaceName.ts
@@ -1,0 +1,14 @@
+import { useAppSelector } from '@/store'
+import { isAuthenticated } from '@/store/authSlice'
+import { useCurrentSpaceId } from '@/features/spaces'
+import { useSpacesGetOneV1Query } from '@safe-global/store/gateway/AUTO_GENERATED/spaces'
+
+const useWorkspaceName = (): string | undefined => {
+  const spaceId = useCurrentSpaceId()
+  const isUserSignedIn = useAppSelector(isAuthenticated)
+  const { currentData: space } = useSpacesGetOneV1Query({ id: spaceId ?? '' }, { skip: !isUserSignedIn || !spaceId })
+
+  return space?.name
+}
+
+export default useWorkspaceName

--- a/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
+++ b/apps/web/src/components/common/EthHashInfo/SrcEthHashInfo/index.tsx
@@ -2,9 +2,8 @@ import classnames from 'classnames'
 import type { ReactElement, ReactNode, SyntheticEvent } from 'react'
 import { isAddress } from 'ethers'
 import { useTheme } from '@mui/material/styles'
-import { Box, SvgIcon, Tooltip } from '@mui/material'
-import AddressBookIcon from '@/public/images/sidebar/address-book.svg'
-import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined'
+import { Box, Tooltip } from '@mui/material'
+import { Building2, HardDrive } from 'lucide-react'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import Identicon from '../../Identicon'
 import CopyAddressButton from '../../CopyAddressButton'
@@ -126,13 +125,12 @@ const SrcEthHashInfo = ({
               ? badgeTooltip
               : !!addressBookNameSource && (
                   <Tooltip title={`From your ${addressBookNameSource} address book`} placement="top">
-                    <span style={{ lineHeight: 0 }}>
-                      <SvgIcon
-                        component={addressBookNameSource === ContactSource.local ? AddressBookIcon : CloudOutlinedIcon}
-                        inheritViewBox
-                        color="border"
-                        fontSize="small"
-                      />
+                    <span style={{ lineHeight: 0, color: 'var(--color-border-main)' }}>
+                      {addressBookNameSource === ContactSource.local ? (
+                        <HardDrive size={16} />
+                      ) : (
+                        <Building2 size={16} />
+                      )}
                     </span>
                   </Tooltip>
                 )}

--- a/apps/web/src/components/common/InitialsAvatar/index.tsx
+++ b/apps/web/src/components/common/InitialsAvatar/index.tsx
@@ -8,12 +8,13 @@ const InitialsAvatar = ({
   rounded = false,
 }: {
   name: string
-  size?: 'xsmall' | 'small' | 'medium' | 'large'
+  size?: 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large'
   rounded?: boolean
 }) => {
   const logoLetters = name.slice(0, 1)
   const logoColor = getDeterministicColor(name)
   const dimensions = {
+    xxsmall: { width: 16, height: 16, fontSize: '9px !important' },
     xsmall: { width: 20, height: 20, fontSize: '12px !important' },
     small: { width: 24, height: 24, fontSize: '12px !important' },
     medium: { width: 32, height: 32, fontSize: '16px !important' },

--- a/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
+++ b/apps/web/src/features/spaces/components/SpaceAddressBook/SpaceAddressBookTable.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import { useMediaQuery } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
@@ -59,6 +61,8 @@ function SpaceAddressBookTable({
 }: SpaceAddressBookTableProps) {
   const [page, setPage] = useState(0)
   const resolveMemberName = useMemberNameResolver()
+  const theme = useTheme()
+  const isSmallScreen = useMediaQuery(theme.breakpoints.down('lg'))
 
   useEffect(() => {
     setPage(0)
@@ -103,10 +107,10 @@ function SpaceAddressBookTable({
 
               {/* Address */}
               <TableCell>
-                <div className="text-[0.8em]">
+                <div className="text-[0.8em] font-mono">
                   <EthHashInfo
                     address={entry.address}
-                    shortAddress={false}
+                    shortAddress={isSmallScreen}
                     showPrefix={false}
                     showName={false}
                     highlight4bytes

--- a/apps/web/src/features/spaces/index.ts
+++ b/apps/web/src/features/spaces/index.ts
@@ -58,6 +58,7 @@ export {
 export { default as useFeatureFlagRedirect } from './hooks/useFeatureFlagRedirect'
 export { default as useFeatureRedirect } from './hooks/useFeatureRedirect'
 export { default as useGetSpaceAddressBook } from './hooks/useGetSpaceAddressBook'
+export { useMemberNameResolver } from './hooks/useMemberNameResolver'
 export { default as useGetSpaceAuditLog } from './hooks/useGetSpaceAuditLog'
 export { default as useGetSpaceAuditLogActors } from './hooks/useGetSpaceAuditLogActors'
 export { default as useGetAddressBookRequests } from './hooks/useGetAddressBookRequests'


### PR DESCRIPTION
Based on #8081. I will mark this as ready once we merge #8081 

## Screenshots

<img width="1063" height="645" alt="Screenshot 2026-06-15 at 11 48 26" src="https://github.com/user-attachments/assets/1a70f18f-93a4-4daa-8be3-3b69c250bfba" />
<img width="495" height="1033" alt="Screenshot 2026-06-15 at 11 48 40" src="https://github.com/user-attachments/assets/539fa703-f1d8-40ed-826c-c84869f3d769" />

## Tests

Added the following e2e tests:

- Click on caret, does dropdown expand and collapse?
- Make sure that the dropdown only ever suggests addresses from the address book that were defined exclusively for that network
- Fuzz test that selects and drops multiple addresses and ensure that it's still the correct address that's the value of the input
- Select an address from the dropdown, check if that address is now also in the input